### PR TITLE
Prevent early return or returning None by fixing indentation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -82,6 +82,9 @@ Changelog
   (min and max) when querying for dates.
   [deiferni]
 
+- Fix an issue with username/contacts-name based sorting in tabbedviews.
+  [deiferni]
+
 
 4.1.0 (2014-12-18)
 ------------------

--- a/opengever/ogds/base/sort_helpers.py
+++ b/opengever/ogds/base/sort_helpers.py
@@ -52,4 +52,4 @@ class SortHelpers(object):
         for contact in contact_service().all_contact_brains():
             sort_dict['contact:%s' % (contact.id)] = u'%s %s' % (
                 contact.lastname, contact.firstname)
-            return sort_dict
+        return sort_dict

--- a/opengever/ogds/base/tests/test_sort_helpers.py
+++ b/opengever/ogds/base/tests/test_sort_helpers.py
@@ -31,8 +31,8 @@ class TestUserSortDict(FunctionalTestCase):
         self.assertEqual(
             {u'albert.peter': u'Peter Albert',
              u'test_user_1_': u'Test User',
-             'inbox:client1': u'Inbox: Client1',
-             'inbox:arch': u'Inbox: Landesarchiv',
+             u'inbox:client1': u'Inbox: Client1',
+             u'inbox:arch': u'Inbox: Landesarchiv',
              u'hugo.boss': u'Boss Hugo',
              u'james.bond': u'Bond James'},
             SortHelpers().get_user_sort_dict())
@@ -50,10 +50,22 @@ class TestUserSortDict(FunctionalTestCase):
 
         self.assertEqual(
             {u'albert.peter': u'Peter Albert',
-             'contact:croft-lara': u'Croft Lara',
+             u'contact:croft-lara': u'Croft Lara',
+             u'contact:man-super': u'M\xe4n Super',
              u'test_user_1_': u'Test User',
-             'inbox:client1': u'Inbox: Client1',
-             'inbox:arch': u'Inbox: Landesarchiv',
+             u'inbox:client1': u'Inbox: Client1',
+             u'inbox:arch': u'Inbox: Landesarchiv',
+             u'hugo.boss': u'Boss Hugo',
+             u'james.bond': u'Bond James'},
+            SortHelpers().get_user_contact_sort_dict())
+
+    def test_user_contact_sort_dict_is_not_none_for_emtpy_contacts(self):
+        self.assertIsNotNone(SortHelpers().get_user_contact_sort_dict())
+        self.assertEqual(
+            {u'albert.peter': u'Peter Albert',
+             u'test_user_1_': u'Test User',
+             u'inbox:client1': u'Inbox: Client1',
+             u'inbox:arch': u'Inbox: Landesarchiv',
              u'hugo.boss': u'Boss Hugo',
              u'james.bond': u'Bond James'},
             SortHelpers().get_user_contact_sort_dict())


### PR DESCRIPTION
Fixes #751.

![triple-facepalm-picard-812](https://cloud.githubusercontent.com/assets/736583/6168318/9f65b042-b2c4-11e4-917f-7f097c85a88d.jpg)
