### PR TITLE
Dossierdetails: Fixed label for the `end` attribute.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Dossierdetails: Fixed label for the Dossier end.
+  [phgross]
+
 - Added reviewer role on admin groups.
   This role ensures that admins can see the menu bar.
   [lknoepfel]

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -125,7 +125,7 @@ class DossierDetailsLaTeXView(grok.MultiAdapter, MakoLaTeXView):
                 'label': _('label_start', default='Start'),
                 'getter': self.get_start_date},
             'end': {
-                'label': _('label_start', default='Start'),
+                'label': _('label_end', default='End'),
                 'getter': self.get_end_date},
             'participants': {
                 'label': _('label_participants', default='Participants'),


### PR DESCRIPTION
The label for the `end` was wrong.

The translation for `label_end` exists already.

@lukasgraf please take a look.  
