### PR TITLE
Fix submitting mails with proposals

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Fix submitting proposals that reference mails.
+ [deiferni]
+
 - Meeting: add editing protocols, creating/downloading/updating protocol documents.
   [deiferni]
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -114,6 +114,11 @@ class OGMail(Item):
         """
         return False
 
+    def get_current_version(self):
+        """Mails cannot be edited, they are read-only."""
+
+        return 0
+
 
 class OGMailBase(metadata.MetadataBase):
 

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4217</version>
+    <version>4300</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/workflows.xml
+++ b/opengever/meeting/profiles/default/workflows.xml
@@ -4,6 +4,7 @@
   <object name="opengever_proposal_workflow" meta_type="Workflow"/>
   <object name="opengever_committee_workflow" meta_type="Workflow"/>
   <object name="opengever_committeecontainer_workflow" meta_type="Workflow"/>
+  <object name="opengever_submitted_proposal_workflow" meta_type="Workflow"/>
 
   <bindings>
     <type type_id="opengever.meeting.proposal">
@@ -14,6 +15,9 @@
     </type>
     <type type_id="opengever.meeting.committee">
       <bound-workflow workflow_id="opengever_committee_workflow"/>
+    </type>
+    <type type_id="opengever.meeting.submittedproposal">
+      <bound-workflow workflow_id="opengever_submitted_proposal_workflow"/>
     </type>
   </bindings>
 

--- a/opengever/meeting/profiles/default/workflows/opengever_submitted_proposal_workflow/definition.xml
+++ b/opengever/meeting/profiles/default/workflows/opengever_submitted_proposal_workflow/definition.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<dc-workflow workflow_id="opengever_submitted_proposal_workflow" title="SubmittedProposal Workflow" description="" state_variable="review_state" initial_state="proposal-state-active" manager_bypass="False">
+ <permission>ftw.mail: Add Mail</permission>
+ <state state_id="proposal-state-active" title="proposal-state-active">
+  <permission-map name="ftw.mail: Add Mail" acquired="True">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+ </state>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+  <description>Previous transition</description>
+  <default>
+
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+  <description>The ID of the user who performed the previous transition</description>
+  <default>
+
+   <expression>user/getUserName</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+  <description>Comment about the last transition</description>
+  <default>
+
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+  <description>Provides access to workflow history</description>
+  <default>
+
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard>
+   <guard-permission>Request review</guard-permission>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+  <description>When the previous transition was performed</description>
+  <default>
+
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+</dc-workflow>

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -191,6 +191,31 @@ class TestProposal(FunctionalTestCase):
             browser.open(submitted_proposal, view='edit')
 
     @browsing
+    def test_regression_proposal_submission_with_mails(self, browser):
+        self.grant('Contributor', 'Reader')
+
+        committee = create(Builder('committee').titled('My committee'))
+        mail = create(Builder('mail')
+                      .within(self.dossier)
+                      .with_dummy_message())
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model())
+                          .relate_to(mail))
+
+        browser.login().open(proposal)
+        browser.open(proposal, view='tabbedview_view-overview')
+        browser.find('Submit').click()
+
+        # submitted proposal created
+        self.assertEqual(1, len(committee.listFolderContents()))
+        submitted_proposal = committee.listFolderContents()[0]
+
+        submitted_mail = submitted_proposal.get_documents()[0]
+        self.assertSubmittedDocumentCreated(proposal, mail, submitted_mail)
+
+    @browsing
     def test_proposal_submission_works_correctly(self, browser):
         committee = create(Builder('committee').titled('My committee'))
         document = create(Builder('document')

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -180,4 +180,23 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4217 -> 4300 -->
+    <genericsetup:upgradeStep
+        title="Add submitted proposal workflow."
+        description=""
+        source="4217"
+        destination="4300"
+        handler="opengever.meeting.upgrades.to4300.AddSubmittedProposalWorkflow"
+        profile="opengever.meeting:default"
+        />
+
+    <genericsetup:registerProfile
+        name="4300"
+        title="opengever.meeting: upgrade profile 4300"
+        description=""
+        directory="profiles/4300"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4300/workflows.xml
+++ b/opengever/meeting/upgrades/profiles/4300/workflows.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <object name="opengever_submitted_proposal_workflow" meta_type="Workflow"/>
+
+  <bindings>
+    <type type_id="opengever.meeting.submittedproposal">
+      <bound-workflow workflow_id="opengever_submitted_proposal_workflow"/>
+    </type>
+  </bindings>
+
+</object>

--- a/opengever/meeting/upgrades/profiles/4300/workflows/opengever_submitted_proposal_workflow/definition.xml
+++ b/opengever/meeting/upgrades/profiles/4300/workflows/opengever_submitted_proposal_workflow/definition.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<dc-workflow workflow_id="opengever_submitted_proposal_workflow" title="SubmittedProposal Workflow" description="" state_variable="review_state" initial_state="proposal-state-active" manager_bypass="False">
+ <permission>ftw.mail: Add Mail</permission>
+ <state state_id="proposal-state-active" title="proposal-state-active">
+  <permission-map name="ftw.mail: Add Mail" acquired="True">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+ </state>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+  <description>Previous transition</description>
+  <default>
+
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+  <description>The ID of the user who performed the previous transition</description>
+  <default>
+
+   <expression>user/getUserName</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+  <description>Comment about the last transition</description>
+  <default>
+
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+  <description>Provides access to workflow history</description>
+  <default>
+
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard>
+   <guard-permission>Request review</guard-permission>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+  <description>When the previous transition was performed</description>
+  <default>
+
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+</dc-workflow>

--- a/opengever/meeting/upgrades/to4300.py
+++ b/opengever/meeting/upgrades/to4300.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddSubmittedProposalWorkflow(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile('profile-opengever.meeting.upgrades:4300')
+
+        self.update_workflow_security(
+            ['opengever_submitted_proposal_workflow'], reindex_security=False)


### PR DESCRIPTION
- Add missing workflow for `SubmittedProposal`, allow adding `ftw.mail.mail`
- Add initial version to mails, allow tracking as `SubmittedDocument`