### PR TITLE
Fixed message after resolving a subdossier

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Corrected message after resolving a subdossier.
+  [phgross]
+
 - Inbox overview: List only active tasks and forwardings.
   [phgross]
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2013-10-24 09:25+0000\n"
+"POT-Creation-Date: 2013-11-27 15:55+0000\n"
 "PO-Revision-Date: 2013-04-03 10:08+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -26,7 +26,7 @@ msgstr "Geschäftsdossier hinzufügen"
 msgid "Add Participant"
 msgstr "Beteiligung hinzufügen"
 
-#: ./opengever/dossier/behaviors/dossier.py:229
+#: ./opengever/dossier/behaviors/dossier.py:222
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
@@ -39,7 +39,7 @@ msgstr "Geschäftsdossier"
 msgid "Copy documents to remote client"
 msgstr "In eigenes Dossier kopieren"
 
-#: ./opengever/dossier/browser/report.py:128
+#: ./opengever/dossier/browser/report.py:84
 msgid "Could not generate the report"
 msgstr "Report konnte nicht generiert werden."
 
@@ -51,11 +51,11 @@ msgstr "Beteiligung löschen"
 msgid "Document ${name} is connected to a Task.                    Please move the Task."
 msgstr "Dokument ${name} ist mit einer Aufgabe verbunden, bitte Aufgabe verschieben."
 
-#: ./opengever/dossier/resolve.py:70
+#: ./opengever/dossier/resolve.py:77
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
-#: ./opengever/dossier/behaviors/dossier.py:244
+#: ./opengever/dossier/behaviors/dossier.py:237
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
@@ -76,7 +76,7 @@ msgstr ""
 msgid "It isn't allowed to add such items there"
 msgstr "Sie dürfen dieses Objekt nicht an den Zielort verschieben"
 
-#: ./opengever/dossier/resolve.py:75
+#: ./opengever/dossier/resolve.py:82
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossier muss wieder eröffnet werden."
 
@@ -84,7 +84,7 @@ msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossi
 msgid "Move Items"
 msgstr "Elemente verschieben"
 
-#: ./opengever/dossier/archive.py:51
+#: ./opengever/dossier/archive.py:52
 msgid "Not all required fields are filled"
 msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 
@@ -121,39 +121,43 @@ msgstr "Das Dossier wurde aktiviert."
 msgid "The Dossier has been deactivated"
 msgstr "Das Dossier wurde storniert."
 
-#: ./opengever/dossier/archive.py:266
+#: ./opengever/dossier/archive.py:267
 msgid "The Dossier has been resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen"
 
-#: ./opengever/dossier/resolve.py:41
+#: ./opengever/dossier/resolve.py:43
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "Das Dossier ${dossier} hat ein ungültiges Enddatum."
 
-#: ./opengever/dossier/resolve.py:53
+#: ./opengever/dossier/resolve.py:59
 msgid "The dossier has been succesfully resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 
-#: ./opengever/dossier/archive.py:237
+#: ./opengever/dossier/archive.py:238
 msgid "The filing number has been given"
 msgstr "Die Ablagenummer wurde vergeben."
 
-#: ./opengever/dossier/archive.py:66
+#: ./opengever/dossier/archive.py:67
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date})."
 
-#: ./opengever/dossier/archive.py:84
+#: ./opengever/dossier/archive.py:85
 msgid "The given value is not a valid Year"
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
-#: ./opengever/dossier/behaviors/dossier.py:201
+#: ./opengever/dossier/behaviors/dossier.py:194
 msgid "The start date must be before the end date."
 msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 
-#: ./opengever/dossier/behaviors/dossier.py:251
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
-#: ./opengever/dossier/archive.py:166
+#: ./opengever/dossier/resolve.py:56
+msgid "The subdossier has been succesfully resolved"
+msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
+
+#: ./opengever/dossier/archive.py:167
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."
 
@@ -170,12 +174,12 @@ msgid "button_add"
 msgstr "Erstellen"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:210
+#: ./opengever/dossier/archive.py:211
 msgid "button_archive"
 msgstr "Speichern"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:269
+#: ./opengever/dossier/archive.py:270
 #: ./opengever/dossier/behaviors/participation.py:164
 #: ./opengever/dossier/browser/transport.py:170
 msgid "button_cancel"
@@ -233,59 +237,65 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in den Zielordner eingefügt werden: ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:61
+#: ./opengever/dossier/archive.py:62
 msgid "error_enddate"
 msgstr "Enddatum erforderlich"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/dossier/browser/report.py:77
+#: ./opengever/dossier/browser/report.py:68
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py:93
+#: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Ablage"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:153
+#: ./opengever/dossier/archive.py:154
 msgid "filing_action"
 msgstr "Aktion"
 
 #. Default: "Filing number"
-#: ./opengever/dossier/behaviors/dossier.py:116
-#: ./opengever/dossier/browser/report.py:113
+#: ./opengever/dossier/behaviors/filing.py:23
+#: ./opengever/dossier/filing/report.py:65
 msgid "filing_no"
 msgstr "Ablagenummer"
 
-#: ./opengever/dossier/browser/report.py:104
+#: ./opengever/dossier/filing/report.py:53
 msgid "filing_no_filing"
 msgstr "Ablage"
 
-#: ./opengever/dossier/browser/report.py:110
+#: ./opengever/dossier/filing/report.py:61
 msgid "filing_no_number"
 msgstr "Ablagenummer"
 
