### PR TITLE
Show proposal history on proposal overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -68,6 +68,7 @@ Changelog
     - Add cancel buttons and form labels.
     - Add tabs to committee container for committees and members.
     - Allow submission of additional documents to already submitted proposals.
+    - Log proposal history and display changes on the proposal overview.
 
   [deiferni]
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -159,11 +159,6 @@ class DeleteAgendaItem(BrowserView):
         if not agenda_item:
             raise NotFound
 
-        meeting = agenda_item.meeting
-        assert meeting.is_editable()
-
-        session = create_session()
-        session.delete(agenda_item)
-        meeting.reorder_agenda_items()
+        agenda_item.remove()
 
         return self.request.response.redirect(self.nextURL())

--- a/opengever/meeting/browser/proposaloverview.py
+++ b/opengever/meeting/browser/proposaloverview.py
@@ -31,6 +31,9 @@ class OverviewBase(object):
     def documents(self):
         return self.context.get_documents()
 
+    def history(self):
+        return self.context.load_model().history_records
+
 
 class ProposalOverview(OverviewBase, DisplayForm, OpengeverTab):
     grok.context(IProposal)

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -47,5 +47,28 @@
 
     <div tal:replace="structure provider:plone.belowcontentbody" />
     <div class="visualClear"><!----></div>
+
+    <h3 i18n:translate="">History</h3>
+
+    <div class="answers">
+      <tal:repeat tal:repeat="history_record view/history">
+
+          <div tal:attributes="class string:answer ${history_record/css_class}">
+
+            <div class="answerType">&nbsp;</div>
+            <div class="answerBody">
+              <div class="date" tal:content="python:here.toLocalizedTime(history_record.created, long_format=True)" />
+
+              <div class="manageActions">
+              </div>
+
+              <h3 tal:content="structure history_record/message" i18n:translate="">
+              </h3>
+            </div>
+          </div>
+          <div style="clear:both"><!-- --></div>
+      </tal:repeat>
+    </div>
+
   </tal:i18n>
 </html>

--- a/opengever/meeting/container.py
+++ b/opengever/meeting/container.py
@@ -48,9 +48,15 @@ class ModelContainer(Container):
         # the just created plone content now.
         aq_wrapped_self = self.__of__(context)
         data.update(self.get_model_create_arguments(context))
-        session.add(self.model_class(oguid=oguid, **data))
+        model_instance = self.model_class(oguid=oguid, **data)
+        session.add(model_instance)
+        self._after_model_created(model_instance)
 
         notify(ObjectModifiedEvent(aq_wrapped_self))
