### PR TITLE
Document tooltip helper: Fixed link for the icon.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Document tooltip helper: Fixed link for the icon.
+  [phgross]
+
 - Logout overlay: use absolute url to redirect to the logout view.
   [phgross]
 

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -235,7 +235,7 @@ def _linked_document_with_tooltip(item, value, trashed=False):
                 """.join(tooltip_links)
 
     link = """<div class='linkWrapper'>
-    <a class='tabbedview-tooltip %(css_class)s' href='#'></a>
+    <a class='tabbedview-tooltip %(css_class)s' href='%(url)s'></a>
     <a href='%(url)s'>%(value)s</a>
     <div class='tabbedview-tooltip-data'>
         <div class='tooltip-content'>

--- a/opengever/tabbedview/tests/test_document_helper.py
+++ b/opengever/tabbedview/tests/test_document_helper.py
@@ -108,6 +108,11 @@ class LinkTestCase(MockTestCase):
         breadcrumbs = tooltip_content('.tooltip-breadcrumb' )[0]
         return self.assertEquals(breadcrumbs_text, breadcrumbs.text)
 
+    def assertIconLink(self, expected_link, content):
+        content = PyQuery(content)
+        link = content('.tabbedview-tooltip')[0]
+        self.assertEquals(expected_link, link.get('href'))
+
 
 class TestWithoutPDFConverter(LinkTestCase):
     """TestCase base class to simulate PDF converter NOT being available.
@@ -159,6 +164,12 @@ class TestTooltipLinkedHelperWithDocuments(TestWithPDFConverter):
         self.assertTooltipBreadcrumbsEquals(
             'Dossier1 > Task 1 > lorem ipsum <with tags>', self.markup())
 
+    def test_tooltip_icon_links_to_document(self):
+        self.replay()
+        self.assertIconLink(
+            'http://nohost/plone/dossier-1/task-1/document',
+            self.markup())
+
 
 class TestTooltipLinkedHelperWithMails(TestWithPDFConverter):
 
@@ -190,6 +201,12 @@ class TestTooltipLinkedHelperWithMails(TestWithPDFConverter):
         self.replay()
         self.assertTooltipBreadcrumbsEquals(
             'Dossier1 > Task 1 > lorem ipsum <with tags>', self.markup())
+
+    def test_tooltip_icon_links_to_document(self):
+        self.replay()
+        self.assertIconLink(
+            'http://nohost/plone/dossier-1/task-1/document',
+            self.markup())
 
 
 class TestTooltipLinkedHelperWithTrashedDocs(TestWithPDFConverter):


### PR DESCRIPTION
The icon now links to the documet itself.

@lukasgraf Like we discussed, could you take a look?
