### PR TITLE
Task byline: Use adminUnit abbreviation instead of label for sequence_number display.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Task byline: Use adminUnit abbreviation instead of label for sequence_number display.
+  [phgross]
 
 
 4.0.2 (2014-11-03)

--- a/opengever/task/tests/test_task_byline.py
+++ b/opengever/task/tests/test_task_byline.py
@@ -9,9 +9,17 @@ import transaction
 
 class TestTaskByline(TestBylineBase):
 
+    use_default_fixture = False
+
     def setUp(self):
         super(TestTaskByline, self).setUp()
         self.intids = getUtility(IIntIds)
+
+        self.user, self.org_unit, self.admin_unit = create(
+            Builder('fixture')
+            .with_user()
+            .with_org_unit()
+            .with_admin_unit(abbreviation='c1'))
 
         create(Builder('fixture').with_hugo_boss())
 
@@ -46,6 +54,6 @@ class TestTaskByline(TestBylineBase):
         start_date = self.get_byline_value_by_label('last modified:')
         self.assertEquals('Aug 11, 2011 08:10 PM', start_date.text_content())
 
-    def test_dossier_byline_sequence_number_display(self):
+    def test_dossier_byline_sequence_number_display_is_prefixed_with_admin_unit_abbreviation(self):
         seq_number = self.get_byline_value_by_label('Sequence Number:')
-        self.assertEquals('Client1 1', seq_number.text_content())
+        self.assertEquals('c1 1', seq_number.text_content())

--- a/opengever/task/viewlets/byline.py
+++ b/opengever/task/viewlets/byline.py
@@ -18,11 +18,8 @@ class TaskByline(BylineBase):
 
     def sequence_number(self):
         sequence = getUtility(ISequenceNumber)
-        return '{} {}'.format(self.get_base_client_id(),
-                              sequence.get_number(self.context))
-
-    def get_base_client_id(self):
-        return get_current_admin_unit().label()
+        return u'{} {}'.format(get_current_admin_unit().abbreviation,
+                               sequence.get_number(self.context))
 
     def get_items(self):
         return [


### PR DESCRIPTION
For example: `AFI 234` instaed of `Amt fuer Informatik 234`

@deiferni please have a look ...
