### PR TITLE
Only show "Paste" action if objects in clipboard are in allowed addable types of target container.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,12 +5,16 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Only show "Paste" action if objects in clipboard are in allowed addable
+  types of target container.
+  [lgraf]
+
 - XlsSource: Handle values that are already a valid term for vocabulary fields.
   [lgraf]
 
 - XlsSource: Raise KeyError if a value can't be found in the translation mapping
   for fields with a vocabulary, instead of just setting the translated value anyway.
-  [lgraf] 
+  [lgraf]
 
 - XlsSource: Add some more alternate spellings for archival_value mapping.
   [lgraf]

--- a/opengever/base/tests/test_paste_items.py
+++ b/opengever/base/tests/test_paste_items.py
@@ -28,7 +28,7 @@ class TestPasteItems(FunctionalTestCase):
     def test_paste_action_not_displayed_for_templatedossier(self, browser):
         templatedossier = create(Builder('templatedossier'))
         document = create(Builder('document')
-                         .within(templatedossier))
+                          .within(templatedossier))
 
         paths = ['/'.join(document.getPhysicalPath())]
         browser.login().open(templatedossier, {'paths:list': paths},
@@ -44,7 +44,7 @@ class TestPasteItems(FunctionalTestCase):
         document = create(Builder('document').within(dossier))
         mail = create(Builder('mail').within(dossier))
 
-        paths = ['/'.join(document.getPhysicalPath()),]
+        paths = ['/'.join(document.getPhysicalPath())]
         browser.login().open(dossier, {'paths:list': paths}, view='copy_items')
 
         browser.open(mail)
@@ -54,7 +54,7 @@ class TestPasteItems(FunctionalTestCase):
     def test_pasting_copied_document_into_dossier_succeeds(self):
         dossier = create(Builder('dossier'))
         document = create(Builder('document')
-                         .within(dossier))
+                          .within(dossier))
 
         cb = dossier.manage_copyObjects(document.id)
         dossier.manage_pasteObjects(cb)

--- a/opengever/base/tests/test_paste_items.py
+++ b/opengever/base/tests/test_paste_items.py
@@ -83,3 +83,16 @@ class TestPasteItems(FunctionalTestCase):
 
         self.assertIn(copied_dossier_id, repofolder.objectIds())
         self.assertIn(document.id, repofolder["copy_of_%s" % dossier.id])
+
+    def test_pasting_not_allowed_if_disallowed_subobject_type(self):
+        repofolder = create(Builder('repository'))
+        dossier = create(Builder('dossier')
+                         .within(repofolder))
+        document = create(Builder('document')
+                          .within(dossier))
+
+        dossier.manage_copyObjects(document.id)
+        pasting_allowed_view = repofolder.restrictedTraverse(
+            'is_pasting_allowed')
+        allowed = pasting_allowed_view()
+        self.assertFalse(allowed)


### PR DESCRIPTION
Only show the "Paste" action in the menu if all objects in clipboard are of a type that is allowed to be added to the target container. Fixes #648 and #612.

Since this check is being done pretty much on every single request, it's rather performance critical.
I therefore inlined some code from `OFS.CopySupport` because the previous `cb_dataValid()` does nothing else than trying to decode the clipboard. So if we were to call that, and then decode the clipboard again to get to the clipboard objects' types we would do it twice.

@deiferni @phgross 