### PR TITLE
Give better error messages when client setup fails because of inexistent groups.

### DIFF
--- a/opengever/setup/browser/admin.py
+++ b/opengever/setup/browser/admin.py
@@ -31,6 +31,11 @@ SQL_BASES = (
     )
 
 
+class SetupError(Exception):
+    """An Error happened during OpenGever setup.
+    """
+
+
 # these profiles will be installed automatically
 EXTENSION_PROFILES = (
     'plonetheme.classic:default',
@@ -193,10 +198,22 @@ class CreateOpengeverClient(BrowserView):
                 session.delete(clients[0])
 
             # groups must exist
-            users_group = session.query(Group).filter_by(
-                groupid=form['group'])[0]
-            inbox_group = session.query(Group).filter_by(
-                groupid=form['inbox_group'])[0]
+            users_groups = session.query(Group).filter_by(
+                groupid=form['group'])
+            inbox_groups = session.query(Group).filter_by(
+                groupid=form['inbox_group'])
+
+            try:
+                users_group = users_groups[0]
+            except IndexError:
+                raise SetupError("User group '%s' could not be found." %
+                                 form['group'])
+
+            try:
+                inbox_group = inbox_groups[0]
+            except IndexError:
+                raise SetupError("Inbox group '%s' could not be found." %
+                                 form['inbox_group'])
 
             active = bool(form.get('active', False))
 


### PR DESCRIPTION
Before:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module opengever.setup.browser.admin, line 197, in __call__
  Module sqlalchemy.orm.query, line 2028, in __getitem__
IndexError: list index out of range
```

After:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module opengever.setup.browser.admin, line 215, in __call__
SetupError: User group 'sdfsdfsdfandant1_users' could not be found.
```
