### PR TITLE
Disable public_trial edit_form when parents dossier is inactive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Disable public_trial edit_form when parents dossier is inactive.
+  [phgross]
+
 - Journalize AttachmentsDeleted event.
   [lgraf]
 
@@ -143,7 +146,7 @@ Changelog
 
 - Added limited-public option for public trial.
   [lknoepfel]
-  
+
 - Document: Refactor behaviors to be a package with separate modules.
   [lgraf]
 

--- a/opengever/base/browser/edit_public_trial.py
+++ b/opengever/base/browser/edit_public_trial.py
@@ -13,17 +13,21 @@ from zExceptions import Unauthorized
 
 def can_access_public_trial_edit_form(user, content):
     """Returns True if the user has 'Modify portal content' permission in any
-    open dossier state.
+    open dossier state. And the containing dossier is
+     - not a templatedossier
+     - not inactive
     """
-    wftool = getToolByName(content, 'portal_workflow')
 
     assert IBaseDocument.providedBy(
         content), 'Content needs to provide IBaseDocument'
 
+    wftool = getToolByName(content, 'portal_workflow')
     dossier = find_parent_dossier(content)
 
     if ITemplateDossier.providedBy(dossier):
-        # Template dossiers don't have the IClassification behavior
+        return False
+
+    if wftool.getInfoFor(dossier, 'review_state') == 'dossier-state-inactive':
         return False
 
     workflow_id = wftool.getChainForPortalType(dossier.portal_type)[0]

--- a/opengever/base/tests/test_edit_public_trial_form.py
+++ b/opengever/base/tests/test_edit_public_trial_form.py
@@ -38,6 +38,15 @@ class TestEditPublicTrialHelperFunction(FunctionalTestCase):
 
         self.assertTrue(self.can_edit(user, document))
 
+    def test_user_CANNOT_edit_when_parent_dossier_is_inactive(self):
+        user = self.portal.portal_membership.getAuthenticatedMember()
+        dossier = create(Builder('dossier').in_state('dossier-state-inactive'))
+        document = create(Builder('document')
+                          .with_dummy_content()
+                          .within(dossier))
+
+        self.assertFalse(self.can_edit(user, document))
+
     def test_user_WITH_modify_permission_in_open_state_CAN_edit(self):
         user = self.portal.portal_membership.getAuthenticatedMember()
 


### PR DESCRIPTION
This PR fixes Issue #432.

@lukasgraf please review ... 
