### PR TITLE
Display more details in proposal history.

### DIFF
--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -68,7 +68,11 @@ class UpdateSubmittedDocumentCommand(object):
             self.proposal, self.document)
         submitted_document.submitted_version = submitted_version
 
-        session.add(proposalhistory.DocumentUpdated(proposal=proposal_model))
+        session.add(proposalhistory.DocumentUpdated(
+            proposal=proposal_model,
+            submitted_document=submitted_document,
+            submitted_version=submitted_version,
+            document_title=self.document.title))
 
     def show_message(self):
         portal = api.portal.get()
@@ -124,7 +128,11 @@ class CopyProposalDocumentCommand(object):
                                 submitted_version=submitted_version)
         session.add(doc)
 
-        session.add(proposalhistory.DocumentSubmitted(proposal=proposal_model))
+        session.add(proposalhistory.DocumentSubmitted(
+            proposal=proposal_model,
+            submitted_document=doc,
+            submitted_version=submitted_version,
+            document_title=self.document.title))
 
     def copy_document(self, target_path, target_admin_unit_id):
         return OgCopyCommand(

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-05 10:18+0000\n"
+"POT-Creation-Date: 2015-03-05 10:25+0000\n"
 "PO-Revision-Date: 2015-03-03 12:33+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:76
+#: ./opengever/meeting/command.py:80
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neue eingereichte Version des Dokuments ${title} wurde erstellt."
 
@@ -37,7 +37,7 @@ msgstr "Mitglied hinzufügen"
 msgid "Add Membership"
 msgstr "Mitgliedschaft hinzufügen"
 
-#: ./opengever/meeting/command.py:109
+#: ./opengever/meeting/command.py:113
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
@@ -438,17 +438,17 @@ msgid "pending"
 msgstr "In Bearbeitung"
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:47
+#: ./opengever/meeting/model/proposalhistory.py:60
 msgid "proposal_history_label_created"
 msgstr "Erstellt durch ${user}"
 
-#. Default: "Document submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:95
+#. Default: "Document ${title} submitted in version ${version} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:112
 msgid "proposal_history_label_document_submitted"
 msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 
-#. Default: "Submitted document updated by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:107
+#. Default: "Submitted document ${title} updated to version ${version} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:126
 msgid "proposal_history_label_document_updated"
 msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
 
@@ -463,7 +463,7 @@ msgid "proposal_history_label_scheduled"
 msgstr "Geplant für Sitzung ${meeting} durch ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:59
+#: ./opengever/meeting/model/proposalhistory.py:72
 msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-04 16:45+0000\n"
-"PO-Revision-Date: 2015-02-25 13:06+0100\n"
+"POT-Creation-Date: 2015-03-05 10:18+0000\n"
+"PO-Revision-Date: 2015-03-03 12:33+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -452,15 +452,15 @@ msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 msgid "proposal_history_label_document_updated"
 msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
 
-#. Default: "Removed from schedule by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:83
+#. Default: "Removed from schedule of meeting ${meeting} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:99
 msgid "proposal_history_label_remove_scheduled"
-msgstr "Von der Traktandeniste entfernt durch ${user}"
+msgstr "Von der Traktandenliste der Sitzung ${meeting} entfernt durch ${user}"
 
-#. Default: "Scheduled by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:71
+#. Default: "Scheduled for meeting ${meeting} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:85
 msgid "proposal_history_label_scheduled"
-msgstr "Geplant durch ${user}"
+msgstr "Geplant für Sitzung ${meeting} durch ${user}"
 
 #. Default: "Submitted by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:59

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -445,12 +445,12 @@ msgstr "Erstellt durch ${user}"
 #. Default: "Document submitted by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:95
 msgid "proposal_history_label_document_submitted"
-msgstr "Dokument eingereicht durch ${user}"
+msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 
 #. Default: "Submitted document updated by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:107
 msgid "proposal_history_label_document_updated"
-msgstr "Eingereichtes Dokument aktualisiert durch ${user}"
+msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
 
 #. Default: "Removed from schedule by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:83

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-04 16:45+0000\n"
+"POT-Creation-Date: 2015-03-05 10:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -452,13 +452,13 @@ msgstr ""
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
-#. Default: "Removed from schedule by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:83
+#. Default: "Removed from schedule of meeting ${meeting} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:99
 msgid "proposal_history_label_remove_scheduled"
 msgstr ""
 
-#. Default: "Scheduled by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:71
+#. Default: "Scheduled for meeting ${meeting} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:85
 msgid "proposal_history_label_scheduled"
 msgstr ""
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-05 10:18+0000\n"
+"POT-Creation-Date: 2015-03-05 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:76
+#: ./opengever/meeting/command.py:80
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
@@ -37,7 +37,7 @@ msgstr ""
 msgid "Add Membership"
 msgstr ""
 
-#: ./opengever/meeting/command.py:109
+#: ./opengever/meeting/command.py:113
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
@@ -438,17 +438,17 @@ msgid "pending"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:47
+#: ./opengever/meeting/model/proposalhistory.py:60
 msgid "proposal_history_label_created"
 msgstr ""
 
-#. Default: "Document submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:95
+#. Default: "Document ${title} submitted in version ${version} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:112
 msgid "proposal_history_label_document_submitted"
 msgstr ""
 
-#. Default: "Submitted document updated by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:107
+#. Default: "Submitted document ${title} updated to version ${version} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:126
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid "proposal_history_label_scheduled"
 msgstr ""
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:59
+#: ./opengever/meeting/model/proposalhistory.py:72
 msgid "proposal_history_label_submitted"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-04 16:45+0000\n"
+"POT-Creation-Date: 2015-03-05 10:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -454,13 +454,13 @@ msgstr ""
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
-#. Default: "Removed from schedule by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:83
+#. Default: "Removed from schedule of meeting ${meeting} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:99
 msgid "proposal_history_label_remove_scheduled"
 msgstr ""
 
-#. Default: "Scheduled by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:71
+#. Default: "Scheduled for meeting ${meeting} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:85
 msgid "proposal_history_label_scheduled"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-05 10:18+0000\n"
+"POT-Creation-Date: 2015-03-05 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:76
+#: ./opengever/meeting/command.py:80
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
@@ -40,7 +40,7 @@ msgstr ""
 msgid "Add Membership"
 msgstr ""
 
-#: ./opengever/meeting/command.py:109
+#: ./opengever/meeting/command.py:113
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
@@ -440,17 +440,17 @@ msgid "pending"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:47
+#: ./opengever/meeting/model/proposalhistory.py:60
 msgid "proposal_history_label_created"
 msgstr ""
 
-#. Default: "Document submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:95
+#. Default: "Document ${title} submitted in version ${version} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:112
 msgid "proposal_history_label_document_submitted"
 msgstr ""
 
-#. Default: "Submitted document updated by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:107
+#. Default: "Submitted document ${title} updated to version ${version} by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:126
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
@@ -465,7 +465,7 @@ msgid "proposal_history_label_scheduled"
 msgstr ""
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:59
+#: ./opengever/meeting/model/proposalhistory.py:72
 msgid "proposal_history_label_submitted"
 msgstr ""
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -153,9 +153,10 @@ class Proposal(Base):
         self.execute_transition('submitted-scheduled')
         session = create_session()
         session.add(AgendaItem(meeting=meeting, proposal=self))
-        session.add(proposalhistory.Scheduled(proposal=self))
+        session.add(proposalhistory.Scheduled(proposal=self, meeting=meeting))
 
     def remove_scheduled(self, meeting):
         self.execute_transition('scheduled-submitted')
         session = create_session()
-        session.add(proposalhistory.RemoveScheduled(proposal=self))
+        session.add(
+            proposalhistory.RemoveScheduled(proposal=self, meeting=meeting))

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -36,6 +36,9 @@ class ProposalHistory(Base):
     def message(self):
         raise NotImplementedError()
 
+    def get_actor_link(self):
+        return Actor.lookup(self.userid).get_link()
+
 
 class Created(ProposalHistory):
 
@@ -46,7 +49,7 @@ class Created(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_created',
                  u'Created by ${user}',
-                 mapping={'user': Actor.lookup(self.userid).get_link()})
+                 mapping={'user': self.get_actor_link()})
 
 
 class Submitted(ProposalHistory):
