### PR TITLE
Add plone.formwidget.namedfile to development packages.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Include newest plone.formwidget.namedfile version (solves MIME-Type upload problems).
+  [phgross]
+
 - Add DictstorageMigrator that migrates user IDs in dictstorage keys (in SQL).
   (to be used with ftw.usermigration).
   [lgraf]

--- a/sources.cfg
+++ b/sources.cfg
@@ -6,6 +6,7 @@ development-packages =
   opengever.maintenance
   opengever.ogds.models
   plonetheme.teamraum
+  plone.formwidget.namedfile
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
To make sure that the newest `plone.formwidget.namedfile` is included in the next release, I've added it to the `development-packages`.

We need the fixes from https://github.com/plone/plone.formwidget.namedfile/pull/9.

@lukasgraf @deiferni please have a look ...