### PR TITLE
Referenceprefix manager fix, when subitems are already removed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.4.2 (unreleased)
 ------------------
 
+- Make reference_prefix_manager deal properly with already deleted objects.
+  [phgross]
+
 - Use `ftw.profilehook` instead of setuphandlers.
   [deiferni]
 

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -3,8 +3,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2014-08-21 14:16+0000\n"
-"PO-Revision-Date: 2013-11-25 09:25+0100\n"
+"POT-Creation-Date: 2014-09-03 23:01+0000\n"
+"PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "MIME-Version: 1.0\n"
@@ -160,6 +160,11 @@ msgstr ""
 #: ./opengever/base/viewlets/history.pt:17
 msgid "label_actor"
 msgstr "Geändert von"
+
+#. Default: "-- Already removed object --"
+#: ./opengever/base/adapters.py:177
+msgid "label_already_removed"
+msgstr "-- Bereits gelöscht --"
 
 #. Default: "Archival value"
 #: ./opengever/base/behaviors/lifecycle.py:57
@@ -336,4 +341,3 @@ msgstr "Nicht geprüft"
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr "Nicht klassifiziert"
-

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-21 14:16+0000\n"
+"POT-Creation-Date: 2014-09-03 23:01+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -155,6 +155,11 @@ msgstr ""
 #: ./opengever/base/viewlets/history.pt:17
 msgid "label_actor"
 msgstr "Modifier par"
+
+#. Default: "-- Already removed object --"
+#: ./opengever/base/adapters.py:177
+msgid "label_already_removed"
+msgstr ""
 
 #. Default: "Archival value"
 #: ./opengever/base/behaviors/lifecycle.py:57

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-21 14:16+0000\n"
+"POT-Creation-Date: 2014-09-03 23:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -157,6 +157,11 @@ msgstr ""
 #. Default: "Actor"
 #: ./opengever/base/viewlets/history.pt:17
 msgid "label_actor"
+msgstr ""
+
+#. Default: "-- Already removed object --"
+#: ./opengever/base/adapters.py:177
+msgid "label_already_removed"
 msgstr ""
 
 #. Default: "Archival value"

--- a/opengever/repository/browser/referenceprefix_manager_templates/referenceprefixmanager.pt
+++ b/opengever/repository/browser/referenceprefix_manager_templates/referenceprefixmanager.pt
@@ -30,7 +30,7 @@
             </tr>
 			      <tr tal:repeat="posnumber view/prefix_mapping">
 				      <td tal:content="posnumber/prefix"></td>
-				      <td tal:content="posnumber/obj/effective_title"></td>
+				      <td tal:content="posnumber/title"></td>
               <td tal:condition="not: posnumber/active">
                 <a class="unlock button"
                    tal:attributes="href string:@@referenceprefix_manager?prefix=${posnumber/prefix}"

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
 from opengever.journal.tests.utils import get_journal_entry
 from opengever.testing import FunctionalTestCase
+from plone import api
 from zExceptions import Unauthorized
 from zope.i18n import translate
 import transaction
@@ -54,6 +55,19 @@ class TestReferencePrefixManager(FunctionalTestCase):
 
     def test_manager_throws_error_when_delete_request_for_used_prefix_occurs(self):
         self.assertRaises(Exception, self.reference_manager.free_number, (2))
+
+    @browsing
+    def test_manager_handles_deleted_repositories_correclty(self, browser):
+        api.content.delete(obj=self.repo2)
+        transaction.commit()
+
+        browser.login().open(self.repo, view='referenceprefix_manager')
+
+        table = browser.css('#reference_prefix_manager_table').first.lists()
+
+        self.assertEquals([['1', 'One', 'Unlock'],
+                           ['2', '-- Already removed object --', 'In use'],
+                           ['3', 'One', 'In use']], table)
 
     @browsing
     def test_manager_shows_default_message_when_no_repositorys_available(self, browser):


### PR DESCRIPTION
When a repositoryfolder get's removed by a user the reference_prefix manager for the parent object fails with an KeyError because the intid utility can't get the object (see [current implementation](https://github.com/4teamwork/opengever.core/blob/fa8dff2032e2624b8ad6c2cf97f2f8e38ae3db3a/opengever/base/adapters.py#L169))

This PR solve this problem, additionally i've reworked the tests (including ftw.testbrowser) and fixed another bug in the unlock link generation.

Following a simple example how the prefix manager looks with deleted objects:
![bildschirmfoto 2014-09-04 um 08 45 41](https://cloud.githubusercontent.com/assets/485755/4145764/5093dee2-33ff-11e4-9792-2a4c6a531793.png)
@lukasgraf please take a look ...
