### PR TITLE
Response viewlet: add permissionCheck for edit and delete actions.

### DIFF
--- a/opengever/task/tests/test_response_viewlet.py
+++ b/opengever/task/tests/test_response_viewlet.py
@@ -1,7 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.testing import FunctionalTestCase
 from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
 
 
 class TestResponseViewlet(FunctionalTestCase):
@@ -10,15 +10,66 @@ class TestResponseViewlet(FunctionalTestCase):
         super(TestResponseViewlet, self).setUp()
 
         self.dossier = create(Builder('dossier'))
-        self.task = create(Builder('task').having(task_type='comment'))
+        self.task = create(Builder('task')
+                           .having(task_type='comment'))
+
+    def add_sample_answer(self, browser):
+        browser.login().open(self.task, view='tabbedview_view-overview')
+        browser.css('#task-transition-open-in-progress').first.click()
+        browser.fill({'Response': u'Sample response'})
+        browser.css('#form-buttons-save').first.click()
+        browser.open(self.task, view='tabbedview_view-overview')
 
     @browsing
     def test_task_history(self, browser):
         browser.login().open(self.task, view='tabbedview_view-overview')
+
         self.assertEqual(1, len(browser.css('#task-responses div.answer')))
 
-        browser.css('#task-transition-open-tested-and-closed').first.click()
-        browser.css('#form-buttons-save').first.click()
+        self.add_sample_answer(browser)
 
         browser.open(self.task, view='tabbedview_view-overview')
         self.assertEqual(2, len(browser.css('#task-responses div.answer')))
+
+    @browsing
+    def test_progress_starts_with_created_answer(self, browser):
+        browser.login().open(self.task, view='tabbedview_view-overview')
+
+        answer = browser.css('div.answers .answer').first
+        self.assertEqual('Created by Test User (test_user_1_)',
+                         answer.css('h3').first.text)
+        self.assertEqual('http://nohost/plone/@@user-details/test_user_1_',
+                         answer.css('h3 a').first.get('href'))
+
+    @browsing
+    def test_answer_contains_response_description(self, browser):
+        self.add_sample_answer(browser)
+        answer = browser.css('div.answers .answer').first
+        self.assertEqual('Accepted by Test User (test_user_1_)',
+                         answer.css('h3').first.text)
+        self.assertEqual('http://nohost/plone/@@user-details/test_user_1_',
+                         answer.css('h3 a').first.get('href'))
+
+    @browsing
+    def test_answer_contains_response_text(self, browser):
+        self.add_sample_answer(browser)
+
+        answer = browser.css('div.answers .answer').first
+        self.assertEqual(u'Sample response', answer.css('.text').first.text)
+
+    @browsing
+    def test_manage_actions_are_not_shown_for_default_user(self, browser):
+        self.add_sample_answer(browser)
+
+        self.assertEqual([], browser.css('.manageActions .delete'))
+        self.assertEqual([], browser.css('.manageActions .edit'))
+
+    @browsing
+    def test_manage_actions_are_shown_for_managers(self, browser):
+        self.grant('Manager')
+        self.add_sample_answer(browser)
+
+        self.assertEqual('Delete',
+                         browser.css('.manageActions .delete').first.text)
+        self.assertEqual('Edit',
+                         browser.css('.manageActions .edit').first.text)

--- a/opengever/task/viewlets/response.py
+++ b/opengever/task/viewlets/response.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_inner
 from five import grok
 from opengever.base.browser.helper import get_css_class
 from opengever.globalindex.model.task import Task
@@ -43,9 +44,21 @@ class ResponseView(grok.Viewlet, Base):
 
         return responses
 
+    @property
+    def can_edit(self):
+        # TODO: this permission should renamed!!!
+        return self.memship.checkPermission('Poi: Edit response',
+                                            aq_inner(self.context))
+
     def edit_link(self, id):
         return '{}/@@task_response_edit?response_id={}'.format(
             self.context.absolute_url(), id)
+
+    @property
+    def can_delete(self):
+        # TODO: should be solved with a separate permission
+        return self.memship.checkPermission('Manage portal',
+                                            aq_inner(self.context))
 
     def delete_link(self, id):
         return '{}/@@task_response_delete?response_id={}'.format(

--- a/opengever/task/viewlets/response_templates/responseview.pt
+++ b/opengever/task/viewlets/response_templates/responseview.pt
@@ -15,11 +15,11 @@
             <div class="date" tal:content="python:here.toLocalizedTime(response.date, long_format=True)" />
 
             <div class="manageActions">
-              <a href="#" class="edit"
+              <a tal:condition="viewlet/can_edit" href="#" class="edit"
                  tal:attributes="href response_info/edit_link" i18n:translate="">
                 Edit
               </a>
-              <a href="#" class="delete"
+              <a tal:condition="viewlet/can_delete" href="#" class="delete"
                  tal:attributes="href response_info/delete_link" i18n:translate="">
                 Delete
               </a>
@@ -29,7 +29,7 @@
               Response Header
             </h3>
 
-            <div class="text" tal:content="response/text">hhh</div>
+            <div class="text" tal:content="response/text"></div>
 
           </div>
         </div>


### PR DESCRIPTION
![bildschirmfoto 2014-08-28 um 18 48 56](https://cloud.githubusercontent.com/assets/485755/4079257/412b22d4-2ed3-11e4-893f-e9d5d4d51db3.png)

The `Edit` and `Delete` action should only be displayed, when the user has the permission to edit/delete. 

@deiferni
