### PR TITLE
Ou selector: active unit is now included in the unit's list.

### DIFF
--- a/opengever/ogds/base/ou_selector.py
+++ b/opengever/ogds/base/ou_selector.py
@@ -20,7 +20,7 @@ class OrgUnitSelector(object):
         self._storage[CURRENT_ORG_UNIT_KEY] = unitid
 
     def available_units(self):
-        return [unit for id, unit in self._units.items() if id != self.get_current_unit().id()]
+        return self._units.values()
 
     def _get_current_unit_id(self):
         if self._storage.has_key(CURRENT_ORG_UNIT_KEY):

--- a/opengever/ogds/base/tests/test_ou_selector.py
+++ b/opengever/ogds/base/tests/test_ou_selector.py
@@ -39,19 +39,11 @@ class TestOrgUnitSelector(unittest2.TestCase):
         self.assertEquals(self.unit_a._client,
                           selector.get_current_unit()._client)
 
-    def test_available_units_are_all_except_the_defaul_one_when_current_is_not_set(self):
+    def test_available_units_are_all_units(self):
         selector = OrgUnitSelector({},
             [self.unit_a, self.unit_b, self.unit_c])
 
-        self.assertEquals([self.unit_b, self.unit_c],
-                          selector.available_units())
-
-    def test_available_units_are_all_units_except_the_current_one(self):
-        selector = OrgUnitSelector(
-            {CURRENT_ORG_UNIT_KEY: 'clientb'},
-            [self.unit_a, self.unit_b, self.unit_c])
-
-        self.assertEquals([self.unit_a, self.unit_c],
+        self.assertEquals([self.unit_a, self.unit_b, self.unit_c],
                           selector.available_units())
 
     def test_set_current_unit_updates_current_id(self):
@@ -64,12 +56,11 @@ class TestOrgUnitSelector(unittest2.TestCase):
         self.assertEquals(self.unit_a,
                           selector.get_current_unit())
 
-    def test_set_current_unit_updates_available_units(self):
+    def test_set_current_unit_updates_activ_unit(self):
         selector = OrgUnitSelector(
             {CURRENT_ORG_UNIT_KEY: 'clientb'},
             [self.unit_a, self.unit_b, self.unit_c])
 
         selector.set_current_unit('clienta')
 
-        self.assertEquals([self.unit_b, self.unit_c],
-                          selector.available_units())
+        self.assertEquals(self.unit_a, selector.get_current_unit())

--- a/opengever/ogds/base/tests/test_viewlet_ou_selector.py
+++ b/opengever/ogds/base/tests/test_viewlet_ou_selector.py
@@ -29,7 +29,7 @@ class TestOrgUnitSelectorViewlet(FunctionalTestCase):
         units = browser.css('.orgunitMenuContent li')
 
         self.assertEquals(
-            ['Client 3', 'Client 4'], units.text)
+            ['Client 1', 'Client 3', 'Client 4'], units.text)
 
     @browsing
     def test_first_unit_is_marked_as_active_per_default(self, browser):
@@ -40,12 +40,26 @@ class TestOrgUnitSelectorViewlet(FunctionalTestCase):
             ['Client 1'], active_unit.text)
 
     @browsing
-    def test_list_all_assigned_units_except_current_one(self, browser):
+    def test_list_all_assigned_units(self, browser):
         browser.login().open(self.repo_root)
         units = browser.css('.orgunitMenuContent li')
 
         self.assertEquals(
-            ['Client 3', 'Client 4'], units.text)
+            ['Client 1', 'Client 3', 'Client 4'], units.text)
+
+    @browsing
+    def test_active_unit_is_not_linked(self, browser):
+        browser.login().open(self.repo_root)
+        units = browser.css('.orgunitMenuContent li span')
+
+        self.assertEquals(['Client 1'], units.text)
+
+    @browsing
+    def test_active_unit_has_class_active(self, browser):
+        browser.login().open(self.repo_root)
+        units = browser.css('.orgunitMenuContent li span.active')
+
+        self.assertEquals(['Client 1'], units.text)
 
     @browsing
     def test_selecting_a_unit_changes_active_unit(self, browser):

--- a/opengever/ogds/base/viewlets/ou_selector_viewlet.pt
+++ b/opengever/ogds/base/viewlets/ou_selector_viewlet.pt
@@ -12,9 +12,14 @@
     <dd class="actionMenuContent orgunitMenuContent" >
       <ul>
         <li tal:repeat="unit view/get_units">
-          <a href="" tal:attributes="href string:${unit/public_url}/change_org_unit?unit_id=${unit/id}" tal:content="unit/label">
-            OrgUnit title
-          </a>
+          <tal:define tal:define="is_active python:active_unit.id() == unit.id()">
+            <span tal:condition="is_active" tal:content="unit/label" class="active" />
+            <a href="" tal:condition="not: is_active" tal:content="unit/label"
+               tal:attributes="href string:${unit/public_url}/change_org_unit?unit_id=${unit/id}">
+              OrgUnit title
+            </a>
+          </tal:define>
+
         </li>
       </ul>
     </dd>


### PR DESCRIPTION
We decided that the select orgunit should also be displayed in the selection list.
![bildschirmfoto 2014-06-24 um 07 46 26](https://cloud.githubusercontent.com/assets/485755/3367560/f0e7fb4c-fb62-11e3-8120-63786616c325.png)

Some special styling for the active orgunit is arranged. 

@deiferni please take a look.
