### PR TITLE
Meeting listings improvements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Meeting listing improvments:
+    - Disable selection links for listins without checkbox column.
+
+  [phgross]
+
 - Task workflow: Make workflow also manage add permissions for mails,
   the same way it does for documents. In particular, this avoids mails
   being addable in tasks in state 'tested-and-closed'.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
-- Meeting listing improvments:
+- Meeting listing improvements:
     - Disable selection links for listins without checkbox column.
+    - Extend proposal listing columns.
 
   [phgross]
 

--- a/opengever/meeting/browser/committeecontainertabs.py
+++ b/opengever/meeting/browser/committeecontainertabs.py
@@ -2,11 +2,14 @@ from five import grok
 from opengever.meeting.committeecontainer import ICommitteeContainer
 from opengever.meeting.tabs.committeelisting import CommitteeListingTab
 from opengever.meeting.tabs.memberlisting import MemberListingTab
+from zope.app.pagetemplate import ViewPageTemplateFile
 
 
 class Committees(CommitteeListingTab):
     grok.name('tabbedview_view-committees')
     grok.context(ICommitteeContainer)
+
+    selection = ViewPageTemplateFile("templates/no_selection.pt")
 
     enabled_actions = []
     major_actions = []
@@ -15,6 +18,8 @@ class Committees(CommitteeListingTab):
 class Members(MemberListingTab):
     grok.name('tabbedview_view-members')
     grok.context(ICommitteeContainer)
+
+    selection = ViewPageTemplateFile("templates/no_selection.pt")
 
     enabled_actions = []
     major_actions = []

--- a/opengever/meeting/browser/committeetabs.py
+++ b/opengever/meeting/browser/committeetabs.py
@@ -3,11 +3,14 @@ from opengever.meeting.committee import ICommittee
 from opengever.meeting.tabs.meetinglisting import MeetingListingTab
 from opengever.meeting.tabs.membershiplisting import MembershipListingTab
 from opengever.meeting.tabs.submittedproposallisting import SubmittedProposalListingTab
+from zope.app.pagetemplate import ViewPageTemplateFile
 
 
 class Meetings(MeetingListingTab):
     grok.name('tabbedview_view-meetings')
     grok.context(ICommittee)
+
+    selection = ViewPageTemplateFile("templates/no_selection.pt")
 
     enabled_actions = []
     major_actions = []
@@ -17,6 +20,8 @@ class SubmittedProposals(SubmittedProposalListingTab):
     grok.name('tabbedview_view-submittedproposals')
     grok.context(ICommittee)
 
+    selection = ViewPageTemplateFile("templates/no_selection.pt")
+
     enabled_actions = []
     major_actions = []
 
@@ -24,6 +29,8 @@ class SubmittedProposals(SubmittedProposalListingTab):
 class Memberships(MembershipListingTab):
     grok.name('tabbedview_view-memberships')
     grok.context(ICommittee)
+
+    selection = ViewPageTemplateFile("templates/no_selection.pt")
 
     enabled_actions = []
     major_actions = []

--- a/opengever/meeting/browser/meetings/preprotocol.py
+++ b/opengever/meeting/browser/meetings/preprotocol.py
@@ -94,12 +94,12 @@ class EditPreProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
         self.model.update_model(model_data)
 
     # this renames the button but otherwise preserves super's behaviour
-    @button.buttonAndHandler(_('Save'), name='save')
+    @button.buttonAndHandler(_('Save', default=u'Save'), name='save')
     def handleApply(self, action):
         # self as first argument is required by to the decorator
         super(EditPreProtocol, self).handleApply(self, action)
 
-    @button.buttonAndHandler(_('Cancel'), name='cancel')
+    @button.buttonAndHandler(_('Cancel', default=u'Cancel'), name='cancel')
     def handleCancel(self, action):
         return self.redirect_to_meetinglist()
 

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -54,7 +54,7 @@
                               </option>
                           </tal:repeat>
                       </select>
-                      <span class="inputIcon"><input type="submit" name="submit" id="submit-schedule"
+                      <span class="inputIcon"><input type="submit" name="submit" id="submit-schedule" value="Schedule"
                          i18n:attributes="value schedule" /></span>
                   </div>
                 </form>

--- a/opengever/meeting/browser/templates/no_selection.pt
+++ b/opengever/meeting/browser/templates/no_selection.pt
@@ -1,0 +1,3 @@
+<div i18n:domain="opengever.meeting" i18n:translate="tab_matches">
+  <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
+</div>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-02-24 13:09+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"POT-Creation-Date: 2015-02-25 11:55+0000\n"
+"PO-Revision-Date: 2015-02-25 13:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:68
+#: ./opengever/meeting/command.py:76
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neue eingereichte Version des Dokuments ${title} wurde erstellt."
 