-#: ./opengever/dossier/browser/report.py:107
+#: ./opengever/dossier/filing/report.py:57
 msgid "filing_no_year"
 msgstr "Ablagejahr"
 
 msgid "filing_nr"
 msgstr "Ablagenummer vergeben"
 
+#. Default: "Filing Number"
+#: ./opengever/dossier/filing/tabs.py:10
+msgid "filing_number"
+msgstr "Ablagenummer"
+
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:132
+#: ./opengever/dossier/archive.py:133
 #: ./opengever/dossier/behaviors/dossier.py:105
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:147
+#: ./opengever/dossier/archive.py:148
 msgid "filing_year"
 msgstr "Ablage Jahr"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:202
+#: ./opengever/dossier/archive.py:203
 msgid "heading_archive_form"
 msgstr "Dossier ablegen"
 
@@ -302,11 +312,11 @@ msgstr ""
 msgid "help_contact"
 msgstr "Wählen Sie einen Benutzer oder einen Kontakt aus."
 
-#: ./opengever/dossier/behaviors/dossier.py:150
+#: ./opengever/dossier/behaviors/dossier.py:143
 msgid "help_container_location"
 msgstr "Standortangabe des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
-#: ./opengever/dossier/behaviors/dossier.py:133
+#: ./opengever/dossier/behaviors/dossier.py:126
 msgid "help_container_type"
 msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
@@ -315,20 +325,24 @@ msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 msgid "help_destination"
 msgstr "Live Search: Durchsuchen Sie diesen Mandanten"
 
-#: ./opengever/dossier/archive.py:142
+#: ./opengever/dossier/archive.py:143
 #: ./opengever/dossier/behaviors/dossier.py:73
 msgid "help_end"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:117
+#: ./opengever/dossier/behaviors/filing.py:24
 msgid "help_filing_no"
+msgstr ""
+
+#: ./opengever/dossier/filing/advanced_search.py:17
+msgid "help_filing_number"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:106
 msgid "help_filing_prefix"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:178
+#: ./opengever/dossier/behaviors/dossier.py:171
 msgid "help_former_reference_number"
 msgstr ""
 
@@ -336,11 +350,11 @@ msgstr ""
 msgid "help_keywords"
 msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
 
-#: ./opengever/dossier/behaviors/dossier.py:144
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_number_of_containers"
 msgstr "Anzahl Behälter, die ein (grosses) Dossier in Papierform enthalten"
 
-#: ./opengever/dossier/behaviors/dossier.py:185
+#: ./opengever/dossier/behaviors/dossier.py:178
 msgid "help_reference_number "
 msgstr ""
 
@@ -365,7 +379,7 @@ msgstr ""
 msgid "help_target_dossier"
 msgstr "Wählen Sie ein Dossier auf dem eigenen Mandanten aus"
 
-#: ./opengever/dossier/behaviors/dossier.py:127
+#: ./opengever/dossier/behaviors/dossier.py:120
 msgid "help_temporary_former_reference_number"
 msgstr ""
 
@@ -386,7 +400,6 @@ msgstr "Beteiligung hinzufügen"
 
 #. Default: "by ${author}"
 #: ./opengever/dossier/project_templates/byline.pt:14
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:22
 msgid "label_by_author"
 msgstr "Federführend: ${author}"
 
@@ -401,12 +414,12 @@ msgid "label_contact"
 msgstr "Person"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:149
+#: ./opengever/dossier/behaviors/dossier.py:142
 msgid "label_container_location"
 msgstr "Behältnis-Standort"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:132
+#: ./opengever/dossier/behaviors/dossier.py:125
 msgid "label_container_type"
 msgstr "Behältnis-Art"
 
@@ -425,31 +438,36 @@ msgstr "Zielposition / Zieldossier"
 msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
-#. Default: "E-Mail:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:77
+#. Default: "E-Mail"
+#: ./opengever/dossier/viewlets/byline.py:75
 msgid "label_email_address"
 msgstr "E-Mail"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:141
+#: ./opengever/dossier/archive.py:142
 #: ./opengever/dossier/behaviors/dossier.py:72
-#: ./opengever/dossier/browser/report.py:97
+#: ./opengever/dossier/browser/report.py:40
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "to:"
 #: ./opengever/dossier/project_templates/byline.pt:42
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:43
+#: ./opengever/dossier/viewlets/byline.py:56
 msgid "label_end_byline"
 msgstr "Ende"
 
-#. Default: "Filing Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:70
+#. Default: "Filing Number"
+#: ./opengever/dossier/filing/byline.py:21
 msgid "label_filing_no"
 msgstr "Ablagenummer"
 
+#. Default: "Filing number"
+#: ./opengever/dossier/filing/advanced_search.py:16
+msgid "label_filing_number"
+msgstr ""
+
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:176
+#: ./opengever/dossier/behaviors/dossier.py:169
 msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
@@ -463,13 +481,13 @@ msgstr "Schlagworte"
 msgid "label_modified"
 msgstr "Zuletzt Bearbeitet"
 
-#. Default: "Reference Number will be generated after content creation"
+#. Default: "Reference Number will be generated                 after content creation"
 #: ./opengever/dossier/widget.py:25
 msgid "label_no_reference_number"
 msgstr "Die Archivnummer wird erst beim Erstellen generiert."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:142
+#: ./opengever/dossier/behaviors/dossier.py:135
 msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
@@ -479,26 +497,26 @@ msgid "label_participation"
 msgstr "Beteiligung"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:184
-#: ./opengever/dossier/browser/report.py:118
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:63
+#: ./opengever/dossier/behaviors/dossier.py:177
+#: ./opengever/dossier/browser/report.py:50
+#: ./opengever/dossier/viewlets/byline.py:68
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:155
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "label_related_dossier"
 msgstr "Verwandte Dossiers"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:85
 #: ./opengever/dossier/browser/participants.py:161
