### PR TITLE
Repository Title accessor: Made separator configurable by reference formatter.

### DIFF
--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -12,6 +12,7 @@ class DottedReferenceFormatter(grok.Adapter):
 
     repository_dossier_seperator = u'/'
     dossier_document_seperator = u'/'
+    repository_title_seperator = u'.'
 
     def complete_number(self, numbers):
         """Generate the complete reference number, for the given numbers dict.
@@ -73,6 +74,7 @@ class GroupedByThreeReferenceFormatter(DottedReferenceFormatter):
 
     repository_dossier_seperator = u'-'
     dossier_document_seperator = u'-'
+    repository_title_seperator = u''
 
     def repository_number(self, numbers):
 

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -95,9 +95,13 @@ class RepositoryFolder(content.Container):
     implements(IRepositoryFolder)
 
     def Title(self):
-        title = u'%s. %s' % (
-            IReferenceNumber(self).get_repository_number(),
-            self.effective_title)
+
+        reference_adapter = IReferenceNumber(self)
+
+        title = u'{number}{sep} {title}'.format(
+            number=reference_adapter.get_repository_number(),
+            sep=reference_adapter.get_active_formatter().repository_title_seperator,
+            title=self.effective_title)
 
         return title.encode('utf-8')
 

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -1,8 +1,13 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix
 from opengever.repository.repositoryfolder import IRepositoryFolderSchema
 from opengever.testing import FunctionalTestCase
 from plone.dexterity.interfaces import IDexterityFTI
+from plone.registry.interfaces import IRegistry
 from zope.component import createObject
+from zope.component import getUtility
 from zope.component import queryUtility
 
 
@@ -28,6 +33,35 @@ class TestRepositoryFolder(FunctionalTestCase):
         factory = fti.factory
         new_object = createObject(factory)
         self.failUnless(IRepositoryFolderSchema.providedBy(new_object))
+
+
+class TestRepositoryFolderTitleAccessor(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRepositoryFolderTitleAccessor, self).setUp()
+
+        repository_1 = create(Builder('repository'))
+
+        repository_1_1 = create(Builder('repository')
+                                .within(repository_1))
+
+        self.repository_folder = create(Builder('repository')
+                                  .within(repository_1_1)
+                                  .titled(u'Repositoryfolder XY'))
+
+    def test_returns_reference_number_and_title_seperatoded_with_space(self):
+        self.assertEquals(
+            '1.1.1. Repositoryfolder XY',
+            self.repository_folder.Title())
+
+    def test_Title_accessor_use_reference_formatters_seperator(self):
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IReferenceNumberSettings)
+        proxy.formatter = 'grouped_by_three'
+
+        self.assertEquals(
+            '111 Repositoryfolder XY',
+            self.repository_folder.Title())
 
 
 class TestRepositoryFolderWithBrowser(FunctionalTestCase):


### PR DESCRIPTION
The separator between Referencenumber and Title, depends on the current reference number formatter. Therefore i implement the seperator configurable by the `ReferenceNumberFormatter`. 

`dotted`:
![bildschirmfoto 2013-11-14 um 20 17 24](https://f.cloud.github.com/assets/485755/1544057/6929291a-4d61-11e3-924f-5cf54bce8709.png)

`grouped_by_three`:
![bildschirmfoto 2013-11-14 um 20 15 16](https://f.cloud.github.com/assets/485755/1544045/4d5a5754-4d61-11e3-83cc-1d357c807fda.png)
