### PR TITLE
Don't set a value for `receipt_date` when migrating mails in upgrade step

### DIFF
--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -176,7 +176,7 @@ class TestMailUpgradeStep(FunctionalTestCase):
         self.assertEquals(get_header_date(mail).date(),
                           mail.document_date)
 
-        self.assertEquals(date.today(),
+        self.assertEquals(None,
                           mail.receipt_date)
 
         self.assertIsNone(mail.delivery_date,

--- a/opengever/mail/upgrades/to3401.py
+++ b/opengever/mail/upgrades/to3401.py
@@ -1,8 +1,10 @@
 from Acquisition import aq_base
 from Acquisition import aq_parent
+from datetime import datetime
+from ftw.mail import utils
 from ftw.upgrade import UpgradeStep
 from opengever.document.behaviors.metadata import IDocumentMetadata
-from opengever.mail.mail import initialize_metadata
+from opengever.mail.mail import get_author_by_email
 from plone.dexterity.interfaces import IDexterityFTI
 from z3c.form.interfaces import IValue
 from zope.component import getUtility
@@ -28,15 +30,21 @@ class ActivateBehaviors(UpgradeStep):
 
         query = {'portal_type': 'ftw.mail.mail'}
         for mail in self.objects(query, 'Initialize metadata on mail'):
-            initialize_metadata(mail, None)
-            self.set_receipt_date_equals_creation_date(mail)
+            self.initialize_required_metadata(mail)
             self.set_default_values_for_missing_fields(mail)
             # Indexes and catalog metadata for these objects will be rebuilt in
             # upgrade step opengever.policy.base.upgrades:3400
 
-    def set_receipt_date_equals_creation_date(self, mail):
+    def initialize_required_metadata(self, mail):
         mail_metadata = IDocumentMetadata(mail)
-        mail_metadata.receipt_date = mail.created().asdatetime().date()
+
+        date_time = datetime.fromtimestamp(
+            utils.get_date_header(mail.msg, 'Date'))
+        mail_metadata.document_date = date_time.date()
+
+        # Receipt date should be None for migrated mails
+        mail_metadata.receipt_date = None
+        mail_metadata.document_author = get_author_by_email(mail)
 
     def set_preserved_as_paper(self, mail):
         field = IDocumentMetadata[u'preserved_as_paper']

--- a/opengever/policy/base/upgrades/to3400.py
+++ b/opengever/policy/base/upgrades/to3400.py
@@ -13,6 +13,8 @@ class RebuildIndexesForDocumentishObjects(UpgradeStep):
 
     def __call__(self):
         idxs = [
+            'document_date',
+            'document_author',
             'delivery_date',
             'receipt_date',
             'object_provides',


### PR DESCRIPTION
(Specification says the value should not be set for migrated mails.)
