### PR TITLE
Contact test: add missing setUp super call.

### DIFF
--- a/opengever/contact/tests/test_contact.py
+++ b/opengever/contact/tests/test_contact.py
@@ -5,6 +5,7 @@ class TestContact(FunctionalTestCase):
     use_browser = True
 
     def setUp(self):
+        super(TestContact, self).setUp()
         self.grant('Member', 'Contributor', 'Manager')
 
     def obj2brain(self, obj):


### PR DESCRIPTION
Fixes opengever.contact tests

``` python
  File "/var/lib/jenkins/jobs/opengever.core-master-test-plone-4.2.x.cfg/workspace/opengever/contact/tests/test_contact.py", line 8, in setUp
    self.grant('Member', 'Contributor', 'Manager')
  File "/var/lib/jenkins/jobs/opengever.core-master-test-plone-4.2.x.cfg/workspace/opengever/testing/test_case.py", line 25, in grant
    setRoles(self.portal, TEST_USER_ID, list(roles))
AttributeError: 'TestContact' object has no attribute 'portal'
```
