### PR TITLE
Reworked client setup functionality

### DIFF
--- a/opengever/examplecontent/configure.zcml
+++ b/opengever/examplecontent/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
+    xmlns:opengever="http://namespaces.zope.org/opengever"
     xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
     i18n_domain="opengever.examplecontent">
 
@@ -43,6 +44,34 @@
     <utility
         component=".jsonsource.JSONSourceSection"
         name="opengever.examplecontent.jsonsource.jsonsourcesection"
+        />
+
+    <opengever:registerClient
+        name="exampleclient"
+        client_id="mandant{client_number}"
+        active="True"
+        local_roles="True"
+        title="Mandant {client_number}"
+        ip_address="172.0.0.1"
+        site_url="http://localhost:8080/mandant{client_number}"
+        public_url="http://localhost:8080/mandant{client_number}"
+        group="og_mandant{client_number}_users"
+        inbox_group="og_mandant{client_number}_eingangskorb"
+        reader_group="og_mandant{client_number}_leser"
+        rolemanager_group="og_mandant{client_number}_rolemanager"
+        mail_domain="localhost"
+        />
+
+    <opengever:registerPolicy
+        title="Development with examplecontent"
+        base_profile="opengever.policy.base:default"
+        additional_profiles="opengever.setup:default,opengever.examplecontent:developer"
+        client_ids="exampleclient"
+        multi_clients="True"
+        purge_sql="True"
+        import_users="True"
+        repository_root_id="ordnungssystem"
+        repository_root_title="Ordnungssystem"
         />
 
 </configure>

