### PR TITLE
Extract attachments: Improve consistency in wording

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Improved wording of German translations in extract attachments view.
+  [lgraf]
+
 - Disable the editable border for the extract attachments view.
   [lgraf]
 

--- a/opengever/mail/browser/extract_attachments_templates/extract_attachments.pt
+++ b/opengever/mail/browser/extract_attachments_templates/extract_attachments.pt
@@ -39,14 +39,17 @@
 
 
             <div class="field">
-              <label i18n:translate="label_select_attachments"
+              <label i18n:translate="label_attachments_to_save"
                      class="horizontal">
-                Attachments to extract
+                Attachments to save
               </label>
 
-              <div class="formHelp" i18n:translate="help_select_attachments">
-                Select the attachments to extract.
+              <div class="formHelp" i18n:translate="help_attachments_to_save">
+                Select the attachments that should be saved. From every selected attachment
+                a document in the parent dossier will be created.
+
               </div>
+              <br />
               <p i18n:domain="opengever.tabbedview" >
                   <span i18n:translate="Choose:">Choose</span>: 
                   <a i18n:translate="all" href="#" id="all">All</a>
@@ -99,7 +102,7 @@
 
             <div class="formControls">
               <input type="submit" name="form.submitted"
-                     value="Create documents"
+                     value="Save attachments"
                      class="submit-widget button-field context"
                      i18n:attributes="value" />
 

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -19,8 +19,8 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:101
-msgid "Create documents"
-msgstr "Dokumente extrahieren"
+msgid "Save attachments"
+msgstr "Anhänge speichern"
 
 #: ./opengever/mail/browser/send_document.py:46
 msgid "No Mail Address"
@@ -111,10 +111,10 @@ msgstr "Live Search: Nachname/Vorname der internen Mitarbeiter oder Kontakte ein
 msgid "help_message"
 msgstr ""
 
-#. Default: "Select the attachments to extract."
+#. Default: "Select the attachments that should be saved. From every selected attachment a document in the parent dossier will be created."
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:47
-msgid "help_select_attachments"
-msgstr "Wählen Sie die Anhänge aus, die extrahiert werden sollen. Aus jedem ausgewähltem Anhang wird ein Dokument im übergeordneten Dossier erzeugt."
+msgid "help_attachments_to_save"
+msgstr "Wählen Sie die Anhänge aus, die gespeichert werden sollen. Aus jedem ausgewähltem Anhang wird ein Dokument im übergeordneten Dossier erzeugt."
 
 #: ./opengever/mail/browser/send_document.py:75
 msgid "help_subject"
@@ -185,10 +185,10 @@ msgstr "Aktenzeichen"
 msgid "label_see_attachment"
 msgstr "siehe Anhänge"
 
-#. Default: "Attachments to extract"
+#. Default: "Attachments to save"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:42
-msgid "label_select_attachments"
-msgstr "Anhänge"
+msgid "label_attachments_to_save"
+msgstr "Zu speichernde Anhänge"
 
 #. Default: "Sequence Number"
 #: ./opengever/mail/browser/byline.py:20

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -19,7 +19,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:101
-msgid "Create documents"
+msgid "Save attachments"
 msgstr "Extraire documents"
 
 #: ./opengever/mail/browser/send_document.py:46
@@ -111,9 +111,9 @@ msgstr "Recherche en direct : Saisir nom et prénom des collaborateurs internes 
 msgid "help_message"
 msgstr ""
 
-#. Default: "Select the attachments to extract."
+#. Default: "Select the attachments that should be saved. From every selected attachment a document in the parent dossier will be created."
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:47
-msgid "help_select_attachments"
+msgid "help_attachments_to_save"
 msgstr "Sélectionner les annexes à extraire. De chaque annexe sélectionnée un document est créé  dans le dossier maître."
 
 #: ./opengever/mail/browser/send_document.py:75
@@ -185,9 +185,9 @@ msgstr "Numéro de référence"
 msgid "label_see_attachment"
 msgstr "Voir  fichiers attachés"
 
-#. Default: "Attachments to extract"
+#. Default: "Attachments to save"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:42
-msgid "label_select_attachments"
+msgid "label_attachments_to_save"
 msgstr "Fichiers attachés"
 
 #. Default: "Sequence Number"

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -22,7 +22,7 @@ msgid "Cancel"
 msgstr ""
 
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:101
-msgid "Create documents"
+msgid "Save attachments"
 msgstr ""
 
 #: ./opengever/mail/browser/send_document.py:46
@@ -114,9 +114,9 @@ msgstr ""
 msgid "help_message"
 msgstr ""
 
-#. Default: "Select the attachments to extract."
+#. Default: "Select the attachments that should be saved. From every selected attachment a document in the parent dossier will be created."
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:47
-msgid "help_select_attachments"
+msgid "help_attachments_to_extract"
 msgstr ""
 
 #: ./opengever/mail/browser/send_document.py:75
@@ -188,9 +188,9 @@ msgstr ""
 msgid "label_see_attachment"
 msgstr ""
 
-#. Default: "Attachments to extract"
+#. Default: "Attachments to save"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:42
-msgid "label_select_attachments"
+msgid "label_attachments_to_save"
 msgstr ""
 
 #. Default: "Sequence Number"


### PR DESCRIPTION
![bildschirmfoto 2014-07-31 um 08 41 46](https://cloud.githubusercontent.com/assets/485600/3760773/2e5e3b52-187e-11e4-9e80-ac53eba703b3.png)

Button reads "Dokumente extrahieren", should be "Anhänge speichern". Also, description should use wording "gespeichert" instead of "extrahiert".

Furthermore, caption title "Anhänge" should be something like "Zu speichernde Anhänge".

Typ column is empty (for pdf content).
