### PR TITLE
Fixed table display in add-tasktemplate form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Fixed table display in add-tasktemplate form.
+  [phgross]
+
 - Fixed widget definition for date fields in tasks edit form.
   [phgross]
 

--- a/opengever/tasktemplates/browser/form.pt
+++ b/opengever/tasktemplates/browser/form.pt
@@ -7,9 +7,19 @@
       i18n:domain="opengever.tasktemplates">
 
     <tal:head metal:fill-slot="javascript_head_slot">
-        <script type="text/javascript" language="javsacript"
-                tal:attributes="src view/javascript_url">
-        </script>
+      <script type="text/javascript" language="javsacript"
+              tal:attributes="src view/javascript_url">
+      </script>
+
+      <script type="text/javascript"
+                  tal:attributes="src string:${here/portal_url}/++resource++ext-jquery-adapter.js"></script>
+
+        <script type="text/javascript"
+                  tal:attributes="src string:${here/portal_url}/++resource++collective.js.extjs-resources/js/ext-all.js"></script>
+        <script type="text/javascript"
+                  tal:attributes="src string:${here/portal_url}/++resource++collective.js.extjs-resources/ux/dd/GridDragDropRowOrder.js"></script>
+        <script type="text/javascript"
+                  tal:attributes="src string:${here/portal_url}/++resource++ftwtable.extjs.js"></script>
 
     </tal:head>
 
@@ -37,4 +47,3 @@
         </div>
     </body>
 </html>
-


### PR DESCRIPTION
With this changes (https://github.com/4teamwork/ftw.tabbedview/pull/31),
the tabbedview and extjs javascripts are only loaded in tabbedviews. Therefore
we need to include the javscript manually.

This is the easiest but maybe not the best way to solve this issue. But because we will
drop out the tasktemplate feature in the near future it's ok like this. i think.

@lukasgraf please review.
