### PR TITLE
Allow submitting additional documents to an already made proposal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -61,7 +61,8 @@ Changelog
     - Add forms for Members and their Memberships in Committees.
     - Add tab to committees listing all memberships.
     - Add cancel buttons and form labels.
-    - Add tabs to committee container for committees and members
+    - Add tabs to committee container for committees and members.
+    - Allow submission of additional documents to already submitted proposals.
 
   [deiferni]
 

--- a/opengever/base/source.py
+++ b/opengever/base/source.py
@@ -1,7 +1,8 @@
-from plone.formwidget.contenttree import ObjPathSourceBinder
 from Acquisition import aq_inner, aq_parent
-from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from opengever.base import interfaces
+from plone.formwidget.contenttree import ObjPathSourceBinder
+from plone.formwidget.contenttree.source import CustomFilter
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.component import queryMultiAdapter
 
 
@@ -61,6 +62,10 @@ class DossierPathSourceBinder(ObjPathSourceBinder):
     """A Special PathSourceBinder wich only search in the main Dossier
     of the actual context
     """
+
+    def __init__(self, navigation_tree_query=None, filter_class=CustomFilter, **kw):
+        self.selectable_filter = filter_class(**kw)
+        self.navigation_tree_query = navigation_tree_query
 
     def __call__(self, context):
         """ gets main-dossier path and put it to the navigation_tree_query """

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -60,3 +60,7 @@ def ok_response(request=None):
         request =  api.portal.get().REQUEST
     request.response.setHeader("Content-type", "text/plain")
     return 'OK'
+
+
+def disable_edit_bar():
+    api.portal.get().REQUEST.set('disable_border', True)

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -7,7 +7,7 @@ from opengever.document import _
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.meeting.model import SubmittedDocument
+from opengever.meeting.proposal import ISubmittedProposal
 from opengever.task.task import ITask
 from plone import api
 from plone.autoform import directives as form_directives
@@ -198,17 +198,15 @@ class Document(Item):
         return self.checked_out_by() is not None
 
     def is_movable(self):
-        return not self.is_inside_a_task()
+        return not self.is_inside_a_task() and not self.is_submitted_document()
 
     def is_inside_a_task(self):
         parent = aq_parent(aq_inner(self))
-        if ITask.providedBy(parent):
-            return True
-        else:
-            return False
+        return ITask.providedBy(parent)
 
     def is_submitted_document(self):
-        return SubmittedDocument.query.get_by_target(self) is not None
+        parent = aq_parent(aq_inner(self))
+        return ISubmittedProposal.providedBy(parent)
 
     def get_current_version(self):
         """Return the current document history version."""

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -7,6 +7,7 @@ from opengever.document import _
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.meeting.model import SubmittedDocument
 from opengever.task.task import ITask
 from plone import api
 from plone.autoform import directives as form_directives
@@ -205,6 +206,9 @@ class Document(Item):
             return True
         else:
             return False
+
+    def is_submitted_document(self):
+        return SubmittedDocument.query.get_by_target(self) is not None
 
     def get_current_version(self):
         """Return the current document history version."""

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -205,3 +205,15 @@ class Document(Item):
             return True
         else:
             return False
+
+    def get_current_version(self):
+        """Return the current document history version."""
+
+        repository = api.portal.get_tool("portal_repository")
+        assert repository.isVersionable(self), \
+            'Document is not versionable'
+        history = repository.getHistoryMetadata(self)
+        current_version = history.getLength(countPurged=False) - 1
+        assert history.retrieve(current_version), \
+            'missing history entry for verion {}'.format(current_version)
+        return current_version

--- a/opengever/document/profiles/default/actions.xml
+++ b/opengever/document/profiles/default/actions.xml
@@ -76,6 +76,18 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="submit_additional_documents" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Submit additional documents</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:submit_additional_documents:method</property>
+      <property name="icon_expr"></property>
+      <property name="available_expr">object/@@submit_additional_documents/available</property>
+      <property name="permissions">
+        <element value="opengever.meeting: Add Proposal"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+
 
   </object>
   <object name="object_checkin_menu" meta_type="CMF Action Category">

--- a/opengever/document/profiles/default/metadata.xml
+++ b/opengever/document/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4100</version>
+    <version>4200</version>
     <dependencies>
         <dependency>profile-plone.app.versioningbehavior:default</dependency>
     </dependencies>

--- a/opengever/document/profiles/default/types/opengever.document.document.xml
+++ b/opengever/document/profiles/default/types/opengever.document.document.xml
@@ -112,5 +112,14 @@
     <permission value="opengever.document: Cancel"/>
   </action>
 
+  <action
+        action_id="submit_additional_document"
+        visible="True"
+        title="Submit additional document"
+        url_expr="string:${object_url}/@@submit_additional_document"
+        condition_expr="object/@@is_meeting_feature_enabled"
+        category="object_buttons">
+    <permission value="opengever.meeting: Add Proposal"/>
+  </action>
 
 </object>

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -17,6 +17,7 @@ from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
 from opengever.testing import obj2brain
 from opengever.testing import OPENGEVER_FUNCTIONAL_TESTING
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.fti import register
@@ -174,6 +175,14 @@ class TestDocument(FunctionalTestCase):
 
         self.assertFalse(doc.is_movable())
 
+    def test_current_document_version_is_increased(self):
+        document = create(Builder("document"))
+        self.assertEqual(0, document.get_current_version())
+
+        repository = api.portal.get_tool('portal_repository')
+        repository.save(document)
+
+        self.assertEqual(1, document.get_current_version())
 
 class TestDocumentDefaultValues(FunctionalTestCase):
 

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -175,6 +175,21 @@ class TestDocument(FunctionalTestCase):
 
         self.assertFalse(doc.is_movable())
 
