### PR TITLE
Drop development-packages after releasing them for 2.9.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -3,18 +3,11 @@ extends = http://kgs.4teamwork.ch/sources.cfg
 extensions = mr.developer
 
 development-packages =
-    plone.app.versioningbehavior
-    ftw.treeview
-    plonetheme.teamraum
-    ftw.mail
-    ftw.tabbedview
-    ftw.upgrade
 
 auto-checkout = ${buildout:development-packages}
 
 [branches]
 plone.formwidget.autocomplete = master
-plone.app.versioningbehavior = 1.1.x
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    http://dist.plone.org/release/4.2.1/versions.cfg
+    http://dist.plone.org/release/4.2.2/versions.cfg
     http://kgs.4teamwork.ch/release/opengever/latest
 
 versions = versions


### PR DESCRIPTION
(Also bumped Plone version from `4.2.1` to `4.2.2` to be consistent with 2.9 KGS)

@phgross 
