### PR TITLE
Add dev script to easily test inbound mail.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,3 +158,16 @@ Now you can use the ``self.browser`` instance:
 Have a look at the `opengever.testing.browser module
 <https://github.com/4teamwork/opengever.core/blob/master/opengever/testing/browser.py>`_
 to see the complete API.
+
+
+Testing Inbound Mail
+--------------------
+
+For easy testing of inbound mail (without actually going through an MTA) there's
+a script ``bin/test-inbound-mail`` that can be used to test creation of inbound
+mail:
+
+``cat testmail.eml | bin/test-inbound-mail``
+
+The script assumes you got an instance running on port ``${instance:http-address}``, a GEVER client called ``mandant1`` and an omelette with ``ftw.mail`` in it installed. It will then feed the mail from stdin to
+the ``ftw.mail`` inbound view, like Postfix would.

--- a/development.cfg
+++ b/development.cfg
@@ -3,6 +3,8 @@ extends =
     test-plone-4.2.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
+parts +=
+    test-inbound-mail
 
 [instance]
 zserver-threads = 4
@@ -26,3 +28,10 @@ recipe = collective.recipe.cmd
 on_install=true
 on_update=true
 cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build
+
+[test-inbound-mail]
+# Usage: cat testmail.eml | bin/test-inbound-mail
+recipe = collective.recipe.scriptgen
+cmd = python
+arguments = parts/omelette/ftw/mail/mta2plone.py http://127.0.0.1:${instance:http-address}/mandant1/mail-inbound
+


### PR DESCRIPTION
A tiny script in the `bin` folder of the buildout that can be used to quickly test inbound mail.

Usage: `cat testmail.eml | bin/test-inbound-mail`

(Assumes you got an instance running on port `${instance:http-address}`, a GEVER client called `mandant1` and an omelette with `ftw.mail` in it installed).

@phgross
