### PR TITLE
Dropped `prevent_deletion` handler.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.1.0 (unreleased)
 ------------------
 
+- Dropped prevent_deletion handler.
+  [phgross]
+
 - Added new document workflow state `document-state-removed`.
   [phgross]
 

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -1,10 +1,7 @@
-from AccessControl import Unauthorized
 from five import grok
 from OFS.interfaces import IObjectClonedEvent
-from OFS.interfaces import IObjectWillBeRemovedEvent
 from opengever.base import _
 from plone.dexterity.interfaces import IDexterityContent
-from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 
 
@@ -22,14 +19,3 @@ def create_initial_version(obj, event):
         # Create an initial version
         pr._recursiveSave(obj, {}, pr._prepareSysMetadata(comment),
             autoapply=pr.autoapply)
-
-
-@grok.subscribe(IDexterityContent, IObjectWillBeRemovedEvent)
-def prevent_deletion(obj, event):
-    """Prevent deletion of objects by anyone except Managers
-    """
-    site = event.object
-    membership = getMultiAdapter((site, site.REQUEST),
-                                 name=u"plone_tools").membership()
-    if not membership.checkPermission('Manage portal', obj):
-        raise Unauthorized()


### PR DESCRIPTION
An event handler for preventing object deletion is the wrong way, furthermore
it makes impossible to remove repositories for administrators.

@lukasgraf please have a look
