### PR TITLE
Treeportlet: define context-url data object instead of context-path.

### DIFF
--- a/opengever/portlets/tree/tests/test_treeportlet.py
+++ b/opengever/portlets/tree/tests/test_treeportlet.py
@@ -1,0 +1,79 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.portlets.tree import treeportlet
+from opengever.testing import FunctionalTestCase
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from plone.registry.interfaces import IRegistry
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+import transaction
+
+
+class TestTreePortlet(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestTreePortlet, self).setUp()
+        self.repository_root = create(Builder('repository_root')
+                                      .titled(u'Repo 1'))
+        self.repository = create(Builder('repository')
+                                 .within(self.repository_root)
+                                 .titled(u'Repository A'))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repository))
+
+        self.add_treeportlet(self.repository_root, self.repository_root)
+
+        transaction.commit()
+
+    def add_treeportlet(self, context, repository_root):
+        manager = getUtility(IPortletManager,
+                             name=u'plone.leftcolumn',
+                             context=self.portal)
+        assignments = getMultiAdapter((context, manager),
+                                      IPortletAssignmentMapping,
+                                      context=self.portal)
+
+        portlet = treeportlet.Assignment(
+            root_path='/'.join(repository_root.getPhysicalPath()))
+
+        name = 'treeportlet_1'
+        portlet.__name__ = portlet
+        assignments[name] = portlet
+
+    def tearDown(self):
+        super(TestTreePortlet, self).tearDown()
+        registry = getUtility(IRegistry)
+        registry['opengever.portlets.tree.enable_favorites'] = False
+
+    @browsing
+    def test_context_url_data_object_is_absolute_url_of_current_context(self, browser):
+        browser.login().open(self.dossier)
+        self.assertEqual(
+            self.dossier.absolute_url(),
+            browser.css('.portletTreePortlet').first.get('data-context-url'))
+
+        browser.open(self.repository)
+        self.assertEquals(
+            self.repository.absolute_url(),
+            browser.css('.portletTreePortlet').first.get('data-context-url'))
+
+    @browsing
+    def test_favorite_tab_is_not_rendered_when_favorites_are_disabled(self, browser):
+        browser.login().open(self.dossier)
+
+        self.assertEquals(
+            ['Repo 1'],
+            browser.css('.portletTreePortlet .portlet-header-tabs li').text)
+
+    @browsing
+    def test_favorite_tab_is_rendered_when_favorites_are_enabled(self, browser):
+        registry = getUtility(IRegistry)
+        registry['opengever.portlets.tree.enable_favorites'] = True
+        transaction.commit()
+
+        browser.login().open(self.dossier)
+        self.assertEquals(
+            ['Repo 1', 'Favorites'],
+            browser.css('.portletTreePortlet .portlet-header-tabs li').text)

--- a/opengever/portlets/tree/treeportlet.pt
+++ b/opengever/portlets/tree/treeportlet.pt
@@ -2,7 +2,7 @@
     tal:attributes="data-navigation-url view/navigation_url;
                     data-favorites-url view/favorites_url;
                     data-favorites-cache-param view/favorites_cache_param;
-                    data-context-path view/context_path"
+                    data-context-url view/context_url"
     i18n:attributes="data-i18n-add-to-favorites label_add_to_favorites;
                      data-i18n-remove-from-favorites label_remove_from_favorites;"
     i18n:domain="opengever.portlets.tree">

--- a/opengever/portlets/tree/treeportlet.py
+++ b/opengever/portlets/tree/treeportlet.py
@@ -85,8 +85,8 @@ class Renderer(base.Renderer):
     def root_path(self):
         return getattr(self.data, 'root_path', None)
 
-    def context_path(self):
-        return '/'.join(self.context.getPhysicalPath())
+    def context_url(self):
+        return self.context.absolute_url()
 
     @property
     def available(self):


### PR DESCRIPTION
This is a follow up of #596: 

During the changes to support virtual host monster configurations, the tree data has changed from path to url. But to adjust the data attribute, was forgotten.

@deiferni please have a look.
