### PR TITLE
Remove all traces of DocuComposer from og.core

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Moved docucomposer in own package.
+  [lknoepfel]
+
 - LDAP util: Only use PagedResults controls if the server advertises to support them.
   [lgraf]
 
@@ -32,7 +35,6 @@ Changelog
 - Fixed CleanupReferencePrefixMapping upgradestep
   (works now for reference to no longer existing objects):
   [phgross]
-
 
 3.1 (2013-10-23)
 ----------------

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2013-04-03 08:06+0000\n"
+"POT-Creation-Date: 2013-10-24 09:25+0000\n"
 "PO-Revision-Date: 2013-04-03 10:08+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -9,6 +9,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
@@ -24,7 +26,7 @@ msgstr "Geschäftsdossier hinzufügen"
 msgid "Add Participant"
 msgstr "Beteiligung hinzufügen"
 
-#: ./opengever/dossier/behaviors/dossier.py:222
+#: ./opengever/dossier/behaviors/dossier.py:229
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
@@ -53,11 +55,12 @@ msgstr "Dokument ${name} ist mit einer Aufgabe verbunden, bitte Aufgabe verschie
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
-#: ./opengever/dossier/behaviors/dossier.py:237
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
 #: ./opengever/dossier/profiles/default/actions.xml
+#: ./opengever/dossier/upgrades/profiles/2601/actions.xml
 msgid "Export selection"
 msgstr "Auswahl exportieren"
 
@@ -110,7 +113,7 @@ msgstr "Vorlagen"
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr "Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} bereits abgeschlossen ist. Das Subdossier muss vorgängig wieder eröffnet werden."
 
-#: ./opengever/dossier/deactivate.py:69
+#: ./opengever/dossier/deactivate.py:68
 msgid "The Dossier has been activated"
 msgstr "Das Dossier wurde aktiviert."
 
@@ -142,11 +145,11 @@ msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das D
 msgid "The given value is not a valid Year"
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
-#: ./opengever/dossier/behaviors/dossier.py:194
+#: ./opengever/dossier/behaviors/dossier.py:201
 msgid "The start date must be before the end date."
 msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 
-#: ./opengever/dossier/behaviors/dossier.py:244
+#: ./opengever/dossier/behaviors/dossier.py:251
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
@@ -220,9 +223,6 @@ msgstr "Dokument aus Vorlage erstellen"
 
 msgid "description"
 msgstr "Beschreibung"
-
-msgid "document_with_docucomposer"
-msgstr "Dokument mit Docucomposer"
 
 msgid "documents"
 msgstr "Dokumente"
@@ -385,8 +385,8 @@ msgid "label_add_participant"
 msgstr "Beteiligung hinzufügen"
 
 #. Default: "by ${author}"
-#: ./opengever/dossier/project_templates/byline.pt:16
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:19
+#: ./opengever/dossier/project_templates/byline.pt:14
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:22
 msgid "label_by_author"
 msgstr "Federführend: ${author}"
 
@@ -426,7 +426,7 @@ msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
 #. Default: "E-Mail:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:89
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:77
 msgid "label_email_address"
 msgstr "E-Mail:"
 
@@ -438,13 +438,13 @@ msgid "label_end"
 msgstr "Ende"
 
 #. Default: "to:"
-#: ./opengever/dossier/project_templates/byline.pt:44
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:45
+#: ./opengever/dossier/project_templates/byline.pt:42
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:43
 msgid "label_end_byline"
 msgstr "Ende:"
 
 #. Default: "Filing Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:79
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:70
 msgid "label_filing_no"
 msgstr "Ablagenummer:"
 
@@ -481,7 +481,7 @@ msgstr "Beteiligung"
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:184
 #: ./opengever/dossier/browser/report.py:118
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:69
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:63
 msgid "label_reference_number"
 msgstr "Aktenzeichen:"
 
@@ -508,7 +508,7 @@ msgid "label_roles"
 msgstr "Rollen"
 
 #. Default: "Sequence Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:59
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:56
 msgid "label_sequence_number"
 msgstr "Laufnummer:"
 
@@ -524,8 +524,8 @@ msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "from:"
-#: ./opengever/dossier/project_templates/byline.pt:35
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:36
+#: ./opengever/dossier/project_templates/byline.pt:33
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:34
 msgid "label_start_byline"
 msgstr "Beginn:"
 
@@ -547,8 +547,8 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "State:"
-#: ./opengever/dossier/project_templates/byline.pt:28
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:30
+#: ./opengever/dossier/project_templates/byline.pt:26
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:29
 msgid "label_workflow_state"
 msgstr "Status:"
 
@@ -624,8 +624,8 @@ msgid "the dossier start date is missing."
 msgstr "Es wurde kein Beginn-Datum gesetzt."
 
 #. Default: "expired"
