### PR TITLE
Make FileOrPaperValidator consider mails properly.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Make FileOrPaperValidator consider mails properly (always digitally available).
+  [lgraf]
+
 - Override ftw.mail default view with our customized dexterity default view.
   [lgraf]
 

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -3,6 +3,7 @@ from collective.elephantvocabulary import wrap_vocabulary
 from datetime import date
 from five import grok
 from ftw.datepicker.widget import DatePickerFieldWidget
+from ftw.mail.mail import IMail
 from opengever.document import _
 from opengever.document.interfaces import IDocumentSettings
 from plone.directives import form
@@ -158,6 +159,10 @@ class FileOrPaperValidator(validator.SimpleFieldValidator):
         """
         # Bail if not called during a regular add form
         if self.request.form == {}:
+            return
+
+        # Mails are always available in digital form
+        if IMail.providedBy(self.context):
             return
 
         if not (self.has_file() or self.is_preserved_as_paper()):


### PR DESCRIPTION
Currently the [validator that checks that a document is either preserved as paper or has a digital file](https://github.com/4teamwork/opengever.core/blob/feature_public_trial/opengever/document/behaviors/metadata.py#L150) does not properly handle mails, because their file field has a different name (`message`).

This makes it impossible to disable `preserved as paper` for mails:

![bildschirmfoto 2014-07-29 um 15 44 19](https://cloud.githubusercontent.com/assets/405124/3735685/ea847138-1726-11e4-8b42-4e6b311bcc3d.png)

The validator should not be applied for mails anyway, because they by definition are always digitally available.

@phgross please review.
