### PR TITLE
Fix adding related dossiers to an existing dossier.

### DIFF
--- a/opengever/ogds/base/ou_selector.py
+++ b/opengever/ogds/base/ou_selector.py
@@ -62,3 +62,22 @@ class NullOrgUnit(object):
 
     def public_url(self):
         return '__dummy_public_url__'
+
+    def inbox_group(self):
+        return None
+
+    def assigned_users(self):
+        return []
+
+    def users_group(self):
+        return None
+
+    def inbox(self):
+        return None
+
+    def prefix_label(self, label):
+        return label
+
+    @property
+    def admin_unit(self):
+        return None

--- a/opengever/ogds/base/tests/test_ou_selector.py
+++ b/opengever/ogds/base/tests/test_ou_selector.py
@@ -1,7 +1,9 @@
 from opengever.ogds.base.ou_selector import CURRENT_ORG_UNIT_KEY
+from opengever.ogds.base.ou_selector import NullOrgUnit
 from opengever.ogds.base.ou_selector import OrgUnitSelector
 from opengever.ogds.models.client import Client
 from opengever.ogds.models.org_unit import OrgUnit
+import inspect
 import unittest2
 
 
@@ -64,3 +66,13 @@ class TestOrgUnitSelector(unittest2.TestCase):
         selector.set_current_unit('clienta')
 
         self.assertEquals(self.unit_a, selector.get_current_unit())
+
+    def test_null_org_unit_interface_implements_org_unit(self):
+        ignore = ['assign_to_admin_unit']
+        methods = inspect.getmembers(OrgUnit)
+        for name, method in methods:
+            if name.startswith('_') or name in ignore:
+                continue
+            if not hasattr(NullOrgUnit, name):
+                self.fail('Missing null-implementation: "NullOrgUnit.{}"'
+                          .format(name))


### PR DESCRIPTION
The following error occurred rendering the ou-selector viewlet while traversing
on to the related-dossier selection widget:
`NullOrgUnit`, i.e. `OrgUnit` null implementation, was missing a method. We
added a test to make sure that the null-implementation always implements the
same "interface" as `OrgUnit`.

 Fixes #324.
