### PR TITLE
Rebuild broken Reference-Prefix Upgrade-Step 

### DIFF
--- a/opengever/base/upgrades/to2601.py
+++ b/opengever/base/upgrades/to2601.py
@@ -3,6 +3,7 @@ from opengever.base.adapters import CHILD_REF_KEY, PREFIX_REF_KEY
 from opengever.base.adapters import REPOSITORY_FOLDER_KEY, DOSSIER_KEY
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from persistent.dict import PersistentDict
+from persistent.list import PersistentList
 from zope.annotation.interfaces import IAnnotations
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
@@ -11,6 +12,12 @@ from zope.component import getUtility
 class CleanupReferencePrefixMapping(UpgradeStep):
 
     def __call__(self):
+
+        for root in self.objects(
+                {'portal_type': 'opengever.repository.repositoryroot'},
+                'Cleanup reference prefix mapping on repositoryroots'):
+            self.move_repository_root_mappings(root)
+
         for repository in self.objects(
                 {'portal_type': 'opengever.repository.repositoryfolder'},
                 'Cleanup reference prefix mapping on repositoryfolders'):
@@ -20,7 +27,7 @@ class CleanupReferencePrefixMapping(UpgradeStep):
                 {'object_provides':
                  'opengever.dossier.behaviors.dossier.IDossierMarker'},
                 'Cleanup reference prefix mapping on dossiers'):
-            self.move_dossier_mappings(repository)
+            self.move_dossier_mappings(dossier)
 
     def move_repository_reference_mappings(self, obj):
         intids = getUtility(IIntIds)
@@ -28,11 +35,11 @@ class CleanupReferencePrefixMapping(UpgradeStep):
 
         if annotations and annotations.get(CHILD_REF_KEY):
             repository_mapping = PersistentDict(
-                {CHILD_REF_KEY: {},
-                 PREFIX_REF_KEY: {}})
+                {CHILD_REF_KEY: PersistentDict(),
+                 PREFIX_REF_KEY: PersistentDict()})
             dossier_mapping = PersistentDict(
-                {CHILD_REF_KEY: {},
-                 PREFIX_REF_KEY: {}})
+                {CHILD_REF_KEY: PersistentDict(),
+                 PREFIX_REF_KEY: PersistentDict()})
 
             for number, intid in annotations.get(CHILD_REF_KEY).items():
                 try:
@@ -52,6 +59,16 @@ class CleanupReferencePrefixMapping(UpgradeStep):
             annotations[REPOSITORY_FOLDER_KEY] = repository_mapping
             annotations[DOSSIER_KEY] = dossier_mapping
 
+            # check new annotations
+            if not is_persistent(annotations[REPOSITORY_FOLDER_KEY]):
+                raise Exception(
+                    "The REPOSITORY_FOLDER_KEY mapping is not persistent for %s." %
+                    obj.Title())
+
+            if not is_persistent(annotations[DOSSIER_KEY]):
+                raise Exception(
+                    "The DOSSIER_KEY mapping is not persistent for %s." % obj.Title())
+
             # drop old mapings
             annotations.pop(CHILD_REF_KEY)
             annotations.pop(PREFIX_REF_KEY)
@@ -66,6 +83,56 @@ class CleanupReferencePrefixMapping(UpgradeStep):
 
             annotations[DOSSIER_KEY] = dossier_mapping
 
+            # check new annotations
+            if not is_persistent(annotations[DOSSIER_KEY]):
+                raise Exception(
+                    "The DOSSIER_KEY mapping is not persistent for %s." % obj.Title())
+
             # drop old mapings
             annotations.pop(CHILD_REF_KEY)
             annotations.pop(PREFIX_REF_KEY)
+
+    def move_repository_root_mappings(self, obj):
+        annotations = IAnnotations(obj)
+
+        if annotations and annotations.get(CHILD_REF_KEY):
+            repo_mapping = PersistentDict(
+                {CHILD_REF_KEY: annotations.get(CHILD_REF_KEY),
+                 PREFIX_REF_KEY: annotations.get(PREFIX_REF_KEY)})
+
+            annotations[REPOSITORY_FOLDER_KEY] = repo_mapping
+
+            # check new annotations
+            if not is_persistent(annotations[REPOSITORY_FOLDER_KEY]):
+                raise Exception(
+                    "The REPOSITORY_FOLDER_KEY mapping is not persistent for %s." %
+                    obj.Title())
+
+            # drop old mapings
+            annotations.pop(CHILD_REF_KEY)
+            annotations.pop(PREFIX_REF_KEY)
+
+
+def instance_of(obj, types):
+    """Checks if item is an instance of any of the types.
+    """
+    return any([isinstance(obj, t) for t in types])
+
+
+def is_persistent(thing):
+    """Recursive function that checks if a structure containing nested lists
+    and dicts uses the Persistent types all the way down.
+    """
+    if not instance_of(thing, [list, dict]):
+        # It's neither a subclass of list or dict, so it's fine
+        return True
+
+    if not instance_of(thing, [PersistentList, PersistentDict]):
+        # It's a subclass of list or dict, but not a persistent one - bad!
+        return False
+
+    if isinstance(thing, PersistentList):
+        return all([is_persistent(i) for i in thing])
+
+    elif isinstance(thing, PersistentDict):
+        return all([is_persistent(v) for v in thing.values()])


### PR DESCRIPTION
The upgrade-step in https://github.com/4teamwork/opengever.core/blob/master/opengever/base/upgrades/to2601.py is currently broken, because it replaces persistent mappings with non-persistent ones as a side effect.

This needs to be fixed before any other sites are upgraded to >= 2.6.x
