### PR TITLE
AdvancedSearch: Adds condition for multiclient specific infos in field description

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+- AdvancedSearch: Added special description for the portal types field
+  in a multiclientsetup.
+  [phgross]
+
 - Added filter_pattern option to LDAPSource blueprint.
   If set, only imports users whose email address match `filter_pattern`.
   [lgraf]

--- a/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-05-27 12:21+0000\n"
+"POT-Creation-Date: 2013-06-10 15:13+0000\n"
 "PO-Revision-Date: 2012-12-06 12:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9,182 +9,188 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:280
+#: ./opengever/advancedsearch/advanced_search.py:282
 msgid "advanced_search"
 msgstr "Erweiterte Suche"
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:335
+#: ./opengever/advancedsearch/advanced_search.py:355
 msgid "button_search"
 msgstr "Suchen"
 
-#: ./opengever/advancedsearch/advanced_search.py:66
+#: ./opengever/advancedsearch/advanced_search.py:67
 msgid "document"
 msgstr "Dokument"
 
-#: ./opengever/advancedsearch/advanced_search.py:54
+#: ./opengever/advancedsearch/advanced_search.py:55
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/advancedsearch/advanced_search.py:227
+#: ./opengever/advancedsearch/advanced_search.py:229
 msgid "help_checked_out"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:220
+#: ./opengever/advancedsearch/advanced_search.py:222
 msgid "help_document_author"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:163
+#: ./opengever/advancedsearch/advanced_search.py:165
 msgid "help_filing_number"
 msgstr "Geben Sie die vollständige Ablagenummer an."
 
-#: ./opengever/advancedsearch/advanced_search.py:242
+#: ./opengever/advancedsearch/advanced_search.py:244
 msgid "help_issuer"
 msgstr "Auftraggeber auswählen"
 
-#: ./opengever/advancedsearch/advanced_search.py:121
+#. Default: "Select the contenttype to be searched for."
+#: ./opengever/advancedsearch/advanced_search.py:122
 msgid "help_portal_type"
+msgstr "Wählen Sie den Inhaltstyp aus, nach dem gesucht werden soll."
+
+#. Default: "Select the contenttype to be searched for.It searches only items from the current client."
+#: ./opengever/advancedsearch/advanced_search.py:346
+msgid "help_portal_type_multiclient_setup"
 msgstr ""
 "Wählen Sie den Inhaltstyp aus, nach dem gesucht werden soll.\n"
 "Durchsucht werden nur Inhalte, die sich im aktuellen Mandanten befinden."
 
-#: ./opengever/advancedsearch/advanced_search.py:151
+#: ./opengever/advancedsearch/advanced_search.py:153
 msgid "help_reference_number"
 msgstr "Aktenzeichen angeben (z.B: OG 2.4 / 1 / 3)"
 
-#: ./opengever/advancedsearch/advanced_search.py:170
+#: ./opengever/advancedsearch/advanced_search.py:172
 msgid "help_responsible"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:177
+#: ./opengever/advancedsearch/advanced_search.py:179
 msgid "help_review_state"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:115
+#: ./opengever/advancedsearch/advanced_search.py:116
 msgid "help_searchable_text"
 msgstr "Suchbegriffe eingeben."
 
-#: ./opengever/advancedsearch/advanced_search.py:157
+#: ./opengever/advancedsearch/advanced_search.py:159
 msgid "help_sequence_number"
 msgstr "Genaue Laufnummer eingeben."
 
-#: ./opengever/advancedsearch/advanced_search.py:261
+#: ./opengever/advancedsearch/advanced_search.py:263
 msgid "help_tasktyp"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:234
+#: ./opengever/advancedsearch/advanced_search.py:236
 msgid "help_trashed"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:226
+#: ./opengever/advancedsearch/advanced_search.py:228
 msgid "label_checked_out"
 msgstr "Ausgecheckt von"
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:248
+#: ./opengever/advancedsearch/advanced_search.py:250
 msgid "label_deadline"
 msgstr "Frist"
 
