### PR TITLE
Display document-icons in ContentTreeWidget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Display document mimetype icons in ContentTreeWidget.
+  [phgross]
+
 - Use existing styles for table in tasktemplate view.
   [Julian Infanger]
 

--- a/opengever/base/browser/navtree.py
+++ b/opengever/base/browser/navtree.py
@@ -1,50 +1,21 @@
+from opengever.base.browser.helper import get_css_class
 from plone.app.layout.navigation.interfaces import INavtreeStrategy
 from plone.dexterity.interfaces import IDexterityContent
 from plone.formwidget.contenttree.interfaces import IContentTreeWidget
 from plone.formwidget.contenttree.navtree import NavtreeStrategy
-from plone.memoize.instance import memoize
 from zope.component import adapts
 from zope.interface import implements
 
 
-class FakeCatalogBrainContentIcon(object):
-    """A fake CatalogBrainContentIcon.
-
-    This is needed because on the original CatalogBrainContentIcon `url` is a
-    read only property, therefore we can't override it in the decoratorFactory
-    of our custom navtree strategy for the ContentTreeWidget.
-    """
-
-    def __init__(self):
-        self.url = ''
-        self.width = 16
-        self.height = 16
-        self.title = None
-        self.description = ""
-
-    @memoize
-    def html_tag(self):
-
-        if not self.url:
-            return None
-
-        tag = '<img width="%s" height="%s" src="%s"' % (
-            self.width, self.height, self.url,)
-
-        if self.title:
-            tag += ' title="%s"' % self.title
-        if self.description:
-            tag += ' alt="%s"' % self.description
-        tag += ' />'
-        return tag
-
-
 class OpengeverNavtreeStrategy(NavtreeStrategy):
-    """The navtree strategy used for the content tree widget in OpenGever.
+    """The navtree strategy used for the contenttree widget in OpenGever.
 
-    We use this to override the item_icon's url for documents without a file,
-    so the generic document icon is displayed even if no mimetype can be
-    determined.
+    We use this to override the `normalized_portal_type` attribute for
+    document nodes. This allow us to include the sprite mimetype icons
+    for all documents. (See plone.formwidget.contenttree.input_recurse.pt)
+
+    Because the `normalized_portal_type` attribute is only used by the
+    contenttree widgets, it's save to overwrite this attribute.
     """
 
     implements(INavtreeStrategy)
@@ -53,12 +24,10 @@ class OpengeverNavtreeStrategy(NavtreeStrategy):
     def decoratorFactory(self, node):
         new_node = super(OpengeverNavtreeStrategy, self).decoratorFactory(node)
         if new_node.get('portal_type', '') == 'opengever.document.document':
-            doc = new_node['item'].getObject()
-            if not doc.file:
-                # If document doesn't have a file, and therefore the
-                # mimetype can't be determined, override the icon
-                # with the generic document icon
-                new_icon = FakeCatalogBrainContentIcon()
-                new_icon.url = 'document_icon.gif'
-                new_node['item_icon'] = new_icon
+            brain = new_node.get('item_icon').brain
+            new_node['normalized_portal_type'] = ' {}'.format(
+                get_css_class(brain))
+
+            new_node['item_icon'] = None
+
         return new_node


### PR DESCRIPTION
To allow displaying the document mimetype icons in the ContentTreeWidget, like the following picture shows, some rework in the OpengeverNavtreeStrategy was needed: 
- Drop the `item_icon` attribute for all documents nodes, so it doesn't show a `<img>` tag for documents
- Reset `normalized_portal_type` to mimetypes css class, leading with a space to avoid the `contenttype` prefixing (see https://github.com/plone/plone.formwidget.contenttree/blob/1.0.5/plone/formwidget/contenttree/input_recurse.pt#L14).  This hack is save because, the `normalized_portal_type` attribute is only used by the contenttree widgets.

![bildschirmfoto 2014-07-09 um 10 22 39](https://cloud.githubusercontent.com/assets/485755/3521624/36e01946-0742-11e4-85e6-0442b5386289.png)

An final solution for this problem should be find, when solve the complete [mimetypes-sprites-icon problem](https://github.com/4teamwork/gever/issues/7).
