### PR TITLE
SchemaMigration: Fix tracking table creation for DBs supporting transactional DDL

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,19 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
+- SchemaMigration: Fix tracking table creation for DBs supporting transactional DDL:
+
+  If the tracking table is created for the first time, it's not visible in
+  metadata until the transaction has been committed.
+
+  Therefore we need to have a method that tries to fetch an existing tracking
+  table and return it, or if it doesn't exist yet, creates it and then
+  returns the created table. In order to keep a reference to the tracking table
+  across several SchemaMigration upgrade steps, a module global is used.
+
+  Returning the table created by op.create_table requires alembic >= 0.7.0.
+  [lgraf]
+
 - Rename UniqueConstraints names of the SubmittedDocument table,
   because of oracle's limitation to 30 chars.
   [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
+- SchemaMigration: Make sure transaction is marked as changed even if it
+  only contains DDL statements. See zope/sqlalchemy/README.txt#L145-L164
+  [lgraf]
+
 - SchemaMigration: Fix tracking table creation for DBs supporting transactional DDL:
 
   If the tracking table is created for the first time, it's not visible in

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -175,7 +175,8 @@ class SchemaMigration(UpgradeStep):
         self.metadata.reflect()
 
     def get_foreign_key_name(self, table_name, column_name):
-        foreign_keys = self.op.metadata.tables.get(table_name).columns.get(column_name).foreign_keys
+        table = self.op.metadata.tables.get(table_name)
+        foreign_keys = table.columns.get(column_name).foreign_keys
         assert len(foreign_keys) == 1
         return foreign_keys.pop().name
 
@@ -203,7 +204,7 @@ class SchemaMigration(UpgradeStep):
         current_version_row = self.execute(
             select([versions_table.c.upgradeid]).where(
                 versions_table.c.profileid == self.profileid).distinct()
-            ).fetchone()
+        ).fetchone()
         return current_version_row.upgradeid or 0
 
     def _has_upgrades_to_install(self):
@@ -225,7 +226,7 @@ class SchemaMigration(UpgradeStep):
         result = self.execute(
             versions_table.select().where(
                 versions_table.c.profileid == self.profileid)
-            ).fetchall()
+        ).fetchall()
         if result:
             return
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(name='opengever.core',
         # Remove ftw.treeview when uninstall upgrade installed.
         'ftw.treeview',
 
-        'alembic',
+        'alembic >= 0.7.0',
         'collective.autopermission',
         'collective.blueprint.jsonmigrator',
         'collective.blueprint.usersandgroups',


### PR DESCRIPTION
If the tracking table is created for the first time, it's not visible in `metadata` until the transaction has been committed.

Therefore we need to have a method that tries to fetch an existing tracking table and return it, or if it doesn't exist yet, creates it and then returns the created table.

Returning the table created by op.create_table requires `alembic >= 0.7.0`.