### PR TITLE
LDAP import: Consider all possible group objectClasses and member attribute names 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- OGDS updater: Consider all possible member attribute names when getting members from a group.
+  [lgraf]
+
 - LDAP util: Consider all possible objectClasses when searching for groups.
   [lgraf]
 

--- a/opengever/ogds/base/ldap_import/ogds_updater.py
+++ b/opengever/ogds/base/ldap_import/ogds_updater.py
@@ -7,6 +7,7 @@ from opengever.ogds.models.group import Group
 from opengever.ogds.models.user import User
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.LDAPMultiPlugins.interfaces import ILDAPMultiPlugin
+from Products.LDAPUserFolder.utils import GROUP_MEMBER_MAP
 
 
 class OGDSUpdater(grok.Adapter):
@@ -177,7 +178,12 @@ class OGDSUpdater(grok.Adapter):
                 session.flush()
 
     def get_group_members(self, info):
-        if 'uniqueMember' in info:
-            return info.get('uniqueMember', [])
-        else:
-            return info.get('member', [])
+        members = []
+        member_attrs = list(set(GROUP_MEMBER_MAP.values()))
+        for member_attr in member_attrs:
+            if member_attr in info:
+                m = info.get(member_attr, [])
+                if isinstance(m, basestring):
+                    m = [m]
+                members.extend(m)
+        return members

--- a/opengever/ogds/base/ldap_util.py
+++ b/opengever/ogds/base/ldap_util.py
@@ -234,11 +234,16 @@ class LDAPSearch(grok.Adapter):
         is used to further filter the results.
         """
         # Build a filter expression that matches objectClasses for all
-        # possible group objectClasses
-        oc_filter = '(|%s)' % ''.join([filter_format('(%s=%s)',
-                                                     ('objectClass', o))
-                                      for o in GROUP_MEMBER_MAP.keys() ])
-        search_filter = oc_filter
+        # possible group objectClasseses encountered in the wild
+
+        possible_classes = ''
+        for oc in GROUP_MEMBER_MAP.keys():
+            # concatenate (objectClass=foo) pairs
+            possible_classes += filter_format('(%s=%s)', ('objectClass', oc))
+
+        # Build the final OR expression:
+        # (|(objectClass=aaa)(objectClass=bbb)(objectClass=ccc))
+        search_filter = '(|%s)' % possible_classes
 
         custom_filter = self.get_group_filter()
         if custom_filter not in [None, '']:


### PR DESCRIPTION
LDAP util:
- Consider all possible group objectClasses (`groupOfUniqueNames`, `groupOfNames`, `group`, ...) when searching for groups

OGDS updater:
- Consider all possible member attribute names (`uniqueMember`, `member`, ...) when getting users from a group
- Make sure `get_group_members()` always returns a list
