### PR TITLE
Search type filter: limit types to main types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- Search type filter: limit types to main types.
+  [phgross]
+
 - Overwrite searchbox viewlet and javascript.
   So there is always a advanced search link.
   [Julian Infanger]

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -5,6 +5,14 @@ from plone.app.search.browser import Search, quote_chars, EVER
 from zope.component import getMultiAdapter
 
 
+FILTER_TYPES = [
+    'ftw.mail.mail',
+    'opengever.document.document',
+    'opengever.dossier.businesscasedossier',
+    'opengever.inbox.forwarding',
+    'opengever.task.task']
+
+
 class OpengeverSearch(Search):
     """Customizing the plone default Search View.
     """
@@ -16,6 +24,10 @@ class OpengeverSearch(Search):
         breadcrumbs = list(view.breadcrumbs())[:-1]
 
         return breadcrumbs
+
+    def types_list(self):
+        types = super(OpengeverSearch, self).types_list()
+        return list(set(FILTER_TYPES) & set(types))
 
     def filter_query(self, query):
         """The filter query of the standard search view (plone.app.search)

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -1,0 +1,31 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.testing import FunctionalTestCase
+from zope.interface import alsoProvides
+
+
+class TestOpengeverSearch(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestOpengeverSearch, self).setUp()
+
+        alsoProvides(self.portal.REQUEST, IOpengeverBaseLayer)
+
+    def test_types_filters_list_is_limited_to_main_types(self):
+        create(Builder('repository'))
+        create(Builder('repository_root'))
+        create(Builder('dossier'))
+        create(Builder('document'))
+        create(Builder('mail'))
+        create(Builder('task'))
+        create(Builder('inbox'))
+        create(Builder('forwarding'))
+        create(Builder('contactfolder'))
+        create(Builder('contact'))
+
+        self.assertItemsEqual(
+            ['opengever.task.task', 'ftw.mail.mail',
+             'opengever.document.document', 'opengever.inbox.forwarding',
+             'opengever.dossier.businesscasedossier'],
+            self.portal.unrestrictedTraverse('@@search').types_list())


### PR DESCRIPTION
The type filter is limited to the following types:
- Dossier
- Document/Mail
- Task/Forwarding

Before:
![bildschirmfoto 2014-07-24 um 18 19 52](https://cloud.githubusercontent.com/assets/485755/3691045/62d7bf64-134e-11e4-9029-b7652489e22a.png)

After:
![bildschirmfoto 2014-07-24 um 18 20 28](https://cloud.githubusercontent.com/assets/485755/3691066/7a8fd2b8-134e-11e4-8ea0-87a27e7770e1.png)