-#: ./opengever/dossier/browser/report.py:101
+#: ./opengever/dossier/browser/report.py:44
 msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:115
+#: ./opengever/dossier/browser/report.py:47
 msgid "label_review_state"
 msgstr "Status"
 
@@ -507,8 +525,8 @@ msgstr "Status"
 msgid "label_roles"
 msgstr "Rollen"
 
-#. Default: "Sequence Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:56
+#. Default: "Sequence Number"
+#: ./opengever/dossier/viewlets/byline.py:62
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
@@ -519,13 +537,13 @@ msgstr "Ziel-Mandant"
 
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py:64
-#: ./opengever/dossier/browser/report.py:93
+#: ./opengever/dossier/browser/report.py:36
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "from:"
 #: ./opengever/dossier/project_templates/byline.pt:33
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:34
+#: ./opengever/dossier/viewlets/byline.py:50
 msgid "label_start_byline"
 msgstr "Beginn"
 
@@ -540,7 +558,7 @@ msgid "label_template"
 msgstr "Vorlage"
 
 #. Default: "title"
-#: ./opengever/dossier/browser/report.py:90
+#: ./opengever/dossier/browser/report.py:33
 #: ./opengever/dossier/templatedossier.py:180
 #: ./opengever/dossier/templatedossier_templates/template_form.pt:30
 msgid "label_title"
@@ -548,7 +566,7 @@ msgstr "Titel"
 
 #. Default: "State:"
 #: ./opengever/dossier/project_templates/byline.pt:26
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:29
+#: ./opengever/dossier/viewlets/byline.py:44
 msgid "label_workflow_state"
 msgstr "Status"
 
@@ -562,19 +580,19 @@ msgstr "Neuste Aufgaben"
 msgid "no_content"
 msgstr "Keine Inhalte"
 
-#: ./opengever/dossier/resolve.py:8
+#: ./opengever/dossier/resolve.py:10
 msgid "not all documents and tasks are stored in a subdossier"
 msgstr "Es sind nicht alle Dokumente und Aufgaben in Subdossiers abgelegt."
 
-#: ./opengever/dossier/resolve.py:10
+#: ./opengever/dossier/resolve.py:12
 msgid "not all documents are checked in"
 msgstr "Es sind nicht alle Dokumente eingecheckt"
 
-#: ./opengever/dossier/resolve.py:11
+#: ./opengever/dossier/resolve.py:13
 msgid "not all task are closed"
 msgstr "Es sind nicht alle Aufgaben abgeschlossen"
 
-#: ./opengever/dossier/archive.py:31
+#: ./opengever/dossier/archive.py:32
 msgid "only resolve, set filing no later"
 msgstr "Nur abschliessen (keine Ablagenummer vergeben)"
 
@@ -585,19 +603,19 @@ msgstr "Beteiligte"
 msgid "required"
 msgstr "erforderlich"
 
-#: ./opengever/dossier/archive.py:33
+#: ./opengever/dossier/archive.py:34
 msgid "resolve and set a new filing no"
 msgstr "Abschliessen und Ablagenummer neu vergeben"
 
-#: ./opengever/dossier/archive.py:30
+#: ./opengever/dossier/archive.py:31
 msgid "resolve and set filing no"
 msgstr "Abschliessen und Ablagenummer vergeben"
 
-#: ./opengever/dossier/archive.py:32
+#: ./opengever/dossier/archive.py:33
 msgid "resolve and take the existing filing no"
 msgstr "Abschliessen und die existierende Ablagenummer verwenden"
 
-#: ./opengever/dossier/archive.py:34
+#: ./opengever/dossier/archive.py:35
 msgid "set a filing no"
 msgstr "Ablagenummer vergeben"
 
@@ -615,17 +633,16 @@ msgid "tasks"
 msgstr "Aufgaben"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:125
+#: ./opengever/dossier/behaviors/dossier.py:118
 msgid "temporary_former_reference_number"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:12
+#: ./opengever/dossier/resolve.py:14
 msgid "the dossier start date is missing."
 msgstr "Es wurde kein Beginn-Datum gesetzt."
 
 #. Default: "expired"
 #: ./opengever/dossier/project_templates/byline.pt:51
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:52
 msgid "time_expired"
 msgstr "abgelaufen"
 
@@ -643,4 +660,3 @@ msgstr "Sie können die Dokumente nicht an einen anderen Mandanten senden, da Si
 #: ./opengever/dossier/behaviors/participation.py:194
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
-

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-10-24 09:25+0000\n"
+"POT-Creation-Date: 2013-11-27 15:55+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr "Insérer un dossier d'affaire"
 msgid "Add Participant"
 msgstr "Participant"
 
-#: ./opengever/dossier/behaviors/dossier.py:229
+#: ./opengever/dossier/behaviors/dossier.py:222
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
 
@@ -37,7 +37,7 @@ msgstr "Dossier"
 msgid "Copy documents to remote client"
 msgstr "Copier dans son propre dossier"
 
-#: ./opengever/dossier/browser/report.py:128
+#: ./opengever/dossier/browser/report.py:84
 msgid "Could not generate the report"
 msgstr "Impossible de générer l'affichage"
 
@@ -49,11 +49,11 @@ msgstr "Effacer la participation"
 msgid "Document ${name} is connected to a Task.                    Please move the Task."
 msgstr "Document ${name} est lié avec une tâche, déplacer la tâche, svp."
 
