### PR TITLE
Use checkbox widget to select participations roles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Use checkbox widget to select participations roles.
+  This fixes an issue with ie10 and ie11 where no selection could be made.
+  [deiferni]
+
 - Keep predecessor's issuing_org_unit for successor tasks.
   [phgross]
 

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -1,4 +1,3 @@
-from Products.statusmessages.interfaces import IStatusMessage
 from collective.elephantvocabulary import wrap_vocabulary
 from five import grok
 from opengever.dossier import _
@@ -8,7 +7,9 @@ from persistent.list import PersistentList
 from plone.directives import form
 from plone.formwidget.autocomplete import AutocompleteFieldWidget
 from plone.z3cform import layout
+from Products.statusmessages.interfaces import IStatusMessage
 from rwproperty import getproperty, setproperty
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zope import schema
 from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
@@ -147,6 +148,7 @@ class ParticipationAddForm(z3c.form.form.Form):
     label = _(u'label_participation', default=u'Participation')
     ignoreContext = True
     fields['contact'].widgetFactory = AutocompleteFieldWidget
+    fields['roles'].widgetFactory = CheckBoxFieldWidget
 
     @z3c.form.button.buttonAndHandler(_(u'button_add', default=u'Add'))
     def handle_add(self, action):


### PR DESCRIPTION
This fixes an issue with ie10 and ie11 where no selection could be made and
improves usability.

The new widget looks like this:
![screen shot 2015-03-11 at 11 47 33](https://cloud.githubusercontent.com/assets/736583/6594805/b996a8ec-c7e4-11e4-9769-d49aafdec6a3.png)

Before it looked like so:
![screen shot 2015-03-11 at 11 57 41](https://cloud.githubusercontent.com/assets/736583/6594955/e2b2388a-c7e5-11e4-8794-1cbbdf5139c5.png)

