### PR TITLE
Replaced three date/time fields in favour of two datetime fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop three date/time fields in favour of two datetime fields.
+  [deiferni, phgross]
 
 
 4.2.0 (2015-03-12)

--- a/opengever/base/tests/test_pathbar.py
+++ b/opengever/base/tests/test_pathbar.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -53,7 +53,7 @@ class TestPathBar(FunctionalTestCase):
         committee = create(Builder('committee').within(container))
         meeting = create(Builder('meeting')
                          .having(committee=committee.load_model(),
-                                 date=date(2010, 1, 1)))
+                                 start=datetime(2010, 1, 1)))
 
         browser.login().open(view=meeting.physical_path)
         last_link = browser.css('#portal-breadcrumbs a')[-1]

--- a/opengever/meeting/browser/committeetabs.py
+++ b/opengever/meeting/browser/committeetabs.py
@@ -12,7 +12,7 @@ class Meetings(MeetingListingTab):
 
     selection = ViewPageTemplateFile("templates/no_selection.pt")
 
-    sort_on = 'date'
+    sort_on = 'start'
 
     enabled_actions = []
     major_actions = []

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -1,4 +1,3 @@
-from ftw.datepicker.widget import DatePickerFieldWidget
 from opengever.meeting import _
 from opengever.meeting.browser.meetings.agendaitem import DeleteAgendaItem
 from opengever.meeting.browser.meetings.agendaitem import ScheduleSubmittedProposal
@@ -36,17 +35,12 @@ class IMeetingModel(form.Schema):
         max_length=256,
         required=False)
 
