### PR TITLE
Backport "Pin down zope.testrunner in tests to avoid layer isolation issues." to 4.1-stable

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -17,3 +17,8 @@ collective.z3cinspector = 1.1
 profilestats = 1.0.2
 pyprof2calltree = 1.1.0
 mocker = 1.1.1
+
+# zope.testrunner 4.4.5 has changed the testing layer ordering
+# which causes test isolation problems with PloneTestCase layers
+# which are not isolating properly.
+zope.testrunner = 4.4.4


### PR DESCRIPTION
Backport PR #722 to [`4.1-stable` branch](https://github.com/4teamwork/opengever.core/tree/4.1-stable)