### PR TITLE
Add helper function to set GS version for a particular profile.

### DIFF
--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -1,0 +1,21 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def set_profile_version(portal, profile_id, version):
+    """Set the DB version for a particular profile.
+
+    (This function will be included in ftw.upgrade at some point.)
+    """
+
+    if profile_id.startswith('profile-'):
+        raise Exception("Please specify the profile_id WITHOUT "
+                        "the 'profile-' prefix!")
+
+    if not len(profile_id.split(':')) == 2:
+        raise Exception("Invalid profile id '%s'" % profile_id)
+
+    ps = getToolByName(portal, 'portal_setup')
+    ps.setLastVersionForProfile(profile_id, unicode(version))
+    assert(ps.getLastVersionForProfile(profile_id) == (version, ))
+    print "Set version for '%s' to '%s'." % (profile_id, version)
+    return [version]


### PR DESCRIPTION
This change adds a helper function that allows us to set the GenericSetup profile version for a particular profile (to initialize it via an upgrade step for example).