-#: ./opengever/dossier/resolve.py:70
+#: ./opengever/dossier/resolve.py:77
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès"
 
-#: ./opengever/dossier/behaviors/dossier.py:244
+#: ./opengever/dossier/behaviors/dossier.py:237
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "It isn't allowed to add such items there"
 msgstr "Cet élément ne peut être déplacé ici."
 
-#: ./opengever/dossier/resolve.py:75
+#: ./opengever/dossier/resolve.py:82
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr "Il n'est pas possible d'ouvrir un sous-dossier, le dossier principale doit être ouvert à nouveau."
 
@@ -82,7 +82,7 @@ msgstr "Il n'est pas possible d'ouvrir un sous-dossier, le dossier principale do
 msgid "Move Items"
 msgstr "Déplacer l'élément"
 
-#: ./opengever/dossier/archive.py:51
+#: ./opengever/dossier/archive.py:52
 msgid "Not all required fields are filled"
 msgstr "Manque des champs obligatoires"
 
@@ -117,39 +117,43 @@ msgstr ""
 msgid "The Dossier has been deactivated"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:266
+#: ./opengever/dossier/archive.py:267
 msgid "The Dossier has been resolved"
 msgstr "Dossier a été fermé avec succès"
 
-#: ./opengever/dossier/resolve.py:41
+#: ./opengever/dossier/resolve.py:43
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "La date du dossier ${dossier} n'est pas valable."
 
-#: ./opengever/dossier/resolve.py:53
+#: ./opengever/dossier/resolve.py:59
 msgid "The dossier has been succesfully resolved"
 msgstr "Le dossier a été fermé avec succès"
 
-#: ./opengever/dossier/archive.py:237
+#: ./opengever/dossier/archive.py:238
 msgid "The filing number has been given"
 msgstr "Le numéro d'inventaire va être attribué"
 
-#: ./opengever/dossier/archive.py:66
+#: ./opengever/dossier/archive.py:67
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou égale à la date la plus récente de l'objet contenu."
 
-#: ./opengever/dossier/archive.py:84
+#: ./opengever/dossier/archive.py:85
 msgid "The given value is not a valid Year"
 msgstr "L'année de dépôt attribuée n'est pas valable"
 
-#: ./opengever/dossier/behaviors/dossier.py:201
+#: ./opengever/dossier/behaviors/dossier.py:194
 msgid "The start date must be before the end date."
 msgstr "La date de début doit être plus récente que la date de clôture."
 
-#: ./opengever/dossier/behaviors/dossier.py:251
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
-#: ./opengever/dossier/archive.py:166
+#: ./opengever/dossier/resolve.py:56
+msgid "The subdossier has been succesfully resolved"
+msgstr "Le sous-dossier a été fermé avec succès"
+
+#: ./opengever/dossier/archive.py:167
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution de numéro d'inventaire, tous les champs sont obligatoires"
 
@@ -166,12 +170,12 @@ msgid "button_add"
 msgstr "Etablir"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:210
+#: ./opengever/dossier/archive.py:211
 msgid "button_archive"
 msgstr "Enregistrer"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:269
+#: ./opengever/dossier/archive.py:270
 #: ./opengever/dossier/behaviors/participation.py:164
 #: ./opengever/dossier/browser/transport.py:170
 msgid "button_cancel"
@@ -229,59 +233,65 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Pas d'objet déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi : ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:61
+#: ./opengever/dossier/archive.py:62
 msgid "error_enddate"
 msgstr "Date de clôture obligatoire"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/dossier/browser/report.py:77
+#: ./opengever/dossier/browser/report.py:68
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun objet."
 
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py:93
+#: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Classeur"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:153
+#: ./opengever/dossier/archive.py:154
 msgid "filing_action"
 msgstr "Action"
 
 #. Default: "Filing number"
-#: ./opengever/dossier/behaviors/dossier.py:116
-#: ./opengever/dossier/browser/report.py:113
+#: ./opengever/dossier/behaviors/filing.py:23
+#: ./opengever/dossier/filing/report.py:65
 msgid "filing_no"
 msgstr "Numéro d'inventaire"
 
-#: ./opengever/dossier/browser/report.py:104
+#: ./opengever/dossier/filing/report.py:53
 msgid "filing_no_filing"
 msgstr "Classeur"
 
-#: ./opengever/dossier/browser/report.py:110
+#: ./opengever/dossier/filing/report.py:61
 msgid "filing_no_number"
 msgstr "Numéro d'inventaire"
 
-#: ./opengever/dossier/browser/report.py:107
+#: ./opengever/dossier/filing/report.py:57
 msgid "filing_no_year"
 msgstr "Année de dépôt"
 
 msgid "filing_nr"
 msgstr "Attribuer un numéro d'inventaire"
 
+#. Default: "Filing Number"
+#: ./opengever/dossier/filing/tabs.py:10
+msgid "filing_number"
+msgstr ""
+
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:132
+#: ./opengever/dossier/archive.py:133
 #: ./opengever/dossier/behaviors/dossier.py:105
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:147
+#: ./opengever/dossier/archive.py:148
 msgid "filing_year"
 msgstr "Année de dépôt"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:202
+#: ./opengever/dossier/archive.py:203
 msgid "heading_archive_form"
 msgstr "Classer le dossier"
 
@@ -298,11 +308,11 @@ msgstr ""
 msgid "help_contact"
 msgstr "Choix d'un utilisateur ou un contact."
 
-#: ./opengever/dossier/behaviors/dossier.py:150
+#: ./opengever/dossier/behaviors/dossier.py:143
 msgid "help_container_location"
 msgstr "Emplacement du dossier imprimé"
 
