### PR TITLE
Fixed widget definition for some date fields in tasks edit form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Fixed widget definition for date fields in tasks edit form.
+  [phgross]
+
 - Added viewlet to colorize special pages as dev, test, ...
   [Julian Infanger]
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -104,7 +104,7 @@ class ITask(form.Schema):
         required=True,
         )
 
-    form.widget(deadline=DatePickerFieldWidget)
+    form.widget(date_of_completion=DatePickerFieldWidget)
     date_of_completion = schema.Date(
         title=_(u"label_date_of_completion", default=u"Date of completion"),
         description=_(u"help_date_of_completion", default=u""),
@@ -138,7 +138,7 @@ class ITask(form.Schema):
         required=False,
         )
 
-    form.widget(deadline=DatePickerFieldWidget)
+    form.widget(expectedStartOfWork=DatePickerFieldWidget)
     expectedStartOfWork = schema.Date(
         title=_(u"label_expectedStartOfWork", default="Start with work"),
         description=_(u"help_expectedStartOfWork", default=""),


### PR DESCRIPTION
Affected fields:
- `expectedStartOfWork`
- `date_of_completion`

closes #378 

@deiferni please have a look.