-#: ./opengever/advancedsearch/advanced_search.py:254
+#: ./opengever/advancedsearch/advanced_search.py:256
 msgid "label_deadline_2"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:197
+#: ./opengever/advancedsearch/advanced_search.py:199
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:219
+#: ./opengever/advancedsearch/advanced_search.py:221
 msgid "label_document_author"
 msgstr "Autor des Dokuments"
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:208
+#: ./opengever/advancedsearch/advanced_search.py:210
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "End date"
-#: ./opengever/advancedsearch/advanced_search.py:139
+#: ./opengever/advancedsearch/advanced_search.py:141
 msgid "label_end"
 msgstr "Enddatum"
 
 #. Default: "Filing number"
-#: ./opengever/advancedsearch/advanced_search.py:162
+#: ./opengever/advancedsearch/advanced_search.py:164
 msgid "label_filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "From"
-#: ./opengever/advancedsearch/advanced_search.py:129
+#: ./opengever/advancedsearch/advanced_search.py:131
 msgid "label_from"
 msgstr "Von"
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:241
+#: ./opengever/advancedsearch/advanced_search.py:243
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "Type"
-#: ./opengever/advancedsearch/advanced_search.py:120
+#: ./opengever/advancedsearch/advanced_search.py:121
 msgid "label_portal_type"
 msgstr "Inhaltstyp"
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:186
+#: ./opengever/advancedsearch/advanced_search.py:188
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference number"
-#: ./opengever/advancedsearch/advanced_search.py:150
+#: ./opengever/advancedsearch/advanced_search.py:152
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Responsible"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py:171
 msgid "label_reponsible"
 msgstr "Federführung"
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:176
+#: ./opengever/advancedsearch/advanced_search.py:178
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Text"
-#: ./opengever/advancedsearch/advanced_search.py:114
+#: ./opengever/advancedsearch/advanced_search.py:115
 msgid "label_searchable_text"
 msgstr "Suchtext"
 
 #. Default: "Sequence number"
-#: ./opengever/advancedsearch/advanced_search.py:156
+#: ./opengever/advancedsearch/advanced_search.py:158
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Start date"
-#: ./opengever/advancedsearch/advanced_search.py:128
+#: ./opengever/advancedsearch/advanced_search.py:130
 msgid "label_start"
 msgstr "Startdatum"
 
-#: ./opengever/advancedsearch/advanced_search.py:260
+#: ./opengever/advancedsearch/advanced_search.py:262
 msgid "label_tasktype"
 msgstr "Auftragstyp"
 
 #. Default: "To"
-#: ./opengever/advancedsearch/advanced_search.py:134
+#: ./opengever/advancedsearch/advanced_search.py:136
 msgid "label_to"
 msgstr "Bis"
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:233
+#: ./opengever/advancedsearch/advanced_search.py:235
 msgid "label_trashed"
 msgstr "Papierkorb auch durchsuchen"
 
-#: ./opengever/advancedsearch/advanced_search.py:60
+#: ./opengever/advancedsearch/advanced_search.py:61
 msgid "task"
 msgstr "lokal gespeicherte Aufgaben"
-
-

--- a/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-05-27 12:21+0000\n"
+"POT-Creation-Date: 2013-06-10 15:13+0000\n"
 "PO-Revision-Date: 2013-06-05 09:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9,178 +9,186 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:280
+#: ./opengever/advancedsearch/advanced_search.py:282
 msgid "advanced_search"
 msgstr "Recherche avancée"
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:335
+#: ./opengever/advancedsearch/advanced_search.py:355
 msgid "button_search"
 msgstr "Rechercher"
 
-#: ./opengever/advancedsearch/advanced_search.py:66
+#: ./opengever/advancedsearch/advanced_search.py:67
 msgid "document"
 msgstr "Document"
 
