### PR TITLE
Task: Use dates instead of datetimes when setting fields in ActionSucceeded subscribers.

### DIFF
--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -1,6 +1,6 @@
 from Acquisition import aq_inner, aq_parent
 from Products.CMFCore.interfaces import IActionSucceededEvent
-from datetime import datetime
+from datetime import date
 from five import grok
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
@@ -41,8 +41,8 @@ def set_dates(task, event):
                             ]
 
     if event.action == 'task-transition-open-in-progress':
-        task.expectedStartOfWork = datetime.now()
+        task.expectedStartOfWork = date.today()
     elif event.action in resolved_transitions:
-        task.date_of_completion = datetime.now()
+        task.date_of_completion = date.today()
     if event.action == 'task-transition-resolved-in-progress':
         task.date_of_completion = None

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.task.adapters import IResponseContainer
@@ -99,24 +99,25 @@ class TestTaskIntegration(FunctionalTestCase):
 
         wft = t1.portal_workflow
 
-        self.failUnless(t1.expectedStartOfWork == None)
+        self.failUnless(t1.expectedStartOfWork is None)
         wft.doActionFor(t1, 'task-transition-open-in-progress')
-        self.failUnless(t1.expectedStartOfWork.date() == datetime.now().date())
 
-        self.failUnless(t1.date_of_completion == None)
+        self.failUnless(t1.expectedStartOfWork == date.today())
+
+        self.failUnless(t1.date_of_completion is None)
         wft.doActionFor(t1, 'task-transition-in-progress-resolved')
-        self.failUnless(t1.date_of_completion.date() == datetime.now().date())
+        self.failUnless(t1.date_of_completion == date.today())
 
         wft.doActionFor(t1, 'task-transition-resolved-in-progress')
-        self.failUnless(t1.date_of_completion == None)
+        self.failUnless(t1.date_of_completion is None)
 
         t2 = create(Builder('task')
                     .titled('Task 2')
                     .having(issuer=member.getId()))
 
-        self.failUnless(t2.date_of_completion == None)
+        self.failUnless(t2.date_of_completion is None)
         wft.doActionFor(t2, 'task-transition-open-tested-and-closed')
-        self.failUnless(t2.date_of_completion.date() == datetime.now().date())
+        self.failUnless(t2.date_of_completion == date.today())
 
     def test_adding_a_subtask_add_response_on_main_task(self):
         intids = getUtility(IIntIds)


### PR DESCRIPTION
`expectedStartOfWork` and `date_of_completion` are `Date` fields, not `DateTime`. So are the corresponding columns in SQL. This change therefore avoids the SQL DB having to imlicitely convert a datetime to a date and warning about it with

```
Warning: Incorrect date value: '2014-09-11 10:31:57' for column 'completed' at row 1
```

when trying to [sync](https://github.com/4teamwork/opengever.core/blob/master/opengever/globalindex/model/task.py#L120) OGDS tasks <-> Plone Tasks.

I also adapted the tests that incorrectly assumed `datetime` objects.

_(Deliberately did not create a changelog entry, since this was supposed to work this way from the beginning)._

@deiferni @phgross 
