### PR TITLE
LDAP util: When querying for schema, deal with servers that don't support listing all operational attributes (RFC 3673).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -114,6 +114,12 @@ Changelog
   - Add db-migration for changes to `opengever.globalindex`.
 
 
+- OGDS synchronization [lgraf]:
+
+  - LDAP util: When querying for schema, deal with servers that don't support
+    listing all operational attributes (RFC 3673).
+
+
 - Additional Improvements:
 
   - Simplify LaTex listing adapters and include base-class.

--- a/opengever/ogds/base/ldap_util.py
+++ b/opengever/ogds/base/ldap_util.py
@@ -23,7 +23,11 @@ except AttributeError:
     PYTHON_LDAP_24 = False
 
 
+ALL_OPERATIONAL_ATTRS = '1.3.6.1.4.1.4203.1.5.1'
 KNOWN_MULTIVALUED_FIELDS = ['member', 'memberOf']
+SUBSCHEMA_ATTRS = ['attributeTypes', 'dITContentRules', 'dITStructureRules',
+                   'matchingRules', 'matchingRuleUse', 'nameForms',
+                   'objectClasses']
 
 
 class LDAPSearch(grok.Adapter):
@@ -124,10 +128,17 @@ class LDAPSearch(grok.Adapter):
             except KeyError:
                 schema_dn = 'cn=schema'
 
+            attr_list = ['*', '+']
+            if ALL_OPERATIONAL_ATTRS not in self.supported_features:
+                # Server does not support RFC 3673 (returning all operational
+                # attributes by using "+" in attribute list). We therefore
+                # need to specify all known subschema attributes explicitely
+                attr_list = SUBSCHEMA_ATTRS
+
             res = conn.search_s(schema_dn,
                                 ldap.SCOPE_BASE,
                                 '(objectclass=*)',
-                                ['*', '+'])
+                                attr_list)
 
             if len(res) > 1:
                 logger.warn("More than one LDAP schema found!")


### PR DESCRIPTION
In order to correctly determine multivaluedness of attributes in LDAP, the schema must be considered. A typical query for the LDAP schema (once the schema DN is known) looks like this:

`ldapsearch -D "BIND_DN" -w "BIND_PW" -p 389 -h ldap.example.org -b "cn=schema" -s base "objectclass=*" "+"`

The attribute list placeholder `+` is needed because all attributes on schema enrties (type `subschema`) are so called **operational attributes**, which are _not_ returned in a regular query - instead they must be explicitely requested. The `+` placeholder is shorthand for _"please return all operational attributes"_. This feature is specified in [RFC 3673](https://tools.ietf.org/html/rfc3673) and supported by most LDAP servers.

However, we recently had to find out that our [389 Directory Server](http://en.wikipedia.org/wiki/389_Directory_Server) does not support this feature. This means, instead of simply querying for all operational attributes, we need to explicitely list all the operational attributes we want to query for.

These are the attributes described in the [`subschema` object class (2.5.20.1)](http://www.alvestrand.no/objectid/2.5.20.1.html):

```
        MAY CONTAIN { 
                dITStructureRule |
                nameForms |
                dITContentRules |
                objectClasses |
                attributeTypes |
                matchingRules |
                matchingRuleUse 
        }
```

So the change in this PR makes the LDAP util
- first check whether the server supports RFC 3673 (querying for all operational attributes)
- and if not, queries for the explicit list of attributes defined above
- if the server does support RFC 3673, the existing query with the placeholder attributes `+` (and `*`) will be used

Long story short: this PR fixes #579

@phgross
