### PR TITLE
Make sure that an admin-unit is created before it is queried.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,10 @@ Changelog
   even when `SQL` is not ticked.
   [lgraf]
 
+- Setup: Make sure that an admin-unit is created before it is queried
+  during `sync-ogds`.
+  [deiferni]
+
 
 4.0.7 (2015-01-06)
 ------------------

--- a/opengever/setup/browser/admin.py
+++ b/opengever/setup/browser/admin.py
@@ -187,6 +187,19 @@ class CreateOpengeverClient(BrowserView):
             plugins.movePluginsUp(IPropertiesPlugin, ('ldap',))
             plugins.movePluginsUp(IPropertiesPlugin, ('ldap',))
 
+        # create admin-unit before sync_ogds - it might be required
+        if form.get('configsql'):
+            admin_unit = AdminUnit(
+                form['client_id'],
+                enabled=bool(form.get('active')),
+                title=form['title'],
+                abbreviation=form['title'],
+                ip_address=form['ip_address'],
+                site_url=form['site_url'],
+                public_url=form['public_url'],
+            )
+            session.add(admin_unit)
+
         if form.get('first') and form.get('import_users'):
             print '===== SYNC LDAP ===='
             # Import LDAP users and groups
@@ -218,27 +231,13 @@ class CreateOpengeverClient(BrowserView):
                 raise SetupError("Inbox group '%s' could not be found." %
                                  form['inbox_group'])
 
-            active = bool(form.get('active'))
-
-            admin_unit = AdminUnit(
-                form['client_id'],
-                enabled=active,
-                title=form['title'],
-                abbreviation=form['title'],
-                ip_address=form['ip_address'],
-                site_url=form['site_url'],
-                public_url=form['public_url'],
-            )
-
             client = OrgUnit(form['client_id'],
-                             enabled=active,
+                             enabled=bool(form.get('active')),
                              title=form['title'],
                              admin_unit=admin_unit)
 
             client.users_group = users_group
             client.inbox_group = inbox_group
-
-            session.add(admin_unit)
             session.add(client)
 
         # create the admin user in the ogds if he not exist

--- a/versions.cfg
+++ b/versions.cfg
@@ -17,3 +17,8 @@ collective.z3cinspector = 1.1
 profilestats = 1.0.2
 pyprof2calltree = 1.1.0
 mocker = 1.1.1
+
+# zope.testrunner 4.4.5 has changed the testing layer ordering
+# which causes test isolation problems with PloneTestCase layers
+# which are not isolating properly.
+zope.testrunner = 4.4.4


### PR DESCRIPTION
This fixes an issue while developing policies locally for customers that are still on the 4.0 release.

Also backport https://github.com/4teamwork/opengever.core/pull/722 to fix failing tests.