### PR TITLE
Rewrite search/advanced search, especially date querying.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -65,6 +65,11 @@ Changelog
 - OrgUnitSelector: Store selected OrgUnit after determining fallback.
   [lgraf]
 
+- Rewrite advancedsearch to fix an issue with invalid requests to the search view.
+  It is now allowed to filter by min or max value instead of just by date ranges
+  (min and max) when querying for dates.
+  [deiferni]
+
 
 4.1.0 (2014-12-18)
 ------------------


### PR DESCRIPTION
Allow filtering by min or max value instead of just by date ranges when
querying for dates. This allows a major simplification and eliminates several
code smells.

Fixes #671.