### PR TITLE
Switch EPS logo with a PDF one.

### DIFF
--- a/opengever/latex/layouts/resources/default_layout.tex
+++ b/opengever/latex/layouts/resources/default_layout.tex
@@ -75,9 +75,9 @@
 
 %% -- LOGO --
 % if show_logo:
-\begin{textblock}{60mm\TPHorizModule} (35.3mm\TPHorizModule,
+\begin{textblock}{60mm\TPHorizModule} (17mm\TPHorizModule,
   10mm\TPVertModule)
-  \includegraphics[height=28mm]{logo.eps}
+  \includegraphics[height=40mm]{logo.pdf}
 \end{textblock}
 % endif
 


### PR DESCRIPTION
In some case it's not possible to include a *.eps file, so it's the better way to use a PDF instead.
