### PR TITLE
Made different SchemaMigration Upgradesteps more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Made different SchemaMigration Upgradesteps more robust.
+  [phgross]
+
 - Customize CSRF confirmation page and add German translations.
   [lgraf]
 

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -64,10 +64,23 @@ class IdempotentOperations(Operations):
             return None
         return table.columns.get(column_name)
 
+    def _constraint_exists(self, name, table_name, type_):
+        if type_ == 'unique':
+            return self._has_index(name, table_name)
+        else:
+            return self._has_constraint(name, table_name)
+
     def _has_index(self, indexname, tablename):
         table = self.metadata.tables.get(tablename)
         for index in table.indexes:
             if index.name == indexname:
+                return True
+        return False
+
+    def _has_constraint(self, name, tablename):
+        table = self.metadata.tables.get(tablename)
+        for constraint in table.constraints:
+            if constraint.name == name:
                 return True
         return False
 
@@ -112,7 +125,7 @@ class IdempotentOperations(Operations):
 
     @metadata_operation
     def drop_constraint(self, name, table_name, type_=None, schema=None):
-        if not self._has_index(name, table_name):
+        if not self._constraint_exists(name, table_name, type_):
             logger.log(logging.INFO,
                        "Skipping drop constraint '{0}' for table '{1}', "
                        "constraint does not exists."

--- a/opengever/globalindex/upgrades/to4003.py
+++ b/opengever/globalindex/upgrades/to4003.py
@@ -27,8 +27,9 @@ class AlterSequenceNumberType(SchemaMigration):
         else:
             self.migrate_mysql()
 
-        self.op.create_index('ix_dossier_sequence_number', 'tasks',
-                             ['dossier_sequence_number'])
+        if not self.op._has_index('ix_dossier_sequence_number', 'tasks'):
+            self.op.create_index('ix_dossier_sequence_number', 'tasks',
+                                 ['dossier_sequence_number'])
 
     def migrate_oracle(self):
         # sequence_number

--- a/opengever/meeting/upgrades/to4216.py
+++ b/opengever/meeting/upgrades/to4216.py
@@ -25,10 +25,14 @@ class CreateGeneratedDocument(SchemaMigration):
             Column("generated_version", Integer, nullable=False),
             Column("generated_document_type", String(100), nullable=False),
         )
-        self.op.create_index(
-            'ix_generated_document_unique',
-            'generateddocuments',
-            ['admin_unit_id', 'int_id'])
+
+        if not self.op._has_index('ix_generated_document_unique',
+                                  'generateddocuments'):
+
+            self.op.create_index(
+                'ix_generated_document_unique',
+                'generateddocuments',
+                ['admin_unit_id', 'int_id'])
 
     def create_meeting_columns(self):
         self.op.add_column(


### PR DESCRIPTION
I've adjusted some of our existing SchemaMigration because of problems I've run into while updating a GEVER installation from release `2.7.x` to `3.3`.

@lukasgraf please have a look.