+    def test_document_inside_a_submitted_proposal_is_not_movable(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+        committee = create(Builder('committee'))
+        proposal = create(Builder('proposal')
+                          .within(dossier)
+                          .having(title='Mach doch',
+                                  committee=committee.load_model())
+                          .relate_to(document))
+
+        submitted_proposal = create(
+            Builder('submitted_proposal').submitting(proposal))
+        submitted_document = submitted_proposal.get_documents()[0]
+        self.assertFalse(submitted_document.is_movable())
+
     def test_current_document_version_is_increased(self):
         document = create(Builder("document"))
         self.assertEqual(0, document.get_current_version())
@@ -183,6 +198,7 @@ class TestDocument(FunctionalTestCase):
         repository.save(document)
 
         self.assertEqual(1, document.get_current_version())
+
 
 class TestDocumentDefaultValues(FunctionalTestCase):
 

--- a/opengever/document/upgrades/configure.zcml
+++ b/opengever/document/upgrades/configure.zcml
@@ -148,4 +148,13 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4100 -> 4200 -->
+    <upgrade-step:importProfile
+        title="Add update proposal action"
+        profile="opengever.document:default"
+        source="4100"
+        destination="4200"
+        directory="profiles/4200"
+        />
+
 </configure>

--- a/opengever/document/upgrades/profiles/4200/actions.xml
+++ b/opengever/document/upgrades/profiles/4200/actions.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <object name="folder_buttons" meta_type="CMF Action Category">
+    <object name="submit_additional_documents" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Submit additional documents</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:submit_additional_documents:method</property>
+      <property name="icon_expr"></property>
+      <property name="available_expr">object/@@submit_additional_documents/available</property>
+      <property name="permissions">
+        <element value="opengever.meeting: Add Proposal"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+
+</object>

--- a/opengever/document/upgrades/profiles/4200/types/opengever.document.document.xml
+++ b/opengever/document/upgrades/profiles/4200/types/opengever.document.document.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<object name="opengever.document.document" meta_type="Dexterity FTI"
+        i18n:domain="opengever.document" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <action
+        action_id="submit_additional_document"
+        visible="True"
+        title="Submit additional document"
+        url_expr="string:${object_url}/@@submit_additional_document"
+        condition_expr="object/@@is_meeting_feature_enabled"
+        category="object_buttons">
+    <permission value="opengever.meeting: Add Proposal"/>
+  </action>
+
+</object>

--- a/opengever/dossier/templatedossier/tabs.py
+++ b/opengever/dossier/templatedossier/tabs.py
@@ -35,12 +35,13 @@ class TemplateDossierDocuments(Documents):
             super(TemplateDossierDocuments, self).enabled_actions)
 
     disabled_actions = [
-        'send_as_email',
-        'checkout',
-        'checkin',
         'cancel',
-        'move_items',
+        'checkin',
+        'checkout',
         'create_task',
+        'move_items',
+        'send_as_email',
+        'submit_additional_documents',
     ]
 
 

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -310,7 +310,6 @@ class TestTemplateDossierListings(FunctionalTestCase):
         view = self.templatedossier.unrestrictedTraverse(DOCUMENT_TAB)
         self.assertEquals(['checkin_with_comment',
                            'checkin_without_comment',
-                           'submit_additional_documents',
                            'trashed',
                            'copy_items',
                            'zip_selected'],

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -310,6 +310,7 @@ class TestTemplateDossierListings(FunctionalTestCase):
         view = self.templatedossier.unrestrictedTraverse(DOCUMENT_TAB)
         self.assertEquals(['checkin_with_comment',
                            'checkin_without_comment',
+                           'submit_additional_documents',
                            'trashed',
                            'copy_items',
                            'zip_selected'],

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -4,6 +4,7 @@ from ftw.mail.utils import get_attachments
 from ftw.mail.utils import get_filename
 from ftw.mail.utils import remove_attachments
 from ftw.table.interfaces import ITableGenerator
+from opengever.base.utils import disable_edit_bar
 from opengever.base.utils import find_parent_dossier
 from opengever.mail import _
 from opengever.mail.events import AttachmentsDeleted
@@ -137,8 +138,7 @@ class ExtractAttachments(grok.View):
         return generator.generate(items, columns, sortable=False)
 
     def __call__(self):
-        # Disable the editable border for extract attachments view
-        self.request.set('disable_border', 1)
+        disable_edit_bar()
 
         items = get_attachments(self.context.msg)
         if not len(items):

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -32,4 +32,11 @@
       permission="zope2.View"
     />
 
+  <browser:page
+      for="zope.interface.Interface"
+      name="submit_additional_documents"
+      class=".submitdocuments.SubmitDocumentsByPaths"
+      permission="zope2.View"
+    />
+
 </configure>

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="opengever.meeting">
 
+  <include package=".documents" />
   <include package=".meetings" />
 
   <browser:resourceDirectory
@@ -21,6 +22,13 @@
       for="opengever.meeting.committeecontainer.ICommitteeContainer"
       name="add-member"
       class=".members.AddMember"
+      permission="zope2.View"
+    />
+
+  <browser:page
+      for="opengever.meeting.proposal.IProposal"
+      name="submit_additional_documents"
+      class=".submitdocuments.SubmitAdditionalDocuments"
       permission="zope2.View"
     />
 

--- a/opengever/meeting/browser/documents/configure.zcml
+++ b/opengever/meeting/browser/documents/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="opengever.meeting">
+
+  <browser:page
+      for="opengever.document.document.IDocumentSchema"
+      name="submit_additional_document"
+      class=".submit.SubmitAdditionalDocument"
+      permission="zope2.View"
+    />
+
+</configure>

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -1,4 +1,5 @@
 from opengever.base.source import DossierPathSourceBinder
+from opengever.base.utils import disable_edit_bar
 from opengever.document import _
 from opengever.meeting.proposal import IProposal
 from plone import api
@@ -45,6 +46,10 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
     ignoreContext = True
 
     schema = ISubmitAdditionalDocument
+
+    def __call__(self):
+        disable_edit_bar()
+        return super(SubmitAdditionalDocument, self).__call__()
 
     @buttonAndHandler(_(u'button_submit_document', default=u'Submit Document'))
     def submit_documents(self, action):

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -1,11 +1,26 @@
 from opengever.base.source import DossierPathSourceBinder
 from opengever.document import _
+from opengever.meeting.proposal import IProposal
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.directives import form
+from plone.formwidget.contenttree.source import CustomFilter
 from z3c.form.button import buttonAndHandler
 from z3c.form.form import Form
 from z3c.relationfield.schema import RelationChoice
+
+
+class SubmittableProposalFilter(CustomFilter):
+    """Custom selectable filter to only allow selection of proposals which
+    allow submission of additional documents.
+
+    """
+    def __call__(self, brain, index_data):
+        obj = brain.getObject()
+        if IProposal.providedBy(obj):
+            return IProposal(obj).is_submit_additional_documents_allowed()
+        return super(SubmittableProposalFilter, self).__call__(
+            brain, index_data)
 
 
 class ISubmitAdditionalDocument(form.Schema):
@@ -13,6 +28,7 @@ class ISubmitAdditionalDocument(form.Schema):
     proposal = RelationChoice(
         title=_(u'Proposal', default=u'Proposal'),
         source=DossierPathSourceBinder(
+            filter_class=SubmittableProposalFilter,
             portal_type=("opengever.meeting.proposal"),
             navigation_tree_query={
                 'object_provides':

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -2,7 +2,6 @@ from opengever.base.source import DossierPathSourceBinder
 from opengever.base.utils import disable_edit_bar
 from opengever.document import _
 from opengever.meeting.proposal import IProposal
-from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.directives import form
 from plone.formwidget.contenttree.source import CustomFilter
@@ -60,15 +59,9 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
 
         proposal = data['proposal']
         document = self.context
-        if proposal.submit_additional_document(document):
-            api.portal.show_message(
-                _(u'This document was already submitted in that version.'),
-                self.request,
-                type='warn')
+        command = proposal.submit_additional_document(document)
+        command.show_message()
 
-        api.portal.show_message(
-            _(u'Additional document has been submitted successfully'),
-            self.request)
         self.request.RESPONSE.redirect(self.nextURL())
 
     @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -1,0 +1,57 @@
+from opengever.base.source import DossierPathSourceBinder
+from opengever.document import _
+from plone import api
+from plone.autoform.form import AutoExtensibleForm
+from plone.directives import form
+from z3c.form.button import buttonAndHandler
+from z3c.form.form import Form
+from z3c.relationfield.schema import RelationChoice
+
+
+class ISubmitAdditionalDocument(form.Schema):
+
+    proposal = RelationChoice(
+        title=_(u'Proposal', default=u'Proposal'),
+        source=DossierPathSourceBinder(
+            portal_type=("opengever.meeting.proposal"),
+            navigation_tree_query={
+                'object_provides':
+                    ['opengever.dossier.behaviors.dossier.IDossierMarker',
+                     'opengever.meeting.proposal.IProposal'],
+                }),
+        )
+
+
+class SubmitAdditionalDocument(AutoExtensibleForm, Form):
+    """View for submitting an additional document to an already made proposal.
+
+    """
+    ignoreContext = True
+
+    schema = ISubmitAdditionalDocument
+
+    @buttonAndHandler(_(u'button_submit_document', default=u'Submit Document'))
+    def submit_documents(self, action):
+        data, errors = self.extractData()
+        if errors:
+            return
+
+        proposal = data['proposal']
+        document = self.context
+        if proposal.submit_additional_document(document):
+            api.portal.show_message(
+                _(u'This document was already submitted in that version.'),
+                self.request,
+                type='warn')
+
+        api.portal.show_message(
+            _(u'Additional document has been submitted successfully'),
+            self.request)
+        self.request.RESPONSE.redirect(self.nextURL())
+
+    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.request.RESPONSE.redirect(self.nextURL())
+
+    def nextURL(self):
+        return self.context.absolute_url()

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -36,6 +36,7 @@ class ISubmitAdditionalDocument(form.Schema):
                     ['opengever.dossier.behaviors.dossier.IDossierMarker',
                      'opengever.meeting.proposal.IProposal'],
                 }),
+        required=True
         )
 
 

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -71,11 +71,9 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
 
         proposal = self.context
         for document in data['additionalDocuments']:
-            proposal.submit_additional_document(document)
+            command = proposal.submit_additional_document(document)
+            command.show_message()
 
-        api.portal.show_message(
-            _(u'Additional documents have been submitted successfully'),
-            self.request)
         self.request.RESPONSE.redirect(self.nextURL())
 
     @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
@@ -113,7 +111,8 @@ class SubmitDocumentsByPaths(AutoExtensibleForm, Form):
 
         proposal = data['proposal']
         for document in self.get_documents():
-            proposal.submit_additional_document(document)
+            command = proposal.submit_additional_document(document)
+            command.show_message()
 
         self.request.RESPONSE.redirect(self.nextURL())
 

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -1,0 +1,112 @@
+from five import grok
+from opengever.base.source import DossierPathSourceBinder
+from opengever.base.transport import Transporter
+from opengever.document import _
+from opengever.document.document import IDocumentSchema
+from opengever.meeting import is_meeting_feature_enabled
+from plone import api
+from plone.autoform.form import AutoExtensibleForm
+from plone.directives import form
+from z3c.form.button import buttonAndHandler
+from z3c.form.form import Form
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+import json
+
+
+class ISubmitAdditionalDocuments(form.Schema):
+    """Meeting model schema interface."""
+
+    additionalDocuments = RelationList(
+        title=_(u'label_documents', default=u'Documents'),
+        default=[],
+        missing_value=[],
+        value_type=RelationChoice(
+            title=u"Related",
+            source=DossierPathSourceBinder(
+                portal_type=("opengever.document.document", "ftw.mail.mail"),
+                navigation_tree_query={
+                    'object_provides':
+                        ['opengever.dossier.behaviors.dossier.IDossierMarker',
+                         'opengever.document.document.IDocumentSchema',
+                         'opengever.task.task.ITask',
+                         'ftw.mail.mail.IMail', ],
+                    }),
+            ),
+        required=True,
+        )
+
+
+class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
+    """View for submitting additional documents to an already submitted
+    proposal.
+
+    This view is available on proposals to submit multiple documents.
+
+    """
+    ignoreContext = True
+
+    schema = ISubmitAdditionalDocuments
+
+    def available(self):
+        return is_meeting_feature_enabled() and \
+            self.context.is_submit_additional_documents_allowed()
+
+    @buttonAndHandler(_(u'button_submit_documents', default=u'Submit Documents'))
+    def submit_documents(self, action):
+        data, errors = self.extractData()
+        if errors:
+            return
+
+        proposal = self.context
+        for document in data['additionalDocuments']:
+            proposal.submit_additional_document(document)
+
+        api.portal.show_message(
+            _(u'Additional documents have been submitted successfully'),
+            self.request)
+        self.request.RESPONSE.redirect(self.nextURL())
+
+    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.request.RESPONSE.redirect(self.nextURL())
+
+    def nextURL(self):
+        return self.context.absolute_url()
+
+
+class ReceiveObject(grok.View):
+    """Receives a JSON serialized object and creates or updates an instance
+    within its context.
+
+    Returns JSON containing the created object's path and intid.
+
+    """
+    grok.name('update-submitted-document')
+    grok.require('cmf.AddPortalContent')
+    grok.context(IDocumentSchema)
+
+    # XXX only allow if document is in a submitted proposal
+    # XXX only allow if document is not checked out
+    def render(self):
+        transporter = Transporter()
+        transporter.update(self.context, self.request)
+
+        portal_path = '/'.join(api.portal.get().getPhysicalPath())
+        intids = getUtility(IIntIds)
+        repository = api.portal.get_tool('portal_repository')
+        comment = _(u"Updated with a newer docment version from proposal's "
+                    "dossier.")
+        repository.save(obj=self.context, comment=comment)
+
+        data = {
+            'path': '/'.join(self.context.getPhysicalPath())[
+                len(portal_path) + 1:],
+            'intid': intids.queryId(self.context)
+            }
+
+        # Set correct content type for JSON response
+        self.request.response.setHeader("Content-type", "application/json")
+        return json.dumps(data)

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -164,9 +164,6 @@ class ReceiveObject(grok.View):
     grok.require('cmf.AddPortalContent')
     grok.context(IDocumentSchema)
 
-    def is_submitted_document(self):
-        return SubmittedDocument.query.get_by_target(self.context) is not None
-
     def render(self):
         if not self.context.is_submitted_document():
             raise NoSubmittedDocument()

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -5,15 +5,19 @@ from opengever.base.utils import disable_edit_bar
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.meeting import is_meeting_feature_enabled
+from opengever.meeting.browser.documents.submit import ISubmitAdditionalDocument
+from opengever.tabbedview.utils import get_containing_document_tab_url
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.directives import form
 from z3c.form.button import buttonAndHandler
 from z3c.form.form import Form
+from z3c.form.interfaces import HIDDEN_MODE
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
+from zope.schema import TextLine
 import json
 
 
@@ -80,6 +84,71 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
 
     def nextURL(self):
         return self.context.absolute_url()
+
+
+class ISubmitDocumentsByPaths(ISubmitAdditionalDocument):
+
+    paths = TextLine(title=u'Selected Items')
+
+
+class SubmitDocumentsByPaths(AutoExtensibleForm, Form):
+    """View for submitting additional documents to an already submitted
+    proposal.
+
+    This view is available on proposals to submit multiple documents.
+
+    """
+
+    ignoreContext = True
+    schema = ISubmitDocumentsByPaths
+
+    def available(self):
+        return is_meeting_feature_enabled()
+
+    @buttonAndHandler(_(u'button_submit_documents', default=u'Submit Documents'))
+    def submit_documents(self, action):
+        data, errors = self.extractData()
+        if errors:
+            return
+
+        proposal = data['proposal']
+        for document in self.get_documents():
+            proposal.submit_additional_document(document)
+
+        self.request.RESPONSE.redirect(self.nextURL())
+
+    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.request.RESPONSE.redirect(self.nextURL())
+
+    def updateWidgets(self):
+        super(SubmitDocumentsByPaths, self).updateWidgets()
+        self.widgets['paths'].mode = HIDDEN_MODE
+        self.widgets['paths'].value = ';;'.join(self.get_document_paths())
+
+    def get_documents(self):
+        """Return the documents by resolving the submitted paths."""
+
+        docs = []
+        portal = api.portal.get()
+        for document_path in self.get_document_paths():
+            docs.append(
+                portal.unrestrictedTraverse(document_path.encode('utf-8')))
+        return docs
+
+    def get_document_paths(self):
+        """Return document paths from a tabbedview-tab request or from the
+        submitted form.
+
+         """
+        field_name = self.prefix + self.widgets.prefix + 'paths'
+        value = self.request.get(field_name, False)
+        if value:
+            return value.split(';;')
+        return self.request.get('paths', [])
+
+    def nextURL(self):
+        return get_containing_document_tab_url(self.context)
 
 
 class ReceiveObject(grok.View):

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -1,6 +1,7 @@
 from five import grok
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.transport import Transporter
+from opengever.base.utils import disable_edit_bar
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.meeting import is_meeting_feature_enabled
@@ -49,6 +50,10 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
     ignoreContext = True
 
     schema = ISubmitAdditionalDocuments
+
+    def __call__(self):
+        disable_edit_bar()
+        return super(SubmitAdditionalDocuments, self).__call__()
 
     def available(self):
         return is_meeting_feature_enabled() and \

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -1,6 +1,9 @@
+from opengever.base.model import create_session
+from opengever.base.oguid import Oguid
 from opengever.base.request import dispatch_json_request
 from opengever.base.transport import REQUEST_KEY
 from opengever.base.transport import Transporter
+from opengever.meeting.model import SubmittedDocument
 import json
 
 
@@ -22,15 +25,45 @@ class CreateSubmittedProposalCommand(object):
 
 
 class CopyProposalDocumentCommand(object):
+    """Copy documents attached to a proposal to the proposal's associated
+    committee once a proposal is submitted.
 
-    def __init__(self, document, parent_action):
+    """
+    def __init__(self, proposal, document, parent_action=None,
+                 target_path=None, target_admin_unit_id=None):
+        self.proposal = proposal
         self.document = document
-        self.parent_action = parent_action
+        self._parent_action = parent_action
+        self._target_path = target_path
+        self._target_admin_unit_id = target_admin_unit_id
+
+    @property
+    def target_path(self):
+        return self._target_path or self._parent_action.submitted_proposal_path
+
+    @property
+    def target_admin_unit_id(self):
+        return self._target_admin_unit_id or self._parent_action.admin_unit_id
 
     def execute(self):
-        assert self.parent_action.submitted_proposal_path
-        target = self.parent_action.submitted_proposal_path
-        OgCopyCommand(self.document, self.parent_action.admin_unit_id, target).run()
+        reponse = self.copy_document(self.target_path, self.target_admin_unit_id)
+        self.add_database_entry(reponse, self.target_admin_unit_id)
+
+    def add_database_entry(self, reponse, target_admin_unit_id):
+        oguid = Oguid.for_object(self.document)
+        submitted_version = self.document.get_current_version()
+        doc = SubmittedDocument(oguid=oguid,
+                                proposal=self.proposal.load_model(),
+                                submitted_admin_unit_id=target_admin_unit_id,
+                                submitted_int_id=reponse['intid'],
+                                submitted_physical_path=reponse['path'],
+                                submitted_version=submitted_version)
+        session = create_session()
+        session.add(doc)
+
+    def copy_document(self, target_path, target_admin_unit_id):
+        return OgCopyCommand(
+            self.document, target_admin_unit_id, target_path).execute()
 
 
 class OgCopyCommand(object):
@@ -40,6 +73,6 @@ class OgCopyCommand(object):
         self.target_path = target_path
         self.target_admin_unit_id = target_admin_unit_id
 
-    def run(self):
-        Transporter().transport_to(
+    def execute(self):
+        return Transporter().transport_to(
             self.source, self.target_admin_unit_id, self.target_path)

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -38,7 +38,7 @@ class NullUpdateSubmittedDocumentCommand(object):
         portal = api.portal.get()
         api.portal.show_message(
             _(u'Document ${title} has already been submitted in that version',
-              mapping=dict(title=self.document.Title().decode('utf-8'))),
+              mapping=dict(title=self.document.title)),
             portal.REQUEST,
             type='warn')
 
@@ -66,7 +66,7 @@ class UpdateSubmittedDocumentCommand(object):
         portal = api.portal.get()
         api.portal.show_message(
             _(u'A new submitted version of document ${title} has been created',
-              mapping=dict(title=self.document.Title().decode('utf-8'))),
+              mapping=dict(title=self.document.title)),
             portal.REQUEST)
 
 
@@ -99,7 +99,7 @@ class CopyProposalDocumentCommand(object):
         portal = api.portal.get()
         api.portal.show_message(
             _(u'Additional document ${title} has been submitted successfully',
-              mapping=dict(title=self.document.Title().decode('utf-8'))),
+              mapping=dict(title=self.document.title)),
             portal.REQUEST)
 
     def add_database_entry(self, reponse, target_admin_unit_id):

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -24,6 +24,26 @@ class CreateSubmittedProposalCommand(object):
         self.submitted_proposal_path = response['path']
 
 
