### PR TITLE
Fixed unicode decode bug in task overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 
 - General fixes:
 
+  - Fixed unicode decode bug in task overview.
+    [lknoepfel]
   - OGQuickUploadCapableFileFactory: Set default values before adding content to container.
     (Prevents values set by handlers on ObjectAddedEvent to be overwritten again).
     [lgraf]

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -269,7 +269,7 @@ class Overview(DisplayForm, OpengeverTab):
         if not item.responsible_client or len(info.get_clients()) <= 1:
             # No responsible client is set yet or we have a single client
             # setup.
-            return info.describe(item.responsible)
+            return info.describe(item.responsible).encode('utf-8')
 
         # Client
         client = client_title_helper(item, item.responsible_client)

--- a/opengever/task/tests/test_functional_overview.py
+++ b/opengever/task/tests/test_functional_overview.py
@@ -243,14 +243,14 @@ class TestOverviewFunctions(MockTestCase):
         directlyProvides(item_task, ITask)
         mock_item_task = self.mocker.proxy(item_task, spec=False, count=False)
         self.expect(mock_item_task.responsible_client).result('client_name')
-        self.expect(mock_item_task.responsible).result('user1')
+        self.expect(mock_item_task.responsible).result(u'\u00fcser1')
 
         # Task-Object wihout responsible client
         item_task_without = self.create_dummy()
         directlyProvides(item_task_without, ITask)
         mock_item_task_without = self.mocker.proxy(item_task_without, spec=False, count=False)
         self.expect(mock_item_task_without.responsible_client).result(None)
-        self.expect(mock_item_task_without.responsible).result('user2')
+        self.expect(mock_item_task_without.responsible).result(u'\u00fcser2')
 
         # Others
         item_obj = self.create_dummy()
@@ -271,6 +271,11 @@ class TestOverviewFunctions(MockTestCase):
         info_with = view.get_task_info(mock_item_task)
         info_without = view.get_task_info(mock_item_task_without)
 
+        # if info is unicode it tries to decode everything to unicode - which
+        # fails e.g. for the breadcumbs
+        self.assertTrue(isinstance(info_with, str))
+        self.assertTrue(isinstance(info_without, str))
+
         self.assertEqual(info_obj, '')
-        self.assertEqual(info_with, 'client_name / user1')
-        self.assertEqual(info_without, 'user2')
+        self.assertEqual(info_with, 'client_name / \xc3\xbcser1')
+        self.assertEqual(info_without, '\xc3\xbcser2')


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.phvs/issues/27

Bug happens only in single client setups. He appears if a task is displayed who has a special character in its title or its breadcrumb.

@lukasgraf 
