### PR TITLE
Reword German translations for public_trial_statement label and description

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,11 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Reword German translations for public_trial_statement label and description:
+  New label: Bearbeitungsinformation
+  New description: Datum Gesuch, Datum Entscheid, Verweis auf GEVER-Zugangsgeschaeft
+  [lgraf]
+
 - Fix issue with `prevent_deletion` subscriber not being able to acquire membership_tool
   because of broken acquisition during Plone site deletion.
   [lgraf]

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -153,7 +153,7 @@ msgstr "Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz besonders schü
 #. Default: "BegrÃ¼undung Schutzgrad"
 #: ./opengever/base/behaviors/classification.py:66
 msgid "help_public_trial_statement"
-msgstr "Argumente gegen die öffentliche Zugänglichkeit gemäss Öffentlichkeitsgesetz"
+msgstr "Datum Gesuch, Datum Entscheid, Verweis auf GEVER-Zugangsgeschäft"
 
 #: ./opengever/base/behaviors/lifecycle.py:42
 msgid "help_retention_period"
@@ -256,7 +256,7 @@ msgstr "Öffentlichkeitsstatus"
 #. Default: "Public trial statement"
 #: ./opengever/base/behaviors/classification.py:64
 msgid "label_public_trial_statement"
-msgstr "Begründung für die Aufhebung des Öffentlichkeitsstatus"
+msgstr "Bearbeitungsinformation"
 
 #. Default: "reset"
 #: ./opengever/base/viewlets/history.pt:58


### PR DESCRIPTION
**Before**
Label: `Begründung für die Aufhebung des Öffentlichkeitsstatus`
Description: `Argumente gegen die öffentliche Zugänglichkeit gemäss Öffentlichkeitsgesetz`

**After**
Label: `Bearbeitungsinformation`
Description: `Datum Gesuch, Datum Entscheid, Verweis auf GEVER-Zugangsgeschäft`

---

![public_trial_translations](https://cloud.githubusercontent.com/assets/405124/3573266/37833400-0b70-11e4-8d2e-fa29531612c8.png)
