### PR TITLE
Show portal messages when creating/editing content.

### DIFF
--- a/opengever/meeting/browser/meetings/preprotocol.py
+++ b/opengever/meeting/browser/meetings/preprotocol.py
@@ -1,4 +1,3 @@
-from five import grok
 from opengever.meeting import _
 from opengever.meeting.browser.meetings.meetinglist import MeetingList
 from opengever.meeting.browser.preprotocol import PreProtocol
@@ -6,6 +5,7 @@ from opengever.meeting.form import ModelProxyEditForm
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Member
 from opengever.meeting.vocabulary import get_committee_member_vocabulary
+from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.directives import form
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -57,14 +57,12 @@ class EditPreProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
     def __init__(self, context, request, model):
         super(EditPreProtocol, self).__init__(context, request)
         self.model = model
-        self._has_finished_edit = False
 
     def applyChanges(self, data):
         ModelProxyEditForm.applyChanges(self, data)
         for protocol in self.get_pre_protocols():
             protocol.update(self.request)
         # pretend to always change the underlying data
-        self._has_finished_edit = True
         return True
 
     def partition_data(self, data):
@@ -98,6 +96,10 @@ class EditPreProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
     def handleApply(self, action):
         # self as first argument is required by to the decorator
         super(EditPreProtocol, self).handleApply(self, action)
+        api.portal.show_message(
+            _(u'message_changes_saved', default='Changes saved'),
+            self.request)
+        return self.redirect_to_meetinglist()
 
     @button.buttonAndHandler(_('Cancel', default=u'Cancel'), name='cancel')
     def handleCancel(self, action):
@@ -105,9 +107,6 @@ class EditPreProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
 
     def render(self):
         ModelProxyEditForm.render(self)
-        if self._has_finished_edit:
-            return self.redirect_to_meetinglist()
-
         return self.template()
 
     def get_pre_protocols(self):

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -2,6 +2,7 @@ from opengever.base.model import create_session
 from opengever.base.utils import disable_edit_bar
 from opengever.meeting import _
 from opengever.meeting import is_meeting_feature_enabled
+from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from z3c.form import button
 from z3c.form.form import AddForm
@@ -36,6 +37,9 @@ class ModelAddForm(AutoExtensibleForm, AddForm):
     def handleAdd(self, action):
         # self as first argument is required by the decorator
         super(ModelAddForm, self).handleAdd(self, action)
+        api.portal.show_message(
+            _(u'message_record_created', default='Record created'),
+            api.portal.get().REQUEST)
 
     @button.buttonAndHandler(_(u'Cancel', default=u'Cancel'), name='cancel')
     def cancel(self, action):
@@ -88,6 +92,9 @@ class ModelEditForm(EditForm):
     def handleApply(self, action):
         # self as first argument is required by the decorator
         super(ModelEditForm, self).handleApply(self, action)
+        api.portal.show_message(
+            _(u'message_changes_saved', default='Changes saved'),
+            api.portal.get().REQUEST)
 
     @button.buttonAndHandler(_(u'Cancel', default=u'Cancel'), name='cancel')
     def cancel(self, action):

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -66,7 +66,6 @@ class ModelEditForm(EditForm):
     def __init__(self, context, request, model):
         super(ModelEditForm, self).__init__(context, request)
         self.model = model
-        self._has_finished_edit = False
 
     def inject_initial_data(self):
         if self.request.method != 'GET':
@@ -84,7 +83,6 @@ class ModelEditForm(EditForm):
     def applyChanges(self, data):
         self.model.update_model(data)
         # pretend to always change the underlying data
-        self._has_finished_edit = True
         return True
 
     # this renames the button but otherwise preserves super's behavior
@@ -95,6 +93,7 @@ class ModelEditForm(EditForm):
         api.portal.show_message(
             _(u'message_changes_saved', default='Changes saved'),
             api.portal.get().REQUEST)
+        return self.request.RESPONSE.redirect(self.nextURL())
 
     @button.buttonAndHandler(_(u'Cancel', default=u'Cancel'), name='cancel')
     def cancel(self, action):
