### PR TITLE
Issued inbox tasks: fixed listing query, to search the complete client.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 - Adjusted seperator of the `grouped_by_three` formatter.
   [phgross]
 
+- Issued inbox task: fixed listing query, to search the complete client.
+  [phgross]
+
 - Corrected message after resolving a subdossier.
   [phgross]
 

--- a/opengever/inbox/browser/tabs.py
+++ b/opengever/inbox/browser/tabs.py
@@ -60,6 +60,13 @@ class IssuedInboxTasks(Tasks):
 
         return columns
 
+    def update_config(self):
+        """Remove the default path filter to the current context.
+        It should search tasks over the complete client."""
+
+        super(IssuedInboxTasks, self).update_config()
+        self.filter_path = None
+
 
 class ClosedForwardings(Tasks):
 

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -113,3 +113,14 @@ class TestIssuedInboxTaskTab(FunctionalTestCase):
 
         self.assert_listing_results(
             'issued_inbox_tasks', [issued_by_inbox1, ])
+
+    def test_list_also_tasks_outside_of_the_inbox(self):
+        task_inside = create(Builder('task')
+              .within(self.inbox)
+              .having(issuer='inbox:client1'))
+
+        task_outside = create(Builder('task')
+              .having(issuer='inbox:client1'))
+
+        self.assert_listing_results(
+            'issued_inbox_tasks', [task_inside, task_outside])


### PR DESCRIPTION
By default the `CatalogListingView` limits the search to the current context(https://github.com/4teamwork/ftw.tabbedview/blob/master/ftw/tabbedview/browser/listing.py#L543). For the `IssuedInboxTasks` listing is this behavior unwished. Therefore i overwrite the update_config method.

@lukasgraf could you take a look.
