### PR TITLE
Fixed encoding issues in the `EmailContactsAndUsersVocabularyFactory`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,8 @@ Changelog
   - Replace `ContactInformation` utility with a service implemetation, available as `ogds_service`.
   - Update to latest `opengever.ogds.models` version.
 
+  - Fixed encoding issues in the `EmailContactsAndUsersVocabularyFactory`.
+
 
 - Replace Clients with OrgUnit/AdminUnit [phgross, deiferni]:
 

--- a/opengever/ogds/base/tests/test_vocabularies.py
+++ b/opengever/ogds/base/tests/test_vocabularies.py
@@ -364,25 +364,27 @@ class TestEmailContactsAndUsersVocabularyFactory(FunctionalTestCase):
             name='opengever.ogds.base.EmailContactsAndUsersVocabulary')
 
     def test_terms_contains_fullname_and_principal_and_email_in_parentheses(self):
-        create_ogds_user('hugo.boss', firstname=u'Hugo',
+        create_ogds_user('hugo.boss', firstname=u'H\xfcgo',
                          lastname=u'Boss', email='hugo@boss.local')
         create(Builder('contact')
                .having(firstname=u'Elisabeth', lastname=u'K\xe4ppeli',
                        email= 'elisabeth.kaeppeli@test.ch'))
 
         self.assertTerms(
-            [('hugo@boss.local:hugo.boss',
-              'Boss Hugo (hugo.boss, hugo@boss.local)'),
-             ('elisabeth.kaeppeli@test.ch:kappeli-elisabeth',
+            [(u'hugo@boss.local:hugo.boss',
+              u'Boss H\xfcgo (hugo.boss, hugo@boss.local)'),
+             (u'elisabeth.kaeppeli@test.ch:kappeli-elisabeth',
               u'K\xe4ppeli Elisabeth (elisabeth.kaeppeli@test.ch)')],
             self.vocabulary_factory(self.portal))
 
     def test_contains_emails_for_all_users(self):
-        create_ogds_user('hugo.boss', firstname=u'Hugo', lastname=u'Boss', email='hugo@boss.local')
-        create_ogds_user('robin.hood', firstname=u'Robin', lastname=u'Hood', email='robin@hood.tld')
+        create_ogds_user('hugo.boss', firstname=u'H\xfcgo',
+                         lastname=u'Boss', email='hugo@boss.local')
+        create_ogds_user('robin.hood', firstname=u'Robin',
+                         lastname=u'Hood', email='robin@hood.tld')
 
         self.assertTermKeys(
-            ['hugo@boss.local:hugo.boss', u'robin@hood.tld:robin.hood'],
+            [u'hugo@boss.local:hugo.boss', u'robin@hood.tld:robin.hood'],
             self.vocabulary_factory(self.portal))
 
     def test_contains_emails_for_all_contacts(self):

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -394,13 +394,13 @@ class EmailContactsAndUsersVocabularyFactory(grok.GlobalUtility):
         # users
         for user in ogds_service().all_users():
             if user.email:
-                key = '{}:{}'.format(user.email, user.userid)
+                key = u'{}:{}'.format(user.email, user.userid)
                 value = u'{} ({}, {})'.format(user.fullname(),
                                               user.userid, user.email)
                 user_data.append((key, value))
 
             if user.email2:
-                key = '{}:{}'.format(user.email2, user.userid)
+                key = u'{}:{}'.format(user.email2, user.userid)
                 value = u'{} ({}, {})'.format(user.fullname(),
                                               user.userid, user.email2)
                 user_data.append((key, value))
@@ -409,13 +409,16 @@ class EmailContactsAndUsersVocabularyFactory(grok.GlobalUtility):
         for contact in contact_service().all_contact_brains():
             if contact.email:
                 user_data.append(
-                    ('{}:{}'.format(contact.email, contact.id),
-                     '{} ({})'.format(contact.Title, contact.email)))
+                    (u'{}:{}'.format(contact.email,
+                                     contact.id.decode('utf-8')),
+                     u'{} ({})'.format(contact.Title.decode('utf-8'),
+                                       contact.email)))
 
             if contact.email2:
                 user_data.append(
-                    ('{}:{}'.format(contact.email2, contact.id),
-                     '{} ({})'.format(contact.Title, contact.email2)))
+                    (u'{}:{}'.format(contact.email2, contact.id.decode('utf-8')),
+                     u'{} ({})'.format(contact.Title.decode('utf-8'),
+                                       contact.email2)))
 
         return user_data
 


### PR DESCRIPTION
Fixes #594

The key and the value should always return unicode. 
Because of our mysql connection string `mysql://opengever:opengever@localhost/opengever?charset=utf8"` this is guaranteed for all `OGDS` objects. For the contacts we had to decode some attributes.

SqlAlchemy Docu:

_MySQLdb requires a “charset” parameter to be passed in order for it to handle non-ASCII characters correctly. When this parameter is passed, MySQLdb will also implicitly set the “use_unicode” flag to true, which means that it will return Python unicode objects instead of bytestrings._

@deiferni please have a look.