-#: ./opengever/dossier/project_templates/byline.pt:53
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:54
+#: ./opengever/dossier/project_templates/byline.pt:51
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:52
 msgid "time_expired"
 msgstr "abgelaufen"
 
@@ -643,5 +643,4 @@ msgstr "Sie können die Dokumente nicht an einen anderen Mandanten senden, da Si
 #: ./opengever/dossier/behaviors/participation.py:194
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
-
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/plone.po
@@ -17,9 +17,6 @@ msgstr ""
 msgid "Add Participant"
 msgstr "Beteiligung hinzufügen"
 
-msgid "Document with docucomposer"
-msgstr "Dokument mit Docucomposer"
-
 msgid "Dossier state changed to dossier-state-active"
 msgstr "Status des Dossiers geändert zu In Bearbeitung"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2012-11-26 16:22+0000\n"
+"POT-Creation-Date: 2013-10-24 09:25+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9,10 +9,12 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/dossier/move_items.py:133
+#: ./opengever/dossier/move_items.py:132
 msgid "${copied_items} Elements were moved successfully"
 msgstr "${copied_items} éléments déplacés avec succès"
 
@@ -23,7 +25,7 @@ msgstr "Insérer un dossier d'affaire"
 msgid "Add Participant"
 msgstr "Participant"
 
-#: ./opengever/dossier/behaviors/dossier.py:222
+#: ./opengever/dossier/behaviors/dossier.py:229
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
 
@@ -51,23 +53,24 @@ msgstr "Document ${name} est lié avec une tâche, déplacer la tâche, svp."
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès"
 
-#: ./opengever/dossier/behaviors/dossier.py:237
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
 #: ./opengever/dossier/profiles/default/actions.xml
+#: ./opengever/dossier/upgrades/profiles/2601/actions.xml
 msgid "Export selection"
 msgstr "Exporter le choix"
 
-#: ./opengever/dossier/move_items.py:139
+#: ./opengever/dossier/move_items.py:138
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr "Impossible de déplacer les éléments suivants: ${failed_objects}"
 
-#: ./opengever/dossier/move_items.py:145
-msgid "Failed to copy following objects: ${failed_objects}                    . Locket via WebDAV"
-msgstr "Impossible de déplacer les éléments suivants vérrouillés par un autre utilisateur: {failed_objects}."
+#: ./opengever/dossier/move_items.py:144
+msgid "Failed to copy following objects: ${failed_objects}                    . Locked via WebDAV"
+msgstr ""
 
-#: ./opengever/dossier/move_items.py:186
+#: ./opengever/dossier/move_items.py:185
 msgid "It isn't allowed to add such items there"
 msgstr "Cet élément ne peut être déplacé ici."
 
@@ -102,6 +105,18 @@ msgstr "Dossier des modèles"
 msgid "Templates"
 msgstr "Modèles"
 
+#: ./opengever/dossier/deactivate.py:26
+msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py:68
+msgid "The Dossier has been activated"
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py:44
+msgid "The Dossier has been deactivated"
+msgstr ""
+
 #: ./opengever/dossier/archive.py:266
 msgid "The Dossier has been resolved"
 msgstr "Dossier a été fermé avec succès"
@@ -126,11 +141,11 @@ msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou 
 msgid "The given value is not a valid Year"
 msgstr "L'année de dépôt attribuée n'est pas valable"
 
-#: ./opengever/dossier/behaviors/dossier.py:194
+#: ./opengever/dossier/behaviors/dossier.py:201
 msgid "The start date must be before the end date."
 msgstr "La date de début doit être plus récente que la date de clôture."
 
-#: ./opengever/dossier/behaviors/dossier.py:244
+#: ./opengever/dossier/behaviors/dossier.py:251
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
@@ -138,7 +153,7 @@ msgstr "La date de début ou la date de clôture n'est pas valable."
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution de numéro d'inventaire, tous les champs sont obligatoires"
 
-#: ./opengever/dossier/move_items.py:169
+#: ./opengever/dossier/move_items.py:168
 msgid "You have not selected any items"
 msgstr "Pas d'élément sélectionné"
 
@@ -205,14 +220,11 @@ msgstr "Créer un document à partir d'un modèle"
 msgid "description"
 msgstr "Description"
 
-msgid "document_with_docucomposer"
-msgstr "Document avec DocuComposer"
-
 msgid "documents"
 msgstr "Documents"
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:217
+#: ./opengever/dossier/move_items.py:216
 msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Pas d'objet déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi : ${failed_objects}"
 
@@ -369,8 +381,8 @@ msgid "label_add_participant"
 msgstr "Participant"
 
 #. Default: "by ${author}"
-#: ./opengever/dossier/project_templates/byline.pt:16
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:19
+#: ./opengever/dossier/project_templates/byline.pt:14
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:22
 msgid "label_by_author"
 msgstr "Responsable: ${author}"
 
