### PR TITLE
LDAP import: Deal with mutli-valued fields named the same as an OGDS column

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,11 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- OGDS updater: Deal with mutli-valued fields named the same as an OGDS column.
+  [lgraf]
+
 - OGDS updater: fullname field is already single-valued, don't try to treat it like a list.
-  [lukasg]
+  [lgraf]
 
 - Moved docucomposer in own package.
   [lknoepfel]

--- a/opengever/ogds/base/ldap_import/ogds_updater.py
+++ b/opengever/ogds/base/ldap_import/ogds_updater.py
@@ -102,6 +102,12 @@ class OGDSUpdater(grok.Adapter):
                         # in our SQL model
                         continue
                     value = info.get(col.name)
+
+                    # We can't store sequences in SQL columns. So if we do get a multi-valued field
+                    # to be stored directly in OGDS, we treat it as a multi-line string and join it.
+                    if isinstance(value, list) or isinstance(value, tuple):
+                        value = ' '.join([str(v) for v in value])
+
                     setattr(user, col.name, value)
 
                 # Set the user active
@@ -144,6 +150,13 @@ class OGDSUpdater(grok.Adapter):
                 columns = Group.__table__.columns
                 for col in columns:
                     value = info.get(col.name)
+
+                    # We can't store sequences in SQL columns. So if we do get
+                    # a multi-valued field to be stored directly in OGDS, we
+                    # treat it as a multi-line string and join it.
+                    if isinstance(value, list) or isinstance(value, tuple):
+                        value = ' '.join([str(v) for v in value])
+
                     setattr(group, col.name, value)
 
                 contained_users = []


### PR DESCRIPTION
If an LDAP attribute is called the same as an OGDS column, and is multi-valued, the current code tries to store it directly in the SQL. Which will fail with

```
(DatabaseError) ORA-01484: arrays can only be bound to PL/SQL statements
```

for example.
