### PR TITLE
Renamed german version of move-items-button.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Renamed german version of move-items-button.
+  [lknoepfel]
+
 - Initialized opengever.sharing version. Moved prepoverlay initialization to opengever.base.
   [lknopfel]
 

--- a/opengever/base/locales/de/LC_MESSAGES/plone.formwidget.contenttree.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.formwidget.contenttree.po
@@ -1,0 +1,3 @@
+#. Default: "browse..."
+msgid "label_contenttree_browse"
+msgstr "Durchsuchen..."

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.formwidget.contenttree.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.formwidget.contenttree.po
@@ -1,0 +1,3 @@
+#. Default: "browse..."
+msgid "label_contenttree_browse"
+msgstr "Parcourir..."

--- a/opengever/base/locales/plone.formwidget.contenttree.pot
+++ b/opengever/base/locales/plone.formwidget.contenttree.pot
@@ -1,0 +1,23 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2010-08-11 09:27+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: plone.formwidget.contenttree\n"
+
+
+#. Default: "browse..."
+msgid "label_contenttree_browse"
+msgstr ""


### PR DESCRIPTION
This is the implementation of OPT-8 from [OGIP-7](https://my.teamraum.com/workspaces/onegov-gever-innovation-session/improvement-proposals/ogip7-optimierungen-user-interface/view).

![screen shot 2014-07-15 at 11 42 03](https://cloud.githubusercontent.com/assets/1375745/3583060/500f90a6-0c04-11e4-81ee-d0e6a02c51af.png)

@lukasgraf Should i also customize the french version?
