### PR TITLE
Customize CSRF confirmation page and add German translations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Customize CSRF confirmation page and add German translations.
+  [lgraf]
+
 - Added translations for the SearchBoxViewlet placeholder.
   [phgross]
 

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -42,6 +42,14 @@
         layer="opengever.base.interfaces.IOpengeverBaseLayer"
         />
 
+    <browser:page
+        name="confirm-action"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        template="confirm.pt"
+        permission="zope2.View"
+        layer="opengever.base.interfaces.IOpengeverBaseLayer"
+    />
+
     <configure package="plone.app.search">
       <browser:page
           name="updated_search"

--- a/opengever/base/browser/confirm.pt
+++ b/opengever/base/browser/confirm.pt
@@ -1,0 +1,45 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
+<body>
+  <metal:title define-slot="content-title">
+     <h1 class="documentFirstHeading">
+         Confirming User Action.
+     </h1>
+  </metal:title>
+
+  <metal:description define-slot="content-description">
+     <div class="documentDescription">
+         Confirm that you'd like to perform this action.
+     </div>
+  </metal:description>
+
+  <metal:content-core fill-slot="content-core">
+    <metal:content-core define-macro="content-core">
+      <p class="discreet">
+        Careful, it's possible someone is executing an exploit against you.
+        Verify you just performed an action on this site and that you were
+        not referred here by a different website or email.
+      </p>
+      <form tal:attributes="action request/original_url;" method="GET">
+        <tal:values tal:repeat="key python: request.form.keys()">
+          <input type="hidden" tal:attributes="name key; value python: request.form[key]" />
+        </tal:values>
+        <dl>
+          <dt>Original URL</dt>
+          <dd tal:content="request/original_url" />
+        </dl>
+        <div class="formControls">
+          <input type="submit" value="Confirm action" name="form.button.confirm" class="standalone" />
+        </div>
+      </form>
+    </metal:content-core>
+  </metal:content-core>
+
+</body>
+</html>
+

--- a/opengever/base/browser/confirm.pt
+++ b/opengever/base/browser/confirm.pt
@@ -6,13 +6,13 @@
       metal:use-macro="context/main_template/macros/master"
       i18n:domain="plone">
 <body>
-  <metal:title define-slot="content-title">
+  <metal:title fill-slot="content-title">
      <h1 class="documentFirstHeading">
          Confirming User Action.
      </h1>
   </metal:title>
 
-  <metal:description define-slot="content-description">
+  <metal:description fill-slot="content-description">
      <div class="documentDescription">
          Confirm that you'd like to perform this action.
      </div>

--- a/opengever/base/browser/confirm.pt
+++ b/opengever/base/browser/confirm.pt
@@ -4,23 +4,23 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
       metal:use-macro="context/main_template/macros/master"
-      i18n:domain="plone">
+      i18n:domain="opengever.base">
 <body>
   <metal:title fill-slot="content-title">
-     <h1 class="documentFirstHeading">
+     <h1 class="documentFirstHeading" i18n:translate="title_confirming_user_action">
          Confirming User Action.
      </h1>
   </metal:title>
 
   <metal:description fill-slot="content-description">
-     <div class="documentDescription">
+     <div class="documentDescription" i18n:translate="desc_confirm_action">
          Confirm that you'd like to perform this action.
      </div>
   </metal:description>
 
   <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core">
-      <p class="discreet">
+      <p class="discreet" i18n:translate="msg_verify_you_performed_this_action">
         Careful, it's possible someone is executing an exploit against you.
         Verify you just performed an action on this site and that you were
         not referred here by a different website or email.
@@ -34,7 +34,7 @@
           <dd tal:content="request/original_url" />
         </dl>
         <div class="formControls">
-          <input type="submit" value="Confirm action" name="form.button.confirm" class="standalone" />
+          <input i18n:attributes="value label_confirm_action" type="submit" value="Confirm action" name="form.button.confirm" class="standalone" />
         </div>
       </form>
     </metal:content-core>

