### PR TITLE
Logout overlay: use absolute url to redirect to the logout view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Logout overlay: use absolute url to redirect to the logout view.
+  [phgross]
+
 - OGDS Updater: Gracefully skip users outside users_base referenced in groups.
   [lgraf]
 

--- a/opengever/document/browser/logout_overlay.py
+++ b/opengever/document/browser/logout_overlay.py
@@ -1,7 +1,7 @@
 from AccessControl import getSecurityManager
-from five import grok
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from five import grok
 from zope.interface import Interface
 
 
@@ -25,6 +25,8 @@ class LogoutOverlay(grok.View):
         self.items = self.get_checkedout_documents()
 
     def render(self):
+        portal_url_tool = getToolByName(self.context, 'portal_url')
+        self.redirect_url = '{}/logout'.format(portal_url_tool())
 
         if not self.items:
             return "empty:%s" % self.redirect_url

--- a/opengever/document/tests/test_logout_overlay.py
+++ b/opengever/document/tests/test_logout_overlay.py
@@ -14,7 +14,7 @@ class TestLogoutOverlayWithoutCheckouts(FunctionalTestCase):
 
     def test_logout_is_handled_using_a_js_script(self):
         view = self.portal.restrictedTraverse('@@logout_overlay')
-        self.assertEquals("empty:./logout", view())
+        self.assertEquals("empty:http://nohost/plone/logout", view())
 
 class TestLogoutOverlayWithCheckouts(FunctionalTestCase):
 
@@ -43,4 +43,4 @@ class TestLogoutOverlayWithCheckouts(FunctionalTestCase):
     def test_contains_hidden_field_with_redirect_url(self):
         view = self.portal.restrictedTraverse('@@logout_overlay')()
         self.assertIn('<input type="hidden" name="form.redirect.url" ' \
-            'value="./logout" />', view)
+            'value="http://nohost/plone/logout" />', view)


### PR DESCRIPTION
In some cases, for example when logging out from the `UserDetails` View, the relative url which is used (`./logout`) doesn't work. Therefore the logout overlay should use absolute_links to the logout view.

@lukasgraf could you take a look?