-#: ./opengever/dossier/behaviors/dossier.py:133
+#: ./opengever/dossier/behaviors/dossier.py:126
 msgid "help_container_type"
 msgstr "Type de conteneur du dossier imprimé"
 
@@ -311,20 +321,24 @@ msgstr "Type de conteneur du dossier imprimé"
 msgid "help_destination"
 msgstr "Recherche en direct: Recherche de ce client"
 
-#: ./opengever/dossier/archive.py:142
+#: ./opengever/dossier/archive.py:143
 #: ./opengever/dossier/behaviors/dossier.py:73
 msgid "help_end"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:117
+#: ./opengever/dossier/behaviors/filing.py:24
 msgid "help_filing_no"
+msgstr ""
+
+#: ./opengever/dossier/filing/advanced_search.py:17
+msgid "help_filing_number"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:106
 msgid "help_filing_prefix"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:178
+#: ./opengever/dossier/behaviors/dossier.py:171
 msgid "help_former_reference_number"
 msgstr ""
 
@@ -332,11 +346,11 @@ msgstr ""
 msgid "help_keywords"
 msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de la position"
 
-#: ./opengever/dossier/behaviors/dossier.py:144
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_number_of_containers"
 msgstr "Nombre de conteneurs contenant des dossiers imprimés (volumineux)"
 
-#: ./opengever/dossier/behaviors/dossier.py:185
+#: ./opengever/dossier/behaviors/dossier.py:178
 msgid "help_reference_number "
 msgstr ""
 
@@ -361,7 +375,7 @@ msgstr ""
 msgid "help_target_dossier"
 msgstr "Choix d'un dossier dans votre service"
 
-#: ./opengever/dossier/behaviors/dossier.py:127
+#: ./opengever/dossier/behaviors/dossier.py:120
 msgid "help_temporary_former_reference_number"
 msgstr ""
 
@@ -382,7 +396,6 @@ msgstr "Participant"
 
 #. Default: "by ${author}"
 #: ./opengever/dossier/project_templates/byline.pt:14
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:22
 msgid "label_by_author"
 msgstr "Responsable: ${author}"
 
@@ -397,12 +410,12 @@ msgid "label_contact"
 msgstr "Personne"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:149
+#: ./opengever/dossier/behaviors/dossier.py:142
 msgid "label_container_location"
 msgstr "Emplacement du conteneur"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:132
+#: ./opengever/dossier/behaviors/dossier.py:125
 msgid "label_container_type"
 msgstr "Type de conteneur"
 
@@ -421,31 +434,36 @@ msgstr "Destination"
 msgid "label_edit_after_creation"
 msgstr "Modifier après avoir créé"
 
-#. Default: "E-Mail:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:77
+#. Default: "E-Mail"
+#: ./opengever/dossier/viewlets/byline.py:75
 msgid "label_email_address"
 msgstr "Email"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:141
+#: ./opengever/dossier/archive.py:142
 #: ./opengever/dossier/behaviors/dossier.py:72
-#: ./opengever/dossier/browser/report.py:97
+#: ./opengever/dossier/browser/report.py:40
 msgid "label_end"
 msgstr "Date de fin :"
 
 #. Default: "to:"
 #: ./opengever/dossier/project_templates/byline.pt:42
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:43
+#: ./opengever/dossier/viewlets/byline.py:56
 msgid "label_end_byline"
 msgstr "Jusqu'au"
 
-#. Default: "Filing Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:70
+#. Default: "Filing Number"
+#: ./opengever/dossier/filing/byline.py:21
 msgid "label_filing_no"
 msgstr "Numéro d'inventaire"
 
+#. Default: "Filing number"
+#: ./opengever/dossier/filing/advanced_search.py:16
+msgid "label_filing_number"
+msgstr ""
+
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:176
+#: ./opengever/dossier/behaviors/dossier.py:169
 msgid "label_former_reference_number"
 msgstr "Ancienne numéro référence"
 
@@ -465,7 +483,7 @@ msgid "label_no_reference_number"
 msgstr "Le numéro de classement est généré lors de la création du document."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:142
+#: ./opengever/dossier/behaviors/dossier.py:135
 msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
@@ -475,26 +493,26 @@ msgid "label_participation"
 msgstr "Participation"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:184
-#: ./opengever/dossier/browser/report.py:118
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:63
+#: ./opengever/dossier/behaviors/dossier.py:177
+#: ./opengever/dossier/browser/report.py:50
+#: ./opengever/dossier/viewlets/byline.py:68
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:155
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "label_related_dossier"
 msgstr "Dossiers liés"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:85
 #: ./opengever/dossier/browser/participants.py:161
-#: ./opengever/dossier/browser/report.py:101
+#: ./opengever/dossier/browser/report.py:44
 msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:115
+#: ./opengever/dossier/browser/report.py:47
 msgid "label_review_state"
 msgstr "Etat"
 
@@ -503,8 +521,8 @@ msgstr "Etat"
 msgid "label_roles"
 msgstr "Rôles"
 
-#. Default: "Sequence Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:56
+#. Default: "Sequence Number"
+#: ./opengever/dossier/viewlets/byline.py:62
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
@@ -515,13 +533,13 @@ msgstr "Client de destination"
 
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py:64
-#: ./opengever/dossier/browser/report.py:93
+#: ./opengever/dossier/browser/report.py:36
 msgid "label_start"
 msgstr "Date début"
 
 #. Default: "from:"
 #: ./opengever/dossier/project_templates/byline.pt:33
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:34
+#: ./opengever/dossier/viewlets/byline.py:50
 msgid "label_start_byline"
 msgstr "De"
 
