### PR TITLE
Fixed dossier overview tests

### DIFF
--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import FunctionalTestCase
@@ -19,28 +20,29 @@ class TestOverview(FunctionalTestCase):
             expected, [aa.plain_text() for aa in subdossiers],
             'the subdossierbox does not contain the expected subdossiers')
 
-    def test_subdossier_box_items_are_limited_to_five(self):
+    def test_subdossier_box_items_are_limited_to_five_sort_by_modified(self):
         for i in range(6):
             create(Builder('dossier')
                    .within(self.dossier)
+                   .with_modification_date(DateTime()+i)
                    .titled(u'Dossier %s' % i))
 
         self.browser.open(
             '%s/tabbedview_view-overview' % self.dossier.absolute_url())
 
         self.assert_subdossier_box(
-            ['Dossier 0', 'Dossier 1', 'Dossier 2', 'Dossier 3', 'Dossier 4'])
+            ['Dossier 5', 'Dossier 4', 'Dossier 3', 'Dossier 2', 'Dossier 1'])
 
     def test_subdossier_box_only_list_open_dossiers(self):
-        open = create(Builder('dossier').within(self.dossier)
+        create(Builder('dossier').within(self.dossier)
                .titled(u'Dossier Open')
                .in_state('dossier-state-active'))
 
-        inactive = create(Builder('dossier').within(self.dossier)
+        create(Builder('dossier').within(self.dossier)
                .titled(u'Dossier Inactive')
                .in_state('dossier-state-inactive'))
 
-        resolved = create(Builder('dossier').within(self.dossier)
+        create(Builder('dossier').within(self.dossier)
                .titled(u'Dossier Resolved')
                .in_state('dossier-state-resolved'))
 


### PR DESCRIPTION
I reworked the dossier overview tests. Set modification date on test data to avoid a random subdossier order.

@lukasgraf @jone please take a look.