+
+    def _after_model_created(self, model_instance):
+        """Hook called right after creating a model instance."""
+        pass
 
     def update_model(self, data):
         """Store form input in relational database.

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -42,5 +42,7 @@ class AgendaItem(Base):
         assert self.meeting.is_editable()
 
         session = create_session()
+        if self.proposal:
+            self.proposal.remove_scheduled(self.meeting)
         session.delete(self)
         self.meeting.reorder_agenda_items()

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -1,4 +1,5 @@
 from opengever.base.model import Base
+from opengever.base.model import create_session
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -36,3 +37,10 @@ class AgendaItem(Base):
 
     def get_css_class(self):
         return "paragraph" if self.is_paragraph else ""
+
+    def remove(self):
+        assert self.meeting.is_editable()
+
+        session = create_session()
+        session.delete(self)
+        self.meeting.reorder_agenda_items()

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+from opengever.base.model import Base
+from opengever.meeting import _
+from opengever.ogds.base.actor import Actor
+from plone import api
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
+
+
+def get_current_user_id():
+    return api.user.get_current().getId()
+
+
+class ProposalHistory(Base):
+
+    css_class = None
+
+    __tablename__ = 'proposalhistory'
+
+    proposal_history_record_id = Column(
+        "id", Integer,
+        Sequence("proposal_history_id_seq"), primary_key=True)
+    proposal_id = Column(Integer, ForeignKey('proposals.id'), nullable=False)
+    proposal = relationship('Proposal')
+    created = Column(DateTime, default=datetime.now, nullable=False)
+    userid = Column(String(256), default=get_current_user_id, nullable=False)
+
+    proposal_history_type = Column(String(100), nullable=False)
+    __mapper_args__ = {'polymorphic_on': proposal_history_type}
+
+    def message(self):
+        raise NotImplementedError()
+
+
+class Created(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'created'}
+
+    css_class = 'created'
+
+    def message(self):
+        return _(u'proposal_history_label_created',
+                 u'Created by ${user}',
+                 mapping={'user': Actor.lookup(self.userid).get_link()})
+
+
+class Submitted(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'submitted'}
+
+    def message(self):
+        return _(u'proposal_history_label_submitted',
+                 u'Submitted by ${user}',
+                 mapping={'user': Actor.lookup(self.userid).get_link()})
+
+
+class Scheduled(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'scheduled'}
+
+    def message(self):
+        return _(u'proposal_history_label_scheduled',
+                 u'Scheduled by ${user}',
+                 mapping={'user': Actor.lookup(self.userid).get_link()})
+
+
+class RemoveScheduled(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'removescheduled'}
+
+    def message(self):
+        return _(u'proposal_history_label_remove_scheduled',
+                 u'Removed from schedule by ${user}',
+                 mapping={'user': Actor.lookup(self.userid).get_link()})
+
+
+class DocumentSubmitted(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'documentsubmitted'}
+
+    css_class = 'addDocument'
+
+    def message(self):
+        return _(u'proposal_history_label_document_submitted',
+                 u'Document submitted by ${user}',
+                 mapping={'user': Actor.lookup(self.userid).get_link()})
+
+
+class DocumentUpdated(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'documentupdated'}
+
+    css_class = 'updateDocument'
+
+    def message(self):
+        return _(u'proposal_history_label_document_submitted',
+                 u'Submitted document updated by ${user}',
+                 mapping={'user': Actor.lookup(self.userid).get_link()})

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4209</version>
+    <version>4210</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -1,3 +1,4 @@
+from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.source import DossierPathSourceBinder
 from opengever.meeting import _
@@ -6,6 +7,7 @@ from opengever.meeting.command import CreateSubmittedProposalCommand
 from opengever.meeting.command import NullUpdateSubmittedDocumentCommand
 from opengever.meeting.command import UpdateSubmittedDocumentCommand
 from opengever.meeting.container import ModelContainer
+from opengever.meeting.model import proposalhistory
 from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.proposal import Proposal as ProposalModel
 from opengever.meeting.workflow import State
@@ -282,6 +284,10 @@ class Proposal(ProposalBase):
         Submit('pending', 'submitted',
                title=_('submit', default='Submit')),
         ])
+
+    def _after_model_created(self, model_instance):
+        session = create_session()
+        session.add(proposalhistory.Created(proposal=model_instance))
 
     def get_documents(self):
         documents = [relation.to_object for relation in self.relatedItems]

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -1,0 +1,134 @@
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.browser.meetings.meetinglist import MeetingList
+from opengever.testing import FunctionalTestCase
+from plone import api
+import transaction
+
+
+class TestProposalHistory(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestProposalHistory, self).setUp()
+        container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee').within(container))
+        self.meeting = create(Builder('meeting')
+                              .having(committee=self.committee.load_model(),
+                                      date=date(2013, 1, 1),
+                                      location='There',))
+        root = create(Builder('repository_root'))
+        folder = create(Builder('repository').within(root))
+        self.dossier = create(Builder('dossier').within(folder))
+        self.document = create(Builder('document')
+                               .within(self.dossier)
+                               .titled('A Document'))
+        self.proposal = create(Builder('proposal')
+                               .within(self.dossier)
+                               .having(title='Mach doch',
+                                       committee=self.committee.load_model())
+                               .relate_to(self.document))
+
+    def open_overview(self, browser):
+        browser.open(self.proposal, view='tabbedview_view-overview')
+
+    def get_latest_history_entry_text(self, browser):
+        return browser.css('div.answers .answer h3').first.text
+
+    def get_history_entries_text(self, browser):
+        return browser.css('div.answers .answer h3').text
+
+    def submit_proposal(self):
+        self.proposal.execute_transition('pending-submitted')
+
+    @browsing
+    def test_creation_creates_history_entry(self, browser):
+        browser.login()
+
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Created by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))
+
+    @browsing
+    def test_submitting_proposal_creates_history_entries(self, browser):
+        browser.login()
+        self.open_overview(browser)
+
+        # submit proposal
+        browser.css('#pending-submitted').first.click()
+
+        self.open_overview(browser)
+        self.assertSequenceEqual(
+            [u'Document submitted by Test User (test_user_1_)',
+             u'Submitted by Test User (test_user_1_)'],
+            self.get_history_entries_text(browser)[:2])
+
+    @browsing
+    def test_submitting_additional_document_creates_history_entry(self, browser):
+        self.submit_proposal()
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .titled('Another document'))
+
+        browser.login().visit(self.proposal)
+        browser.find('Submit additional documents').click()
+        browser.fill({'Documents': document})
+        browser.find('Submit Documents').click()
+
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Document submitted by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))
+
+    @browsing
+    def test_upading_existing_document_creates_history_entry(self, browser):
+        self.submit_proposal()
+        repository = api.portal.get_tool('portal_repository')
+        repository.save(self.document)
+        transaction.commit()
+
+        browser.login().visit(self.proposal)
+        browser.find('Submit additional documents').click()
+        browser.fill({'Documents': self.document})
+        browser.find('Submit Documents').click()
+
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Submitted document updated by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))
+
+    @browsing
+    def test_scheduling_creates_history_entry(self, browser):
+        self.submit_proposal()
+        browser.login().open(MeetingList.url_for(self.committee, self.meeting))
+        form = browser.css('#schedule_proposal').first
+        form.fill(
+            {'proposal_id': str(self.proposal.load_model().proposal_id)}
+        ).submit()
+
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Scheduled by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))
+
+    @browsing
+    def test_removing_from_schedule_creates_history_entry(self, browser):
+        self.submit_proposal()
+        # schedule proposal
+        browser.login().open(MeetingList.url_for(self.committee, self.meeting))
+        form = browser.css('#schedule_proposal').first
+        form.fill(
+            {'proposal_id': str(self.proposal.load_model().proposal_id)}
+        ).submit()
+
+        browser.css('.delete_agenda_item').first.click()
+
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Removed from schedule by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -101,4 +101,14 @@
         directory="profiles/4209"
         />
 
+    <!-- 4209 -> 4210 -->
+    <genericsetup:upgradeStep
+        title="Add proposal history table."
+        description=""
+        source="4209"
+        destination="4210"
+        handler="opengever.meeting.upgrades.to4210.AddProposalHistory"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4210.py
+++ b/opengever/meeting/upgrades/to4210.py
@@ -1,0 +1,28 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.schema import Sequence
+
+
+class AddProposalHistory(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4210
+
+    def migrate(self):
+        self.add_proposal_history_table()
+
+    def add_proposal_history_table(self):
+        self.op.create_table(
+            'proposalhistory',
+            Column("id", Integer, Sequence("proposal_history_id_seq"),
+                   primary_key=True),
+            Column("proposal_id", Integer, ForeignKey('proposals.id'),
+                   nullable=False),
+            Column("created", DateTime, nullable=False),
+            Column("userid", String(256), nullable=False),
+            Column("proposal_history_type", String(100), nullable=False)
+        )


### PR DESCRIPTION
Creates history entries for the following proposal-related actions:
 - creating a proposal
 - submitting a proposal
 - scheduling a proposal
 - removing a proposal from schedule
 - submit documents/additional documents
 - update submitted documents

It looks like this:

![screen shot 2015-02-23 at 15 58 14](https://cloud.githubusercontent.com/assets/736583/6350576/7842b418-bc35-11e4-8c77-b3f8acb44938.png)

Note that the history should contain addtitional information for some actions and that icons are missing. These todos are tracked in #728.