### PR TITLE
Update opengever.mail tests according to changes in ftw.mail.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Update og.mail tests according to changes in ftw.mail.
+  (See https://github.com/4teamwork/ftw.mail/pull/17)
+
 - Fixed typo in test_overview.py.
   [lknoepfel]
 

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -30,13 +30,14 @@ class TestMailIndexers(MockTestCase):
             u'"Hugo Boss" <hugo.boss@boss.com>')
         self.replay()
 
+        # ftw.mail removes quotes around name in 'From:'
         self.assertEqual(
             document_author(mail)(),
-            '"Hugo Boss" &lt;hugo.boss@boss.com&gt;')
+            'Hugo Boss &lt;hugo.boss@boss.com&gt;')
 
         self.assertEqual(
             sortable_author(mail)(),
-            '"Hugo Boss" &lt;hugo.boss@boss.com&gt;')
+            'Hugo Boss &lt;hugo.boss@boss.com&gt;')
 
     def test_author_indexes_with_bad_from_header(self):
         mail = self.stub()


### PR DESCRIPTION
See https://github.com/4teamwork/ftw.mail/pull/17.

`ftw.mail` now removes quote around names in the `From:` header, so we need to update our assertions.
