### PR TITLE
top-level `create` function for the `Builder API`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,19 +41,18 @@ To use the `Builder API` you need to import the `Builder` function:
 .. code:: python
 
      from opengever.testing import Builder
+     from opengever.testing import create
 
 
 Then you can use the `Builder` function in your test cases:
 
 .. code:: python
 
-     dossier = Builder("dossier").create()
-     task = Builder("task").within(dossier).create()
-     document = Builder("document") \
-         .within(dossier) \
-         .attach_file_containing("test_data") \
-         .create()
-         
+     dossier = create(Builder("dossier"))
+     task = create(Builder("task").within(dossier))
+     document = create(Builder("document")
+                       .within(dossier)
+                       .attach_file_containing("test_data"))
+
 Note that `Builder` will automatically do a `transaction.commit()` when `create()` is called.
 You can disable this feature on a per test-case basis on the `BuilderSession`
-     

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -1,10 +1,10 @@
-from plone.app.testing import TEST_USER_ID
-from opengever.testing import FunctionalTestCase
-
-from opengever.testing import create_client
-from opengever.testing import set_current_client_id
-from opengever.testing import create_ogds_user
 from opengever.testing import Builder
+from opengever.testing import FunctionalTestCase
+from opengever.testing import create
+from opengever.testing import create_client
+from opengever.testing import create_ogds_user
+from opengever.testing import set_current_client_id
+from plone.app.testing import TEST_USER_ID
 
 class TestSearchWithContent(FunctionalTestCase):
     use_browser = True
@@ -16,8 +16,8 @@ class TestSearchWithContent(FunctionalTestCase):
         set_current_client_id(self.layer['portal'])
         create_ogds_user(TEST_USER_ID)
 
-        self.dossier1 = Builder("dossier").titled("Dossier1").create()
-        self.dossier2 = Builder("dossier").titled("Dossier2").create()
+        self.dossier1 = create(Builder("dossier").titled("Dossier1"))
+        self.dossier2 = create(Builder("dossier").titled("Dossier2"))
 
     def test_search_dossiers(self):
         self.browser.open('%s/advanced_search' % self.dossier1.absolute_url())
@@ -30,8 +30,8 @@ class TestSearchWithContent(FunctionalTestCase):
 
 
     def test_search_documents(self):
-        Builder("document").within(self.dossier1).titled("Document1").create()
-        Builder("document").within(self.dossier2).titled("Document2").create()
+        create(Builder("document").within(self.dossier1).titled("Document1"))
+        create(Builder("document").within(self.dossier2).titled("Document2"))
 
         # search documents (we can't find the document because we must change the content-type)
         self.browser.open('%s/advanced_search' % self.dossier1.absolute_url())
@@ -51,8 +51,8 @@ class TestSearchWithContent(FunctionalTestCase):
         self.assertSearchResultCount(1)
 
     def test_search_tasks(self):
-        Builder("task").within(self.dossier1).titled("Task1").create()
-        Builder("task").within(self.dossier2).titled("Task2").create()
+        create(Builder("task").within(self.dossier1).titled("Task1"))
+        create(Builder("task").within(self.dossier2).titled("Task2"))
 
         # search tasks (we can't find the task because we must change the content-type)
         self.browser.open('%s/advanced_search' % self.dossier1.absolute_url())
@@ -85,7 +85,7 @@ class TestSearchWithoutContent(FunctionalTestCase):
         set_current_client_id(self.layer['portal'])
         create_ogds_user(TEST_USER_ID)
 
-        self.dossier1 = Builder("dossier").create()
+        self.dossier1 = create(Builder("dossier"))
 
     def test_validate_searchstring_for_dossiers(self):
         self.browser.open('%s/advanced_search' % self.dossier1.absolute_url())

--- a/opengever/base/tests/test_download_viewlet.py
+++ b/opengever/base/tests/test_download_viewlet.py
@@ -1,7 +1,8 @@
 from Products.CMFCore.utils import getToolByName
-from plone.namedfile.file import NamedBlobFile
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
+from plone.namedfile.file import NamedBlobFile
 
 
 class TestDownloadViewlet(FunctionalTestCase):
@@ -13,7 +14,7 @@ class TestDownloadViewlet(FunctionalTestCase):
         self.ptool = getToolByName(self.portal, 'plone_utils')
 
     def test_without_file(self):
-        test_doc = Builder("document").create()
+        test_doc = create(Builder("document"))
 
         response = self.download(test_doc)
         self.assertEquals('http://nohost/plone/document-1', response)
@@ -22,7 +23,8 @@ class TestDownloadViewlet(FunctionalTestCase):
                           self.ptool.showPortalMessages()[-1].message)
 
     def test_with_file(self):
-        test_doc = Builder("document").attach_file_containing("lorem ipsum", name=u"foobar.txt").create()
+        test_doc = create(Builder("document")
+                          .attach_file_containing("lorem ipsum", name=u"foobar.txt"))
 
         response = self.download(test_doc)
 
