### PR TITLE
Update status messages when documents are sent by e-mail

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Reword status message after sending documents by e-mail.
+  [lgraf]
+
 - Mail overview: display the original message including a download link.
   [phgross]
 

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -220,7 +220,7 @@ class SendDocumentForm(form.Form):
                 self.file_sent_mail_in_dossier(msg)
 
             # let the user know that the mail was sent
-            info = _(u'info_mails_sent', 'Mails sent')
+            info = _(u'info_mail_sent', 'E-mail has been sent.')
             notify(DocumentSent(
                     self.context, userid, header_to, data.get('subject'),
                     data.get('message'), data.get('documents')))

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -120,10 +120,10 @@ msgstr ""
 msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
-#. Default: "Mails sent"
+#. Default: "E-mail has been sent."
 #: ./opengever/mail/browser/send_document.py:223
-msgid "info_mails_sent"
-msgstr "Mails wurden versendet."
+msgid "info_mail_sent"
+msgstr "E-Mail wurde versendet."
 
 #. Default: "Intern receiver"
 #: ./opengever/mail/browser/send_document.py:54

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -120,10 +120,10 @@ msgstr ""
 msgid "info_extracted_document"
 msgstr "Document créé : ${title}"
 
-#. Default: "Mails sent"
+#. Default: "E-mail has been sent."
 #: ./opengever/mail/browser/send_document.py:223
-msgid "info_mails_sent"
-msgstr "Emails envoyés."
+msgid "info_mail_sent"
+msgstr ""
 
 #. Default: "Intern receiver"
 #: ./opengever/mail/browser/send_document.py:54

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -123,9 +123,9 @@ msgstr ""
 msgid "info_extracted_document"
 msgstr ""
 
-#. Default: "Mails sent"
+#. Default: "E-mail has been sent."
 #: ./opengever/mail/browser/send_document.py:223
-msgid "info_mails_sent"
+msgid "info_mail_sent"
 msgstr ""
 
 #. Default: "Intern receiver"


### PR DESCRIPTION
![bildschirmfoto 2014-07-31 um 08 58 33](https://cloud.githubusercontent.com/assets/485600/3760884/7192b9fa-1880-11e4-9cfe-686aca59c0d2.png)
- First message says "Versandtes E-Mail", second message "Mails". Either singular or plural
- Use "E-Mails" instead of "Mails"
- Could the referenced e-mail content be linked in the status message? Would be very helpful. 