+class UpdateSubmittedDocumentCommand(object):
+
+    def __init__(self, proposal, document, submitted_document):
+        self.proposal = proposal
+        self.document = document
+        self.submitted_document = submitted_document
+
+    def execute(self):
+        Transporter().transport_to(
+            self.document,
+            self.submitted_document.submitted_admin_unit_id,
+            self.submitted_document.submitted_physical_path,
+            view='update-submitted-document')
+
+        submitted_version = self.document.get_current_version()
+        submitted_document = SubmittedDocument.query.get_by_source(
+            self.proposal, self.document)
+        submitted_document.submitted_version = submitted_version
+
+
 class CopyProposalDocumentCommand(object):
     """Copy documents attached to a proposal to the proposal's associated
     committee once a proposal is submitted.

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -1,0 +1,4 @@
+class NoSubmittedDocument(Exception):
+    """A document could not be updates remotely since it is not a submitted
+    document.
+    """

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -1,4 +1,5 @@
 from opengever.base.model import create_session
+from opengever.base.utils import disable_edit_bar
 from opengever.meeting import _
 from opengever.meeting import is_meeting_feature_enabled
 from plone.autoform.form import AutoExtensibleForm
@@ -19,7 +20,7 @@ class ModelAddForm(AutoExtensibleForm, AddForm):
     def __init__(self, context, request):
         super(ModelAddForm, self).__init__(context, request)
         self._created_object = None
-        self.request.set('disable_border', True)  # disables the edit bar.
+        disable_edit_bar()
 
     def create(self, data):
         return self.model_class(**data)

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -1,0 +1,12 @@
+from five import grok
+from OFS.interfaces import IObjectWillBeRemovedEvent
+from opengever.base.model import create_session
+from opengever.document.document import IDocumentSchema
+from opengever.meeting.model import SubmittedDocument
+
+
+@grok.subscribe(IDocumentSchema, IObjectWillBeRemovedEvent)
+def document_deleted(context, event):
+    session = create_session()
+    for doc in SubmittedDocument.query.by_document(context).all():
+        session.delete(doc)

--- a/opengever/meeting/model/__init__.py
+++ b/opengever/meeting/model/__init__.py
@@ -4,3 +4,4 @@ from opengever.meeting.model.meeting import Meeting
 from opengever.meeting.model.member import Member
 from opengever.meeting.model.membership import Membership
 from opengever.meeting.model.proposal import Proposal
+from opengever.meeting.model.submitteddocument import SubmittedDocument

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -2,6 +2,7 @@ from datetime import date
 from opengever.base.oguid import Oguid
 from opengever.ogds.models.query import BaseQuery
 from plone import api
+from sqlalchemy import or_
 
 
 class ProposalQuery(BaseQuery):
@@ -60,3 +61,14 @@ class SubmittedDocumentQuery(BaseQuery):
     def get_by_target(self, document):
         oguid = Oguid.for_object(document)
         return self.filter(self._attribute('submitted_oguid') == oguid).first()
+
+    def by_document(self, document):
+        """Filter by document's oguid on source or target side of a submitted
+        doucment.
+
+        """
+        oguid = Oguid.for_object(document)
+        return self.filter(or_(
+            self._attribute('submitted_oguid') == oguid,
+            self._attribute('oguid') == oguid
+        ))

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -1,4 +1,5 @@
 from datetime import date
+from opengever.base.oguid import Oguid
 from opengever.ogds.models.query import BaseQuery
 from plone import api
 
@@ -45,3 +46,17 @@ class MembershipQuery(BaseQuery):
 
     def only_active(self):
         return self.filter(self._attribute('date_from') <= date.today())
+
+
+class SubmittedDocumentQuery(BaseQuery):
+
+    def get_by_source(self, proposal, document):
+        oguid = Oguid.for_object(document)
+        proposal_model = proposal.load_model()
+        return self.filter(self._attribute('oguid') == oguid)\
+                   .filter(self._attribute('proposal') == proposal_model)\
+                   .first()
+
+    def get_by_target(self, document):
+        oguid = Oguid.for_object(document)
+        return self.filter(self._attribute('submitted_oguid') == oguid).first()

--- a/opengever/meeting/model/submitteddocument.py
+++ b/opengever/meeting/model/submitteddocument.py
@@ -1,0 +1,53 @@
+from opengever.base.model import Base
+from opengever.base.oguid import Oguid
+from opengever.meeting.model.query import SubmittedDocumentQuery
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.orm import composite
+from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
+
+
+class SubmittedDocument(Base):
+    """Represents a document that was submitted with a proposal.
+
+    Links document in a proposal's dossier to the submitted version in a
+    submitted proposal.
+
+    """
+    query_cls = SubmittedDocumentQuery
+
+    __tablename__ = 'submitteddocuments'
+    __table_args__ = (
+        UniqueConstraint('admin_unit_id', 'int_id', 'proposal_id',
+                         name='ix_submitted_document_unique_source'),
+        UniqueConstraint('submitted_admin_unit_id', 'submitted_int_id',
+                         name='ix_submitted_document_unique_target'),
+        {})
+
+    document_id = Column("id", Integer, Sequence("submitteddocument_id_seq"),
+                         primary_key=True)
+    admin_unit_id = Column(String(30), nullable=False)
+    int_id = Column(Integer, nullable=False)
+    oguid = composite(Oguid, admin_unit_id, int_id)
+    proposal_id = Column(Integer, ForeignKey('proposals.id'), nullable=False)
+    proposal = relationship("Proposal", backref='submitted_documents')
+    submitted_version = Column(Integer, nullable=False)
+
+    submitted_admin_unit_id = Column(String(30))
+    submitted_int_id = Column(Integer)
+    submitted_oguid = composite(
+        Oguid, submitted_admin_unit_id, submitted_int_id)
+    submitted_physical_path = Column(String(256))
+
+    def __repr__(self):
+        return "<SubmittedDocument {}@{}>".format(
+            self.int_id, self.admin_unit_id)
+
+    def is_up_to_date(self, document):
+        assert Oguid.for_object(document) == self.oguid, 'invalid document'
+
+        return self.submitted_version == document.get_current_version()

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4207</version>
+    <version>4208</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4208</version>
+    <version>4209</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/types/opengever.meeting.proposal.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.proposal.xml
@@ -67,4 +67,14 @@
     <permission value="View"/>
   </action>
 
+  <action
+        action_id="submit_additional_documents"
+        visible="True"
+        title="Submit additional documents"
+        url_expr="string:${object_url}/@@submit_additional_documents"
+        condition_expr="object/@@submit_additional_documents/available"
+        category="object_buttons">
+    <permission value="opengever.meeting: Add Proposal"/>
+  </action>
+
 </object>

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -256,6 +256,9 @@ class SubmittedProposal(ProposalBase):
 
         return [document.getObject() for document in documents]
 
+    def is_submit_additional_documents_allowed(self):
+        return False
+
 
 class Proposal(ProposalBase):
     """Act as proxy for the proposal stored in the database.

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -3,6 +3,7 @@ from opengever.base.source import DossierPathSourceBinder
 from opengever.meeting import _
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
+from opengever.meeting.command import NullUpdateSubmittedDocumentCommand
 from opengever.meeting.command import UpdateSubmittedDocumentCommand
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.model import SubmittedDocument
@@ -315,9 +316,10 @@ class Proposal(ProposalBase):
 
         if submitted_document:
             if submitted_document.is_up_to_date(document):