@@ -536,7 +554,7 @@ msgid "label_template"
 msgstr "Modèle"
 
 #. Default: "title"
-#: ./opengever/dossier/browser/report.py:90
+#: ./opengever/dossier/browser/report.py:33
 #: ./opengever/dossier/templatedossier.py:180
 #: ./opengever/dossier/templatedossier_templates/template_form.pt:30
 msgid "label_title"
@@ -544,7 +562,7 @@ msgstr "Titre"
 
 #. Default: "State:"
 #: ./opengever/dossier/project_templates/byline.pt:26
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:29
+#: ./opengever/dossier/viewlets/byline.py:44
 msgid "label_workflow_state"
 msgstr "Etat"
 
@@ -558,19 +576,19 @@ msgstr "Dernières tâches"
 msgid "no_content"
 msgstr "Pas de contenu"
 
-#: ./opengever/dossier/resolve.py:8
+#: ./opengever/dossier/resolve.py:10
 msgid "not all documents and tasks are stored in a subdossier"
 msgstr "Pas de document ni de tâche classés dans le sous-dossier"
 
-#: ./opengever/dossier/resolve.py:10
+#: ./opengever/dossier/resolve.py:12
 msgid "not all documents are checked in"
 msgstr "Tous les documents n'ont pas le statut checkin"
 
-#: ./opengever/dossier/resolve.py:11
+#: ./opengever/dossier/resolve.py:13
 msgid "not all task are closed"
 msgstr "Toutes les tâches ne sont pas fermées"
 
-#: ./opengever/dossier/archive.py:31
+#: ./opengever/dossier/archive.py:32
 msgid "only resolve, set filing no later"
 msgstr "Uniquement fermé (numéro d'inventaire non attribué)"
 
@@ -581,19 +599,19 @@ msgstr "Participants"
 msgid "required"
 msgstr "Obligatoire"
 
-#: ./opengever/dossier/archive.py:33
+#: ./opengever/dossier/archive.py:34
 msgid "resolve and set a new filing no"
 msgstr "Fermer et attribuer un nouveau numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py:30
+#: ./opengever/dossier/archive.py:31
 msgid "resolve and set filing no"
 msgstr "Fermer et attribuer un numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py:32
+#: ./opengever/dossier/archive.py:33
 msgid "resolve and take the existing filing no"
 msgstr "Fermer et utiliser un numéro d'inventaire existant"
 
-#: ./opengever/dossier/archive.py:34
+#: ./opengever/dossier/archive.py:35
 msgid "set a filing no"
 msgstr "Attribuer numéro d'inventaire"
 
@@ -611,17 +629,16 @@ msgid "tasks"
 msgstr "Tâches"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:125
+#: ./opengever/dossier/behaviors/dossier.py:118
 msgid "temporary_former_reference_number"
 msgstr "Ancien numéro de référence temporaire"
 
-#: ./opengever/dossier/resolve.py:12
+#: ./opengever/dossier/resolve.py:14
 msgid "the dossier start date is missing."
 msgstr "Aucune date de début n'a été saisie"
 
 #. Default: "expired"
 #: ./opengever/dossier/project_templates/byline.pt:51
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:52
 msgid "time_expired"
 msgstr "Périmé"
 
@@ -639,4 +656,3 @@ msgstr "Aucun envoi possible de documents à un autre service. Vous êtes unique
 #: ./opengever/dossier/behaviors/participation.py:194
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation"
-

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-10-24 09:25+0000\n"
+"POT-Creation-Date: 2013-11-27 15:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Add Participant"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:229
+#: ./opengever/dossier/behaviors/dossier.py:222
 msgid "Add Subdossier"
 msgstr ""
 
@@ -40,7 +40,7 @@ msgstr ""
 msgid "Copy documents to remote client"
 msgstr ""
 
-#: ./opengever/dossier/browser/report.py:128
+#: ./opengever/dossier/browser/report.py:84
 msgid "Could not generate the report"
 msgstr ""
 
@@ -52,11 +52,11 @@ msgstr ""
 msgid "Document ${name} is connected to a Task.                    Please move the Task."
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:70
+#: ./opengever/dossier/resolve.py:77
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:244
+#: ./opengever/dossier/behaviors/dossier.py:237
 msgid "Edit Subdossier"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgstr ""
 msgid "It isn't allowed to add such items there"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:75
+#: ./opengever/dossier/resolve.py:82
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr ""
 
@@ -85,7 +85,7 @@ msgstr ""
 msgid "Move Items"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:51
+#: ./opengever/dossier/archive.py:52
 msgid "Not all required fields are filled"
 msgstr ""
 
@@ -120,39 +120,43 @@ msgstr ""
 msgid "The Dossier has been deactivated"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:266
+#: ./opengever/dossier/archive.py:267
 msgid "The Dossier has been resolved"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:41
+#: ./opengever/dossier/resolve.py:43
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:53
+#: ./opengever/dossier/resolve.py:59
 msgid "The dossier has been succesfully resolved"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:237
+#: ./opengever/dossier/archive.py:238
 msgid "The filing number has been given"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:66
+#: ./opengever/dossier/archive.py:67
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr ""
 
-#: ./opengever/dossier/archive.py:84
+#: ./opengever/dossier/archive.py:85
 msgid "The given value is not a valid Year"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:201