-    form.widget(date=DatePickerFieldWidget)
-    date = schema.Date(
-        title=_('label_date', default=u"Date"),
+    start = schema.Datetime(
+        title=_('label_start', default=u"Start"),
         required=True)
 
-    start_time = schema.Time(
-        title=_('label_start_time', default=u'Start time'),
-        required=False)
-
-    end_time = schema.Time(
-        title=_('label_end_time', default=u'End time'),
+    end = schema.Datetime(
+        title=_('label_end', default=u"End"),
         required=False)
 
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-09 12:42+0000\n"
-"PO-Revision-Date: 2015-03-09 13:47+0100\n"
+"POT-Creation-Date: 2015-03-13 10:38+0000\n"
+"PO-Revision-Date: 2015-03-13 11:44+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -26,7 +26,7 @@ msgid "Add Agenda Item"
 msgstr "Traktandum hinzufügen"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:58
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
@@ -49,7 +49,7 @@ msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:147
+#: ./opengever/meeting/browser/meetings/meeting.py:141
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -173,12 +173,12 @@ msgid "button_submit_documents"
 msgstr "Dokumente einreichen"
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:48
+#: ./opengever/meeting/model/meeting.py:45
 msgid "close"
 msgstr "Schliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:38
+#: ./opengever/meeting/model/meeting.py:35
 msgid "closed"
 msgstr "geschlossen"
 
@@ -270,7 +270,7 @@ msgid "decided"
 msgstr "Beschlossen"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:37
+#: ./opengever/meeting/model/meeting.py:34
 msgid "held"
 msgstr "Durchgeführt"
 
@@ -291,12 +291,12 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:46
+#: ./opengever/meeting/model/meeting.py:43
 msgid "hold meeting"
 msgstr "Sitzung durchführen"
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:30
+#: ./opengever/meeting/browser/meetings/meeting.py:29
 #: ./opengever/meeting/proposal.py:34
 msgid "label_committee"
 msgstr "Kommission"
@@ -310,11 +310,6 @@ msgstr "Erwägungen"
 #: ./opengever/meeting/browser/committee.py:31
 msgid "label_current_members"
 msgstr "Aktuelle Mitglieder"
-
-#. Default: "Date"
-#: ./opengever/meeting/browser/meetings/meeting.py:41
-msgid "label_date"
-msgstr "Datum"
 
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:14
@@ -338,10 +333,10 @@ msgstr "Dokumente"
 msgid "label_email"
 msgstr "E-Mail"
 
-#. Default: "End time"
-#: ./opengever/meeting/browser/meetings/meeting.py:49
-msgid "label_end_time"
-msgstr "Bis (Uhrzeit)"
+#. Default: "End"
+#: ./opengever/meeting/browser/meetings/meeting.py:43
+msgid "label_end"
+msgstr "Ende"
 
 #. Default: "Firstname"
 #: ./opengever/meeting/browser/members.py:22
@@ -364,7 +359,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:35
+#: ./opengever/meeting/browser/meetings/meeting.py:34
 msgid "label_location"
 msgstr "Ort"
 
@@ -418,10 +413,10 @@ msgstr "Rolle"
 msgid "label_secretary"
 msgstr "Sekretär"
 
-#. Default: "Start time"
-#: ./opengever/meeting/browser/meetings/meeting.py:45
-msgid "label_start_time"
-msgstr "Von (Uhrzeit)"
+#. Default: "Start"
+#: ./opengever/meeting/browser/meetings/meeting.py:39
+msgid "label_start"
+msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/committee.py:22
@@ -461,7 +456,7 @@ msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:36
+#: ./opengever/meeting/model/meeting.py:33
 #: ./opengever/meeting/model/proposal.py:71
 msgid "pending"
 msgstr "In Bearbeitung"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-09 12:42+0000\n"
+"POT-Creation-Date: 2015-03-13 10:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgid "Add Agenda Item"
 msgstr ""
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:58
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 msgid "Add Meeting"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:147
+#: ./opengever/meeting/browser/meetings/meeting.py:141
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -173,12 +173,12 @@ msgid "button_submit_documents"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:48
+#: ./opengever/meeting/model/meeting.py:45
 msgid "close"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:38
+#: ./opengever/meeting/model/meeting.py:35
 msgid "closed"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgid "decided"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:37
+#: ./opengever/meeting/model/meeting.py:34
 msgid "held"
 msgstr ""
 
@@ -291,12 +291,12 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:46
+#: ./opengever/meeting/model/meeting.py:43
 msgid "hold meeting"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:30
+#: ./opengever/meeting/browser/meetings/meeting.py:29
 #: ./opengever/meeting/proposal.py:34
 msgid "label_committee"
 msgstr ""
@@ -309,11 +309,6 @@ msgstr ""
 #. Default: "Current members"
 #: ./opengever/meeting/browser/committee.py:31
 msgid "label_current_members"
-msgstr ""
-
-#. Default: "Date"
-#: ./opengever/meeting/browser/meetings/meeting.py:41
-msgid "label_date"
 msgstr ""
 
 #. Default: "Start date"
@@ -338,9 +333,9 @@ msgstr ""
 msgid "label_email"
 msgstr ""
 
-#. Default: "End time"
-#: ./opengever/meeting/browser/meetings/meeting.py:49
-msgid "label_end_time"
+#. Default: "End"
+#: ./opengever/meeting/browser/meetings/meeting.py:43
+msgid "label_end"
 msgstr ""
 
 #. Default: "Firstname"
@@ -364,7 +359,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:35
+#: ./opengever/meeting/browser/meetings/meeting.py:34
 msgid "label_location"
 msgstr ""
 
@@ -418,9 +413,9 @@ msgstr ""
 msgid "label_secretary"
 msgstr ""
 
-#. Default: "Start time"
-#: ./opengever/meeting/browser/meetings/meeting.py:45
-msgid "label_start_time"
+#. Default: "Start"
+#: ./opengever/meeting/browser/meetings/meeting.py:39
+msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
@@ -461,7 +456,7 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:36
+#: ./opengever/meeting/model/meeting.py:33
 #: ./opengever/meeting/model/proposal.py:71
 msgid "pending"
 msgstr ""

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-03-09 12:42+0000\n"
+"POT-Creation-Date: 2015-03-13 10:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgid "Add Agenda Item"
 msgstr ""
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:58
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 msgid "Add Meeting"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:147
+#: ./opengever/meeting/browser/meetings/meeting.py:141
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -173,12 +173,12 @@ msgid "button_submit_documents"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:48
+#: ./opengever/meeting/model/meeting.py:45
 msgid "close"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:38
+#: ./opengever/meeting/model/meeting.py:35
 msgid "closed"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgid "decided"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:37
+#: ./opengever/meeting/model/meeting.py:34
 msgid "held"
 msgstr ""
 
@@ -291,12 +291,12 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:46
+#: ./opengever/meeting/model/meeting.py:43
 msgid "hold meeting"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:30
+#: ./opengever/meeting/browser/meetings/meeting.py:29
 #: ./opengever/meeting/proposal.py:34
 msgid "label_committee"
 msgstr ""
@@ -309,11 +309,6 @@ msgstr ""
 #. Default: "Current members"
 #: ./opengever/meeting/browser/committee.py:31
 msgid "label_current_members"
-msgstr ""
-
-#. Default: "Date"
-#: ./opengever/meeting/browser/meetings/meeting.py:41
-msgid "label_date"
 msgstr ""
 
 #. Default: "Start date"
@@ -338,9 +333,9 @@ msgstr ""
 msgid "label_email"
 msgstr ""
 
-#. Default: "End time"
-#: ./opengever/meeting/browser/meetings/meeting.py:49
-msgid "label_end_time"
+#. Default: "End"
+#: ./opengever/meeting/browser/meetings/meeting.py:43
+msgid "label_end"
 msgstr ""
 
 #. Default: "Firstname"
@@ -364,7 +359,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:35
+#: ./opengever/meeting/browser/meetings/meeting.py:34
 msgid "label_location"
 msgstr ""
 
@@ -417,9 +412,9 @@ msgstr ""
 msgid "label_secretary"
 msgstr ""
 
-#. Default: "Start time"
-#: ./opengever/meeting/browser/meetings/meeting.py:45
-msgid "label_start_time"
+#. Default: "Start"
+#: ./opengever/meeting/browser/meetings/meeting.py:39
+msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
@@ -460,7 +455,7 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:36
+#: ./opengever/meeting/model/meeting.py:33
 #: ./opengever/meeting/model/proposal.py:71
 msgid "pending"
 msgstr ""

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import datetime
 from opengever.base.oguid import Oguid
 from opengever.ogds.models.query import BaseQuery
 from plone import api
@@ -87,14 +88,14 @@ class MeetingQuery(BaseQuery):
 
     def _upcoming_meetings(self, committee):
         query = self._committee_meetings(committee)
-        query = query.filter(self._attribute('date') >= date.today())
-        query = query.order_by(self._attribute('date'))
+        query = query.filter(self._attribute('start') >= datetime.now())
+        query = query.order_by(self._attribute('start'))
         return query
 
     def _past_meetings(self, committee):
         query = self._committee_meetings(committee)
-        query = query.filter(self._attribute('date') < date.today())
-        query = query.order_by(desc(self._attribute('date')))
+        query = query.filter(self._attribute('start') < datetime.now())
+        query = query.order_by(desc(self._attribute('start')))
         return query
 
     def all_upcoming_meetings(self, committee):

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4213</version>
+    <version>4214</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/tabs/meetinglisting.py
+++ b/opengever/meeting/tabs/meetinglisting.py
@@ -30,11 +30,11 @@ class MeetingListingTab(BaseListingTab):
         {'column': 'location',
          'column_title': _(u'column_location', default=u'Location')},
 
-        {'column': 'start_time',
+        {'column': 'start',
          'column_title': _(u'column_start_time', default=u'Start Time'),
          'transform': lambda item, value: item.get_start_time()},
 
-        {'column': 'end_time',
+        {'column': 'end',
          'column_title': _(u'column_end_time', default=u'End Time'),
          'transform': lambda item, value: item.get_end_time()},
         )

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -19,7 +19,7 @@ class TestAgendaItem(FunctionalTestCase):
         self.committee = create(Builder('committee').within(container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model(),
-                                      date=date(2013, 1, 1),
+                                      start=datetime(2013, 1, 1),
                                       location='There',))
 
     @browsing

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -1,9 +1,8 @@
-from datetime import date
 from datetime import datetime
+from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testing import freeze
 from opengever.testing import FunctionalTestCase
 
 
@@ -127,21 +126,21 @@ class TestCommitteesTab(FunctionalTestCase):
     def test_meetings_display(self, browser):
         meeting1 = create(Builder('meeting')
                           .having(committee=self.committee_model,
-                                  date=date(2015, 01, 01)))
+                                  start=datetime(2015, 01, 01)))
 
         meeting2 = create(Builder('meeting')
                           .having(committee=self.committee_model,
-                                  date=date(2015, 03, 01)))
+                                  start=datetime.now() + timedelta(days=1)))
 
