### PR TITLE
Switch to PostgreSQL for local development.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,16 +34,24 @@ Before you can configure your first client you need to set up a database.
 
 Currently there are three SQL databases supported:
 
+- **PostgreSQL**
+
+.. code::
+
+    $ brew install postgresql --with-python
+    $ ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
+    $ launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
+    $ createdb opengever
+
 - **MySQL**
 
 .. code::
 
     $ brew install mysql
     $ mysql -u root
-    > CREATE DATABASE opengever;
+    > CREATE DATABASE opengever CHARACTER SET utf8;
     > GRANT ALL ON opengever.* TO opengever@localhost IDENTIFIED BY 'opengever';
-
-- **PostgreSQL**
+    > FLUSH PRIVILEGES;
 
 - **Oracle**
 

--- a/development.cfg
+++ b/development.cfg
@@ -6,13 +6,39 @@ extends =
 parts +=
     test-inbound-mail
 
+ogds-db-name = opengever
+ogds-db-user = opengever
+ogds-db-pw = opengever
+
+ogds-dsn-postgres = postgresql+psycopg2:///${buildout:ogds-db-name}
+ogds-dsn-mysql = mysql://${buildout:ogds-db-user}:${buildout:ogds-db-pw}@localhost/${buildout:ogds-db-name}?charset=utf8
+
+ogds-dsn = ${buildout:ogds-dsn-postgres}
+ogds-db-driver = psycopg2
+
+#ogds-dsn = ${buildout:ogds-dsn-mysql}
+#ogds-db-driver = MySQL-python
+
+
 [instance]
 zserver-threads = 4
 user = zopemaster:admin
 eggs +=
-    opengever.mysqlconfig
     plonetheme.teamraum
     opengever.maintenance
+    ${buildout:ogds-db-driver}
+
+zcml-additional =
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:db="http://namespaces.zope.org/db">
+
+        <include package="z3c.saconfig" file="meta.zcml" />
+
+        <db:engine name="opengever.db"
+          url="${buildout:ogds-dsn}" pool_recycle="3600" />
+        <db:session name="opengever" engine="opengever.db" />
+    </configure>
 
 zope-conf-additional =
     datetime-format international

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Switch to PostgreSQL for local development.
+  [lgraf]
+
 - Only assign 'Remove GEVER content' permission to manager by default.
   [lgraf]
 


### PR DESCRIPTION
This change switches to **PostgreSQL** as the default DB for local development.

If required, the OGDS DB configuration can be switched back to MySQL by uncommenting the following lines in `development.cfg`:

```ini
ogds-dsn = ${buildout:ogds-dsn-mysql}
ogds-db-driver = MySQL-python
```

Other than installing and setting up PostgreSQL [as documented in the README](https://github.com/4teamwork/opengever.core/blob/1d2c7d1c3f0c497ac922d9f2eaaa0aba5551e97c/README.rst#sql-database) no other action is required.