### PR TITLE
Hide duplicate title in mail preview tab

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Hide duplicate mail title in mail preview tab.
+  [lgraf]
+
 - Customized document default view in order to render `file`
   field in NO_DOWNLOAD_DISPLAY_MODE.
   [lgraf]

--- a/opengever/mail/browser/mail_templates/previewtab.pt
+++ b/opengever/mail/browser/mail_templates/previewtab.pt
@@ -7,8 +7,6 @@
 <body tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime">
 
 
-        <h1 class="documentFirstHeading" tal:content="context/title" />
-
         <table class="mailHeaders listing vertical">
             <tr class="mailFrom"
                 tal:define="mailFrom python:view.get_header('From')"


### PR DESCRIPTION
Hides the duplicate title in mail preview tab via CSS.

![duplicate_mail_title](https://cloud.githubusercontent.com/assets/405124/3723539/7404a9ae-1674-11e4-9e73-b974b66cd14a.png)

(Closes #423).

@phgross please review.
