### PR TITLE
Originally this PR was meant to fix the double journal entry bug, but the fix lead into several other problems

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,12 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Fix double journal entries using quickupload.
+  [mathias.leimgruber]
+
+- Test quickupload: Replace mock tests by functional tests.
+  [mathias.leimgruber]
+
 - Enforce correct order in inbox-task-tab tests.
   [lknoepfel]
 

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -7,6 +7,7 @@ from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
 from plone.dexterity.utils import iterSchemata
 from plone.rfc822.interfaces import IPrimaryField
+from plone.rfc822.interfaces import IPrimaryFieldInfo
 from z3c.form.interfaces import IValue
 from zope.component import queryMultiAdapter
 from zope.event import notify
@@ -26,8 +27,12 @@ class OGQuickUploadCapableFileFactory(grok.Adapter):
     def __init__(self, context):
         self.context = aq_inner(context)
 
-    def __call__(
-        self, filename, title, description, content_type, data, portal_type):
+    def __call__(self,
+                 filename,
+                 title,
+                 description,
+                 content_type,
+                 data, portal_type):
 
         if filename.lower().endswith('msg'):
             # its a outlook msg file
@@ -62,12 +67,9 @@ class OGQuickUploadCapableFileFactory(grok.Adapter):
         if not isinstance(filename, unicode):
             filename = filename.decode('utf-8')
 
-        for schemata in iterSchemata(obj):
-            for name, field in getFieldsInOrder(schemata):
-                if IPrimaryField.providedBy(field):
-                    value = field._type(data=data, filename=filename)
-                    field.set(field.interface(obj), value)
-                    break
+        field = IPrimaryFieldInfo(obj).field
+        value = field._type(data=data, filename=filename)
+        field.set(field.interface(obj), value)
 
     def set_default_values(self, obj):
         # set default values for all fields
@@ -77,12 +79,12 @@ class OGQuickUploadCapableFileFactory(grok.Adapter):
                     continue
                 else:
                     default = queryMultiAdapter((
-                            obj,
-                            obj.REQUEST,
-                            None,
-                            field,
-                            None,
-                            ), IValue, name='default')
+                        obj,
+                        obj.REQUEST,
+                        None,
+                        field,
+                        None,
+                    ), IValue, name='default')
                     if default is not None:
                         default = default.get()
                     if default is None:

--- a/opengever/base/tests/test_quickupload.py
+++ b/opengever/base/tests/test_quickupload.py
@@ -1,196 +1,74 @@
 from collective.quickupload.interfaces import IQuickUploadFileFactory
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.tabbedview.interfaces import ITabbedviewUploadable
-from ftw.testing import MockTestCase
-from grokcore.component.testing import grok, grok_component
 from opengever.journal.browser import JournalHistory
 from opengever.testing import FunctionalTestCase
-from plone.directives import form
-from plone.namedfile.field import NamedFile as nf_field
-from plone.namedfile.file import NamedFile
-from unittest2 import TestCase
-from zope import schema
 from zope.i18n import translate
-import zope.component.testing
 
 
-class ITest1(form.Schema):
-    title = schema.TextLine(
-        title=u'label_title',
-        required=False)
-
-    description = schema.Text(
-        title=u'description',
-        default=u'hanspeter',
-        required=False,
-        )
-
-
-class ITest2(form.Schema):
-    form.primary('file')
-    file = nf_field(
-        title=u'label_file',
-        required=False,
-        )
-
-
-class TestOGQuickupload(MockTestCase, TestCase):
+class TestOGQuickupload(FunctionalTestCase):
 
     def setUp(self):
         super(TestOGQuickupload, self).setUp()
-        grok('plone.directives.form.meta')
-        grok('opengever.base.quickupload')
-
-    def tearDown(self):
-        zope.component.testing.tearDown()
+        self.grant('Manager')
+        self.dossier = create(Builder('dossier'))
+        self.adapter = IQuickUploadFileFactory(self.dossier)
 
     def test_get_mimetype(self):
-        mock_context = self.providing_stub([ITabbedviewUploadable])
-        self.replay()
-        adapter = IQuickUploadFileFactory(mock_context)
-        self.assertEqual(adapter._get_mimetype('hanspeter.doc'),
-            'application/msword')
+        self.assertEqual('application/msword',
+                         self.adapter._get_mimetype('hanspeter.doc'))
 
-        self.assertEqual(adapter._get_mimetype('hanspeter.jpeg'),
-            'image/jpeg')
+        self.assertEqual('image/jpeg',
+                         self.adapter._get_mimetype('hanspeter.jpeg'))
 
     def test_get_portal_type(self):
-        mock_context = self.providing_stub([ITabbedviewUploadable])
-        self.replay()
-        adapter = IQuickUploadFileFactory(mock_context)
 
         self.assertEqual(
-            adapter.get_portal_type('image.jpeg'),
+            self.adapter.get_portal_type('image.jpeg'),
             'opengever.document.document')
         self.assertEqual(
-            adapter.get_portal_type('mail.eml'), 'ftw.mail.mail')
+            self.adapter.get_portal_type('mail.eml'), 'ftw.mail.mail')
         self.assertEqual(
-            adapter.get_portal_type('test.doc'),
+            self.adapter.get_portal_type('test.doc'),
             'opengever.document.document')
 
