### PR TITLE
Referencenumber formatter: configurable `dossier_document_seperator`

### DIFF
--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -11,6 +11,7 @@ class DottedReferenceFormatter(grok.Adapter):
     grok.name('dotted')
 
     repository_dossier_seperator = u'/'
+    dossier_document_seperator = u'/'
 
     def complete_number(self, numbers):
         """Generate the complete reference number, for the given numbers dict.
@@ -30,8 +31,9 @@ class DottedReferenceFormatter(grok.Adapter):
                 self.dossier_number(numbers))
 
         if self.document_number(numbers):
-            reference_number = u'%s / %s' % (
+            reference_number = u'%s %s %s' % (
                 reference_number,
+                self.dossier_document_seperator,
                 self.document_number(numbers))
 
         return reference_number.encode('utf-8')
@@ -70,6 +72,7 @@ class GroupedByThreeReferenceFormatter(DottedReferenceFormatter):
     grok.name('grouped_by_three')
 
     repository_dossier_seperator = u'-'
+    dossier_document_seperator = u'-'
 
     def repository_number(self, numbers):
 

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -162,3 +162,12 @@ class TestGroupedbyThreeFormatter(FunctionalTestCase):
 
         self.assertEquals(
             'OG 573.2 - 4.6.2', self.formatter.complete_number(numbers))
+
+    def test_document_part_is_separated_with_hyphen(self):
+        numbers = {'site': ['OG', ],
+                   'repository': [u'5', u'7', u'3', u'2'],
+                   'dossier': [u'4', u'6', u'2'],
+                   'document': [u'27']}
+
+        self.assertEquals(
+            'OG 573.2 - 4.6.2 - 27', self.formatter.complete_number(numbers))


### PR DESCRIPTION
I implemented the dossier_document_seperator wich separtes the dossier and the document part in the referenceNumber configurable.

This is used in the `grouped_by_three` formatter, which use hyphen instead of a slash as seperator:

`OG 573.2 - 4.6 / 27` --> `OG 573.2 - 4.6 - 27`
