### PR TITLE
Disable the reference prefix manager for administrators for the moment.

### DIFF
--- a/opengever/repository/profiles/default/rolemap.xml
+++ b/opengever/repository/profiles/default/rolemap.xml
@@ -16,7 +16,6 @@
     </permission>
     <permission name="opengever.repository: Unlock Reference Prefix" acquire="True">
       <role name="Manager" />
-      <role name="Administrator" />
     </permission>
   </permissions>
 </rolemap>

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -14,7 +14,7 @@ class TestReferencePrefixManager(FunctionalTestCase):
 
     def setUp(self):
         super(TestReferencePrefixManager, self).setUp()
-        self.grant('Administrator')
+        self.grant('Manager')
 
         self.root = create(Builder('repository_root'))
         self.repo = create(Builder('repository')


### PR DESCRIPTION
The reference prefix manager should not activate for administrator till the release 2.6.1.

Upgradestep is not necessary, because the reference prefix isn't installed somewhere.
