### PR TITLE
LaTeX layout client title: use current `AdminUnits` label.

### DIFF
--- a/opengever/latex/dossiercover.py
+++ b/opengever/latex/dossiercover.py
@@ -40,7 +40,7 @@ class DossierCoverLaTeXView(grok.MultiAdapter, MakoLaTeXView):
 
     def get_render_arguments(self):
         args = {
-            'clienttitle': self.convert_plain(self.get_client_title()),
+            'clienttitle': self.convert_plain(self.get_current_admin_unit_label()),
             'repositoryversion': self.convert_plain(
                 self.get_repository_version()),
             'referencenr': self.convert_plain(self.get_referencenumber()),
@@ -65,7 +65,7 @@ class DossierCoverLaTeXView(grok.MultiAdapter, MakoLaTeXView):
     def get_responsible(self):
         return self.context.responsible_label
 
-    def get_client_title(self):
+    def get_current_admin_unit_label(self):
         return get_current_admin_unit().label() or ''
 
     def get_repository_version(self):

--- a/opengever/latex/layouts/default.py
+++ b/opengever/latex/layouts/default.py
@@ -3,7 +3,7 @@ from ftw.pdfgenerator.interfaces import IBuilder
 from ftw.pdfgenerator.interfaces import ILaTeXLayout
 from ftw.pdfgenerator.layout.customizable import CustomizableLayout
 from opengever.latex.interfaces import ILaTeXSettings
-from opengever.ogds.base.utils import get_current_org_unit
+from opengever.ogds.base.utils import get_current_admin_unit
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
@@ -60,15 +60,15 @@ class DefaultLayout(CustomizableLayout, grok.MultiAdapter):
 
         convert = self.get_converter().convert
         return {
-            'client_title': convert(self.get_client_title()),
+            'client_title': convert(self.get_current_admin_unit_label()),
             'member_phone': convert(owner_phone),
             'show_contact': self.show_contact,
             'show_logo': self.show_logo,
             'show_organisation': self.show_organisation,
             'location': convert(self.get_location())}
 
-    def get_client_title(self):
-        return get_current_org_unit().id()
+    def get_current_admin_unit_label(self):
+        return get_current_admin_unit().label()
 
     def get_location(self):
         registry = getUtility(IRegistry)

--- a/opengever/latex/tests/test_default_layout.py
+++ b/opengever/latex/tests/test_default_layout.py
@@ -18,14 +18,13 @@ class TestDefaultLayout(MockTestCase):
     def setUp(self):
         super(TestDefaultLayout, self).setUp()
 
-        orgunit = self.stub()
-        self.expect(orgunit.label()).result('CLIENT ONE')
+        admin_unit = self.stub()
 
-        self._ori_get_current_org_unit = utils.get_current_org_unit
-        get_current_org_unit = self.mocker.replace(
-            'opengever.ogds.base.utils.get_current_org_unit')
-        self.expect(get_current_org_unit()).result(orgunit).count(0, None)
-        self.expect(orgunit.id()).result(FAKE_CLIENT_TITLE).count(0, None)
+        self._ori_get_current_admin_unit = utils.get_current_admin_unit
+        get_current_admin_unit = self.mocker.replace(
+            'opengever.ogds.base.utils.get_current_admin_unit')
+        self.expect(get_current_admin_unit()).result(admin_unit).count(0, None)
+        self.expect(admin_unit.label()).result(FAKE_CLIENT_TITLE).count(0, None)
 
         registry_mock = self.stub()
         self.expect(
@@ -37,7 +36,7 @@ class TestDefaultLayout(MockTestCase):
 
     def tearDown(self):
         super(TestDefaultLayout, self).tearDown()
-        utils.get_current_org_unit = self._ori_get_current_org_unit
+        utils.get_current_admin_unit = self._ori_get_current_admin_unit
 
     def test_configuration(self):
         context = self.create_dummy()

--- a/opengever/latex/tests/test_landscape_layout.py
+++ b/opengever/latex/tests/test_landscape_layout.py
@@ -21,14 +21,12 @@ class TestLandscapeLayout(MockTestCase):
         super(TestLandscapeLayout, self).setUp()
         self.context = self.stub()
 
-        orgunit = self.stub()
-        self.expect(orgunit.label()).result('CLIENT ONE')
-
-        self._ori_get_current_org_unit = utils.get_current_org_unit
-        get_current_org_unit = self.mocker.replace(
-            'opengever.ogds.base.utils.get_current_org_unit')
-        self.expect(get_current_org_unit()).result(orgunit).count(0, None)
-        self.expect(orgunit.id()).result(FAKE_CLIENT_TITLE).count(0, None)
+        admin_unit = self.stub()
+        self._ori_get_current_admin_unit = utils.get_current_admin_unit
+        get_current_admin_unit = self.mocker.replace(
+            'opengever.ogds.base.utils.get_current_admin_unit')
+        self.expect(get_current_admin_unit()).result(admin_unit).count(0, None)
+        self.expect(admin_unit.label()).result(FAKE_CLIENT_TITLE).count(0, None)
 
         self.portal_membership = self.stub()
         self.mock_tool(self.portal_membership, 'portal_membership')
@@ -48,7 +46,7 @@ class TestLandscapeLayout(MockTestCase):
 
     def tearDown(self):
         super(TestLandscapeLayout, self).tearDown()
-        utils.get_current_org_unit = self._ori_get_current_org_unit
+        utils.get_current_admin_unit = self._ori_get_current_admin_unit
 
     def test_adapts_landscape_request_layer(self):
         self.replay()


### PR DESCRIPTION
Instead of using the current `OrgUnits` label as client title, it uses now the current `AdminUnits` label. 

It makes more sense because all PDF, which can be generated are `AdminUnit` specific ...

@deiferni please have a look.

_Changelog entry is not necessary, changes are already mentioned_