-        with freeze(datetime(2015, 02, 01)):
-            browser.login().open(self.container, view='tabbedview_view-committees')
+        browser.login().open(self.container, view='tabbedview_view-committees')
 
-            self.assertEquals(
-                ['Last Meeting: Jan 01, 2015', 'Next Meeting: Mar 01, 2015'],
-                browser.css('#committees_view .meetings li').text)
+        self.assertEquals(
+            ['Last Meeting: Jan 01, 2015',
+             'Next Meeting: {}'.format(meeting2.get_date())],
+            browser.css('#committees_view .meetings li').text)
 
-            last_meeting = browser.css('#committees_view .meetings li a')[0]
-            next_meeting = browser.css('#committees_view .meetings li a')[1]
+        last_meeting = browser.css('#committees_view .meetings li a')[0]
+        next_meeting = browser.css('#committees_view .meetings li a')[1]
 
-            self.assertEquals(meeting1.get_url(), last_meeting.get('href'))
-            self.assertEquals(meeting2.get_url(), next_meeting.get('href'))
+        self.assertEquals(meeting1.get_url(), last_meeting.get('href'))
+        self.assertEquals(meeting2.get_url(), next_meeting.get('href'))

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import datetime
 from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
@@ -58,13 +59,13 @@ class TestCommitteeOverview(FunctionalTestCase):
     def test_upcoming_meetings_box_only_lists_meetings_in_the_future(self, browser):
         create(Builder('meeting')
                .having(committee=self.committee_model,
-                       date=date.today() - timedelta(days=1)))
+                       start=datetime.now() - timedelta(days=1)))
         meeting2 = create(Builder('meeting')
                           .having(committee=self.committee_model,
-                                  date=date.today()))
+                                  start=datetime.now() + timedelta(hours=1)))
         meeting3 = create(Builder('meeting')
                           .having(committee=self.committee_model,
-                                  date=date.today() + timedelta(days=1)))
+                                  start=datetime.now() + timedelta(days=1)))
 
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
@@ -78,10 +79,10 @@ class TestCommitteeOverview(FunctionalTestCase):
         committee_b_model = committee_b.load_model()
         meeting1 = create(Builder('meeting')
                           .having(committee=self.committee_model,
-                                  date=date.today()))
+                                  start=datetime.now() + timedelta(hours=1)))
         create(Builder('meeting')
                .having(committee=committee_b_model,
-                       date=date.today()))
+                       start=datetime.now() + timedelta(hours=1)))
 
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
@@ -93,7 +94,7 @@ class TestCommitteeOverview(FunctionalTestCase):
     def test_meetings_are_linked_correctly(self, browser):
         meeting = create(Builder('meeting')
                          .having(committee=self.committee_model,
-                                 date=date.today()))
+                                 start=datetime.now() + timedelta(days=1)))
 
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
@@ -106,7 +107,7 @@ class TestCommitteeOverview(FunctionalTestCase):
         for i in range(0, 12):
             create(Builder('meeting')
                    .having(committee=self.committee_model,
-                           date=date.today() + timedelta(days=i)))
+                           start=datetime.now() + timedelta(days=i)))
 
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
@@ -118,7 +119,7 @@ class TestCommitteeOverview(FunctionalTestCase):
         for i in range(0, 12):
             create(Builder('meeting')
                    .having(committee=self.committee_model,
-                           date=date.today() + timedelta(days=i)))
+                           start=datetime.now() + timedelta(days=i)))
 
         browser.login().open(self.committee, view='tabbedview_view-overview')
 

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -115,18 +115,6 @@ class TestCommitteeOverview(FunctionalTestCase):
         self.assertEquals(10, len(meetings))
 
     @browsing
