### PR TITLE
Replaced ext-js function 'remove' with pure js version in advancedsearch.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Replaced ext-js function 'remove' with pure js version in advancedsearch.
+  [lknoepfel]
+
 - Fixed backref name of the groups_user join table.
   [phgross]
 

--- a/opengever/advancedsearch/resources/advanced_search.js
+++ b/opengever/advancedsearch/resources/advanced_search.js
@@ -15,7 +15,7 @@ $(function(){
   $('input[name=form.widgets.object_provides:list]').change(function(){
     var types = ['opengever-dossier-behaviors-dossier-IDossierMarker', 'opengever-task-task-ITask', 'opengever-document-behaviors-IBaseDocument'];
     selected = $('input[name=form.widgets.object_provides:list]:checked').attr('value').replace(/\./g, '-');
-    types.remove(selected);
+    types.splice(types.indexOf(selected),1)
 
     // show current
     $('.'+selected).each(function(){


### PR DESCRIPTION
The advanced search used the array function `remove` which was provided by `ext-js`. Since `ext-js` is no longer included by default the function fails.

The `remove` function has been replaced by a plain js variant.

@lukasgraf 
