### PR TITLE
Exception at generating dossier cover

### DIFF
--- a/opengever/latex/dossiercover.py
+++ b/opengever/latex/dossiercover.py
@@ -77,4 +77,4 @@ class DossierCoverLaTeXView(grok.MultiAdapter, MakoLaTeXView):
         while not IRepositoryRoot.providedBy(obj):
             obj = aq_parent(aq_inner(obj))
 
-        return obj.version
+        return obj.version or ''

--- a/opengever/latex/tests/test_dossiercover.py
+++ b/opengever/latex/tests/test_dossiercover.py
@@ -30,9 +30,9 @@ class TestDossierCoverRenderArguments(FunctionalTestCase):
 
         create_ogds_user('hugo.boss')
 
-        repository = create(Builder('repository_root')
+        self.repository = create(Builder('repository_root')
                             .having(version='Repository 2013 & 2014'))
-        repofolder = create(Builder('repository').within(repository))
+        repofolder = create(Builder('repository').within(self.repository))
         dossier = create(Builder('dossier')
                          .having(title=u'Foo & bar',
                                  responsible='hugo.boss',
@@ -53,6 +53,12 @@ class TestDossierCoverRenderArguments(FunctionalTestCase):
     def test_contains_repository_version(self):
         arguments = self.dossiercover.get_render_arguments()
         self.assertEquals(u'Repository 2013 \\& 2014',
+                          arguments.get('repositoryversion'))
+
+    def test_repository_returns_empty_string_and_not_none_if_version_is_not_set(self):
+        self.repository.version = None
+        arguments = self.dossiercover.get_render_arguments()
+        self.assertEquals('',
                           arguments.get('repositoryversion'))
 
     def test_contains_referencenr(self):


### PR DESCRIPTION
Exception on opengever.sg.

URL: http://localhost:10101/stasg/ordnungssystem/ressourcen/personal/rekrutierung/dossier-3/dossier_cover_pdf

Traceback (innermost last):

Module ZPublisher.Publish, line 60, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 46, in call_object
Module grokcore.view.components, line 101, in **call**
Module zope.publisher.publish, line 107, in mapply
**traceback_info**: <bound method DossierCoverPDFView.render of <opengever.latex.dossiercover.DossierCoverPDFView object at 0x7fc7f17c2d10>>
Module zope.publisher.publish, line 113, in debug_call
Module opengever.latex.dossiercover, line 31, in render
Module ftw.pdfgenerator.browser.views, line 20, in **call**
Module ftw.pdfgenerator.browser.views, line 45, in export
Module ftw.pdfgenerator.assembler, line 25, in build_pdf
Module ftw.pdfgenerator.assembler, line 75, in render_latex
Module ftw.pdfgenerator.layout.baselayout, line 234, in render_latex_for
Module ftw.pdfgenerator.view, line 60, in render
Module opengever.latex.dossiercover, line 45, in get_render_arguments
Module ftw.pdfgenerator.view, line 72, in convert_plain
Module ftw.pdfgenerator.html2latex.converter, line 134, in convert_plain
Module ftw.pdfgenerator.utils, line 69, in encode_htmlentities
AttributeError: 'NoneType' object has no attribute 'decode'
