### PR TITLE
Make sure metadata-fix profile is always installed last as policy-depency.

### DIFF
--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -29,6 +29,5 @@
     <dependency>profile-ftw.zipexport:default</dependency>
     <dependency>profile-plone.formwidget.autocomplete:default</dependency>
     <dependency>profile-plone.formwidget.contenttree:default</dependency>
-    <dependency>profile-opengever.policy.base:mimetype</dependency>
   </dependencies>
 </metadata>

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -27,6 +27,9 @@ EXTENSION_PROFILES = (
 SQL_BASES = (BASE, opengever.globalindex.model.Base)
 
 
+MIMETYPE_FIX_PROFILE = 'profile-opengever.policy.base:mimetype'
+
+
 class GeverDeployment(object):
 
     def __init__(self, context, config, db_session,
@@ -134,6 +137,8 @@ class GeverDeployment(object):
         stool = getToolByName(self.site, 'portal_setup')
         stool.runAllImportStepsFromProfile(
             'profile-{}'.format(policy_profile))
+        # fix mime-type definitions by overriding temaraum-theme mimetypes
+        stool.runAllImportStepsFromProfile(MIMETYPE_FIX_PROFILE)
 
     def configure_plone_site(self):
         # configure mail settings


### PR DESCRIPTION
The order specified in metadata.xml is not guaranteed, thus we hard-code
the depencency in the deploy class and install it once the policy has been
installed.
