### PR TITLE
Fix fieldset tagged values for mail schemata.

### DIFF
--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -33,7 +33,7 @@ import re
 IMail.setTaggedValue(FIELDSETS_KEY, [
     Fieldset('common',
              label=base_mf(u'fieldset_common', u'Common'),
-             fields=[u'title', u'message'])
+             fields=[u'message'])
 ])
 
 
@@ -48,7 +48,7 @@ class IOGMail(form.Schema):
     form.fieldset(
         u'common',
         label=base_mf(u'fieldset_common', u'Common'),
-        fields=[u'title', u'message'])
+        fields=[u'title'])
 
     form.order_before(title='message')
     dexteritytextindexer.searchable('title')


### PR DESCRIPTION
The `fieldset` tagged values should only be set for fields that are part of the respective schema.
