### PR TITLE
Added upgradestep to harmonize column lengths of groupid and userid columns

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Harmonize column lengths of groupid and userid columns.
+  [phgross]
 
 
 4.0.0 (2014-10-26)

--- a/opengever/ogds/base/profiles/default/metadata.xml
+++ b/opengever/ogds/base/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-    <version>4005</version>
+    <version>4006</version>
 </metadata>

--- a/opengever/ogds/base/upgrades/configure.zcml
+++ b/opengever/ogds/base/upgrades/configure.zcml
@@ -81,4 +81,14 @@
         profile="opengever.ogds.base:default"
         />
 
+    <!-- 4005 -> 4006 -->
+    <genericsetup:upgradeStep
+        title="Increase lengths for userid and groupid columns."
+        description="Increase lengths for userid and groupid columns to 255"
+        source="4005"
+        destination="4006"
+        handler="opengever.ogds.base.upgrades.to4006.IncreaseColumnLength"
+        profile="opengever.ogds.base:default"
+        />
+
 </configure>

--- a/opengever/ogds/base/upgrades/to4006.py
+++ b/opengever/ogds/base/upgrades/to4006.py
@@ -1,0 +1,62 @@
+from opengever.core.upgrade import DeactivatedFKConstraint
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+class IncreaseColumnLength(SchemaMigration):
+    """The userid colum in the users table was already increased
+    by an earlier change see
+    https://github.com/4teamwork/opengever.ogds.models/commit/daaa420a
+    """
+
+    profileid = 'opengever.ogds.base'
+    upgradeid = 4006
+
+    def migrate(self):
+        self.increase_userid_length()
+        self.increase_groupid_length()
+
+    def increase_length(self, tablename, column, existing_type, new_type,
+                        fk_name, fk_table_name, source_cols, referent_cols):
+
+        with DeactivatedFKConstraint(self.op, fk_name,
+                                     tablename, fk_table_name,
+                                     source_cols, referent_cols):
+
+            self.op.alter_column(tablename,
+                                 column,
+                                 nullable=False,
+                                 new_column_name=column,
+                                 type_=new_type,
+                                 existing_nullable=False,
+                                 existing_type=existing_type)
+
+    def increase_userid_length(self):
+        self.increase_length('groups_users', 'userid',
+                             String(30), String(255),
+                             fk_name='groups_users_ibfk_2',
+                             fk_table_name='users',
+                             source_cols=['userid'],
+                             referent_cols=['userid'])
+
+    def increase_groupid_length(self):
+        self.increase_length('groups_users', 'groupid',
+                             String(50), String(255),
+                             fk_name='groups_users_ibfk_1',
+                             fk_table_name='groups',
+                             source_cols=['groupid'],
+                             referent_cols=['groupid'])
+
+        self.increase_length('org_units', 'users_group_id',
+                             String(30), String(255),
+                             fk_name='org_units_ibfk_1',
+                             fk_table_name='groups',
+                             source_cols=['users_group_id'],
+                             referent_cols=['groupid'])
+
+        self.increase_length('org_units', 'inbox_group_id',
+                             String(30), String(255),
+                             fk_name='org_units_ibfk_2',
+                             fk_table_name='groups',
+                             source_cols=['inbox_group_id'],
+                             referent_cols=['groupid'])


### PR DESCRIPTION
Right now the `user` resp. the `group` table defines an other column size than the foreign_key tables does.

This PR solves this issue. Schema changes in the `opengever.ogds.models` package (see https://github.com/4teamwork/opengever.ogds.models/pull/25)

@deiferni please have a look ... 