@@ -37,7 +37,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Add Membership"
 msgstr "Mitgliedschaft hinzufügen"
 
-#: ./opengever/meeting/command.py:101
+#: ./opengever/meeting/command.py:109
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
@@ -76,13 +76,17 @@ msgstr "Beschluss"
 msgid "Discussion"
 msgstr "Diskussion"
 
-#: ./opengever/meeting/command.py:40
+#: ./opengever/meeting/command.py:43
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:38
 msgid "Edit pre-protocol"
 msgstr "Vorprotokoll bearbeiten"
+
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:51
+msgid "History"
+msgstr "Verlauf"
 
 #: ./opengever/meeting/browser/meetings/templates/pre_protocol.pt:23
 msgid "Initial position"
@@ -108,7 +112,7 @@ msgstr "Antrag"
 
 #: ./opengever/meeting/browser/meetings/templates/pre_protocol.pt:35
 msgid "Proposed action"
-msgstr ""
+msgstr "Erwägungen"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:33
 msgid "Protocols"
@@ -171,6 +175,11 @@ msgstr "Schliessen"
 msgid "closed"
 msgstr "geschlossen"
 
+#. Default: "Comittee"
+#: ./opengever/meeting/tabs/proposallisting.py:37
+msgid "column_comittee"
+msgstr "Kommission"
+
 #. Default: "Date"
 #: ./opengever/meeting/tabs/meetinglisting.py:27
 msgid "column_date"
@@ -202,8 +211,7 @@ msgid "column_firstname"
 msgstr "Vorname"
 
 #. Default: "Initial Position"
-#: ./opengever/meeting/tabs/proposallisting.py:31
-#: ./opengever/meeting/tabs/submittedproposallisting.py:33
+#: ./opengever/meeting/tabs/proposallisting.py:41
 msgid "column_initial_position"
 msgstr "Ausgangslage"
 
@@ -211,6 +219,11 @@ msgstr "Ausgangslage"
 #: ./opengever/meeting/tabs/memberlisting.py:30
 msgid "column_lastname"
 msgstr "Nachname"
+
+#. Default: "Proposed action"
+#: ./opengever/meeting/tabs/proposallisting.py:45
+msgid "column_proposed_action"
+msgstr "Erwägungen"
 
 #. Default: "Role"
 #: ./opengever/meeting/tabs/membershiplisting.py:35
@@ -222,6 +235,11 @@ msgstr "Rolle"
 msgid "column_start_time"
 msgstr "Von (Uhrzeit)"
 
+#. Default: "State"
+#: ./opengever/meeting/tabs/proposallisting.py:33
+msgid "column_state"
+msgstr "Status"
+
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:23
@@ -230,12 +248,12 @@ msgid "column_title"
 msgstr "Titel"
 
 #. Default: "Decide"
-#: ./opengever/meeting/proposal.py:198
+#: ./opengever/meeting/proposal.py:209
 msgid "decide"
 msgstr "Beschliessen"
 
 #. Default: "Decided"
-#: ./opengever/meeting/proposal.py:193
+#: ./opengever/meeting/proposal.py:204
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -244,19 +262,19 @@ msgstr "Beschlossen"
 msgid "held"
 msgstr "Durchgeführt"
 
-#: ./opengever/meeting/proposal.py:63
+#: ./opengever/meeting/proposal.py:71
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:57
+#: ./opengever/meeting/proposal.py:65
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:69
-msgid "help_proposal"
+#: ./opengever/meeting/proposal.py:48
+msgid "help_proposed_action"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:50
+#: ./opengever/meeting/proposal.py:58
 msgid "help_title"
 msgstr ""
 
@@ -267,12 +285,12 @@ msgstr "Sitzung durchführen"
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:30
-#: ./opengever/meeting/proposal.py:40
+#: ./opengever/meeting/proposal.py:42
 msgid "label_committee"
 msgstr "Kommission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/proposal.py:62
+#: ./opengever/meeting/proposal.py:70
 msgid "label_considerations"
 msgstr "Erwägungen"
 
@@ -294,7 +312,7 @@ msgstr "Bis"
 #. Default: "Documents"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:31
 #: ./opengever/meeting/browser/submitdocuments.py:31
-#: ./opengever/meeting/proposal.py:78
+#: ./opengever/meeting/proposal.py:86
 msgid "label_documents"
 msgstr "Dokumente"
 
