### PR TITLE
Create inital journal entry when adding `IJournalizable` behavior to mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -59,6 +59,8 @@ Changelog
     [lgraf]
   - Journalize AttachmentsDeleted event.
     [lgraf]
+  - Create initial journal entry for mails.
+    [lgraf]
 
 
 - Changes related to mail content type:

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-05 08:27+0000\n"
+"POT-Creation-Date: 2014-08-21 14:47+0000\n"
 "PO-Revision-Date: 2014-08-05 10:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Keine E-Mail Adresse"
 msgid "Save attachments"
 msgstr "Anhänge speichern"
 
-#: ./opengever/mail/browser/send_document.py:313
+#: ./opengever/mail/browser/send_document.py:314
 msgid "Sent mail filed as '${title}'."
 msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 
@@ -170,6 +170,11 @@ msgstr "Dokumente nur als Link versenden."
 msgid "label_file_copy_in_dossier"
 msgstr "Kopie des versandten Mails in Dossier ablegen"
 
+#. Default: "Journal initialized"
+#: ./opengever/mail/upgrades/to3403.py:7
+msgid "label_journal_initialized"
+msgstr "Dokument migriert"
+
 #. Default: "Message"
 #: ./opengever/mail/browser/send_document.py:81
 msgid "label_message"
@@ -207,3 +212,4 @@ msgstr "Keine Nachricht"
 #: ./opengever/mail/browser/send_document.py:70
 msgid "receiver"
 msgstr "Empfänger"
+

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-05 08:27+0000\n"
+"POT-Creation-Date: 2014-08-21 14:47+0000\n"
 "PO-Revision-Date: 2012-09-06 13:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Pas d'adresse Email"
 msgid "Save attachments"
 msgstr "Extraire documents"
 
-#: ./opengever/mail/browser/send_document.py:313
+#: ./opengever/mail/browser/send_document.py:314
 msgid "Sent mail filed as '${title}'."
 msgstr ""
 
@@ -168,6 +168,11 @@ msgstr "Envoyer seulement le lien du document"
 #. Default: "File a copy of the sent mail in dossier"
 #: ./opengever/mail/browser/send_document.py:111
 msgid "label_file_copy_in_dossier"
+msgstr ""
+
+#. Default: "Journal initialized"
+#: ./opengever/mail/upgrades/to3403.py:7
+msgid "label_journal_initialized"
 msgstr ""
 
 #. Default: "Message"

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-05 08:27+0000\n"
+"POT-Creation-Date: 2014-08-21 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Save attachments"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:313
+#: ./opengever/mail/browser/send_document.py:314
 msgid "Sent mail filed as '${title}'."
 msgstr ""
 
@@ -171,6 +171,11 @@ msgstr ""
 #. Default: "File a copy of the sent mail in dossier"
 #: ./opengever/mail/browser/send_document.py:111
 msgid "label_file_copy_in_dossier"
+msgstr ""
+
+#. Default: "Journal initialized"
+#: ./opengever/mail/upgrades/to3403.py:7
+msgid "label_journal_initialized"
 msgstr ""
 
 #. Default: "Message"

--- a/opengever/mail/profiles/default/metadata.xml
+++ b/opengever/mail/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3405</version>
+  <version>3406</version>
   <dependencies>
     <dependency>profile-ftw.mail:default</dependency>
   </dependencies>

--- a/opengever/mail/upgrades/configure.zcml
+++ b/opengever/mail/upgrades/configure.zcml
@@ -111,4 +111,14 @@
         directory="profiles/3405"
         />
 
+    <!-- 3405 -> 3406 -->
+    <genericsetup:upgradeStep
+        title="Create initial journal entry"
+        description=""
+        source="3405"
+        destination="3406"
+        handler="opengever.mail.upgrades.to3406.CreateInitialJournalEntry"
+        profile="opengever.mail:default"
+        />
+
 </configure>

--- a/opengever/mail/upgrades/to3406.py
+++ b/opengever/mail/upgrades/to3406.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.journal.handlers import journal_entry_factory
+from opengever.mail import _
+
+
+def create_initial_journal_entry(mail):
+    title = _(
+        u'label_journal_initialized',
+        default=u'Journal initialized')
+    journal_entry_factory(mail, 'Journal initialized', title)
+
+
+class CreateInitialJournalEntry(UpgradeStep):
+
+    def __call__(self):
+        query = {'portal_type': 'ftw.mail.mail'}
+        for mail in self.objects(query, "Creating initial journal entry"):
+            create_initial_journal_entry(mail)


### PR DESCRIPTION
When adding `IJournalizable` behavior to mails, an initial journal entry should be created for all mails, indicating that the journalization now begins. Timestamp of the journal entry should be the time of migration.

German translation should be:
`Dokument migriert`
