### PR TITLE
AdvancedSearch: Fixed bug which renders the wrong widget for first request

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.3.1 (unreleased)
 ------------------
 
+- AdvancedSearch: Fixed bug which renders the wrong widget for first request.
+  [phgross]
+
 - Search type filter: limit types to main types.
   [phgross]
 

--- a/opengever/dossier/filing/advanced_search.py
+++ b/opengever/dossier/filing/advanced_search.py
@@ -19,25 +19,24 @@ class IFilingnumberSearchAddition(directives_form.Schema):
     )
 
 
-class AdvancedSearchForm(AdvancedSearchForm):
+class FilingAdvancedSearchForm(AdvancedSearchForm):
     grok.context(Interface)
     grok.name('advanced_search')
     grok.require('zope2.View')
     grok.layer(IFilingNumberActivatedLayer)
 
-    fields = field.Fields(IAdvancedSearch, IFilingnumberSearchAddition)
+    schemas = (IAdvancedSearch, IFilingnumberSearchAddition)
 
-    def update(self):
-        super(AdvancedSearchForm, self).update()
+    def move_fields(self):
         move(self, 'searchable_filing_no', before='responsible')
 
     def field_mapping(self):
         """Append searchable_filing_no to default field mappings"""
-        mapping = super(AdvancedSearchForm, self).field_mapping()
+        mapping = super(FilingAdvancedSearchForm, self).field_mapping()
         dossier_fields = mapping.get(
             'opengever-dossier-behaviors-dossier-IDossierMarker')
 
-        if not 'searchable_filing_no' in dossier_fields:
+        if 'searchable_filing_no' not in dossier_fields:
             dossier_fields.insert(
                 dossier_fields.index('responsible'), 'searchable_filing_no')
 


### PR DESCRIPTION
Since the filing number splitting, the very first requests of the advancedsearch form, renders the wrong widget for the fiels.
As a consequence, that all the javascript (hiding fields etc.) does not work.

![image](https://cloud.githubusercontent.com/assets/485755/3702184/51dc9ed8-13fc-11e4-9624-99787398906b.png)

That happens because the fields variable was saved on the class. Reworking them and define a property instead fix that bug. 
