### PR TITLE
File a copy of the mail in the dossier by default when sending documents from GEVER

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- File a copy of the mail in the dossier by default when sending documents from GEVER.
+  [lgraf]
+
 - Add overview tab for mail (Shows metadata).
   [mathias.leimgruber]
 

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -1,5 +1,3 @@
-from Products.CMFCore.utils import getToolByName
-from Products.statusmessages.interfaces import IStatusMessage
 from email import Encoders
 from email.Header import Header
 from email.MIMEBase import MIMEBase
@@ -7,6 +5,7 @@ from email.MIMEMultipart import MIMEMultipart
 from email.MIMEText import MIMEText
 from email.Utils import formatdate
 from five import grok
+from ftw.mail.inbound import createMailInContainer
 from ftw.mail.mail import IMail
 from opengever.base.source import DossierPathSourceBinder
 from opengever.mail import _
@@ -23,16 +22,22 @@ from plone.formwidget.autocomplete import AutocompleteMultiFieldWidget
 from plone.registry.interfaces import IRegistry
 from plone.z3cform import layout
 from plone.z3cform.textlines.textlines import TextLinesFieldWidget
+from Products.CMFCore.utils import getToolByName
+from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form import form, button, field, validator
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
 from z3c.form.interfaces import INPUT_MODE
-from z3c.relationfield.schema import RelationChoice, RelationList
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import getUtility, provideAdapter
 from zope.event import notify
 from zope.i18n import translate
 from zope.interface import Interface
-from zope.interface import invariant, Invalid
+from zope.interface import Invalid
+from zope.interface import invariant
+from datetime import date
+
 
 CHARSET = 'utf-8'
 
@@ -101,6 +106,14 @@ class ISendDocumentSchema(Interface):
                 default=u'Send documents only als links'),
         required=True,
         )
+
+    file_copy_in_dossier = schema.Bool(
+        title=_(u'label_file_copy_in_dossier',
+                default=u'File a copy of the sent mail in dossier'),
+        required=True,
+        default=True,
+        )
+
 
     @invariant
     def validateHasEmail(self):
@@ -184,7 +197,8 @@ class SendDocumentForm(form.Form):
                 only_links=data.get('documents_as_links'))
 
             msg['Subject'] = Header(data.get('subject'), CHARSET)
-            sender_address = contact_info.get_user(userid).email
+            user = contact_info.get_user(userid)
+            sender_address = getattr(user, 'email', None)
             if not sender_address:
                 portal = self.context.portal_url.getPortalObject()
                 sender_address = portal.email_from_address
@@ -200,6 +214,10 @@ class SendDocumentForm(form.Form):
 
             # send it
             mh.send(msg, mfrom=mail_from, mto=','.join(addresses))
+
+            # Store a copy of the sent mail in dossier
+            if data.get('file_copy_in_dossier', False):
+                self.file_sent_mail_in_dossier(msg)
 
             # let the user know that the mail was sent
             info = _(u'info_mails_sent', 'Mails sent')
@@ -286,6 +304,16 @@ class SendDocumentForm(form.Form):
             msg.attach(part)
 
         return msg
+
+    def file_sent_mail_in_dossier(self, msg):
+        dossier = self.context
+        mail = createMailInContainer(dossier, msg.as_string())
+        mail.delivery_date = date.today()
+        mail.reindexObject(idxs=['delivery_date'])
+        status_msg = _(
+            u"Sent mail filed as '${title}'.",
+            mapping={'title': mail.title_or_id()})
+        IStatusMessage(self.request).addStatusMessage(status_msg, type='info')
 
 
 class SendDocumentFormView(layout.FormWrapper, grok.View):

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-11-11 07:31+0000\n"
+"POT-Creation-Date: 2014-07-04 13:41+0000\n"
 "PO-Revision-Date: 2012-09-03 14:47+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,69 +22,73 @@ msgstr "Abbrechen"
 msgid "Create documents"
 msgstr "Dokumente extrahieren"
 
-#: ./opengever/mail/browser/send_document.py:42
+#: ./opengever/mail/browser/send_document.py:46
 msgid "No Mail Address"
 msgstr "Keine E-Mail Adresse"
+
+#: ./opengever/mail/browser/send_document.py:310
+msgid "Sent mail filed as '${title}'."
+msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 
 #: ./opengever/mail/validators.py:20
 msgid "The files you selected are larger than the maximum size"
 msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maximalgrösse."
 
-#: ./opengever/mail/browser/send_document.py:109
+#: ./opengever/mail/browser/send_document.py:121
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:174
 msgid "button_send"
 msgstr "Senden"
 
 #. Default: "Created"