-    def test_meetings_are_limited_to_ten_entries(self, browser):
-        for i in range(0, 12):
-            create(Builder('meeting')
-                   .having(committee=self.committee_model,
-                           start=datetime.now() + timedelta(days=i)))
-
-        browser.login().open(self.committee, view='tabbedview_view-overview')
-
-        meetings = browser.css('#upcoming_meetingsBox li:not(.moreLink) a')
-        self.assertEquals(10, len(meetings))
-
-    @browsing
     def test_proposal_box_only_lists_unscheduled_proposals(self, browser):
         proposal_a = create(Builder('proposal')
                             .having(title=u'Proposal A',

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -1,5 +1,4 @@
-from datetime import date
-from datetime import time
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -22,20 +21,19 @@ class TestMeeting(FunctionalTestCase):
     def test_meeting_title(self):
         self.assertEqual(
             u'Bern, Oct 18, 2013',
-            Meeting(location=u'Bern', date=date(2013, 10, 18)).get_title())
+            Meeting(location=u'Bern', start=datetime(2013, 10, 18)).get_title())
 
         self.assertEqual(
             u'Oct 18, 2013',
-            Meeting(date=date(2013, 10, 18)).get_title())
+            Meeting(start=datetime(2013, 10, 18)).get_title())
 
     @browsing
     def test_add_meeting(self, browser):
         browser.login().open(self.committee, view='add-meeting')
         browser.fill({
-            'Date': '1/1/10',
+            'Start': datetime(2010, 1, 1, 10),
+            'End': datetime(2010, 1, 1, 11),
             'Location': 'Somewhere',
-            'Start time': '10:00 AM',
-            'End time': '11:00 AM'
         }).submit()
 
         self.assertEquals([u'Record created'], info_messages())