-                return None
-            command = UpdateSubmittedDocumentCommand(
-                self, document, submitted_document)
+                command = NullUpdateSubmittedDocumentCommand(document)
+            else:
+                command = UpdateSubmittedDocumentCommand(
+                    self, document, submitted_document)
 
         else:
             command = CopyProposalDocumentCommand(

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.oguid import Oguid
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.proposal import Proposal
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
@@ -168,6 +169,16 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(document.Title(), submitted_document.Title())
         self.assertEqual(document.file.filename,
                          submitted_document.file.filename)
+
+        # submitted document is created
+        submitted_document_model = SubmittedDocument.query.get_by_source(
+            proposal, document)
+        self.assertIsNotNone(submitted_document_model)
+        self.assertEqual(Oguid.for_object(submitted_document),
+                         submitted_document_model.submitted_oguid)
+        self.assertEqual(0, submitted_document_model.submitted_version)
+        self.assertEqual(proposal.load_model(),
+                         submitted_document_model.proposal)
 
     @browsing
     def test_proposal_can_be_submitted(self, browser):

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -7,6 +7,7 @@ from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.proposal import Proposal
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
+from plone import api
 from zExceptions import Unauthorized
 
 
@@ -170,15 +171,7 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(document.file.filename,
                          submitted_document.file.filename)
 
-        # submitted document is created
-        submitted_document_model = SubmittedDocument.query.get_by_source(
-            proposal, document)
-        self.assertIsNotNone(submitted_document_model)
-        self.assertEqual(Oguid.for_object(submitted_document),
-                         submitted_document_model.submitted_oguid)
-        self.assertEqual(0, submitted_document_model.submitted_version)
-        self.assertEqual(proposal.load_model(),
-                         submitted_document_model.proposal)
+        self.assertSubmittedDocumentCreated(proposal, document, submitted_document)
 
     @browsing
     def test_proposal_can_be_submitted(self, browser):
@@ -192,3 +185,70 @@ class TestProposal(FunctionalTestCase):
         browser.css('#pending-submitted').first.click()
 
         self.assertEqual(Proposal.STATE_SUBMITTED, proposal.get_state())
+
+    def test_submit_additional_document_creates_new_document(self):
+        committee = create(Builder('committee').titled('My committee'))
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .titled(u'A Document')
+                          .with_dummy_content())
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model()))
+
+        self.assertFalse(proposal.is_submit_additional_documents_allowed())
+        proposal.execute_transition('pending-submitted')
+        self.assertTrue(proposal.is_submit_additional_documents_allowed())
+
+        proposal.submit_additional_document(document)
+        submitted_proposal = api.portal.get().restrictedTraverse(
+            proposal.load_model().submitted_physical_path.encode('utf-8'))
+        docs = submitted_proposal.listFolderContents()
+        self.assertEqual(1, len(docs))
+        submitted_document = docs.pop()
+
+        self.assertEqual(document.Title(), submitted_document.Title())
+        self.assertEqual(document.file.filename,
+                         submitted_document.file.filename)
+
+        self.assertSubmittedDocumentCreated(proposal, document, submitted_document)
+
+    def test_submit_new_document_version_updates_submitted_document(self):
+        committee = create(Builder('committee').titled('My committee'))
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .titled(u'A Document')
+                          .with_dummy_content())
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model())
+                          .relate_to(document))
+
+        proposal.execute_transition('pending-submitted')
+        self.assertTrue(proposal.is_submit_additional_documents_allowed())
+
+        submitted_proposal = api.portal.get().restrictedTraverse(
+            proposal.load_model().submitted_physical_path.encode('utf-8'))
+        docs = submitted_proposal.get_documents()
+        submitted_document = docs.pop()
+        self.assertEqual(0, submitted_document.get_current_version())
+
+        # create some new document versions
+        repository = api.portal.get_tool('portal_repository')
+        repository.save(document)
+        repository.save(document)
+        proposal.submit_additional_document(document)
+
+        self.assertEqual(1, submitted_document.get_current_version())
+
+    def assertSubmittedDocumentCreated(self, proposal, document, submitted_document):
+        submitted_document_model = SubmittedDocument.query.get_by_source(
+            proposal, document)
+        self.assertIsNotNone(submitted_document_model)
+        self.assertEqual(Oguid.for_object(submitted_document),
+                         submitted_document_model.submitted_oguid)
+        self.assertEqual(0, submitted_document_model.submitted_version)
+        self.assertEqual(proposal.load_model(),
+                         submitted_document_model.proposal)

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -1,0 +1,108 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.base.oguid import Oguid
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.model import SubmittedDocument
+from opengever.testing import FunctionalTestCase
+from plone import api
+import transaction
+
+
+class TestSubmitAdditionalDocuments(FunctionalTestCase):
+    """Functional tests to make sure submitting additional documents for
+    proposals works as expected.
+
+    """
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestSubmitAdditionalDocuments, self).setUp()
+        root = create(Builder('repository_root'))
+        folder = create(Builder('repository').within(root))
+        self.dossier = create(Builder('dossier').within(folder))
+        self.committee = create(Builder('committee').titled('My committee'))
+        self.document = create(Builder('document')
+                               .within(self.dossier)
+                               .titled(u'A Document')
+                               .with_dummy_content())
+
+    def setup_proposal(self, attach_document=False):
+        builder = (
+            Builder('proposal')
+            .within(self.dossier)
+            .titled(u'My Proposal')
+            .having(committee=self.committee.load_model()))
+        if attach_document:
+            builder = builder.relate_to(self.document)
+
+        proposal = create(builder)
+        proposal.execute_transition('pending-submitted')
+        self.assertTrue(proposal.is_submit_additional_documents_allowed())
+        transaction.commit()
+        return proposal
+
+    @browsing
+    def test_submit_new_document_to_proposal_on_document_view(self, browser):
+        proposal = self.setup_proposal()
+
+        browser.login().visit(self.document)
+        browser.find('Submit additional document').click()
+        browser.fill({'Proposal': proposal})
+        browser.find('Submit Document').click()
+
+        self.assertSubmittedDocumentCreated(proposal, self.document)
+        self.assertSequenceEqual(
+            ['Additional document A Document has been submitted successfully'],
+            info_messages())
+
+    @browsing
+    def test_submit_new_document_to_proposal_on_proposal_view(self, browser):
+        proposal = self.setup_proposal()
+
+        browser.login().visit(proposal)
+        browser.find('Submit additional documents').click()
+        browser.fill({'Documents': self.document})
+        browser.find('Submit Documents').click()
+
+        self.assertSubmittedDocumentCreated(proposal, self.document)
+        self.assertSequenceEqual(
+            ['Additional document A Document has been submitted successfully'],
+            info_messages())
+
+    @browsing
+    def test_update_existing_document_version_on_proposal_view(self, browser):
+        proposal = self.setup_proposal(attach_document=True)
+
+        # create some new document versions
+        repository = api.portal.get_tool('portal_repository')
+        repository.save(self.document)
+        repository.save(self.document)
+        transaction.commit()
+
+        browser.login().visit(proposal)
+        browser.find('Submit additional documents').click()
+        browser.fill({'Documents': self.document})
+        browser.find('Submit Documents').click()
+
+        self.assertSubmittedDocumentCreated(
+            proposal, self.document, submitted_version=2)
+        self.assertSequenceEqual(
+            ['A new submitted version of document A Document has been created'],
+            info_messages())
+
+    def assertSubmittedDocumentCreated(self, proposal, document,
+                                       submitted_version=0):
+        portal = api.portal.get()
+        submitted_document_model = SubmittedDocument.query.get_by_source(
+            proposal, document)
+        submitted_document = portal.restrictedTraverse(
+            submitted_document_model.submitted_physical_path.encode('utf-8'))
+        self.assertIsNotNone(submitted_document_model)
+        self.assertEqual(Oguid.for_object(submitted_document),
+                         submitted_document_model.submitted_oguid)
+        self.assertEqual(submitted_version,
+                         submitted_document_model.submitted_version)
+        self.assertEqual(proposal.load_model(),
+                         submitted_document_model.proposal)

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -111,7 +111,6 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
             ['A new submitted version of document A Document has been created'],
             info_messages())
 