--- a/opengever/setup/browser/addclient.js
+++ b/opengever/setup/browser/addclient.js
@@ -26,7 +26,7 @@ $(function($) {
     /* returns the config dict of the current selected policy */
     var id = $('[name=policy]').val();
     return $(policy_configs).filter(function() {
-      if(this['id'] == id) {
+      if(this['title'] == id) {
         return true;
       }
       return false;
@@ -75,19 +75,11 @@ $(function($) {
       client_cfg = config.clients[index-1];
     }
 
-    // If development profile, set client active by default
-    if(config.id == "opengever.examplecontent:0") {
-        client.find('input[name=clients.active:boolean]').attr("checked", "checked");
-    } else {
-      client.find('input[name=clients.active:boolean]').attr('checked', client_cfg.active);
-    }
+    // active field
+    client.find('input[name=clients.active:boolean]').attr('checked', client_cfg.active);
 
-    // If development profile, set default local roles by default
-    if(config.id == "opengever.examplecontent:0") {
-        client.find('input[name=clients.local_roles:boolean]').attr("checked", "checked");
-    } else {
-      client.find('input[name=clients.local_roles:boolean]').attr('checked', client_cfg.local_roles);
-    }
+    // set local roles by default
+    client.find('input[name=clients.local_roles:boolean]').attr('checked', client_cfg.local_roles);
 
     if(index) {
       // just created.. need to update
@@ -103,107 +95,35 @@ $(function($) {
     }
 
     // title
-    if(client_cfg && client_cfg.title) {
-      client.find('input[name=clients.title:records]').val(
-        client_cfg.title);
-    } else {
-      client.find('input[name=clients.title:records]').val(
-        'Mandant '.concat(index));
-    }
+    client.find('input[name=clients.title:records]').val(client_cfg.title);
 
     // configure sql
     if(client_cfg && !client_cfg.configsql) {
       client.find('[name=clients.configsql:records]').attr('checked', null);
     }
-
     // ip address
-    if(client_cfg && client_cfg.ip_address) {
-      client.find('[name=clients.ip_address:records]').val(
-        client_cfg.ip_address);
-    } else {
-      client.find('[name=clients.ip_address:records]').val('127.0.0.1');
-    }
+    client.find('[name=clients.ip_address:records]').val(client_cfg.ip_address);
 
     // internal site URL
-    if(client_cfg && client_cfg.site_url) {
-      client.find('[name=clients.site_url:records]').val(
-        client_cfg.site_url);
-    } else {
-      client.find('[name=clients.site_url:records]').val(
-        'http://localhost:'.concat(
-          server_port).concat('/').concat(cid));
-    }
+    client.find('[name=clients.site_url:records]').val(client_cfg.site_url);
 
     // public site URL
-    if(client_cfg && client_cfg.public_url) {
-      client.find('[name=clients.public_url:records]').val(
-        client_cfg.public_url);
-
-    } else if(location.hostname == 'localhost' && index == 2) {
-      client.find('input[name=clients.public_url:records]').val(
-        location.protocol.concat('//127.0.0.1:').concat(
-          location.port).concat('/').concat(cid));
-
-    } else if(subdoms && location.hostname != 'localhost') {
-      client.find('input[name=clients.public_url:records]').val(
-        location.protocol.concat('//').concat(cid).concat(
-          '.').concat(location.hostname).concat('/'));
-
-    } else {
-      client.find('input[name=clients.public_url:records]').val(
-        location.protocol.concat('//').concat(
-          location.port != '80' ? location.host :
-            location.hostname).concat('/').concat(cid));
-    }
+    client.find('[name=clients.public_url:records]').val(client_cfg.public_url);
 
     // user group
-    if(client_cfg && client_cfg.group) {
-      client.find('input[name=clients.group:records]').val(
-        client_cfg.group);
-    } else {
-      client.find('input[name=clients.group:records]').val(
-        'og_'.concat(cid).concat('_users'));
-    }
+    client.find('input[name=clients.group:records]').val(client_cfg.group);
 
     // inbox group
-    if(client_cfg && client_cfg.inbox_group) {
-      client.find('input[name=clients.inbox_group:records]').val(
-        client_cfg.inbox_group);
-    } else {
-      client.find('input[name=clients.inbox_group:records]').val(
-        'og_'.concat(cid).concat('_eingangskorb'));
-    }
+    client.find('input[name=clients.inbox_group:records]').val(client_cfg.inbox_group);
 
     // reader group
-    if(client_cfg && client_cfg.reader_group) {
-      client.find('input[name=clients.reader_group:records]').val(
-        client_cfg.reader_group);
-    } else {
-      client.find('input[name=clients.reader_group:records]').val(
-        'og_'.concat(cid).concat('_leser'));
-    }
+    client.find('input[name=clients.reader_group:records]').val(client_cfg.reader_group);
 
-    // reader group
-    if(client_cfg && client_cfg.rolemanager_group) {
-      client.find('input[name=clients.rolemanager_group:records]').val(
-        client_cfg.rolemanager_group);
-    } else {
-      client.find('input[name=clients.rolemanager_group:records]').val(
-        'og_'.concat(cid).concat('_rolemanager'));
-    }
+    // rolemanager group
+    client.find('input[name=clients.rolemanager_group:records]').val(client_cfg.rolemanager_group);
 
     // mail domain
-    if(client_cfg && client_cfg.mail_domain) {
-      client.find('input[name=clients.mail_domain:records]').val(
-        client_cfg.mail_domain);
-
-    } else if(location.hostname == 'localhost') {
-      client.find('input[name=clients.mail_domain:records]').val(
-        'localhost');
-    } else {
-      client.find('input[name=clients.mail_domain:records]').val(
-        cid.concat('.').concat(location.hostname));
-    }
+    client.find('input[name=clients.mail_domain:records]').val(client_cfg.mail_domain);
 
     client.find('[name=clients.client_id:records]').change();
   }

--- a/opengever/setup/browser/addsite.pt
+++ b/opengever/setup/browser/addsite.pt
@@ -139,8 +139,8 @@
 
           <select name="policy">
             <option tal:repeat="item view/get_policy_options"
-                    tal:content="item/title"
-                    tal:attributes="value item/value;
+                    tal:content="item"
+                    tal:attributes="value item;
                                     selected python:repeat['item'].index == 0 and 'selected' or ''">
             </option>
           </select>
@@ -277,4 +277,3 @@
     </form>
   </body>
 </html>
-

--- a/opengever/setup/directives.py
+++ b/opengever/setup/directives.py
@@ -1,0 +1,42 @@
+from opengever.setup.interfaces import IClientConfigurationRegistry
+from opengever.setup.registry import ClientConfigurationRegistry
+from zope.component import queryUtility, provideUtility
+
+
+class ClientDirective(object):
+
+    def __call__(self, *args, **kwargs):
+        registry = queryUtility(IClientConfigurationRegistry)
+        if registry is None:
+            registry = ClientConfigurationRegistry()
+            provideUtility(registry)
+
+        registry.update_clients(args[0], kwargs)
+
+
+client_directive = ClientDirective()
+
+
+class PolicyDirective(object):
+
+    def __call__(self, *args, **kwargs):
+        registry = queryUtility(IClientConfigurationRegistry)
+        if registry is None:
+            registry = ClientConfigurationRegistry()
+            provideUtility(registry)
+
+        if kwargs.get('additional_profiles'):
+            kwargs['additional_profiles'] = self.get_stripped_list(
+                kwargs.get('additional_profiles'))
+
+        if kwargs.get('client_ids'):
+            kwargs['client_ids'] = self.get_stripped_list(
+                kwargs.get('client_ids'))
+
+        registry.update_policy(args[0], kwargs)
+
+    def get_stripped_list(self, value):
+        return [item.strip() for item in value.split(',')]
+
+
+policy_directive = PolicyDirective()

--- a/opengever/setup/interfaces.py
+++ b/opengever/setup/interfaces.py
@@ -1,0 +1,29 @@
+from zope.interface import Interface
+
+
+class IClientConfigurationRegistry(Interface):
+    """A client configuration registry is a utility which.
+    Knows all the registered configurations."""
+
+    def update_clients(id, attr):
+        """Update or add client configuration to the
+        client-configuration registry."""
+
+    def update_policy(id, attr):
+        """Update or add policy to the client-configuration registry."""
+
+    def get_configuration(id):
+        """Returns the client configuration (a dict) for the given id. """
+
+    def get_policy(id):
+        """Returns a dict with all policy attributes. Include a list
+        of client configurations on the key `clients`.
+
+        For policies with the multiclient option, it appends ten generated
+        clients, and fill in the client_number if it's necessary."""
+
+    def get_policies():
+        """Returns a generator wiht all registered policy configurations."""
+
+    def list_policies():
+        """Returns a list policy titles."""

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -1,0 +1,149 @@
+from opengever.setup.directives import client_directive
+from opengever.setup.directives import policy_directive
+from opengever.setup.interfaces import IClientConfigurationRegistry
+from opengever.setup.registry import ClientConfigurationRegistry
+from zope.component import queryUtility, provideUtility
+from zope.interface import Interface
+from zope.schema import Bool
+from zope.schema import TextLine
+
+
+def register_client(_context, **kwargs):
+    _context.action(
+        kwargs.get('name'),
+        client_directive,
+        (kwargs.get('name'), ), kw=kwargs)
+
+
+def register_policy(_context, **kwargs):
+    _context.action(
+        kwargs.get('title'),
+        policy_directive,
+        (kwargs.get('title'), ), kw=kwargs)
+
+
+class IClientConfiguration(Interface):
+
+    active = Bool(
+        title=u'Active Client',
+        description=u'Set client as active in the ogds',
+        default=False)
+
+    local_roles = Bool(
+        title=u'Set default local roles',
+        default=False)
+
+    name = TextLine(
+        title=u'Client name',
+        required=True)
+
+    client_id = TextLine(
+        title=u'Client ID',
+        required=True)
+
+    title = TextLine(
+        title=u'Client Title',
+        description=u'Client Title (for example FOO BAR)',
+        required=True)
+
+    configsql = Bool(
+        title=u'configsql',
+        description=u'Register the client in the OGDS clients registry.',
+        default=True,
+        required=False)
+
+    ip_address = TextLine(
+        title=u'IP address',
+        description=u'One ore more (seperated by coma) ip-address(es), '
+        'Which are used foc communcations beetwen clients.',
+        required=True)
+
+    site_url = TextLine(
+        title=u'Site URL',
+        description=u'Url for internal communications.',
+        required=True)
+
+    public_url = TextLine(
+        title=u'Public URL',
+        description=u'Public URL, accessed by the users.',
+        required=True)
+
+    group = TextLine(
+        title=u'Users group',
+        description=u'Groupname of the clients users group.',
+        required=True)
+
+    inbox_group = TextLine(
+        title=u'Inbox group',
+        description=u'Groupname of the clients inbox group.',
+        required=True)
+
+    reader_group = TextLine(
+        title=u'Reader group',
+        description=u'Groupname of the clients reader group.',
+        required=False)
+
+    rolemanager_group = TextLine(
+        title=u'Reader group',
+        description=u'Groupname of the clients reader group.',
+        required=False)
+
+    mail_domain = TextLine(
+        title=u'Mail domain',
+        default=u'localhost',
+        required=False
+    )
+
+
+class IPolicyConfiguration(Interface):
+
+    title = TextLine(
+        title=u'Policy title',
+        required=True)
+
+    base_profile = TextLine(
+        title=u'Base profile',
+        default=u'opengever.policy.base:default',
+        required=False)
+
+    additional_profiles = TextLine(
+        title=u'Additional profiles',
+        description=u'Mutlitple values allowed (coma sperated list)',
+        required=False)
+
+    purge_sql = Bool(
+        title=u'Drop ALL SQL tables! This option should only'
+        'be used for development profiles!',
+        default=False,
+        required=False)
+
+    import_users = Bool(
+        title=u'Import users by default.',
+        description=u'Import users after creating client.',
+        default=True,
+        required=False)
+
+    language = TextLine(
+        title=u'Language',
+        default=u'de-ch',
+        required=False)
+
+    client_ids = TextLine(
+        title=u'Ids of client configurations',
+        description=u'Multiple values allowed (coma sperated list)',
+        required=False)
+
+    multi_clients = Bool(
+        title=u'Policy support multiclient installations',
+        required=False,
+        default=False)
+
+    repository_root_id = TextLine(
+        title=u'Repository root id',
+        default=u'ordnungssystem',
+        required=False)
+
+    repository_root_title = TextLine(
+        title=u'Repository Root Title',
+        default=u'Ordnungssystem',
+        required=False)

--- a/opengever/setup/meta.zcml
+++ b/opengever/setup/meta.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:meta="http://namespaces.zope.org/meta">
+
+    <meta:directive
+        namespace="http://namespaces.zope.org/opengever"
+        name="registerClient"
+        schema=".meta.IClientConfiguration"
+        handler=".meta.register_client"
+        />
+
+    <meta:directive
+        namespace="http://namespaces.zope.org/opengever"
+        name="registerPolicy"
+        schema=".meta.IPolicyConfiguration"
+        handler=".meta.register_policy"
+        />
+
+</configure>

--- a/opengever/setup/registry.py
+++ b/opengever/setup/registry.py
@@ -1,0 +1,57 @@
+from opengever.setup.interfaces import IClientConfigurationRegistry
+from zope.interface import implements
+
+
+class ClientConfigurationRegistry(object):
+    implements(IClientConfigurationRegistry)
+
+    def __init__(self):
+        self.clients = {}
+        self.policies = {}
+
+    def update_clients(self, id, attr):
+        if id in self.clients:
+            self.clients[id].update(attr)
+        else:
+            self.clients[id] = attr
+
+    def update_policy(self, id, kwargs):
+        if id in self.policies:
+            self.policies[id].update(kwargs)
+        else:
+            self.policies[id] = kwargs
+
+    def get_configuration(self, id):
+        return self.clients.get(id)
+
+    def get_policy(self, id):
+        configuration = self.policies.get(id).copy()
+        configuration['clients'] = []
+
+        if configuration.get('multi_clients'):
+            return self.generate_multi_policies(configuration)
+
+        for client_id in configuration.get('client_ids'):
+            configuration['clients'].append(self.get_configuration(client_id))
+        return configuration
+
+    def generate_multi_policies(self, configuration):
+        configuration['clients'] = []
+        client_id = configuration.get('client_ids')[0]
+        muster_configuration = self.get_configuration(client_id)
+
+        for i in range(1, 11):
+            client = muster_configuration.copy()
+            for key, value in client.items():
+                if isinstance(value, unicode):
+                    client[key] = value.format(client_number=str(i))
+            configuration['clients'].append(client)
+
+        return configuration
+
+    def get_policies(self):
+        for policy_id in self.policies.keys():
+            yield self.get_policy(policy_id)
+
+    def list_policies(self):
+        return self.policies.keys()

--- a/opengever/setup/utils.py
+++ b/opengever/setup/utils.py
@@ -17,13 +17,3 @@ def get_ldap_configs():
     for ep in get_entry_points('ldap'):
         module = ep.load()
         yield getattr(module, 'LDAP_PROFILE')
-
-
-def get_policy_configs():
-    """Returns all policy configs
-    """
-    for ep in get_entry_points('policies'):
-        module = ep.load()
-        for index, policy in enumerate(getattr(module, 'POLICIES')):
-            policy['id'] = '%s:%i' % (ep.module_name, index)
-            yield policy


### PR DESCRIPTION
Right now the client register functionality works with entrypoints and some hacks in the setup form for the examplecontent profile.

To enable a bigger policy package which includes multiple client configurations in separate and conditionally subpackages, i reworked the register and setup functionality:
- Replaced the old client and policy registration with two new zcml directives `registerPolicy` and `registerClient`.
- Implements an `ClientConfigurationRegistry` Utility, which handles and store all the registered clients.
- Reworked the setup form, which use now the `ClientConfigurationRegistry` utility.
- Rebuild registration of the `examplecontent` clients, use the new zcml-directives.

@jone @lukasgraf could you take a look?
