### PR TITLE
Add OGDSMigrator that migrates users and inbox groups in OGDS SQL tables

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Add OGDSMigrator that migrates users and inbox groups in OGDS SQL tables
+  (to be used with ftw.usermigration).
+  [lgraf]
+
 - Do not show resolved tasks as overdue.
   [phgross]
 

--- a/opengever/usermigration/ogds.py
+++ b/opengever/usermigration/ogds.py
@@ -1,0 +1,66 @@
+"""
+Helpers for migrating user and group related data in OGDS SQL tables.
+"""
+
+from opengever.ogds.base.utils import ogds_service
+from opengever.usermigration.exceptions import UserMigrationException
+import logging
+
+
+logger = logging.getLogger('opengever.usermigration')
+
+
+class OGDSMigrator(object):
+
+    def __init__(self, portal, principal_mapping, mode='move'):
+        self.portal = portal
+        self.principal_mapping = principal_mapping
+
+        if mode != 'move':
+            raise NotImplementedError(
+                "OGDSMigrator only supports 'move' mode")
+        self.mode = mode
+
+    def _verify_group(self, groupid):
+        ogds_group = ogds_service().fetch_group(groupid)
+        if ogds_group is None:
+            msg = "Group '{}' not found in OGDS!".format(groupid)
+            raise UserMigrationException(msg)
+
+    def _migrate_group(self, org_unit, column_name):
+        moved = []
+        old_groupid = getattr(org_unit, column_name).groupid
+
+        if old_groupid in self.principal_mapping:
+            new_groupid = self.principal_mapping[old_groupid]
+            logger.info("Migrating {} for {} ({} -> {})".format(
+                column_name, str(org_unit), old_groupid, new_groupid))
+            self._verify_group(new_groupid)
+            new_group = ogds_service().fetch_group(new_groupid)
+            setattr(org_unit, column_name, new_group)
+            moved.append((str(org_unit), old_groupid, new_groupid))
+
+        return moved
+
+    def migrate(self):
+        users_groups_moved = []
+        inbox_groups_moved = []
+
+        org_units = ogds_service().all_org_units()
+
+        for org_unit in org_units:
+            # Migrate users_group
+            moved = self._migrate_group(org_unit, 'users_group')
+            users_groups_moved.extend(moved)
+
+            # Migrate inbox_group
+            moved = self._migrate_group(org_unit, 'inbox_group')
+            inbox_groups_moved.extend(moved)
+
+        results = {
+            'users_groups': {
+                'moved': users_groups_moved, 'copied': [], 'deleted': []},
+            'inbox_groups': {
+                'moved': inbox_groups_moved, 'copied': [], 'deleted': []},
+        }
+        return results

--- a/opengever/usermigration/tests/test_ogds_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_migrator.py
@@ -1,0 +1,63 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.ogds.base.utils import ogds_service
+from opengever.testing import FunctionalTestCase
+from opengever.usermigration.exceptions import UserMigrationException
+from opengever.usermigration.ogds import OGDSMigrator
+
+
+class TestOGDSMigrator(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestOGDSMigrator, self).setUp()
+        self.portal = self.layer['portal']
+
+        self.new_users_group = create(Builder('ogds_group')
+                                      .id('new_users_group'))
+        self.new_inbox_group = create(Builder('ogds_group')
+                                      .id('new_inbox_group'))
+
+    def test_users_group_gets_migrated(self):
+        org_unit_id = self.org_unit.unit_id
+        migrator = OGDSMigrator(
+            self.portal, {'client1_users': 'new_users_group'}, 'move')
+        migrator.migrate()
+
+        org_unit = ogds_service().fetch_org_unit(org_unit_id)
+        self.assertEquals('new_users_group', org_unit.users_group.groupid)
+
+    def test_inbox_group_gets_migrated(self):
+        org_unit_id = self.org_unit.unit_id
+        migrator = OGDSMigrator(
+            self.portal, {'client1_inbox_users': 'new_inbox_group'}, 'move')
+        migrator.migrate()
+
+        org_unit = ogds_service().fetch_org_unit(org_unit_id)
+        self.assertEquals('new_inbox_group', org_unit.inbox_group.groupid)
+
+    def test_raises_if_group_doesnt_exist(self):
+        migrator = OGDSMigrator(
+            self.portal, {'client1_users': 'doesnt.exist'}, 'move')
+
+        with self.assertRaises(UserMigrationException):
+            migrator.migrate()
+
+    def test_returns_proper_results_for_moving_users_group(self):
+        migrator = OGDSMigrator(
+            self.portal, {'client1_users': 'new_users_group'}, 'move')
+        results = migrator.migrate()
+
+        self.assertEquals(
+            [('<OrgUnit client1>', 'client1_users', 'new_users_group')],
+            results['users_groups']['moved']
+        )
+
+    def test_returns_proper_results_for_moving_inbox_group(self):
+        migrator = OGDSMigrator(
+            self.portal, {'client1_inbox_users': 'new_inbox_group'}, 'move')
+        results = migrator.migrate()
+
+        self.assertEquals(
+            [('<OrgUnit client1>', 'client1_inbox_users', 'new_inbox_group')],
+            results['inbox_groups']['moved']
+        )


### PR DESCRIPTION
Add `OGDSMigrator` that migrates `users_group` and `inbox group` for `OrgUnits` in OGDS SQL tables (to be used with `ftw.usermigration`).

Needs to be [backported to all `4.x-stable` branches](https://github.com/4teamwork/opengever.core/issues/804).

@phgross @deiferni 