### PR TITLE
Fixed start- and enddate validation in the dossier edit form

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+- Dossier: Fixed start- and end-date validation in edit forms.
+  [phgross]
+
 - AdvancedSearch: Added special description for the portal types field
   in a multiclientsetup.
   [phgross]

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -188,8 +188,15 @@ class IDossier(form.Schema):
 
     @invariant
     def validateStartEnd(data):
-        if data.start is not None and data.end is not None:
-            if data.start > data.end:
+        # Do not get the data from the context when it is not in the current
+        # fields / z3cform group
+        data = data._Data_data___
+
+        if 'start' not in data or 'end' not in data:
+            return
+
+        if data['start'] is not None and data['end'] is not None:
+            if data['start'] > data['end']:
                 raise StartBeforeEnd(
                     _(u"The start date must be before the end date."))
 

--- a/opengever/dossier/tests/test_validators.py
+++ b/opengever/dossier/tests/test_validators.py
@@ -1,0 +1,49 @@
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from opengever.testing import create_client
+from opengever.testing import create_ogds_user
+from opengever.testing import set_current_client_id
+from plone.app.testing import TEST_USER_ID
+
+
+class TestStardEndValidator(FunctionalTestCase):
+
+    use_browser = True
+
+    def setUp(self):
+        super(TestStardEndValidator, self).setUp()
+        self.grant('Manager')
+
+        client = create_client(clientid='Plone')
+        create_ogds_user(TEST_USER_ID, assigned_client=[client, ])
+        set_current_client_id(self.portal, clientid='Plone')
+
+    def test_start_date_must_be_before_end_date(self):
+        dossier = create(Builder('dossier')
+                         .having(title=u'Testdossier',
+                                 responsible=TEST_USER_ID,
+                                 start=date(2013, 02, 01),
+                                 end=date(2013, 01, 01)))
+
+        self.browser.open('%s/edit' % (dossier.absolute_url()))
+        self.browser.click('Save')
+
+        self.assertEquals(
+            u'The start date must be before the end date.',
+            self.browser.css('div.error')[0].plain_text())
+
+    def test_changing_invalid_dates_on_edit_form_is_possible(self):
+
+        dossier = create(Builder('dossier')
+                         .having(title=u'Testdossier',
+                                 responsible=TEST_USER_ID,
+                                 start=date(2013, 02, 01),
+                                 end=date(2013, 01, 01)))
+
+        self.browser.open('%s/edit' % (dossier.absolute_url()))
+        self.browser.fill({'Closing Date': 'February 2, 2013'})
+        self.browser.click('Save')
+
+        self.browser.assert_url(dossier.absolute_url())


### PR DESCRIPTION
Problem:
If you have a dossier with an invalid end date (end date is before the start date), it's not possible to change the dates and save it. The `validateStartEnd` validator allways raise an invalid exception.

Reason:
The cooperation of an invariant validator and multiple fieldsets in the same schema, does not work like expected. The validator is called for each fieldset with a different z3c.form datawrapper object. The datawrapper only contains the values of the fieldset fields and for all other gettings it use the fallback - the actual context.

Solution:
I've reworked the invariant validator, so that it don't get the data from the context when it is not in the current fields.

@Jone @lukasgraf could you take a look
