### PR TITLE
Monkey patch manage_pasteObjects permissions on Dexterity Container.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,10 @@ Changelog
   Use additional interface instead of overrides.zcml
   [phgross]
 
+- Monkey patch plone.dexterity.content.Container.__ac_permissions__ in order
+  to declare sane permissions for manage_pasteObjects.
+  [lgraf]
+
 - Added bin/build-translations script to opengever.core buildout.
   [lgraf]
 


### PR DESCRIPTION
`manage_pasteObjects` is protected by `Modify Portal Content` by default. Therefore we patch `plone.dexterity.content.Container` to apply the much more sensible `Add Cortal Content` permission.

@phgross could you please take a look?
