### PR TITLE
Backport "Add DictstorageMigrator that migrates user IDs in dictstorage keys (in SQL)" to 4.2-stable

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.2.2 (unreleased)
 ------------------
 
+- Add DictstorageMigrator that migrates user IDs in dictstorage keys (in SQL).
+  (to be used with ftw.usermigration).
+  [lgraf]
+
 - Add OGDSMigrator that migrates users and inbox groups in OGDS SQL tables
   (to be used with ftw.usermigration).
   [lgraf]

--- a/opengever/usermigration/dictstorage.py
+++ b/opengever/usermigration/dictstorage.py
@@ -1,0 +1,78 @@
+"""
+Helpers for migrating user and group related data in dictstorage SQL tables.
+"""
+
+from ftw.dictstorage.sql import DictStorageModel
+from opengever.ogds.base.utils import create_session
+from opengever.ogds.base.utils import ogds_service
+from opengever.usermigration.exceptions import UserMigrationException
+import logging
+
+
+logger = logging.getLogger('opengever.usermigration')
+
+
+def rreplace(s, old, new, maxreplace=-1):
+    """Pendant to str.replace() that replaces substrings from the right
+    instead of the left (if maxreplace != -1).
+    """
+    return new.join(s.rsplit(old, maxreplace))
+
+
+class DictstorageMigrator(object):
+    """Migrates occurences of a username in dictstorage keys in SQL.
+
+    Will replace the first occurence of the old user ID *from the right*
+    if the key ends with '-olduserid'.
+
+    This approach will fail if there exists a user ID that is a substring of
+    another user ID with a dash, for example:
+    'user42' and 'other-user42'. That should be highly unlikely though.
+    """
+
+    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+        self.portal = portal
+        self.principal_mapping = principal_mapping
+
+        if mode != 'move':
+            raise NotImplementedError(
+                "OGDSMigrator only supports 'move' mode as of yet")
+        self.mode = mode
+
+        self.strict = strict
+        self.session = create_session()
+
+    def _verify_user(self, userid):
+        ogds_user = ogds_service().fetch_user(userid)
+        if ogds_user is None:
+            msg = "User '{}' not found in OGDS!".format(userid)
+            if self.strict:
+                raise UserMigrationException(msg)
+            else:
+                logger.warn(msg)
+
+    def _migrate_dictstorage_keys(self):
+        moved = []
+
+        entries = self.session.query(DictStorageModel).all()
+        for entry in entries:
+            old_key = entry.key
+            for old_userid in self.principal_mapping:
+                if old_key.endswith('-{}'.format(old_userid)):
+                    new_userid = self.principal_mapping[old_userid]
+                    self._verify_user(new_userid)
+                    # Replace one occurence of old_userid from the right
+                    new_key = rreplace(old_key, old_userid, new_userid, 1)
+                    entry.key = new_key
+                    moved.append((old_key, old_userid, new_userid))
+                    print new_key
+        return moved
+
+    def migrate(self):
+        keys_moved = self._migrate_dictstorage_keys()
+
+        results = {
+            'keys': {
+                'moved': keys_moved, 'copied': [], 'deleted': []},
+        }
+        return results

--- a/opengever/usermigration/tests/test_dictstorage_migrator.py
+++ b/opengever/usermigration/tests/test_dictstorage_migrator.py
@@ -1,0 +1,82 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.dictstorage.sql import DictStorageModel
+from opengever.ogds.base.utils import create_session
+from opengever.testing import FunctionalTestCase
+from opengever.usermigration.dictstorage import DictstorageMigrator
+from opengever.usermigration.exceptions import UserMigrationException
+
+
+class TestDictstorageMigrator(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDictstorageMigrator, self).setUp()
+        self.portal = self.layer['portal']
+        self.session = create_session()
+
+        self.old_user = create(Builder('ogds_user').id('old.user'))
+        self.new_user = create(Builder('ogds_user').id('new.user'))
+
+        self.old_user_with_dash = create(Builder('ogds_user').id('old-user'))
+        self.new_user_with_dash = create(Builder('ogds_user').id('new-user'))
+
+        self.session.add(self.old_user)
+        self.session.add(self.new_user)
+        self.session.add(self.old_user_with_dash)
+        self.session.add(self.new_user_with_dash)
+
+    def test_keys_get_migrated(self):
+        entry = DictStorageModel(
+            key='ftw.tabbedview-foo-tabbedview_view-bar-old.user',
+            value='{}')
+        self.session.add(entry)
+
+        migrator = DictstorageMigrator(
+            self.portal, {'old.user': 'new.user'}, 'move')
+        migrator.migrate()
+
+        self.assertEquals('ftw.tabbedview-foo-tabbedview_view-bar-new.user',
+                          entry.key)
+
+    def test_keys_get_migrated_for_users_with_dash_in_username(self):
+        entry = DictStorageModel(
+            key='ftw.tabbedview-foo-tabbedview_view-bar-old-user',
+            value='{}')
+        self.session.add(entry)
+
+        migrator = DictstorageMigrator(
+            self.portal, {'old-user': 'new-user'}, 'move')
+        migrator.migrate()
+
+        self.assertEquals('ftw.tabbedview-foo-tabbedview_view-bar-new-user',
+                          entry.key)
+
+    def test_raises_if_strict_and_user_doesnt_exist(self):
+        entry = DictStorageModel(key='foo-old.user', value='{}')
+        self.session.add(entry)
+        migrator = DictstorageMigrator(
+            self.portal, {'old.user': 'doesnt.exist'}, 'move')
+
+        with self.assertRaises(UserMigrationException):
+            migrator.migrate()
+
+    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
+        entry = DictStorageModel(key='bar-old.user', value='{}')
+        self.session.add(entry)
+        migrator = DictstorageMigrator(
+            self.portal, {'old.user': 'doesnt.exist'}, 'move', strict=False)
+
+        migrator.migrate()
+        self.assertEquals('bar-doesnt.exist', entry.key)
+
+    def test_returns_proper_results_for_moving_keys(self):
+        entry = DictStorageModel(key='baz-old.user', value='{}')
+        self.session.add(entry)
+        migrator = DictstorageMigrator(
+            self.portal, {'old.user': 'new.user'}, 'move', strict=False)
+
+        results = migrator.migrate()
+        self.assertIn(
+            ('baz-old.user', 'old.user', 'new.user'),
+            results['keys']['moved']
+        )


### PR DESCRIPTION
Backport PR #819 to [`4.2-stable` branch](https://github.com/4teamwork/opengever.core/tree/4.2-stable).
