### PR TITLE
refactor, get rid of `contact_info.get_email2`.

### DIFF
--- a/opengever/ogds/base/contact_info.py
+++ b/opengever/ogds/base/contact_info.py
@@ -539,36 +539,6 @@ class ContactInformation(grok.GlobalUtility):
             raise ValueError('Unknown principal type: %s' %
                              str(principal))
 
-    def get_email2(self, principal):
-        """Returns the second email address of a `principal`.
-        """
-
-        # inbox does not have a email
-        if isinstance(principal, types.StringTypes) and \
-                self.is_inbox(principal):
-            return None
-
-        # principal may be a contact brain
-        elif ICatalogBrain.providedBy(principal) and \
-                brain_is_contact(principal):
-            return principal.email2
-
-        # principal may be a user object
-        elif IUser.providedBy(principal) or isinstance(principal, UserDict):
-            return principal.email2
-
-        # principal may ba a string contact principal
-        elif self.is_contact(principal):
-            return self.get_contact(principal).email2
-
-        # principal may be a string user principal
-        elif self.is_user(principal):
-            return self.get_user(principal).email2
-
-        else:
-            raise ValueError('Unknown principal type: %s' %
-                             str(principal))
-
     @ram.cache(ogds_principal_cachekey)
     def get_profile_url(self, principal):
         """Returns the profile url of this `principal`.

--- a/opengever/ogds/base/tests/test_contact_info.py
+++ b/opengever/ogds/base/tests/test_contact_info.py
@@ -175,18 +175,6 @@ class TestEmailGetter(FunctionalTestCase):
         self.assertEquals(u'hugo@boss.local',
                           self.info.get_email(self.info.get_user('hugo.boss')))
 
-    def test_get_email2_for_a_user_return_his_second_email(self):
-        create_ogds_user('hugo.boss', **{'firstname': 'Hugo',
-                                'lastname': 'Boss',
-                                'email': 'hugo@boss.local',
-                                'email2': 'hugo@private.ch'})
-
-        self.assertEquals(u'hugo@private.ch',
-                          self.info.get_email2('hugo.boss'))
-
-        self.assertEquals(u'hugo@private.ch',
-                          self.info.get_email2(self.info.get_user('hugo.boss')))
-
     def test_get_email_for_a_contact_return_his_email(self):
         create(Builder('contact')
                .having(**{'firstname': u'Lara',
@@ -200,22 +188,9 @@ class TestEmailGetter(FunctionalTestCase):
             'lara.croft@test.ch',
             self.info.get_email(self.info.get_contact('contact:croft-lara')))
 
-    def test_get_email2_for_a_contact_return_his_second_email(self):
-        create(Builder('contact')
-               .having(**{'firstname': u'Lara',
-                          'lastname': u'Croft',
-                          'email': u'lara.croft@test.ch',
-                          'email2': u'tombraider_lara@test2.ch'}))
-
-        self.assertEquals('tombraider_lara@test2.ch',
-                          self.info.get_email2(u'contact:croft-lara'))
-
     def test_get_email_for_a_inbox_return_none(self):
         self.assertEquals(
             None, self.info.get_email(u'inbox:client1'))
-
-        self.assertEquals(
-            None, self.info.get_email2(u'inbox:client1'))
 
 
 class TestGroupHelpers(FunctionalTestCase):

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -425,7 +425,7 @@ class EmailContactsAndUsersVocabularyFactory(grok.GlobalUtility):
                     ('%s:%s' % (email, userid),
                      info.describe(contact_or_user, with_email=True)))
 
-            email2 = info.get_email2(contact_or_user)
+            email2 = contact_or_user.email2
             if email2:
                 if not active:
                     self.hidden_terms.append(email2)


### PR DESCRIPTION
This method was called from exactly one place.
It handled 6 different kind of inputs but the only reference
called it with only 2 distinct inputs. Those inputs then
both share the same duck-type interface.

There is no need for indirection, which is not used.