@@ -44,28 +42,26 @@ class TestMeeting(FunctionalTestCase):
         self.assertEqual(1, len(committee_model.meetings))
         meeting = committee_model.meetings[0]
 
-        self.assertEqual(date(2010, 1, 1), meeting.date)
+        self.assertEqual(datetime(2010, 1, 1, 10), meeting.start)
+        self.assertEqual(datetime(2010, 1, 1, 11), meeting.end)
         self.assertEqual('Somewhere', meeting.location)
-        self.assertEqual(time(10), meeting.start_time)
-        self.assertEqual(time(11), meeting.end_time)
 
     @browsing
     def test_edit_meeting(self, browser):
         committee_model = self.committee.load_model()
         meeting = create(Builder('meeting')
                          .having(committee=committee_model,
-                                 date=date(2013, 1, 1),
+                                 start=datetime(2013, 1, 1),
                                  location='There',))
 
         browser.login()
         browser.open(MeetingList.url_for(self.committee, meeting) + '/edit')
-        browser.fill({'Date': '5/5/12', 'Start time': '3:00 PM'}).submit()
+        browser.fill({'Start': datetime(2012, 5, 5, 15)}).submit()
 
         self.assertEquals([u'Changes saved'], info_messages())
 
         # refresh meeting, due to above request it has lost its session
         # this is expected behavior
         meeting = Meeting.query.get(meeting.meeting_id)
-        self.assertEqual(date(2012, 5, 5), meeting.date)
-        self.assertEqual(time(15), meeting.start_time)
+        self.assertEqual(datetime(2012, 5, 5, 15), meeting.start)
         self.assertEqual('There', meeting.location)

--- a/opengever/meeting/tests/test_meeting_query.py
+++ b/opengever/meeting/tests/test_meeting_query.py
@@ -1,5 +1,5 @@
-from datetime import date
 from datetime import datetime
