### PR TITLE
Add bin/build-translations script to opengever.core buildout.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,13 @@ opengever.core requires a sql database to store some configuriation. Before you 
     > CREATE DATABASE opengever;
     > GRANT ALL ON opengever.* TO opengever@localhost IDENTIFIED BY 'opengever';
 
+Updating translations
+---------------------
+
+Updating translations can be done with the `bin/i18n-build` script.
+It will scan the entire `opengever.core` package for translation files that
+need updating, rebuild the respective `.pot` files and sync the `.po` files.
+
 Tests
 -----
 

--- a/development.cfg
+++ b/development.cfg
@@ -4,7 +4,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 
-
 [instance]
 zserver-threads = 4
 user = zopemaster:admin
@@ -17,3 +16,12 @@ zope-conf-additional =
     <product-config opengever.ogds.base>
         log_file ${buildout:directory}/var/log/ogds-update.log
     </product-config>
+
+
+[i18n-build]
+# Overrides the i18n-build part defined in plone-development.cfg in order to
+# provide a opengever.core specific script
+recipe = collective.recipe.cmd
+on_install=true
+on_update=true
+cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+- Added bin/build-translations script to opengever.core buildout.
+  [lgraf]
+
 - Lay out date range fields in advanced search form side by side.
   Note: This requires the "Init og.advancedsearch profile version" upgrade
   step from opengever.base to be run first!

--- a/i18n-build.in
+++ b/i18n-build.in
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# This script builds translation files for opengever.core.
+#
+# It does so by finding all the 'locales' directories, rebuilds
+# pkg.name.pot, merging pkg.name-manual.pot files if necessary, and 
+# then syncs translations to the .respective po files for all languages
+# defined in $LANGUAGES.
+
+LANGUAGES="de fr"
+
+pkg_dir=`bin/package-directory`
+core_dir=`dirname $pkg_dir`
+locales_dirs=`find $pkg_dir -name 'locales'`
+
+for locale_dir in $locales_dirs
+do
+    # Strip /locales
+    pkg_path=${locale_dir%%/locales*}
+    # Remove $core_dir
+    pkg_relpath=${pkg_path##*${core_dir}}   # /opengever/dossier
+    # Strip leading slash
+    pkg_relpath=${pkg_relpath##/}           # opengever/dossier
+    pkgname=${pkg_relpath//\//.}            # opengever.dossier
+    potfile="$locale_dir/$pkgname.pot"
+
+    # Check for my.package-manual.pot
+    merge_cmd=""
+    manual_pot="${locale_dir}/${pkgname}-manual.pot"
+    if [ -e "$manual_pot" ]
+    then
+        merge_cmd="--merge $manual_pot"
+    fi
+
+    build_cmd="bin/i18ndude rebuild-pot --pot $potfile --create $pkgname $merge_cmd ./${pkg_relpath}"
+    echo $build_cmd
+    eval $build_cmd
+
+    # Sync all lanuguages defined in $LANGUAGES
+    for lang in $LANGUAGES
+    do
+        # Sync all .pot files so foreign domains like 'plone' also get covered
+        pot_files=`find $locale_dir -name '*.pot'`
+        for potfile in $pot_files
+        do
+            domain=`basename ${potfile}`
+            # Strip trailing .pot
+            domain=${domain%%.pot*}
+            if [[ "$domain" != *-manual ]]
+            then
+              sync_cmd="bin/i18ndude sync --pot $potfile $locale_dir/$lang/LC_MESSAGES/$domain.po"
+              echo $sync_cmd
+              eval $sync_cmd
+            fi
+        done
+    done
+done


### PR DESCRIPTION
This script builds translation files for opengever.core.

It does so by finding all the 'locales' directories, rebuilds
`pkg.name.pot`, merging `pkg.name-manual.pot` files if necessary, and
then syncs translations to the respective `.po` files for all languages
defined in `$LANGUAGES`.