--- a/opengever/base/browser/confirm.pt
+++ b/opengever/base/browser/confirm.pt
@@ -6,6 +6,10 @@
       metal:use-macro="context/main_template/macros/master"
       i18n:domain="opengever.base">
 <body>
+
+  <metal:block fill-slot="top_slot"
+               tal:define="dummy python:request.set('disable_border',1)" />
+
   <metal:title fill-slot="content-title">
      <h1 class="documentFirstHeading" i18n:translate="title_confirming_user_action">
          Confirming User Action.

--- a/opengever/base/browser/resources/opengever.css
+++ b/opengever/base/browser/resources/opengever.css
@@ -352,4 +352,11 @@ dl.portlet ul.filetree a.toggleNav.expanded {
 
   /* @end */
 
+  /* @group general */
+
+  .template-confirm-action .documentByLine {
+    display: none;
+  }
+
+/* @end */
 }

--- a/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -68,6 +68,9 @@ msgstr "Letzte Änderungen"
 msgid "closed-forwardings"
 msgstr "Abgeschlossene Weiterleitungen"
 
+msgid "committees"
+msgstr "Kommissionen"
+
 msgid "contacts"
 msgstr "Kontakte"
 
@@ -130,6 +133,15 @@ msgstr "Kostenstelle"
 
 msgid "local"
 msgstr "Lokal"
+
+msgid "meetings"
+msgstr "Sitzungen"
+
+msgid "members"
+msgstr "Mitglieder"
+
+msgid "memberships"
+msgstr "Mitgliedschaften"
 
 msgid "my_issues"
 msgstr "Meine Tickets"
@@ -209,20 +221,3 @@ msgstr "Papierkorb"
 msgid "users"
 msgstr "OGDS"
 
-msgid "proposals"
-msgstr "Anträge"
-
-msgid "committees"
-msgstr "Kommissionen"
-
-msgid "members"
-msgstr "Mitglieder"
-
-msgid "meetings"
-msgstr "Sitzungen"
-
-msgid "submittedproposals"
-msgstr "Anträge"
-
-msgid "memberships"
-msgstr "Mitgliedschaften"

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-10 07:28+0000\n"
+"POT-Creation-Date: 2015-04-10 07:35+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -67,6 +67,11 @@ msgstr "Geheim"
 #: opengever/repository/classification.py
 msgid "confidential"
 msgstr "Vertraulich"
+
+#. Default: "Confirm that you'd like to perform this action."
+#: ./opengever/base/browser/confirm.pt:16
+msgid "desc_confirm_action"
+msgstr "Bestätigen Sie bitte, dass Sie diese Aktion durchführen möchten."
 
 #. Default: "You have not selected any Items"
 #: ./opengever/base/browser/copy_items.py:47
@@ -187,6 +192,11 @@ msgstr "Klassifikation"
 msgid "label_comment"
 msgstr "Kommentar"
 
+#. Default: "Confirm action"
+#: ./opengever/base/browser/confirm.pt:37
+msgid "label_confirm_action"
+msgstr "Aktion bestätigen"
+
 #. Default: "Created"
 #: ./opengever/base/viewlets/byline.py:60
 msgid "label_created"
@@ -287,6 +297,11 @@ msgstr "Version"
 msgid "limited-public"
 msgstr "Eingeschränkt öffentlich"
 
+#. Default: "Careful, it's possible someone is executing an exploit against you. Verify you just performed an action on this site and that you were not referred here by a different website or email."
+#: ./opengever/base/browser/confirm.pt:23
+msgid "msg_verify_you_performed_this_action"
+msgstr "Bitte bestätigen Sie, dass Sie selbst diese Aktion durchgeführt haben und nicht durch einen Link in einem E-Mail oder von einer externen Website auf GEVER weitergeleitet wurden. Dies ist eine Sicherheitsmassnahme um sogenannte CSRF Angriffe zu verhindern. Falls Sie diese Meldung sehen, obwohl Sie eine Aktion innerhalb GEVER durchgeführt haben, teilen Sie dies bitte dem Support mit (inkl. einem Screenshot dieser Meldung und der untenstehenden URL)."
+
 #. Default ""
 #: opengever/repository/classification.py
 msgid "not archival worthy"
