### PR TITLE
Extend transition guards with agency-checks for some forwarding transitions:

### DIFF
--- a/opengever/inbox/browser/transitioncontroller.py
+++ b/opengever/inbox/browser/transitioncontroller.py
@@ -37,6 +37,10 @@ class ForwardingTransitionController(TaskTransitionController):
     def is_assign_to_dossier_or_reassign_possible(self, conditions, include_agency):
         """Check it the user is in the inbox group of the current client.
         """
+        if include_agency:
+            return (conditions.is_assigned_to_current_admin_unit and
+                    conditions.is_responsible_orgunit_agency_member)
+
         return (conditions.is_assigned_to_current_admin_unit and
                 conditions.is_responsible)
 

--- a/opengever/inbox/tests/test_transitioncontroller.py
+++ b/opengever/inbox/tests/test_transitioncontroller.py
@@ -49,9 +49,9 @@ class TestRefuseGuard(TestAcceptGuard):
 
 
 class TestAssignToDossierGuard(InboxBaseTransitionGuardTests):
-    transition = 'forwarding-transition-refuse'
+    transition = 'forwarding-transition-assign-to-dossier'
 
-    def is_only_available_for_responsible_of_admin_unit_intern_forwardings(self):
+    def test_is_only_available_for_responsible_of_admin_unit_intern_forwardings(self):
         conditions = FakeConditions()
         self.assertFalse(self.controller._is_transition_possible(
             self.transition, False, conditions))
@@ -63,6 +63,11 @@ class TestAssignToDossierGuard(InboxBaseTransitionGuardTests):
         conditions.is_assigned_to_current_admin_unit = True
         self.assertTrue(self.controller._is_transition_possible(
             self.transition, False, conditions))
+
+        conditions.is_responsible = False
+        conditions.is_responsible_orgunit_agency_member = True
+        self.assertTrue(self.controller._is_transition_possible(
+            self.transition, True, conditions))
 
 
 class TestReassignGuard(TestAssignToDossierGuard):


### PR DESCRIPTION
The following transitions should also be available, as agency transition,
when the user is a agency member of the assigned org_unit.
- `forwarding-transition-assign-to-dossier`
- `forwarding-transition-reassign`
- `forwarding-transition-close`
- `forwarding-transition-reassign-refused`

@lukasgraf please have a look...
