### PR TITLE
Task overview: Hide client prefix in issuer value for a one client setup...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 - Fixed backref name of the groups_user join table.
   [phgross]
 
+- Task overview: Hide client prefix in issuer value for a one client setup.
+  [phgross]
+
 
 3.2.3 (2014-04-01)
 ------------------

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -155,14 +155,15 @@ class Overview(DisplayForm, OpengeverTab):
             info = getUtility(IContactInformation)
             task = ITask(self.context)
 
+            if info.is_one_client_setup():
+                return info.render_link(task.issuer)
+
             client_id = get_client_id()
             predecessors = self.get_predecessor_task()
 
             if predecessors and \
                 predecessors[0].task_type != 'forwarding_task_type':
                 client_id = predecessors[0].client_id
-            else:
-                client_id = get_client_id()
 
             client = client_title_helper(task, client_id)
 
@@ -200,6 +201,7 @@ class Overview(DisplayForm, OpengeverTab):
             },
             {
                 'label': _(u"label_issuer", default=u"Issuer"),
+                'css_class': "issuer",
                 'value': _get_issuer(),
             },
             {

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -1,0 +1,62 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from opengever.testing import create_client
+from opengever.testing import create_ogds_user
+from opengever.testing import set_current_client_id
+from plone.app.testing import TEST_USER_ID
+
+
+class TestTaskOverview(FunctionalTestCase):
+
+    use_browser = True
+
+    def setUp(self):
+        super(TestTaskOverview, self).setUp()
+        create_ogds_user(TEST_USER_ID)
+        create_client(clientid="client1")
+        set_current_client_id(self.portal, clientid="client1")
+
+    def test_issuer_is_linked_to_issuers_details_view(self):
+        task = create(Builder("task").having(issuer=TEST_USER_ID))
+        self.browser.open(
+            '%s/tabbedview_view-overview' % task.absolute_url())
+
+        link = self.browser.locate('.issuer a')
+        self.assertEquals(
+            'http://nohost/plone/@@user-details/test_user_1_',
+            link.target.get('href'))
+
+    def test_issuer_is_labeld_by_user_description(self):
+        task = create(Builder("task").having(issuer=TEST_USER_ID))
+        self.browser.open(
+            '%s/tabbedview_view-overview' % task.absolute_url())
+
+        link = self.browser.locate('.issuer a')
+        self.assertEquals(
+            'Boss Hugo (test_user_1_)', link.plain_text())
+
+    def test_issuer_is_prefixed_by_current_client_title_and_slash_on_a_multiclient_setup(self):
+        client2 = create_client(clientid="client2")
+        task = create(Builder("task").having(issuer=TEST_USER_ID))
+
+        self.browser.open(
+            '%s/tabbedview_view-overview' % task.absolute_url())
+
+        td = self.browser.locate('.issuer')
+        self.assertEquals(
+            'Client1 / Boss Hugo (test_user_1_)', td.plain_text())
+
+    def test_issuer_is_prefixed_by_predecessor_client_title_on_a_forwarding_successor(self):
+        client2 = create_client(clientid="client2")
+
+        forwarding = create(Builder('forwarding').(issuer=TEST_USER_ID))
+        successor = create(Builder('task')
+                           .having(issuer=TEST_USER_ID)
+                           .successor_from(forwarding))
+        self.browser.open(
+            '%s/tabbedview_view-overview' % successor.absolute_url())
+
+        link = self.browser.locate('.issuer')
+        self.assertEquals(
+            'Client1 / Boss Hugo (test_user_1_)', link.plain_text())


### PR DESCRIPTION
In a one client setup the prefixed client title is not necessary:
![bildschirmfoto 2014-04-11 um 12 40 34](https://cloud.githubusercontent.com/assets/485755/2679270/1b2a945a-c170-11e3-8bbc-6f5f189dc7ea.png)

Additionaly i add tests for the different possabilities for the issuer display.

@lukasgraf 

(this pr replace #234)