-    def test_set_default_value(self):
-        grok_component('ITest2', ITest2)
+    def test_set_default_values(self):
+        result = self.adapter(filename='document.txt',
+                              title='',  # ignored by adapter
+                              description='Description',  # ignored by adapter
+                              content_type='text/plain',
+                              data='text',
+                              portal_type='opengever.document.document')
+        content = result['success']
 
-        # mock stuf
-        mock_context = self.providing_stub([ITabbedviewUploadable, ])
-        named_file = NamedFile('bla bla', filename=u'test.txt')
-
-        obj = self.providing_stub([ITest1, ITest2])
-        request = self.stub()
-        self.expect(obj.REQUEST).result(request)
-
-        iterSchemata = self.mocker.replace(
-            'plone.dexterity.utils.iterSchemata')
-        self.expect(iterSchemata(obj)).result([ITest1, ITest2])
-
-        self.replay()
-
-        # test if it's sets the default value and
-        # also if it add the created file to the primary field
-        adapter = IQuickUploadFileFactory(mock_context)
-        adapter.set_default_values(obj, named_file)
-        self.assertEquals(obj.description, 'hanspeter')
-        self.assertEquals(obj.file, named_file)
-
-    def test_create_file(self):
-        grok_component('ITest2', ITest2)
-
-        # mock stuf
-        mock_context = self.providing_stub([ITabbedviewUploadable, ])
-        named_file = NamedFile('bla bla', filename=u'test.txt')
-
-        obj = self.providing_stub([ITest1, ITest2])
-        request = self.stub()
-        self.expect(obj.REQUEST).result(request)
-
-        iterSchemata = self.mocker.replace(
-            'plone.dexterity.utils.iterSchemata')
-        self.expect(iterSchemata(obj)).result([ITest1, ITest2])
-
-        self.replay()
-
-        # test if it's sets the default value and
-        # also if it add the created file to the primary field
-        adapter = IQuickUploadFileFactory(mock_context)
-        named_file = adapter.create_file(
-            u'hugo.jpeg', u'data data', obj)
-
-        self.assertEquals(named_file.data, u'data data')
-
-    def test_complete_creation(self):
-        grok_component('ITest2', ITest2)
-
-        # mock stuf
-        mock_context = self.providing_stub([ITabbedviewUploadable, ])
-
-        obj = self.providing_stub([ITest1, ITest2])
-        request = self.stub()
-        self.expect(obj.REQUEST).result(request)
-        self.expect(obj.reindexObject()).result(None)
-        self.expect(obj.__parent__).result(mock_context)
-        self.expect(obj.__name__).result('test_context')
-
-        iterSchemata = self.mocker.replace(
-            'plone.dexterity.utils.iterSchemata')
-        self.expect(iterSchemata(obj)).result([ITest1, ITest2]).count(0, None)
-
-        createContentInContainer = self.mocker.replace(
-            'plone.dexterity.utils.createContentInContainer')
-        self.expect(createContentInContainer(
-                mock_context, 'opengever.document.document')).result(obj)
-
-        # filedata
-        filename = u'hugo.doc'
-        title = None
-        description = None
-        content_type = None
-        data = u'Data data'
-        portal_type = None
-
-        self.replay()
-
-        adapter = IQuickUploadFileFactory(mock_context)
-        result = adapter(filename, title, description,
-                         content_type, data, portal_type)
-        obj = result.get('success')
-        self.assertEquals(obj.description, 'hanspeter')
-        self.assertEquals(obj.file.data, u'Data data')
-
-
-class TestJournalEntriesWithQuickupload(FunctionalTestCase):
+        self.assertEquals('document', content.Title())
+        self.assertEquals('text', content.file.data)
+        self.assertIsNone(content.description)
 
     def test_expect_one_journal_entry_after_upload(self):
-        self.grant('Manager')
 
-        dossier = create(Builder('dossier'))
-        adapter = IQuickUploadFileFactory(dossier)
-
-        result = adapter(filename='document.txt',
-                         title='Title of document',
-                         description='',
-                         content_type='text/plain',
-                         data='text',
-                         portal_type='opengever.document.document')['success']
-        history = JournalHistory(result, result.REQUEST)
+        result = self.adapter(filename='document.txt',
+                              title='Title of document',
+                              description='',
+                              content_type='text/plain',
+                              data='text',
+                              portal_type='opengever.document.document')
+        content = result['success']
+        history = JournalHistory(content, content.REQUEST)
 
         self.assertEquals(1,
                           len(history.data()),
                           'Expect exactly one journal entry after upload')
 
     def test_filename_is_used_as_default_title_for_journal_entry(self):
-        self.grant('Manager')
-
-        dossier = create(Builder('dossier'))
-        adapter = IQuickUploadFileFactory(dossier)
-
-        result = adapter(filename='document.txt',
-                         title='',
-                         description='',
-                         content_type='text/plain',
-                         data='text',
-                         portal_type='opengever.document.document')['success']
-        history = JournalHistory(result, result.REQUEST)
+        result = self.adapter(filename='document.txt',
+                              title='',
+                              description='',
+                              content_type='text/plain',
+                              data='text',
+                              portal_type='opengever.document.document')
+        content = result['success']
+        history = JournalHistory(content, content.REQUEST)
 
         self.assertEquals(u'Document added: document.txt',
                           translate(history.data()[0]['action']['title']),


### PR DESCRIPTION
@phgross @lukasgraf 
- Set the title while creating the content: So the journal can set the title correctly.
- Replace mock tests with functional tests
- Fix quickupload.py - Fire ObjectAddedEvent only once. 

Fixes #301 
