### PR TITLE
Fixed examplecontent setup

### DIFF
--- a/opengever/setup/cfgs/repository.cfg
+++ b/opengever/setup/cfgs/repository.cfg
@@ -29,7 +29,7 @@ dialect=OpenGeverCSV
 
 [path-from-referencenumber]
 blueprint=opengever.setup.pathfromreferencenumber
-repo_root_id=ordnungssystem1
+repo_root_id=ordnungssystem
 
 [emptystringcaster]
 blueprint=opengever.setup.emptystrincaster


### PR DESCRIPTION
Right now the examplecontent wrongly creates two repositoryroot and activate the tree portlet for the wrong one.

To fix that problem i changed the default of the `repository_root_id` for the `PathFromReferenceNumber` blueprint. I guess it's the best option, because it makes no sense to have a numbered repositoryroot by default. 

@lukasgraf what you think? or should I only adjust the repository_root_id for the examplecontent repository import configuration?
