### PR TITLE
Use Products.CMFEditions from source because p.a.versioningbehavior requires >2.2.9.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -3,6 +3,7 @@ extends = http://kgs.4teamwork.ch/sources.cfg
 extensions = mr.developer
 
 development-packages =
+    Products.CMFEditions
     plone.app.versioningbehavior
     ftw.treeview
     plonetheme.teamraum


### PR DESCRIPTION
Required because
- `plone.app.versioningbehavior:master` [now depends on Products.CMFEditions > 2.2.9](https://github.com/plone/plone.app.versioningbehavior/commit/2b8e434ea3133560386340467c66c730538866c3)
- we need `plone.app.versioningbehavior` from source because of https://github.com/plone/plone.app.versioningbehavior/pull/5
- There is no release of `Products.CMFEditions` > 2.2.9 yet (see [here](http://plone.293351.n2.nabble.com/When-will-4-3-4-be-released-tt7572110.html#none))
