### PR TITLE
Create savepoints every 500 items during expensive upgrade steps for public_trial upgrade.

### DIFF
--- a/opengever/mail/upgrades/to3401.py
+++ b/opengever/mail/upgrades/to3401.py
@@ -29,7 +29,8 @@ class ActivateBehaviors(UpgradeStep):
         fti._updateProperty('behaviors', tuple(behaviors))
 
         query = {'portal_type': 'ftw.mail.mail'}
-        for mail in self.objects(query, 'Initialize metadata on mail'):
+        for mail in self.objects(query, 'Initialize metadata on mail',
+                                 savepoints=500):
             self.initialize_required_metadata(mail)
             self.set_default_values_for_missing_fields(mail)
             # Indexes and catalog metadata for these objects will be rebuilt in

--- a/opengever/policy/base/upgrades/to3400.py
+++ b/opengever/policy/base/upgrades/to3400.py
@@ -23,4 +23,4 @@ class RebuildIndexesForDocumentishObjects(UpgradeStep):
         ]
         self.catalog_reindex_objects(
             {'object_provides': IBaseDocument.__identifier__},
-            idxs=idxs)
+            idxs=idxs, savepoints=500)

--- a/sources.cfg
+++ b/sources.cfg
@@ -8,6 +8,7 @@ development-packages =
     plonetheme.teamraum
     ftw.mail
     ftw.tabbedview
+    ftw.upgrade
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
This is to avoid running out of memory during upgrade of large installations that still use a 32-bit Python.

This PR depends on https://github.com/4teamwork/ftw.upgrade/pull/50 being merged.
