### PR TITLE
Refactor some hard to change test data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Refactored some hard to change test data.
+  [lgraf]
 
 
 3.3 (2014-06-05)

--- a/opengever/task/tests/data.py
+++ b/opengever/task/tests/data.py
@@ -1,10 +1,85 @@
 from plone.app.testing import TEST_USER_ID
+import json
 
 
-DOCUMENT_EXTRACTION = u'[{"unicode:field-data": {"utf8:IRelatedDocuments": {"utf8:relatedItems": []}, "utf8:ICreator": {"utf8:creators": []}, "utf8:IDocumentSchema": {"utf8:document_date": "utf8:2012-10-19", "utf8:delivery_date": null, "utf8:digitally_available": true, "utf8:preview": null, "utf8:description": null, "utf8:archival_file": null, "utf8:thumbnail": null, "utf8:receipt_date": null, "utf8:keywords": [], "utf8:document_type": null, "utf8:preserved_as_paper": true, "utf8:foreign_reference": null, "utf8:document_author": null, "utf8:file": {"utf8:filename": "unicode:test.txt", "utf8:data": "utf8:test data"}, "utf8:title": "unicode:test"}, "utf8:IClassification": {"utf8:privacy_layer": "unicode:privacy_layer_no", "utf8:public_trial": "unicode:unchecked", "utf8:public_trial_statement": "unicode:", "utf8:classification": "unicode:unprotected"}, "utf8:IVersionable": {"utf8:changeNote": "utf8:"}}, "utf8:basedata": {"utf8:id": "utf8:document-10", "utf8:portal_type": "utf8:opengever.document.document", "utf8:title": "utf8:test"}, "unicode:dublin-core": {"utf8:creator": "utf8:zopemaster", "utf8:created": "utf8:2012/10/19 15:57:30.879365 GMT+2"}, "unicode:intid-data": 389258091}]'
+DOCUMENT_EXTRACTION = json.dumps(
+[{u'unicode:dublin-core': {u'utf8:created': u'utf8:2012/10/19 15:57:30.879365 GMT+2',
+                           u'utf8:creator': u'utf8:zopemaster'},
+  u'unicode:field-data': {u'utf8:IClassification': {u'utf8:classification': u'unicode:unprotected',
+                                                    u'utf8:privacy_layer': u'unicode:privacy_layer_no',
+                                                    u'utf8:public_trial': u'unicode:unchecked',
+                                                    u'utf8:public_trial_statement': u'unicode:'},
+                          u'utf8:ICreator': {u'utf8:creators': []},
+                          u'utf8:IDocumentSchema': {u'utf8:archival_file': None,
+                                                    u'utf8:delivery_date': None,
+                                                    u'utf8:description': None,
+                                                    u'utf8:digitally_available': True,
+                                                    u'utf8:document_author': None,
+                                                    u'utf8:document_date': u'utf8:2012-10-19',
+                                                    u'utf8:document_type': None,
+                                                    u'utf8:file': {u'utf8:data': u'utf8:test data',
+                                                                   u'utf8:filename': u'unicode:test.txt'},
+                                                    u'utf8:foreign_reference': None,
+                                                    u'utf8:keywords': [],
+                                                    u'utf8:preserved_as_paper': True,
+                                                    u'utf8:preview': None,
+                                                    u'utf8:receipt_date': None,
+                                                    u'utf8:thumbnail': None,
+                                                    u'utf8:title': u'unicode:test'},
+                          u'utf8:IRelatedDocuments': {u'utf8:relatedItems': []},
+                          u'utf8:IVersionable': {u'utf8:changeNote': u'utf8:'}},
+  u'unicode:intid-data': 389258091,
+  u'utf8:basedata': {u'utf8:id': u'utf8:document-10',
+                     u'utf8:portal_type': u'utf8:opengever.document.document',
+                     u'utf8:title': u'utf8:test'}}]
+)
 
 
-TASK_EXTRACTION = '{"unicode:field-data": {"utf8:ITask": {"utf8:deadline": "utf8:2012-10-24", "utf8:responsible_client": "unicode:plone", "utf8:effectiveCost": null, "utf8:effectiveDuration": null, "utf8:task_type": "utf8:approval", "utf8:text": null, "utf8:expectedCost": null, "utf8:responsible": "unicode:%s", "utf8:date_of_completion": null, "utf8:predecessor": null, "utf8:issuer": "unicode:testuser2", "utf8:expectedStartOfWork": null, "utf8:expectedDuration": null, "utf8:relatedItems": [], "utf8:title": "unicode:Testaufgabe"}}, "utf8:basedata": {"utf8:id": "utf8:task-1", "utf8:portal_type": "utf8:opengever.task.task", "utf8:title": "utf8:Testaufgabe"}, "unicode:dublin-core": {"utf8:creator": "utf8:zopemaster", "utf8:created": "utf8:2012/10/19 15:40:19.649945 GMT+2"}, "unicode:intid-data": 389258089}' %(TEST_USER_ID)
+TASK_EXTRACTION = json.dumps(
+{u'unicode:dublin-core': {u'utf8:created': u'utf8:2012/10/19 15:40:19.649945 GMT+2',
+                          u'utf8:creator': u'utf8:zopemaster'},
+ u'unicode:field-data': {u'utf8:ITask': {u'utf8:date_of_completion': None,
+                                         u'utf8:deadline': u'utf8:2012-10-24',
+                                         u'utf8:effectiveCost': None,
+                                         u'utf8:effectiveDuration': None,
+                                         u'utf8:expectedCost': None,
+                                         u'utf8:expectedDuration': None,
+                                         u'utf8:expectedStartOfWork': None,
+                                         u'utf8:issuer': u'unicode:testuser2',
+                                         u'utf8:predecessor': None,
+                                         u'utf8:relatedItems': [],
+                                         u'utf8:responsible': u'unicode:%s' % TEST_USER_ID,
+                                         u'utf8:responsible_client': u'unicode:plone',
+                                         u'utf8:task_type': u'utf8:approval',
+                                         u'utf8:text': None,
+                                         u'utf8:title': u'unicode:Testaufgabe'}},
+ u'unicode:intid-data': 389258089,
+ u'utf8:basedata': {u'utf8:id': u'utf8:task-1',
+                    u'utf8:portal_type': u'utf8:opengever.task.task',
+                    u'utf8:title': u'utf8:Testaufgabe'}}
+)
 
 
-FORWARDING_EXTRACTION = '{"unicode:field-data": {"utf8:IForwarding": {"utf8:deadline": "utf8:2012-10-24", "utf8:responsible_client": "unicode:plone", "utf8:effectiveCost": null, "utf8:effectiveDuration": null, "utf8:task_type": "utf8:forwarding_task_type", "utf8:text": null, "utf8:expectedCost": null, "utf8:responsible": "unicode:inbox:plone", "utf8:date_of_completion": null, "utf8:predecessor": null, "utf8:issuer": "unicode:inbox:client2", "utf8:expectedStartOfWork": null, "utf8:expectedDuration": null, "utf8:relatedItems": [], "utf8:title": "unicode:Ein Testdokument"}}, "utf8:basedata": {"utf8:id": "utf8:forwarding-1", "utf8:portal_type": "utf8:opengever.inbox.forwarding", "utf8:title": "utf8:Ein Testdokument"}, "unicode:dublin-core": {"utf8:creator": "utf8:zopemaster", "utf8:created": "utf8:2012/10/19 15:58:8.235873 GMT+2"}, "unicode:intid-data": 389258092}'
+FORWARDING_EXTRACTION = json.dumps(
+{u'unicode:dublin-core': {u'utf8:created': u'utf8:2012/10/19 15:58:8.235873 GMT+2',
+                          u'utf8:creator': u'utf8:zopemaster'},
+ u'unicode:field-data': {u'utf8:IForwarding': {u'utf8:date_of_completion': None,
+                                               u'utf8:deadline': u'utf8:2012-10-24',
+                                               u'utf8:effectiveCost': None,
+                                               u'utf8:effectiveDuration': None,
+                                               u'utf8:expectedCost': None,
+                                               u'utf8:expectedDuration': None,
+                                               u'utf8:expectedStartOfWork': None,
+                                               u'utf8:issuer': u'unicode:inbox:client2',
+                                               u'utf8:predecessor': None,
+                                               u'utf8:relatedItems': [],
+                                               u'utf8:responsible': u'unicode:inbox:plone',
+                                               u'utf8:responsible_client': u'unicode:plone',
+                                               u'utf8:task_type': u'utf8:forwarding_task_type',
+                                               u'utf8:text': None,
+                                               u'utf8:title': u'unicode:Ein Testdokument'}},
+ u'unicode:intid-data': 389258092,
+ u'utf8:basedata': {u'utf8:id': u'utf8:forwarding-1',
+                    u'utf8:portal_type': u'utf8:opengever.inbox.forwarding',
+                    u'utf8:title': u'utf8:Ein Testdokument'}}
+)


### PR DESCRIPTION
The test data in [`opengever.task.tests.data`](https://github.com/4teamwork/opengever.core/blob/6737c4d728d5d8356d12ea42af6c82ed6c8ee62c/opengever/task/tests/data.py) is nearly impossible to update or even read.

This PR changes it to be pretty printed Python, that then dynamically gets converted to JSON, resulting in the same data but better readability. We might still need to revisit that test though ;)