@@ -58,7 +61,7 @@ class Submitted(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_submitted',
                  u'Submitted by ${user}',
-                 mapping={'user': Actor.lookup(self.userid).get_link()})
+                 mapping={'user': self.get_actor_link()})
 
 
 class Scheduled(ProposalHistory):
@@ -70,7 +73,7 @@ class Scheduled(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_scheduled',
                  u'Scheduled by ${user}',
-                 mapping={'user': Actor.lookup(self.userid).get_link()})
+                 mapping={'user': self.get_actor_link()})
 
 
 class RemoveScheduled(ProposalHistory):
@@ -82,7 +85,7 @@ class RemoveScheduled(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_remove_scheduled',
                  u'Removed from schedule by ${user}',
-                 mapping={'user': Actor.lookup(self.userid).get_link()})
+                 mapping={'user': self.get_actor_link()})
 
 
 class DocumentSubmitted(ProposalHistory):
@@ -94,7 +97,7 @@ class DocumentSubmitted(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_document_submitted',
                  u'Document submitted by ${user}',
-                 mapping={'user': Actor.lookup(self.userid).get_link()})
+                 mapping={'user': self.get_actor_link()})
 
 
 class DocumentUpdated(ProposalHistory):
@@ -106,4 +109,4 @@ class DocumentUpdated(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_document_updated',
                  u'Submitted document updated by ${user}',
-                 mapping={'user': Actor.lookup(self.userid).get_link()})
+                 mapping={'user': self.get_actor_link()})

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -106,8 +106,10 @@ class DocumentSubmitted(ProposalHistory):
 
     def message(self):
         return _(u'proposal_history_label_document_submitted',
-                 u'Document submitted by ${user}',
-                 mapping={'user': self.get_actor_link()})
+                 u'Document ${title} submitted in version ${version} by ${user}',
+                 mapping={'user': self.get_actor_link(),
+                          'title': self.document_title or '',
+                          'version': self.submitted_version})
 
 
 class DocumentUpdated(ProposalHistory):
