### PR TITLE
Livesearch: Dropped not used icon <img> tag.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Livesearch: Dropped unused icon <img> tag.
+  [phgross]
+
 - Style meeting form.
   Add agendaitem sorting implementation.
   [deiferni, Kevin Bieri]

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -125,7 +125,6 @@ else:
     write('''<ul class="LSTable">''')
     for result in results[:limit]:
 
-        icon = plone_view.getIcon(result)
         itemUrl = result.getURL()
         if result.portal_type in useViewAction:
             itemUrl += '/view'
@@ -133,7 +132,6 @@ else:
         itemUrl = itemUrl + searchterm_query
 
         write('''<li class="LSRow">''')
-        write(icon.html_tag() or '')
         full_title = safe_unicode(pretty_title_or_id(result))
         if len(full_title) > MAX_TITLE:
             display_title = ''.join((full_title[:MAX_TITLE], '...'))


### PR DESCRIPTION
Disable `plonetheme.teamraum` `livesearch.js` to avoid doubled javascript action. This fixes the bug #681.

Additionally I've dropped the not used icon `<img>` tag. Because the livesearch use the sprite icon.
