### PR TITLE
Added public_trial_statement field to the public_trail edit form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Added public_trial_statement field to the public_trail edit form.
+  [phgross]
+
 - Disable public_trial edit_form when parents dossier is inactive.
   [phgross]
 

--- a/opengever/base/browser/edit_public_trial.py
+++ b/opengever/base/browser/edit_public_trial.py
@@ -56,7 +56,8 @@ class EditPublicTrialForm(dexterity.EditForm):
 
     schema = None
 
-    fields = Fields(IClassification).select('public_trial')
+    fields = Fields(IClassification).select(
+        'public_trial', 'public_trial_statement')
 
     label = _(u'label_change_public_trial',
               default=u'Change public trial information.')

--- a/opengever/base/tests/test_edit_public_trial_form.py
+++ b/opengever/base/tests/test_edit_public_trial_form.py
@@ -103,6 +103,14 @@ class TestEditPublicTrialForm(FunctionalTestCase):
         self.assertEquals('private', self.document.public_trial)
 
     @browsing
+    def test_user_CAN_modify_public_trial_statement(self, browser):
+        browser.login().visit(self.document, view='edit_public_trial')
+        browser.fill({'Public trial statement': 'Foo statement'}).submit()
+
+        self.assertEquals('Foo statement',
+                          self.document.public_trial_statement)
+
+    @browsing
     def test_user_submit_cancel_button(self, browser):
         browser.login().visit(self.document, view='edit_public_trial')
         browser.find('Cancel').click()


### PR DESCRIPTION
This PR fixes the issue #448.

![bildschirmfoto 2014-08-05 um 08 11 32](https://cloud.githubusercontent.com/assets/485755/3807471/68a951d8-1c67-11e4-8e1e-40e9aee7c0b5.png)

@lukasgraf could you have a look?