@@ -313,8 +331,8 @@ msgstr "Bis (Uhrzeit)"
 msgid "label_firstname"
 msgstr "Vorname"
 
-#. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:35
+#. Default: "Initial position"
+#: ./opengever/meeting/proposal.py:37
 msgid "label_initial_position"
 msgstr "Antrag"
 
@@ -354,9 +372,14 @@ msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:68
+#: ./opengever/meeting/proposal.py:221
 msgid "label_proposal"
 msgstr "Antrag"
+
+#. Default: "Proposed action"
+#: ./opengever/meeting/proposal.py:47
+msgid "label_proposed_action"
+msgstr "Erwägungen"
 
 #. Default: "Role"
 #: ./opengever/meeting/browser/memberships.py:28
@@ -375,38 +398,73 @@ msgstr "Von (Uhrzeit)"
 
 #. Default: "Title"
 #: ./opengever/meeting/committee.py:21
-#: ./opengever/meeting/proposal.py:29
+#: ./opengever/meeting/proposal.py:31
 msgid "label_title"
 msgstr "Titel"
 
-#: ./opengever/meeting/proposal.py:141
+#. Default: "State"
+#: ./opengever/meeting/proposal.py:152
 msgid "label_workflow_state"
 msgstr "Status"
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/meeting.py:31
-#: ./opengever/meeting/proposal.py:190
+#: ./opengever/meeting/proposal.py:201
 msgid "pending"
 msgstr "In Bearbeitung"
 
+#. Default: "Created by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:47
+msgid "proposal_history_label_created"
+msgstr "Erstellt durch ${user}"
+
+#. Default: "Document submitted by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:95
+msgid "proposal_history_label_document_submitted"
+msgstr "Dokument eingereicht durch ${user}"
+
+#. Default: "Submitted document updated by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:107
+msgid "proposal_history_label_document_updated"
+msgstr "Eingereichtes Dokument aktualisiert durch ${user}"
+
+#. Default: "Removed from schedule by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:83
+msgid "proposal_history_label_remove_scheduled"
+msgstr "Von der Traktandeniste entfernt durch ${user}"
+
+#. Default: "Scheduled by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:71
+msgid "proposal_history_label_scheduled"
+msgstr "Geplant durch ${user}"
+
+#. Default: "Submitted by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:59
+msgid "proposal_history_label_submitted"
+msgstr "Eingereicht durch ${user}"
+
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:57
-#: ./opengever/meeting/proposal.py:196
+#: ./opengever/meeting/proposal.py:207
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/proposal.py:192
+#: ./opengever/meeting/proposal.py:203
 msgid "scheduled"
 msgstr "Traktandiert"
 
 #. Default: "Submit"
-#: ./opengever/meeting/proposal.py:283
+#: ./opengever/meeting/proposal.py:294
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submited"
-#: ./opengever/meeting/proposal.py:191
+#: ./opengever/meeting/proposal.py:202
 msgid "submitted"
 msgstr "Eingereicht"
 
+#. Default: "${amount} matches."
+#: ./opengever/meeting/browser/templates/no_selection.pt:2
+msgid "tab_matches"
+msgstr "${amount} Treffer"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-02-24 13:09+0000\n"
+"POT-Creation-Date: 2015-02-25 11:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:68
+#: ./opengever/meeting/command.py:76
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add Membership"
 msgstr ""
 
-#: ./opengever/meeting/command.py:101
+#: ./opengever/meeting/command.py:109
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
@@ -76,12 +76,16 @@ msgstr ""
 msgid "Discussion"
 msgstr ""
 
-#: ./opengever/meeting/command.py:40
+#: ./opengever/meeting/command.py:43
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:38
 msgid "Edit pre-protocol"
+msgstr ""
+
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:51
+msgid "History"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/pre_protocol.pt:23
@@ -171,6 +175,11 @@ msgstr ""
 msgid "closed"
 msgstr ""
 
+#. Default: "Comittee"
+#: ./opengever/meeting/tabs/proposallisting.py:37
+msgid "column_comittee"
+msgstr ""
+
 #. Default: "Date"
 #: ./opengever/meeting/tabs/meetinglisting.py:27
 msgid "column_date"
@@ -202,14 +211,18 @@ msgid "column_firstname"
 msgstr ""
 
 #. Default: "Initial Position"
-#: ./opengever/meeting/tabs/proposallisting.py:31
-#: ./opengever/meeting/tabs/submittedproposallisting.py:33
+#: ./opengever/meeting/tabs/proposallisting.py:41
 msgid "column_initial_position"
 msgstr ""
 
 #. Default: "Lastname"
 #: ./opengever/meeting/tabs/memberlisting.py:30
 msgid "column_lastname"
