### PR TITLE
Fix public_trial DictStorage upgrade step

### DIFF
--- a/opengever/tabbedview/upgrades/to3400.py
+++ b/opengever/tabbedview/upgrades/to3400.py
@@ -24,7 +24,7 @@ class AddPublicTrialColumn(UpgradeStep):
             or_(DictStorageModel.key.contains('tabbedview_view-documents'),
                 DictStorageModel.key.contains('tabbedview_view-mydocuments')))
 
-        for record in query.all():
+        for record in query:
             # Deal with broken DictStorage entries (NULL)
             if record.value is None:
                 log.warn("DictStorage record with key '%s' has "


### PR DESCRIPTION
Two fixes for upgrade step `3400` in `opengever.tabbedview`:
- Deal with broken records that have a `NULL` in the DB
- Iterate over `query` instead of `query.all()` to keep things lazy and avoid fetching all records at once
