### PR TITLE
Update changelog after bugfix releases

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,9 +8,6 @@ Changelog
 - Made the AddPublicTrialColumn more robust.
   [phgross]
 
-- Extract attachments view: Fixed contenttype helper when lookup via filename.
-  [phgross]
-
 - Dropped no longer used document state journalization.
   [phgross]
 
@@ -40,6 +37,13 @@ Changelog
     - Configure development options and add environment variable to enable them easily.
 
   [deiferni]
+
+
+4.0.5 (2014-11-25)
+------------------
+
+- Extract attachments view: Fixed contenttype helper when lookup via filename.
+  [phgross]
 
 
 4.0.4 (2014-11-13)


### PR DESCRIPTION
Update manually the changelog after bugfix releases `3.4.2` and `4.0.5`.

@lukasgraf or @deiferni please have a look ... 