@@ -326,6 +341,11 @@ msgstr "Haben Sie nicht gefunden, wonach Sie gesucht haben? Die ${advanced_searc
 #: ./opengever/base/browser/search.pt:61
 msgid "search_results_advanced_link"
 msgstr "erweiterte Suche"
+
+#. Default: "Confirming User Action."
+#: ./opengever/base/browser/confirm.pt:10
+msgid "title_confirming_user_action"
+msgstr "Benutzer-Aktion bestätigen"
 
 #. Default: "unchecked"
 #. Default ""

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-02-19 17:05+0000\n"
+"POT-Creation-Date: 2015-04-10 07:28+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -158,7 +158,7 @@ msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:191
+#: ./opengever/base/adapters.py:192
 msgid "label_already_removed"
 msgstr "-- Bereits gelöscht --"
 
@@ -228,7 +228,7 @@ msgid "label_history"
 msgstr "Versionen"
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/base/subscribers.py:17
+#: ./opengever/base/subscribers.py:23
 msgid "label_initial_version_copied"
 msgstr "Dokument kopiert (Initialversion)"
 

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -86,6 +86,9 @@ msgstr "Pendenzenliste"
 msgid "Overview"
 msgstr "Übersicht"
 
+msgid "Search OneGov Gever"
+msgstr "OneGov GEVER durchsuchen"
+
 #: plone.app.search/plone/app/search/search.pt:59
 msgid "Search results"
 msgstr "Suchresultate"
@@ -285,5 +288,3 @@ msgstr "Deaktivieren"
 msgid "tasktemplatefolder-transition-inactiv-activ"
 msgstr "Aktivieren"
 
-msgid "Search OneGov Gever"
-msgstr "OneGov GEVER durchsuchen"

--- a/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -68,6 +68,9 @@ msgstr "Dernières modifications"
 msgid "closed-forwardings"
 msgstr "Transmissions fermé"
 
+msgid "committees"
+msgstr ""
+
 msgid "contacts"
 msgstr "Contacts"
 
@@ -130,6 +133,15 @@ msgstr "Centre de coûts"
 
 msgid "local"
 msgstr "Local"
+
+msgid "meetings"
+msgstr ""
+
+msgid "members"
+msgstr ""
+
+msgid "memberships"
+msgstr ""
 
 msgid "my_issues"
 msgstr "Mes tickets"

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-02-19 17:05+0000\n"
+"POT-Creation-Date: 2015-04-10 07:28+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -155,7 +155,7 @@ msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:191
+#: ./opengever/base/adapters.py:192
 msgid "label_already_removed"
 msgstr ""
 
@@ -225,7 +225,7 @@ msgid "label_history"
 msgstr "Versions"
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/base/subscribers.py:17
+#: ./opengever/base/subscribers.py:23
 msgid "label_initial_version_copied"
 msgstr "Version initiale (documents copiés)"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-10 07:28+0000\n"
+"POT-Creation-Date: 2015-04-10 07:35+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,6 +66,11 @@ msgstr "Strictement confidentiel"
 #: opengever/repository/classification.py
 msgid "confidential"
 msgstr "Confidentiel"
+
+#. Default: "Confirm that you'd like to perform this action."
+#: ./opengever/base/browser/confirm.pt:16
+msgid "desc_confirm_action"
+msgstr ""
 
 #. Default: "You have not selected any Items"
 #: ./opengever/base/browser/copy_items.py:47
@@ -184,6 +189,11 @@ msgstr "Classification"
 msgid "label_comment"
 msgstr "commentaire"
 
+#. Default: "Confirm action"
+#: ./opengever/base/browser/confirm.pt:37
+msgid "label_confirm_action"
+msgstr ""
+
 #. Default: "Created"
 #: ./opengever/base/viewlets/byline.py:60
 msgid "label_created"
@@ -284,6 +294,11 @@ msgstr "Version"
 msgid "limited-public"
 msgstr ""
 
