### PR TITLE
Treeportlet: Only try to load the tree if there is a treeportlet.

### DIFF
--- a/opengever/portlets/tree/resources/init_tree.js
+++ b/opengever/portlets/tree/resources/init_tree.js
@@ -1,13 +1,16 @@
 $(function() {
- var root_path = $('.filetree').data()['root_path'];
+  var filetree = $('.filetree');
+  if (filetree.length) {
+    var root_path = filetree.data()['root_path'];
 
-  $('.filetree').load('./tree',{'root_path': root_path}, function(){
-    var tree = $(".filetree").treeview({
-      collapsed: true,
-      animated: "fast",
-      persist: "cookie",
-      cookieId: "opengever-treeview"
+    filetree.load('./tree',{'root_path': root_path}, function(){
+      var tree = filetree.treeview({
+        collapsed: true,
+        animated: "fast",
+        persist: "cookie",
+        cookieId: "opengever-treeview"
+      });
     });
-  });
+  }
 
 });


### PR DESCRIPTION
@lukasgraf This fixes a JavaScript error on views without the treeportlet.
