### PR TITLE
Dropped inbox_group agency for tasks in a oneclient setup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1 (unreleased)
 ----------------
 
+- Dropped inbox_group agency for tasks in a oneclient setup.
+  [phgross]
+
 - LDAP import: Use the respective property from LDAPUserFolder to determine which is the
   UID attribute.
   [lgraf]

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -58,6 +58,11 @@ class LocalRolesSetter(object):
 
         return self._inbox_group
 
+    def is_inboxgroup_agency_active(self):
+        """The inbox group acengy is only activated in a multiclient setup."""
+        info = getUtility(IContactInformation)
+        return not info.is_one_client_setup()
+
     def _add_local_roles(self, context, principal, roles):
         """Adds local roles to the context.
         `roles` example:
@@ -72,7 +77,7 @@ class LocalRolesSetter(object):
         """Set local roles on task
         """
         self._add_local_roles(self.task, self.responsible, ('Editor',))
-        if self.inbox_group:
+        if self.is_inboxgroup_agency_active() and self.inbox_group:
             self._add_local_roles(self.task, self.inbox_group, ('Editor',))
 
     def globalindex_reindex_task(self):
@@ -91,7 +96,7 @@ class LocalRolesSetter(object):
         while context.Type() == self.task.Type():
             context = aq_parent(aq_inner(context))
         self._add_local_roles(context, self.responsible, ('Contributor', ))
-        if self.inbox_group:
+        if self.is_inboxgroup_agency_active() and self.inbox_group:
             self._add_local_roles(context, self.inbox_group, ('Contributor', ))
 
     def set_roles_on_related_items(self):
@@ -104,7 +109,7 @@ class LocalRolesSetter(object):
 
         for item in getattr(self.task, 'relatedItems', []):
             self._add_local_roles(item.to_object, self.responsible, roles)
-            if self.inbox_group:
+            if self.is_inboxgroup_agency_active() and self.inbox_group:
                 self._add_local_roles(item.to_object, self.inbox_group, roles)
 
 

--- a/opengever/task/tests/test_menu.py
+++ b/opengever/task/tests/test_menu.py
@@ -2,6 +2,8 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentmenu.menu import FactoriesMenu
 from opengever.testing import FunctionalTestCase
+from opengever.testing import create_client
+from opengever.testing import set_current_client_id
 from plone.app.testing import TEST_USER_ID
 from zope.component import getMultiAdapter
 
@@ -11,6 +13,9 @@ class TestFactoryMenu(FunctionalTestCase):
     def setUp(self):
         super(TestFactoryMenu, self).setUp()
         self.menu = FactoriesMenu(self.portal)
+
+        create_client()
+        set_current_client_id(self.portal)
 
     def test_task_menu_item_is_titled_task_in_a_dossier(self):
         dossier = create(Builder('dossier'))

--- a/opengever/task/tests/test_transporter.py
+++ b/opengever/task/tests/test_transporter.py
@@ -3,6 +3,8 @@ from opengever.ogds.base.utils import get_client_id
 from opengever.task.interfaces import ITaskDocumentsTransporter
 from opengever.task.task import ITask
 from opengever.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.testing import create_client
+from opengever.testing import set_current_client_id
 from plone.app.testing import TEST_USER_ID
 from plone.dexterity.utils import createContentInContainer
 from plone.dexterity.utils import iterSchemata
@@ -44,7 +46,9 @@ class TestTransporter(unittest.TestCase):
         self.app = self.layer['app']
         self.portal = self.layer['portal']
 
-        # setSite(self.portal)
+        create_client()
+        set_current_client_id(self.portal)
+
 
     def _create_task(self, context, with_docs=False, return_docs=False):
 


### PR DESCRIPTION
For a one client setup the inbox_group agency for tasks is not necessary and leads to confusion because of the localroles wich are added for the inbox_group  (on the dossiers, tasks and documents). Besides the acgeny functionality in a one client setup is already given, with the local administrator functionality (see  https://github.com/4teamwork/opengever.core/blob/master/opengever/task/browser/transitioncontroller.py#L94).

Therefore I reworked the LocalRolesSetter, so that in a oneclient setup it doesn't add local roles for the inbox_group.

@lukasgraf do you have any object against?
cc @jone  
