### PR TITLE
Fixed label translations for the task byline (doubled `:`).

### DIFF
--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "POT-Creation-Date: 2013-11-21 09:02+0000\n"
-"PO-Revision-Date: 2012-12-03 16:30+0100\n"
+"PO-Revision-Date: 2013-11-25 09:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "MIME-Version: 1.0\n"
@@ -181,7 +181,7 @@ msgstr "Kommentar"
 #. Default: "Created"
 #: ./opengever/base/viewlets/byline.py:60
 msgid "label_created"
-msgstr "Erstellt am:"
+msgstr "Erstellt am"
 
 #. Default: "Creators"
 #: ./opengever/base/behaviors/creator.py:20

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -462,7 +462,7 @@ msgstr "Weiterleitung zuweisen an ein ..."
 #. Default: "by"
 #: ./opengever/task/viewlets/byline.py:44
 msgid "label_by_author"
-msgstr "Auftragnehmer:"
+msgstr "Auftragnehmer"
 
 #. Default: "Sequence Number"
 #: ./opengever/task/viewlets/byline.py:55
@@ -691,7 +691,7 @@ msgstr "Status"
 #. Default: "State"
 #: ./opengever/task/viewlets/byline.py:50
 msgid "label_workflow_state_byline"
-msgstr "Status:"
+msgstr "Status"
 
 #. Default: "Deadline successfully changed."
 #: ./opengever/task/browser/modify_deadline.py:57


### PR DESCRIPTION
![bildschirmfoto 2013-11-24 um 22 01 17](https://f.cloud.github.com/assets/485755/1609566/11c46f48-554c-11e3-9b65-559e64c6a47a.png)
