### PR TITLE
When creating a subtask it redirects to a not existing tab.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1 (unreleased)
 ----------------
 
+- Fixed redirect when creating a subtask.
+  [phgross]
+
 - Reworked forwarding refuse and reassign functionality.
   [phgross]
 

--- a/opengever/task/browser/redirector.py
+++ b/opengever/task/browser/redirector.py
@@ -1,0 +1,21 @@
+from Acquisition import aq_inner, aq_parent
+from five import grok
+from opengever.task.task import ITask
+
+
+class TaskRedirector(grok.View):
+    """Redirector view which is called when creating a task.
+    For maintasks it redirects to the dossier's task-tab,
+    For subtasks it redirects to maintask-overview."""
+
+    grok.context(ITask)
+    grok.name('task_redirector')
+
+    def render(self):
+        parent = aq_inner(aq_parent(self.context))
+        if ITask.providedBy(parent):
+            redirect_to = '%s#overview' % parent.absolute_url()
+        else:
+            redirect_to = '%s#tasks' % parent.absolute_url()
+
+        return self.request.RESPONSE.redirect(redirect_to)

--- a/opengever/task/profiles/default/metadata.xml
+++ b/opengever/task/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-  <version>2601</version>
+  <version>2602</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/opengever/task/profiles/default/types/opengever.task.task.xml
+++ b/opengever/task/profiles/default/types/opengever.task.task.xml
@@ -39,7 +39,7 @@
 
     <!-- View information -->
     <property name="default_view">tabbed_view</property>
-    <property name="immediate_view">../#tasks</property>
+    <property name="immediate_view">task_redirector</property>
     <property name="default_view_fallback">False</property>
     <property name="view_methods">
         <element value="view"/>

--- a/opengever/task/tests/test_redirector.py
+++ b/opengever/task/tests/test_redirector.py
@@ -1,0 +1,56 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from opengever.testing import assign_user_to_client
+from opengever.testing import create_client
+from opengever.testing import create_ogds_user
+from opengever.testing import set_current_client_id
+from plone.app.testing import TEST_USER_ID
+
+
+class TestTaskRedirector(FunctionalTestCase):
+
+    use_browser = True
+
+    def setUp(self):
+        super(TestTaskRedirector, self).setUp()
+
+        client = create_client()
+        user = create_ogds_user(TEST_USER_ID)
+        assign_user_to_client(user, client)
+        set_current_client_id(self.portal)
+
+        self.dossier = create(Builder('dossier'))
+
+    def test_redirects_to_dossiers_task_tab_when_creating_a_maintask(self):
+        self.create_task(self.dossier, 'Main task')
+
+        self.browser.assert_url('%s#tasks' % self.dossier.absolute_url())
+
+    def test_redirects_to_maintask_overview_tab_when_creating_a_subtask(self):
+
+        task = create(Builder('task')
+                      .within(self.dossier)
+                      .having(title='Subtask',
+                              task_type='approval',
+                              responsible=TEST_USER_ID,
+                              issuer=TEST_USER_ID)
+                      .in_state('task-state-in-progress'))
+
+        self.create_task(task, 'Subtask')
+
+        self.browser.assert_url('%s#overview' % task.absolute_url())
+
+    def create_task(self, container, title, task_type='For direct execution',
+                    responsible_name='Boss', responsible_id=TEST_USER_ID):
+        self.browser.open(
+            '%s/++add++opengever.task.task' % container.absolute_url())
+
+        self.browser.fill({'Title': title})
+        self.browser.getControl(task_type).selected = True
+        self.browser.getControl(
+            name='form.widgets.responsible.widgets.query').value = responsible_name
+        self.browser.click('form.widgets.responsible.buttons.search')
+        self.browser.getControl(
+            name='form.widgets.responsible:list').value = [responsible_id]
+        self.browser.click('Save')

--- a/opengever/task/upgrades/configure.zcml
+++ b/opengever/task/upgrades/configure.zcml
@@ -36,4 +36,21 @@
         directory="profiles/2601"
         />
 
+    <!-- 2601 -> 2602 -->
+    <genericsetup:upgradeStep
+        title="Update immediate view for the task type"
+        description=""
+        source="2601"
+        destination="2602"
+        handler="opengever.task.upgrades.to2602.UpdateImmediateViewForTasks"
+        profile="opengever.task:default"
+        />
+
+    <genericsetup:registerProfile
+        name="2602"
+        title="opengever.task: upgrade profile 2602"
+        description=""
+        directory="profiles/2602"
+        />
+
 </configure>

--- a/opengever/task/upgrades/profiles/2602/types/opengever.task.task.xml
+++ b/opengever/task/upgrades/profiles/2602/types/opengever.task.task.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="opengever.task.task" meta_type="Dexterity FTI"
+        i18n:domain="opengever.task" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <property name="immediate_view">task_redirector</property>
+
+</object>

--- a/opengever/task/upgrades/to2602.py
+++ b/opengever/task/upgrades/to2602.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateImmediateViewForTasks(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-opengever.task.upgrades:2602')


### PR DESCRIPTION
When creating a task it redirects to the `tasks` tab of the dossier. For main task this works like expected. But when creating a subtask, it redirects to the not existing `tasks` tab on the main task. Therefore it starts flickering and can't display the tab content:
![bildschirmfoto 2013-10-04 um 11 54 06](https://f.cloud.github.com/assets/485755/1268256/f369a3cc-2cda-11e3-9475-e6dbaad7ec24.png)
