### PR TITLE
LDAP Util: When checking if attributes are multivalued, store results in a cache

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,12 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- LDAP util: When checking if attributes are multivalued, store results in a cache.
+  This prevents us from hitting the schema more often than necessary, and, as a side
+  effect, causes warnings about attributes not declared in schemata to be printed
+  only once.
+  [lgraf]
+
 - LDAP util: Added method to list all objectClasses defined in schema.
   [lgraf]
 


### PR DESCRIPTION
This prevents us from hitting the schema more often than necessary, and, as a side
effect, causes warnings about attributes not declared in schemata to be printed
only once.
