### PR TITLE
CSRF: always allow object annotations to be written.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- CSRF: always allow object annotations to be written.
+  [jone, deiferni]
+
 - Fix icons for the treeporlet favorite functionality.
   [phgross]
 

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -2,6 +2,8 @@ from plone.protect.auto import ProtectTransform
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.annotation.attribute import AttributeAnnotations
+from zope.annotation.interfaces import IAnnotatable
+from zope.annotation.interfaces import IAnnotations
 from zope.component import adapts
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
@@ -70,3 +72,8 @@ class OGProtectTransform(ProtectTransform):
         # portal_memberdata._members cache will be written sometimes.
         if IPloneSiteRoot.providedBy(getSite()):
             unprotected_write(getToolByName(getSite(), 'portal_memberdata')._members)
+
+        # always allow writes to context's annotations.
+        context = self.request.PARENTS[0]
+        if IAnnotatable.providedBy(context):
+            unprotected_write(IAnnotations(context))


### PR DESCRIPTION
Fixes #838.

The problem was caused by ftw.footer's FooterViewlet creating
portlet-assignments that are stored in annotations. This causes a write for the
first request on context.