### PR TITLE
Fixed UnicodeEncodeError in task link generation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed UnicodeEncodeError in task link generation.
+  [phgross]
 
 
 4.0.1 (2014-10-27)

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -280,7 +280,7 @@ class Task(Base):
             link = link_content
 
         if with_responsible_info:
-            link = '{} {}'.format(link, responsible_info)
+            link = u'{} {}'.format(link, responsible_info)
 
         # wrapped it into span tag
         if with_state_icon:

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -123,3 +123,9 @@ class TestTaskLinkGeneration(FunctionalTestCase):
 
         link_tag = link.xpath(css_to_xpath('a span'))[0]
         self.assertEquals('Foo ', link_tag.text)
+
+    def test_handles_non_ascii_characters_correctly(self):
+        link = self.add_task_and_get_link(title=u'D\xfc it')
+        span_tag = link.xpath(css_to_xpath('a span'))[0]
+
+        self.assertEquals(u'D\xfc it', span_tag.text)


### PR DESCRIPTION
The current task link generation (see PR #631) does not handle non-ascii character
correctly in all case. Which ends up in an UnicodeEncodeError.

@deiferni please have a look 
