### PR TITLE
disable QuickInstallerTool events in testing for speed boost.

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -3,6 +3,7 @@ from ftw.builder import session
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import set_builder_session_factory
 from ftw.testing import ComponentRegistryLayer
+from opengever.core.tests import patches
 from opengever.globalindex import model
 from opengever.ogds.base.setup import create_sql_tables
 from opengever.ogds.base.utils import create_session
@@ -29,6 +30,9 @@ from zope.component import provideUtility
 from zope.configuration import xmlconfig
 from zope.sqlalchemy import datamanager
 import transaction
+
+
+patches.disable_quickinstaller_snapshots()
 
 
 def clear_transmogrifier_registry():

--- a/opengever/core/tests/patches.py
+++ b/opengever/core/tests/patches.py
@@ -1,0 +1,44 @@
+import inspect
+from Products.CMFQuickInstallerTool import events
+
+
+def disable_quickinstaller_snapshots():
+    """Patches Products.CMFQuickInstallerTool:
+    Removes the quickinstaller's subscribers to GenericSetup events
+    which create snapshots for each installed profile.
+
+    The snapshots are used for uninstalling products, which is ususally
+    not done in tests.
+
+    Creating the snapshots consume quite a lot of time.
+    Disabling it speeds up the testing layer setup time.
+
+    We do an early monkey patch so that the event registration still works
+    and the Plone fixture also profits from the patch.
+    It is a marmoset patch so that we don't have to cope with function pointers.
+    """
+
+    marmoset_patch(events.handleBeforeProfileImportEvent,
+                   noop_event_handler)
+
+    marmoset_patch(events.handleProfileImportedEvent,
+                   noop_event_handler)
+
+
+def noop_event_handler(event):
+    """An event handler that does nothing.
+    """
+
+
+def marmoset_patch(old, new, extra_globals={}):
+    print 'PATCH {}: replace {}.{} with {}'.format(
+        marmoset_patch.__module__,
+        old.__module__, old.__name__,
+        new.__name__)
+
+    g = old.func_globals
+    g.update(extra_globals)
+    c = inspect.getsource(new)
+    exec c in g
+
+    old.func_code = g[new.__name__].func_code


### PR DESCRIPTION
Patches Products.CMFQuickInstallerTool:
Removes the quickinstaller's subscribers to GenericSetup events
which create snapshots for each installed profile.

The snapshots are used for uninstalling products, which is ususally
not done in tests.

Creating the snapshots consume quite a lot of time.
Disabling it speeds up the testing layer setup time.

We do an early monkey patch so that the event registration still works
and the Plone fixture also profits from the patch.
It is a marmoset patch so that we don't have to cope with function pointers.
## Performance:

```
Without patch:
time ./bin/test -t test_filing_number_fields_is_hidden_in_site_without_filing_number_support
./bin/test -t   24.06s user 3.68s system 99% cpu 27.764 total

With QuickInstallerTool patch:
time ./bin/test -t test_filing_number_fields_is_hidden_in_site_without_filing_number_support
./bin/test -t   17.22s user 3.56s system 99% cpu 20.841 total
```

@phgross :wink: 
