### PR TITLE
Personal Overview: Raise Unauthorized for unauthenticated users

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,11 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
+- Personal Overview: Raise Unauthorized for unauthenticated users instead of
+  hardcoded redirect to login form.
+  This is required for Single-Sign-On with SPNEGO plugin to work.
+  [lgraf] 
+
 - Use always logged in user as responsible of a subdossier.
   [lknoepfel]
 

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -1,4 +1,4 @@
-from Products.CMFPlone.utils import getToolByName
+from AccessControl import Unauthorized
 from five import grok
 from ftw.tabbedview.browser.tabbed import TabbedView
 from opengever.globalindex.interfaces import ITaskQuery
@@ -6,6 +6,7 @@ from opengever.ogds.base.interfaces import IContactInformation
 from opengever.ogds.base.utils import get_client_id
 from opengever.tabbedview.browser.tabs import Documents, Dossiers, Tasks
 from opengever.tabbedview.browser.tasklisting import GlobalTaskListingTab
+from Products.CMFPlone.utils import getToolByName
 from zope.component import getUtility
 from zope.interface import Interface
 import AccessControl
@@ -51,8 +52,7 @@ class PersonalOverview(TabbedView):
         """
         user = AccessControl.getSecurityManager().getUser()
         if user == AccessControl.SecurityManagement.SpecialUsers.nobody:
-            login = self.context.portal_url() + '/login'
-            return self.request.RESPONSE.redirect(login)
+            raise Unauthorized
 
         if not self.user_is_allowed_to_view():
             catalog = getToolByName(self.context, 'portal_catalog')


### PR DESCRIPTION
Personal Overview:
Raise Unauthorized for unauthenticated users instead of hardcoded redirect to login form.
This is required for Single-Sign-On with SPNEGO plugin to work - otherwise accessing the Plone Site (as opposed to content below it) will lead to a redirect to `/login` instead of letting the SPNEGO challenge plugin do its work.
