### PR TITLE
Include newest theme adjustments for the next release.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -4,6 +4,7 @@ extensions = mr.developer
 
 development-packages =
     opengever.maintenance
+    plonetheme.teamraum
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Include `plonetheme.teamraum` to the `development_packages.

So we include the fix which solves #543 (see https://github.com/4teamwork/plonetheme.teamraum/pull/251).

@lukasgraf
