### PR TITLE
Added viewlet to colorize special pages as dev, test, ...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.2.5 (unreleased)
 ------------------
 
+- Added viewlet to colorize special pages as dev, test, ...
+  [Julian Infanger]
+
 - Fixed zipexport-enable upgrade step to match the new registry entry.
   With ftw.zipexport 1.2.0 the registry name changes which brakes our upgrade step.
   [lknoepfel]

--- a/opengever/base/viewlets/colorization.pt
+++ b/opengever/base/viewlets/colorization.pt
@@ -1,0 +1,12 @@
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    tal:define="css view/css"
+    tal:omit-tag="python: True">
+
+  <style type="text/css" media="all"
+         tal:condition="css"
+         tal:content="css"
+         />
+
+</html>

--- a/opengever/base/viewlets/colorization.py
+++ b/opengever/base/viewlets/colorization.py
@@ -1,0 +1,22 @@
+from plone.app.layout.viewlets.common import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+import os
+
+
+COLORS = {
+    'red': '#C3375A',
+    'yellow': '#EBD21E',
+    'green': '#37C35A'}
+
+ENVIRONMENT_KEY = 'GEVER_COLORIZATION'
+
+
+class ColorizationViewlet(ViewletBase):
+
+    index = ViewPageTemplateFile('colorization.pt')
+
+    def css(self):
+        colorname = os.environ.get(ENVIRONMENT_KEY, None)
+        if colorname is not None and colorname in COLORS:
+            return "body {border: 5px solid %s;}" % COLORS[colorname]
+        return None

--- a/opengever/base/viewlets/configure.zcml
+++ b/opengever/base/viewlets/configure.zcml
@@ -42,5 +42,13 @@
        class="opengever.base.viewlets.byline.PloneSiteByline"
        permission="zope2.View"
        />
+	   
+       <browser:viewlet
+           name="gever-colorization"
+           manager="plone.app.layout.viewlets.interfaces.IPortalTop"
+           template="colorization.pt"
+           class=".colorization.ColorizationViewlet"
+           permission="zope2.View"
+           />
 
 </configure>


### PR DESCRIPTION
To set a color for your system, just add in your buildout in the instance section:

```
environment-vars +=
    GEVER_COLORIZATION MY_COLOR
```

MY_COLOR can be the here defined colors (now they are 'green', 'red' and 'yellow'):
https://github.com/4teamwork/opengever.core/blob/48e50d6d141d7a1f24f7dac70b7ae68ecc38a05f/opengever/base/viewlets/colorization.py#L6

@phgross Please feel free to complete this list if you misses some colors.

I've chosen a simple border around the whole page to identify the special systems, so it will work, even if you have a customized theme configuration:
![bildschirmfoto 2014-07-03 um 16 08 52](https://cloud.githubusercontent.com/assets/157533/3470642/5cdaf402-02bc-11e4-9e71-ec7c4e11be5e.png)
