### PR TITLE
Add specific icon and watermark-icon for subtasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -82,6 +82,7 @@ Changelog
   - Display icon on task overview when task is overdue.
   - Add task-type to searchable text.
   - Improve Task-Form styling and Usability
+  - Add specific icon and watermark-icons for subtasks.
 
 
 - Actor [phgross, deiferni]:

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -45,4 +45,12 @@
         class=".response.Save"
         />
 
+    <browser:page
+        name="plone_layout"
+        for="opengever.task.task.ITask"
+        permission="zope.Public"
+        class=".layout.TaskLayoutPolicy"
+        allowed_interface="plone.app.layout.globals.interfaces.ILayoutPolicy"
+        />
+
 </configure>

--- a/opengever/task/layout.py
+++ b/opengever/task/layout.py
@@ -1,0 +1,16 @@
+from plone.app.layout.globals.layout import LayoutPolicy
+
+
+class TaskLayoutPolicy(LayoutPolicy):
+
+    def bodyClass(self, template, view):
+        """Extends default body class with the subtask class, for subtasks.
+        Used for displaying different icons for subtasks.
+        """
+
+        body_class = super(TaskLayoutPolicy, self).bodyClass(template, view)
+
+        if self.context.get_is_subtask():
+            body_class = '{} subtask'.format(body_class)
+
+        return body_class

--- a/opengever/task/tests/test_layout.py
+++ b/opengever/task/tests/test_layout.py
@@ -1,0 +1,29 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestTaskLayout(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestTaskLayout, self).setUp()
+        self.task = create(Builder('task'))
+
+    @browsing
+    def test_body_class_is_default_for_main_taks(self, browser):
+        browser.login().open(self.task)
+
+        self.assertEquals(
+            'template-tabbed_view portaltype-opengever-task-task site-plone section-task-1 icons-on',
+            browser.css('body').first.get('class'))
+
+    @browsing
+    def test_body_class_is_extended_with_subtask_class_for_subtasks(self, browser):
+        subtask = create(Builder('task').within(self.task))
+
+        browser.login().open(subtask)
+
+        self.assertEquals(
+            'template-tabbed_view portaltype-opengever-task-task site-plone section-task-1 icons-on subtask',
+            browser.css('body').first.get('class'))


### PR DESCRIPTION
Used for the icon implementation (see https://github.com/4teamwork/plonetheme.teamraum/pull/259).

Maintask:
![bildschirmfoto 2014-09-29 um 11 26 23](https://cloud.githubusercontent.com/assets/485755/4439644/c18bcece-47ba-11e4-80f1-5770252eb619.png)
Subtask:
![bildschirmfoto 2014-09-29 um 11 26 39](https://cloud.githubusercontent.com/assets/485755/4439643/c1889060-47ba-11e4-89f7-9381153ee748.png)

Close #542
@deiferni please have a look ...
