### PR TITLE
Added missing kgs inclusion.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends =
     http://dist.plone.org/release/4.2.1/versions.cfg
+    http://kgs.4teamwork.ch/release/opengever/2.7.4
 
 versions = versions
 


### PR DESCRIPTION
The commit 9cba578e dropped the
opengever-zug kgs inclusion, which is right, but it dropped the
complete inclusion of the kgs version. The standard opengever
version pinings are necessary.

@lukasgraf 
