### PR TITLE
Added reviewer role on admin groups.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Added reviewer role on admin groups.
+  This role ensures that admins can see the menu bar.
+  [lknoepfel]
+
 - Inbox: Removed icon from byline.
   [Julian Infanger]
 

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -130,5 +130,13 @@
         directory="profiles/2606"
         />
 
+  <genericsetup:upgradeStep
+      title="Add reviewer role on admin groups"
+      description=""
+      source="2606"
+      destination="2607"
+      handler="opengever.base.upgrades.to2607.AddReviewerOnAdmin"
+      profile="opengever.base:default"
+      />
 
 </configure>

--- a/opengever/base/upgrades/to2607.py
+++ b/opengever/base/upgrades/to2607.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddReviewerOnAdmin(UpgradeStep):
+
+    def __call__(self):
+
+        prm = self.portal.acl_users.portal_role_manager
+
+        for group in prm.listAssignedPrincipals('Administrator'):
+            prm.assignRoleToPrincipal('Reviewer', group[0])

--- a/opengever/setup/setuphandlers.py
+++ b/opengever/setup/setuphandlers.py
@@ -78,6 +78,7 @@ def assign_roles(context, admin_file):
         prm.assignRoleToPrincipal('Member', admin_group.strip())
         prm.assignRoleToPrincipal('Editor', admin_group.strip())
         prm.assignRoleToPrincipal('Role Manager', admin_group.strip())
+        prm.assignRoleToPrincipal('Reviewer', admin_group.strip())
 
 
 def assign_tree_portlet(context, root_path, remove_nav=False,


### PR DESCRIPTION
This role ensures that admins can see the menu bar.

@phgross 
`opengever.setup` uses the `administrator.txt` to determine the admin groups. Should i use the same file for the upgrade-step? Or should i add the role to all groups with the `Administrator` role (group names may have changed..)?
Is this testable? It would require a full site installation, so i guess not.
