### PR TITLE
Implement migrating participants in DossierMigrator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Implement migrating participants in DossierMigrator.
+  [lgraf]
+
 - Add DictstorageMigrator that migrates user IDs in dictstorage keys (in SQL).
   (to be used with ftw.usermigration).
   [lgraf]

--- a/opengever/usermigration/ogds.py
+++ b/opengever/usermigration/ogds.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('opengever.usermigration')
 
 class OGDSMigrator(object):
 
-    def __init__(self, portal, principal_mapping, mode='move'):
+    def __init__(self, portal, principal_mapping, mode='move', strict=True):
         self.portal = portal
         self.principal_mapping = principal_mapping
 
@@ -20,6 +20,7 @@ class OGDSMigrator(object):
             raise NotImplementedError(
                 "OGDSMigrator only supports 'move' mode")
         self.mode = mode
+        self.strict = strict
 
     def _verify_group(self, groupid):
         ogds_group = ogds_service().fetch_group(groupid)

--- a/opengever/usermigration/tests/test_dossier_migrator.py
+++ b/opengever/usermigration/tests/test_dossier_migrator.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import obj2brain
 from opengever.usermigration.dossier import DossierMigrator
@@ -8,10 +9,10 @@ from opengever.usermigration.exceptions import UserMigrationException
 from plone import api
 
 
-class TestDossierMigrator(FunctionalTestCase):
+class TestDossierMigratorForResponsible(FunctionalTestCase):
 
     def setUp(self):
-        super(TestDossierMigrator, self).setUp()
+        super(TestDossierMigratorForResponsible, self).setUp()
         self.portal = self.layer['portal']
         self.catalog = api.portal.get_tool('portal_catalog')
 
@@ -54,12 +55,84 @@ class TestDossierMigrator(FunctionalTestCase):
         migrator.migrate()
         self.assertEquals('doesnt.exist', IDossier(self.dossier).responsible)
 
-    def test_returns_proper_results_for_moving_responsible(self):
+    def test_returns_proper_results_for_moving_responsibles(self):
         migrator = DossierMigrator(
             self.portal, {'old.user': 'new.user'}, 'move')
         results = migrator.migrate()
 
         self.assertEquals(
             [('/plone/dossier-1', 'old.user', 'new.user')],
-            results['responsible']['moved']
+            results['responsibles']['moved']
+        )
+
+
+class TestDossierMigratorForParticipants(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDossierMigratorForParticipants, self).setUp()
+        self.portal = self.layer['portal']
+
+        create(Builder('ogds_user').id('old.participant'))
+        create(Builder('ogds_user').id('new.participant'))
+
+        self.dossier = create(Builder('dossier')
+                              .titled(u'Testdossier'))
+
+        self.phandler = IParticipationAware(self.dossier)
+        p = self.phandler.create_participation('old.participant', ['regard'])
+        self.phandler.append_participiation(p)
+
+    def test_dossier_participation_gets_migrated(self):
+
+        migrator = DossierMigrator(
+            self.portal, {'old.participant': 'new.participant'}, 'move')
+        migrator.migrate()
+
+        self.assertEquals('new.participant',
+                          self.phandler.get_participations()[0].contact)
+
+    def test_contacts_dont_match_principal_mapping(self):
+        # Create a contact with the same name as a mapped user in order to
+        # verify the mapping doesn't match the contact.id
+        contact = create(Builder('contact')
+                         .having(firstname='contact',
+                                 lastname='old'))
+
+        # Create a participation using that contact
+        p = self.phandler.create_participation(contact.contactid(), ['regard'])
+        self.phandler.append_participiation(p)
+
+        migrator = DossierMigrator(self.portal, {contact.id: 'new'}, 'move')
+        migrator.migrate()
+
+        # Should not have been migrated, participation should still refer
+        # to contact:old-contact
+        self.assertEquals('contact:old-contact',
+                          self.phandler.get_participations()[-1].contact)
+
+    def test_raises_if_strict_and_user_doesnt_exist(self):
+        migrator = DossierMigrator(
+            self.portal, {'old.participant': 'doesnt.exist'}, 'move')
+
+        with self.assertRaises(UserMigrationException):
+            migrator.migrate()
+
+    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
+        migrator = DossierMigrator(
+            self.portal, {'old.participant': 'doesnt.exist'},
+            'move', strict=False)
+
+        migrator.migrate()
+
+        self.assertEquals('doesnt.exist',
+                          self.phandler.get_participations()[0].contact)
+
+    def test_returns_proper_results_for_moving_participants(self):
+        migrator = DossierMigrator(
+            self.portal, {'old.participant': 'new.participant'}, 'move')
+        results = migrator.migrate()
+
+        self.assertEquals(
+            [('/plone/dossier-1', 'old.participant', 'new.participant')],
+            results['participations']['moved']
         )


### PR DESCRIPTION
Implement migrating participants in `DossierMigrator`.

Participations are stored as persistent `Participation` objects in the dossier's annotations. The `Participation` objects have a `contact` attribute that contains a string with a user ID of an OGDS user (or a contact, not relevant for this case).

I also sneaked in a commit that adds the `strict` keyword argument previously missing from the `OGDSMigrator`.

Needs to be [backported to all `4.x-stable` branches](https://github.com/4teamwork/opengever.core/issues/804).