### PR TITLE
Hide ftw.mail.mail-in viewlet, yet again.

### DIFF
--- a/opengever/mail/profiles/default/metadata.xml
+++ b/opengever/mail/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3406</version>
+  <version>4000</version>
   <dependencies>
     <dependency>profile-ftw.mail:default</dependency>
   </dependencies>

--- a/opengever/mail/profiles/default/viewlets.xml
+++ b/opengever/mail/profiles/default/viewlets.xml
@@ -16,5 +16,9 @@
    <viewlet name="ftw.mail.mail-in"/>
   </hidden>
 
+  <hidden manager="plone.belowcontenttitle" skinname="Teamraum Theme">
+    <viewlet name="ftw.mail.mail-in"/>
+  </hidden>
+
 </object>
 

--- a/opengever/mail/upgrades/configure.zcml
+++ b/opengever/mail/upgrades/configure.zcml
@@ -121,4 +121,13 @@
         profile="opengever.mail:default"
         />
 
+    <!-- 3406 -> 4000 -->
+    <upgrade-step:importProfile
+        title="Disable mail-in viewlet, yet again."
+        profile="opengever.mail:default"
+        source="3406"
+        destination="4000"
+        directory="profiles/4000"
+        />
+
 </configure>

--- a/opengever/mail/upgrades/profiles/4000/viewlets.xml
+++ b/opengever/mail/upgrades/profiles/4000/viewlets.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object>
+
+  <hidden manager="plone.belowcontenttitle" skinname="Teamraum Theme">
+    <viewlet name="ftw.mail.mail-in"/>
+  </hidden>
+
+</object>
+


### PR DESCRIPTION
Plonetheme.teamraum has its own skinname, thus we need to remove the viewlet for
that skin as well.

Fixes #601.

_no changelog necessary i'd say_
