### PR TITLE
OGDS Listing: Display empty string for users without a name or firstname.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 - Advancedsearch: Dropped reference number solution.
   [phgross]
 
+- OGDS Listing: Display empty string for users without a name or firstname.
+  [phgross]
+
 - OGDS updater: Make check for AD user IDs more robust.
   [lgraf]
 

--- a/opengever/tabbedview/browser/users.py
+++ b/opengever/tabbedview/browser/users.py
@@ -17,6 +17,9 @@ def linked_value_helper(item, value):
     """Helper for linking the value with the user profile.
     """
 
+    if not value:
+        return ''
+
     info = getUtility(IContactInformation)
     url = info.get_profile_url(getattr(item, 'userid', None))
 

--- a/opengever/tabbedview/tests/test_helpers.py
+++ b/opengever/tabbedview/tests/test_helpers.py
@@ -1,10 +1,8 @@
 from ftw.testing import MockTestCase
-from mocker import ANY
 from opengever.ogds.base.interfaces import IContactInformation
+from opengever.tabbedview.browser.users import linked_value_helper
 from opengever.tabbedview.helper import linked_ogds_author
 from opengever.tabbedview.helper import task_id_checkbox_helper
-from opengever.tabbedview.utils import get_containg_document_tab_url
-from zope.interface import Interface
 
 
 class TestDocumentsUrl(MockTestCase):
@@ -50,3 +48,39 @@ class TestDocumentsUrl(MockTestCase):
             task_id_checkbox_helper(brain, ''),
             '<input class="noborder selectable" id="123" name="task_ids:list" '
             'title="Select The brain of a task" type="checkbox" value="123" />')
+
+
+class TestLinkedValueHelper(MockTestCase):
+
+    def test_returns_empty_string_for_none_value(self):
+        item = self.stub()
+        self.replay()
+
+        self.assertEquals('', linked_value_helper(item, None))
+
+    def test_returns_username_linked_to_profile(self):
+        item = self.stub()
+        self.expect(item.userid).result('hugo.boss')
+
+        info = self.stub()
+        self.mock_utility(info, IContactInformation)
+        self.expect(info.get_profile_url('hugo.boss')).result(
+            'http://localhost:8080/userdetails/hugo-boss')
+
+        self.replay()
+
+        self.assertEquals(
+            '<a href="http://localhost:8080/userdetails/hugo-boss">Hugo</a>',
+            linked_value_helper(item, 'Hugo'))
+
+    def test_returns_only_value_for_values_without_a_entry_in_ogds(self):
+        item = self.stub()
+        self.expect(item.userid).result('hugo.boss')
+
+        info = self.stub()
+        self.mock_utility(info, IContactInformation)
+        self.expect(info.get_profile_url('hugo.boss')).result(None)
+
+        self.replay()
+
+        self.assertEquals('Hugo', linked_value_helper(item, 'Hugo'))


### PR DESCRIPTION
Before:
![bildschirmfoto 2013-11-21 um 16 14 51](https://f.cloud.github.com/assets/485755/1592675/c3b5620a-52bf-11e3-84bf-0a7b28fe38e4.png)
After:
![bildschirmfoto 2013-11-21 um 16 14 09](https://f.cloud.github.com/assets/485755/1592674/c3b51250-52bf-11e3-88a6-c7063c0c9b4f.png)
