### PR TITLE
Only provide things in opengever.testing when [tests] is installed.

### DIFF
--- a/opengever/testing/__init__.py
+++ b/opengever/testing/__init__.py
@@ -1,8 +1,18 @@
-from opengever.testing.helpers import create_plone_user
-from opengever.testing.sql import create_client
-from opengever.testing.sql import create_ogds_user
-from opengever.testing.sql import set_current_client_id
-from opengever.testing.test_case import FunctionalTestCase
+import pkg_resources
 
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
-from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+try:
+    pkg_resources.get_distribution('ftw.testing')
+
+except pkg_resources.DistributionNotFound:
+    # [tests] is not installed - z3c.autoinclude is scanning.
+    pass
+
+else:
+    from opengever.testing.helpers import create_plone_user
+    from opengever.testing.sql import create_client
+    from opengever.testing.sql import create_ogds_user
+    from opengever.testing.sql import set_current_client_id
+    from opengever.testing.test_case import FunctionalTestCase
+
+    from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
+    from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING


### PR DESCRIPTION
This is detected by checking whether the ftw.testing distribution is installed.
The reasion for this is that z3c.autoinclude scans every package in opengever, this includes opengever.testing.
When booting the instance we don't have test extras and therefore it will get import errors (e.g. ftw.testing).

/cc @phgross @lukasgraf 
(did not run tests, wait for PR test result)
