### PR TITLE
LDAP import: Group ID may be in `cn` or `fullname` attribute - deal with it

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- LDAP import: groupid may be in 'cn' or 'fullname' attribute.
+  Handle both cases gracefully.
+  [lgraf]
 
 
 3.1.1 (2013-10-23)

--- a/opengever/ogds/base/ldap_import/ogds_updater.py
+++ b/opengever/ogds/base/ldap_import/ogds_updater.py
@@ -123,9 +123,15 @@ class OGDSUpdater(grok.Adapter):
             for ldap_group in ldap_groups:
                 dn, info = ldap_group
 
-                # Group name is in the 'cn' attribute, which is mapped to 'fullname'
-                info['groupid'] = info['fullname']
+                # Group name is in the 'cn' attribute, which may be mapped to 'fullname'
+                try:
+                    info['groupid'] = info['cn'][0]
+                except KeyError:
+                    info['groupid'] = info['fullname'][0]
+
+                info['groupid'] = info['groupid'].decode('utf-8')
                 groupid = info['groupid']
+
                 if not self.group_exists(groupid):
                     # Create the new group
                     group = Group(groupid)


### PR DESCRIPTION
LDAP synchronization failed at group ids.
@phgross pached that in the egg. Please move the fix to opengever.core.

```
# Group name is in the 'cn' attribute, which is mapped to 'fullname'
            # XXX PATHCHED
            info['groupid'] = info.get('cn')[0]
            info['groupid'] = info['groupid'].decode('utf-8')
```

https://github.com/4teamwork/opengever.core/blob/master/opengever/ogds/base/ldap_import/ogds_updater.py#L127
