### PR TITLE
Remove `public_trial` field from repository byline.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Remove `public_trial` from repository byline.
+  [lgraf]
+
 - Journalize any changes to `public_trial` field.
   [lgraf]
 

--- a/opengever/repository/tests/test_repositoryfolder_byline.py
+++ b/opengever/repository/tests/test_repositoryfolder_byline.py
@@ -24,9 +24,10 @@ class TestRepositoryfolderByline(TestBylineBase):
 
     def test_repository_byline_privacy_layer_display(self):
         privacy_layer = self.get_byline_value_by_label('Privacy layer:')
-
         self.assertEquals('privacy_layer_no', privacy_layer.text_content())
 
-    def test_repository_byline_public_trial_display(self):
+    def test_repository_byline_public_trial_is_not_present(self):
         public_trial = self.get_byline_value_by_label('Public Trial:')
-        self.assertEquals('unchecked', public_trial.text_content())
+        self.assertIsNone(
+            public_trial,
+            "Public trial must NOT be part of repository byline any more")

--- a/opengever/repository/viewlets/byline.py
+++ b/opengever/repository/viewlets/byline.py
@@ -11,11 +11,6 @@ class RepositoryByline(BylineBase):
                          context=self.request,
                          domain='opengever.base')
 
-    def public_trial(self):
-        return translate(self.context.public_trial,
-                         context=self.request,
-                         domain='opengever.base')
-
     def get_items(self):
         return [
             {'class': 'review_state',
@@ -28,13 +23,6 @@ class RepositoryByline(BylineBase):
                                           default=u'Privacy layer'),
              'content': self.privacy_layer(),
              'replace': False},
-
-            {'class': 'public_trial',
-             'label': base_messagefactory(u'label_public_trial',
-                                          default=u'Public Trial'),
-             'content': self.public_trial(),
-             'replace': False},
-
         ]
 
 


### PR DESCRIPTION
As per [specification](https://my.teamraum.com/workspaces/onegov-gever-innovation-session/improvement-proposals/ogip6-umsetzung-offentlichkeitsgesetz/view), the `public_trial` field should not show up in the byline of repository folders any more. This pull request removes the `public_trial` field from the already customized repository folder byline:

---
#### Before

![repo_folder_byline_before](https://cloud.githubusercontent.com/assets/405124/3660554/ba5fb86e-11b8-11e4-8406-c6a074a70463.png)

---
#### After

![repo_folder_byline_after](https://cloud.githubusercontent.com/assets/405124/3660556/bf160502-11b8-11e4-9bfb-18dbeb5894cb.png)

@phgross please review. 
