### PR TITLE
Also check for not supplied mails, when checking if dossier could resolved

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,8 @@ Changelog
 
   - Fixed translation for filing_number column in dossier listings.
     [phgross]
+  - Also check for not supplied mails, when check if dossier could be resolved.
+    [phgross]
   - Fixed unicode decode bug in task overview.
     [lknoepfel]
   - OGQuickUploadCapableFileFactory: Set default values before adding content to container.

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -1,16 +1,18 @@
 from Acquisition import aq_inner, aq_parent
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from datetime import datetime
 from five import grok
+from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IConstrainTypeDecider
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.task import OPEN_TASK_STATES
+from opengever.task.task import ITask
 from plone.dexterity.content import Container
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.component import queryMultiAdapter, queryUtility
 from zope.interface import Interface
 
@@ -101,10 +103,10 @@ class DossierContainer(Container):
             return parent
 
     def is_all_supplied(self):
-        """Check if all tasks and all documents are supplied in a subdossier
-        provided there are any (active) subdossiers
-
+        """Check if all tasks and all documents(incl. mails) are supplied in
+        a subdossier provided there are any (active) subdossiers
         """
+
         subdossiers = self.getFolderContents({
             'object_provides':
             'opengever.dossier.behaviors.dossier.IDossierMarker'})
@@ -114,8 +116,8 @@ class DossierContainer(Container):
 
         if len(active_dossiers) > 0:
             results = self.getFolderContents({
-                'portal_type': ['opengever.task.task',
-                                'opengever.document.document']})
+                'object_provides': [ITask.__identifier__,
+                                    IBaseDocument.__identifier__]})
 
             if len(results) > 0:
                 return False

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -3,7 +3,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
-from opengever.testing import OPENGEVER_INTEGRATION_TESTING
 from plone.app.testing import TEST_USER_ID
 
 
@@ -11,6 +10,10 @@ class TestDossierContainerFunctional(FunctionalTestCase):
     """This test-case should eventually replace TestDossierContainer.
     New tests will be added to this case.
     """
+
+    def setUp(self):
+        super(TestDossierContainerFunctional, self).setUp()
+        self.grant('Reader')
 
     def test_is_all_supplied_without_any_subdossiers(self):
         dossier = create(Builder("dossier"))
@@ -29,6 +32,14 @@ class TestDossierContainerFunctional(FunctionalTestCase):
         dossier = create(Builder("dossier"))
         create(Builder("dossier").within(dossier))
         create(Builder("task").within(dossier))
+
+        self.assertFalse(dossier.is_all_supplied())
+
+    def test_is_not_all_supplied_with_subdossier_and_mails(self):
+        dossier = create(Builder("dossier"))
+        create(Builder("dossier").within(dossier))
+        create(Builder("mail").within(dossier)
+               .with_dummy_message())
 
         self.assertFalse(dossier.is_all_supplied())
 
@@ -100,8 +111,8 @@ class TestDossierChecks(FunctionalTestCase):
 
     def test_its_not_all_closed_if_a_task_stays_in_an_active_state(self):
         dossier = create(Builder("dossier"))
-        task = create(Builder("task").within(dossier)
-                      .in_state('task-state-open'))
+        create(Builder("task").within(dossier)
+               .in_state('task-state-open'))
 
         self.assertFalse(dossier.is_all_closed())
 
@@ -196,9 +207,8 @@ class TestDateCalculations(FunctionalTestCase):
 
     def test_no_end_date_is_valid(self):
         dossier = create(Builder("dossier"))
-        subdossier = create(Builder("dossier")
-                            .within(dossier)
-                            .having(start=date(2012, 02, 24)))
+        create(Builder("dossier").within(dossier)
+               .having(start=date(2012, 02, 24)))
         self.assertTrue(dossier.has_valid_enddate())
 
     def test_end_date_afterward_the_latest_document_date_is_valid(self):


### PR DESCRIPTION
The check if all content of a dossier is supplied in subdossier's, when they are any active subdossiers, has not include mails.

![bildschirmfoto 2014-08-20 um 17 48 50](https://cloud.githubusercontent.com/assets/485755/3983714/c21b60fa-2881-11e4-9dbd-f9c9b140630d.png)

@lukasgraf 