+msgstr ""
+
+#. Default: "Proposed action"
+#: ./opengever/meeting/tabs/proposallisting.py:45
+msgid "column_proposed_action"
 msgstr ""
 
 #. Default: "Role"
@@ -222,6 +235,11 @@ msgstr ""
 msgid "column_start_time"
 msgstr ""
 
+#. Default: "State"
+#: ./opengever/meeting/tabs/proposallisting.py:33
+msgid "column_state"
+msgstr ""
+
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:23
@@ -230,12 +248,12 @@ msgid "column_title"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/proposal.py:198
+#: ./opengever/meeting/proposal.py:209
 msgid "decide"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/proposal.py:193
+#: ./opengever/meeting/proposal.py:204
 msgid "decided"
 msgstr ""
 
@@ -244,19 +262,19 @@ msgstr ""
 msgid "held"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:63
+#: ./opengever/meeting/proposal.py:71
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:57
+#: ./opengever/meeting/proposal.py:65
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:69
-msgid "help_proposal"
+#: ./opengever/meeting/proposal.py:48
+msgid "help_proposed_action"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:50
+#: ./opengever/meeting/proposal.py:58
 msgid "help_title"
 msgstr ""
 
@@ -267,12 +285,12 @@ msgstr ""
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:30
-#: ./opengever/meeting/proposal.py:40
+#: ./opengever/meeting/proposal.py:42
 msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/proposal.py:62
+#: ./opengever/meeting/proposal.py:70
 msgid "label_considerations"
 msgstr ""
 
@@ -294,7 +312,7 @@ msgstr ""
 #. Default: "Documents"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:31
 #: ./opengever/meeting/browser/submitdocuments.py:31
-#: ./opengever/meeting/proposal.py:78
+#: ./opengever/meeting/proposal.py:86
 msgid "label_documents"
 msgstr ""
 
@@ -313,8 +331,8 @@ msgstr ""
 msgid "label_firstname"
 msgstr ""
 
-#. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:35
+#. Default: "Initial position"
+#: ./opengever/meeting/proposal.py:37
 msgid "label_initial_position"
 msgstr ""
 
@@ -354,8 +372,13 @@ msgid "label_presidency"
 msgstr ""
 
 #. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:68
+#: ./opengever/meeting/proposal.py:221
 msgid "label_proposal"
+msgstr ""
+
+#. Default: "Proposed action"
+#: ./opengever/meeting/proposal.py:47
+msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Role"
@@ -375,38 +398,74 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/committee.py:21
-#: ./opengever/meeting/proposal.py:29
+#: ./opengever/meeting/proposal.py:31
 msgid "label_title"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:141
+#. Default: "State"
+#: ./opengever/meeting/proposal.py:152
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/meeting.py:31
-#: ./opengever/meeting/proposal.py:190
+#: ./opengever/meeting/proposal.py:201
 msgid "pending"
+msgstr ""
+
+#. Default: "Created by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:47
+msgid "proposal_history_label_created"
+msgstr ""
+
+#. Default: "Document submitted by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:95
+msgid "proposal_history_label_document_submitted"
+msgstr ""
+
+#. Default: "Submitted document updated by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:107
+msgid "proposal_history_label_document_updated"
+msgstr ""
+
+#. Default: "Removed from schedule by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:83
+msgid "proposal_history_label_remove_scheduled"
+msgstr ""
+
+#. Default: "Scheduled by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:71
+msgid "proposal_history_label_scheduled"
+msgstr ""
+
+#. Default: "Submitted by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:59
+msgid "proposal_history_label_submitted"
 msgstr ""
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:57
-#: ./opengever/meeting/proposal.py:196
+#: ./opengever/meeting/proposal.py:207
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/proposal.py:192
+#: ./opengever/meeting/proposal.py:203
 msgid "scheduled"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/proposal.py:283
+#: ./opengever/meeting/proposal.py:294
 msgid "submit"
 msgstr ""
 
 #. Default: "Submited"
-#: ./opengever/meeting/proposal.py:191
+#: ./opengever/meeting/proposal.py:202
 msgid "submitted"
+msgstr ""
+
+#. Default: "${amount} matches."
+#: ./opengever/meeting/browser/templates/no_selection.pt:2
+msgid "tab_matches"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-02-24 13:09+0000\n"
+"POT-Creation-Date: 2015-02-25 11:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:68
+#: ./opengever/meeting/command.py:76
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
@@ -40,7 +40,7 @@ msgstr ""
 msgid "Add Membership"
 msgstr ""
 
