### PR TITLE
Task transporter tests: Commit pending transaction in order to avoid StorageTransactionError

### DIFF
--- a/opengever/task/tests/test_transporter.py
+++ b/opengever/task/tests/test_transporter.py
@@ -12,6 +12,7 @@ from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.intid.interfaces import IIntIds
 from zope.schema import getFieldsInOrder
+import transaction
 
 
 def set_defaults(obj):
@@ -74,6 +75,11 @@ class TestTransporter(FunctionalTestCase):
         intids = getUtility(IIntIds)
         ITask(task).relatedItems = [
             RelationValue(intids.getId(documents[2]))]
+
+        # commit any pending transaction in order to avoid
+        # StorageTransactionError: Duplicate tpc_begin calls for same transaction
+        # See https://github.com/4teamwork/opengever.core/pull/556
+        transaction.commit()
 
         if return_docs:
             return task, documents


### PR DESCRIPTION
Task transporter tests: Commit pending transaction in order to avoid

```
StorageTransactionError: Duplicate tpc_begin calls for same transaction.
```

We currently got a flaky test in [`TestTransporter.test_documents_task_transport_selected_docs`](https://github.com/4teamwork/opengever.core/blob/master/opengever/task/tests/test_transporter.py#L94) that occasionaly fails like this:

``` pytb
Error in test test_documents_task_transport_selected_docs (opengever.task.tests.test_transporter.TestTransporter)
Traceback (most recent call last):
  File "eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
    testMethod()
  File "workspace/opengever/task/tests/test_transporter.py", line 99, in test_documents_task_transport_selected_docs
    target = self._create_task(self.portal)
  File "workspace/opengever/task/tests/test_transporter.py", line 55, in _create_task
    task_type='correction'))
  File "workspace/src/ftw.builder/ftw/builder/builder.py", line 11, in create
    return builder.create(**kwargs)
  File "workspace/src/ftw.builder/ftw/builder/dexterity.py", line 37, in create
    self.after_create(obj)
  File "workspace/opengever/testing/builders/dx.py", line 105, in after_create
    super(TaskBuilder, self).after_create(obj)
  File "workspace/src/ftw.builder/ftw/builder/builder.py", line 77, in after_create
    transaction.commit()
  File "eggs/transaction-1.1.1-py2.7.egg/transaction/_manager.py", line 89, in commit
    return self.get().commit()
  File "eggs/transaction-1.1.1-py2.7.egg/transaction/_transaction.py", line 329, in commit
    self._commitResources()
  File "eggs/transaction-1.1.1-py2.7.egg/transaction/_transaction.py", line 441, in _commitResources
    rm.tpc_begin(self)
  File "eggs/ZODB3-3.10.5-py2.7-linux-x86_64.egg/ZODB/Connection.py", line 551, in tpc_begin
    self._normal_storage.tpc_begin(transaction)
  File "eggs/ZODB3-3.10.5-py2.7-linux-x86_64.egg/ZODB/BaseStorage.py", line 229, in tpc_begin
    "Duplicate tpc_begin calls for same transaction")
StorageTransactionError: Duplicate tpc_begin calls for same transaction
```

From [this comment in the `plone.app.async` tests](https://github.com/plone/plone.app.async/blob/master/src/plone/app/async/testing.py#L146) it looks like pending transactions between tests might be the cause of the problem. The [actual commit in `plone.app.async`](https://github.com/plone/plone.app.async/commit/f3a13d8bf6a1af1b1cb4aef9878e3a32c1789524) just sprinkled `transaction.commit()` _everywhere_. However, in our case it seems a `transaction.commit()` at the end of [`_create_task`](https://github.com/4teamwork/opengever.core/blob/master/opengever/task/tests/test_transporter.py#L48) does the trick.

I ran the affected test (`test_documents_task_transport_selected_docs`) 100 times in isolation in a loop and couldn't reproduce the error any more. Also ran the entire test suite a couple times, all green.

@phgross @deiferni 
