### PR TITLE
Fix issue with `prevent_deletion` subscriber not being able to acquire membership_tool

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Fix issue with `prevent_deletion` subscriber not being able to acquire membership_tool
+  because of broken acquisition during Plone site deletion.
+  [lgraf]
+
 - Make default value adapter for `public_trial` use the configurable default
   value from IClassificationSettings registry record.
 

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -28,7 +28,8 @@ def create_initial_version(obj, event):
 def prevent_deletion(obj, event):
     """Prevent deletion of objects by anyone except Managers
     """
-    membership = getMultiAdapter((obj, obj.REQUEST),
-                                        name=u"plone_tools").membership()
+    site = event.object
+    membership = getMultiAdapter((site, site.REQUEST),
+                                 name=u"plone_tools").membership()
     if not membership.checkPermission('Manage portal', obj):
         raise Unauthorized()


### PR DESCRIPTION
Fixes issue with `prevent_deletion` subscriber not being able to acquire `membership_tool` because of broken acquisition during Plone site deletion.

During Plone site deletion, on some objects of type `opengever.document.document`, `obj.portal_membership` fails to acquire the membership tool, even though it still available on the Plone site. `event.object` on the other hand seems to give us a reliable reference to the Plone site and a valid acquisition conext.
