### PR TITLE
Check for downloadability using new property from pdfconverter.

### DIFF
--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -21,7 +21,6 @@ from zope.component import queryMultiAdapter
 try:
     from opengever.pdfconverter.behaviors.preview import IPreviewMarker
     from opengever.pdfconverter.behaviors.preview import IPreview
-    from opengever.pdfconverter.behaviors.preview import CONVERSION_STATE_READY
 
     PDFCONVERTER_AVAILABLE = True
 except ImportError:
@@ -172,9 +171,8 @@ class Overview(DisplayForm, OpengeverTab):
 
     def is_pdf_download_available(self):
         if self.is_preview_supported():
-            if IPreview(
-                    self.context).conversion_state == CONVERSION_STATE_READY:
-                return True
+            return IPreview(self.context).is_downloadable
+
         return False
 
     def is_checkout_and_edit_available(self):

--- a/sources.cfg
+++ b/sources.cfg
@@ -11,6 +11,7 @@ development-packages =
   ooxml_docprops
   ftw.mail
   ftw.table
+  opengever.pdfconverter
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Don't violate encapsulation by using recent changes in documentconverter. Based on https://github.com/4teamwork/opengever.pdfconverter/pull/3, plz merge that PR first.

_doesn't need a changelog entry._