-#: ./opengever/mail/browser/byline.py:14
+#: ./opengever/mail/browser/byline.py:15
 msgid "byline_created"
 msgstr "Erstellt"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:215
+#: ./opengever/mail/browser/send_document.py:232
 msgid "cancel_back"
 msgstr "Abbrechen"
 
-#: ./opengever/mail/browser/extract_attachments.py:108
+#: ./opengever/mail/browser/extract_attachments.py:109
 msgid "column_attachment_checkbox"
 msgstr ""
 
 #. Default: "Filename"
-#: ./opengever/mail/browser/extract_attachments.py:118
+#: ./opengever/mail/browser/extract_attachments.py:119
 msgid "column_attachment_filename"
 msgstr "Dateiname"
 
 #. Default: "Size"
-#: ./opengever/mail/browser/extract_attachments.py:123
+#: ./opengever/mail/browser/extract_attachments.py:124
 msgid "column_attachment_size"
 msgstr "Grösse"
 
 #. Default: "Type"
-#: ./opengever/mail/browser/extract_attachments.py:113
+#: ./opengever/mail/browser/extract_attachments.py:114
 msgid "column_attachment_type"
 msgstr "Typ"
 
 #. Default: "You have not selected any attachments."
-#: ./opengever/mail/browser/extract_attachments.py:149
+#: ./opengever/mail/browser/extract_attachments.py:150
 msgid "error_no_attachments_selected"
 msgstr "Sie haben keine Anhänge ausgewählt."
 
 #. Default: "This mail has no attachments to extract."
-#: ./opengever/mail/browser/extract_attachments.py:136
+#: ./opengever/mail/browser/extract_attachments.py:137
 msgid "error_no_attachments_to_extract"
 msgstr "Diese E-Mail hat keine Anhänge, die extrahiert werden könnten."
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:61
+#: ./opengever/mail/browser/send_document.py:65
 msgid "extern_receiver"
 msgstr "Externer Empfänger"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:142
+#: ./opengever/mail/browser/send_document.py:154
 msgid "heading_send_as_email"
 msgstr "Dokumente als E-Mail versenden"
 
@@ -94,16 +98,16 @@ msgid "help_delete_action"
 msgstr "Wählen Sie aus, ob und welche Anhänge aus dieser E-Mail gelöscht werden sollen."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py:66
 msgid "help_extern_receiver"
 msgstr "E-Mail Adressen der externen Empfänger manuell eintragen. Pro Zeile eine Adresse eingeben."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:50
+#: ./opengever/mail/browser/send_document.py:54
 msgid "help_intern_receiver"
 msgstr "Live Search: Nachname/Vorname der internen Mitarbeiter oder Kontakte eingeben. Mehrauswahl möglich."
 
-#: ./opengever/mail/browser/send_document.py:77
+#: ./opengever/mail/browser/send_document.py:81
 msgid "help_message"
 msgstr ""
 
@@ -112,22 +116,22 @@ msgstr ""
 msgid "help_select_attachments"
 msgstr "Wählen Sie die Anhänge aus, die extrahiert werden sollen. Aus jedem ausgewähltem Anhang wird ein Dokument im übergeordneten Dossier erzeugt."
 
-#: ./opengever/mail/browser/send_document.py:71
+#: ./opengever/mail/browser/send_document.py:75
 msgid "help_subject"
 msgstr ""
 
 #. Default: "Created document ${title}"
-#: ./opengever/mail/browser/extract_attachments.py:221
+#: ./opengever/mail/browser/extract_attachments.py:222
 msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
 #. Default: "Mails sent"
-#: ./opengever/mail/browser/send_document.py:205
+#: ./opengever/mail/browser/send_document.py:222
 msgid "info_mails_sent"
 msgstr "Mails wurden versendet."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:49
+#: ./opengever/mail/browser/send_document.py:53
 msgid "intern_receiver"
 msgstr "Interne Empfänger"
 
@@ -152,27 +156,32 @@ msgid "label_delete_action_selected"
 msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:82
+#: ./opengever/mail/browser/send_document.py:86
 msgid "label_documents"
 msgstr "Anhänge"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:100
+#: ./opengever/mail/browser/send_document.py:104
 msgid "label_documents_as_link"
 msgstr "Dokumente nur als Link versenden."
 
+#. Default: "File a copy of the sent mail in dossier"
+#: ./opengever/mail/browser/send_document.py:110
+msgid "label_file_copy_in_dossier"
+msgstr "Kopie des versandten Mails in Dossier ablegen"
+
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:76
+#: ./opengever/mail/browser/send_document.py:80
 msgid "label_message"
 msgstr "Mitteilung"
 
 #. Default: "Reference Number"
