### PR TITLE
Added `restore_transition` property to document and mail class.

### DIFF
--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -119,6 +119,10 @@ class Document(Item):
     def remove_transition(self):
         return 'document-transition-remove'
 
+    @property
+    def restore_transition(self):
+        return 'document-transition-restore'
+
     def related_items(self):
         relations = IRelatedDocuments(self).relatedItems
         if relations:

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -84,6 +84,10 @@ class OGMail(Item):
     def remove_transition(self):
         return 'mail-transition-remove'
 
+    @property
+    def restore_transition(self):
+        return 'mail-transition-restore'
+
     def css_class(self):
         return get_css_class(self)
 


### PR DESCRIPTION
The `restore_transition` was wrongly dropped during interactive rebasing the PR #676. This should fix the failing tests.

@lukasgraf please have a look.
