### PR TITLE
Change german wording for descriptions of `public_trial` and `public_trial_statement`

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -44,6 +44,8 @@ Changelog
   - Changed German wording for value `unchecked` for both public_trial and archival_value:
     "Noch nicht geprüft" -> "Nicht geprüft"
     [lgraf]
+  - Change german wording for descriptions of `public_trial` and `public_trial_statement`
+    [lgraf]
 
 
 - Changes to journaling:

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2014-07-07 13:37+0000\n"
+"POT-Creation-Date: 2014-08-21 14:16+0000\n"
 "PO-Revision-Date: 2013-11-25 09:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -47,11 +47,6 @@ msgstr "Archivwürdig"
 msgid "archival worthy with sampling"
 msgstr "Sampling"
 
-#. Default: "Cancel"
-#: ./opengever/base/browser/edit_public_trial.py:70
-msgid "button_cancel"
-msgstr "Abbrechen"
-
 #. Default: "Download"
 #: ./opengever/base/viewlets/history.pt:44
 msgid "button_file"
@@ -61,11 +56,6 @@ msgstr "Kopie herunterladen"
 #: ./opengever/base/viewlets/history.pt:54
 msgid "button_pdf"
 msgstr "PDF Vorschau"
-
-#. Default: "Save"
-#: ./opengever/base/browser/edit_public_trial.py:59
-msgid "button_save"
-msgstr "Speichern"
 
 #. Default: "Show"
 #: ./opengever/base/viewlets/history.pt:50
@@ -93,7 +83,7 @@ msgid "error_not_copyable"
 msgstr "Der gewählte Inhalt kann nicht kopiert werden"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:33
+#: ./opengever/base/behaviors/classification.py:43
 msgid "fieldset_classification"
 msgstr "Sichtbarkeit"
 
@@ -117,7 +107,7 @@ msgid "help_archival_value_annotation"
 msgstr ""
 
 #. Default: ""
-#: ./opengever/base/behaviors/classification.py:44
+#: ./opengever/base/behaviors/classification.py:54
 msgid "help_classification"
 msgstr "Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen"
 
@@ -142,18 +132,21 @@ msgid "help_description"
 msgstr ""
 
 #. Default: ""
-#: ./opengever/base/behaviors/classification.py:51
+#: ./opengever/base/behaviors/classification.py:61
 msgid "help_privacy_layer"
 msgstr "Markierung, die angibt, ob die Unterlagen besonders schützenswerte Personendaten oder Persönlichkeitsprofile gemäss Datenschutzrecht enthalten"
 
-#: ./opengever/base/behaviors/classification.py:58
+#: ./opengever/base/behaviors/classification.py:68
 msgid "help_public_trial"
-msgstr "Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz besonders schützenswert sind oder nicht"
+msgstr "Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht"
 
-#. Default: "BegrÃ¼undung Schutzgrad"
-#: ./opengever/base/behaviors/classification.py:66
+#: ./opengever/base/behaviors/classification.py:97
+msgid "help_public_trial_default_value"
+msgstr ""
+
+#: ./opengever/base/behaviors/classification.py:76
 msgid "help_public_trial_statement"
-msgstr "Datum Gesuch, Datum Entscheid, Verweis auf GEVER-Zugangsgeschäft"
+msgstr "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier"
 
 #: ./opengever/base/behaviors/lifecycle.py:42
 msgid "help_retention_period"
@@ -179,12 +172,12 @@ msgid "label_archival_value_annotation"
 msgstr "Kommentar zur Archivwürdigkeit"
 
 #. Default: "Change public trial information."
-#: ./opengever/base/browser/edit_public_trial.py:47
+#: ./opengever/base/browser/edit_public_trial.py:62
 msgid "label_change_public_trial"
 msgstr "Öffentlichkeitsstatus ändern"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:43
+#: ./opengever/base/behaviors/classification.py:53
 msgid "label_classification"
 msgstr "Klassifikation"
 
@@ -244,17 +237,22 @@ msgid "label_last_modified"
 msgstr "Zuletzt verändert"
 
 #. Default: "Privacy layer"
-#: ./opengever/base/behaviors/classification.py:50
+#: ./opengever/base/behaviors/classification.py:60
 msgid "label_privacy_layer"
 msgstr "Datenschutzstufe"
 
 #. Default: "Public Trial"
