### PR TITLE
Hiding client id at task in one client setup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,8 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Hiding client id at task in one client setup.
+  [lknoepfel]
 
 3.2.3 (2014-04-01)
 ------------------

--- a/opengever/ogds/base/contact_info.py
+++ b/opengever/ogds/base/contact_info.py
@@ -369,13 +369,6 @@ class ContactInformation(grok.GlobalUtility):
 
         return self._is_client_assigned(userid, client_id)
 
-    def is_one_client_setup(self):
-        """Return True if only one client is available"""
-
-        clients = self.get_clients()
-
-        return len(clients) == 1
-
     # general principal methods
     def describe(self, principal, with_email=False, with_email2=False,
                  with_principal=True):

--- a/opengever/ogds/base/tests/test_contact_info.py
+++ b/opengever/ogds/base/tests/test_contact_info.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from opengever.ogds.base.interfaces import IContactInformation
 from opengever.ogds.base.utils import get_client_id
 from opengever.ogds.base.utils import get_current_client
+from opengever.ogds.base.utils import is_one_client_setup
 from opengever.testing import FunctionalTestCase
 from opengever.testing import create_client
 from opengever.testing import create_ogds_user
@@ -101,14 +102,14 @@ class TestOneClientSetupHelper(FunctionalTestCase):
         create_client(clientid='client')
         set_current_client_id(self.portal, clientid='client')
 
-        self.assertTrue(self.info.is_one_client_setup())
+        self.assertTrue(is_one_client_setup())
 
     def test_a_setup_with_multiple_clients_is_not_a_one_client_setup(self):
         create_client(clientid='client')
         create_client(clientid='client2')
         set_current_client_id(self.portal, clientid='client')
 
-        self.assertFalse(self.info.is_one_client_setup())
+        self.assertFalse(is_one_client_setup())
 
 
 class TestUserHelpers(FunctionalTestCase):

--- a/opengever/ogds/base/utils.py
+++ b/opengever/ogds/base/utils.py
@@ -73,6 +73,15 @@ def get_client_id():
     return proxy.client_id
 
 
+def is_one_client_setup():
+    """Return True if only one client is available"""
+
+    info = getUtility(IContactInformation)
+    clients = info.get_clients()
+
+    return len(clients) == 1
+
+
 def client_public_url_cachekey(method):
     """chackekey for the get_client_public_url, wich is unique for every plone
     site. So a setup with multiple opengever sites on one plone instance is

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -5,6 +5,7 @@ from opengever.ogds.base.interfaces import IClientCommunicator
 from opengever.ogds.base.interfaces import IContactInformation
 from opengever.ogds.base.interfaces import ISyncStamp
 from opengever.ogds.base.utils import get_current_client
+from opengever.ogds.base.utils import is_one_client_setup
 from opengever.ogds.base.vocabulary import ContactsVocabulary
 from plone.memoize import ram
 from zope.app.component.hooks import getSite, setSite
@@ -180,7 +181,7 @@ class AllUsersAndInboxesVocabularyFactory(grok.GlobalUtility):
             for user in info.list_assigned_users(client_id=client_id):
                 value = u'%s:%s' % (client_id, user.userid)
                 # prepend client if there are multiple clients
-                if info.is_one_client_setup():
+                if is_one_client_setup():
                     label = u'%s' % (info.describe(user))
                 else:
                     label = u'%s: %s' % (

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -5,6 +5,7 @@ from opengever.base.browser.helper import client_title_helper
 from opengever.base.browser.helper import get_css_class
 from opengever.globalindex.model.task import Task
 from opengever.ogds.base.interfaces import IContactInformation
+from opengever.ogds.base.utils import is_one_client_setup
 from opengever.tabbedview.browser.tabs import OpengeverTab
 from opengever.task import _
 from opengever.task.interfaces import ISuccessorTaskController
@@ -154,6 +155,9 @@ class Overview(DisplayForm, OpengeverTab):
         def _get_issuer():
             info = getUtility(IContactInformation)
             task = ITask(self.context)
+
+            if is_one_client_setup():
+                return info.render_link(task.issuer)
 
             client_id = get_client_id()
             predecessors = self.get_predecessor_task()

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner, aq_parent
 from five.grok import subscribe
 from opengever.globalindex.handlers.task import index_task
 from opengever.ogds.base.interfaces import IContactInformation
+from opengever.ogds.base.utils import is_one_client_setup
 from opengever.task.task import ITask
 from zope.app.container.interfaces import IObjectAddedEvent
 from zope.component import getUtility
@@ -61,7 +62,7 @@ class LocalRolesSetter(object):
     def is_inboxgroup_agency_active(self):
         """The inbox group acengy is only activated in a multiclient setup."""
         info = getUtility(IContactInformation)
-        return not info.is_one_client_setup()
+        return not is_one_client_setup()
 
     def _add_local_roles(self, context, principal, roles):
         """Adds local roles to the context.


### PR DESCRIPTION
Also moved `is_one_client_setup` to `opengever.ogds.base.utils`.

@phgross do you know of other instances where we should hide the client id?
