### PR TITLE
Remove remaining traces of `related_items` index.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
+- Remove remaining traces of `related_items` index.
+  [lgraf]
+
 - Dossier resolving: Fixed `its_all_closed` check, for nested subtasks.
   [phgross]
 

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -1,4 +1,4 @@
-from Acquisition import aq_inner, aq_base
+from Acquisition import aq_inner
 from collective import dexteritytextindexer
 from five import grok
 from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
@@ -8,37 +8,13 @@ from opengever.document.interfaces import IDocumentIndexer
 from opengever.tabbedview.helper import readable_ogds_author
 from plone.indexer import indexer
 from Products.CMFCore.utils import getToolByName
-from zc.relation.interfaces import ICatalog
 from ZODB.POSException import ConflictError
-from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility, queryMultiAdapter, getAdapter
 from zope.interface import Interface
 import logging
 
 
 logger = logging.getLogger('opengever.document')
-
-
-@indexer(IDocumentSchema)
-def related_items(obj):
-    catalog = getUtility(ICatalog)
-    intids = getUtility(IIntIds)
-
-    try:
-        obj_id = intids.getId(aq_base(obj))
-    # In some cases we might not have an intid yet.
-    except KeyError:
-        return None
-
-    results = []
-    relations = catalog.findRelations(
-        {'to_id': obj_id, 'from_attribute': 'relatedItems'})
-    for rel in relations:
-        results.append(rel.from_id)
-    return results
-
-
-grok.global_adapter(related_items, name='related_items')
 
 
 class DefaultDocumentIndexer(grok.Adapter):

--- a/opengever/document/setuphandlers.py
+++ b/opengever/document/setuphandlers.py
@@ -37,7 +37,6 @@ def add_catalog_indexes(context, logger=None):
         ('checked_out', 'FieldIndex', {}),
         ('document_date', 'DateIndex', {}),
         ('receipt_date', 'DateIndex', {}),
-        ('related_items', 'KeywordIndex', {}),
         ('sortable_author', 'FieldIndex', {}),
         )
     indexables = []


### PR DESCRIPTION
PR #182 was supposed to remove the `related_items` indexer, but only removed part of it.

This change removes the remaining traces, namely the actual indexer in `opengever.document.indexers.related_items` and the index definition in `setuphandlers.py`. 
