### PR TITLE
LDAP import: If server doesn't support page controls, fall back to issuing search request without them.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.1 (unreleased)
 ----------------
 
+- LDAP import: If server doesn't support page controls, fall back to issuing
+  search request without them.
+  [lgraf]
+
 - Fixed redirect when creating a subtask.
   [phgross]
 

--- a/opengever/ogds/base/ldap_util.py
+++ b/opengever/ogds/base/ldap_util.py
@@ -104,16 +104,32 @@ class LDAPSearch(grok.Adapter):
                                            (page_size, ''),)
         is_last_page = False
         results = []
+
         while not is_last_page:
-            msgid = conn.search_ext(base_dn,
-                                    scope,
-                                    filter,
-                                    attrs,
-                                    serverctrls=[lc])
-            rtype, rdata, rmsgid, serverctrls = conn.result3(msgid)
+            try:
+                msgid = conn.search_ext(base_dn,
+                                        scope,
+                                        filter,
+                                        attrs,
+                                        serverctrls=[lc])
+
+                rtype, rdata, rmsgid, serverctrls = conn.result3(msgid)
+                pctrls = [c for c in serverctrls
+                          if c.controlType == LDAP_CONTROL_PAGED_RESULTS]
+
+            except ldap.UNAVAILABLE_CRITICAL_EXTENSION:
+                # Server does not support pagination controls - send search
+                # request again without pagination controls
+                msgid = conn.search_ext(base_dn,
+                                        scope,
+                                        filter,
+                                        attrs,
+                                        serverctrls=[])
+                rtype, rdata, rmsgid, serverctrls = conn.result3(msgid)
+                pctrls = []
+
             results.extend(rdata)
-            pctrls = [c for c in serverctrls
-                      if c.controlType == LDAP_CONTROL_PAGED_RESULTS]
+
             if pctrls:
                 if PYTHON_LDAP_24:
                     cookie = pctrls[0].cookie


### PR DESCRIPTION
If a extended search request with paged result controls is issued, but the server doesn't support them, python-ldap fails like this:

```
  Module ldap.ldapobject, line 432, in result3
  Module ldap.ldapobject, line 96, in _ldap_call
UNAVAILABLE_CRITICAL_EXTENSION: {'info': '', 'desc': 'Critical extension is unavailable'} 
```

This PR wraps this request in a `try..except`, and upon failure issues a second request without the pagination controls.

A possible different solution would be to not use `ldap.CONTROL_PAGEDRESULTS`, but instead instanciate our own `ldap.controls.libldap.SimplePagedResultsControl` with `criticality=False`.