@@ -102,11 +101,6 @@ class ModelEditForm(EditForm):
 
     def nextURL(self):
         raise NotImplementedError()
-
-    def render(self):
-        if self._has_finished_edit:
-            return self.request.response.redirect(self.nextURL())
-        return super(ModelEditForm, self).render()
 
 
 class ModelProxyAddForm(object):

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-05 10:25+0000\n"
+"POT-Creation-Date: 2015-03-05 10:35+0000\n"
 "PO-Revision-Date: 2015-03-03 12:33+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,8 +51,8 @@ msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/preprotocol.py:102
-#: ./opengever/meeting/form.py:40
+#: ./opengever/meeting/browser/meetings/preprotocol.py:104
+#: ./opengever/meeting/form.py:44
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -119,8 +119,8 @@ msgid "Protocols"
 msgstr "Protokolle"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/preprotocol.py:97
-#: ./opengever/meeting/form.py:35
+#: ./opengever/meeting/browser/meetings/preprotocol.py:95
+#: ./opengever/meeting/form.py:36
 msgid "Save"
 msgstr "Speichern"
 
@@ -430,6 +430,17 @@ msgstr "Kommende Sitzungen"
 #: ./opengever/meeting/proposal.py:133
 msgid "label_workflow_state"
 msgstr "Status"
+
+#. Default: "Changes saved"
+#: ./opengever/meeting/browser/meetings/preprotocol.py:100
+#: ./opengever/meeting/form.py:94
+msgid "message_changes_saved"
+msgstr "Änderungen gespeichert"
+
+#. Default: "Record created"
+#: ./opengever/meeting/form.py:41
+msgid "message_record_created"
+msgstr "Eintrag erzeugt"
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/meeting.py:33

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-05 10:25+0000\n"
+"POT-Creation-Date: 2015-03-05 10:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,8 +51,8 @@ msgid "An unexpected error has occurred"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/preprotocol.py:102
-#: ./opengever/meeting/form.py:40
+#: ./opengever/meeting/browser/meetings/preprotocol.py:104
+#: ./opengever/meeting/form.py:44
 msgid "Cancel"
 msgstr ""
 
@@ -119,8 +119,8 @@ msgid "Protocols"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/preprotocol.py:97
-#: ./opengever/meeting/form.py:35
+#: ./opengever/meeting/browser/meetings/preprotocol.py:95
+#: ./opengever/meeting/form.py:36
 msgid "Save"
 msgstr ""
 
@@ -429,6 +429,17 @@ msgstr ""
 #. Default: "State"
 #: ./opengever/meeting/proposal.py:133
 msgid "label_workflow_state"
+msgstr ""
+
+#. Default: "Changes saved"
+#: ./opengever/meeting/browser/meetings/preprotocol.py:100
+#: ./opengever/meeting/form.py:94
+msgid "message_changes_saved"
+msgstr ""
+
+#. Default: "Record created"
+#: ./opengever/meeting/form.py:41
+msgid "message_record_created"
 msgstr ""
 
 #. Default: "Pending"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-05 10:25+0000\n"
+"POT-Creation-Date: 2015-03-05 10:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,8 +54,8 @@ msgid "An unexpected error has occurred"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/preprotocol.py:102
-#: ./opengever/meeting/form.py:40
+#: ./opengever/meeting/browser/meetings/preprotocol.py:104
+#: ./opengever/meeting/form.py:44
 msgid "Cancel"
 msgstr ""
 
@@ -122,8 +122,8 @@ msgid "Protocols"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/preprotocol.py:97
-#: ./opengever/meeting/form.py:35
+#: ./opengever/meeting/browser/meetings/preprotocol.py:95
+#: ./opengever/meeting/form.py:36
 msgid "Save"
 msgstr ""
 
@@ -431,6 +431,17 @@ msgstr ""
 #. Default: "State"
 #: ./opengever/meeting/proposal.py:133
 msgid "label_workflow_state"
