### PR TITLE
Builder API: Reworked values setter

### DIFF
--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -51,8 +51,8 @@ class TestSearchWithContent(FunctionalTestCase):
         set_current_client_id(self.layer['portal'])
         create_ogds_user(TEST_USER_ID)
 
-        self.dossier1 = create(Builder("dossier").titled("Dossier1"))
-        self.dossier2 = create(Builder("dossier").titled("Dossier2"))
+        self.dossier1 = create(Builder("dossier").titled(u"Dossier1"))
+        self.dossier2 = create(Builder("dossier").titled(u"Dossier2"))
 
     def test_search_dossiers(self):
         self.browser.open('%s/advanced_search' % self.dossier1.absolute_url())

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -32,7 +32,7 @@ class TestOpengeverContentListing(FunctionalTestCase):
             IContentListingObject(obj2brain(document)).ContentTypeClass())
 
     def test_containing_dossier_of_a_dossier_returns_dossiers_title(self):
-        dossier = create(Builder('dossier').titled('Testdossier'))
+        dossier = create(Builder('dossier').titled(u'Testdossier'))
 
         self.assertEquals(
             'Testdossier',
@@ -46,7 +46,7 @@ class TestOpengeverContentListing(FunctionalTestCase):
             IContentListingObject(obj2brain(repository)).containing_dossier())
 
     def test_containing_dossier_returns_the_title_of_the_containing_dossier(self):
-        dossier = create(Builder('dossier').titled('Testdossier'))
+        dossier = create(Builder('dossier').titled(u'Testdossier'))
         document = create(Builder('document').within(dossier))
 
         self.assertEquals(
@@ -55,7 +55,7 @@ class TestOpengeverContentListing(FunctionalTestCase):
 
     def test_containing_dossier_title_is_cropped_to_near_200_chars(self):
         dossier = create(Builder('dossier')
-                         .titled(25 * 'lorem ipsum '))
+                         .titled(25 * u'lorem ipsum '))
         document = create(Builder('document').within(dossier))
 
         self.assertCropping(

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -50,7 +50,7 @@ class TestMoveItems(FunctionalTestCase):
         task1 = create(Builder("task")
                        .within(self.source_dossier).titled("a Task"))
         subdossier1 = create(Builder("dossier")
-                             .within(self.source_dossier).titled("a Dossier"))
+                             .within(self.source_dossier).titled(u"a Dossier"))
 
         self.assert_contains(self.source_dossier,
                              ['Dossier \xc2\xb6c1', 'a Task', 'a Dossier'])

--- a/opengever/ogds/base/tests/test_transport.py
+++ b/opengever/ogds/base/tests/test_transport.py
@@ -23,10 +23,10 @@ class TestTransporter(FunctionalTestCase):
 
 
     def test_transport_from_copies_the_object_inclusive_metadata_and_dublin_core_data(self):
-        dossier = create(Builder("dossier").titled("Dossier"))
+        dossier = create(Builder("dossier").titled(u"Dossier"))
         document = create(Builder("document")
                           .within(dossier)
-                          .titled('Testdocument')
+                          .titled(u'Testdocument')
                           .with_dummy_content()
                           .with_default_values())
 
@@ -46,8 +46,8 @@ class TestTransporter(FunctionalTestCase):
         self.assertEquals(TEST_USER_ID, transported_doc.Creator())
 
     def test_transport_to_returns_a_dict_with_the_path_to_the_new_object(self):
-        source_dossier = create(Builder("dossier").titled("Source"))
-        target_dossier = create(Builder("dossier").titled("Target"))
+        source_dossier = create(Builder("dossier").titled(u"Source"))
+        target_dossier = create(Builder("dossier").titled(u"Target"))
         document = create(Builder("document")
                           .within(source_dossier)
                           .titled(u'Fo\xf6')


### PR DESCRIPTION
The helper function `createContentInContainer` only sets the value for the schema fields, but not for the behavior fields. Therefore I changed the way, how we set the values on the object.

Additionally i combined all `create_object` methods in to a main method.

@senny, @jones: Please take a look.