@@ -34,7 +36,7 @@ class TestDownloadViewlet(FunctionalTestCase):
     def test_custom_content_type(self):
         test_file = NamedBlobFile("some text", filename=u"sometext.txt")
         test_file.contentType = 'foo/bar'
-        test_doc = Builder("document").attach(test_file).create()
+        test_doc = create(Builder("document").attach(test_file))
 
         self.download(test_doc)
 

--- a/opengever/document/tests/test_behaviors.py
+++ b/opengever/document/tests/test_behaviors.py
@@ -1,14 +1,15 @@
 from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from zope.component import getUtility
 
 
 class TestDocumentNameFromTitle(FunctionalTestCase):
 
     def test_id_generation(self):
-        doc1 = Builder('document').create()
-        doc2 = Builder('document').create()
+        doc1 = create(Builder('document'))
+        doc2 = create(Builder('document'))
 
         self.assertEquals(1, getUtility(ISequenceNumber).get_number(doc1))
         self.assertEquals('document-1', doc1.id)

--- a/opengever/document/tests/test_download.py
+++ b/opengever/document/tests/test_download.py
@@ -4,6 +4,7 @@ from mocker import ANY
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
 from opengever.document.interfaces import IFileCopyDownloadedEvent
 from opengever.testing import Builder
+from opengever.testing import create
 from opengever.testing import FunctionalTestCase
 from opengever.testing.builders import BuilderSession
 from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
@@ -28,9 +29,9 @@ class TestDocumentDownloadView(MockTestCase):
         BuilderSession.instance().reset()
 
     def test_download_view(self):
-        doc1 = Builder("document").attach_file_containing("bla bla").create()
-        doc2 = Builder("document") \
-          .attach_file_containing("blub blub", name=u't\xf6st.txt').create()
+        doc1 = create(Builder("document").attach_file_containing("bla bla"))
+        doc2 = create(Builder("document")
+                      .attach_file_containing("blub blub", name=u't\xf6st.txt'))
 
         downloaded_handler = self.mocker.mock()
         self.mock_handler(downloaded_handler, [IFileCopyDownloadedEvent, ])
@@ -47,7 +48,7 @@ class TestDocumentDownloadView(MockTestCase):
         self.assertEquals(result.read(), 'blub blub')
 
     def test_download_file_version_view(self):