-#: ./opengever/advancedsearch/advanced_search.py:54
+#: ./opengever/advancedsearch/advanced_search.py:55
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/advancedsearch/advanced_search.py:227
+#: ./opengever/advancedsearch/advanced_search.py:229
 msgid "help_checked_out"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:220
+#: ./opengever/advancedsearch/advanced_search.py:222
 msgid "help_document_author"
 msgstr "Auteur du document"
 
-#: ./opengever/advancedsearch/advanced_search.py:163
+#: ./opengever/advancedsearch/advanced_search.py:165
 msgid "help_filing_number"
 msgstr "Saisir le numéro d'inventaire complet"
 
-#: ./opengever/advancedsearch/advanced_search.py:242
+#: ./opengever/advancedsearch/advanced_search.py:244
 msgid "help_issuer"
 msgstr "Choix du client"
 
-#: ./opengever/advancedsearch/advanced_search.py:121
+#. Default: "Select the contenttype to be searched for."
+#: ./opengever/advancedsearch/advanced_search.py:122
 msgid "help_portal_type"
+msgstr "Choix du type de contenu à rechercher."
+
+#. Default: "Select the contenttype to be searched for.It searches only items from the current client."
+#: ./opengever/advancedsearch/advanced_search.py:346
+msgid "help_portal_type_multiclient_setup"
 msgstr "Choix du type de contenu à rechercher. Ne sont parcourus que les contenus du mandant actuel."
 
-#: ./opengever/advancedsearch/advanced_search.py:151
+#: ./opengever/advancedsearch/advanced_search.py:153
 msgid "help_reference_number"
 msgstr "Saisir le numéro de référence"
 
-#: ./opengever/advancedsearch/advanced_search.py:170
+#: ./opengever/advancedsearch/advanced_search.py:172
 msgid "help_responsible"
 msgstr "Responsable"
 
-#: ./opengever/advancedsearch/advanced_search.py:177
+#: ./opengever/advancedsearch/advanced_search.py:179
 msgid "help_review_state"
 msgstr "Etat de révision"
 
-#: ./opengever/advancedsearch/advanced_search.py:115
+#: ./opengever/advancedsearch/advanced_search.py:116
 msgid "help_searchable_text"
 msgstr "Saisir les critères de recherche"
 
-#: ./opengever/advancedsearch/advanced_search.py:157
+#: ./opengever/advancedsearch/advanced_search.py:159
 msgid "help_sequence_number"
 msgstr "Saisir le numéro courant"
 
-#: ./opengever/advancedsearch/advanced_search.py:261
+#: ./opengever/advancedsearch/advanced_search.py:263
 msgid "help_tasktyp"
 msgstr "Type de tâche"
 
-#: ./opengever/advancedsearch/advanced_search.py:234
+#: ./opengever/advancedsearch/advanced_search.py:236
 msgid "help_trashed"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:226
+#: ./opengever/advancedsearch/advanced_search.py:228
 msgid "label_checked_out"
 msgstr "Checkout fait par"
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:248
+#: ./opengever/advancedsearch/advanced_search.py:250
 msgid "label_deadline"
 msgstr "Délai"
 
-#: ./opengever/advancedsearch/advanced_search.py:254
+#: ./opengever/advancedsearch/advanced_search.py:256
 msgid "label_deadline_2"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:197
+#: ./opengever/advancedsearch/advanced_search.py:199
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:219
+#: ./opengever/advancedsearch/advanced_search.py:221
 msgid "label_document_author"
 msgstr "Auteur du document"
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:208
+#: ./opengever/advancedsearch/advanced_search.py:210
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "End date"
-#: ./opengever/advancedsearch/advanced_search.py:139
+#: ./opengever/advancedsearch/advanced_search.py:141
 msgid "label_end"
 msgstr "Date de fin"
 
 #. Default: "Filing number"
