### PR TITLE
Update master after release 3.2.4.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-3.2.4 (unreleased)
+3.2.5 (unreleased)
 ------------------
 
 - Added responsible org field on repositoryfolder.
@@ -32,10 +32,6 @@ Changelog
 - Dossierdetails PDF: Fixed UnicodeEncodeError in responsible getter.
   [phgross]
 
-- Added missing french (and german) translations.
-  Fixed i18n domain and translated vdex.
-  [lknoepfel]
-
 - Passing search string from live search to advanced search.
   Using SearchableText from the url as default value in advanced search.
   [lknoepfel]
@@ -57,6 +53,13 @@ Changelog
 
 - Fixed German translation in logout overlay.
   [pha]
+
+3.2.4 (2014-05-26)
+------------------
+
+- Added missing french (and german) translations.
+  Fixed i18n domain and translated vdex.
+  [lknoepfel]
 
 - Mail view: use sprite icons in the attachments list.
   [phgross]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '3.2.4.dev0'
+version = '3.2.5.dev0'
 maintainer = 'Jonas Baumann'
 
 tests_require = [


### PR DESCRIPTION
This PR updates the changelog so that it includes the version recently released for PHVS.

Release 3.2.4 is based on cf184661682b59415980797974f05c72dffdd7dc with a backport of c260aeb3779971cb5a535b75af3848fd73a888b5.
