### PR TITLE
Made DeactivatedFKConstraint compatible with newer alembic versions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Made DeactivatedFKConstraint compatible with newer alembic versions.
+  [phgross]
+
 - Fix submitting proposals that reference mails.
  [deiferni]
 

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -198,7 +198,7 @@ class DeactivatedFKConstraint(object):
         self.referent_cols = referent_cols
 
     def __enter__(self):
-        self.op.drop_constraint(self.name, self.source, type='foreignkey')
+        self.op.drop_constraint(self.name, self.source, type_='foreignkey')
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.op.create_foreign_key(self.name, self.source, self.referent,


### PR DESCRIPTION
The type parameter is now named type_ (see http://alembic.readthedocs.org/en/rel_0_6/ops.html#alembic.operations.Operations.drop_constraint.params.type_).

@lukasgraf please have a look ... 