### PR TITLE
Forwarding Transitioncontroller: Fixed assign_to_dossier check.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,9 +5,12 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
-- Fixed mail download for mails with already CRLF.
+- Forwarding Transitioncontroller: Fixed assign_to_dossier check.
   [phgross]
 
+- Fixed mail download for mails with already CRLF.
+  [phgross]
+  
 - Add new type Inbox Container.
   [phgross]
 

--- a/opengever/inbox/browser/transitioncontroller.py
+++ b/opengever/inbox/browser/transitioncontroller.py
@@ -37,12 +37,15 @@ class ForwardingTransitionController(TaskTransitionController):
     def is_assign_to_dossier_or_reassign_possible(self, conditions, include_agency):
         """Check it the user is in the inbox group of the current client.
         """
-        if include_agency:
-            return (conditions.is_assigned_to_current_admin_unit and
-                    conditions.is_responsible_orgunit_agency_member)
 
-        return (conditions.is_assigned_to_current_admin_unit and
-                conditions.is_responsible)
+        if conditions.is_assigned_to_current_admin_unit:
+            if include_agency:
+                return (conditions.is_responsible or
+                        conditions.is_responsible_orgunit_agency_member)
+
+            return conditions.is_responsible
+
+        return False
 
     @action('forwarding-transition-assign-to-dossier')
     def assign_to_dossier_action(self, transition):

--- a/opengever/inbox/tests/test_transitioncontroller.py
+++ b/opengever/inbox/tests/test_transitioncontroller.py
@@ -64,6 +64,9 @@ class TestAssignToDossierGuard(InboxBaseTransitionGuardTests):
         self.assertTrue(self.controller._is_transition_possible(
             self.transition, False, conditions))
 
+        self.assertTrue(self.controller._is_transition_possible(
+            self.transition, True, conditions))
+        
         conditions.is_responsible = False
         conditions.is_responsible_orgunit_agency_member = True
         self.assertTrue(self.controller._is_transition_possible(


### PR DESCRIPTION
Right now the `assign_to_dossier` (etc.) guard does not work correctly, when a forwarding has a responsible user without agency_group belonging. This results that the responsible user of the forwarding can't do any action.

This commit solves this problem.

@lukasgraf please have a look ...