-        doc1 = Builder("document").create()
+        doc1 = create(Builder("document"))
 
         repo_tool = getToolByName(self.portal, 'portal_repository')
         repo_tool._recursiveSave(doc1, {},
@@ -88,7 +89,7 @@ class TestDocumentDownloadConfirmation(FunctionalTestCase):
         super(TestDocumentDownloadConfirmation, self).setUp()
         self.grant('Manager')
         login(self.portal, TEST_USER_NAME)
-        self.document = Builder("document").create()
+        self.document = create(Builder("document"))
 
         file_ = NamedBlobFile('bla bla', filename=u'test.txt')
         self.document.file = file_

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -1,6 +1,7 @@
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from zope.component import queryMultiAdapter
@@ -14,10 +15,10 @@ class TestDocumentIntegration(FunctionalTestCase):
         super(TestDocumentIntegration, self).setUp()
         self.grant('Manager')
         login(self.portal, TEST_USER_NAME)
-        self.document = Builder("document") \
-            .attach_file_containing(u"bla bla", name=u"test.txt") \
-            .having(digitally_available=True,
-                    keywords=()).create()
+        self.document = create(Builder("document")
+                               .attach_file_containing(u"bla bla", name=u"test.txt")
+                               .having(digitally_available=True,
+                                       keywords=()))
 
     def test_edit_form_document_not_checked_out(self):
         self.browser.open('%s/edit' % self.document.absolute_url())

--- a/opengever/document/tests/test_logout_overlay.py
+++ b/opengever/document/tests/test_logout_overlay.py
@@ -1,5 +1,6 @@
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import Builder
+from opengever.testing import create
 from opengever.testing import FunctionalTestCase
 from zope.component import getMultiAdapter
 
@@ -9,7 +10,7 @@ class TestLogoutOverlayWithoutCheckouts(FunctionalTestCase):
     def setUp(self):
         super(TestLogoutOverlayWithoutCheckouts, self).setUp()
         self.grant('Manager')
-        self.document = Builder("document").create()
+        self.document = create(Builder("document"))
 
     def test_logout_is_handled_using_a_js_script(self):
         view = self.portal.restrictedTraverse('@@logout_overlay')
@@ -21,9 +22,9 @@ class TestLogoutOverlayWithCheckouts(FunctionalTestCase):
         super(TestLogoutOverlayWithCheckouts, self).setUp()
         self.grant('Manager')
 
-        self.checkout1 = Builder("document").titled("About Plone").create()
-        self.document = Builder("document").titled("NOT checkedout").create()
-        self.checkout2 = Builder("document").titled("About Python").create()
+        self.checkout1 = create(Builder("document").titled("About Plone"))
+        self.document = create(Builder("document").titled("NOT checkedout"))
+        self.checkout2 = create(Builder("document").titled("About Python"))
         getMultiAdapter(
             (self.checkout1, self.portal.REQUEST),
             ICheckinCheckoutManager).checkout()

--- a/opengever/document/tests/test_title_filename_syncer.py
+++ b/opengever/document/tests/test_title_filename_syncer.py
@@ -1,4 +1,5 @@
 from opengever.testing import Builder
+from opengever.testing import create
 from opengever.testing import FunctionalTestCase
 
 
@@ -8,14 +9,14 @@ class TestTitleFilenameSyncer(FunctionalTestCase):
         super(TestTitleFilenameSyncer, self).setUp()
 
     def test_infer_title_from_filename(self):
-        document = Builder("document") \
-            .attach_file_containing(u"blup", name=u'T\xf6st.txt').create()
+        document = create(Builder("document")
+                          .attach_file_containing(u"blup", name=u'T\xf6st.txt'))
         self.assertEqual(document.title, u'T\xf6st')
         self.assertEqual(document.file.filename, u'tost.txt')
 
     def test_infer_filename_from_title(self):
-        document = Builder("document") \
-            .titled("My Title") \
-            .attach_file_containing(u"blup", name=u"wrong.txt").create()
+        document = create(Builder("document")
+                          .titled("My Title") \
+                          .attach_file_containing(u"blup", name=u"wrong.txt"))
         self.assertEqual(document.title, u'My Title')
         self.assertEqual(document.file.filename, u'my-title.txt')

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -5,6 +5,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
 from opengever.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.testing import create
 from plone.app.testing import TEST_USER_ID
 from plone.dexterity.utils import createContentInContainer
 from zope.annotation.interfaces import IAnnotations
@@ -16,30 +17,30 @@ class TestDossierContainerFunctional(FunctionalTestCase):
     """
 
     def test_is_all_supplied_without_any_subdossiers(self):
-        dossier = Builder("dossier").create()
-        Builder("document").within(dossier).create()
+        dossier = create(Builder("dossier"))
+        create(Builder("document").within(dossier))
 
         self.assertTrue(dossier.is_all_supplied())
 
     def test_is_not_all_supplied_with_subdossier_and_document(self):
-        dossier = Builder("dossier").create()
-        Builder("dossier").within(dossier).create()
-        Builder("document").within(dossier).create()
+        dossier = create(Builder("dossier"))
+        create(Builder("dossier").within(dossier))
+        create(Builder("document").within(dossier))
 
         self.assertFalse(dossier.is_all_supplied())
 
     def test_is_not_all_supplied_with_subdossier_and_tasks(self):
-        dossier = Builder("dossier").create()
-        Builder("dossier").within(dossier).create()
-        Builder("task").within(dossier).create()
+        dossier = create(Builder("dossier"))
+        create(Builder("dossier").within(dossier))
+        create(Builder("task").within(dossier))
 
         self.assertFalse(dossier.is_all_supplied())
 
     def test_is_all_supplied_with_subdossier_containing_tasks_or_documents(self):
-        dossier = Builder("dossier").create()
-        subdossier = Builder("dossier").within(dossier).create()
-        Builder("task").within(subdossier).create()
-        Builder("document").within(subdossier).create()
+        dossier = create(Builder("dossier"))
+        subdossier = create(Builder("dossier").within(dossier))
+        create(Builder("task").within(subdossier))
+        create(Builder("document").within(subdossier))
 
         self.assertTrue(dossier.is_all_supplied())
 

--- a/opengever/dossier/tests/test_dossier_ids.py
+++ b/opengever/dossier/tests/test_dossier_ids.py
@@ -1,5 +1,6 @@
-from opengever.testing import FunctionalTestCase
 from opengever.testing import Builder
+from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 
 
 class DossierIdsTestCase(FunctionalTestCase):
@@ -9,8 +10,8 @@ class DossierIdsTestCase(FunctionalTestCase):
         self.grant('Contributor')
 
     def test_dossier_id_format(self):
-        dossier1 = Builder("dossier").create()
-        dossier2 = Builder("dossier").create()
+        dossier1 = create(Builder("dossier"))
+        dossier2 = create(Builder("dossier"))
 
         self.assertEquals("dossier-1", dossier1.id)
         self.assertEquals("dossier-2", dossier2.id)

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -2,6 +2,7 @@ from opengever.base.behaviors.base import IOpenGeverBase
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from opengever.testing import index_data_for
 from opengever.testing import obj2brain
 from zope.event import notify
@@ -16,14 +17,15 @@ class TestIndexers(FunctionalTestCase):
         super(TestIndexers, self).setUp()
         self.grant('Contributor')
 
-        self.dossier = Builder("dossier").titled(u"Testd\xf6ssier XY").create()
+        self.dossier = create(Builder("dossier").titled(u"Testd\xf6ssier XY"))
         self.dossier.reindexObject()
 
-        self.subdossier = Builder("dossier") \
-            .within(self.dossier).titled(u"Subd\xf6ssier XY").create()
+        self.subdossier = create(Builder("dossier")
+                                 .within(self.dossier)
+                                 .titled(u"Subd\xf6ssier XY"))
         self.subdossier.reindexObject()
 
-        self.document = Builder("document").within(self.subdossier).create()
+        self.document = create(Builder("document").within(self.subdossier))
         self.document.reindexObject()
 
     def test_containing_dossier(self):

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -1,5 +1,6 @@
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 
 
 class TestMoveItems(FunctionalTestCase):
@@ -9,14 +10,14 @@ class TestMoveItems(FunctionalTestCase):
         self.grant('Contributor')
         self.request = self.layer['request']
 
-        self.source_repo = Builder("repository").create()
-        self.source_dossier = Builder("dossier") \
-            .within(self.source_repo).create()
+        self.source_repo = create(Builder("repository"))
+        self.source_dossier = create(Builder("dossier")
+                                     .within(self.source_repo))
 
     def test_cant_move_items_to_invalid_target(self):
-        bad_target = Builder("repository").create()
-        task1 = Builder("task") \
-            .within(self.source_dossier).titled("a Task").create()
+        bad_target = create(Builder("repository"))
+        task1 = create(Builder("task")
+                       .within(self.source_dossier).titled("a Task"))
 
         self.assert_contains(self.source_dossier, ['a Task'])
         self.assert_contains(bad_target, [])
@@ -40,16 +41,16 @@ class TestMoveItems(FunctionalTestCase):
         """ Test integration of move_items method
         """
 
-        target_repo = Builder("repository").create()
+        target_repo = create(Builder("repository"))
 
-        target_dossier = Builder("dossier").within(target_repo).create()
+        target_dossier = create(Builder("dossier").within(target_repo))
 
-        doc1 = Builder("document") \
-            .within(self.source_dossier).titled(u"Dossier \xb6c1").create()
-        task1 = Builder("task") \
-            .within(self.source_dossier).titled("a Task").create()
-        subdossier1 = Builder("dossier") \
-            .within(self.source_dossier).titled("a Dossier").create()
+        doc1 = create(Builder("document")
+                      .within(self.source_dossier).titled(u"Dossier \xb6c1"))
+        task1 = create(Builder("task")
+                       .within(self.source_dossier).titled("a Task"))
+        subdossier1 = create(Builder("dossier")
+                             .within(self.source_dossier).titled("a Dossier"))
 
         self.assert_contains(self.source_dossier,
                              ['Dossier \xc2\xb6c1', 'a Task', 'a Dossier'])

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -1,6 +1,7 @@
 from opengever.mail.mail import IOGMailMarker
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 import os
 
 
@@ -16,23 +17,23 @@ class TestOGMailAddition(FunctionalTestCase):
         self.grant('Contributor', 'Editor', 'Member', 'Manager')
 
     def test_og_mail_behavior(self):
-        mail = Builder("mail").create()
+        mail = create(Builder("mail"))
         self.assertTrue(
             IOGMailMarker.providedBy(mail),
             'ftw mail obj does not provide the OGMail behavior interface.')
 
     def test_title_accessor(self):
-        mail = Builder("mail").create()
+        mail = create(Builder("mail"))
         self.assertEquals(u'[No Subject]', mail.title)
         self.assertEquals('[No Subject]', mail.Title())
 
-        mail = Builder("mail").with_message(MAIL_DATA).create()
+        mail = create(Builder("mail").with_message(MAIL_DATA))
 
         self.assertEquals(u'Die B\xfcrgschaft', mail.title)
         self.assertEquals('Die B\xc3\xbcrgschaft', mail.Title())
 
     def test_mail_behavior(self):
-        mail = Builder("mail").with_message(MAIL_DATA).create()
+        mail = create(Builder("mail").with_message(MAIL_DATA))
 
         self.browser.open('%s/edit' % mail.absolute_url())
         self.browser.getControl(

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -4,6 +4,7 @@ from opengever.mail.behaviors import ISendableDocsContainer
 from opengever.mail.interfaces import IDocumentSent
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from opengever.testing import create_client
 from opengever.testing import create_ogds_user
 from opengever.testing import set_current_client_id
@@ -45,13 +46,15 @@ class TestSendDocument(FunctionalTestCase):
         Mailing(self.portal).set_up()
 
     def test_dossier_is_sendable(self):
-        dossier = Builder("dossier").create()
+        dossier = create(Builder("dossier"))
         self.assertTrue(
             ISendableDocsContainer.providedBy(dossier))
 
     def test_document_size_validator(self):
-        dossier = Builder("dossier").create()
-        document = Builder("document").within(dossier).attach_file_containing(600000 * '_FAKE_DATA').create()
+        dossier = create(Builder("dossier"))
+        document = create(Builder("document")
+                          .within(dossier)
+                          .attach_file_containing(600000 * '_FAKE_DATA'))
 
         mail = self.send_documents(dossier, [document, ])
         self.assertEquals(mail, None)
@@ -63,8 +66,8 @@ class TestSendDocument(FunctionalTestCase):
         self.assert_mail_links_to(mail, document.absolute_url())
 
     def test_address_validator(self):
-        dossier = Builder("dossier").create()
-        documents = [Builder("document").within(dossier).create(), ]
+        dossier = create(Builder("dossier"))
+        documents = [create(Builder("document").within(dossier)), ]
 
         mail = self.send_documents(
             dossier, documents, extern_receiver=None, intern_receiver=None)
@@ -77,8 +80,8 @@ class TestSendDocument(FunctionalTestCase):
         create_ogds_user(
             TEST_USER_ID, firstname="Hugo", lastname="Boss", email="hugo@boss.ch")
 
-        dossier = Builder("dossier").create()
-        documents = [Builder("document").within(dossier).with_dummy_content().create(), ]
+        dossier = create(Builder("dossier"))
+        documents = [create(Builder("document").within(dossier).with_dummy_content()), ]
         mail = self.send_documents(dossier, documents)
 
         self.assertEquals(TEST_FORM_DATA.get('subject'), mail.get('Subject'),
@@ -94,8 +97,8 @@ class TestSendDocument(FunctionalTestCase):
         self.assert_attachment(mail, 'test.doc', 'application/msword')
 
     def test_send_documents_with_non_ascii_message(self):
-        dossier = Builder("dossier").create()
-        documents = [Builder("document").within(dossier).with_dummy_content().create(), ]
+        dossier = create(Builder("dossier"))
+        documents = [create(Builder("document").within(dossier).with_dummy_content()), ]
 
         non_ascii_message = """
 Als Beilage erhalten Sie:\r\n\r\n\xe2\x80\xa2\tPensionierten
@@ -108,32 +111,32 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
             'The message(non ascii) of the created mail is incorrect')
 
     def test_send_empty_documents(self):
