### PR TITLE
opengever.policy.base: Change profile order.

### DIFF
--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -5,8 +5,8 @@
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>
 
-    <dependency>profile-opengever.globalindex:default</dependency>
     <dependency>profile-opengever.ogds.base:default</dependency>
+    <dependency>profile-opengever.globalindex:default</dependency>
     <dependency>profile-opengever.base:default</dependency>
     <dependency>profile-collective.mtrsetup:default</dependency>
     <dependency>profile-opengever.document:default</dependency>


### PR DESCRIPTION
The 'opengever.ogds.base' profile has to be installed before the `opengever.globalindex` profile,
to avoid problems when upgrading to the release 3.0.

@deiferni please have a look
