### PR TITLE
LDAP util: Only apply schema mapping to user objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- LDAP util: Only apply schema mapping to user objects.
+  [lgraf]
+
 - DefaultDocumentIndexer: Catch any exceptions raised by transforms and log them.
   [lgraf]
 


### PR DESCRIPTION
Currently the schema map retrieved from LDAPUserFolder is applied to all entities. However, LDAPUserFolder apparently only applies it to user entries, so our LDAP utility should do the same.
