### PR TITLE
ldap_util: Make check for user object classes case-insensitive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 3.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ldap_util: Make check for user object classes case-insensitive.
+  [lgraf]
 
 
 3.2.2 (2014-03-11)

--- a/opengever/ogds/base/ldap_util.py
+++ b/opengever/ogds/base/ldap_util.py
@@ -344,7 +344,8 @@ class LDAPSearch(grok.Adapter):
         is_user = False
         obj_classes = attrs['objectClass']
         for obj_class in obj_classes:
-            if obj_class in self.context._user_objclasses:
+            if obj_class.lower() in [uc.lower() for uc in
+                    self.context._user_objclasses]:
                 is_user = True
                 break
 


### PR DESCRIPTION
In [`apply_schema_map()`](https://github.com/4teamwork/opengever.core/blob/master/opengever/ogds/base/ldap_util.py#L332), a check is being done if the object is in fact a user, and only user objects will have the schema map applied:

``` python
# Check if entry is a user object - we only want to apply the
# LDAPUserFolder mapping to those
is_user = False
obj_classes = attrs['objectClass']
for obj_class in obj_classes:
    if obj_class in self.context._user_objclasses:
        is_user = True
```

This check is done by comparing its object classes to the `_user_objclasses` setting of the LDAPUserFolder. This check needs to be **case-insensitive**, otherwise we might fail to detect certain user objects as such, and not map their attributes, leading to the user id attribute not being found.
