### PR TITLE
OGDS updater: Make check for AD user IDs more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- OGDS updater: Make check for AD user IDs more robust.
+  [lgraf]
+
 - DefaultDocumentIndexer: Store transform cache on context.file._blob, not context.file.
   (NamedFileInstances are not recreated when updating file contents)
   [lgraf]


### PR DESCRIPTION
Depending on what `groupid_attr` and `User ID Attribute` are set to for the Active Directory plugin and LDAPUserFolder, the user and group IDs may end up in different attributes, and may or may not be mapped.

This change make the check for a valid UID more robust, trying `['userid', 'sAMAccountName', 'windows_login_name']` in this order.
