### PR TITLE
Add specific byline for the PloneSite(Personal overview).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Add specific byline for the PloneSite(Personal overview).
+  [phgross]
+
 - Adjusted seperator of the `grouped_by_three` formatter.
   [phgross]
 

--- a/opengever/base/viewlets/byline.pt
+++ b/opengever/base/viewlets/byline.pt
@@ -2,9 +2,10 @@
      id="plone-document-byline"
      tal:condition="view/show">
 
-  <ul>
+  <ul tal:define="css_class view/get_css_class">
 
-    <li tal:attributes="class string:byline-icon ${view/get_css_class};
+    <li tal:condition="css_class"
+        tal:attributes="class string:byline-icon ${css_class};
                         title context/Type">
       &nbsp;
     </li>
@@ -13,7 +14,7 @@
       <span id="lock-icon" class="function-lock"/>
     </li>
 
-    <tal:repeat tal:repeat="item view/get_items"> 
+    <tal:repeat tal:repeat="item view/get_items">
       <li tal:attributes="class item/class" tal:condition="item/content">
          <span class="label"><span tal:content="item/label"></span>:</span>
          <span tal:condition="not: item/replace" tal:content="item/content"></span>

--- a/opengever/base/viewlets/byline.py
+++ b/opengever/base/viewlets/byline.py
@@ -66,3 +66,12 @@ class BylineBase(content.DocumentBylineViewlet):
              'content': self.modified(),
              'replace': False},
         ]
+
+
+class PloneSiteByline(BylineBase):
+
+    def get_css_class(self):
+        """No sensible icon exists for the PloneSite respectively
+        personal overview, so we return None."""
+
+        return None

--- a/opengever/base/viewlets/configure.zcml
+++ b/opengever/base/viewlets/configure.zcml
@@ -35,5 +35,12 @@
        permission="zope2.View"
        />
 
+   <browser:viewlet
+       name="plone.belowcontenttitle.documentbyline"
+       for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
+       manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+       class="opengever.base.viewlets.byline.PloneSiteByline"
+       permission="zope2.View"
+       />
 
 </configure>


### PR DESCRIPTION
![bildschirmfoto 2013-11-28 um 15 05 31](https://f.cloud.github.com/assets/485755/1640329/37585c46-5836-11e3-951d-99d02c9734e3.png)

At a later point, it would be nice to define a sensefull icon for the personal overview. Ideas are welcome...

@lukasgraf could you take a look?
