### PR TITLE
Add utility method to generate an `Oguid` for an object.

### DIFF
--- a/opengever/globalindex/oguid.py
+++ b/opengever/globalindex/oguid.py
@@ -1,6 +1,17 @@
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+from opengever.ogds.base.utils import get_current_admin_unit
+
+
 class Oguid(object):
 
     SEPARATOR = ':'
+
+    @classmethod
+    def for_object(cls, context):
+        intids = getUtility(IIntIds)
+        int_id = intids.getId(context)
+        return cls(admin_unit_id=get_current_admin_unit().id(), int_id=int_id)
 
     def __init__(self, admin_unit_id=None, int_id=None, id=None):
         # poor mans XOR

--- a/opengever/globalindex/tests/test_oguid.py
+++ b/opengever/globalindex/tests/test_oguid.py
@@ -1,5 +1,10 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.globalindex.oguid import Oguid
+from opengever.testing import FunctionalTestCase
 from unittest2 import TestCase
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
 
 
 class TestOguid(TestCase):
@@ -40,3 +45,15 @@ class TestOguid(TestCase):
         self.assertNotEqual(None, Oguid('foo', 2))
         self.assertNotEqual(Oguid('foo', 3), Oguid('foo', 2))
         self.assertNotEqual(Oguid('bar', 2), Oguid('foo', 2))
+
+
+class TestOguidFunctional(FunctionalTestCase):
+
+    def test_oguid_for_object(self):
+        intids = getUtility(IIntIds)
+
+        obj = create(Builder('dossier'))
+        int_id = intids.getId(obj)
+        oguid = Oguid.for_object(obj)
+
+        self.assertEqual('client1:{}'.format(int_id), oguid)

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -37,6 +37,7 @@ class FunctionalTestCase(TestCase):
         if self.use_default_fixture:
             self.user, self.org_unit, self.admin_unit = create(
                 Builder('fixture').with_all_unit_setup())
+        # currently necessary to have persistent SQL data
         transaction.commit()
 
     def setup_fullname(self, user_id=TEST_USER_ID, fullname=None):


### PR DESCRIPTION
_I did not add an additional changelog entry since the `Oguid` class is new in release `4.x`_
