### PR TITLE
Made the AddPublicTrialColumn upgrade step more robust, when value contains no JSON data

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.1.0 (unreleased)
 ------------------
 
+- Made the AddPublicTrialColumn more robust.
+  [phgross]
+
 - Extract attachments view: Fixed contenttype helper when lookup via filename.
   [phgross]
 

--- a/opengever/tabbedview/upgrades/to3400.py
+++ b/opengever/tabbedview/upgrades/to3400.py
@@ -31,7 +31,13 @@ class AddPublicTrialColumn(UpgradeStep):
                          "NULL value - skipping record!" % record.key)
                 continue
 
-            data = json.loads(record.value.encode('utf-8'))
+            try:
+                data = json.loads(record.value.encode('utf-8'))
+            except ValueError:
+                log.warn("DictStorage record with key '%s' has invalid value "
+                         "- skipping record!" % record.key)
+                continue
+
             columns = data.get('columns')
             if PUBLIC_TRIAL_COL_ID not in [col.get('id') for col in columns]:
 


### PR DESCRIPTION
@lukasgraf please have a look ... 
