### PR TITLE
Update metadata version of `opengever.base` 

### DIFF
--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2607</version>
+  <version>2608</version>
   <dependencies>
 	    <dependency>profile-opengever.ogds.base:default</dependency>
   </dependencies>


### PR DESCRIPTION
There is an upgrade-step on a fresh installed installation.

**https://github.com/4teamwork/opengever.core/pull/386**
https://github.com/4teamwork/opengever.core/blob/master/opengever/base/upgrades/configure.zcml#L146
https://github.com/4teamwork/opengever.core/blob/master/opengever/base/profiles/default/metadata.xml#L3