-#: ./opengever/base/behaviors/classification.py:57
+#: ./opengever/base/behaviors/classification.py:67
 msgid "label_public_trial"
 msgstr "Öffentlichkeitsstatus"
 
+#. Default: "Public Trial default value"
+#: ./opengever/base/behaviors/classification.py:95
+msgid "label_public_trial_default_value"
+msgstr ""
+
 #. Default: "Public trial statement"
-#: ./opengever/base/behaviors/classification.py:64
+#: ./opengever/base/behaviors/classification.py:74
 msgid "label_public_trial_statement"
 msgstr "Bearbeitungsinformation"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-07-07 13:37+0000\n"
+"POT-Creation-Date: 2014-08-21 14:16+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,11 +44,6 @@ msgstr "Valeur archivistique"
 msgid "archival worthy with sampling"
 msgstr "Echantillon"
 
-#. Default: "Cancel"
-#: ./opengever/base/browser/edit_public_trial.py:70
-msgid "button_cancel"
-msgstr "Annuler"
-
 #. Default: "Download"
 #: ./opengever/base/viewlets/history.pt:44
 msgid "button_file"
@@ -58,11 +53,6 @@ msgstr "Télécharger"
 #: ./opengever/base/viewlets/history.pt:54
 msgid "button_pdf"
 msgstr "Aperçu pdf"
-
-#. Default: "Save"
-#: ./opengever/base/browser/edit_public_trial.py:59
-msgid "button_save"
-msgstr "Enregistrer"
 
 #. Default: "Show"
 #: ./opengever/base/viewlets/history.pt:50
@@ -90,7 +80,7 @@ msgid "error_not_copyable"
 msgstr "Le contenu choisi ne peut être copié"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:33
+#: ./opengever/base/behaviors/classification.py:43
 msgid "fieldset_classification"
 msgstr "Visibilité"
 
@@ -113,7 +103,7 @@ msgstr "Valeur archivistique"
 msgid "help_archival_value_annotation"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:44
+#: ./opengever/base/behaviors/classification.py:54
 msgid "help_classification"
 msgstr "Classification permettant la protection des documents contre la consultation non-autorisée "
 
@@ -137,17 +127,21 @@ msgstr ""
 msgid "help_description"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:51
+#: ./opengever/base/behaviors/classification.py:61
 msgid "help_privacy_layer"
 msgstr "Marquage des documents contenant des données sensibles (loi sur la protection des données)"
 
-#: ./opengever/base/behaviors/classification.py:58
+#: ./opengever/base/behaviors/classification.py:68
 msgid "help_public_trial"
-msgstr "Mentionne si les documents contiennent des données sensibles ou non selon la loi sur le principe de la transparence"
+msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:66
+#: ./opengever/base/behaviors/classification.py:97
+msgid "help_public_trial_default_value"
+msgstr ""
+
+#: ./opengever/base/behaviors/classification.py:76
 msgid "help_public_trial_statement"
-msgstr "Arguments contre l'accès pulic selon la loi sur le principe de la transparence"
+msgstr ""
 
 #: ./opengever/base/behaviors/lifecycle.py:42
 msgid "help_retention_period"
@@ -173,12 +167,12 @@ msgid "label_archival_value_annotation"
 msgstr "Commentaire concernant la valeur archivistique"
 
 #. Default: "Change public trial information."
-#: ./opengever/base/browser/edit_public_trial.py:47
+#: ./opengever/base/browser/edit_public_trial.py:62
 msgid "label_change_public_trial"
 msgstr "Modifier 'Statut public'"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:43
+#: ./opengever/base/behaviors/classification.py:53
 msgid "label_classification"
 msgstr "Classification"
 
@@ -238,17 +232,22 @@ msgid "label_last_modified"
 msgstr "Dernière modification"
 
 #. Default: "Privacy layer"
-#: ./opengever/base/behaviors/classification.py:50
+#: ./opengever/base/behaviors/classification.py:60
 msgid "label_privacy_layer"
 msgstr "Niveau du délai de protection"
 
 #. Default: "Public Trial"
