### PR TITLE
Set initial profile version for opengever.ogds.base:default

### DIFF
--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3100</version>
+  <version>3101</version>
   <dependencies>
     <dependency>profile-opengever.globalindex:default</dependency>
     <dependency>profile-opengever.base:default</dependency>

--- a/opengever/policy/base/upgrades/configure.zcml
+++ b/opengever/policy/base/upgrades/configure.zcml
@@ -22,4 +22,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 3100 -> 3101 -->
+    <genericsetup:upgradeStep
+        title="Set initial profile version for og.ogds.base:default"
+        description=""
+        source="3100"
+        destination="3101"
+        handler="opengever.policy.base.upgrades.to3101.SetInitialProfileVersionForOGDSBase"
+        profile="opengever.policy.base:default"
+        />
+
 </configure>

--- a/opengever/policy/base/upgrades/to3101.py
+++ b/opengever/policy/base/upgrades/to3101.py
@@ -1,0 +1,26 @@
+from ftw.upgrade import UpgradeStep
+from Products.CMFCore.utils import getToolByName
+
+
+class SetInitialProfileVersionForOGDSBase(UpgradeStep):
+    """Set initial profile version for og.ogds.base:default"""
+
+    def __call__(self):
+        set_profile_version(self.portal, 'opengever.ogds.base:default', '1')
+
+
+def set_profile_version(context, profile_id, version):
+    """Set the DB version for a particular profile.
+    """
+
+    if profile_id.startswith('profile-'):
+        raise Exception("Please specify the profile_id WITHOUT "
+                        "the 'profile-' prefix!")
+
+    ps = getToolByName(context, 'portal_setup')
+    if not len(profile_id.split(':')) == 2:
+        raise Exception("Invalid profile id '%s'" % profile_id)
+    ps.setLastVersionForProfile(profile_id, unicode(version))
+    assert(ps.getLastVersionForProfile(profile_id) == (version, ))
+    print "Set version for '%s' to '%s'." % (profile_id, version)
+    return [version]


### PR DESCRIPTION
The `opengever.ogds.base:default` profile is installed, but apparently didn't have a `metadata.xml` from the beginning, so it currently doesn't have a profile version set.

This change adds an upgrade step to `opengever.policy.base:default` that sets that initial profile version (to 1).
