### PR TITLE
Adjusted dossier document seperator of the `grouped_by_three` formatter.

### DIFF
--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -11,7 +11,7 @@ class DottedReferenceFormatter(grok.Adapter):
     grok.name('dotted')
 
     repository_dossier_seperator = u' / '
-    dossier_document_seperator = u'/'
+    dossier_document_seperator = u' / '
     repository_title_seperator = u'.'
 
     def complete_number(self, numbers):
@@ -32,7 +32,7 @@ class DottedReferenceFormatter(grok.Adapter):
                 self.dossier_number(numbers))
 
         if self.document_number(numbers):
-            reference_number = u'%s %s %s' % (
+            reference_number = u'%s%s%s' % (
                 reference_number,
                 self.dossier_document_seperator,
                 self.document_number(numbers))

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -170,4 +170,4 @@ class TestGroupedbyThreeFormatter(FunctionalTestCase):
                    'document': [u'27']}
 
         self.assertEquals(
-            'OG 573.2-4.6.2 - 27', self.formatter.complete_number(numbers))
+            'OG 573.2-4.6.2-27', self.formatter.complete_number(numbers))


### PR DESCRIPTION
`OG 573.2-4.6.2 - 27` --> `OG 573.2-4.6.2-27`

Fore more information see the PR #170.

@lukasgraf please take a look.