-#: ./opengever/advancedsearch/advanced_search.py:162
+#: ./opengever/advancedsearch/advanced_search.py:164
 msgid "label_filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "From"
-#: ./opengever/advancedsearch/advanced_search.py:129
+#: ./opengever/advancedsearch/advanced_search.py:131
 msgid "label_from"
 msgstr "de"
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:241
+#: ./opengever/advancedsearch/advanced_search.py:243
 msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "Type"
-#: ./opengever/advancedsearch/advanced_search.py:120
+#: ./opengever/advancedsearch/advanced_search.py:121
 msgid "label_portal_type"
 msgstr "Type de contenu"
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:186
+#: ./opengever/advancedsearch/advanced_search.py:188
 msgid "label_receipt_date"
 msgstr "Date de réception"
 
 #. Default: "Reference number"
-#: ./opengever/advancedsearch/advanced_search.py:150
+#: ./opengever/advancedsearch/advanced_search.py:152
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Responsible"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py:171
 msgid "label_reponsible"
 msgstr "Responsable"
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:176
+#: ./opengever/advancedsearch/advanced_search.py:178
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Text"
-#: ./opengever/advancedsearch/advanced_search.py:114
+#: ./opengever/advancedsearch/advanced_search.py:115
 msgid "label_searchable_text"
 msgstr "Texte de recherche"
 
 #. Default: "Sequence number"
-#: ./opengever/advancedsearch/advanced_search.py:156
+#: ./opengever/advancedsearch/advanced_search.py:158
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Start date"
-#: ./opengever/advancedsearch/advanced_search.py:128
+#: ./opengever/advancedsearch/advanced_search.py:130
 msgid "label_start"
 msgstr "Date de début"
 
-#: ./opengever/advancedsearch/advanced_search.py:260
+#: ./opengever/advancedsearch/advanced_search.py:262
 msgid "label_tasktype"
 msgstr "Type de mandat"
 
 #. Default: "To"
-#: ./opengever/advancedsearch/advanced_search.py:134
+#: ./opengever/advancedsearch/advanced_search.py:136
 msgid "label_to"
 msgstr "à"
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:233
+#: ./opengever/advancedsearch/advanced_search.py:235
 msgid "label_trashed"
 msgstr "Parcourir également la corbeille"
 
-#: ./opengever/advancedsearch/advanced_search.py:60
+#: ./opengever/advancedsearch/advanced_search.py:61
 msgid "task"
 msgstr "Tâches sauvegardées localement"

--- a/opengever/advancedsearch/locales/opengever.advancedsearch.pot
+++ b/opengever/advancedsearch/locales/opengever.advancedsearch.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-05-27 12:21+0000\n"
+"POT-Creation-Date: 2013-06-10 15:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,175 +18,181 @@ msgstr ""
 "Domain: opengever.advancedsearch\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:280
+#: ./opengever/advancedsearch/advanced_search.py:282
 msgid "advanced_search"
 msgstr ""
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:335
+#: ./opengever/advancedsearch/advanced_search.py:355
 msgid "button_search"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:66
+#: ./opengever/advancedsearch/advanced_search.py:67
 msgid "document"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:54
+#: ./opengever/advancedsearch/advanced_search.py:55
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:227
+#: ./opengever/advancedsearch/advanced_search.py:229
 msgid "help_checked_out"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:220
+#: ./opengever/advancedsearch/advanced_search.py:222
 msgid "help_document_author"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:163
+#: ./opengever/advancedsearch/advanced_search.py:165
 msgid "help_filing_number"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:242
+#: ./opengever/advancedsearch/advanced_search.py:244
 msgid "help_issuer"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:121
+#. Default: "Select the contenttype to be searched for."
+#: ./opengever/advancedsearch/advanced_search.py:122
 msgid "help_portal_type"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:151
