### PR TITLE
Fix an unicode issue while syncing document filename and title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -196,6 +196,9 @@ Changelog
     Added temporary monkeypatch to ignore mimetypes sent by the browser.
     [phgross]
 
+  - Fix an unicode issue while syncing document filename and title.
+    [deiferni]
+
 
 3.4.1 (2014-09-03)
 ------------------

--- a/opengever/document/subscribers.py
+++ b/opengever/document/subscribers.py
@@ -39,21 +39,25 @@ def set_digitally_available(doc, event):
 @grok.subscribe(IDocumentSchema, IObjectModifiedEvent)
 def sync_title_and_filename_handler(doc, event):
     """Syncs the document and the filename (#586):
-    o If there is no title but a file, use the filename (without extension) as
+
+    - If there is no title but a file, use the filename (without extension) as
     title.
-    o If there is a title and a file, use the normalized title as filename
+    - If there is a title and a file, use the normalized title as filename
+
     """
     normalizer = getUtility(IIDNormalizer)
-    if not doc.title and doc.file:
+    if not doc.file:
+        return
+
+    basename, ext = os.path.splitext(doc.file.filename)
+    if not doc.title:
         # use the filename without extension as title
-        basename, ext = os.path.splitext(doc.file.filename)
         doc.title = basename
-        doc.file.filename = ''.join(
+        doc.file.filename = u''.join(
             [normalizer.normalize(basename), ext])
-    elif doc.title and doc.file:
+    elif doc.title:
         # use the title as filename
-        basename, ext = os.path.splitext(doc.file.filename)
-        doc.file.filename = ''.join(
+        doc.file.filename = u''.join(
             [normalizer.normalize(doc.title), ext])
 
 

--- a/opengever/document/tests/test_title_filename_syncer.py
+++ b/opengever/document/tests/test_title_filename_syncer.py
@@ -1,6 +1,8 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import FunctionalTestCase
+from zope.event import notify
+from zope.lifecycleevent import ObjectModifiedEvent
 
 
 class TestTitleFilenameSyncer(FunctionalTestCase):
@@ -17,3 +19,12 @@ class TestTitleFilenameSyncer(FunctionalTestCase):
                           .attach_file_containing(u"blup", name=u"wrong.txt"))
         self.assertEqual(document.title, u'My Title')
         self.assertEqual(document.file.filename, u'my-title.txt')
+
+    def test_filename_is_unicode(self):
+        document = create(Builder("document")
+                          .attach_file_containing(u"12", name=u"hmm.txt"))
+        # set non-unicode title bypassing schema checks
+        document.title = 'Ohh'
+        notify(ObjectModifiedEvent(document))
+
+        self.assertEqual(document.file.filename, u'ohh.txt')


### PR DESCRIPTION
Fixes #584.
