### PR TITLE
Make sure `digitally_available` is always true for mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -103,6 +103,8 @@ Changelog
     [lgraf]
   - Don't encode attached mails when sending documents as email.
     [lgraf]
+  - Always set `digitally_available` to `True` upon mail creation.
+    [lgraf]
 
 - Changes related to public_trial field:
 

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -1,0 +1,11 @@
+from five import grok
+from ftw.mail.mail import IMail
+from zope.lifecycleevent.interfaces import IObjectCreatedEvent
+
+
+@grok.subscribe(IMail, IObjectCreatedEvent)
+def set_digitally_available(mail, event):
+    """Set the `digitally_available` field upon creation
+    (always True for mails by definition).
+    """
+    mail.digitally_available = True

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -2,7 +2,6 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.mail import utils
 from opengever.document.behaviors import metadata
 from opengever.document.interfaces import IDocumentSettings
 from opengever.mail.mail import extract_email
@@ -66,8 +65,8 @@ class TestMailMetadataWithBuilder(FunctionalTestCase):
         self.assertIsNone(mail.document_type,
                           'Document type should have no value')
 
-        self.assertIsNone(mail.digitally_available,
-                          'Digitally available should have no value')
+        self.assertTrue(mail.digitally_available,
+                        'Digitally available should be True')
 
         self.assertEquals(get_preserved_as_paper_default(),
                           mail.preserved_as_paper)
@@ -176,8 +175,8 @@ class TestMailUpgradeStep(FunctionalTestCase):
         self.assertIsNone(mail.document_type,
                           'Document type has no value')
 
-        self.assertIsNone(mail.digitally_available,
-                          'Digitally available has no value')
+        self.assertTrue(mail.digitally_available,
+                        'Digitally available should be True')
 
         self.assertEquals(get_preserved_as_paper_default(),
                           mail.preserved_as_paper)

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -35,7 +35,7 @@ class TestOverview(FunctionalTestCase):
                   ['Description', ''],
                   ['Foreign Reference', ''],
                   ['Original message', u'testmail.eml \u2014 1 KB Download copy'],
-                  ['Digital Available', 'no'],
+                  ['Digital Available', 'yes'],
                   ['Preserved as paper', 'yes'],
                   ['Date of receipt', date_format_helper(date.today())],
                   ['Date of delivery', ''],

--- a/opengever/mail/upgrades/to3401.py
+++ b/opengever/mail/upgrades/to3401.py
@@ -55,6 +55,11 @@ class ActivateBehaviors(UpgradeStep):
         for fieldname in fields:
             field = IDocumentMetadata[fieldname]
 
+            # `digitally_available` is always True for mails
+            if fieldname == u'digitally_available':
+                field.set(field.interface(mail), True)
+                continue
+
             # Don't overwrite existing values.
             if hasattr(aq_base(mail), fieldname):
                 # Existing value - skip unless it's a broken tuple
@@ -62,7 +67,6 @@ class ActivateBehaviors(UpgradeStep):
                         getattr(mail, fieldname) is None):
                     continue
 
-            field = IDocumentMetadata[fieldname]
             default_adapter = queryMultiAdapter(
                 (aq_parent(mail), mail.REQUEST, None, field, None),
                 IValue, name='default')


### PR DESCRIPTION
E-mails are digitally available by definition - the field should therefore always be set to `True`.