-#: ./opengever/meeting/command.py:101
+#: ./opengever/meeting/command.py:109
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
@@ -79,12 +79,16 @@ msgstr ""
 msgid "Discussion"
 msgstr ""
 
-#: ./opengever/meeting/command.py:40
+#: ./opengever/meeting/command.py:43
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:38
 msgid "Edit pre-protocol"
+msgstr ""
+
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:51
+msgid "History"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/pre_protocol.pt:23
@@ -174,6 +178,11 @@ msgstr ""
 msgid "closed"
 msgstr ""
 
+#. Default: "Comittee"
+#: ./opengever/meeting/tabs/proposallisting.py:37
+msgid "column_comittee"
+msgstr ""
+
 #. Default: "Date"
 #: ./opengever/meeting/tabs/meetinglisting.py:27
 msgid "column_date"
@@ -205,14 +214,18 @@ msgid "column_firstname"
 msgstr ""
 
 #. Default: "Initial Position"
-#: ./opengever/meeting/tabs/proposallisting.py:31
-#: ./opengever/meeting/tabs/submittedproposallisting.py:33
+#: ./opengever/meeting/tabs/proposallisting.py:41
 msgid "column_initial_position"
 msgstr ""
 
 #. Default: "Lastname"
 #: ./opengever/meeting/tabs/memberlisting.py:30
 msgid "column_lastname"
+msgstr ""
+
+#. Default: "Proposed action"
+#: ./opengever/meeting/tabs/proposallisting.py:45
+msgid "column_proposed_action"
 msgstr ""
 
 #. Default: "Role"
@@ -225,6 +238,11 @@ msgstr ""
 msgid "column_start_time"
 msgstr ""
 
+#. Default: "State"
+#: ./opengever/meeting/tabs/proposallisting.py:33
+msgid "column_state"
+msgstr ""
+
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:23
@@ -233,12 +251,12 @@ msgid "column_title"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/proposal.py:198
+#: ./opengever/meeting/proposal.py:209
 msgid "decide"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/proposal.py:193
+#: ./opengever/meeting/proposal.py:204
 msgid "decided"
 msgstr ""
 
@@ -247,19 +265,19 @@ msgstr ""
 msgid "held"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:63
+#: ./opengever/meeting/proposal.py:71
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:57
+#: ./opengever/meeting/proposal.py:65
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:69
-msgid "help_proposal"
+#: ./opengever/meeting/proposal.py:48
+msgid "help_proposed_action"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:50
+#: ./opengever/meeting/proposal.py:58
 msgid "help_title"
 msgstr ""
 
@@ -270,12 +288,12 @@ msgstr ""
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:30
-#: ./opengever/meeting/proposal.py:40
+#: ./opengever/meeting/proposal.py:42
 msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/proposal.py:62
+#: ./opengever/meeting/proposal.py:70
 msgid "label_considerations"
 msgstr ""
 
@@ -297,7 +315,7 @@ msgstr ""
 #. Default: "Documents"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:31
 #: ./opengever/meeting/browser/submitdocuments.py:31
-#: ./opengever/meeting/proposal.py:78
+#: ./opengever/meeting/proposal.py:86
 msgid "label_documents"
 msgstr ""
 
@@ -316,8 +334,8 @@ msgstr ""
 msgid "label_firstname"
 msgstr ""
 
-#. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:35
+#. Default: "Initial position"
+#: ./opengever/meeting/proposal.py:37
 msgid "label_initial_position"
 msgstr ""
 
@@ -356,9 +374,13 @@ msgstr ""
 msgid "label_presidency"
 msgstr ""
 
-#. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:68
+#: ./opengever/meeting/proposal.py:221
 msgid "label_proposal"
+msgstr ""
+
+#. Default: "Proposed action"
+#: ./opengever/meeting/proposal.py:47
+msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Role"
@@ -378,37 +400,74 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/committee.py:21
-#: ./opengever/meeting/proposal.py:29
+#: ./opengever/meeting/proposal.py:31
 msgid "label_title"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:141
+#. Default: "State"
+#: ./opengever/meeting/proposal.py:152
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/meeting.py:31
-#: ./opengever/meeting/proposal.py:190
+#: ./opengever/meeting/proposal.py:201
 msgid "pending"
 msgstr ""
 
