### PR TITLE
Switch og.ogds.models to master after merging `rework-mandanten-concept`branch.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -15,7 +15,6 @@ auto-checkout = ${buildout:development-packages}
 
 [branches]
 plone.formwidget.autocomplete = master
-opengever.ogds.models = rework-mandanten-concept
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}


### PR DESCRIPTION
Switch `opengever.ogds.models` to `master` after merging `rework-mandanten-concept`branch.
