### PR TITLE
Send document: new option "Save mail in dossier"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Added option so save a copy of an outgoing mail in a dossier.
+  [lknoepfel]
+
 - Dossierdetails: Fixed label for the Dossier end.
   [phgross]
 

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -7,6 +7,8 @@ from email.MIMEMultipart import MIMEMultipart
 from email.MIMEText import MIMEText
 from email.Utils import formatdate
 from five import grok
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.mail.mail import IMail
 from opengever.base.source import DossierPathSourceBinder
 from opengever.mail import _
@@ -33,6 +35,7 @@ from zope.event import notify
 from zope.i18n import translate
 from zope.interface import Interface
 from zope.interface import invariant, Invalid
+import random
 
 CHARSET = 'utf-8'
 
@@ -99,6 +102,12 @@ class ISendDocumentSchema(Interface):
     documents_as_links = schema.Bool(
         title=_(u'label_documents_as_link',
                 default=u'Send documents only als links'),
+        required=True,
+        )
+
+    save_copy_in_dossier = schema.Bool(
+        title=_(u'label_save_copy_in_dossier',
+                default=u'Save a copy of the sent mail in the Dossier'),
         required=True,
         )
 
@@ -197,6 +206,17 @@ class SendDocumentForm(form.Form):
 
             header_to = Header(','.join(addresses), CHARSET)
             msg['To'] = header_to
+
+            if data.get('save_copy_in_dossier'):
+                # id = str(random.randint(0, 99999999)) #  temporary id
+                # self.context.invokeFactory("ftw.mail.mail", id)
+                # content = self.context[id]
+                # content.message = msg
+                mail = create(Builder("mail")
+                       .within(self.context)
+                       .titled(data.get('subject')))
+                import pdb; pdb.set_trace()
+
 
             # send it
             mh.send(msg, mfrom=mail_from, mto=','.join(addresses))

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -171,6 +171,11 @@ msgstr "Mitteilung"
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
+#. Default: "Send documents only als links"
+#: ./opengever/mail/browser/send_document.py:106
+msgid "label_save_copy_in_dossier"
+msgstr "Kopie des versandten Mails im Dossier ablegen."
+
 #. Default: "see attachment"
 #: ./opengever/mail/browser/send_document.py:261
 msgid "label_see_attachment"

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -168,6 +168,11 @@ msgstr "Message"
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
+#. Default: "Send documents only als links"
+#: ./opengever/mail/browser/send_document.py:106
+msgid "label_save_copy_in_dossier"
+msgstr "Copie des mails envoyés mis dans le dossier."
+
 #. Default: "see attachment"
 #: ./opengever/mail/browser/send_document.py:261
 msgid "label_see_attachment"
@@ -200,5 +205,3 @@ msgstr "Email"
 #: ./opengever/mail/browser/send_document.py:65
 msgid "receiver"
 msgstr "Destinataire"
-
-

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -174,6 +174,11 @@ msgstr ""
 msgid "label_reference_number"
 msgstr ""
 
+#. Default: "Send documents only als links"
+#: ./opengever/mail/browser/send_document.py:106
+msgid "label_save_copy_in_dossier"
+msgstr ""
+
 #. Default: "see attachment"
 #: ./opengever/mail/browser/send_document.py:261
 msgid "label_see_attachment"
@@ -206,4 +211,3 @@ msgstr ""
 #: ./opengever/mail/browser/send_document.py:65
 msgid "receiver"
 msgstr ""
-


### PR DESCRIPTION
The send document functionality should be extended with a new option "save copy in the dossier":
![image](https://cloud.githubusercontent.com/assets/485755/3223342/9bf010a8-f021-11e3-894c-099bd0e044e4.png)

Todos:
- New checkbox (not activated by default)
- Mail saving
- Translations
- Tests