@@ -410,7 +422,7 @@ msgid "label_edit_after_creation"
 msgstr "Modifier après avoir créé"
 
 #. Default: "E-Mail:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:89
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:77
 msgid "label_email_address"
 msgstr "Email"
 
@@ -422,13 +434,13 @@ msgid "label_end"
 msgstr "Date de fin :"
 
 #. Default: "to:"
-#: ./opengever/dossier/project_templates/byline.pt:44
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:45
+#: ./opengever/dossier/project_templates/byline.pt:42
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:43
 msgid "label_end_byline"
 msgstr "Jusqu'au :"
 
 #. Default: "Filing Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:79
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:70
 msgid "label_filing_no"
 msgstr "Numéro d'inventaire"
 
@@ -465,7 +477,7 @@ msgstr "Participation"
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:184
 #: ./opengever/dossier/browser/report.py:118
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:69
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:63
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
@@ -492,7 +504,7 @@ msgid "label_roles"
 msgstr "Rôles"
 
 #. Default: "Sequence Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:59
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:56
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
@@ -508,8 +520,8 @@ msgid "label_start"
 msgstr "Date début"
 
 #. Default: "from:"
-#: ./opengever/dossier/project_templates/byline.pt:35
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:36
+#: ./opengever/dossier/project_templates/byline.pt:33
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:34
 msgid "label_start_byline"
 msgstr "De :"
 
@@ -531,8 +543,8 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "State:"
-#: ./opengever/dossier/project_templates/byline.pt:28
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:30
+#: ./opengever/dossier/project_templates/byline.pt:26
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:29
 msgid "label_workflow_state"
 msgstr "Etat:"
 
@@ -608,8 +620,8 @@ msgid "the dossier start date is missing."
 msgstr "Aucune date de début n'a été saisie"
 
 #. Default: "expired"
-#: ./opengever/dossier/project_templates/byline.pt:53
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:54
+#: ./opengever/dossier/project_templates/byline.pt:51
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:52
 msgid "time_expired"
 msgstr "Périmé"
 
@@ -627,5 +639,4 @@ msgstr "Aucun envoi possible de documents à un autre service. Vous êtes unique
 #: ./opengever/dossier/behaviors/participation.py:194
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation"
-
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/plone.po
@@ -17,9 +17,6 @@ msgstr ""
 msgid "Add Participant"
 msgstr "Participant"
 
-msgid "Document with docucomposer"
-msgstr "Document avec DocuComposer"
-
 msgid "Dossier state changed to dossier-state-active"
 msgstr "Etat du dossier modifié : En modification"
 

--- a/opengever/dossier/locales/opengever.dossier-manual.pot
+++ b/opengever/dossier/locales/opengever.dossier-manual.pot
@@ -41,9 +41,6 @@ msgstr ""
 msgid "sharing"
 msgstr ""
 
-msgid "document_with_docucomposer"
-msgstr ""
-
 msgid "participants"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-04-03 08:06+0000\n"
+"POT-Creation-Date: 2013-10-24 09:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Add Participant"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:222
+#: ./opengever/dossier/behaviors/dossier.py:229
 msgid "Add Subdossier"
 msgstr ""
 
@@ -56,11 +56,12 @@ msgstr ""
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:237
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "Edit Subdossier"
 msgstr ""
 
 #: ./opengever/dossier/profiles/default/actions.xml
+#: ./opengever/dossier/upgrades/profiles/2601/actions.xml
 msgid "Export selection"
 msgstr ""
 
@@ -111,7 +112,7 @@ msgstr ""
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:69
+#: ./opengever/dossier/deactivate.py:68
 msgid "The Dossier has been activated"
 msgstr ""
 
@@ -143,11 +144,11 @@ msgstr ""
 msgid "The given value is not a valid Year"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:194
+#: ./opengever/dossier/behaviors/dossier.py:201
 msgid "The start date must be before the end date."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:244
+#: ./opengever/dossier/behaviors/dossier.py:251
 msgid "The start or end date is invalid"
 msgstr ""
 
@@ -220,9 +221,6 @@ msgid "create_document_with_template"
 msgstr ""
 
 msgid "description"
-msgstr ""
-
-msgid "document_with_docucomposer"
 msgstr ""
 
 msgid "documents"
@@ -385,8 +383,8 @@ msgid "label_add_participant"
 msgstr ""
 
 #. Default: "by ${author}"
-#: ./opengever/dossier/project_templates/byline.pt:16
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:19
+#: ./opengever/dossier/project_templates/byline.pt:14
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:22
 msgid "label_by_author"
 msgstr ""
 
@@ -426,7 +424,7 @@ msgid "label_edit_after_creation"
 msgstr ""
 
 #. Default: "E-Mail:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:89
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:77
 msgid "label_email_address"
 msgstr ""
 