@@ -118,5 +120,7 @@ class DocumentUpdated(ProposalHistory):
 
     def message(self):
         return _(u'proposal_history_label_document_updated',
-                 u'Submitted document updated by ${user}',
-                 mapping={'user': self.get_actor_link()})
+                 u'Submitted document ${title} updated to version ${version} by ${user}',
+                 mapping={'user': self.get_actor_link(),
+                          'title': self.document_title or '',
+                          'version': self.submitted_version})

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -30,6 +30,16 @@ class ProposalHistory(Base):
     created = Column(DateTime, default=datetime.now, nullable=False)
     userid = Column(String(256), default=get_current_user_id, nullable=False)
 
+    # intended to be used only by DocumentSubmitted/DocumentUpdated
+    submitted_document_id = Column(Integer, ForeignKey('submitteddocuments.id'))
+    submitted_document = relationship("SubmittedDocument")
+    document_title = Column(String(256))
+    submitted_version = Column(Integer)
+
+    # intended to be used only by Scheduled
+    meeting_id = Column(Integer, ForeignKey('meetings.id'))
+    meeting = relationship("Meeting")
+
     proposal_history_type = Column(String(100), nullable=False)
     __mapper_args__ = {'polymorphic_on': proposal_history_type}
 

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -81,9 +81,11 @@ class Scheduled(ProposalHistory):
     css_class = 'scheduled'
 
     def message(self):
