### PR TITLE
Rename UniqueConstraints names of the SubmittedDocument table.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
+- Rename UniqueConstraints names of the SubmittedDocument table,
+  because of oracle's limitation to 30 chars.
+  [phgross]
+
 - Drop three date/time fields in favour of two datetime fields.
   [deiferni, phgross]
 

--- a/opengever/meeting/model/submitteddocument.py
+++ b/opengever/meeting/model/submitteddocument.py
@@ -23,9 +23,9 @@ class SubmittedDocument(Base):
     __tablename__ = 'submitteddocuments'
     __table_args__ = (
         UniqueConstraint('admin_unit_id', 'int_id', 'proposal_id',
-                         name='ix_submitted_document_unique_source'),
+                         name='ix_s_docs_unique_src'),
         UniqueConstraint('submitted_admin_unit_id', 'submitted_int_id',
-                         name='ix_submitted_document_unique_target'),
+                         name='ix_s_docs_unique_dst'),
         {})
 
     document_id = Column("id", Integer, Sequence("submitteddocument_id_seq"),

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4214</version>
+    <version>4215</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -150,4 +150,14 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4214 -> 4215 -->
+    <genericsetup:upgradeStep
+        title="Rename UniqueConstraints."
+        description="The UniqueConstraints name has to be limited to 30 chars for Oraclecompatibility."
+        source="4214"
+        destination="4215"
+        handler="opengever.meeting.upgrades.to4215.RenameUniqueConstraints"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4215.py
+++ b/opengever/meeting/upgrades/to4215.py
@@ -1,0 +1,31 @@
+from opengever.core.upgrade import SchemaMigration
+
+
+class RenameUniqueConstraints(SchemaMigration):
+    """For Oracle compatibility the names of UniqueConstraints has to
+    be limitted to max. 30 chars (see ORA-00972)."""
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4215
+
+    def migrate(self):
+        self.remove_old_constraints()
+        self.add_new_constraints()
+
+    def remove_old_constraints(self):
+        self.op.drop_constraint('ix_submitted_document_unique_target',
+                                'submitteddocuments', type_='unique')
+
+        self.op.drop_constraint('ix_submitted_document_unique_source',
+                                'submitteddocuments', type_='unique')
+
+    def add_new_constraints(self):
+        self.op.create_unique_constraint(
+            'ix_s_docs_unique_src',
+            'submitteddocuments',
+            ['admin_unit_id', 'int_id', 'proposal_id'])
+
+        self.op.create_unique_constraint(
+            'ix_s_docs_unique_dst',
+            'submitteddocuments',
+            ['submitted_admin_unit_id', 'submitted_int_id'])


### PR DESCRIPTION
Because of oracle's limitation to 30 chars (ORA-00972) we have to use shorter names for our UniqueConstraints.

@deiferni or @lukasgraf 