### PR TITLE
Fix handling of mapped vocabulary terms in XlsSource

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- XlsSource: Add some more alternate spellings for archival_value mapping.
+  [lgraf]
+
 - Move items: handle twice submitted forms or invalid selected paths.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- XlsSource: Handle values that are already a valid term for vocabulary fields.
+  [lgraf]
+
 - XlsSource: Raise KeyError if a value can't be found in the translation mapping
   for fields with a vocabulary, instead of just setting the translated value anyway.
   [lgraf] 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- XlsSource: Raise KeyError if a value can't be found in the translation mapping
+  for fields with a vocabulary, instead of just setting the translated value anyway.
+  [lgraf] 
+
 - XlsSource: Add some more alternate spellings for archival_value mapping.
   [lgraf]
 

--- a/opengever/setup/sections/xlssource.py
+++ b/opengever/setup/sections/xlssource.py
@@ -113,13 +113,13 @@ class XlsSource(object):
                 cell = [t for t in cell if not t == '']
 
             if key == 'archival_value':
-                cell = ARCHIVAL_VALUE_MAPPING.get(cell, cell)
+                cell = ARCHIVAL_VALUE_MAPPING[cell]
             if key == 'classification':
-                cell = CLASSIFICATION_MAPPING.get(cell, cell)
+                cell = CLASSIFICATION_MAPPING[cell]
             if key == 'privacy_layer':
-                cell = PRIVACY_LAYER_MAPPING.get(cell, cell)
+                cell = PRIVACY_LAYER_MAPPING[cell]
             if key == 'public_trial':
-                cell = PUBLIC_TRIAL_MAPPING.get(cell, cell)
+                cell = PUBLIC_TRIAL_MAPPING[cell]
 
             data[key] = cell
 

--- a/opengever/setup/sections/xlssource.py
+++ b/opengever/setup/sections/xlssource.py
@@ -28,8 +28,10 @@ ARCHIVAL_VALUE_MAPPING = {u'Nicht geprüft': u'unchecked',
                           u"Noch nicht geprüft": u'unchecked',
                           u'Anbieten': u'prompt',
                           u'Archivwürdig': u'archival worthy',
+                          u'Archivieren': u'archival worthy',
                           u'Nicht archivwürdig': u'not archival worthy',
                           u'Sampling': u'archival worthy with sampling',
+                          u'Auswahl archivw\xfcrdig': u'archival worthy with sampling',
                           }
 
 

--- a/opengever/setup/sections/xlssource.py
+++ b/opengever/setup/sections/xlssource.py
@@ -35,6 +35,13 @@ ARCHIVAL_VALUE_MAPPING = {u'Nicht geprüft': u'unchecked',
                           }
 
 
+MAPPED_FIELDS = {'archival_value': ARCHIVAL_VALUE_MAPPING,
+                 'classification': CLASSIFICATION_MAPPING,
+                 'privacy_layer': PRIVACY_LAYER_MAPPING,
+                 'public_trial': PUBLIC_TRIAL_MAPPING,
+                 }
+
+
 class XlsSource(object):
     classProvides(ISectionBlueprint)
     implements(ISection)
@@ -112,14 +119,14 @@ class XlsSource(object):
                 cell = cell.replace(' ', '').split(',')
                 cell = [t for t in cell if not t == '']
 
-            if key == 'archival_value':
-                cell = ARCHIVAL_VALUE_MAPPING[cell]
-            if key == 'classification':
-                cell = CLASSIFICATION_MAPPING[cell]
-            if key == 'privacy_layer':
-                cell = PRIVACY_LAYER_MAPPING[cell]
-            if key == 'public_trial':
-                cell = PUBLIC_TRIAL_MAPPING[cell]
+            if key in MAPPED_FIELDS.keys():
+                mapping = MAPPED_FIELDS[key]
+
+                # Data is already a valid term
+                if cell in mapping.values():
+                    continue
+
+                cell = mapping[cell]
 
             data[key] = cell
 


### PR DESCRIPTION
 - Raise `KeyError` if a value can't be found in the translation mapping for fields with a vocabulary, instead of just setting the translated value anyway.
 - Add some more alternate spellings for the `archival_value` mapping.

Needs to be backported to `4.0-stable` and `4.1-stable`.