### PR TITLE
Adjusted seperator of the `grouped_by_three` formatter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Adjusted seperator of the `grouped_by_three` formatter.
+  [phgross]
+
 - Corrected message after resolving a subdossier.
   [phgross]
 

--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -10,7 +10,7 @@ class DottedReferenceFormatter(grok.Adapter):
     grok.context(Interface)
     grok.name('dotted')
 
-    repository_dossier_seperator = u'/'
+    repository_dossier_seperator = u' / '
     dossier_document_seperator = u'/'
     repository_title_seperator = u'.'
 
@@ -26,7 +26,7 @@ class DottedReferenceFormatter(grok.Adapter):
                 self.repository_number(numbers))
 
         if self.dossier_number(numbers):
-            reference_number = u'%s %s %s' % (
+            reference_number = u'%s%s%s' % (
                 reference_number,
                 self.repository_dossier_seperator,
                 self.dossier_number(numbers))

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -84,7 +84,7 @@ class TestReferenceNumberAdapter(FunctionalTestCase):
         proxy.formatter = 'grouped_by_three'
 
         self.assertEquals(
-            'OG 247 - 8.2',
+            'OG 247-8.2',
             IReferenceNumber(self.subdossier).get_number())
 
 
@@ -118,7 +118,7 @@ class TestDottedFormatter(FunctionalTestCase):
             'OG 5.7.3.2',
             self.formatter.complete_number(numbers))
 
-    def test_dossier_part_is_separated_with_slash(self):
+    def test_dossier_part_is_separated_with_slash_and_spaces(self):
         numbers = {'site': ['OG', ],
                    'repository': [u'5', u'7', u'3', u'2'],
                    'dossier': [u'4', u'6', u'2']}
@@ -161,13 +161,13 @@ class TestGroupedbyThreeFormatter(FunctionalTestCase):
                    'dossier': [u'4', u'6', u'2']}
 
         self.assertEquals(
-            'OG 573.2 - 4.6.2', self.formatter.complete_number(numbers))
+            'OG 573.2-4.6.2', self.formatter.complete_number(numbers))
 
-    def test_document_part_is_separated_with_hyphen(self):
+    def test_document_part_is_separated_with_hyphen_and_spaces(self):
         numbers = {'site': ['OG', ],
                    'repository': [u'5', u'7', u'3', u'2'],
                    'dossier': [u'4', u'6', u'2'],
                    'document': [u'27']}
 
         self.assertEquals(
-            'OG 573.2 - 4.6.2 - 27', self.formatter.complete_number(numbers))
+            'OG 573.2-4.6.2 - 27', self.formatter.complete_number(numbers))


### PR DESCRIPTION
The spaces around the `repository_dossier_seperator` should be removed for the `groupped_by_three` formatter. Therefore i put the spaces in to the separator itself, so it works for both (`dotted` and `groupped_by_three`)

`dotted` (is unmodified):
`OG 5.7.3.2 / 4.6.2`

`grouped_by_three`:
`OG 573.2 - 4.6.2` --> `OG 573.2-4.6.2`
