### PR TITLE
Classification behavior on mail

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Add classification behavior to mail.
+  [mathias.leimgruber]
+
 - Use document byline also on mail.
   [mathias.leimgruber]
 

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -43,8 +43,8 @@ class TestAssignedInboxTaskTab(FunctionalTestCase):
         view = self.inbox.restrictedTraverse('tabbedview_view-%s' % (viewname))
         view.update()
 
-        self.assertEquals([task2sqltask(obj) for obj in results],
-                          view.contents)
+        self.assertEquals(set([task2sqltask(obj) for obj in results]),
+                          set(view.contents))
 
     def test_lists_only_tasks_assigned_to_current_inbox_group(self):
         create_client(clientid='client2')
@@ -89,8 +89,8 @@ class TestIssuedInboxTaskTab(FunctionalTestCase):
             'tabbedview_view-%s' % (viewname))
         view.update()
 
-        self.assertEquals(results,
-                          [brain.getObject() for brain in view.contents])
+        self.assertEquals(set(results),
+                          set([brain.getObject() for brain in view.contents]))
 
     def test_list_tasks_and_forwardings(self):
         task = create(Builder('task')

--- a/opengever/mail/profiles/default/metadata.xml
+++ b/opengever/mail/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2200</version>
+  <version>2201</version>
   <dependencies>
     <dependency>profile-ftw.mail:default</dependency>
   </dependencies>

--- a/opengever/mail/profiles/default/types/ftw.mail.mail.xml
+++ b/opengever/mail/profiles/default/types/ftw.mail.mail.xml
@@ -15,6 +15,7 @@
     </action>
     <property name="behaviors" purge="False">
         <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+        <element value="opengever.base.behaviors.classification.IClassification" />
         <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
         <element value="opengever.document.behaviors.IBaseDocument" />
         <element value="opengever.document.behaviors.metadata.IDocumentMetadata" />

--- a/opengever/mail/tests/test_mail_classification.py
+++ b/opengever/mail/tests/test_mail_classification.py
@@ -1,0 +1,56 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.behaviors.classification import CLASSIFICATION_UNPROTECTED
+from opengever.base.behaviors.classification import IClassificationMarker
+from opengever.base.behaviors.classification import PRIVACY_LAYER_NO
+from opengever.base.behaviors.classification import PUBLIC_TRIAL_UNCHECKED
+from opengever.testing import FunctionalTestCase
+from pkg_resources import resource_string
+from plone.dexterity.interfaces import IDexterityFTI
+from zope.component import getUtility
+
+
+MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
+
+
+class TestMailMetadata(FunctionalTestCase):
+    use_browser = True
+
+    def setUp(self):
+        super(TestMailMetadata, self).setUp()
+        self.grant('Contributor', 'Editor', 'Member', 'Manager')
+
+    def test_fill_classification_infos_of_new_mail(self):
+        mail = create(Builder("mail").with_message(MAIL_DATA))
+
+        self.assertEquals(mail.classification, CLASSIFICATION_UNPROTECTED)
+        self.assertEquals(mail.privacy_layer, PRIVACY_LAYER_NO)
+        self.assertEquals(mail.public_trial, PUBLIC_TRIAL_UNCHECKED)
+
+        # XXX: imho this should be a empty string, not None, since the field
+        # has a default value (empty string)
+        self.assertIsNone(mail.public_trial_statement)
+
+    def test_classification_initialization_upgrade_step(self):
+        fti = getUtility(IDexterityFTI, name=u'ftw.mail.mail')
+        behaviors = list(fti.behaviors)
+        behaviors.remove(
+            u'opengever.base.behaviors.classification.IClassification')
+        fti._updateProperty('behaviors', tuple(behaviors))
+
+        mail = create(Builder("mail").with_message(MAIL_DATA))
+
+        from opengever.mail.upgrades.to2201 import AddClassifiactionBehavior
+        AddClassifiactionBehavior(self.portal.portal_setup)
+
+        assert IClassificationMarker.providedBy(mail)
+
+        self.assertEquals(mail.classification, CLASSIFICATION_UNPROTECTED)
+        self.assertEquals(mail.privacy_layer, PRIVACY_LAYER_NO)
+        self.assertEquals(mail.public_trial, PUBLIC_TRIAL_UNCHECKED)
+        self.assertEquals(mail.public_trial_statement, u'')
+
+    def test_mail_public_trial_in_catalog_metadata(self):
+        create(Builder("mail").with_message(MAIL_DATA))
+        brain = self.portal.portal_catalog(portal_type='ftw.mail.mail')[0]
+        self.assertEquals(brain.public_trial, PUBLIC_TRIAL_UNCHECKED)

--- a/opengever/mail/upgrades/configure.zcml
+++ b/opengever/mail/upgrades/configure.zcml
@@ -74,4 +74,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 2200 -> 2201 -->
+    <genericsetup:upgradeStep
+        title="Add classification behavior"
+        description=""
+        source="2200"
+        destination="2201"
+        handler="opengever.mail.upgrades.to2201.AddClassifiactionBehavior"
+        profile="opengever.mail:default"
+        />
+
 </configure>

--- a/opengever/mail/upgrades/to2201.py
+++ b/opengever/mail/upgrades/to2201.py
@@ -1,0 +1,48 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.behaviors.classification import IClassification
+from plone.dexterity.interfaces import IDexterityFTI
+from z3c.form.interfaces import IValue
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+
+
+class AddClassifiactionBehavior(UpgradeStep):
+
+    def __call__(self):
+        fti = getUtility(IDexterityFTI, name=u'ftw.mail.mail')
+        behaviors = list(fti.behaviors)
+        behaviors.append(
+            'opengever.base.behaviors.classification.IClassification')
+        fti._updateProperty('behaviors', tuple(behaviors))
+
+        query = {'portal_type': 'ftw.mail.mail'}
+        for mail in self.objects(query, 'Initialize IClassification metadata on mail'):
+            self.set_default_values(mail)
+
+    def set_default_values(self, mail):
+        fields = [
+            u'classification',
+            u'privacy_layer',
+            u'public_trial',
+            u'public_trial_statement']
+
+        for fieldname in fields:
+            field = IClassification[fieldname]
+            default_adapter = queryMultiAdapter(
+                (mail.aq_parent, mail.REQUEST, None, field, None),
+                IValue, name='default')
+
+            default = None
+            if default_adapter is not None:
+                default = default_adapter.get()
+
+            if default is None:
+                default = field.default
+
+            if default is None:
+                try:
+                    default = field.missing_value
+                except AttributeError:
+                    pass
+
+            field.set(field.interface(mail), default)


### PR DESCRIPTION
@lukasgraf 
- Add classification behavior to mail contenttype
- Init classification behavior fields with default values for existing mails.

Important: Check https://github.com/4teamwork/opengever.core/compare/feature_public_trial...mle-public_trial_classification?expand=1#diff-c8cc3da6244d95c930ecc3482d361ca0R31

I guess we need to fix this is ftw.builder, since the field has a default value (empty string), but if the mail is created with ftw.builder the stored default value is None, which is wrong. The upgrade step works, because I also check for the default value on the field
