### PR TITLE
When saving attachments of e-mails, the menu "Edit" is show

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Disable the editable border for the extract attachments view.
+  [lgraf]
+
 - Fix UnicodeError in resolving mail author.
   [lgraf]
 

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -129,6 +129,9 @@ class ExtractAttachments(grok.View):
         return generator.generate(items, columns, sortable=False)
 
     def __call__(self):
+        # Disable the editable border for extract attachments view
+        self.request.set('disable_border', 1)
+
         items = get_attachments(self.context.msg)
         if not len(items):
             msg = _(u'error_no_attachments_to_extract',


### PR DESCRIPTION
This is misleading. I also suggest showing a different title (e.g. "E-Mail-Anhänge speichern").

![bildschirmfoto 2014-07-31 um 08 38 59](https://cloud.githubusercontent.com/assets/485600/3760753/a051ed54-187d-11e4-9b86-15808c76ae81.png)
