### PR TITLE
Don't create dicts but use real objects as temporary participants.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -199,6 +199,9 @@ Changelog
   - Fix an unicode issue while syncing document filename and title.
     [deiferni]
 
+  - Fix an issue with filtering for dossier-participants.
+    [deiferni]
+
 
 3.4.1 (2014-09-03)
 ------------------

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -1,0 +1,36 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+from opengever.dossier.behaviors.participation import ParticipationHandler
+
+
+class TestParticipationTabbedview(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestParticipationTabbedview, self).setUp()
+
+        self.dossier = create(Builder('dossier')
+                              .having(responsible=TEST_USER_ID))
+
+    def get_tabbed_view(self, name):
+        view = self.dossier.restrictedTraverse(name)
+        view.update()
+        return view
+
+    def test_participants_includes_responsible(self):
+        view = self.get_tabbed_view('tabbedview_view-participants')
+        self.assertEqual(1, len(view.contents))
+        responsible = view.contents[0]
+        self.assertEqual(TEST_USER_ID, responsible.contact)
+
+    def test_participants_text_filter(self):
+        self.portal.REQUEST['searchable_text'] = 'sepp'
+
+        handler = ParticipationHandler(self.dossier)
+        sepp = handler.create_participation(
+            contact='sepp', roles=['Reader', 'Editor'])
+        handler.append_participiation(sepp)
+
+        view = self.get_tabbed_view('tabbedview_view-participants')
+        self.assertEqual(1, len(view.contents))


### PR DESCRIPTION
This solves an issue with filtering for the participants tab. Fixes #583.
