### PR TITLE
Fix icon for the treeporlet favorite functionality.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,11 +5,14 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Fix icons for the treeporlet favorite functionality.
+  [phgross]
+
 - Made DeactivatedFKConstraint compatible with newer alembic versions.
   [phgross]
 
 - Fix submitting proposals that reference mails.
- [deiferni]
+  [deiferni]
 
 - Meeting: add editing protocols, creating/downloading/updating protocol documents.
   [deiferni]

--- a/opengever/base/browser/resources/opengever.css
+++ b/opengever/base/browser/resources/opengever.css
@@ -117,8 +117,8 @@ dl.portlet.portletTreePortlet .helptext p {
 }
 
 dl.portlet.portletTreePortlet .favorite-icon:before {
-  font-family: 'Glyphicons';
-  content: "\e050";
+  font-family: 'opengever';
+  content: "\e62c";
   width: 22px;
   color: #AAA;
   text-align: center;
@@ -135,7 +135,7 @@ dl.portlet.portletTreePortlet .filetree a:hover .favorite-icon:before {
 
 dl.portlet.portletTreePortlet .remove-from-favorites:before,
 dl.portlet.portletTreePortlet .filetree a:hover .favorite-icon.bookmarked:before {
-  content: "\e049";
+  content: "\e62b";
   color: #A13333;
 }
 


### PR DESCRIPTION
The css fonts adjustments in https://github.com/4teamwork/plonetheme.teamraum/pull/284, broke up the icons in the treeportlet. This PR in collaboration with https://github.com/4teamwork/plonetheme.teamraum/pull/288, fix this.

@lukasgraf please have a look ... 

--- 
I don't like to splitting up the theming stuff in to two separate packages, but this should be a separate discussion/change.