### PR TITLE
Fixed UnicodeEncodeError in `OGDSActor.get_link`

### DIFF
--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -80,7 +80,7 @@ class Actor(object):
         if not url:
             return label
 
-        return '<a href="{}">{}</a>'.format(url, label)
+        return u'<a href="{}">{}</a>'.format(url, label)
 
 
 class NullActor(object):

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -41,13 +41,18 @@ class TestActorLookup(FunctionalTestCase):
         self.assertIn(actor.get_profile_url(), link)
 
     def test_user_actor_ogds_user(self):
-        create(Builder('fixture').with_hugo_boss())
+        create(Builder('fixture'))
+        create(Builder('ogds_user')
+               .id('hugo.boss')
+               .having(firstname='H\xc3\xbcgo'.decode('utf-8'),
+                       lastname='Boss'))
+
         actor = Actor.lookup('hugo.boss')
 
-        self.assertEqual('Boss Hugo (hugo.boss)', actor.get_label())
+        self.assertEqual(u'Boss H\xfcgo (hugo.boss)', actor.get_label())
         self.assertTrue(
             actor.get_profile_url().endswith('@@user-details/hugo.boss'))
 
-        link = actor.get_link()
-        self.assertIn(actor.get_label(), link)
-        self.assertIn(actor.get_profile_url(), link)
+        self.assertEqual(
+            u'<a href="http://nohost/plone/@@user-details/hugo.boss">Boss H\xfcgo (hugo.boss)</a>',
+            actor.get_link())


### PR DESCRIPTION
Traceback:

```
  Module opengever.dossier.viewlets.byline, line 38, in get_items
  Module opengever.dossier.viewlets.byline, line 18, in responsible
  Module opengever.ogds.base.actor, line 83, in get_link
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 8: ordinal not in range(128)
```

All actors `get_link` method should return unicode, so it makes sense to make this change.
