### PR TITLE
Add opengever.maintenance to development buildout.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -12,6 +12,7 @@ user = zopemaster:admin
 eggs +=
     opengever.mysqlconfig
     plonetheme.teamraum
+    opengever.maintenance
 
 zope-conf-additional =
     datetime-format international

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,6 +3,7 @@ extends = http://kgs.4teamwork.ch/sources.cfg
 extensions = mr.developer
 
 development-packages =
+    opengever.maintenance
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Add `opengever.maintenance` to development buildout. We use it in production everywhere, there's no reason not to have it in development setups as well.
