### PR TITLE
Tolerate `OperationalError` in actions and viewlets.

### DIFF
--- a/opengever/ogds/base/__init__.py
+++ b/opengever/ogds/base/__init__.py
@@ -1,3 +1,6 @@
 from zope.i18nmessageid import MessageFactory
+import logging
 
+
+LOG = logging.getLogger('opengever.document')
 _ = MessageFactory('opengever.ogds.base')

--- a/opengever/ogds/base/viewlets/ou_selector_viewlet.pt
+++ b/opengever/ogds/base/viewlets/ou_selector_viewlet.pt
@@ -2,7 +2,7 @@
 
   <h5 class="hiddenStructure" i18n:translate="heading_client_selector">OrgUnit Selector</h5>
 
-  <dl class="orgunitMenu actionMenu deactivated" id="portal-orgunit-selector-menu">
+  <dl class="orgunitMenu actionMenu deactivated" id="portal-orgunit-selector-menu" tal:condition="active_unit">
     <dt class="orgunitMenuHeader actionMenuHeader">
       <a tal:attributes="href string:#" tal:content="active_unit/label">
         Org Unit ?

--- a/opengever/ogds/base/viewlets/ou_selector_viewlet.py
+++ b/opengever/ogds/base/viewlets/ou_selector_viewlet.py
@@ -1,7 +1,9 @@
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from five import grok
+from opengever.ogds.base import LOG
 from opengever.ogds.base.utils import get_ou_selector
 from plone.app.layout.viewlets import common
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from sqlalchemy.exc import OperationalError
 from zope.interface import Interface
 
 
@@ -15,8 +17,11 @@ class OrgUnitSelectorViewlet(common.ViewletBase):
         self.current_unit = None
 
     def get_active_unit(self):
-        if not self.current_unit:
-            self.current_unit = get_ou_selector().get_current_unit()
+        try:
+            if not self.current_unit:
+                self.current_unit = get_ou_selector().get_current_unit()
+        except OperationalError as e:
+            LOG.exception(e)
         return self.current_unit
 
     def get_units(self):

--- a/opengever/tabbedview/__init__.py
+++ b/opengever/tabbedview/__init__.py
@@ -1,3 +1,6 @@
 from zope.i18nmessageid import MessageFactory
+import logging
 
+
+LOG = logging.getLogger('opengever.tabbedview')
 _ = MessageFactory('opengever.tabbedview')

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -1,12 +1,14 @@
 from AccessControl import Unauthorized
-from Products.CMFPlone.utils import getToolByName
 from five import grok
 from ftw.tabbedview.browser.tabbed import TabbedView
 from opengever.globalindex.model.task import Task
 from opengever.ogds.base.interfaces import IContactInformation
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.tabbedview import LOG
 from opengever.tabbedview.browser.tabs import Documents, Dossiers
 from opengever.tabbedview.browser.tasklisting import GlobalTaskListingTab
+from Products.CMFPlone.utils import getToolByName
+from sqlalchemy.exc import OperationalError
 from zope.component import getUtility
 from zope.interface import Interface
 import AccessControl
@@ -87,14 +89,17 @@ class PersonalOverview(TabbedView):
         clients or an administrator and he therefore is allowed to view
         the PersonalOverview, False otherwise.
         """
+        try:
+            info = getUtility(IContactInformation)
 
-        info = getUtility(IContactInformation)
-
-        if info.is_client_assigned():
-            return True
-        elif self._is_user_admin():
-            return True
-        return False
+            if info.is_client_assigned():
+                return True
+            elif self._is_user_admin():
+                return True
+            return False
+        except OperationalError as e:
+            LOG.exception(e)
+            return False
 
 
 class MyDossiers(Dossiers):


### PR DESCRIPTION
An `OperationalError` can be raised when DB-migrations are not yet exectued.
We catch and log them in viewlets and actions in order order to access the `@@manage-upgrades` view
to perform these upgrades.

Fixes #352.