+#. Default: "Created by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:47
+msgid "proposal_history_label_created"
+msgstr ""
+
+#. Default: "Document submitted by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:95
+msgid "proposal_history_label_document_submitted"
+msgstr ""
+
+#. Default: "Submitted document updated by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:107
+msgid "proposal_history_label_document_updated"
+msgstr ""
+
+#. Default: "Removed from schedule by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:83
+msgid "proposal_history_label_remove_scheduled"
+msgstr ""
+
+#. Default: "Scheduled by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:71
+msgid "proposal_history_label_scheduled"
+msgstr ""
+
+#. Default: "Submitted by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:59
+msgid "proposal_history_label_submitted"
+msgstr ""
+
+#. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:57
-#: ./opengever/meeting/proposal.py:196
+#: ./opengever/meeting/proposal.py:207
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/proposal.py:192
+#: ./opengever/meeting/proposal.py:203
 msgid "scheduled"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/proposal.py:283
+#: ./opengever/meeting/proposal.py:294
 msgid "submit"
 msgstr ""
 
 #. Default: "Submited"
-#: ./opengever/meeting/proposal.py:191
+#: ./opengever/meeting/proposal.py:202
 msgid "submitted"
+msgstr ""
+
+#. Default: "${amount} matches."
+#: ./opengever/meeting/browser/templates/no_selection.pt:2
+msgid "tab_matches"
 msgstr ""
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -45,9 +45,9 @@ class Proposal(Base):
     title = Column(String(256), nullable=False)
     workflow_state = Column(String(256), nullable=False)
     initial_position = Column(Text)
+    proposed_action = Column(Text)
 
     considerations = Column(Text)
-    proposed_action = Column(Text)
 
     committee_id = Column(Integer, ForeignKey('committees.id'))
     committee = relationship('Committee', backref='proposals')

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -104,6 +104,6 @@ class DocumentUpdated(ProposalHistory):
     css_class = 'documentUpdated'
 
     def message(self):
-        return _(u'proposal_history_label_document_submitted',
+        return _(u'proposal_history_label_document_updated',
                  u'Submitted document updated by ${user}',
                  mapping={'user': Actor.lookup(self.userid).get_link()})

--- a/opengever/meeting/profiles/default/types/opengever.meeting.proposal.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.proposal.xml
@@ -3,7 +3,7 @@
         i18n:domain="opengever.meeting" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Basic metadata -->
-  <property name="title" i18n:translate="">Proposal</property>
+  <property name="title" i18n:translate="Proposal">Proposal</property>
   <property name="description" i18n:translate=""></property>
   <property name="icon_expr"></property>
   <property name="allow_discussion">False</property>

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -34,7 +34,7 @@ class IProposalModel(Interface):
         )
 
     initial_position = schema.Text(
-        title=_('label_initial_position', default=u"Proposal"),
+        title=_('label_initial_position', default=u"Initial position"),
         required=False,
         )
 
@@ -61,7 +61,7 @@ class ISubmittedProposalModel(Interface):
         )
 
     initial_position = schema.Text(
-        title=_('label_initial_position', default=u"Proposal"),
+        title=_('label_initial_position', default=u"Initial position"),
         description=_("help_initial_position", default=u""),
         required=False,
         )