+msgstr ""
+
+#. Default: "Changes saved"
+#: ./opengever/meeting/browser/meetings/preprotocol.py:100
+#: ./opengever/meeting/form.py:94
+msgid "message_changes_saved"
+msgstr ""
+
+#. Default: "Record created"
+#: ./opengever/meeting/form.py:41
+msgid "message_record_created"
 msgstr ""
 
 #. Default: "Pending"

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -3,6 +3,7 @@ from datetime import time
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.browser.meetings.meetinglist import MeetingList
 from opengever.meeting.model import Meeting
@@ -37,6 +38,8 @@ class TestMeeting(FunctionalTestCase):
             'End time': '11:00 AM'
         }).submit()
 
+        self.assertEquals([u'Record created'], info_messages())
+
         committee_model = self.committee.load_model()
         self.assertEqual(1, len(committee_model.meetings))
         meeting = committee_model.meetings[0]
@@ -57,6 +60,8 @@ class TestMeeting(FunctionalTestCase):
         browser.login()
         browser.open(MeetingList.url_for(self.committee, meeting) + '/edit')
         browser.fill({'Date': '5/5/12', 'Start time': '3:00 PM'}).submit()
+
+        self.assertEquals([u'Changes saved'], info_messages())
 
         # refresh meeting, due to above request it has lost its session
         # this is expected behavior

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.browser.members import MemberView
 from opengever.meeting.model import Member
@@ -22,8 +23,9 @@ class TestMemberListing(FunctionalTestCase):
         browser.fill({'Firstname': u'Hanspeter',
                       'Lastname': u'Hansj\xf6rg',
                       'E-Mail': u'foo@example.com'}).submit()
-        hans = Member.query.filter_by(firstname=u'Hanspeter').first()
+        self.assertEquals([u'Record created'], info_messages())
 
+        hans = Member.query.filter_by(firstname=u'Hanspeter').first()
         self.assertEqual(MemberView.url_for(self.container, hans),
                          browser.url)
 
@@ -40,6 +42,8 @@ class TestMemberListing(FunctionalTestCase):
         browser.fill({'Firstname': u'Hanspeter',
                       'Lastname': u'Hansj\xf6rg',
                       'E-Mail': u'foo@example.com'}).submit()
+
+        self.assertEquals([u'Changes saved'], info_messages())
 
         member = Member.get(self.member.member_id)
         self.assertIsNotNone(member)

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -3,10 +3,12 @@ from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Member
-from opengever.testing import FunctionalTestCase
 from opengever.meeting.model import Membership
+from opengever.testing import FunctionalTestCase
+
 
 class TestMemberships(FunctionalTestCase):
 
@@ -28,6 +30,8 @@ class TestMemberships(FunctionalTestCase):
                       'End date': '12/31/10',
                       'Member': str(self.member.member_id),
                       'Role': u'H\xe4nswurscht'}).submit()
+
+        self.assertEquals([u'Record created'], info_messages())
 
         memberships = self.committee.get_memberships()
         self.assertEqual(1, len(memberships))

--- a/opengever/meeting/tests/test_preprotocol.py
+++ b/opengever/meeting/tests/test_preprotocol.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.browser.meetings.meetinglist import MeetingList
 from opengever.meeting.browser.meetings.preprotocol import EditPreProtocol
@@ -42,6 +43,8 @@ class TestPreProtocol(FunctionalTestCase):
                       'Discussion': 'We should accept it',
                       'Decision': 'Accepted'}).submit()
 
+        self.assertEquals(['Changes saved'], info_messages())
+
         proposal = Proposal.query.get(self.proposal_model.proposal_id)
         self.assertEqual('It is important', proposal.considerations)
         self.assertEqual('Accept it', proposal.proposed_action)
@@ -76,6 +79,8 @@ class TestPreProtocol(FunctionalTestCase):
                       'Secretary': str(hans.member_id),
                       'Participants': str(peter.member_id),
                       'Other Participants': 'Klara'}).submit()
+
+        self.assertEquals(['Changes saved'], info_messages())
 
         # refresh intances
         meeting = Meeting.query.get(self.meeting.meeting_id)


### PR DESCRIPTION
Currently when creating/editing sql-model driven objects no confirmation messages are shown. This PR adds these messages.