-        dossier = Builder("dossier").create()
-        document = Builder("document").create()
+        dossier = create(Builder("dossier"))
+        document = create(Builder("document"))
 
         mail = self.send_documents(dossier, [document, ])
 
         self.assert_mail_links_to(mail, document.absolute_url())
 
     def test_send_documents_as_links(self):
-        dossier = Builder("dossier").create()
-        document = Builder("document").with_dummy_content().create()
+        dossier = create(Builder("dossier"))
+        document = create(Builder("document").with_dummy_content())
 
         mail = self.send_documents(dossier, [document, ], as_links=True)
 
         self.assert_mail_links_to(mail, document.absolute_url())
 
     def test_send_mails(self):
-        dossier = Builder("dossier").create()
-        mails = [Builder("mail").within(dossier).with_dummy_message().create(), ]
+        dossier = create(Builder("dossier"))
+        mails = [create(Builder("mail").within(dossier).with_dummy_message()), ]
 
         mail = self.send_documents(dossier, mails)
         self.assert_attachment(mail, 'testmail.eml', 'message/rfc822')
 
     def test_send_document_event(self):
         intids = getUtility(IIntIds)
-        dossier = Builder("dossier").create()
-        documents = [Builder("document").within(dossier).with_dummy_content().create(), ]
+        dossier = create(Builder("dossier"))
+        documents = [create(Builder("document").within(dossier).with_dummy_content()), ]
 
         # mock event handler
         mock_event = MockEvent()

