### PR TITLE
Import path for new opengever.pdfconverter changed

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Fixed import for opengever.pdfconverter.
+  [lknoepfel]
+
 - Dossierdetails: Fixed label for the Dossier end.
   [phgross]
 

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -12,8 +12,7 @@ from zope.component import getUtility, queryMultiAdapter
 try:
     from opengever.pdfconverter.behaviors.preview import IPreviewMarker
     from opengever.pdfconverter.behaviors.preview import IPreview
-    from opengever.pdfconverter.behaviors.preview import \
-        CONVERSION_STATE_READY
+    from opengever.pdfconverter import CONVERSION_STATE_READY
 
     PDFCONVERTER_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
`opengever.pdfconverter` changes the location of a constant used by `opengever.core`.

`opengever.core` tries to import the `pdfconverter` classes and constants and if it fails it assumes `opengever.pdfconverter` is not available. There is no error message (which is intended).

This PR updates will restore the functionality for the `master` of `opengever.pdfconverter`, but will break the compatibility to all previous releases.

https://github.com/4teamwork/opengever.core/blob/master/opengever/document/browser/overview.py#L15

https://github.com/4teamwork/opengever.pdfconverter/pull/3
