### PR TITLE
Forwarding refuseform: Implemented already_done check safer.

### DIFF
--- a/opengever/inbox/browser/refuse.py
+++ b/opengever/inbox/browser/refuse.py
@@ -206,6 +206,10 @@ class StoreRefusedForwardingView(grok.View):
         data otherwise False"""
 
         data = json.loads(self.request.get(REQUEST_KEY))
-        orig_intid = IAnnotations(forwarding)[ORIGINAL_INTID_ANNOTATION_KEY]
+        orig_intid = IAnnotations(forwarding).get(
+            ORIGINAL_INTID_ANNOTATION_KEY)
+
+        if not orig_intid:
+            return False
 
         return data.get(u'unicode:intid-data') == orig_intid


### PR DESCRIPTION
It should not fail, when the `ORIGINAL_INTID_ANNOTATION_KEY` is not set in the annotations.

@lukasgraf could you take a look?