+#: ./opengever/dossier/behaviors/dossier.py:194
 msgid "The start date must be before the end date."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:251
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "The start or end date is invalid"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:166
+#: ./opengever/dossier/resolve.py:56
+msgid "The subdossier has been succesfully resolved"
+msgstr ""
+
+#: ./opengever/dossier/archive.py:167
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""
 
@@ -169,12 +173,12 @@ msgid "button_add"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:210
+#: ./opengever/dossier/archive.py:211
 msgid "button_archive"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:269
+#: ./opengever/dossier/archive.py:270
 #: ./opengever/dossier/behaviors/participation.py:164
 #: ./opengever/dossier/browser/transport.py:170
 msgid "button_cancel"
@@ -232,59 +236,65 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr ""
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:61
+#: ./opengever/dossier/archive.py:62
 msgid "error_enddate"
 msgstr ""
 
 #. Default: "You have not selected any Items"
-#: ./opengever/dossier/browser/report.py:77
+#: ./opengever/dossier/browser/report.py:68
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py:93
+#: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:153
+#: ./opengever/dossier/archive.py:154
 msgid "filing_action"
 msgstr ""
 
 #. Default: "Filing number"
-#: ./opengever/dossier/behaviors/dossier.py:116
-#: ./opengever/dossier/browser/report.py:113
+#: ./opengever/dossier/behaviors/filing.py:23
+#: ./opengever/dossier/filing/report.py:65
 msgid "filing_no"
 msgstr ""
 
-#: ./opengever/dossier/browser/report.py:104
+#: ./opengever/dossier/filing/report.py:53
 msgid "filing_no_filing"
 msgstr ""
 
-#: ./opengever/dossier/browser/report.py:110
+#: ./opengever/dossier/filing/report.py:61
 msgid "filing_no_number"
 msgstr ""
 
-#: ./opengever/dossier/browser/report.py:107
+#: ./opengever/dossier/filing/report.py:57
 msgid "filing_no_year"
 msgstr ""
 
 msgid "filing_nr"
 msgstr ""
 
+#. Default: "Filing Number"
+#: ./opengever/dossier/filing/tabs.py:10
+msgid "filing_number"
+msgstr ""
+
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:132
+#: ./opengever/dossier/archive.py:133
 #: ./opengever/dossier/behaviors/dossier.py:105
 msgid "filing_prefix"
 msgstr ""
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:147
+#: ./opengever/dossier/archive.py:148
 msgid "filing_year"
 msgstr ""
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:202
+#: ./opengever/dossier/archive.py:203
 msgid "heading_archive_form"
 msgstr ""
 
@@ -301,11 +311,11 @@ msgstr ""
 msgid "help_contact"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:150
+#: ./opengever/dossier/behaviors/dossier.py:143
 msgid "help_container_location"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:133
+#: ./opengever/dossier/behaviors/dossier.py:126
 msgid "help_container_type"
 msgstr ""
 
@@ -314,20 +324,24 @@ msgstr ""
 msgid "help_destination"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:142
+#: ./opengever/dossier/archive.py:143
 #: ./opengever/dossier/behaviors/dossier.py:73
 msgid "help_end"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:117
+#: ./opengever/dossier/behaviors/filing.py:24
 msgid "help_filing_no"
+msgstr ""
+
+#: ./opengever/dossier/filing/advanced_search.py:17
+msgid "help_filing_number"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:106
 msgid "help_filing_prefix"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:178
+#: ./opengever/dossier/behaviors/dossier.py:171
 msgid "help_former_reference_number"
 msgstr ""
 
@@ -335,11 +349,11 @@ msgstr ""
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:144
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_number_of_containers"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:185
+#: ./opengever/dossier/behaviors/dossier.py:178
 msgid "help_reference_number "
 msgstr ""
 
@@ -363,7 +377,7 @@ msgstr ""
 msgid "help_target_dossier"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:127
+#: ./opengever/dossier/behaviors/dossier.py:120
 msgid "help_temporary_former_reference_number"
 msgstr ""
 
@@ -384,7 +398,6 @@ msgstr ""
 
 #. Default: "by ${author}"
 #: ./opengever/dossier/project_templates/byline.pt:14
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:22
 msgid "label_by_author"
 msgstr ""
 
@@ -399,12 +412,12 @@ msgid "label_contact"
 msgstr ""
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:149
+#: ./opengever/dossier/behaviors/dossier.py:142
 msgid "label_container_location"
 msgstr ""
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:132
+#: ./opengever/dossier/behaviors/dossier.py:125
 msgid "label_container_type"
 msgstr ""
 
@@ -423,31 +436,36 @@ msgstr ""
 msgid "label_edit_after_creation"
 msgstr ""
 
-#. Default: "E-Mail:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:77
+#. Default: "E-Mail"
+#: ./opengever/dossier/viewlets/byline.py:75
 msgid "label_email_address"
 msgstr ""
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:141
+#: ./opengever/dossier/archive.py:142
 #: ./opengever/dossier/behaviors/dossier.py:72
-#: ./opengever/dossier/browser/report.py:97
+#: ./opengever/dossier/browser/report.py:40
 msgid "label_end"
 msgstr ""
 
 #. Default: "to:"
 #: ./opengever/dossier/project_templates/byline.pt:42
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:43
+#: ./opengever/dossier/viewlets/byline.py:56
 msgid "label_end_byline"
 msgstr ""
 
-#. Default: "Filing Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:70
+#. Default: "Filing Number"
+#: ./opengever/dossier/filing/byline.py:21
 msgid "label_filing_no"
 msgstr ""
 
+#. Default: "Filing number"
+#: ./opengever/dossier/filing/advanced_search.py:16
+msgid "label_filing_number"
+msgstr ""
+
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:176
+#: ./opengever/dossier/behaviors/dossier.py:169
 msgid "label_former_reference_number"
 msgstr ""
 