-
     def assertSubmittedDocumentCreated(self, proposal, document,
                                        submitted_version=0):
         portal = api.portal.get()

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -82,4 +82,13 @@
         directory="profiles/4207"
         />
 
+    <!-- 4207 -> 4208 -->
+    <genericsetup:upgradeStep
+        title="Add Submitted Documents table."
+        description=""
+        source="4207"
+        destination="4208"
+        handler="opengever.meeting.upgrades.to4208.AddSubmittedDocumentsTable"
+        profile="opengever.meeting:default"
+        />
 </configure>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -91,4 +91,14 @@
         handler="opengever.meeting.upgrades.to4208.AddSubmittedDocumentsTable"
         profile="opengever.meeting:default"
         />
+
+    <!-- 4208 -> 4209 -->
+    <upgrade-step:importProfile
+        title="Add submit additional documents action to proposal."
+        profile="opengever.meeting:default"
+        source="4208"
+        destination="4209"
+        directory="profiles/4209"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4209/types/opengever.meeting.proposal.xml
+++ b/opengever/meeting/upgrades/profiles/4209/types/opengever.meeting.proposal.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.proposal" meta_type="Dexterity FTI"
+        i18n:domain="opengever.meeting" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <action
+        action_id="submit_additional_documents"
+        visible="True"
+        title="Submit additional documents"
+        url_expr="string:${object_url}/@@submit_additional_documents"
+        condition_expr="object/@@submit_additional_documents/available"
+        category="object_buttons">
+    <permission value="opengever.meeting: Add Proposal"/>
+  </action>
+
+</object>

