### PR TITLE
Improve/fix schema migrations, support transactional and non-transactional DBMS.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,25 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
+- SchemaMigration: Use IdempotentOperations only when executing migrations for MySQL.
+  Also make sure that IdempotentOperations always keeps database metadata up to date.
+  [deiferni]
+
+- Upgrade: fix meeting upgrade to 4200, also migrate data, not only schema.
+  [deiferni]
+
+- Upgrade: add oracle/postgres implementation for upgrade to 4203.
+  [deiferni]
+
+- Upgrade: fix meeting upgrade to 4214, use sqlalchemy expression api as table definition
+  instead of metadata.
+  [deiferni]
+
+- Upgrade: fix meeting upgrate to 4208, correctly create unique constraints.
+
+- Fix an issue with event handlers while deleting a plone-site.
+  [deiferni]
+
 - Update translation for forwarding-transition-reassign transition.
   [phgross]
 

--- a/opengever/core/tests/test_upgrade.py
+++ b/opengever/core/tests/test_upgrade.py
@@ -30,7 +30,7 @@ class TestIdempotentOperations(TestCase):
         self.metadata.create_all()
 
         self.migration_context = MigrationContext.configure(self.connection)
-        self.op = IdempotentOperations(self, self.migration_context)
+        self.op = IdempotentOperations(self.migration_context, self)
         self.inspector = Inspector(self.connection)
 
     def tearDown(self):

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -20,6 +20,10 @@ _tracking_table = None
 logger = logging.getLogger('opengever.upgrade')
 
 
+class AbortUpgrade(Exception):
+    """The upgrade had to be aborted for the reason specified in message."""
+
+
 class IdempotentOperations(Operations):
     """Make alembic.operations tolerant to the same migration instruction being
     called multiple times.
@@ -194,6 +198,14 @@ class SchemaMigration(UpgradeStep):
     @property
     def is_oracle(self):
         return self.dialect_name == 'oracle'
+
+    @property
+    def is_postgres(self):
+        return self.dialect_name == 'postgresql'
+
+    @property
+    def is_mysql(self):
+        return self.dialect_name == 'mysql'
 
     def _log_skipping_migration(self):
         logger.log(logging.INFO,

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -190,7 +190,7 @@ class SchemaMigration(UpgradeStep):
         self.metadata.reflect()
 
     def get_foreign_key_name(self, table_name, column_name):
-        table = self.op.metadata.tables.get(table_name)
+        table = self.metadata.tables.get(table_name)
         foreign_keys = table.columns.get(column_name).foreign_keys
         assert len(foreign_keys) == 1
         return foreign_keys.pop().name
@@ -282,7 +282,7 @@ class SchemaMigration(UpgradeStep):
         session = create_session()
         self.connection = session.connection()
         self.migration_context = MigrationContext.configure(self.connection)
-        self.metadata = MetaData(session.bind, reflect=True)
         self.op = IdempotentOperations(self, self.migration_context)
         self.dialect_name = self.connection.dialect.name
+        self.metadata = MetaData(self.connection, reflect=True)
         return session

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -3,10 +3,21 @@ from OFS.interfaces import IObjectWillBeRemovedEvent
 from opengever.base.model import create_session
 from opengever.document.document import IDocumentSchema
 from opengever.meeting.model import SubmittedDocument
+from zope.component import getUtility
+from zope.component.interfaces import ComponentLookupError
+from zope.intid.interfaces import IIntIds
 
 
 @grok.subscribe(IDocumentSchema, IObjectWillBeRemovedEvent)
 def document_deleted(context, event):
+    # this event is also fired when deleting a plone site. Unfortunately
+    # no deletion-order seems to be guaranteed, so it might happen that the
+    # IntId utility is removed before removing content.
+    try:
+        getUtility(IIntIds)
+    except ComponentLookupError:
+        return
+
     session = create_session()
     for doc in SubmittedDocument.query.by_document(context).all():
         session.delete(doc)

--- a/opengever/meeting/upgrades/to4208.py
+++ b/opengever/meeting/upgrades/to4208.py
@@ -28,11 +28,12 @@ class AddSubmittedDocumentsTable(SchemaMigration):
             Column("submitted_int_id", Integer),
             Column("submitted_physical_path", String(256))
         )
-        self.op.create_index(
+
+        self.op.create_unique_constraint(
             'ix_submitted_document_unique_source',
             'submitteddocuments',
             ['admin_unit_id', 'int_id', 'proposal_id'])
-        self.op.create_index(
+        self.op.create_unique_constraint(
             'ix_submitted_document_unique_target',
             'submitteddocuments',
             ['submitted_admin_unit_id', 'submitted_int_id'])


### PR DESCRIPTION
Use `IdempotentOperations` only for MySQL, i.e. when no transactional DDL is available. Don't use `IdempotentOperations` any more when transactional DDL is available (e.g. for oracle and postgres). Improve `IdempotentOperations` - always update metadata when performing database changes.

*Note, currently not all `IdempotentOperations` methods are overwritten to be idempotent. This should be done on demand - we want to drop MySQL support sooner or later.*

Furthermore fix some existing migrations to work with MySQL and PostgreSQL (and Oracle). Don't use metadata tables for data migrations any more but create local table definitions using [sqlalchemy expressions](http://docs.sqlalchemy.org/en/latest/core/selectable.html).
