### PR TITLE
Don't encode attached mails when sending documents as email.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -93,6 +93,8 @@ Changelog
     [lgraf]
   - Use the same customized download view we use for documents for mails as well.
     [lgraf]
+  - Don't encode attached mails when sending documents as email.
+    [lgraf]
 
 - Changes related to public_trial field:
 

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -285,7 +285,8 @@ class SendDocumentForm(form.Form):
             maintype, subtype = obj_file.contentType.split('/', 1)
             part = MIMEBase(maintype, subtype)
             part.set_payload(obj_file.data)
-            Encoders.encode_base64(part)
+            if mimetype != 'message/rfc822':
+                Encoders.encode_base64(part)
             part.add_header('Content-Disposition', 'attachment; filename="%s"'
                             % obj_file.filename)
             attachment_parts.append(part)

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -132,6 +132,11 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
         mail = self.send_documents(dossier, mails)
         self.assert_attachment(mail, 'testmail.eml', 'message/rfc822')
 
+        attachment = mail.get_payload()[1].get_payload()[0]
+        self.assertIn(
+            'foobar', attachment.get_payload(),
+            'Attached mails should not be base64 encoded')
+
     def test_send_document_event(self):
         intids = getUtility(IIntIds)
         dossier = create(Builder("dossier"))


### PR DESCRIPTION
When attached mails (type `message/rfc822`) are encoded again using base64 this causes the Python `email` module to somehow not decode them properly again.

Also, encoding them again is unnecessary, because `rfc822` messages are already safe for transportation via SMTP.