+#. Default: "Select the contenttype to be searched for.It searches only items from the current client."
+#: ./opengever/advancedsearch/advanced_search.py:346
+msgid "help_portal_type_multiclient_setup"
+msgstr ""
+
+#: ./opengever/advancedsearch/advanced_search.py:153
 msgid "help_reference_number"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:170
+#: ./opengever/advancedsearch/advanced_search.py:172
 msgid "help_responsible"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:177
+#: ./opengever/advancedsearch/advanced_search.py:179
 msgid "help_review_state"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:115
+#: ./opengever/advancedsearch/advanced_search.py:116
 msgid "help_searchable_text"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:157
+#: ./opengever/advancedsearch/advanced_search.py:159
 msgid "help_sequence_number"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:261
+#: ./opengever/advancedsearch/advanced_search.py:263
 msgid "help_tasktyp"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:234
+#: ./opengever/advancedsearch/advanced_search.py:236
 msgid "help_trashed"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:226
+#: ./opengever/advancedsearch/advanced_search.py:228
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:248
+#: ./opengever/advancedsearch/advanced_search.py:250
 msgid "label_deadline"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:254
+#: ./opengever/advancedsearch/advanced_search.py:256
 msgid "label_deadline_2"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:197
+#: ./opengever/advancedsearch/advanced_search.py:199
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:219
+#: ./opengever/advancedsearch/advanced_search.py:221
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:208
+#: ./opengever/advancedsearch/advanced_search.py:210
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "End date"
-#: ./opengever/advancedsearch/advanced_search.py:139
+#: ./opengever/advancedsearch/advanced_search.py:141
 msgid "label_end"
 msgstr ""
 
 #. Default: "Filing number"
-#: ./opengever/advancedsearch/advanced_search.py:162
+#: ./opengever/advancedsearch/advanced_search.py:164
 msgid "label_filing_number"
 msgstr ""
 
 #. Default: "From"
-#: ./opengever/advancedsearch/advanced_search.py:129
+#: ./opengever/advancedsearch/advanced_search.py:131
 msgid "label_from"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:241
+#: ./opengever/advancedsearch/advanced_search.py:243
 msgid "label_issuer"
 msgstr ""
 
 #. Default: "Type"
-#: ./opengever/advancedsearch/advanced_search.py:120
+#: ./opengever/advancedsearch/advanced_search.py:121
 msgid "label_portal_type"
 msgstr ""
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:186
+#: ./opengever/advancedsearch/advanced_search.py:188
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference number"
-#: ./opengever/advancedsearch/advanced_search.py:150
+#: ./opengever/advancedsearch/advanced_search.py:152
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py:171
 msgid "label_reponsible"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:176
+#: ./opengever/advancedsearch/advanced_search.py:178
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Text"
-#: ./opengever/advancedsearch/advanced_search.py:114
+#: ./opengever/advancedsearch/advanced_search.py:115
 msgid "label_searchable_text"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/advancedsearch/advanced_search.py:156
+#: ./opengever/advancedsearch/advanced_search.py:158
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Start date"
-#: ./opengever/advancedsearch/advanced_search.py:128
+#: ./opengever/advancedsearch/advanced_search.py:130
 msgid "label_start"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:260
+#: ./opengever/advancedsearch/advanced_search.py:262
 msgid "label_tasktype"
 msgstr ""
 
 #. Default: "To"
-#: ./opengever/advancedsearch/advanced_search.py:134
+#: ./opengever/advancedsearch/advanced_search.py:136
 msgid "label_to"
 msgstr ""
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:233
+#: ./opengever/advancedsearch/advanced_search.py:235
 msgid "label_trashed"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:60
+#: ./opengever/advancedsearch/advanced_search.py:61
 msgid "task"
 msgstr ""
 


### PR DESCRIPTION
Right now the description of the portal types field contains the information that only make sense in a multiclient setup, so i add a conditional description wich checks if it's a multiclientsetup or not.

@jone or @lukasgraf could you take a look?
