### PR TITLE
Fixed referenceprefix starting point for dossiers.

### DIFF
--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -54,7 +54,10 @@ class ReferenceNumberPrefixAdpater(grok.Adapter):
             return DOSSIER_KEY
         return REPOSITORY_FOLDER_KEY
 
-    def get_first_number(self):
+    def get_first_number(self, obj=None):
+        if self.get_type_key(obj) == DOSSIER_KEY:
+            return u'1'
+
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IReferenceNumberSettings)
         return proxy.reference_prefix_starting_point
@@ -68,7 +71,7 @@ class ReferenceNumberPrefixAdpater(grok.Adapter):
 
         if not child_mapping.keys():
             # It's the first number ever issued
-            return self.get_first_number()
+            return self.get_first_number(obj)
         else:
             prefixes_in_use = child_mapping.keys()
             # Sort the list of unicode strings *numerically*

--- a/opengever/base/tests/test_reference_prefix.py
+++ b/opengever/base/tests/test_reference_prefix.py
@@ -25,6 +25,16 @@ class TestReferencePrefixAdapter(FunctionalTestCase):
         proxy.reference_prefix_starting_point = u'0'
         self.assertEquals(u'0', self.adapter.get_next_number())
 
+    def test_numbering_for_dossiers_starts_always_at_one(self):
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IReferenceNumberSettings)
+        proxy.reference_prefix_starting_point = u'0'
+
+        dossier = create(Builder('dossier').within(self.repository))
+        self.assertEquals(
+            u'1',
+            self.adapter.get_number(dossier))
+
     def test_numbering_continues_after_nine(self):
         self.set_numbering_base(u'9')
         self.assertEquals(u'10', self.adapter.get_next_number())


### PR DESCRIPTION
The referenceprefix startingpoint for dossiers should not be affected by the configured value in the registry (`IReferenceNumberSettings.reference_prefix_starting_point`). The dossier referenceprefix should always start by 1.
