### PR TITLE
Implement pessimistic connection invalidation (MySQL only)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.1.0 (unreleased)
 ------------------
 
+- Implement pessimistic connection invalidation (MySQL only):
+  Check every connection that has been checked out from pool, and
+  invalidate it if it's stale.
+  [lgraf]
+
 - Reworked OrgUnit Selector:
     - Store current unit to regular cookie instead of using the session_data_manager.
     - Differentiate between users_units (selectable) and admin_unit's org_unit


### PR DESCRIPTION
Check every connection that has been checked out from pool, and
invalidate it if it's stale.

This solves the `MySQL has gone away` issues.

See [SQLAlchemy Docs > Connection Pooling > Disconnect Handling - Pessimistic](http://docs.sqlalchemy.org/en/rel_0_7/core/pooling.html#disconnect-handling-pessimistic)

@phgross @deiferni 

(Needs be backported to `opengever-3.0.2` / `opengever.core-4.0.6`)
