### PR TITLE
OGDS updater: Remove is_ldap_reachable check. It's unnecessary and broken

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- OGDS updater: Deactivate is_ldap_reachable check. It's unnecessary and broken.
+  [lgraf]
+
 - OGDS updater: Deal with mutli-valued fields named the same as an OGDS column.
   [lgraf]
 

--- a/opengever/ogds/base/browser/ldapcontrolpanel.py
+++ b/opengever/ogds/base/browser/ldapcontrolpanel.py
@@ -9,7 +9,6 @@ from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.statusmessages.interfaces import IStatusMessage
 from time import strftime
 from zope.component import getUtility
-import ldap
 import time
 import transaction
 
@@ -56,25 +55,8 @@ class LDAPSyncView(grok.View):
     def run_update(self):
         raise NotImplemented
 
-    def _check_if_ldap_is_reachable(self):
-        """Check if LDAP server is reachable before we start any import.
-        """
-        self.log('Checking if LDAP is reachable...')
-        ldap_folder = self.context.acl_users.get('ldap').get('acl_users')
-        server = ldap_folder.getServers()[0]
-        ldap_url = "%s://%s:%s" % (
-            server['protocol'], server['host'], server['port'])
-        ldap_conn = ldap.initialize(ldap_url)
-        ldap_conn.search_s(ldap_folder.users_base, ldap.SCOPE_SUBTREE)
-
     def render(self):
         self.log = self.mklog()
-
-        try:
-            self._check_if_ldap_is_reachable()
-        except ldap.LDAPError, e:
-            return "LDAP is not reachable. \
-                Couldn't start LDAP import. LDAPError: %s" % (e)
 
         # Run import and time it
         now = time.clock()

--- a/opengever/ogds/base/ldap_import/sync_ldap.py
+++ b/opengever/ogds/base/ldap_import/sync_ldap.py
@@ -6,46 +6,13 @@ from optparse import OptionParser
 from Testing.makerequest import makerequest
 from zope.app.component.hooks import setSite
 import AccessControl
-import ldap
 import logging
-import sys
 import time
 import transaction
 
 
 logger = logging.getLogger('opengever.ogds.base')
 LOG_FORMAT = '%(asctime)s %(levelname)s [%(name)s] %(message)s'
-
-
-def check_if_ldap_reachable(site):
-    """This function gets the LDAP server from the
-    LDAPUserFolder Plugin on the Plone site and tries
-    to establish a connection.
-
-    If for some reason we can't get a connection to the LDAP,
-    we abort the entire import, because otherwise we would
-    end up with all users being set to inactive since they
-    can't be found in the LDAP.
-    """
-
-    ldap_folder = site.acl_users.get('ldap').get('acl_users')
-    server = ldap_folder.getServers()[0]
-    ldap_url = "%s://%s:%s" % (
-        server['protocol'], server['host'], server['port'])
-    ldap_conn = ldap.initialize(ldap_url)
-    try:
-        ldap_conn.search_s(ldap_folder.users_base, ldap.SCOPE_SUBTREE)
-    except ldap.LDAPError, e:
-        # If for some reason we can't get a connection to the LDAP,
-        # we abort the entire import, because otherwise we would
-        # end up with all users being set to inactive since they
-        # can't be found in the LDAP.
-        logger.error(
-            "ERROR: Couldn't connect to LDAP server: %s %s" % (
-                e.__class__.__name__, e))
-        logger.error("The import has been aborted.")
-        transaction.abort()
-        sys.exit(1)
 
 
 def run_import(app, options):
@@ -65,8 +32,6 @@ def run_import(app, options):
         log_handler.setFormatter(log_formatter)
         logger.addHandler(log_handler)
         logger.setLevel(logging.INFO)
-
-    check_if_ldap_reachable(plone)
 
     # setup user context
     user = AccessControl.SecurityManagement.SpecialUsers.system


### PR DESCRIPTION
- broken because: The check doesn't properly authenticate the LDAP connection
- unnecessary because: Either `Products.LDAPUserFolder` or `python-ldap` will raise anyway if something goes wrong
