### PR TITLE
Add `regulations` and `directive` options to `document_type` VDEX vocabulary

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -53,6 +53,8 @@ Changelog
     [lgraf]
   - Change german wording for descriptions of `public_trial` and `public_trial_statement`
     [lgraf]
+  - Added `regulations` and `directive` options to `document_type` vocabulary.
+    [lgraf]
 
 
 - Changes to journaling:

--- a/opengever/document/vdexvocabs/document_types.vdex
+++ b/opengever/document/vdexvocabs/document_types.vdex
@@ -57,4 +57,22 @@
             <langstring language="fr">Contrat</langstring>
         </caption>
     </term>
+    <term>
+        <termIdentifier>directive</termIdentifier>
+        <caption>
+            <langstring language="en">Directive</langstring>
+            <langstring language="de-ch">Weisung</langstring>
+            <langstring language="de">Weisung</langstring>
+            <langstring language="fr">Directive</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>regulations</termIdentifier>
+        <caption>
+            <langstring language="en">Regulations</langstring>
+            <langstring language="de-ch">Reglement</langstring>
+            <langstring language="de">Reglement</langstring>
+            <langstring language="fr">Règlement</langstring>
+        </caption>
+    </term>
 </vdex>


### PR DESCRIPTION
Extend the `document_types` VDEX vocabulary by two terms:
- Regulations (**Reglement**)
- Directive (**Weisung**)