+from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testing import freeze
@@ -21,24 +21,27 @@ class TestMeetingQuery(TestCase):
         committee_2 = create(Builder('committee_model').having(int_id=5678))
 
         meeting1 = create(Builder('meeting')
-                          .having(committee=self.committee, date=date.today()))
+                          .having(committee=self.committee,
+                                  start=datetime.now() + timedelta(hours=1)))
         meeting2 = create(Builder('meeting')
-                          .having(committee=self.committee, date=date.today()))
+                          .having(committee=self.committee,
+                                  start=datetime.now() + timedelta(hours=1)))
         create(Builder('meeting')
-               .having(committee=committee_2, date=date.today()))
+               .having(committee=committee_2,
+                       start=datetime.now() + timedelta(hours=1)))
 
         self.assertEquals([meeting1, meeting2],
                           Meeting.query.all_upcoming_meetings(self.committee))
 
     def test_all_upcoming_meetings_returns_only_future_meetings(self):
         create(Builder('meeting').having(committee=self.committee,
-                                         date=date(2015, 01, 01)))
+                                         start=datetime(2015, 01, 01)))
         meeting_1 = create(Builder('meeting')
                            .having(committee=self.committee,
-                                   date=date(2015, 01, 10)))
+                                   start=datetime(2015, 01, 10)))
         meeting_2 = create(Builder('meeting')
                            .having(committee=self.committee,
-                                   date=date(2015, 01, 15)))
+                                   start=datetime(2015, 01, 15)))
 
         with freeze(datetime(2015, 01, 10)):
             self.assertEquals(
@@ -47,15 +50,15 @@ class TestMeetingQuery(TestCase):
 
     def test_get_next_meeting(self):
         create(Builder('meeting')
-               .having(committee=self.committee, date=date(2015, 01, 01)))
+               .having(committee=self.committee, start=datetime(2015, 01, 01)))
         create(Builder('meeting')
-               .having(committee=self.committee, date=date(2015, 01, 31)))
+               .having(committee=self.committee, start=datetime(2015, 01, 31)))
         create(Builder('meeting')
-               .having(committee=self.committee, date=date(2015, 01, 25)))
+               .having(committee=self.committee, start=datetime(2015, 01, 25)))
 
         meeting = create(Builder('meeting')
                          .having(committee=self.committee,
-                                 date=date(2015, 01, 10)))
+                                 start=datetime(2015, 01, 10)))
 
         with freeze(datetime(2015, 01, 10)):
             self.assertEquals(meeting,
@@ -63,11 +66,11 @@ class TestMeetingQuery(TestCase):
 
     def test_get_last_meeting(self):
         create(Builder('meeting')
-               .having(committee=self.committee, date=date(2015, 01, 01)))
+               .having(committee=self.committee, start=datetime(2015, 01, 01)))
         meeting = create(Builder('meeting')
-               .having(committee=self.committee, date=date(2015, 01, 07)))
+               .having(committee=self.committee, start=datetime(2015, 01, 07)))
         create(Builder('meeting')
-               .having(committee=self.committee, date=date(2015, 01, 15)))
+               .having(committee=self.committee, start=datetime(2015, 01, 15)))
 
         with freeze(datetime(2015, 01, 10)):
             self.assertEquals(meeting,

--- a/opengever/meeting/tests/test_preprotocol.py
+++ b/opengever/meeting/tests/test_preprotocol.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import datetime
 from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
@@ -25,7 +26,7 @@ class TestPreProtocol(FunctionalTestCase):
         self.committee_model = self.committee.load_model()
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee_model,
-                                      date=date(2013, 1, 1),
+                                      start=datetime(2013, 1, 1),
                                       location='There',))
         self.proposal_model = create(Builder('proposal_model'))
         self.agenda_item = create(

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -19,7 +19,7 @@ class TestProposalHistory(FunctionalTestCase):
         self.committee = create(Builder('committee').within(container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model(),
-                                      date=date(2013, 1, 1),
+                                      start=datetime(2013, 1, 1),
                                       location='There',))
         root = create(Builder('repository_root'))
         folder = create(Builder('repository').within(root))

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import MEMORY_DB_LAYER
@@ -15,11 +15,11 @@ class TestUnitMeeting(TestCase):
         self.committee = create(Builder('committee_model'))
         self.meeting = create(Builder('meeting').having(
             committee=self.committee,
-            date=date(2010, 1, 1)))
+            start=datetime(2010, 1, 1)))
 
     def test_string_representation(self):