+#. Default: "Careful, it's possible someone is executing an exploit against you. Verify you just performed an action on this site and that you were not referred here by a different website or email."
+#: ./opengever/base/browser/confirm.pt:23
+msgid "msg_verify_you_performed_this_action"
+msgstr ""
+
 #. Default ""
 #: opengever/repository/classification.py
 msgid "not archival worthy"
@@ -323,6 +338,11 @@ msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search}
 #: ./opengever/base/browser/search.pt:61
 msgid "search_results_advanced_link"
 msgstr "Recherche avancée"
+
+#. Default: "Confirming User Action."
+#: ./opengever/base/browser/confirm.pt:10
+msgid "title_confirming_user_action"
+msgstr ""
 
 #. Default ""
 #: opengever/repository/classification.py

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -86,6 +86,9 @@ msgstr "Liste des affaires en suspens"
 msgid "Overview"
 msgstr "Sommaire"
 
+msgid "Search OneGov Gever"
+msgstr "Parcourir OneGov Gever"
+
 #: plone.app.search/plone/app/search/search.pt:59
 msgid "Search results"
 msgstr "Résultat de la recherche"
@@ -285,5 +288,3 @@ msgstr "Déactiver"
 msgid "tasktemplatefolder-transition-inactiv-activ"
 msgstr "Activer"
 
-msgid "Search OneGov Gever"
-msgstr "Parcourir OneGov Gever"

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-10 07:28+0000\n"
+"POT-Creation-Date: 2015-04-10 07:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,6 +65,11 @@ msgstr ""
 #. Default: "confidential"
 #: opengever/repository/classification.py
 msgid "confidential"
+msgstr ""
+
+#. Default: "Confirm that you'd like to perform this action."
+#: ./opengever/base/browser/confirm.pt:16
+msgid "desc_confirm_action"
 msgstr ""
 
 #. Default: "You have not selected any Items"
@@ -184,6 +189,11 @@ msgstr ""
 msgid "label_comment"
 msgstr ""
 
+#. Default: "Confirm action"
+#: ./opengever/base/browser/confirm.pt:37
+msgid "label_confirm_action"
+msgstr ""
+
 #. Default: "Created"
 #: ./opengever/base/viewlets/byline.py:60
 msgid "label_created"
@@ -283,6 +293,11 @@ msgstr ""
 msgid "limited-public"
 msgstr ""
 
+#. Default: "Careful, it's possible someone is executing an exploit against you. Verify you just performed an action on this site and that you were not referred here by a different website or email."
+#: ./opengever/base/browser/confirm.pt:23
+msgid "msg_verify_you_performed_this_action"
+msgstr ""
+
 #. Default ""
 #: opengever/repository/classification.py
 msgid "not archival worthy"
@@ -321,6 +336,11 @@ msgstr ""
 #. Default: "Advanced Search"
 #: ./opengever/base/browser/search.pt:61
 msgid "search_results_advanced_link"
+msgstr ""
+
+#. Default: "Confirming User Action."
+#: ./opengever/base/browser/confirm.pt:10
+msgid "title_confirming_user_action"
 msgstr ""
 
 #. Default ""

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-02-19 17:05+0000\n"
+"POT-Creation-Date: 2015-04-10 07:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -155,7 +155,7 @@ msgid "label_actor"
 msgstr ""
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:191
+#: ./opengever/base/adapters.py:192
 msgid "label_already_removed"
 msgstr ""
 
@@ -225,7 +225,7 @@ msgid "label_history"
 msgstr ""
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/base/subscribers.py:17
+#: ./opengever/base/subscribers.py:23
 msgid "label_initial_version_copied"
 msgstr ""
 


### PR DESCRIPTION
Customize the CSRF confirmation page `@@confirm-action` and add German translations.

- Fix the template: Use `fill-slot` instead of `define-slot` to fill title and description slots properly
- Make the messages in the template translatable
- Hide byline via CSS
- Provide German translations

![csrf-confirmation](https://cloud.githubusercontent.com/assets/405124/7084239/462ce544-df6b-11e4-9a63-c512af299dbf.png)

@phgross 
