### PR TITLE
Breadcrumb: Replace home label with current client label.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Breadcrumb: Replace Home label with curent client label.
+  [phgross]
+
 - Disable edit-bar for the advancedsearch form.
   [phgross]
 

--- a/opengever/base/tests/test_pathbar.py
+++ b/opengever/base/tests/test_pathbar.py
@@ -1,22 +1,69 @@
-from opengever.testing import FunctionalTestCase
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.ogds.base.interfaces import IClientConfiguration
+from opengever.testing import create_client
+from opengever.testing import FunctionalTestCase
+from opengever.testing import set_current_client_id
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 
 class TestPathBar(FunctionalTestCase):
 
     use_browser = True
 
-    def test_last_part_is_linked(self):
+    def setUp(self):
+        super(TestPathBar, self).setUp()
+
+        create_client()
+        set_current_client_id(self.portal)
+
         root = create(Builder('repository_root').titled(u'Repository'))
         repo = create(Builder('repository')
                       .within(root)
                       .titled(u'Testposition'))
-        dossier = create(Builder('dossier')
+        self.dossier = create(Builder('dossier')
                          .within(repo)
                          .titled(u'Dossier 1'))
 
-        self.browser.open(dossier.absolute_url())
+    def test_last_part_is_linked(self):
+        self.browser.open(self.dossier.absolute_url())
+
+        breadcrumb_links = self.browser.css('#portal-breadcrumbs a')
+        self.assertEquals(
+            ['Client1', 'Repository', '1. Testposition', 'Dossier 1'],
+            [aa.plain_text() for aa in breadcrumb_links])
+
+    def test_first_part_is_client_title(self):
+        self.browser.open(self.dossier.absolute_url())
+
+        breadcrumb_links = self.browser.css('#portal-breadcrumbs a')
+        self.assertEquals(
+            ['Client1', 'Repository', '1. Testposition', 'Dossier 1'],
+            [aa.plain_text() for aa in breadcrumb_links])
+
+
+class TestPathBarFallback(FunctionalTestCase):
+
+    use_browser = True
+
+    def setUp(self):
+        super(TestPathBarFallback, self).setUp()
+
+        root = create(Builder('repository_root').titled(u'Repository'))
+        repo = create(Builder('repository')
+                      .within(root)
+                      .titled(u'Testposition'))
+        self.dossier = create(Builder('dossier')
+                         .within(repo)
+                         .titled(u'Dossier 1'))
+
+    def test_fallback_when_client_is_not_found_is_home_label(self):
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IClientConfiguration)
+        proxy.client_id = u'not-existing'
+
+        self.browser.open(self.dossier.absolute_url())
 
         breadcrumb_links = self.browser.css('#portal-breadcrumbs a')
         self.assertEquals(

--- a/opengever/base/viewlets/pathbar.pt
+++ b/opengever/base/viewlets/pathbar.pt
@@ -6,13 +6,13 @@
     <span id="breadcrumbs-you-are-here" i18n:translate="you_are_here">You
 are here:</span>
     <span id="breadcrumbs-home">
-        <a i18n:translate="tabs_home"
-           tal:attributes="href view/navigation_root_url">Home</a>
+        <a tal:attributes="href view/navigation_root_url" tal:content="view/client_title">Home</a>
         <span tal:condition="breadcrumbs" class="breadcrumbSeparator">
             <tal:ltr condition="not: is_rtl">/</tal:ltr>
             <tal:rtl condition="is_rtl">\</tal:rtl>
         </span>
     </span>
+
     <span tal:repeat="crumb breadcrumbs"
           tal:attributes="dir python:is_rtl and 'rtl' or 'ltr';
                           id string:breadcrumbs-${repeat/crumb/number}">

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -1,6 +1,15 @@
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from opengever.ogds.base.utils import get_current_client
 from plone.app.layout.viewlets import common
+from Products.CMFPlone import PloneMessageFactory as pmf
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class PathBar(common.PathBarViewlet):
     index = ViewPageTemplateFile('pathbar.pt')
+
+    def client_title(self):
+        try:
+            return get_current_client().title
+        except ValueError:
+            # Current client was not found we return the default home label
+            return pmf('tabs_home', default="Home")


### PR DESCRIPTION
Before:
![bildschirmfoto 2014-07-22 um 18 15 09](https://cloud.githubusercontent.com/assets/485755/3661016/d349807c-11bc-11e4-97d4-3d911f584ecf.png)
After:
![bildschirmfoto 2014-07-22 um 18 14 40](https://cloud.githubusercontent.com/assets/485755/3661018/d4ac9d5a-11bc-11e4-8e5f-5ccf17ea97b4.png)

@lukasgraf please take a look
