### PR TITLE
Remove ldap_plugin.xml from release exclude list.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,3 @@ include *.txt
 global-exclude *.pyc
 global-exclude ._*
 global-exclude *.mo
-global-exclude ldap_plugin.xml


### PR DESCRIPTION
We added `ldap_plugin.xml` to our `MANIFEST.in` because it contained our ldap password.

We fixed this and added checked it in again: https://github.com/4teamwork/opengever.core/commit/65276f28eedd1053420803384fc58d26232096a3

Since we already have the config public on github we could release it as well. Can save some pain if someone uses the egg (like me).