-#: ./opengever/mail/browser/byline.py:24
+#: ./opengever/mail/browser/byline.py:25
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:261
+#: ./opengever/mail/browser/send_document.py:278
 msgid "label_see_attachment"
 msgstr "siehe Anhänge"
 
@@ -182,24 +191,25 @@ msgid "label_select_attachments"
 msgstr "Anhänge"
 
 #. Default: "Sequence Number"
-#: ./opengever/mail/browser/byline.py:19
+#: ./opengever/mail/browser/byline.py:20
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:70
+#: ./opengever/mail/browser/send_document.py:74
 msgid "label_subject"
 msgstr "Betreff"
 
 #. Default: "Title"
-#: ./opengever/mail/mail.py:31
+#: ./opengever/mail/mail.py:56
 msgid "label_title"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:54
+#: ./opengever/mail/browser/send_document.py:58
 msgid "mails"
 msgstr "E-Mails"
 
-#: ./opengever/mail/browser/send_document.py:65
+#: ./opengever/mail/browser/send_document.py:69
 msgid "receiver"
 msgstr "Empfänger"
+

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-11-11 07:31+0000\n"
+"POT-Creation-Date: 2014-07-04 13:41+0000\n"
 "PO-Revision-Date: 2012-09-06 13:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9,7 +9,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
 
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:106
 msgid "Cancel"
@@ -19,69 +22,73 @@ msgstr "Annuler"
 msgid "Create documents"
 msgstr "Extraire documents"
 
-#: ./opengever/mail/browser/send_document.py:42
+#: ./opengever/mail/browser/send_document.py:46
 msgid "No Mail Address"
 msgstr "Pas d'adresse Email"
+
+#: ./opengever/mail/browser/send_document.py:310
+msgid "Sent mail filed as '${title}'."
+msgstr ""
 
 #: ./opengever/mail/validators.py:20
 msgid "The files you selected are larger than the maximum size"
 msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permise."
 
-#: ./opengever/mail/browser/send_document.py:109
+#: ./opengever/mail/browser/send_document.py:121
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse Email interne ou externe"
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:174
 msgid "button_send"
 msgstr "Envoyer"
 
 #. Default: "Created"
-#: ./opengever/mail/browser/byline.py:14
+#: ./opengever/mail/browser/byline.py:15
 msgid "byline_created"
 msgstr "Créé"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:215
+#: ./opengever/mail/browser/send_document.py:232
 msgid "cancel_back"
 msgstr "Annuler"
 
-#: ./opengever/mail/browser/extract_attachments.py:108
+#: ./opengever/mail/browser/extract_attachments.py:109
 msgid "column_attachment_checkbox"
 msgstr ""
 
 #. Default: "Filename"
-#: ./opengever/mail/browser/extract_attachments.py:118
+#: ./opengever/mail/browser/extract_attachments.py:119
 msgid "column_attachment_filename"
 msgstr "Nom du fichier"
 
 #. Default: "Size"
-#: ./opengever/mail/browser/extract_attachments.py:123
+#: ./opengever/mail/browser/extract_attachments.py:124
 msgid "column_attachment_size"
 msgstr "Taille"
 
 #. Default: "Type"
-#: ./opengever/mail/browser/extract_attachments.py:113
+#: ./opengever/mail/browser/extract_attachments.py:114
 msgid "column_attachment_type"
 msgstr "Type"
 
 #. Default: "You have not selected any attachments."
-#: ./opengever/mail/browser/extract_attachments.py:149
+#: ./opengever/mail/browser/extract_attachments.py:150
 msgid "error_no_attachments_selected"
 msgstr "Vous n'avez sélectionné aucune annexe."
 
 #. Default: "This mail has no attachments to extract."
-#: ./opengever/mail/browser/extract_attachments.py:136
+#: ./opengever/mail/browser/extract_attachments.py:137
 msgid "error_no_attachments_to_extract"
 msgstr "Cet Email n'a pas d'annexe à extraire"
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:61
+#: ./opengever/mail/browser/send_document.py:65
 msgid "extern_receiver"
 msgstr "Destinataire externe"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:142
+#: ./opengever/mail/browser/send_document.py:154
 msgid "heading_send_as_email"
 msgstr "Envoyer les documents comme Email"
 
@@ -91,16 +98,16 @@ msgid "help_delete_action"
 msgstr "Sélectionnez les annexes à effacer."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py:66
 msgid "help_extern_receiver"
 msgstr "Ajouter les adresses email des destinataires externes. Une adresse par ligne."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:50
