### PR TITLE
Setting a different standard tab in an e-mail doesn't seem to be respected

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -8,6 +8,7 @@ development-packages =
     ftw.treeview
     plonetheme.teamraum
     ftw.mail
+    ftw.tabbedview
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
![bildschirmfoto 2014-07-31 um 09 12 22](https://cloud.githubusercontent.com/assets/485600/3760993/3ff81500-1882-11e4-9254-485e5bf6a232.png)

However, this link will show me the overview tab:
http://oeffg.opengever.ch/ordnungssystem/fuehrung/stellungnahmen-mitberichte-zuhanden-dritter/dossier-11/dossier-12/ein-test-aus-offg
