### PR TITLE
Use plone.formwidget.autocomplete from source.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -11,6 +11,7 @@ development-packages =
   ooxml_docprops
   ftw.mail
   ftw.table
+  plone.formwidget.autocomplete
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
This uses an updated version of our fork to fix an issue with autocomplete in google chrome.
