### PR TITLE
Added missing profile register.

### DIFF
--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -52,6 +52,15 @@
         profile="opengever.base:default"
         />
 
+    <genericsetup:registerProfile
+        name="2602"
+        title="opengever.base: upgrade profile 2602"
+        description=""
+        directory="profiles/2602"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
     <!-- 2602 -> 2603 -->
     <genericsetup:upgradeStep
         title="Initialize referencenumber formatters."


### PR DESCRIPTION
Fixed the `to2602` `opengever.base` upgradestep. The profile register part was removed during a merge. 
