### PR TITLE
Use the same byline for mail as for document

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Use document byline also on mail.
+  [mathias.leimgruber]
+
 - OGQuickUploadCapableFileFactory: Set default values before adding content to container.
   (Prevents values set by handlers on ObjectAddedEvent to be overwritten again).
   [lgraf]

--- a/opengever/document/tests/test_document_byline.py
+++ b/opengever/document/tests/test_document_byline.py
@@ -3,34 +3,34 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.tests.byline_base_test import TestBylineBase
 from opengever.testing import create_ogds_user
-from zope.component import getUtility
-from zope.intid.interfaces import IIntIds
 
 
 class TestDocumentByline(TestBylineBase):
 
     def setUp(self):
         super(TestDocumentByline, self).setUp()
-
-        self.intids = getUtility(IIntIds)
-
+        self.grant('Manager')
         create_ogds_user('hugo.boss')
 
-
         self.document = create(Builder('document')
-               .having(start=date(2013, 11, 6),
-                       document_date=date(2013, 11, 5)))
+                               .having(start=date(2013, 11, 6),
+                                       document_date=date(2013, 11, 5),
+                                       document_author='hugo.boss'))
 
         self.browser.open(self.document.absolute_url())
 
-    def test_document_byline_start_date_display(self):
+    def test_document_byline_start_date(self):
         start_date = self.get_byline_value_by_label('from:')
         self.assertEquals('Nov 05, 2013', start_date.text_content())
 
-    def test_document_byline_sequence_number_display(self):
+    def test_document_byline_sequence_number(self):
         seq_number = self.get_byline_value_by_label('Sequence Number:')
         self.assertEquals('1', seq_number.text_content())
 
-    def test_document_byline_reference_number_display(self):
+    def test_document_byline_reference_number(self):
         ref_number = self.get_byline_value_by_label('Reference Number:')
         self.assertEquals('OG / 1', ref_number.text_content())
+
+    def test_document_byline_document_author(self):
+        document_author = self.get_byline_value_by_label('by:')
+        self.assertEquals('Boss Hugo', document_author.text_content())

--- a/opengever/document/viewlets/byline.py
+++ b/opengever/document/viewlets/byline.py
@@ -1,22 +1,14 @@
-from Products.CMFCore.utils import getToolByName
-from opengever.document.document import IDocumentSchema
 from opengever.base.viewlets.byline import BylineBase
 from opengever.document import _
 
 
 class DocumentByline(BylineBase):
 
+    def update(self):
+        super(DocumentByline, self).update()
+
     def document_date(self):
         return self.to_localized_time(self.context.document_date)
-
-    def responsible(self):
-        mt = getToolByName(self.context, 'portal_membership')
-        document = IDocumentSchema(self.context)
-        return mt.getMemberById(document.responsible)
-
-    def end(self):
-        document = IDocumentSchema(self.context)
-        return document.end
 
     def get_items(self):
         return [

--- a/opengever/mail/browser/byline.py
+++ b/opengever/mail/browser/byline.py
@@ -1,28 +1,5 @@
-from opengever.base.browser.helper import get_css_class
-from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
-from opengever.base.viewlets.byline import BylineBase
-from opengever.mail import _
-from plone.app.layout.viewlets import content
-from plone.memoize.instance import memoize
-from zope.component import getUtility, getAdapter
+from opengever.document.viewlets.byline import DocumentByline
 
 
-class OGMailByline(BylineBase):
-
-    def get_items(self):
-        return [
-            {'class': 'created',
-             'label': _('byline_created', default='Created'),
-             'content': self.created(),
-             'replace': False},
-
-            {'class': 'sequenceNumber',
-             'label': _('label_sequence_number', default='Sequence Number'),
-             'content': self.sequence_number(),
-             'replace': False},
-
-            {'class': 'reference_number',
-             'label': _('label_reference_number', default='Reference Number'),
-             'content': self.reference_number(),
-             'replace': False},
-        ]
+class OGMailByline(DocumentByline):
+    """Use own class for easier customizations in the future"""


### PR DESCRIPTION
- [x] Make document byline reusable for mail
- [x] Implement mail byline (same as document byline)
