### PR TITLE
Referenceprefix manager: Made prefix-mappings of already delete objects removable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -157,6 +157,9 @@ Changelog
   - Reactivate statefilter for Dossiers.
     [phgross]
 
+  - Make reference_prefix_manager deal properly with already deleted objects.
+    [phgross]
+
 
 3.4.1 (2014-09-03)
 ------------------

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -66,7 +66,20 @@ class TestReferencePrefixManager(FunctionalTestCase):
         table = browser.css('#reference_prefix_manager_table').first.lists()
 
         self.assertEquals([['1', 'One', 'Unlock'],
-                           ['2', '-- Already removed object --', 'In use'],
+                           ['2', '-- Already removed object --', 'Unlock'],
+                           ['3', 'One', 'In use']], table)
+
+    @browsing
+    def test_stored_mappings_from_deleted_repos_are_marked_as_free(self, browser):
+        api.content.delete(obj=self.repo2)
+        transaction.commit()
+
+        browser.login().open(self.repo, view='referenceprefix_manager')
+        browser.css('.unlock')[1].click()
+
+        table = browser.css('#reference_prefix_manager_table').first.lists()
+
+        self.assertEquals([['1', 'One', 'Unlock'],
                            ['3', 'One', 'In use']], table)
 
     @browsing


### PR DESCRIPTION
This is a follow-up for the PR https://github.com/4teamwork/opengever.core/pull/527. It shoud be possible to free a mapping for an already deleted object.

@deiferni please have a look.
