### PR TITLE
Tabbedview helpers rework

### DIFF
--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -5,6 +5,7 @@ from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
+from opengever.ogds.base.actor import Actor
 from opengever.tabbedview.helper import readable_ogds_author
 from plone.indexer import indexer
 from Products.CMFCore.utils import getToolByName
@@ -146,6 +147,6 @@ def sortable_author(obj):
     """Index to allow users to sort on document_author."""
     author = obj.document_author
     if author:
-        return readable_ogds_author(obj, author)
+        return Actor.user(author).get_label()
     return ''
 grok.global_adapter(sortable_author, name='sortable_author')

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -66,27 +66,18 @@ def readable_ogds_author(item, author):
         else:
             author = ''
 
-    info = getUtility(IContactInformation)
-    if info.is_user(author) or info.is_contact(
-            author) or info.is_inbox(author):
-        return info.describe(author)
-    else:
-        return author
+    return Actor.lookup(author).get_label()
 
 
 @ram.cache(author_cache_key)
-def readable_ogds_user(item, user):
-    if not isinstance(user, unicode):
-        if user is not None:
-            user = user.decode('utf-8')
+def readable_ogds_user(item, userid):
+    if not isinstance(userid, unicode):
+        if userid is not None:
+            userid = userid.decode('utf-8')
         else:
-            user = ''
+            userid = ''
 
-    info = getUtility(IContactInformation)
-    if info.is_user(user) or info.is_contact(user) or info.is_inbox(user):
-        return info.describe(user)
-    else:
-        return user
+    return Actor.user(userid).get_label()
 
 
 @ram.cache(author_cache_key)


### PR DESCRIPTION
- Helpers: Use actor lookup instead of `IContactInformation.describe`.
- Use helper only in tabbedview und LaTex listings, appart from that
  use direct actor lookup.

@deiferni 
