### PR TITLE
Don't hard code reference formatter in tabbed view custom sorter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
+- Don't hard code reference formatter in tabbed view custom sorter. Look it up
+  from IReferenceNumberSettings instead.
+  [lgraf]
+
 - Fixed missing role and available expression in reference prefix manager.
   [lknoepfel]
 

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -5,6 +5,7 @@ from ftw.table import helper
 from ftw.table.catalog_source import CatalogTableSource
 from opengever.base.browser.helper import client_title_helper
 from opengever.base.interfaces import IReferenceNumberFormatter
+from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.ogds.base.interfaces import IContactInformation
 from opengever.tabbedview import _
 from opengever.tabbedview.browser.listing import CatalogListingView
@@ -22,6 +23,7 @@ from opengever.tabbedview.utils import get_translated_transitions
 from opengever.tabbedview.utils import get_translated_types
 from opengever.task.helper import task_type_helper
 from plone.dexterity.interfaces import IDexterityContainer
+from plone.registry.interfaces import IRegistry
 from zope.app.pagetemplate import ViewPageTemplateFile
 from zope.component import getUtility, adapts
 from zope.component import queryAdapter
@@ -80,7 +82,11 @@ class OpengeverTab(object):
                 results.reverse()
 
         elif sort_on == 'reference':
-            formatter = queryAdapter(IReferenceNumberFormatter, name='grouped_by_three')
+            # Get active reference formatter
+            registry = getUtility(IRegistry)
+            proxy = registry.forInterface(IReferenceNumberSettings)
+            formatter = queryAdapter(IReferenceNumberFormatter, name=proxy.formatter)
+
             results = list(results)
             results.sort(key=formatter.sorter)
             if sort_reverse:


### PR DESCRIPTION
Don't hard code reference formatter in tabbed view custom sorter. Look it up
from `IReferenceNumberSettings` instead.

This fixes the problem that caused the following traceback:

```
2014-03-07 10:39:29 ERROR Zope.SiteErrorLog 1394185169.020.129264338005 http://localhost:8080/mandant1/ordnungssystem/fuehrung/strategie-und-planung/@@tabbed_view/listing
Traceback (innermost last):
  Module ZPublisher.Publish, line 126, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 46, in call_object
  Module ftw.tabbedview.browser.tabbed, line 152, in listing
  Module ftw.tabbedview.browser.listing, line 109, in __call__
  Module ftw.tabbedview.browser.listing, line 198, in update
  Module opengever.tabbedview.browser.tabs, line 85, in custom_sort
  Module opengever.base.reference_formatter, line 128, in sorter
ValueError: need more than 1 value to unpack
```