--- a/opengever/sharing/tests/test_integration.py
+++ b/opengever/sharing/tests/test_integration.py
@@ -2,8 +2,9 @@ from opengever.sharing.browser.sharing import OpengeverSharingView
 from opengever.sharing.interfaces import ILocalRolesAcquisitionActivated
 from opengever.sharing.interfaces import ILocalRolesAcquisitionBlocked
 from opengever.sharing.interfaces import ILocalRolesModified
-from opengever.testing import FunctionalTestCase
 from opengever.testing import Builder
+from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.app.testing import setRoles, TEST_USER_ID
 from plone.dexterity.utils import createContentInContainer
@@ -28,7 +29,7 @@ class TestOpengeverSharingIntegration(FunctionalTestCase):
             self.portal, 'opengever.repository.repositoryroot', 'root')
         self.repo = createContentInContainer(
             self.repo_root, 'opengever.repository.repositoryfolder', 'r1')
-        self.dossier = Builder("dossier").within(self.repo).create()
+        self.dossier = create(Builder("dossier").within(self.repo))
 
         transaction.commit()
 

--- a/opengever/task/tests/test_behaviors.py
+++ b/opengever/task/tests/test_behaviors.py
@@ -1,18 +1,17 @@
-from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
-from zope.component import getUtility
+from opengever.testing import create
 
 
 class TestTaskId(FunctionalTestCase):
 
     def test_is_prefixed_with_task_and_starts_at_1(self):
