### PR TITLE
Fixed interface in dossiers ConstrainTypeDecider.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Fixed interface in dossiers ConstrainTypeDecider.
+  [phgross]
+
 - Updated ftw.zipexport registry entry to multi-value field.
   [lknoepfel]
 

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -1,6 +1,5 @@
 from Acquisition import aq_inner, aq_parent
 from Products.CMFCore.utils import getToolByName
-from Products.CMFDefault.interfaces import ICMFDefaultSkin
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from datetime import datetime
 from five import grok
@@ -13,6 +12,7 @@ from plone.dexterity.content import Container
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
 from zope.component import queryMultiAdapter, queryUtility
+from zope.interface import Interface
 
 
 DOSSIER_STATES_OPEN = [
@@ -219,7 +219,7 @@ class DossierContainer(Container):
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):
     grok.provides(IConstrainTypeDecider)
-    grok.adapts(ICMFDefaultSkin, IDossierMarker, IDexterityFTI)
+    grok.adapts(Interface, IDossierMarker, IDexterityFTI)
     grok.name('')
 
     CONSTRAIN_CONFIGURATION = {

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -59,6 +59,17 @@ class TestDossierContainerFunctional(FunctionalTestCase):
         self.assertTrue(subdossier.is_subdossier())
 
 
+    def test_maximum_dossier_level_is_2_by_default(self):
+        dossier = create(Builder('dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+
+        self.assertIn('opengever.dossier.businesscasedossier',
+                      [fti.id for fti in dossier.allowedContentTypes()])
+
+        self.assertNotIn('opengever.dossier.businesscasedossier',
+                      [fti.id for fti in subdossier.allowedContentTypes()])
+
+
 class TestDossierChecks(FunctionalTestCase):
 
     def test_its_all_closed_if_no_task_exists(self):


### PR DESCRIPTION
The default adapter should use `Interface` as adapting interface for the request. Otherwise overriding the ConstrainTypeDecider in a customer package, is not possible without inheriting from `Products.CMFDefault.interfaces.ICMFDefaultSkin` in the customers browserlayer.

@deiferni could you take a look?