-#: ./opengever/base/behaviors/classification.py:57
+#: ./opengever/base/behaviors/classification.py:67
 msgid "label_public_trial"
 msgstr "Statut public"
 
+#. Default: "Public Trial default value"
+#: ./opengever/base/behaviors/classification.py:95
+msgid "label_public_trial_default_value"
+msgstr ""
+
 #. Default: "Public trial statement"
-#: ./opengever/base/behaviors/classification.py:64
+#: ./opengever/base/behaviors/classification.py:74
 msgid "label_public_trial_statement"
 msgstr "Jusitificaton pour le retrait du status public"
 

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-07-07 13:37+0000\n"
+"POT-Creation-Date: 2014-08-21 14:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,11 +47,6 @@ msgstr ""
 msgid "archival worthy with sampling"
 msgstr ""
 
-#. Default: "Cancel"
-#: ./opengever/base/browser/edit_public_trial.py:70
-msgid "button_cancel"
-msgstr ""
-
 #. Default: "Download"
 #: ./opengever/base/viewlets/history.pt:44
 msgid "button_file"
@@ -60,11 +55,6 @@ msgstr ""
 #. Default: "PDF"
 #: ./opengever/base/viewlets/history.pt:54
 msgid "button_pdf"
-msgstr ""
-
-#. Default: "Save"
-#: ./opengever/base/browser/edit_public_trial.py:59
-msgid "button_save"
 msgstr ""
 
 #. Default: "Show"
@@ -93,7 +83,7 @@ msgid "error_not_copyable"
 msgstr ""
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:33
+#: ./opengever/base/behaviors/classification.py:43
 msgid "fieldset_classification"
 msgstr ""
 
@@ -116,7 +106,7 @@ msgstr ""
 msgid "help_archival_value_annotation"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:44
+#: ./opengever/base/behaviors/classification.py:54
 msgid "help_classification"
 msgstr ""
 
@@ -140,15 +130,19 @@ msgstr ""
 msgid "help_description"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:51
+#: ./opengever/base/behaviors/classification.py:61
 msgid "help_privacy_layer"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:58
+#: ./opengever/base/behaviors/classification.py:68
 msgid "help_public_trial"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:66
+#: ./opengever/base/behaviors/classification.py:97
+msgid "help_public_trial_default_value"
+msgstr ""
+
+#: ./opengever/base/behaviors/classification.py:76
 msgid "help_public_trial_statement"
 msgstr ""
 
@@ -176,12 +170,12 @@ msgid "label_archival_value_annotation"
 msgstr ""
 
 #. Default: "Change public trial information."
-#: ./opengever/base/browser/edit_public_trial.py:47
+#: ./opengever/base/browser/edit_public_trial.py:62
 msgid "label_change_public_trial"
 msgstr ""
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:43
+#: ./opengever/base/behaviors/classification.py:53
 msgid "label_classification"
 msgstr ""
 
@@ -241,17 +235,22 @@ msgid "label_last_modified"
 msgstr ""
 
 #. Default: "Privacy layer"
-#: ./opengever/base/behaviors/classification.py:50
+#: ./opengever/base/behaviors/classification.py:60
 msgid "label_privacy_layer"
 msgstr ""
 
 #. Default: "Public Trial"
-#: ./opengever/base/behaviors/classification.py:57
+#: ./opengever/base/behaviors/classification.py:67
 msgid "label_public_trial"
 msgstr ""
 
+#. Default: "Public Trial default value"
+#: ./opengever/base/behaviors/classification.py:95
+msgid "label_public_trial_default_value"
+msgstr ""
+
 #. Default: "Public trial statement"
-#: ./opengever/base/behaviors/classification.py:64
+#: ./opengever/base/behaviors/classification.py:74
 msgid "label_public_trial_statement"
 msgstr ""
 


### PR DESCRIPTION
German wording for fields `public_trial` und `public_trial_statement` shall be changed:
- **Öffentlichkeitsstatus** (`public_trial`)
  Alt: "Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz besonders schützenswert sind oder nicht"
  Neu: **"Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht"**
- **Bearbeitungsinformationen** (`public_trial_statement`)
  Alt: "Datum Gesuch, Datum Entscheid, Verweis auf GEVER-Zugangsgeschäft"
  Neu: **"Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER- Gesuchdossier"**