-        self.assertEqual('<Meeting at "2010-01-01">', str(self.meeting))
-        self.assertEqual('<Meeting at "2010-01-01">', repr(self.meeting))
+        self.assertEqual('<Meeting at "2010-01-01 00:00:00">', str(self.meeting))
+        self.assertEqual('<Meeting at "2010-01-01 00:00:00">', repr(self.meeting))
 
     def test_is_editable(self):
         self.assertTrue(self.meeting.is_editable())

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -140,4 +140,14 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4213 -> 4214 -->
+    <genericsetup:upgradeStep
+        title="Drop three date/time fields in favour of two dattime fields."
+        description="Replace date start_time end_time with two datetime fields (start and end)"
+        source="4213"
+        destination="4214"
+        handler="opengever.meeting.upgrades.to4214.ReplaceTimeFields"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4214.py
+++ b/opengever/meeting/upgrades/to4214.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+
+
+class ReplaceTimeFields(SchemaMigration):
+    """Drop three date/time fields in favour of two dattime fields.
+    It replaces the `date`, `start_time`, `end_time` column with two
+    datetime fields (start & end)"""
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4214
+
+    def migrate(self):
+        self.add_datetime_columns()
+        self.migrate_data()
+        self.drop_date_and_time_columns()
+        self.make_start_column_required()
+
+    def add_datetime_columns(self):
+        self.op.add_column(
+            'meetings', Column('start', DateTime))
+        self.op.add_column(
+            'meetings', Column('end', DateTime))
+
+    def drop_date_and_time_columns(self):
+        self.op.drop_column('meetings', 'date')
+        self.op.drop_column('meetings', 'start_time')
+        self.op.drop_column('meetings', 'end_time')
+
+    def migrate_data(self):
+        self.metadata.clear()
+        self.metadata.reflect()
+
+        meeting_table = self.metadata.tables.get('meetings')
+        meetings = self.connection.execute(meeting_table.select()).fetchall()
+        for meeting in meetings:
+            date = meeting.date
+            start_time = meeting.start_time or datetime.min.time()
+            end_time = meeting.end_time or datetime.min.time()
+
+            start = datetime.combine(date, start_time)
+            end = datetime.combine(date, end_time)
+
+            self.execute(meeting_table.update()
+                .values(start=start, end=end)
+                .where(meeting_table.columns.id == meeting.id)
+            )
+
+    def make_start_column_required(self):
+        self.op.alter_column('meetings', 'start', nullable=False,
+                             existing_type=DateTime)

--- a/opengever/testing/__init__.py
+++ b/opengever/testing/__init__.py
@@ -18,3 +18,4 @@ else:
     from opengever.testing.sql import select_current_org_unit
     from opengever.testing.test_case import FunctionalTestCase
     import opengever.testing.testbrowser_autocomplete_widget
+    import opengever.testing.testbrowser_datetime_widget

--- a/opengever/testing/testbrowser_datetime_widget.py
+++ b/opengever/testing/testbrowser_datetime_widget.py
@@ -1,0 +1,29 @@
+from ftw.testbrowser.widgets.base import widget
+from ftw.testbrowser.widgets.datetime import DateTimeWidget
+
+
+@widget
+class OpengeverDateTimeWidget(DateTimeWidget):
+    """Customize ftw.testbrowser's DateTimeWidget for Opengever/older Plone
+    versions.
+
+    Somehow filling the month field does not work with zero padded month values
+    """
+
+    def fill(self, value):
+        self._field('day').value = value.strftime('%d')
+        self._field('month').value = value.strftime('%m').lstrip('0')
+        self._field('year').value = value.strftime('%Y')
+
+        if not self._field('hour'):
+            return
+
+        if self._field('ampm'):
+            self._field('hour').value = value.strftime('%I')
+            self._field('ampm').value = value.strftime('%p')
+
+        else:
+            self._field('hour').value = value.strftime('%H')
+
+        minute = self._field('min') or self._field('minute')
+        minute.value = value.strftime('%M')


### PR DESCRIPTION
Because Oracle has no Time data type, we change the Date column `date`  and the two time fields (`start_time` and `end_time`) into two DateTime columns `start` and `end`.


@lukasgraf please have a look ... 