### PR TITLE
Use the same customized download view we use for documents for mails as well.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -84,7 +84,8 @@ Changelog
     [phgross]
   - Reword status message after sending documents by e-mail.
     [lgraf]
-
+  - Use the same customized download view we use for documents for mails as well.
+    [lgraf]
 
 - Changes related to public_trial field:
 

--- a/opengever/document/browser/configure.zcml
+++ b/opengever/document/browser/configure.zcml
@@ -6,8 +6,8 @@
 
     <browser:page
         name="download"
-        for="opengever.document.document.IDocumentSchema"
-        class=".download.DocumentDownload"
+        for="opengever.document.behaviors.IBaseDocument"
+        class=".download.DocumentishDownload"
         permission="zope2.View"
         />
 

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -8,9 +8,13 @@ from plone.namedfile.utils import stream_data
 from zope.event import notify
 
 
-class DocumentDownload(Download):
-    """Overriding the Namefile Download view,
-    for implement the special file handling
+class DocumentishDownload(Download):
+    """Overriding the Namefile Download view and implement some OpenGever
+    specific file handling:
+
+    - Deal with an unicode bug in plone.namedfile.utils.set_header
+    - Set Content-Disposition headers based on browser sniffing
+    - Fire our own `FileCopyDownloadedEvent`
     """
 
     def __call__(self):

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -1,0 +1,56 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from pkg_resources import resource_string
+from plone.app.testing import TEST_USER_ID
+from zope.annotation import IAnnotations
+from zope.i18n import translate
+
+
+MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
+
+
+class TestMailDownloadCopy(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestMailDownloadCopy, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_mail_download_copy_yields_correct_headers(self, browser):
+        mail = create(Builder("mail").with_message(MAIL_DATA))
+        browser.login().visit(mail, view='tabbedview_view-overview')
+        browser.find('Download copy').click()
+
+        self.assertDictContainsSubset({
+            'status': '200 Ok',
+            'content-length': str(len(MAIL_DATA)),
+            'content-type': 'message/rfc822',
+            'content-disposition': 'attachment; filename="testmail.eml"'},
+            browser.headers)
+
+    @browsing
+    def test_mail_download_copy_causes_journal_entry(self, browser):
+        mail = create(Builder("mail").with_message(MAIL_DATA))
+        browser.login().visit(mail, view='tabbedview_view-overview')
+        browser.find('Download copy').click()
+
+        def get_journal(obj):
+            annotations = IAnnotations(mail)
+            return annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, {})
+
+        journal = get_journal(mail)
+        last_entry = journal[-1]
+
+        self.assertEquals(TEST_USER_ID, last_entry['actor'])
+
+        action = last_entry['action']
+        self.assertDictContainsSubset(
+            {'type': 'File copy downloaded',
+             'title': u'label_file_copy_downloaded'},
+            action)
+
+        self.assertEquals(u'Download copy',
+                          translate(action['title']))


### PR DESCRIPTION
This solves the unicode issue present in `plone.namedfile.utils.set_headers()`, and makes sure a journal entry is generated when a mail copy is downloaded.
