### PR TITLE
Added handling for missing document_type in document view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Added handling for missing document_type in document view.
+  This field is hidden on a customer installation.
+  [lknoepfel]
+
 - Dossierdetails PDF: Fixed doubled encoded repository_path.
   [phgross]
 

--- a/opengever/document/browser/overview_templates/overview.pt
+++ b/opengever/document/browser/overview_templates/overview.pt
@@ -14,7 +14,7 @@
 			<th i18n:translate="label_document_date">Document Date</th>
 			<td tal:content="structure view/w/document_date/render"/>
 		</tr>
-		<tr tal:condition="python: view.w['document_type'].value">
+		<tr tal:condition="python: 'document_type' in view.w and view.w['document_type'].value">
 			<th i18n:translate="label_document_type">Document Type</th>
 			<td tal:content="structure view/w/document_type/render"/>
 		</tr>

--- a/opengever/document/tests/test_overview_missing_fields.py
+++ b/opengever/document/tests/test_overview_missing_fields.py
@@ -1,0 +1,26 @@
+from ftw.builder import create, Builder
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
+from opengever.document.document import IDocumentSchema
+from opengever.testing import FunctionalTestCase
+from plone.autoform.interfaces import OMITTED_KEY
+from zope.interface import Interface
+
+
+class TestDocumentOverviewMissingFields(FunctionalTestCase):
+
+    def setUp(self):
+        omitted_values = IDocumentSchema.getTaggedValue(OMITTED_KEY)
+        self.org_omitted_values = list(omitted_values)
+        omitted_values.append((Interface, 'document_type', 'true'))
+        IDocumentSchema.setTaggedValue(OMITTED_KEY, omitted_values)
+
+        self.document = create(Builder('document'))
+
+    def tearDown(self):
+        IDocumentSchema.setTaggedValue(OMITTED_KEY, self.org_omitted_values)
+
+    @browsing
+    def test_document_overview_without_document_type(self, browser):
+        browser.login()
+        browser.visit(self.document, view="tabbedview_view-overview")


### PR DESCRIPTION
A customer hides the `document_type` field. The view needs an update to handle this missing field.

Fixes https://github.com/4teamwork/opengever.ai/issues/54

@phgross 
