### PR TITLE
Added upgradestep which add public_trial column to persistent grid-state

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4 (unreleased)
 ----------------
 
+- Added upgradestep which add public_trial column to persistent grid-state.
+  [phgross]
+
 - Reword status message after sending documents by e-mail.
   [lgraf]
 

--- a/opengever/tabbedview/profiles/default/metadata.xml
+++ b/opengever/tabbedview/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>2202</version>
+    <version>3400</version>
     <dependencies>
         <dependency>profile-ftw.tabbedview:extjs</dependency>
         <dependency>profile-ftw.tabbedview:quickupload</dependency>

--- a/opengever/tabbedview/upgrades/configure.zcml
+++ b/opengever/tabbedview/upgrades/configure.zcml
@@ -33,4 +33,14 @@
         profile="opengever.tabbedview:default"
         />
 
+    <!-- 2202 -> 3400 -->
+    <genericsetup:upgradeStep
+        title="Add public trial column to stored grid state's"
+        description=""
+        source="2202"
+        destination="3400"
+        handler="opengever.tabbedview.upgrades.to3400.AddPublicTrialColumn"
+        profile="opengever.tabbedview:default"
+        />
+
 </configure>

--- a/opengever/tabbedview/upgrades/to3400.py
+++ b/opengever/tabbedview/upgrades/to3400.py
@@ -1,0 +1,36 @@
+from ftw.dictstorage.sql import DictStorageModel
+from ftw.upgrade import UpgradeStep
+from opengever.ogds.base.utils import create_session
+from sqlalchemy import or_
+import json
+
+
+PUBLIC_TRIAL_COL_CONFIG = {u'width': 110,
+                           u'sortable': True,
+                           u'id': u'public_trial'}
+
+PUBLIC_TRIAL_COL_ID = 'public_trial'
+
+
+class AddPublicTrialColumn(UpgradeStep):
+
+    def __call__(self):
+
+        session = create_session()
+        query = session.query(DictStorageModel).filter(
+            or_(DictStorageModel.key.contains('tabbedview_view-documents'),
+                DictStorageModel.key.contains('tabbedview_view-mydocuments')))
+
+        for record in query.all():
+            data = json.loads(record.value.encode('utf-8'))
+            columns = data.get('columns')
+            if PUBLIC_TRIAL_COL_ID not in [col.get('id') for col in columns]:
+
+                if columns[-1].get('id') == u'dummy':
+                    columns.insert(len(columns) - 1, PUBLIC_TRIAL_COL_CONFIG)
+                else:
+                    columns.append(PUBLIC_TRIAL_COL_CONFIG)
+
+                data['columns'] = columns
+
+                record.value = json.dumps(data)


### PR DESCRIPTION
This PR contains an upgradestep which fixes #445 for all storred grid-states for document listings.

I've discussed the problematic with @maethu, fixing the real cause in the `ftw.table` ext-js functionality would be much to complicated.

@lukasgraf please have a look.
