### PR TITLE
Automatically set predecessor's issuing_org_unit on successor.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Keep predecessor's issuing_org_unit for successor tasks.
+  [phgross]
+
 - Replaced committees listing tab with a committes overview listing.
   [phgross]
 

--- a/opengever/task/successor.py
+++ b/opengever/task/successor.py
@@ -36,11 +36,8 @@ class SuccessorTaskController(grok.Adapter):
 
     def set_predecessor(self, oguid):
         """Sets the predecessor on the adapted object to ``oguid``.
-        A gouid is the client id and the intid seperated by ":".
-        Example: "m1:2331"
         Returns False if it failed.
         """
-
         oguid = Oguid.parse(oguid)
 
         # do we have it in our indexes?
@@ -51,6 +48,11 @@ class SuccessorTaskController(grok.Adapter):
         # set the predecessor in the task object
         self.task.predecessor = oguid.id
         modified(self.task)
+
+        # keep predecessor's issuing_org_unit
+        successor = self.task.get_sql_object()
+        successor.issuing_org_unit = predecessor.issuing_org_unit
+
         return True
 
     def get_successors(self):


### PR DESCRIPTION
When accepting multiclient tasks, the `issuing_org_unit` of the successors is
wrongly be set to the current_org_unit instead of keeping the issuing_org_unit
from the predecessor. Therefore we reset the `issuing_org_unit` when setting the
predecessor with the SuccessorTaskController.

@deiferni please have a look ... 