### PR TITLE
Fix issue when uploading files with firefox over the Document AddForm

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -192,6 +192,10 @@ Changelog
   - Fix an issue while deactivating dossiers with already closed subdossiers.
     [deiferni]
 
+  - Fix issue when uploading files with firefox over the Document AddForm.
+    Added temporary monkeypatch to ignore mimetypes sent by the browser.
+    [phgross]
+
 
 3.4.1 (2014-09-03)
 ------------------


### PR DESCRIPTION
Added temporary monkeypatch to ignore mimetypes sent by the browser (see https://github.com/plone/plone.formwidget.namedfile/pull/9):
We can't include the fix with the newests version (1.0.11), because this versions need also the newest z3c.form (see https://github.com/plone/plone.formwidget.namedfile/pull/10).

With the planed update to Plone 4.3 this monkeypatch should be removed.

@lukasgraf please have a look ...