+        meeting_title = self.meeting.get_title() if self.meeting else u''
         return _(u'proposal_history_label_scheduled',
-                 u'Scheduled by ${user}',
-                 mapping={'user': self.get_actor_link()})
+                 u'Scheduled for meeting ${meeting} by ${user}',
+                 mapping={'user': self.get_actor_link(),
+                          'meeting': meeting_title})
 
 
 class RemoveScheduled(ProposalHistory):
@@ -93,9 +95,11 @@ class RemoveScheduled(ProposalHistory):
     css_class = 'scheduleRemoved'
 
     def message(self):
+        meeting_title = self.meeting.get_title() if self.meeting else u''
         return _(u'proposal_history_label_remove_scheduled',
-                 u'Removed from schedule by ${user}',
-                 mapping={'user': self.get_actor_link()})
+                 u'Removed from schedule of meeting ${meeting} by ${user}',
+                 mapping={'user': self.get_actor_link(),
+                          'meeting': meeting_title})
 
 
 class DocumentSubmitted(ProposalHistory):

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4212</version>
+    <version>4213</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -113,7 +113,7 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertEqual(
-            u'Scheduled by Test User (test_user_1_)',
+            u'Scheduled for meeting There, Jan 01, 2013 by Test User (test_user_1_)',
             self.get_latest_history_entry_text(browser))
 
     @browsing
@@ -130,5 +130,5 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertEqual(
-            u'Removed from schedule by Test User (test_user_1_)',
+            u'Removed from schedule of meeting There, Jan 01, 2013 by Test User (test_user_1_)',
             self.get_latest_history_entry_text(browser))

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -64,7 +64,7 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertSequenceEqual(
-            [u'Document submitted by Test User (test_user_1_)',
+            [u'Document A Document submitted in version 0 by Test User (test_user_1_)',
              u'Submitted by Test User (test_user_1_)'],
             self.get_history_entries_text(browser)[:2])
 
@@ -82,7 +82,7 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertEqual(
-            u'Document submitted by Test User (test_user_1_)',
+            u'Document Another document submitted in version 0 by Test User (test_user_1_)',
             self.get_latest_history_entry_text(browser))
 
     @browsing
@@ -99,7 +99,7 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertEqual(
-            u'Submitted document updated by Test User (test_user_1_)',
+            u'Submitted document A Document updated to version 1 by Test User (test_user_1_)',
             self.get_latest_history_entry_text(browser))
 
     @browsing

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -130,4 +130,14 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4212 -> 4213 -->
+    <genericsetup:upgradeStep
+        title="Extend proposal history."
+        description=""
+        source="4212"
+        destination="4213"
+        handler="opengever.meeting.upgrades.to4213.ExtendProposalHistory"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4213.py
+++ b/opengever/meeting/upgrades/to4213.py
@@ -1,0 +1,27 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+
+
+class ExtendProposalHistory(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4213
+
+    def migrate(self):
+        self.extend_proposal_history_table()
+
+    def extend_proposal_history_table(self):
+        self.op.add_column(
+            'proposalhistory',
+            Column('submitted_document_id', Integer,
+                   ForeignKey('submitteddocuments.id')))
+        self.op.add_column(
+            'proposalhistory', Column('submitted_version', Integer))
+        self.op.add_column(
+            'proposalhistory', Column('document_title', String(256)))
+        self.op.add_column(
+            'proposalhistory',
+            Column('meeting_id', Integer, ForeignKey('meetings.id')))


### PR DESCRIPTION
:warning: *please merge after #774, i need to rebase and adapt at least one test for changes introduced there*

Currently the proposal history is very basic and does not display valuable information. This PR adds the following information to the proposal history:
- For document related entries display the document name and document version
- For meeting related entries display the meeting title

![screen shot 2015-03-04 at 15 41 56](https://cloud.githubusercontent.com/assets/736583/6485593/13d98f64-c285-11e4-8d4f-597bea77d806.png)