### PR TITLE
Drop og.pdfconverter from development pkgs because it causes test failures

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -11,7 +11,11 @@ development-packages =
   ooxml_docprops
   ftw.mail
   ftw.table
-  opengever.pdfconverter
+
+# Still needs to be released, but dropped from dev-pkgs
+# because it causes test-failures
+#
+#  opengever.pdfconverter
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Drop `opengever.pdfconverter` from development packages because it causes test failures and is not really needed anyway - it's just in `development-packages` to remind us that it needs to be released.

@phgross 