@@ -438,13 +436,13 @@ msgid "label_end"
 msgstr ""
 
 #. Default: "to:"
-#: ./opengever/dossier/project_templates/byline.pt:44
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:45
+#: ./opengever/dossier/project_templates/byline.pt:42
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:43
 msgid "label_end_byline"
 msgstr ""
 
 #. Default: "Filing Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:79
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:70
 msgid "label_filing_no"
 msgstr ""
 
@@ -481,7 +479,7 @@ msgstr ""
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:184
 #: ./opengever/dossier/browser/report.py:118
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:69
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:63
 msgid "label_reference_number"
 msgstr ""
 
@@ -508,7 +506,7 @@ msgid "label_roles"
 msgstr ""
 
 #. Default: "Sequence Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:59
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:56
 msgid "label_sequence_number"
 msgstr ""
 
@@ -524,8 +522,8 @@ msgid "label_start"
 msgstr ""
 
 #. Default: "from:"
-#: ./opengever/dossier/project_templates/byline.pt:35
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:36
+#: ./opengever/dossier/project_templates/byline.pt:33
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:34
 msgid "label_start_byline"
 msgstr ""
 
@@ -547,8 +545,8 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "State:"
-#: ./opengever/dossier/project_templates/byline.pt:28
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:30
+#: ./opengever/dossier/project_templates/byline.pt:26
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:29
 msgid "label_workflow_state"
 msgstr ""
 
@@ -624,8 +622,8 @@ msgid "the dossier start date is missing."
 msgstr ""
 
 #. Default: "expired"
-#: ./opengever/dossier/project_templates/byline.pt:53
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:54
+#: ./opengever/dossier/project_templates/byline.pt:51
+#: ./opengever/dossier/viewlets/businesscase_byline.pt:52
 msgid "time_expired"
 msgstr ""
 

--- a/opengever/dossier/locales/plone.pot
+++ b/opengever/dossier/locales/plone.pot
@@ -17,9 +17,6 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone\n"
 
-msgid "Document with docucomposer"
-msgstr ""
-
 msgid "Add Participant"
 msgstr ""
 

--- a/opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -78,17 +78,6 @@
         <permission value="Modify portal content"/>
     </action>
 
-    <action action_id="document_with_docucomposer"
-            visible="True"
-            title="Document with docucomposer"
-            category="folder_factories"
-            url_expr="string:${object_url}/docucomposer-wizard"
-            icon_expr=""
-            condition_expr=""
-            i18n:domain="opengever.dossier">
-        <permission value="Add portal content"/>
-    </action>
-
     <action action_id="document_with_template"
             visible="True"
             title="document_with_template"

--- a/opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
@@ -65,10 +65,6 @@
           url_expr="string:${object_url}/edit" visible="True">
     <permission value="Modify portal content"/>
   </action>
-  <action title="document_with_docucomposer"  i18n:domain="opengever.dossier" action_id="document_with_docucomposer" category="folder_factories" condition_expr=""
-          url_expr="string:${object_url}/docucomposer-wizard" visible="True">
-    <permission value="Add portal content"/>
-  </action>
 
   <!-- Tabbedview tabs-->
   <action title="Overview" action_id="overview" category="tabbedview-tabs"

--- a/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
@@ -63,17 +63,6 @@
         <permission value="opengever.dossier: Add templatedossier"/>
     </action>
 
-    <action action_id="document_with_docucomposer"
-            visible="True"
-            title="Document with docucomposer"
-            category="folder_factories"
-            url_expr="string:${object_url}/docucomposer-wizard"
-            icon_expr=""
-            condition_expr=""
-            i18n:domain="opengever.dossier">
-        <permission value="Add portal content"/>
-    </action>
-
     <!-- Tabbedview tabs-->
     <action title="Templates" action_id="documents" category="tabbedview-tabs"
             condition_expr="" url_expr="string:#" visible="True">

--- a/opengever/dossier/tests/main_dossier.py
+++ b/opengever/dossier/tests/main_dossier.py
@@ -117,7 +117,6 @@ class TestMainDossier(FunctionalTestCase):
     is_special_dossier = False
 
     default_contentmenu_order = ['Document',
-                                 'Document with docucomposer',
                                  'document_with_template',
                                  'Task',
                                  'Add task from template',
@@ -126,7 +125,6 @@ class TestMainDossier(FunctionalTestCase):
                                 ]
 
     default_contentmenu_order_subdossier = ['Document',
-                                            'Document with docucomposer',
                                             'document_with_template',
                                             'Task',
                                             'Add task from template',


### PR DESCRIPTION
Some parts of the DocuComposer integration are still in `opengever.core`. Those should be moved out to the `opengever.docucomposer` package.
