### PR TITLE
Fixed zipexport-enable upgrade step to match the new registry entry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+- Fixed zipexport-enable upgrade step to match the new registry entry.
+  With ftw.zipexport 1.2.0 the registry name changes which brakes our upgrade step.
+  [lknoepfel]
+
 - Added responsible org field on repositoryfolder.
   [lknoepfel]
 

--- a/opengever/policy/base/upgrades/profiles/3100/registry.xml
+++ b/opengever/policy/base/upgrades/profiles/3100/registry.xml
@@ -1,5 +1,7 @@
 <registry>
     <records interface="ftw.zipexport.interfaces.IZipExportSettings">
-        <value key="enabled_dotted_name">opengever.dossier.behaviors.dossier.IDossierMarker</value>
+        <value key="enabled_dotted_names">
+            <element>opengever.dossier.behaviors.dossier.IDossierMarker</element>
+        </value>
     </records>
 </registry>


### PR DESCRIPTION
With ftw.zipexport 1.2.0 the registry name changes which brakes our upgrade step.

**With this change opengever.core is not compatible anymore with ftw.zipexport prior 1.2.0.**

@phgross review please
