### PR TITLE
Fixed CleanupReferencePrefixMapping upgradestep

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed CleanupReferencePrefixMapping upgradestep
+  (works now for reference to no longer existing objects):
+  [phgross]
 
 
 3.1 (2013-10-23)

--- a/opengever/base/upgrades/to2601.py
+++ b/opengever/base/upgrades/to2601.py
@@ -35,7 +35,13 @@ class CleanupReferencePrefixMapping(UpgradeStep):
                  PREFIX_REF_KEY: {}})
 
             for number, intid in annotations.get(CHILD_REF_KEY).items():
-                if IDossierMarker.providedBy(intids.getObject(intid)):
+                try:
+                    child = intids.getObject(intid)
+                except KeyError:
+                    # the object with this intid does not longer exist.
+                    continue
+
+                if IDossierMarker.providedBy(child):
                     dossier_mapping[CHILD_REF_KEY][number] = intid
                     dossier_mapping[PREFIX_REF_KEY][intid] = number
                 else:


### PR DESCRIPTION
In some cases it could be possible that the Reference Adapter has stored intids which reference to no longer existing objects. In this case the upgradestep should not fail and ignore them instead.