--- a/opengever/meeting/upgrades/to4200.py
+++ b/opengever/meeting/upgrades/to4200.py
@@ -37,7 +37,7 @@ class AddMeetingTable(SchemaMigration):
         self.op.create_table(
             'agendaitems',
             Column("id", Integer, Sequence("agendaitems_id_seq"), primary_key=True),
-            Column("agenda_item_id", Integer, ForeignKey('meetings.id'), nullable=False),
+            Column("meeting_id", Integer, ForeignKey('meetings.id'), nullable=False),
             Column("proposal_id", Integer, ForeignKey('proposals.id')),
             Column("title", Text),
             Column('number', String(16)),

--- a/opengever/meeting/upgrades/to4208.py
+++ b/opengever/meeting/upgrades/to4208.py
@@ -1,0 +1,38 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.schema import Sequence
+
+
+class AddSubmittedDocumentsTable(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4208
+
+    def migrate(self):
+        self.add_submitted_documents_table()
+
+    def add_submitted_documents_table(self):
+        self.op.create_table(
+            'submitteddocuments',
+            Column("id", Integer, Sequence("submitteddocument_id_seq"),
+                   primary_key=True),
+            Column("admin_unit_id", String(30), nullable=False),
+            Column("int_id", Integer, nullable=False),
+            Column("proposal_id", Integer, ForeignKey('proposals.id'),
+                   nullable=False),
+            Column("submitted_version", Integer, nullable=False),
+            Column("submitted_admin_unit_id", String(30)),
+            Column("submitted_int_id", Integer),
+            Column("submitted_physical_path", String(256))
+        )
+        self.op.create_index(
+            'ix_submitted_document_unique_source',
+            'submitteddocuments',
+            ['admin_unit_id', 'int_id', 'proposal_id'])
+        self.op.create_index(
+            'ix_submitted_document_unique_target',
+            'submitteddocuments',
+            ['submitted_admin_unit_id', 'submitted_int_id'])

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -113,6 +113,7 @@ class Documents(OpengeverCatalogListingTab):
         'checkin_without_comment',
         'cancel',
         'create_task',
+        'submit_additional_documents',
         'trashed',
         'move_items',
         'copy_items',

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -8,6 +8,7 @@ from opengever.meeting.proposal import Proposal
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.testing import assets
 from opengever.trash.trash import ITrashable
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
@@ -247,6 +248,27 @@ class ProposalBuilder(DexterityBuilder):
         return self.having(relatedItems=related_documents)
 
 builder_registry.register('proposal', ProposalBuilder)
+
+
+class SubmittedProposalBuilder(object):
+
+    def __init__(self, session):
+        self.session = session
+        self.proposal = None
+
+    def submitting(self, proposal):
+        self.proposal = proposal
+        return self
+
+    def create(self):
+        assert self.proposal, 'source proposal must be specified'
+
+        self.proposal.execute_transition('pending-submitted')
+        proposal_model = self.proposal.load_model()
+        path = proposal_model.submitted_physical_path.encode('utf-8')
+        return api.portal.get().restrictedTraverse(path)
+
+builder_registry.register('submitted_proposal', SubmittedProposalBuilder)
 
 
 class CommitteeContainerBuilder(DexterityBuilder):


### PR DESCRIPTION
This PR allows submitting additional documents to already made proposals. It introduces the following changes:
  - add actions/views to proposal and document/documents tabs
  - track submitted documents in a separate table
  - create entries in the tracking table on proposal submission for all attached documents
  - remove entries in the tracking table when a document is deleted
