### PR TITLE
Fixes some issues in the Dossierdetails PDF generator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Dossierdetails PDF: Fixed doubled encoded repository_path.
+  [phgross]
+
 - Dossierdetails PDF: Fixed UnicodeEncodeError in responsible getter.
   [phgross]
 

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -206,7 +206,7 @@ class DossierDetailsLaTeXView(grok.MultiAdapter, MakoLaTeXView):
 
             obj = aq_parent(aq_inner(obj))
 
-        return ' / '.join(self.convert_list(titles))
+        return ' / '.join(titles)
 
     def get_participants(self):
         dossier = IDossier(self.context)


### PR DESCRIPTION
- Fixed UnicodeEncodeError in `responsible getter`.
- Fixed doubled encoded `repository_path` (see pictures).

![bildschirmfoto 2014-05-11 um 22 25 31](https://cloud.githubusercontent.com/assets/485755/2939501/7147c79e-d94a-11e3-9994-7a86b7ac8ab9.png)

@lukasgraf please take a look?

Fixes https://github.com/4teamwork/opengever.ai/issues/42
