### PR TITLE
Customize Language Selector viewlet to display it as a menu.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Customize LanguageSelector viewlet to display it as a menu.
+  [phgross]
+
 - Fixed actor for all task activities.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Examplecontent profile: Add french to the supported language.
+  [phgross]
+
 - Customize LanguageSelector viewlet to display it as a menu.
   [phgross]
 

--- a/opengever/base/tests/test_selector.py
+++ b/opengever/base/tests/test_selector.py
@@ -1,0 +1,48 @@
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone import api
+import transaction
+
+
+class TestLanguageSelectorMenu(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestLanguageSelectorMenu, self).setUp()
+        tool = api.portal.get_tool('portal_languages')
+        tool.addSupportedLanguage('de')
+        tool.addSupportedLanguage('fr')
+        tool.setDefaultLanguage('de')
+
+        transaction.commit()
+
+    @browsing
+    def test_list_all_available_languages(self, browser):
+        browser.login().open(self.portal)
+        self.assertEquals(['English', 'Deutsch', u'Fran\xe7ais'],
+                          browser.css('dl#portal-languageselector dd li').text)
+
+    @browsing
+    def test_title_contains_current_language(self, browser):
+        browser.login().open(self.portal)
+        title = browser.css('dl#portal-languageselector dt').first
+        self.assertEquals('Deutsch', title.text)
+
+    @browsing
+    def test_current_language_is_marked_as_currentLanguage(self, browser):
+        browser.login().open(self.portal)
+        self.assertEquals(
+            ['Deutsch'],
+            browser.css('dl#portal-languageselector dd li.currentLanguage').text)
+
+    @browsing
+    def test_change_current_language(self, browser):
+        browser.login().open(self.portal)
+
+        link = browser.css('dl#portal-languageselector dd a').first
+
+        self.assertEquals('English', link.text)
+        link.click()
+
+        self.assertEquals(
+            ['English'],
+            browser.css('dl#portal-languageselector dd li.currentLanguage').text)

--- a/opengever/base/viewlets/configure.zcml
+++ b/opengever/base/viewlets/configure.zcml
@@ -69,4 +69,14 @@
       class=".contentviews.ModelContentViewsViewlet"
       />
 
+  <!-- Language selector -->
+  <browser:viewlet
+      name="plone.app.i18n.locales.languageselector"
+      manager="plone.app.layout.viewlets.interfaces.IPortalHeader"
+      class=".selector.LanguageSelectorMenu"
+      permission="zope2.View"
+      template="language_selector.pt"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/base/viewlets/language_selector.pt
+++ b/opengever/base/viewlets/language_selector.pt
@@ -1,0 +1,32 @@
+<div id="portal-languageselector-wrapper"
+     tal:define="languages view/languages;
+                 here_url context/absolute_url;
+                 current view/get_current_language"
+     tal:condition="view/available">
+
+  <dl id="portal-languageselector" class="actionMenu deactivated">
+
+    <dt class="actionMenuHeader" >
+      <a tal:content="current/native|current/name" href="#"/>
+    </dt>
+
+    <dd class="actionMenuContent">
+      <ul>
+
+        <tal:language repeat="lang languages">
+          <li tal:define="code lang/code;
+                          selected lang/selected;
+                          codeclass string:language-${code};
+                          current python: selected and 'currentLanguage ' or '';"
+              tal:attributes="class string:${current}${codeclass}">
+            <a href="" tal:define="name lang/native|lang/name" tal:content="name"
+               tal:attributes="title name;
+                               href string:${here_url}/switchLanguage?set_language=${code};">
+            </a>
+          </li>
+        </tal:language>
+
+      </ul>
+    </dd>
+  </dl>
+</div>

--- a/opengever/base/viewlets/selector.py
+++ b/opengever/base/viewlets/selector.py
@@ -1,0 +1,12 @@
+from plone.app.i18n.locales.browser.selector import LanguageSelector
+
+
+class LanguageSelectorMenu(LanguageSelector):
+    """Opengever custom language selector, which display the
+    selector as a dropdown menu.
+    """
+
+    def get_current_language(self):
+        for language in self.languages():
+            if language.get('selected'):
+                return language

--- a/opengever/examplecontent/profiles/default/metadata.xml
+++ b/opengever/examplecontent/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-  <version>2501</version>
+  <version>4300</version>
   <dependencies>
     <dependency>profile-opengever.policy.base:default</dependency>
     <dependency>profile-plonetheme.teamraum:gever</dependency>

--- a/opengever/examplecontent/profiles/default/portal_languages.xml
+++ b/opengever/examplecontent/profiles/default/portal_languages.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object>
+  <supported_langs>
+    <element value="fr"/>
+    <element value="de-ch"/>
+  </supported_langs>
+</object>

--- a/opengever/examplecontent/upgrades/configure.zcml
+++ b/opengever/examplecontent/upgrades/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <!-- 3 -> 2501 -->
@@ -23,4 +24,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
   </configure>
+
+  <!-- 2501 -> 4300 -->
+  <upgrade-step:importProfile
+      title="Activate french as second language."
+      profile="opengever.examplecontent:default"
+      source="2501"
+      destination="4300"
+      directory="profiles/4300"
+      />
+
 </configure>

--- a/opengever/examplecontent/upgrades/profiles/4300/portal_languages.xml
+++ b/opengever/examplecontent/upgrades/profiles/4300/portal_languages.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object>
+  <supported_langs>
+    <element value="fr"/>
+    <element value="de-ch"/>
+  </supported_langs>
+</object>


### PR DESCRIPTION
The styling is implemented in the https://github.com/4teamwork/plonetheme.teamraum/pull/286 PR.

Additionally I've added french to the supported languages in the examplecontent profile  to make sure that the language selector is activated during development.

@deiferni please have a look ... 