### PR TITLE
Fix setting default for `preserved_as_paper` for mails in upgrade step.

### DIFF
--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -24,6 +24,12 @@ def get_preserved_as_paper_default():
     return registry.forInterface(IDocumentSettings).preserved_as_paper_default
 
 
+def set_preserved_as_paper_default(value):
+    registry = getUtility(IRegistry)
+    settings = registry.forInterface(IDocumentSettings)
+    settings.preserved_as_paper_default = value
+
+
 class TestMailMetadataWithBuilder(FunctionalTestCase):
 
     use_browser = True
@@ -144,6 +150,10 @@ class TestMailUpgradeStep(FunctionalTestCase):
         behaviors.remove(
             u'opengever.document.behaviors.metadata.IDocumentMetadata')
         fti._updateProperty('behaviors', tuple(behaviors))
+
+        # Set the registry default value for `preserved_as_paper` to
+        # something else than the schema default
+        set_preserved_as_paper_default(False)
 
         mail = create(Builder("mail").with_message(MAIL_DATA))
 

--- a/opengever/mail/upgrades/to3401.py
+++ b/opengever/mail/upgrades/to3401.py
@@ -38,6 +38,14 @@ class ActivateBehaviors(UpgradeStep):
         mail_metadata = IDocumentMetadata(mail)
         mail_metadata.receipt_date = mail.created().asdatetime().date()
 
+    def set_preserved_as_paper(self, mail):
+        field = IDocumentMetadata[u'preserved_as_paper']
+        default_adapter = queryMultiAdapter(
+            (aq_parent(mail), mail.REQUEST, None, field, None),
+            IValue, name='default')
+        value = default_adapter.get()
+        field.set(field.interface(mail), value)
+
     def set_default_values_for_missing_fields(self, mail):
 
         fields = [
@@ -54,6 +62,13 @@ class ActivateBehaviors(UpgradeStep):
 
         for fieldname in fields:
             field = IDocumentMetadata[fieldname]
+
+            if fieldname == u'preserved_as_paper':
+                # preserved_as_paper as acquired as a schema default value
+                # - we therefore directly set the value from the default
+                # value adapter to avoid picking up the schema default
+                self.set_preserved_as_paper(mail)
+                continue
 
             # `digitally_available` is always True for mails
             if fieldname == u'digitally_available':


### PR DESCRIPTION
`preserved_as_paper` has a [schema level default](https://github.com/4teamwork/opengever.core/blob/master/opengever/document/behaviors/metadata.py#L123) that causes
the [check `hasattr(aq_base(mail), 'preserved_as_paper'`](https://github.com/4teamwork/opengever.core/blob/master/opengever/mail/upgrades/to3401.py#L64) to be `True` even though
the mail doesn't have a value for that field. This caused the value
from the default value adapter (registry) not to be set.
