### PR TITLE
Fixed version download, when the download confirmation is deactivated.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
+- Fixed version download, when download confirmation is deactivated.
+  [phgross]
+
 - Mail Download: Convert LF to CRLF, to avoid displaing problems in MS Outlook.
   [phgross]
 

--- a/opengever/base/tests/test_history_viewlet.py
+++ b/opengever/base/tests/test_history_viewlet.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.ogds.base.actor import Actor
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_NAME
@@ -23,3 +24,33 @@ class TestHistoryViewlet(FunctionalTestCase):
 
         elem = browser.css('#history table.version_history td.actor').first
         self.assertEqual(self.actor.get_link(), elem.normalized_innerHTML)
+
+    @browsing
+    def test_history_viewlet_shows_confirmation_link_by_default(self, browser):
+        test_doc = create(Builder("document")
+                          .attach_file_containing("lorem ipsum",
+                                                  name=u"foobar.txt"))
+
+        browser.login().open(test_doc)
+        link = browser.css(
+            '#history table.version_history a.function-download-copy').first
+
+        self.assertEquals(
+            'http://nohost/plone/document-1/file_download_confirmation?version_id=0',
+            link.get('href'))
+
+    @browsing
+    def test_history_viewlet_shows_download_version_link_when_confirmation_is_deactivated(self, browser):
+        DownloadConfirmationHelper().deactivate()
+
+        test_doc = create(Builder("document")
+                          .attach_file_containing("lorem ipsum",
+                                                  name=u"foobar.txt"))
+
+        browser.login().open(test_doc)
+        link = browser.css(
+            '#history table.version_history a.function-download-copy').first
+
+        self.assertEquals(
+            'http://nohost/plone/document-1/download_file_version?version_id=0',
+            link.get('href'))

--- a/opengever/base/viewlets/history.py
+++ b/opengever/base/viewlets/history.py
@@ -45,6 +45,7 @@ class DocumentContentHistoryViewlet(content.ContentHistoryViewlet):
         return dc_helper.get_html_tag(
             self.context.absolute_url(),
             url_extension="?version_id=%s" % version_id,
-            additional_classes=['standalone', 'function-download-copy'])
+            additional_classes=['standalone', 'function-download-copy'],
+            viewname='download_file_version')
 
     update = content.ContentHistoryViewlet.update

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -122,17 +122,18 @@ class DownloadConfirmationHelper(object):
         dictstorage.set(key, str(True))
         self.invalidate_is_active()
 
-    def get_html_tag(self, file_url, additional_classes=[], url_extension=''):
+    def get_html_tag(self, file_url, additional_classes=[], url_extension='',
+                     viewname='download'):
         if self.is_active():
+            viewname ='file_download_confirmation'
             clazz = 'link-overlay {0}'.format(' '.join(additional_classes))
-            url = '{0}/file_download_confirmation{1}'.format(
-                file_url, url_extension)
         else:
             clazz = ' '.join(additional_classes)
-            url = '{0}/download{1}'.format(file_url, url_extension)
-        label = translate(_(u'label_download_copy',
-                          default='Download copy'),
+
+        url = '{0}/{1}{2}'.format(file_url, viewname, url_extension)
+        label = translate(_(u'label_download_copy', default='Download copy'),
                           context=self.request).encode('utf-8')
+
         return '<a href="{0}" class="{1}">{2}</a>'.format(url, clazz, label)
 
     def process_request_form(self):


### PR DESCRIPTION
Since the disable option gets implemented on the download confirmation, the `download_version` link in the history viewlet was wrong, when the current user has the download confirmation disabled.

@deiferni please have a look ...