-        task1 = Builder('task').create()
+        task1 = create(Builder('task'))
         self.assertEquals('task-1', task1.id)
 
     def test_is_incremented_by_1(self):
-        task1 = Builder('task').create()
-        task2 = Builder('task').create()
+        task1 = create(Builder('task'))
+        task2 = create(Builder('task'))
 
         self.assertEquals('task-1', task1.id)
         self.assertEquals('task-2', task2.id)

--- a/opengever/task/tests/test_indexer.py
+++ b/opengever/task/tests/test_indexer.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from opengever.ogds.base.interfaces import IClientConfiguration
+from opengever.testing import Builder
+from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from opengever.testing import create_ogds_user
 from opengever.testing import index_data_for
 from opengever.testing import obj2brain
 from opengever.testing import set_current_client_id
 from plone.app.testing import TEST_USER_ID, TEST_USER_NAME
 from plone.app.testing import login
-from opengever.testing import Builder
-from opengever.testing import FunctionalTestCase
 from plone.memoize.interfaces import ICacheChooser
 from plone.registry.interfaces import IRegistry
 from z3c.relationfield.relation import RelationValue
@@ -28,10 +29,10 @@ class TestTaskIndexers(FunctionalTestCase):
         self.grant('Contributor', 'Editor', 'Manager')
         login(self.portal, TEST_USER_NAME)
 
-        self.task = Builder("task").titled("Test task 1").create()
-        self.subtask = Builder("task").within(self.task).titled("Test task 1").create()
-        self.doc1 = Builder("document").titled(u"Doc One").create()
-        self.doc2 = Builder("document").titled(u"Doc Two").create()
+        self.task = create(Builder("task").titled("Test task 1"))
+        self.subtask = create(Builder("task").within(self.task).titled("Test task 1"))
+        self.doc1 = create(Builder("document").titled(u"Doc One"))
+        self.doc2 = create(Builder("document").titled(u"Doc Two"))
 
     def test_date_of_completion(self):
         self.assertEquals(

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -1,5 +1,6 @@
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from opengever.testing import create_client
 from opengever.testing import set_current_client_id
 from zope.event import notify
@@ -9,13 +10,13 @@ from zope.lifecycleevent import ObjectModifiedEvent
 class TestLocalRolesSetter(FunctionalTestCase):
 
     def test_responsible_has_local_editor_role_on_task_when_is_added(self):
-        task = Builder('task').having(responsible='hugo.boss').create()
+        task = create(Builder('task').having(responsible='hugo.boss'))
 
         self.assertEquals(
             ('Editor', ), task.get_local_roles_for_userid('hugo.boss'))
 
     def test_new_responsible_has_local_editor_role_on_task_when_is_changed(self):
-        task = Builder('task').having(responsible='hugo.boss').create()
+        task = create(Builder('task').having(responsible='hugo.boss'))
 
         task.responsible = 'james.bond'
         notify(ObjectModifiedEvent(task))
@@ -24,8 +25,7 @@ class TestLocalRolesSetter(FunctionalTestCase):
             ('Editor', ), task.get_local_roles_for_userid('james.bond'))
 
     def test_dont_remove_editor_role_when_responsible_is_changed(self):
-        task = Builder('task').having(responsible='hugo.boss').create()
-
+        task = create(Builder('task').having(responsible='hugo.boss'))
         task.responsible = 'james.bond'
         notify(ObjectModifiedEvent(task))
 
@@ -33,17 +33,19 @@ class TestLocalRolesSetter(FunctionalTestCase):
             ('Editor', ), task.get_local_roles_for_userid('hugo.boss'))
 
     def test_responsible_has_reader_role_on_related_items_when_task_is_added(self):
-        document = Builder('document').create()
-        Builder('task').having(
-            responsible='hugo.boss').relate_to(document).create()
+        document = create(Builder('document'))
+        create(Builder('task')
+               .having(responsible='hugo.boss')
+               .relate_to(document))
 
         self.assertEquals(
             ('Reader', ), document.get_local_roles_for_userid('hugo.boss'))
 
     def test_responsible_has_reader_role_on_related_items_when_responsible_is_changed(self):
-        document = Builder('document').create()
-        task = Builder('task').having(
-            responsible='hugo.boss').relate_to(document).create()
+        document = create(Builder('document'))
+        task = create(Builder('task')
+                      .having(responsible='hugo.boss')
+                      .relate_to(document))
 
         task.responsible = 'james.bond'
         notify(ObjectModifiedEvent(task))
@@ -53,26 +55,29 @@ class TestLocalRolesSetter(FunctionalTestCase):
             document.get_local_roles_for_userid('james.bond'))
 
     def test_responsible_of_a_bidirectional_by_ref_task_has_reader_and_editor_role_on_related_items(self):