@@ -137,19 +137,19 @@ class ProposalBase(ModelContainer):
         assert model, 'missing db-model for {}'.format(self)
 
         return [
-            {'label': _('label_title'),
+            {'label': _(u"label_title", default=u'Title'),
              'value': model.title},
 
-            {'label': _('label_initial_position'),
+            {'label': _('label_initial_position', default=u'Initial position'),
              'value': model.initial_position},
 
-            {'label': _('label_committee'),
+            {'label': _('label_committee', default=u'Committee'),
              'value': model.committee.title},
 
-            {'label': _('label_proposed_action', default=u"Proposed action"),
+            {'label': _('label_proposed_action', default=u'Proposed action'),
              'value': model.proposed_action},
 
-            {'label': _('label_workflow_state'),
+            {'label': _('label_workflow_state', default=u'State'),
              'value': self.get_state().title},
         ]
 
@@ -214,7 +214,7 @@ class SubmittedProposal(ProposalBase):
         model = self.load_model()
         data.extend([
             {
-                'label': _('label_considerations'),
+                'label': _('label_considerations', default=u"Considerations"),
                 'value': model.considerations,
             },
             {

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -43,6 +43,12 @@ class IProposalModel(Interface):
         source='opengever.meeting.CommitteeVocabulary',
         required=True)
 
+    proposed_action = schema.Text(
+        title=_('label_proposed_action', default=u"Proposed action"),
+        description=_("help_proposed_action", default=u""),
+        required=False,
+    )
+
 
 class ISubmittedProposalModel(Interface):
     """Submitted proposal model schema interface."""
@@ -67,10 +73,10 @@ class ISubmittedProposalModel(Interface):
         )
 
     proposed_action = schema.Text(
-        title=_('label_proposal', default=u"Proposal"),
-        description=_("help_proposal", default=u""),
+        title=_('label_proposed_action', default=u"Proposed action"),
+        description=_("help_proposed_action", default=u""),
         required=False,
-        )
+    )
 
 
 class IProposal(form.Schema):
@@ -139,6 +145,9 @@ class ProposalBase(ModelContainer):
 
             {'label': _('label_committee'),
              'value': model.committee.title},
+
+            {'label': _('label_proposed_action', default=u"Proposed action"),
+             'value': model.proposed_action},
 
             {'label': _('label_workflow_state'),
              'value': self.get_state().title},

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -27,10 +27,24 @@ class ProposalListingTab(BaseListingTab):
          'column_title': _(u'column_title', default=u'Title'),
          'transform': proposal_link},
 
+        # TODO: state translation, therefore the workflow has to moved to
+        # the proposal model
+        {'column': 'state',
+         'column_title': _(u'column_state', default=u'State'),
+         'transform': lambda item, value: item.workflow_state},
+
+        {'column': 'comittee',
+         'column_title': _(u'column_comittee', default=u'Comittee'),
+         'transform': lambda item, value: item.committee.title},
+
         {'column': 'initial_position',
          'column_title': _(u'column_initial_position',
                            default=u'Initial Position')},
-        )
+
+        {'column': 'proposed_action',
+         'column_title': _(u'column_proposed_action',
+                           default=u'Proposed action')},
+    )
 
 
 class ProposalTableSource(BaseTableSource):

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -2,7 +2,7 @@ from five import grok
 from ftw.table.interfaces import ITableSource
 from ftw.table.interfaces import ITableSourceConfig
 from opengever.meeting.model import Proposal
-from opengever.tabbedview import _
+from opengever.meeting import _
 from opengever.tabbedview.browser.base import BaseListingTab
 from opengever.tabbedview.browser.base import BaseTableSource
 from zope.interface import implements

--- a/opengever/meeting/tabs/submittedproposallisting.py
+++ b/opengever/meeting/tabs/submittedproposallisting.py
@@ -24,16 +24,17 @@ class SubmittedProposalListingTab(ProposalListingTab):
         return Proposal.query.visible_for_committee(
             self.context.load_model())
 
-    columns = (
-        {'column': 'title',
-         'column_title': _(u'column_title', default=u'Title'),
-         'transform': proposal_title_link},
+    @property
+    def columns(self):
+        """Inherit column definition from the ProposalListingTab,
+        but replace transform with """
 
-        {'column': 'initial_position',
-         'column_title': _(u'column_initial_position',
-                           default=u'Initial Position')},
-        )
+        columns = super(SubmittedProposalListingTab, self).columns
+        for col in columns:
+            if col.get('column') == 'title':
+                col['transform'] = proposal_title_link
 
+        return columns
 
 class SubmittedProposalTableSource(BaseTableSource):
     grok.implements(ITableSource)

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -24,3 +24,14 @@ class TestCommitteeContainer(FunctionalTestCase):
         browser.open(self.container, view='tabbedview_view-committees')
         href = browser.find(u'My Committee').node.attrib['href']
         self.assertEqual(committee_model.get_url(), href)
+
+    @browsing
+    def test_selection_links_are_hidden(self, browser):
+        committee = create(Builder('committee')
+                           .having(title=u'My Committee')
+                           .within(self.container))
+        committee_model = committee.load_model()
+
+        browser.login()
+        browser.open(self.container, view='tabbedview_view-committees')
+        self.assertEquals([], browser.css('div.tabbedview_select'))

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -73,11 +73,11 @@ class TestProposal(FunctionalTestCase):
 
         browser.fill({
             'Title': u'A pr\xf6posal',
-            'Proposal': u'My pr\xf6posal',
+            'Initial position': u'My pr\xf6posal',
             'Proposed action': u'Lorem ips\xfcm',
             'Committee': str(committee.committee_id),
             'form.widgets.relatedItems:list': True,
-            })
+        })
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Item created',
                       browser.css('.portalMessage.info dd').text)