+#: ./opengever/mail/browser/send_document.py:54
 msgid "help_intern_receiver"
 msgstr "Recherche en direct : Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible. "
 
-#: ./opengever/mail/browser/send_document.py:77
+#: ./opengever/mail/browser/send_document.py:81
 msgid "help_message"
 msgstr ""
 
@@ -109,22 +116,22 @@ msgstr ""
 msgid "help_select_attachments"
 msgstr "Sélectionner les annexes à extraire. De chaque annexe sélectionnée un document est créé  dans le dossier maître."
 
-#: ./opengever/mail/browser/send_document.py:71
+#: ./opengever/mail/browser/send_document.py:75
 msgid "help_subject"
 msgstr ""
 
 #. Default: "Created document ${title}"
-#: ./opengever/mail/browser/extract_attachments.py:221
+#: ./opengever/mail/browser/extract_attachments.py:222
 msgid "info_extracted_document"
 msgstr "Document créé : ${title}"
 
 #. Default: "Mails sent"
-#: ./opengever/mail/browser/send_document.py:205
+#: ./opengever/mail/browser/send_document.py:222
 msgid "info_mails_sent"
 msgstr "Emails envoyés."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:49
+#: ./opengever/mail/browser/send_document.py:53
 msgid "intern_receiver"
 msgstr "Destinataires internes"
 
@@ -149,27 +156,32 @@ msgid "label_delete_action_selected"
 msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:82
+#: ./opengever/mail/browser/send_document.py:86
 msgid "label_documents"
 msgstr "Fichiers attachés"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:100
+#: ./opengever/mail/browser/send_document.py:104
 msgid "label_documents_as_link"
 msgstr "Envoyer seulement le lien du document"
 
+#. Default: "File a copy of the sent mail in dossier"
+#: ./opengever/mail/browser/send_document.py:110
+msgid "label_file_copy_in_dossier"
+msgstr ""
+
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:76
+#: ./opengever/mail/browser/send_document.py:80
 msgid "label_message"
 msgstr "Message"
 
 #. Default: "Reference Number"
-#: ./opengever/mail/browser/byline.py:24
+#: ./opengever/mail/browser/byline.py:25
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:261
+#: ./opengever/mail/browser/send_document.py:278
 msgid "label_see_attachment"
 msgstr "Voir  fichiers attachés"
 
@@ -179,26 +191,25 @@ msgid "label_select_attachments"
 msgstr "Fichiers attachés"
 
 #. Default: "Sequence Number"
-#: ./opengever/mail/browser/byline.py:19
+#: ./opengever/mail/browser/byline.py:20
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:70
+#: ./opengever/mail/browser/send_document.py:74
 msgid "label_subject"
 msgstr "Objet"
 
 #. Default: "Title"
-#: ./opengever/mail/mail.py:31
+#: ./opengever/mail/mail.py:56
 msgid "label_title"
 msgstr "Titre"
 
-#: ./opengever/mail/browser/send_document.py:54
+#: ./opengever/mail/browser/send_document.py:58
 msgid "mails"
 msgstr "Email"
 
-#: ./opengever/mail/browser/send_document.py:65
+#: ./opengever/mail/browser/send_document.py:69
 msgid "receiver"
 msgstr "Destinataire"
-
 

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-11-11 07:31+0000\n"
+"POT-Creation-Date: 2014-07-04 13:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,69 +25,73 @@ msgstr ""
 msgid "Create documents"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:42
+#: ./opengever/mail/browser/send_document.py:46
 msgid "No Mail Address"
+msgstr ""
+
+#: ./opengever/mail/browser/send_document.py:310
+msgid "Sent mail filed as '${title}'."
 msgstr ""
 
 #: ./opengever/mail/validators.py:20
 msgid "The files you selected are larger than the maximum size"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:109
+#: ./opengever/mail/browser/send_document.py:121
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr ""
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:174
 msgid "button_send"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/mail/browser/byline.py:14
+#: ./opengever/mail/browser/byline.py:15
 msgid "byline_created"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:215
+#: ./opengever/mail/browser/send_document.py:232
 msgid "cancel_back"
 msgstr ""
 
-#: ./opengever/mail/browser/extract_attachments.py:108
+#: ./opengever/mail/browser/extract_attachments.py:109
 msgid "column_attachment_checkbox"
 msgstr ""
 
 #. Default: "Filename"
-#: ./opengever/mail/browser/extract_attachments.py:118
+#: ./opengever/mail/browser/extract_attachments.py:119
 msgid "column_attachment_filename"
 msgstr ""
 
 #. Default: "Size"
