### PR TITLE
Remove hardcoded file-size units.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -192,6 +192,9 @@ Changelog
   - Fix an issue while deactivating dossiers with already closed subdossiers.
     [deiferni]
 
+  - Use new plone.formwidget.namedfile which displays internationalized size for files.
+    [deiferni]
+
 
 3.4.1 (2014-09-03)
 ------------------

--- a/opengever/document/browser/overview_templates/file.pt
+++ b/opengever/document/browser/overview_templates/file.pt
@@ -13,7 +13,6 @@
             <span class="filename" tal:content="filename">Filename</span>
             <span class="discreet">
               &mdash; <span tal:define="sizekb view/w/file/file_size" tal:replace="sizekb">100</span>
-              KB
             </span>
         </span>
 

--- a/opengever/mail/browser/mail_templates/file.pt
+++ b/opengever/mail/browser/mail_templates/file.pt
@@ -8,7 +8,6 @@
       <span class="filename" tal:content="filename">Filename</span>
       <span class="discreet">
         &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100</span>
-        KB
       </span>
     </span>
 


### PR DESCRIPTION
They are set dynamically with newest plone.formwidget.namedfile release. This fixes the currently broken master.
