### PR TITLE
Rework development buildout.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -14,14 +14,7 @@ development-packages =
 auto-checkout = ${buildout:development-packages}
 
 [branches]
-ftw.datepicker = master
-ftw.mail = master
-ftw.treeview = master
 plone.formwidget.autocomplete = master
-transmogrify.sqlinserter = master
 
 [sources]
-ftw.datepicker = git gitolite@git.4teamwork.ch:ftw/ftw.datepicker.git  branch=${branches:ftw.datepicker}
-ftw.treeview = git gitolite@git.4teamwork.ch:ftw/ftw.treeview.git  branch=${branches:ftw.treeview}
 plone.formwidget.autocomplete = git gitolite@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
-transmogrify.sqlinserter = git gitolite@git.4teamwork.ch:collective/transmogrify.sqlinserter.git  branch=${branches:transmogrify.sqlinserter}


### PR DESCRIPTION
I reworked the sources definition in the buildout, with the goal that the production buildouts can easily extends from the sources definition to define the auto checked out packages. For more infos  see https://github.com/4teamwork/opengever-buildouts/pull/1.

@jone please take a look?
