### PR TITLE
Dropped not existing keyword attribute `enabled`.

### DIFF
--- a/opengever/ogds/base/contact_info.py
+++ b/opengever/ogds/base/contact_info.py
@@ -348,7 +348,7 @@ class ContactInformation(grok.GlobalUtility):
             sort_dict[userid] = u'%s %s' % (lastname, firstname)
 
         #includes every org-unit-inbox
-        for unit in ogds_service().all_org_units(enabled=True):
+        for unit in ogds_service().all_org_units():
             inbox_id = unit.inbox().id()
             sort_dict[inbox_id] = Actor.lookup(inbox_id).get_label()
         return sort_dict


### PR DESCRIPTION
Because `enabled_only` is the default for `OGDSService.all_org_units` to passing a keyword argument is needless (see https://github.com/4teamwork/opengever.ogds.models/blob/rework-mandanten-concept/opengever/ogds/models/service.py#L58).

@deiferni 
