### PR TITLE
Show issuing org-unit in task listing instead of client.

### DIFF
--- a/opengever/base/browser/helper.py
+++ b/opengever/base/browser/helper.py
@@ -1,26 +1,8 @@
 from Acquisition import aq_inner, aq_parent
-from opengever.ogds.base.interfaces import IContactInformation
 from opengever.ogds.base.utils import get_current_admin_unit
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from zope.component import getUtility
-
-
-# XXX remove me
-def client_title_helper(item, value):
-    """Returns the client title out of the client id (`value`).
-    """
-    if not value:
-        return value
-
-    info = getUtility(IContactInformation)
-    client = info.get_client_by_id(value)
-
-    if client:
-        return client.title
-
-    else:
-        return value
 
 
 def _get_task_css_class(task):

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -140,6 +140,9 @@ class Task(Base):
     def get_admin_unit(self):
         return ogds_service().fetch_admin_unit(self.admin_unit_id)
 
+    def get_issuing_org_unit(self):
+        return ogds_service().fetch_org_unit(self.issuing_org_unit)
+
     def sync_with(self, plone_task):
         """Sync this task instace with its corresponding plone taks.
 

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -2,7 +2,6 @@ from five import grok
 from ftw.journal.interfaces import IJournalizable
 from ftw.table import helper
 from ftw.table.interfaces import ITableSource, ITableSourceConfig
-from opengever.base.browser.helper import client_title_helper
 from opengever.globalindex.model.task import Task
 from opengever.globalindex.utils import indexed_task_link_helper
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -10,7 +9,8 @@ from opengever.tabbedview import _
 from opengever.tabbedview.browser.base import OpengeverTab
 from opengever.tabbedview.browser.listing import ListingView
 from opengever.tabbedview.browser.sqltablelisting import SqlTableSource
-from opengever.tabbedview.helper import display_client_title_condition
+from opengever.tabbedview.helper import display_org_unit_title_condition
+from opengever.tabbedview.helper import org_unit_title_helper
 from opengever.tabbedview.helper import overdue_date_helper
 from opengever.tabbedview.helper import readable_date_set_invisibles
 from opengever.tabbedview.helper import readable_ogds_author
@@ -108,10 +108,11 @@ class GlobalTaskListingTab(grok.View, OpengeverTab,
         {'column': 'containing_dossier',
          'column_title': _('containing_dossier', 'Dossier'), },
 
-        {'column': 'client_id',
-         'column_title': _('column_client', default=u'Client'),
-         'transform': client_title_helper,
-         'condition': display_client_title_condition},
+        {'column': 'issuing_org_unit',
+         'column_title': _('column_issuing_org_unit',
+                           default=u'Organisational Unit'),
+         'transform': org_unit_title_helper,
+         'condition': display_org_unit_title_condition},
 
         {'column': 'sequence_number',
          'column_title': _(u'column_sequence_number',

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -3,7 +3,7 @@ from ftw.mail.utils import get_header
 from opengever.base import _ as base_mf
 from opengever.base.browser.helper import get_css_class
 from opengever.ogds.base.actor import Actor
-from opengever.ogds.base.interfaces import IContactInformation
+from opengever.ogds.base.utils import ogds_service
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import ram
 from Products.CMFCore.interfaces._tools import IMemberData
@@ -24,6 +24,17 @@ except pkg_resources.DistributionNotFound:
     PDFCONVERTER_AVAILABLE = False
 else:
     PDFCONVERTER_AVAILABLE = True
+
+
+def org_unit_title_helper(item, value):
+    return item.get_issuing_org_unit().label()
+
+
+def display_org_unit_title_condition():
+    """A helper for hiding the org-unit title from a task listing if we
+    have a single org-unit setup (it would be the same all the time).
+    """
+    return ogds_service().has_multiple_org_units()
 
 
 def task_id_checkbox_helper(item, value):
@@ -344,17 +355,3 @@ def translated_string(domain='plone'):
         return translate(
             value, context=getRequest(), domain=domain)
     return _translate
-
-
-def display_client_title_condition():
-    """A helper for hiding the client title from a task listing if we
-    have a single client setup (it would be the same all the time).
-    """
-    info = getUtility(IContactInformation)
-    if len(info.get_clients()) <= 1:
-        # Single client setup - hide the client title column
-        return False
-
-    else:
-        # Multi client setup - display the client title column
-        return True

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2014-06-30 11:49+0000\n"
+"POT-Creation-Date: 2014-07-09 07:26+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -87,11 +87,6 @@ msgstr "in Bearbeitung"
 msgid "checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
-#. Default: "Client"
-#: ./opengever/tabbedview/browser/tasklisting.py:112
-msgid "column_client"
-msgstr "Mandant"
-
 #. Default: "Client ID"
 #: ./opengever/tabbedview/browser/clientslisting.py:63
 msgid "column_client_id"
@@ -137,6 +132,11 @@ msgstr "IP-Adresse"
 msgid "column_issued_at"
 msgstr "Erstellt am"
 
+#. Default: "Organisational Unit"
+#: ./opengever/tabbedview/browser/tasklisting.py:112
+msgid "column_issuing_org_unit"
+msgstr "Organisationseinheit"
+
 #. Default: "Public URL"
 #: ./opengever/tabbedview/browser/clientslisting.py:79
 msgid "column_public_url"
@@ -148,7 +148,7 @@ msgid "column_review_state"
 msgstr "Status"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:117
+#: ./opengever/tabbedview/browser/tasklisting.py:118
 msgid "column_sequence_number"
 msgstr "Laufnummer"
 
@@ -364,7 +364,7 @@ msgid "participants"
 msgstr "Beteiligte"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:73
+#: ./opengever/tabbedview/browser/personal_overview.py:74
 msgid "personal_overview_title"
 msgstr "Persönliche Übersicht: ${user_name}"
 

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-06-30 11:49+0000\n"
+"POT-Creation-Date: 2014-07-09 07:26+0000\n"
 "PO-Revision-Date: 2013-03-27 11:23+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,11 +84,6 @@ msgstr "En traitement"
 msgid "checkout_and_edit"
 msgstr "Checkout et modifier"
 
-#. Default: "Client"
-#: ./opengever/tabbedview/browser/tasklisting.py:112
-msgid "column_client"
-msgstr "Client"
-
 #. Default: "Client ID"
 #: ./opengever/tabbedview/browser/clientslisting.py:63
 msgid "column_client_id"
@@ -134,6 +129,11 @@ msgstr "Adresse IP"
 msgid "column_issued_at"
 msgstr "Créé le"
 
+#. Default: "Organisational Unit"
+#: ./opengever/tabbedview/browser/tasklisting.py:112
+msgid "column_issuing_org_unit"
+msgstr "Unité d'organisation"
+
 #. Default: "Public URL"
 #: ./opengever/tabbedview/browser/clientslisting.py:79
 msgid "column_public_url"
@@ -145,7 +145,7 @@ msgid "column_review_state"
 msgstr "Etat"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:117
+#: ./opengever/tabbedview/browser/tasklisting.py:118
 msgid "column_sequence_number"
 msgstr "Numéro courant"
 
@@ -354,7 +354,7 @@ msgid "participants"
 msgstr "Participants"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:73
+#: ./opengever/tabbedview/browser/personal_overview.py:74
 msgid "personal_overview_title"
 msgstr ""
 

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2014-06-30 11:49+0000\n"
+"POT-Creation-Date: 2014-07-09 07:26+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -85,11 +85,6 @@ msgstr ""
 msgid "checkout_and_edit"
 msgstr ""
 
-#. Default: "Client"
-#: ./opengever/tabbedview/browser/tasklisting.py:112
-msgid "column_client"
-msgstr ""
-
 #. Default: "Client ID"
 #: ./opengever/tabbedview/browser/clientslisting.py:63
 msgid "column_client_id"
@@ -135,6 +130,11 @@ msgstr ""
 msgid "column_issued_at"
 msgstr ""
 
+#. Default: "Organisational Unit"
+#: ./opengever/tabbedview/browser/tasklisting.py:112
+msgid "column_issuing_org_unit"
+msgstr ""
+
 #. Default: "Public URL"
 #: ./opengever/tabbedview/browser/clientslisting.py:79
 msgid "column_public_url"
@@ -146,7 +146,7 @@ msgid "column_review_state"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:117
+#: ./opengever/tabbedview/browser/tasklisting.py:118
 msgid "column_sequence_number"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgid "participants"
 msgstr ""
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:73
+#: ./opengever/tabbedview/browser/personal_overview.py:74
 msgid "personal_overview_title"
 msgstr ""
 


### PR DESCRIPTION
But only when multiple org-units are configured.

Fixes #361.
