### PR TITLE
Treeportlet: Implement deferred tree rendering.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Treeportlet: Implement deferred tree rendering.
+  [phgross]
+
 - Fixed German translation in logout overlay.
   [pha]
 

--- a/opengever/portlets/tree/resources/init_tree.js
+++ b/opengever/portlets/tree/resources/init_tree.js
@@ -1,9 +1,13 @@
 $(function() {
-	var tree = $(".filetree").treeview({
-	    collapsed: true,
-		animated: "fast",
-		persist: "cookie",
-		cookieId: "opengever-treeview"
-	});
+ var root_path = $('.filetree').data()['root_path'];
+
+  $('.filetree').load('./tree',{'root_path': root_path}, function(){
+    var tree = $(".filetree").treeview({
+      collapsed: true,
+      animated: "fast",
+      persist: "cookie",
+      cookieId: "opengever-treeview"
+    });
+  });
 
 });

--- a/opengever/portlets/tree/treeportlet.pt
+++ b/opengever/portlets/tree/treeportlet.pt
@@ -8,14 +8,14 @@
     </dt>
 
     <dd class="portletItem odd">
-        <ul class="filetree">
-            <div tal:content="structure python: here.unrestrictedTraverse('tree').render(view.root_path())" /> 
+        <ul class="filetree" tal:attributes="data-root_path view/root_path">
+          <img src="spinner.gif" class="spinner"/>
         </ul>
     </dd>
 
-    <!--<dd class="portletFooter">
-        <span class="portletBottomLeft"></span>
-        <span class="portletBottomRight"></span>
-    </dd> -->
+    <dd class="portletFooter">
+      <span class="portletBottomLeft"></span>
+      <span class="portletBottomRight"></span>
+    </dd>
 
 </dl>

--- a/opengever/portlets/tree/treeportlet.py
+++ b/opengever/portlets/tree/treeportlet.py
@@ -1,16 +1,13 @@
-from zope.interface import implements
-from zope import schema
-
-from plone.portlets.interfaces import IPortletDataProvider
-from plone.app.portlets.portlets import base
-
-from zope.formlib import form
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
-from Products.CMFCore.utils import getToolByName
-
-from Acquisition import aq_inner
 from AccessControl.unauthorized import Unauthorized
+from Acquisition import aq_inner
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.app.portlets.portlets import base
+from plone.portlets.interfaces import IPortletDataProvider
+from zope import schema
+from zope.formlib import form
+from zope.interface import implements
+
 
 class ITreePortlet(IPortletDataProvider):
     """A portlet
@@ -58,6 +55,7 @@ class Assignment(base.Assignment):
         """
         return "Tree portlet"
 
+
 class Renderer(base.Renderer):
     """Portlet renderer.
 
@@ -67,14 +65,13 @@ class Renderer(base.Renderer):
     """
 
     render = ViewPageTemplateFile('treeportlet.pt')
-    
+
     def header(self):
         current = aq_inner(self.context)
         # Don't travsere to top-level application obj if TreePortlet
         # was added to the Plone Site Root
         if self.root_path() != None:
             portal_url = getToolByName(self.context, 'portal_url')
-            
             current = portal_url.getPortalObject().restrictedTraverse(self.root_path().encode('utf-8'))
             return aq_inner(current).Title()
         elif current.Type() != 'Plone Site':
@@ -84,8 +81,8 @@ class Renderer(base.Renderer):
         return aq_inner(self.context).Title()
 
     def root_path(self):
-        return getattr(self.data,'root_path', None)
-        
+        return getattr(self.data, 'root_path', None)
+
     @property
     def available(self):
         if self.root_path() != None:


### PR DESCRIPTION
When having a large repository-tree with more than 2000 objects,
the three portlet slows down every site reload. To avoid this performance issue
we render the the tree deferred.

@lukasgraf please take a look.