-        document = Builder('document').create()
-        Builder('task').bidirectional_by_reference().\
-            having(responsible='hugo.boss').relate_to(document).create()
+        document = create(Builder('document'))
+        create(Builder('task')
+               .bidirectional_by_reference()
+               .having(responsible='hugo.boss')
+               .relate_to(document))
 
         self.assertEquals(
             ('Editor', 'Reader', ), document.get_local_roles_for_userid('hugo.boss'))
 
     def test_responsible_has_contributor_role_on_distinct_parent_when_task_is_added(self):
-        dossier = Builder('dossier').create()
-        Builder('task').within(
-            dossier).having(responsible='hugo.boss').create()
+        dossier = create(Builder('dossier'))
+        create(Builder('task')
+               .within(dossier)
+               .having(responsible='hugo.boss'))
 
         self.assertEquals(
             ('Contributor', ),
             dossier.get_local_roles_for_userid('hugo.boss'))
 
     def test_responsible_has_contributor_role_on_distinct_parent_when_task_is_updated(self):
-        dossier = Builder('dossier').create()
-        task = Builder('task').within(
-            dossier).having(responsible='hugo.boss').create()
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task')
+                      .within(dossier).having(responsible='hugo.boss'))
 
         task.responsible = 'james.bond'
         notify(ObjectModifiedEvent(task))
@@ -86,12 +91,13 @@ class TestLocalRolesSetter(FunctionalTestCase):
                       inbox_group='client1_inbox_users')
         set_current_client_id(self.portal)
 
