### PR TITLE
Extract attachments view: Fixed contenttype helper when lookup via filename.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.1.0 (unreleased)
 ------------------
 
+- Extract attachments view: Fixed contenttype helper when lookup via filename.
+  [phgross]
+
 - Dropped no longer used document state journalization.
   [phgross]
 

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -51,13 +51,15 @@ def content_type_helper(item, content_type):
 
     css_class = 'icon-dokument_verweis'
     if content_type == 'application/octet-stream':
-        lookup = mtr.globFilename(item.get('filename'))
+        mimetype = mtr.globFilename(item.get('filename'))
     else:
-        lookup = mtr.lookup(content_type)
+        result = mtr.lookup(content_type)
+        if result and isinstance(result, tuple):
+            mimetype = result[0]
 
-    if lookup:
+    if mimetype:
         # Strip '.gif' from end of icon name and remove leading 'icon_'
-        icon_filename = lookup[0].icon_path
+        icon_filename = mimetype.icon_path
         filetype = os.path.splitext(icon_filename)[0].replace('icon_', '')
         css_class = 'icon-{}'.format(normalize(filetype))
 

--- a/opengever/mail/tests/test_extract_attachments.py
+++ b/opengever/mail/tests/test_extract_attachments.py
@@ -6,6 +6,7 @@ from ftw.mail.utils import get_attachments
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.document.interfaces import IDocumentSettings
+from opengever.mail.browser.extract_attachments import content_type_helper
 from opengever.testing import FunctionalTestCase
 from opengever.testing import obj2brain
 from plone.app.testing import TEST_USER_ID
@@ -156,3 +157,21 @@ class TestAttachmentExtraction(FunctionalTestCase):
         browser.css('.formControls input.standalone').first.click()
 
         self.assertEquals(self.mail.absolute_url(), browser.url)
+
+
+class TestContentTypeHelper(FunctionalTestCase):
+
+    def test_lookup_the_contenttype(self):
+        self.assertEquals(
+            '<span class=icon-image />',
+            content_type_helper({}, 'image/gif'))
+
+    def test_lookup_via_filename_when_contenttype_is_octet_stream(self):
+        item = {'position': 5,
+                'size': 1835,
+                'content-type': 'application/octet-stream',
+                'filename': 'ATT00001.gif'}
+
+        self.assertEquals(
+            '<span class=icon-image />',
+            content_type_helper(item, 'application/octet-stream'))


### PR DESCRIPTION
The `content_type_helper` used for displaying the according icon in the `type`
column of the attachments table, has a fallback for attachments with
`application/octet-stream` as contenttype.

But this fallback did not work correctly, because the `globFilename` method
always returns the mimetype itself.

@lukasgraf please have a look ... 
