### PR TITLE
Wrap checks in is_pasting_allowed in a try..except for safety.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Wrap checks in is_pasting_allowed in a try..except for safety.
+  [lgraf]
+
 - Make sure response descriptions are always unicode.
   [lgraf]
 

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -149,6 +149,25 @@ class TestMoveItems(FunctionalTestCase):
         browser.fill({'Destination': subdossier})
         browser.css('#form-buttons-button_submit').first.click()
 
+    @browsing
+    def test_copy_then_move(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+        document = create(Builder('document').within(dossier))
+
+        browser.login()
+
+        # Copy the document
+        paths = ['/'.join(document.getPhysicalPath())]
+        browser.open(dossier, {'paths:list': paths}, view='copy_items')
+
+        # Move the same document we copied before
+        browser.open(dossier, {'paths:list': paths}, view='move_items')
+        browser.fill({'Destination': subdossier})
+
+        # Should not cause our check in is_pasting_allowed view to fail
+        browser.css('#form-buttons-button_submit').first.click()
+
     def get_uids_from_tree_widget(self):
         view = self.source_repo.restrictedTraverse('move_items')
         form = view.form(self.source_repo, self.request)


### PR DESCRIPTION
This view is called on *every request*, and the checks may fail with a `KeyError` if an object is first copied, and then the same object is moved. Therefore we wrap all the checks in a `try..except` because this view must never fail.