-#: ./opengever/mail/browser/extract_attachments.py:123
+#: ./opengever/mail/browser/extract_attachments.py:124
 msgid "column_attachment_size"
 msgstr ""
 
 #. Default: "Type"
-#: ./opengever/mail/browser/extract_attachments.py:113
+#: ./opengever/mail/browser/extract_attachments.py:114
 msgid "column_attachment_type"
 msgstr ""
 
 #. Default: "You have not selected any attachments."
-#: ./opengever/mail/browser/extract_attachments.py:149
+#: ./opengever/mail/browser/extract_attachments.py:150
 msgid "error_no_attachments_selected"
 msgstr ""
 
 #. Default: "This mail has no attachments to extract."
-#: ./opengever/mail/browser/extract_attachments.py:136
+#: ./opengever/mail/browser/extract_attachments.py:137
 msgid "error_no_attachments_to_extract"
 msgstr ""
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:61
+#: ./opengever/mail/browser/send_document.py:65
 msgid "extern_receiver"
 msgstr ""
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:142
+#: ./opengever/mail/browser/send_document.py:154
 msgid "heading_send_as_email"
 msgstr ""
 
@@ -97,16 +101,16 @@ msgid "help_delete_action"
 msgstr ""
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py:66
 msgid "help_extern_receiver"
 msgstr ""
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:50
+#: ./opengever/mail/browser/send_document.py:54
 msgid "help_intern_receiver"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:77
+#: ./opengever/mail/browser/send_document.py:81
 msgid "help_message"
 msgstr ""
 
@@ -115,22 +119,22 @@ msgstr ""
 msgid "help_select_attachments"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:71
+#: ./opengever/mail/browser/send_document.py:75
 msgid "help_subject"
 msgstr ""
 
 #. Default: "Created document ${title}"
-#: ./opengever/mail/browser/extract_attachments.py:221
+#: ./opengever/mail/browser/extract_attachments.py:222
 msgid "info_extracted_document"
 msgstr ""
 
 #. Default: "Mails sent"
-#: ./opengever/mail/browser/send_document.py:205
+#: ./opengever/mail/browser/send_document.py:222
 msgid "info_mails_sent"
 msgstr ""
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:49
+#: ./opengever/mail/browser/send_document.py:53
 msgid "intern_receiver"
 msgstr ""
 
@@ -155,27 +159,32 @@ msgid "label_delete_action_selected"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:82
+#: ./opengever/mail/browser/send_document.py:86
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:100
+#: ./opengever/mail/browser/send_document.py:104
 msgid "label_documents_as_link"
 msgstr ""
 
+#. Default: "File a copy of the sent mail in dossier"
+#: ./opengever/mail/browser/send_document.py:110
+msgid "label_file_copy_in_dossier"
+msgstr ""
+
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:76
+#: ./opengever/mail/browser/send_document.py:80
 msgid "label_message"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/mail/browser/byline.py:24
+#: ./opengever/mail/browser/byline.py:25
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:261
+#: ./opengever/mail/browser/send_document.py:278
 msgid "label_see_attachment"
 msgstr ""
 
@@ -185,25 +194,25 @@ msgid "label_select_attachments"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/mail/browser/byline.py:19
+#: ./opengever/mail/browser/byline.py:20
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:70
+#: ./opengever/mail/browser/send_document.py:74
 msgid "label_subject"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/mail/mail.py:31
+#: ./opengever/mail/mail.py:56
 msgid "label_title"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:54
+#: ./opengever/mail/browser/send_document.py:58
 msgid "mails"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:65
+#: ./opengever/mail/browser/send_document.py:69
 msgid "receiver"
 msgstr ""
 


### PR DESCRIPTION
This implements **OPT5** from [**OGIP 7** (Optimierungen User Interface)](https://docs.google.com/a/4teamwork.ch/document/d/1deP6tiDRf8_vmL0uAXwEpyLNgtBp7CbHouRnWosGYmA/edit#)

![send_documents_file_copy_in_dossier](https://cloud.githubusercontent.com/assets/405124/3483294/7b75a92c-038c-11e4-87de-7ca969cf3fa9.png)

The "**send documents**" form now contains a checkbox "**File sent mail in dossier**" (True by default). When this option is checked, the mail that just has been sent will be archived in the respective dossier. The `delivery_date` of the archived mail will be set to the current date, which implements the requirement from [**OGIP 6** (Umsetzung Öffentlichkeitsgesetz)](https://my.teamraum.com/workspaces/onegov-gever-innovation-session/improvement-proposals/ogip6-umsetzung-offentlichkeitsgesetz/view)

/cc @phgross @maethu 
