### PR TITLE
Do not show resolved tasks as overdue.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Do not show resolved tasks as overdue.
+  [phgross]
+
 - Add DossierMigrator that migrates dossier responsibles (to be used
   with ftw.usermigration).
   [lgraf]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -38,6 +38,7 @@ class Task(Base):
     OVERDUE_INDEPENDENT_STATES = ['task-state-cancelled',
                                   'task-state-rejected',
                                   'task-state-tested-and-closed',
+                                  'task-state-resolved',
                                   'forwarding-state-closed']
 
     __tablename__ = 'tasks'

--- a/opengever/globalindex/tests/test_sql_task.py
+++ b/opengever/globalindex/tests/test_sql_task.py
@@ -101,11 +101,30 @@ class TestGlobalindexTask(TestCase):
         self.assertTrue(overdue.is_overdue)
 
     def test_is_overdue_respect_overdue_independent_states(self):
-        overdue = create(Builder('globalindex_task').having(
-            int_id=12345, deadline=date.today() - timedelta(days=10),
-            review_state='task-state-tested-and-closed'))
+        overdue_date = date.today() - timedelta(days=10)
 
-        self.assertFalse(overdue.is_overdue)
+        closed = create(Builder('globalindex_task')
+                        .having(int_id=1, deadline=overdue_date,
+                                review_state='task-state-tested-and-closed'))
+        cancelled = create(Builder('globalindex_task')
+                           .having(int_id=2, deadline=overdue_date,
+                                   review_state='task-state-cancelled'))
+        resolved = create(Builder('globalindex_task')
+                          .having(int_id=3, deadline=overdue_date,
+                                  review_state='task-state-resolved'))
+        rejected = create(Builder('globalindex_task')
+                          .having(int_id=4, deadline=overdue_date,
+                                  review_state='task-state-rejected'))
+        closed_forwarding = create(Builder('globalindex_task')
+                                   .having(int_id=5, deadline=overdue_date,
+                                           task_type='forwarding',
+                                           review_state='forwarding-state-closed'))
+
+        self.assertFalse(closed.is_overdue)
+        self.assertFalse(cancelled.is_overdue)
+        self.assertFalse(resolved.is_overdue)
+        self.assertFalse(rejected.is_overdue)
+        self.assertFalse(closed_forwarding.is_overdue)
 
     def test_deadline_label_returns_span_tag_with_formated_date(self):
         task = create(Builder('globalindex_task').having(


### PR DESCRIPTION
Added `task-state-resolved` to the overdue independent states, because already resolved tasks should not be flaged as overdue.

@deiferni please have a look ... 