### PR TITLE
Increase task_principals.principal column length to 255.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,9 @@ Changelog
   field from the IVersionable behavior.
   [lgraf]
 
+- Increase task_principals.principal column length to 255.
+  [lgraf]
+
 - Logout overlay: use absolute url to redirect to the logout view.
   [phgross]
 

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -65,7 +65,7 @@ class Task(Base):
 class TaskPrincipal(Base):
     __tablename__ = 'task_principals'
 
-    principal = Column(String(64), primary_key=True)
+    principal = Column(String(255), primary_key=True)
     task_id = Column(Integer, ForeignKey('tasks.id'),
                      primary_key=True)
 

--- a/opengever/globalindex/profiles/default/metadata.xml
+++ b/opengever/globalindex/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2602</version>
 </metadata>

--- a/opengever/globalindex/upgrades/configure.zcml
+++ b/opengever/globalindex/upgrades/configure.zcml
@@ -23,4 +23,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 2601 -> 2602 -->
+    <genericsetup:upgradeStep
+        title="Increase task principal column length in GlobalIndex SQL schema"
+        description=""
+        source="2601"
+        destination="2602"
+        handler="opengever.globalindex.upgrades.to2602.IncreaseTaskPrincipalColumnLength"
+        profile="opengever.globalindex:default"
+        />
+
 </configure>

--- a/opengever/globalindex/upgrades/to2602.py
+++ b/opengever/globalindex/upgrades/to2602.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+from opengever.ogds.base.utils import create_session
+from opengever.ogds.models.utils import alter_column_length
+
+
+class IncreaseTaskPrincipalColumnLength(UpgradeStep):
+    """Increase Task `principal` column length in GlobalIndex SQL schema."""
+
+    def __call__(self):
+        session = create_session()
+        alter_column_length(session, 'task_principals', 'principal', 255)


### PR DESCRIPTION
After increasing the `userid` column length, the length of `task_principals.principal` also needs to be adjusted. See https://github.com/4teamwork/opengever.ogds.models/pull/1