-        dossier = Builder('dossier').create()
-        document = Builder('document').create()
-        task = Builder('task').within(dossier).relate_to(
-            document).having(
-                responsible='hugo.boss',
-                responsible_client='client1').create()
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document'))
+        task = create(Builder('task')
+                      .within(dossier)
+                      .relate_to(document)
+                      .having(responsible='hugo.boss',
+                              responsible_client='client1'))
 
         self.assertEquals(
             ('Editor', ),
@@ -106,7 +112,7 @@ class TestLocalRolesSetter(FunctionalTestCase):
     def test_use_inbox_group_when_inbox_is_responsible(self):
         create_client(clientid="client1", inbox_group='client1_inbox_users')
         set_current_client_id(self.portal)
-        task = Builder('task').having(responsible='inbox:client1').create()
+        task = create(Builder('task').having(responsible='inbox:client1'))
 
         self.assertEquals(
             ('Editor', ),

--- a/opengever/task/tests/test_menu.py
+++ b/opengever/task/tests/test_menu.py
@@ -1,5 +1,6 @@
 from ftw.contentmenu.menu import FactoriesMenu
 from opengever.testing import Builder
+from opengever.testing import create
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from zope.component import getMultiAdapter
@@ -12,7 +13,7 @@ class TestFactoryMenu(FunctionalTestCase):
         self.menu = FactoriesMenu(self.portal)
 
     def test_task_menu_item_is_titled_task_in_a_dossier(self):
-        dossier = Builder('dossier').create()
+        dossier = create(Builder('dossier'))
 
         items = self.menu.getMenuItems(dossier, self.portal.REQUEST)
         task_action = [action for action in items
@@ -21,10 +22,11 @@ class TestFactoryMenu(FunctionalTestCase):
         self.assertIn(u'Task', task_action.get('title'))
 
     def test_task_menu_item_is_titled_subtask_inside_a_task(self):
-        task = Builder('task').having(
-            title='Task One',
-            issuer=TEST_USER_ID,
-            responsible=TEST_USER_ID).in_progress().create()
+        task = create(Builder('task')
+                      .in_progress()
+                      .having(title='Task One',
+                              issuer=TEST_USER_ID,
+                              responsible=TEST_USER_ID))
 
         items = self.menu.getMenuItems(task, self.portal.REQUEST)
         task_action = [action for action in items
@@ -35,10 +37,11 @@ class TestFactoryMenu(FunctionalTestCase):
                           task_action.get('extra').get('class'))
 
     def test_mail_menu_item_is_not_displayed_inside_a_task(self):
-        task = Builder('task').having(
-            title='Task One',
-            issuer=TEST_USER_ID,
-            responsible=TEST_USER_ID).in_progress().create()
+        task = create(Builder('task')
+                      .in_progress()
+                      .having(title='Task One',
+                              issuer=TEST_USER_ID,
+                              responsible=TEST_USER_ID))
 
         self.assert_removed_menu_item('ftw.mail.mail', context=task)
 

--- a/opengever/task/tests/test_successor.py
+++ b/opengever/task/tests/test_successor.py
@@ -2,6 +2,7 @@ from Products.CMFCore.utils import getToolByName
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from opengever.testing import create_client
 from opengever.testing import set_current_client_id
 from zope.component import getUtility
@@ -18,8 +19,8 @@ class TestSuccessorTaskController(FunctionalTestCase):
     def test_oguid_is_client_id_and_task_id_separated_by_a_colon(self):
         intids = getUtility(IIntIds)
 
-        task1 = Builder('task').create()
-        task2 = Builder('task').create()
+        task1 = create(Builder('task'))
+        task2 = create(Builder('task'))
 
         self.assertEquals(
             u'client1:%s' % (intids.getId(task1)),
@@ -32,7 +33,7 @@ class TestSuccessorTaskController(FunctionalTestCase):
         intids = getUtility(IIntIds)
         url_tool = getToolByName(self.portal, 'portal_url')
 
-        task = Builder('task').create()
+        task = create(Builder('task'))
 
         controller = ISuccessorTaskController(task)
         self.assertEquals(
@@ -42,7 +43,7 @@ class TestSuccessorTaskController(FunctionalTestCase):
                 'client1'))
 
     def test_oguid_by_path_returns_none_for_invalid_clientid(self):
-        task = Builder('task').create()
+        task = create(Builder('task'))
 
         controller = ISuccessorTaskController(task)
         self.assertEquals(
@@ -50,7 +51,7 @@ class TestSuccessorTaskController(FunctionalTestCase):
             controller.get_oguid_by_path('/'.join(task.getPhysicalPath()), 'client2'))
 
     def test_oguid_by_path_returns_none_for_invalid_path(self):
-        task = Builder('task').create()
+        task = create(Builder('task'))
 
         controller = ISuccessorTaskController(task)
         self.assertEquals(
@@ -58,15 +59,15 @@ class TestSuccessorTaskController(FunctionalTestCase):
             controller.get_oguid_by_path('/plone/not-existing/', 'client1'))
 
     def test_set_predecessor_with_valid_oguid_returns_true(self):
-        task1 = Builder('task').create()
-        task2 = Builder('task').create()
+        task1 = create(Builder('task'))
+        task2 = create(Builder('task'))
 
         task2_oguid = ISuccessorTaskController(task2).get_oguid()
         self.assertTrue(
             ISuccessorTaskController(task1).set_predecessor(task2_oguid))
 
     def test_set_predecessor_with_invalid_oguid_returns_false(self):
-        task1 = Builder('task').create()
+        task1 = create(Builder('task'))
 
         self.assertFalse(
             ISuccessorTaskController(task1).set_predecessor(u'incorrect:2'))
@@ -74,9 +75,9 @@ class TestSuccessorTaskController(FunctionalTestCase):
             ISuccessorTaskController(task1).set_predecessor(u'client1:3'))
 
     def test_successors_predecessor_relation(self):
-        task1 = Builder('task').create()
-        task2 = Builder('task').create()
-        task3 = Builder('task').create()
+        task1 = create(Builder('task'))
+        task2 = create(Builder('task'))
+        task3 = create(Builder('task'))
 
         task1_oguid = ISuccessorTaskController(task1).get_oguid()
 

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -4,6 +4,7 @@ from opengever.task.response import Response
 from opengever.task.task import ITask
 from opengever.testing import Builder
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import createContent, addContentToContainer
 from z3c.relationfield.relation import RelationValue
@@ -60,13 +61,13 @@ class TestTaskIntegration(FunctionalTestCase):
     def test_relateddocuments(self):
         self.grant('Manager')
         # create document and append it to the relatedItems of the task
-        doc3 = Builder("document").titled("a-testthree").create()
+        doc3 = create(Builder("document").titled("a-testthree"))
         intids = getUtility(IIntIds)
         o_iid = intids.getId(doc3)
         t1 = create_task(
             self.portal, title='Task 1', relatedItems=[RelationValue(o_iid)])
-        doc1 = Builder("document").within(t1).titled("btestone").create()
-        doc2 = Builder("document").within(t1).titled("ctesttwo").create()
+        doc1 = create(Builder("document").within(t1).titled("btestone"))
+        doc2 = create(Builder("document").within(t1).titled("ctesttwo"))
         view = t1.restrictedTraverse('tabbedview_view-relateddocuments')
         results = [aa.Title for aa in view.table_source.build_query()]
         self.assertTrue(doc3.Title() in results)

--- a/opengever/testing/__init__.py
+++ b/opengever/testing/__init__.py
@@ -11,6 +11,7 @@ else:
     from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
     from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
     from opengever.testing.builders import Builder
+    from opengever.testing.builders import create
     from opengever.testing.helpers import create_plone_user
     from opengever.testing.helpers import obj2brain
     from opengever.testing.helpers import index_data_for

--- a/opengever/testing/builders.py
+++ b/opengever/testing/builders.py
@@ -9,6 +9,9 @@ from zope.lifecycleevent import ObjectCreatedEvent, ObjectAddedEvent
 import transaction
 
 
+def create(builder):
+    return builder.create()
+
 def Builder(name):
     if name == "dossier":
         return DossierBuilder(BuilderSession.instance())


### PR DESCRIPTION
This was a suggestion to my blog post on the devblog:
http://www.reddit.com/r/Python/comments/1eyt20/construct_your_test_data_using_the_builder_pattern/ca6cfwl

It's a great way to deal with the anoying line continuations.
Personally this also puts the wording into the right order:

`create document` which reads better than `document create`.

This is a follow up to #28 
