### PR TITLE
Classification behavior: Change default for public_trial, drop restrictions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,10 @@ Changelog
 - Added public_trial index and metadata field.
   [lknoepfel]
 
+- Public trial is no longer a restricted vocab. It behaves like a regular one.
+  New default is "unchecked".
+  [mathias.leimgruber]
+
 - Enforce correct order in inbox-task-tab tests.
   [lknoepfel]
 

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -13,7 +13,7 @@ from opengever.base import _
 from opengever.base.behaviors import utils
 
 
-# PUBLIC: Vocabulary and default value
+# PUBLIC TRIAL: Vocabulary and default value
 PUBLIC_TRIAL_UNCHECKED = u'unchecked'
 PUBLIC_TRIAL_PUBLIC = u'public'
 PUBLIC_TRIAL_PRIVATE = u'private'
@@ -23,7 +23,7 @@ PUBLIC_TRIAL_OPTIONS = (
     PUBLIC_TRIAL_PUBLIC,
     PUBLIC_TRIAL_LIMITED_PUBLIC,
     PUBLIC_TRIAL_PRIVATE,
-    )
+)
 
 
 class IClassification(form.Schema):
@@ -36,31 +36,29 @@ class IClassification(form.Schema):
             u'privacy_layer',
             u'public_trial',
             u'public_trial_statement',
-            ],
-        )
+        ],
+    )
 
     classification = schema.Choice(
         title=_(u'label_classification', default=u'Classification'),
         description=_(u'help_classification', default=u''),
         source=u'classification_classification_vocabulary',
         required=True,
-        )
+    )
 
-    #form.widget(privacy_layer=checkbox.SingleCheckBoxFieldWidget)
     privacy_layer = schema.Choice(
         title=_(u'label_privacy_layer', default=u'Privacy layer'),
         description=_(u'help_privacy_layer', default=u''),
         source=u'classification_privacy_layer_vocabulary',
         required=True,
-        )
+    )
 
     public_trial = schema.Choice(
         title=_(u'label_public_trial', default=u'Public Trial'),
         description=_(u'help_public_trial', default=u''),
         source=u'classification_public_trial_vocabulary',
         required=True,
-        default=PUBLIC_TRIAL_UNCHECKED
-        )
+    )
 
     public_trial_statement = schema.Text(
         title=_(u'label_public_trial_statement',
@@ -68,7 +66,7 @@ class IClassification(form.Schema):
         description=_(u'help_public_trial_statement', default=u''),
         required=False,
         default=u'',
-        )
+    )
 
 
 alsoProvides(IClassification, IFormFieldProvider)
@@ -96,7 +94,7 @@ CLASSIFICATION_OPTIONS = (
     (1, CLASSIFICATION_UNPROTECTED),
     (2, CLASSIFICATION_CONFIDENTIAL),
     (3, CLASSIFICATION_CLASSIFIED),
-    )
+)
 
 
 grok.global_utility(
@@ -112,8 +110,8 @@ form.default_value(field=IClassification['classification'])(
     utils.set_default_with_acquisition(
         field=IClassification['classification'],
         default=CLASSIFICATION_UNPROTECTED
-        )
     )
+)
 
 
 grok.global_utility(
@@ -130,7 +128,7 @@ PRIVACY_LAYER_YES = u'privacy_layer_yes'
 PRIVACY_LAYER_OPTIONS = (
     (1, PRIVACY_LAYER_NO),
     (2, PRIVACY_LAYER_YES),
-    )
+)
 
 
 grok.global_utility(
@@ -146,17 +144,25 @@ form.default_value(field=IClassification['privacy_layer'])(
     utils.set_default_with_acquisition(
         field=IClassification['privacy_layer'],
         default=PRIVACY_LAYER_NO
-        )
     )
+)
+
+
+# XXX: Setting the default value in the field directly, breaks the
+# DCFieldProperty stuff. thus we implement the default value this way.
+@form.default_value(field=IClassification['public_trial'])
+def default_public_trial(data):
+    """Set the actual date as default document_date"""
+    return PUBLIC_TRIAL_UNCHECKED
 
 
 class Classification(metadata.MetadataBase):
 
     classification = metadata.DCFieldProperty(IClassification[
-            'classification'])
+        'classification'])
     privacy_layer = metadata.DCFieldProperty(IClassification[
-            'privacy_layer'])
+        'privacy_layer'])
     public_trial = metadata.DCFieldProperty(IClassification[
-            'public_trial'])
+        'public_trial'])
     public_trial_statement = metadata.DCFieldProperty(IClassification[
-            'public_trial_statement'])
+        'public_trial_statement'])

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -246,12 +246,12 @@ def overrides_child(folder, event, aq_fields, marker):
                 if schema_field.get(schema_field.interface(obj)) not in voc:
                     # obj, request, form, field, widget
                     default = getMultiAdapter((
-                            obj.aq_inner.aq_parent,
-                            obj.REQUEST,
-                            None,
-                            schema_field,
-                            None,
-                            ), IValue, name='default')
+                        obj.aq_inner.aq_parent,
+                        obj.REQUEST,
+                        None,
+                        schema_field,
+                        None,
+                    ), IValue, name='default')
                     if isinstance(default, ComputedValue):
                         default = default.get()
                     setattr(schema_field.interface(obj), field, default)

--- a/opengever/base/tests/test_classification_behavior.py
+++ b/opengever/base/tests/test_classification_behavior.py
@@ -76,7 +76,7 @@ class TestClassificationBehavior(FunctionalTestCase):
 
         public_trial_options = browser.css(
             '#form-widgets-IClassification-public_trial option').text
-        self.assertEquals(classification.PUBLIC_TRIAL_OPTIONS,
+        self.assertEquals(list(classification.PUBLIC_TRIAL_OPTIONS),
                           public_trial_options)
 
     def test_public_trial_default_value_is_unchecked(self):


### PR DESCRIPTION
1. New default value is always "unchecked"
2. It's now a regular vocabulary, without any restrictions (To implement this I created a new generic simple  vocabulary factory)
3. Use ftw.tesbrowser in classification behavior tests.
4. Code cleanup

@phgross @lukasgraf 
