### PR TITLE
Added initalizing upgradestep for the opengever.advancedsearch profile

### DIFF
--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -22,4 +22,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 2500 -> 2501 -->
+    <genericsetup:upgradeStep
+        title="Init og.advancedsearch profile version"
+        description=""
+        source="2500"
+        destination="2501"
+        handler="opengever.base.upgrades.to2501.InitOGAdvancedSearchProfileVersion"
+        profile="opengever.base:default"
+        />
+
 </configure>

--- a/opengever/base/upgrades/to2501.py
+++ b/opengever/base/upgrades/to2501.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InitOGAdvancedSearchProfileVersion(UpgradeStep):
+
+    def __call__(self):
+        profileid = 'opengever.advancedsearch:default'
+        if self.portal_setup.getLastVersionForProfile(profileid) == 'unknown':
+            # Initialize it
+            self.portal_setup.setLastVersionForProfile(profileid, '0')


### PR DESCRIPTION
For the changes in PR https://github.com/4teamwork/opengever.core/pull/40 an upgradestep in `opengever.advancedsearch` was necessary. 

But yet the `opengever.advancedsearch` profile is not initialized, for this reason i add an accordant upgradestep to `opengever.base` which solve this problem.

 @elioschmutz could you take a look!
