### PR TITLE
AllUsersAndInboxesVocabulary: In a one client setup the client Title should not be added to the item 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+- Removed client prefixes in single client setups.
+  [lknoepfel]
+
 - Make exposator work for both izug.basetheme and plonetheme.teamraum.
   [Julian Infanger]
 

--- a/opengever/ogds/base/contact_info.py
+++ b/opengever/ogds/base/contact_info.py
@@ -373,6 +373,13 @@ class ContactInformation(grok.GlobalUtility):
 
         return self._is_client_assigned(userid, client_id)
 
+    def is_one_client_setup(self):
+        """Return True if only one client is available"""
+
+        clients = self.get_clients()
+
+        return len(clients) == 1
+
     # general principal methods
     def describe(self, principal, with_email=False, with_email2=False,
                  with_principal=True):

--- a/opengever/ogds/base/tests/test_contact_info.py
+++ b/opengever/ogds/base/tests/test_contact_info.py
@@ -91,6 +91,26 @@ class TestClientHelpers(FunctionalTestCase):
             self.info.get_assigned_clients(userid='jamie.lannister'))
 
 
+class TestOneClientSetupHelper(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestOneClientSetupHelper, self).setUp()
+        self.info = getUtility(IContactInformation)
+
+    def test_is_one_client_setup(self):
+        create_client(clientid='client')
+        set_current_client_id(self.portal, clientid='client')
+
+        self.assertTrue(self.info.is_one_client_setup())
+
+    def test_a_setup_with_multiple_clients_is_not_a_one_client_setup(self):
+        create_client(clientid='client')
+        create_client(clientid='client2')
+        set_current_client_id(self.portal, clientid='client')
+
+        self.assertFalse(self.info.is_one_client_setup())
+
+
 class TestUserHelpers(FunctionalTestCase):
 
     def setUp(self):

--- a/opengever/ogds/base/tests/test_vocabularies.py
+++ b/opengever/ogds/base/tests/test_vocabularies.py
@@ -33,7 +33,7 @@ class TestContactVocabulary(FunctionalTestCase):
         vocabulary = ContactsVocabulary.create_with_provider(self.key_value_provider)
         self.assertTermKeys(
             ['first-entry', 'second-entry', 'third-entry',
-             'fourth-entry', 'fifth-entry',],
+             'fourth-entry', 'fifth-entry', ],
             vocabulary.search('entry'))
 
         self.assertTermKeys(
@@ -121,7 +121,7 @@ class TestUsersAndInboxesVocabulary(FunctionalTestCase):
         self.portal.REQUEST.set('client', 'client2')
 
         self.assertTermKeys(
-            ['jamie.lannister', 'peter.muster', 'inbox:client2',],
+            ['jamie.lannister', 'peter.muster', 'inbox:client2', ],
             self.vocabulary_factory(self.portal))
 
     def test_use_clientid_from_responsible_client_widget(self):
@@ -143,14 +143,27 @@ class TestAllUsersAndInboxesVocabulary(FunctionalTestCase):
             IVocabularyFactory,
             name='opengever.ogds.base.AllUsersAndInboxesVocabulary')
 
-    def test_terms_are_marked_with_client_prefix(self):
+    def test_terms_are_marked_with_client_prefix_in_a_multiclient_setup(self):
         client1 = create_client(clientid="client1", title="Client 1")
+        create_client(clientid="client2", title="Client 2")
         create_ogds_user('hugo.boss', firstname='Hugo',
                          lastname='Boss', assigned_client=[client1, ])
         set_current_client_id(self.portal)
 
         self.assertTerms(
             [('client1:hugo.boss', 'Client 1: Boss Hugo (hugo.boss)'),
+            ('client1:inbox:client1', 'Inbox: Client 1'),
+            ('client2:inbox:client2', 'Inbox: Client 2')],
+            self.vocabulary_factory(self.portal))
+
+    def test_client_prefix_of_title_is_omitted_in_one_client_setup(self):
+        client1 = create_client(clientid="client1", title="Client 1")
+        create_ogds_user('hugo.boss', firstname='Hugo',
+                         lastname='Boss', assigned_client=[client1, ])
+        set_current_client_id(self.portal)
+
+        self.assertTerms(
+            [('client1:hugo.boss', 'Boss Hugo (hugo.boss)'),
              ('client1:inbox:client1', 'Inbox: Client 1')],
             self.vocabulary_factory(self.portal))
 
@@ -380,6 +393,7 @@ class TestOGDSVocabularies(FunctionalTestCase):
             ['client1', 'client2'], voca_factory(self.portal))
 
     def test_home_dossier_vocabulary_contains_all_open_dossier_from_your_home_client(self):
+
         class ClientCommunicatorMockUtility(communication.ClientCommunicator):
             implements(communication.IClientCommunicator)
 

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -179,9 +179,13 @@ class AllUsersAndInboxesVocabularyFactory(grok.GlobalUtility):
             # all users
             for user in info.list_assigned_users(client_id=client_id):
                 value = u'%s:%s' % (client_id, user.userid)
-                label = u'%s: %s' % (
-                    client.title,
-                    info.describe(user))
+                # prepend client if there are multiple clients
+                if info.is_one_client_setup():
+                    label = u'%s' % (info.describe(user))
+                else:
+                    label = u'%s: %s' % (
+                        client.title,
+                        info.describe(user))
 
                 if not user.active:
                     self.hidden_terms.append(value)
@@ -305,7 +309,6 @@ class ContactsVocabularyFactory(grok.GlobalUtility):
 
 # TODO: should be renamed to something like
 # ContactsUsersAndInboxesVocabularyFactory
-
 
 class ContactsAndUsersVocabularyFactory(grok.GlobalUtility):
     """Vocabulary of contacts, users and the inbox of each client.


### PR DESCRIPTION
When delegating a task the items in the Responsible field are prefixed with the client title. In a one-client setup this information makes no sense. 
![bildschirmfoto 2013-07-29 um 08 42 38](https://f.cloud.github.com/assets/485755/869951/5e27bbcc-f81a-11e2-8ae7-dedfe69a85df.png)

Therefore the vocabulary should be improved, so that the items are only prefixed with the client title in a multiclient setup.

<!---
@huboard:{"order":12.5}
-->
