### PR TITLE
LDAP Util: Only use PagedResults controls if the server advertised to support them

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- LDAP util: Only use PagedResults controls if the server advertises to support them.
+  [lgraf]
+
 - LDAP util: When checking if attributes are multivalued, store results in a cache.
   This prevents us from hitting the schema more often than necessary, and, as a side
   effect, causes warnings about attributes not declared in schemata to be printed

--- a/opengever/ogds/base/interfaces.py
+++ b/opengever/ogds/base/interfaces.py
@@ -1,5 +1,7 @@
 from zope import schema
+from zope.interface import Attribute
 from zope.interface import Interface
+
 import ldap
 
 
@@ -53,6 +55,8 @@ class ILDAPSearch(Interface):
 
     Uses connection settings defined in the adapted LDAPUserFolder.
     """
+
+    supported_controls = Attribute('List of controls supported by server.')
 
     def connect():
         """Establish a connection (or return an existing one for re-use) by


### PR DESCRIPTION
Currently the LDAP util tries to use PagedResults controls for every connection, regardless if the server supports them or not, and deals with the exception by complaining about the server not supporting them and issuing a second request with PagedResult controls.

This should be changed to
- first try to get a list of the supported controls from the server
- only using a PagedResults control in the request if the server advertised to support them
- and only complaining and falling back to the behavior described above if the server claims to support the controls, but doesn't. 
