### PR TITLE
Styling des Dokument aus Vorlage verbessern

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
   Using SearchableText from the url as default value in advanced search.
   [lknoepfel]
 
+- Styled document from template form.
+  [lknoepfel]
+
 - Setup: Activate navigation portlet on the templatedossier.
   [phgross]
 

--- a/opengever/dossier/templatedossier/form.py
+++ b/opengever/dossier/templatedossier/form.py
@@ -46,7 +46,7 @@ class TemplateDocumentFormView(grok.View):
             path = None
             if self.request.get('paths'):
                 path = self.request.get('paths')[0]
-            self.title = self.request.get('title', '').decode('utf8')
+            self.title = self.request.get('form.title', '').decode('utf8')
             self.edit = self.request.get('form.widgets.edit_form') == ['on']
 
             if path and self.title:

--- a/opengever/dossier/templatedossier/form_templates/template_form.pt
+++ b/opengever/dossier/templatedossier/form_templates/template_form.pt
@@ -16,7 +16,7 @@
 
   <form i18n:domain="opengever.dossier" action="./document_with_template" method="POST" tal:attributes="is_first python: request.get('form.buttons.save')">
      <div class="row horizontal">
-      <div class="" tal:attributes="class python: view.errors.get('paths', None) and 'error' or ''">
+      <div class="" tal:attributes="class python: view.errors.get('paths', None) and 'error field' or 'field'">
         <label for="form-widgets-template" class="horizontal">
           <span i18n:translate="label_template">Template</span>
         </label>
@@ -25,17 +25,17 @@
       </div>
     </div>
       <div class="row">
-        <div class="" tal:attributes="class python: view.errors.get('title', None) and 'error' or ''">
+        <div tal:attributes="class python: view.errors.get('title', None) and 'error field' or 'field'">
             <label for="form-widgets-title" class="">
                 <span i18n:translate="label_title">title</span>
             </label>
             <span title="Erforderlich" class="fieldRequired" i18n:translate="required">required</span>
             <div>
-                <input type="text" name="title" id="form-widgets-title" tal:attributes="value   view/title" />
+                <input type="text" name="form.title" id="form-widgets-title" tal:attributes="value   view/title" />
             </div>
         </div>
     </div>
-    <div id="formfield-form-widgets-edit_form" class="">
+    <div id="formfield-form-widgets-edit_form" class="field">
         <div class="">
         <span class="">
         <tal:cond tal:condition="view/edit">


### PR DESCRIPTION
Das aktuelle Formular `Dokument aus Vorlage` insbesondere das Titel Feld entspricht nicht dem sonstigen Styling der Formulare.

![bildschirmfoto 2014-05-06 um 18 03 32](https://cloud.githubusercontent.com/assets/485755/2891978/0812c078-d538-11e3-9bbe-a5735f524e01.png)

@shylux: Allenfalls auch mit @ninfaj Rücksprache nehmen.