@@ -115,7 +115,7 @@ class TestProposal(FunctionalTestCase):
 
         browser.fill({
             'Title': u'A pr\xf6posal',
-            'Proposal': u'My pr\xf6posal',
+            'Initial position': u'My pr\xf6posal',
             'Proposed action': u'Lorem ips\xfcm',
             'Committee': str(committee.committee_id),
             'form.widgets.relatedItems:list': True,

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -74,6 +74,7 @@ class TestProposal(FunctionalTestCase):
         browser.fill({
             'Title': u'A pr\xf6posal',
             'Proposal': u'My pr\xf6posal',
+            'Proposed action': u'Lorem ips\xfcm',
             'Committee': str(committee.committee_id),
             'form.widgets.relatedItems:list': True,
             })
@@ -90,6 +91,7 @@ class TestProposal(FunctionalTestCase):
         self.assertIsNotNone(model)
         self.assertEqual(Oguid.for_object(proposal), model.oguid)
         self.assertEqual(u'A pr\xf6posal', model.title)
+        self.assertEqual(u'Lorem ips\xfcm', model.proposed_action)
         self.assertEqual(u'My pr\xf6posal', model.initial_position)
 
         self.assertEqual(['a', 'pr\xc3\xb6posal', 'my', 'pr\xc3\xb6posal'],
@@ -114,6 +116,7 @@ class TestProposal(FunctionalTestCase):
         browser.fill({
             'Title': u'A pr\xf6posal',
             'Proposal': u'My pr\xf6posal',
+            'Proposed action': u'Lorem ips\xfcm',
             'Committee': str(committee.committee_id),
             'form.widgets.relatedItems:list': True,
             })
@@ -131,6 +134,7 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(Oguid.for_object(proposal), model.oguid)
         self.assertEqual(u'A pr\xf6posal', model.title)
         self.assertEqual(u'My pr\xf6posal', model.initial_position)
+        self.assertEqual(u'Lorem ips\xfcm', model.proposed_action)
 
     @browsing
     def test_proposal_submission_works_correctly(self, browser):

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -1,0 +1,84 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class ProposalListingTests(FunctionalTestCase):
+
+    def setUp(self):
+        super(ProposalListingTests, self).setUp()
+
+        self.dossier = create(Builder('dossier').titled(u'Dossier A'))
+        self.committee = create(Builder('committee').titled('My committee'))
+        self.proposal = create(Builder('proposal')
+                               .within(self.dossier)
+                               .titled(u'My Proposal')
+                               .having(committee=self.committee.load_model(),
+                                       initial_position=u'My p\xf6sition is',
+                                       proposed_action=u'My proposed acti\xf6n'))
+
+
+class TestDossierProposalListing(ProposalListingTests):
+
+    @browsing
+    def test_listing(self, browser):
+        browser.login().open(self.dossier, view='tabbedview_view-proposals')
+        table = browser.css('table.listing').first
+
+        # TODO: state should be translated
+        self.assertEquals(
+            [{'State': 'pending',
+              'Proposed action': u'My proposed acti\xf6n',
+              'Initial Position': u'My p\xf6sition is',
+              'Comittee': 'My committee',
+              'Title': 'My Proposal'}],
+            table.dicts())
+
+    @browsing
+    def test_proposals_are_linked_correctly(self, browser):
+        browser.login().open(self.dossier, view='tabbedview_view-proposals')
+
+        table = browser.css('table.listing').first
+        link = table.rows[1].css('a').first
+
+        self.assertEquals('My Proposal', link.text)
+        self.assertEquals('http://example.com/dossier-1/proposal-1',
+                          link.get('href'))
+
+
+class TestSubmittedProposals(ProposalListingTests):
+
+    def setUp(self):
+        super(TestSubmittedProposals, self).setUp()
+
+        self.submitted_proposal = create(Builder('submitted_proposal')
+                                         .submitting(self.proposal))
+
+    @browsing
+    def test_listing(self, browser):
+        browser.login().open(self.committee,
+                             view='tabbedview_view-submittedproposals')
+        table = browser.css('table.listing').first
+
+        # TODO: state should be translated
+        self.assertEquals(
+            [{'State': 'submitted',
+              'Proposed action': u'My proposed acti\xf6n',
+              'Initial Position': u'My p\xf6sition is',
+              'Comittee': 'My committee',
+              'Title': 'My Proposal'}],
+            table.dicts())
+
+    @browsing
+    def test_proposals_are_linked_correctly_to_the_submitted_proposal(self, browser):
+        browser.login().open(self.committee,
+                             view='tabbedview_view-submittedproposals')
+
+        table = browser.css('table.listing').first
+        link = table.rows[1].css('a').first
+
+        self.assertEquals('My Proposal', link.text)
+        self.assertEquals(
+            'http://example.com/committee-1/submitted-proposal-1',
+            link.get('href'))


### PR DESCRIPTION
- Disable selection links for listings without checkbox column.
- Extend proposal listing columns, with the new columns (state, comittee, proposed action)
- Added tests for the Proposal and the SumittedProposalListing

Additionally I made the `proposed_action` field also available in the proposal add- and edit-form

@deiferni please have a look ... 