### PR TITLE
Mail preview tab: fixed bug in mimetype lookup for attachments with a wrong mimetype

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 3.4.1 (unreleased)
 ------------------
 
+- Mail preview tab: fixed bug in mimetype lookup for attachments with
+  a wrong mimetype.
+  [phgross]
+
 - Use `ftw.profilehook` instead of setuphandlers.
   [deiferni]
 

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -31,7 +31,7 @@ class PreviewTab(ftwView):
         else:
             lookup = self.mtr.lookup(attachment['content-type'])
 
-        if isinstance(lookup, list) or isinstance(lookup, tuple):
+        if lookup and (isinstance(lookup, list) or isinstance(lookup, tuple)):
             lookup = lookup[0]
 
         return lookup

--- a/opengever/mail/tests/attachment_with_wrong_mimetype.txt
+++ b/opengever/mail/tests/attachment_with_wrong_mimetype.txt
@@ -1,0 +1,19 @@
+Mime-Version: 1.0
+Content-Type: multipart/mixed; boundary=908752978
+To: to@example.org
+From: from@example.org
+Subject: Attachment Test
+Date: Thu, 01 Jan 1970 01:00:00 +0100
+Message-Id: <1>
+
+
+--908752978
+Content-Disposition: attachment;
+	filename*=iso-8859-1''B%FCcher.txt
+Content-Type: image/notexisting;
+	name="=?iso-8859-1?Q?B=FCcher.txt?="
+Content-Transfer-Encoding: base64
+
+w6TDtsOcCg==
+
+--908752978--

--- a/opengever/mail/tests/test_mail_previewtab.py
+++ b/opengever/mail/tests/test_mail_previewtab.py
@@ -26,3 +26,14 @@ class TestPreview(FunctionalTestCase):
                   ['To:', u'Christoph M\xf6rgeli <to@example.org>']]
         self.assertEquals(expect,
                           browser.css('.mailHeaders.listing').first.lists())
+
+    @browsing
+    def test_preview_tab_can_handle_attachment_with_wrong_mimetype(self, browser):
+        mail_data = resource_string('opengever.mail.tests',
+                                    'attachment_with_wrong_mimetype.txt')
+        mail = create(Builder('mail').with_message(mail_data))
+
+        browser.login().visit(mail, view='tabbedview_view-preview')
+
+        self.assertEquals([u'B\xfccher.txt'],
+                          browser.css('div.mailAttachment a').text)


### PR DESCRIPTION
When a mail contains attachment with a mimetype, wich is not registered in the mimetypes_registry, the mimetype lookup fails with the following error message:

```
/home/zope/eggs/Zope2-2.13.18-py2.7.egg/Products/PageTemplates/Expressions.py:117→ render
/home/zope/eggs/plone.memoize-1.1.1-py2.7.egg/plone/memoize/instance.py:51→ memogetter
/home/zope/clients/plone01-ska-arch-dev/src/opengever.core/opengever/mail/browser/mail.py:52→ attachments
/home/zope/clients/plone01-ska-arch-dev/src/opengever.core/opengever/mail/browser/mail.py:35→ lookup_mimetype_registry
```

This PR fix this bug. @lukasgraf please take a look ... 
