### PR TITLE
refactor, get rid of `contact_info.get_email`.

### DIFF
--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -184,7 +184,7 @@ class SendDocumentForm(form.Form):
                 only_links=data.get('documents_as_links'))
 
             msg['Subject'] = Header(data.get('subject'), CHARSET)
-            sender_address = contact_info.get_email(userid)
+            sender_address = contact_info.get_user(userid).email
             if not sender_address:
                 portal = self.context.portal_url.getPortalObject()
                 sender_address = portal.email_from_address

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -43,6 +43,7 @@ class TestSendDocument(FunctionalTestCase):
 
         create_client('plone')
         set_current_client_id(self.portal, clientid=u'plone')
+        create_ogds_user(TEST_USER_ID)
         Mailing(self.portal).set_up()
 
     def test_dossier_is_sendable(self):
@@ -77,9 +78,6 @@ class TestSendDocument(FunctionalTestCase):
                             or enter a extern mail-addres')
 
     def test_send_documents(self):
-        create_ogds_user(
-            TEST_USER_ID, firstname="Hugo", lastname="Boss", email="hugo@boss.ch")
-
         dossier = create(Builder("dossier"))
         documents = [create(Builder("document").within(dossier).with_dummy_content()), ]
         mail = self.send_documents(dossier, documents)

--- a/opengever/ogds/base/contact_info.py
+++ b/opengever/ogds/base/contact_info.py
@@ -504,37 +504,6 @@ class ContactInformation(grok.GlobalUtility):
         else:
             raise ValueError('Unknown principal type: %s' % str(principal))
 
-    def get_email(self, principal):
-        """Returns the email address of a `principal`.
-        """
-        # inbox does not have a email
-        if isinstance(principal, types.StringTypes) and \
-                self.is_inbox(principal):
-            return None
-
-        # principal may be a contact brain
-        elif ICatalogBrain.providedBy(principal) and \
-                brain_is_contact(principal):
-            return principal.email
-
-        # principal may be a user object
-        elif IUser.providedBy(principal) or isinstance(principal, UserDict):
-            return principal.email
-
-        # principal may ba a string contact principal
-        elif self.is_contact(principal):
-            return self.get_contact(principal).email
-
-        # principal may be a string user principal
-        elif self.is_user(principal):
-            if not self.get_user(principal):
-                return None
-            return self.get_user(principal).email
-
-        else:
-            raise ValueError('Unknown principal type: %s' %
-                             str(principal))
-
     @ram.cache(ogds_principal_cachekey)
     def get_profile_url(self, principal):
         """Returns the profile url of this `principal`.

--- a/opengever/ogds/base/tests/test_contact_info.py
+++ b/opengever/ogds/base/tests/test_contact_info.py
@@ -158,41 +158,6 @@ class TestUserHelpers(FunctionalTestCase):
             self.info.render_link('hugo.boss'))
 
 
-class TestEmailGetter(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestEmailGetter, self).setUp()
-        self.info = getUtility(IContactInformation)
-
-    def test_get_email_for_a_user_return_his_first_email(self):
-        create_ogds_user('hugo.boss', **{'firstname': 'Hugo',
-                                        'lastname': 'Boss',
-                                        'email': 'hugo@boss.local',
-                                        'email2': 'hugo@private.ch'})
-
-        self.assertEquals(u'hugo@boss.local',
-                          self.info.get_email('hugo.boss'))
-        self.assertEquals(u'hugo@boss.local',
-                          self.info.get_email(self.info.get_user('hugo.boss')))
-
-    def test_get_email_for_a_contact_return_his_email(self):
-        create(Builder('contact')
-               .having(**{'firstname': u'Lara',
-                          'lastname': u'Croft',
-                          'email': u'lara.croft@test.ch',
-                          'email2': u'tombraider_lara@test2.ch'}))
-
-        self.assertEquals('lara.croft@test.ch',
-                  self.info.get_email(u'contact:croft-lara'))
-        self.assertEquals(
-            'lara.croft@test.ch',
-            self.info.get_email(self.info.get_contact('contact:croft-lara')))
-
-    def test_get_email_for_a_inbox_return_none(self):
-        self.assertEquals(
-            None, self.info.get_email(u'inbox:client1'))
-
-
 class TestGroupHelpers(FunctionalTestCase):
 
     def setUp(self):

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -417,7 +417,7 @@ class EmailContactsAndUsersVocabularyFactory(grok.GlobalUtility):
                 userid = contact_or_user.userid
             else:
                 userid = contact_or_user.getId
-            email = info.get_email(contact_or_user)
+            email = contact_or_user.email
             if email:
                 if not active:
                     self.hidden_terms.append(email)


### PR DESCRIPTION
This is a follow up to: #228.

This method was only called from two places.
We inlined both. This allows us to drop this "heavy-switching-logic".