@@ -467,7 +485,7 @@ msgid "label_no_reference_number"
 msgstr ""
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:142
+#: ./opengever/dossier/behaviors/dossier.py:135
 msgid "label_number_of_containers"
 msgstr ""
 
@@ -477,26 +495,26 @@ msgid "label_participation"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:184
-#: ./opengever/dossier/browser/report.py:118
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:63
+#: ./opengever/dossier/behaviors/dossier.py:177
+#: ./opengever/dossier/browser/report.py:50
+#: ./opengever/dossier/viewlets/byline.py:68
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:155
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "label_related_dossier"
 msgstr ""
 
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:85
 #: ./opengever/dossier/browser/participants.py:161
-#: ./opengever/dossier/browser/report.py:101
+#: ./opengever/dossier/browser/report.py:44
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:115
+#: ./opengever/dossier/browser/report.py:47
 msgid "label_review_state"
 msgstr ""
 
@@ -505,8 +523,8 @@ msgstr ""
 msgid "label_roles"
 msgstr ""
 
-#. Default: "Sequence Number:"
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:56
+#. Default: "Sequence Number"
+#: ./opengever/dossier/viewlets/byline.py:62
 msgid "label_sequence_number"
 msgstr ""
 
@@ -517,13 +535,13 @@ msgstr ""
 
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py:64
-#: ./opengever/dossier/browser/report.py:93
+#: ./opengever/dossier/browser/report.py:36
 msgid "label_start"
 msgstr ""
 
 #. Default: "from:"
 #: ./opengever/dossier/project_templates/byline.pt:33
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:34
+#: ./opengever/dossier/viewlets/byline.py:50
 msgid "label_start_byline"
 msgstr ""
 
@@ -538,7 +556,7 @@ msgid "label_template"
 msgstr ""
 
 #. Default: "title"
-#: ./opengever/dossier/browser/report.py:90
+#: ./opengever/dossier/browser/report.py:33
 #: ./opengever/dossier/templatedossier.py:180
 #: ./opengever/dossier/templatedossier_templates/template_form.pt:30
 msgid "label_title"
@@ -546,7 +564,7 @@ msgstr ""
 
 #. Default: "State:"
 #: ./opengever/dossier/project_templates/byline.pt:26
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:29
+#: ./opengever/dossier/viewlets/byline.py:44
 msgid "label_workflow_state"
 msgstr ""
 
@@ -560,19 +578,19 @@ msgstr ""
 msgid "no_content"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:8
+#: ./opengever/dossier/resolve.py:10
 msgid "not all documents and tasks are stored in a subdossier"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:10
+#: ./opengever/dossier/resolve.py:12
 msgid "not all documents are checked in"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:11
+#: ./opengever/dossier/resolve.py:13
 msgid "not all task are closed"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:31
+#: ./opengever/dossier/archive.py:32
 msgid "only resolve, set filing no later"
 msgstr ""
 
@@ -583,19 +601,19 @@ msgstr ""
 msgid "required"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:33
+#: ./opengever/dossier/archive.py:34
 msgid "resolve and set a new filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:30
+#: ./opengever/dossier/archive.py:31
 msgid "resolve and set filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:32
+#: ./opengever/dossier/archive.py:33
 msgid "resolve and take the existing filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:34
+#: ./opengever/dossier/archive.py:35
 msgid "set a filing no"
 msgstr ""
 
@@ -613,17 +631,16 @@ msgid "tasks"
 msgstr ""
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:125
+#: ./opengever/dossier/behaviors/dossier.py:118
 msgid "temporary_former_reference_number"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:12
+#: ./opengever/dossier/resolve.py:14
 msgid "the dossier start date is missing."
 msgstr ""
 
 #. Default: "expired"
 #: ./opengever/dossier/project_templates/byline.pt:51
-#: ./opengever/dossier/viewlets/businesscase_byline.pt:52
 msgid "time_expired"
 msgstr ""
 

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -51,8 +51,13 @@ class DossierResolveView(grok.View):
             self.request.RESPONSE.redirect('transition-archive')
         else:
             resolver.resolve()
-            ptool.addPortalMessage(
-                _('The dossier has been succesfully resolved'), type='info')
+            if self.context.is_subdossier():
+                ptool.addPortalMessage(
+                    _('The subdossier has been succesfully resolved'), type='info')
+            else:
+                ptool.addPortalMessage(
+                    _('The dossier has been succesfully resolved'), type='info')
+
             self.request.RESPONSE.redirect(self.context.absolute_url())
 
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -49,7 +49,7 @@ class TestResolvingDossiers(FunctionalTestCase):
 
         self.browser.assert_url(subdossier.absolute_url())
         self.browser.assert_portal_message(
-            'The dossier has been succesfully resolved')
+            'The subdossier has been succesfully resolved')
 
 
 class TestResolvingDossiersWithFilingNumberSupport(FunctionalTestCase):


### PR DESCRIPTION
When resolving a subdossier, the displayed statusmessage was wrong. This PR fixes that.

before:
![bildschirmfoto 2013-11-27 um 17 05 49](https://f.cloud.github.com/assets/485755/1632817/fc8fd872-577d-11e3-8541-81c085c3eef1.png)

after:
![bildschirmfoto 2013-11-27 um 17 06 12](https://f.cloud.github.com/assets/485755/1632807/e47a4eca-577d-11e3-80c2-bf2f4eb9a3a4.png)

@lukasgraf please take a look.
