### PR TITLE
Remove lovely.buildouthttp from test-plone-4.2.x.cfg.

### DIFF
--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -8,7 +8,6 @@ extends =
 package-name = opengever.core
 package-namespace = opengever
 
-extensions += lovely.buildouthttp
 find-links +=
     http://psc.4teamwork.ch/simple
 


### PR DESCRIPTION
Because the newest version of ftw.recipe.translations pins down `six` to <= `1.2.0`.
Because we don't need the `lovely.buildouthttp` for testing the package I've dropped the including.

In production buildouts we should use the `isotoma` plugin instead of `lovely.buildouthttp`.

@lukasgraf 