### PR TITLE
Allow configuring sablon templates per committee.

### DIFF
--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -6,8 +6,10 @@ from opengever.meeting.model import Committee as CommitteeModel
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Membership
 from opengever.meeting.service import meeting_service
+from opengever.meeting.sources import sablon_template_source
 from plone import api
 from plone.directives import form
+from z3c.relationfield.schema import RelationChoice
 from zope import schema
 from zope.interface import Interface
 
@@ -15,6 +17,24 @@ from zope.interface import Interface
 class ICommittee(form.Schema):
     """Base schema for the committee.
     """
+
+    pre_protocol_template = RelationChoice(
+        title=_('Pre-protocol template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
+    protocol_template = RelationChoice(
+        title=_('Protocol template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
+    excerpt_template = RelationChoice(
+        title=_('Excerpt template'),
+        source=sablon_template_source,
+        required=False,
+    )
 
 
 class ICommitteeModel(Interface):
@@ -69,14 +89,23 @@ class Committee(ModelContainer):
         committee_model = self.load_model()
         return Meeting.query.all_upcoming_meetings(committee_model)
 
+    def get_committee_container(self):
+        return aq_parent(aq_inner(self))
+
     def get_pre_protocol_template(self):
-        container = aq_parent(aq_inner(self))
-        return container.get_pre_protocol_template()
+        if self.pre_protocol_template:
+            return self.pre_protocol_template.to_object
+
+        return self.get_committee_container().get_pre_protocol_template()
 
     def get_protocol_template(self):
-        container = aq_parent(aq_inner(self))
-        return container.get_protocol_template()
+        if self.protocol_template:
+            return self.protocol_template.to_object
+
+        return self.get_committee_container().get_protocol_template()
 
     def get_excerpt_template(self):
-        container = aq_parent(aq_inner(self))
-        return container.get_excerpt_template()
+        if self.excerpt_template:
+            return self.excerpt_template.to_object
+
+        return self.get_committee_container().get_excerpt_template()

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,19 +1,8 @@
 from opengever.meeting import _
+from opengever.meeting.sources import sablon_template_source
 from plone.dexterity.content import Container
 from plone.directives import form
-from plone.formwidget.contenttree import ObjPathSourceBinder
 from z3c.relationfield.schema import RelationChoice
-
-
-sablon_template_source = ObjPathSourceBinder(
-    portal_type=("opengever.meeting.sablontemplate"),
-    navigation_tree_query={
-        'object_provides':
-            ['opengever.dossier.templatedossier.interfaces.ITemplateDossier',
-             'opengever.meeting.sablontemplate.ISablonTemplate',
-             ],
-        }
-)
 
 
 class ICommitteeContainer(form.Schema):

--- a/opengever/meeting/sources.py
+++ b/opengever/meeting/sources.py
@@ -1,0 +1,12 @@
+from plone.formwidget.contenttree import ObjPathSourceBinder
+
+
+sablon_template_source = ObjPathSourceBinder(
+    portal_type=("opengever.meeting.sablontemplate"),
+    navigation_tree_query={
+        'object_provides':
+            ['opengever.dossier.templatedossier.interfaces.ITemplateDossier',
+             'opengever.meeting.sablontemplate.ISablonTemplate',
+             ],
+        }
+)

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -27,7 +27,8 @@ class TestCommittee(FunctionalTestCase):
         browser.login()
         browser.open(self.container, view='++add++opengever.meeting.committee')
 
-        browser.fill({'Title': u'A c\xf6mmittee'}).submit()
+        browser.fill({'Title': u'A c\xf6mmittee'})
+        browser.css('#form-buttons-save').first.click()
         self.assertIn('Item created',
                       browser.css('.portalMessage.info dd').text)
 
@@ -49,7 +50,8 @@ class TestCommittee(FunctionalTestCase):
         form = browser.css('#content-core form').first
         self.assertEqual(u'My Committee', form.find_field('Title').value)
 
-        browser.fill({'Title': u'A c\xf6mmittee'}).submit()
+        browser.fill({'Title': u'A c\xf6mmittee'})
+        browser.css('#form-buttons-save').first.click()
         self.assertIn('Changes saved',
                       browser.css('.portalMessage.info dd').text)
 

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -1,0 +1,49 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.testing import FunctionalTestCase
+
+
+class TestExcerpt(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestExcerpt, self).setUp()
+
+        self.repository_root = create(Builder('repository_root'))
+        self.repository_folder = create(
+            Builder('repository').within(self.repository_root))
+        self.dossier = create(
+            Builder('dossier').within(self.repository_folder))
+
+        self.templates = create(Builder('templatedossier'))
+        self.sablon_template = create(
+            Builder('sablontemplate')
+            .within(self.templates)
+            .with_asset_file('sablon_template.docx'))
+        container = create(Builder('committee_container').having(
+            pre_protocol_template=self.sablon_template,
+            protocol_template=self.sablon_template,
+            excerpt_template=self.sablon_template))
+
+        self.committee = create(Builder('committee').within(container))
+
+    def test_default_excerpt_is_configured_on_commitee_container(self):
+        self.assertEqual(self.sablon_template,
+                         self.committee.get_excerpt_template())
+
+    @browsing
+    def test_excerpt_template_can_be_configured_per_commitee(self, browser):
+        custom_template = create(
+            Builder('sablontemplate')
+            .within(self.templates)
+            .with_asset_file('sablon_template.docx'))
+
+        browser.login().open(self.committee, view='edit')
+        browser.fill({'Excerpt template': custom_template})
+        browser.css('#form-buttons-save').first.click()
+
+        self.assertEqual(custom_template,
+                         self.committee.get_excerpt_template())

--- a/opengever/meeting/tests/test_preprotocol.py
+++ b/opengever/meeting/tests/test_preprotocol.py
@@ -33,10 +33,12 @@ class TestPreProtocol(FunctionalTestCase):
         self.templates = create(Builder('templatedossier'))
         self.sablon_template = create(
             Builder('sablontemplate')
+            .within(self.templates)
             .with_asset_file('sablon_template.docx'))
         container = create(Builder('committee_container').having(
             pre_protocol_template=self.sablon_template,
-            protocol_template=self.sablon_template))
+            protocol_template=self.sablon_template,
+            excerpt_template=self.sablon_template))
 
         self.committee = create(Builder('committee').within(container))
         self.proposal = create(Builder('proposal')
@@ -70,6 +72,24 @@ class TestPreProtocol(FunctionalTestCase):
         browser.find('Generate pre-protocol').click()
         browser.fill({'Target dossier': self.dossier})
         browser.find('Generate').click()
+
+    def test_default_pre_protocol_is_configured_on_commitee_container(self):
+        self.assertEqual(self.sablon_template,
+                         self.committee.get_pre_protocol_template())
+
+    @browsing
+    def test_pre_protocol_template_can_be_configured_per_commitee(self, browser):
+        custom_template = create(
+            Builder('sablontemplate')
+            .within(self.templates)
+            .with_asset_file('sablon_template.docx'))
+
+        browser.login().open(self.committee, view='edit')
+        browser.fill({'Pre-protocol template': custom_template})
+        browser.css('#form-buttons-save').first.click()
+
+        self.assertEqual(custom_template,
+                         self.committee.get_pre_protocol_template())
 
     @browsing
     def test_pre_protocol_can_be_edited(self, browser):

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -33,10 +33,12 @@ class TestProtocol(FunctionalTestCase):
         self.templates = create(Builder('templatedossier'))
         self.sablon_template = create(
             Builder('sablontemplate')
+            .within(self.templates)
             .with_asset_file('sablon_template.docx'))
         container = create(Builder('committee_container').having(
             pre_protocol_template=self.sablon_template,
-            protocol_template=self.sablon_template))
+            protocol_template=self.sablon_template,
+            excerpt_template=self.sablon_template))
 
         self.committee = create(Builder('committee').within(container))
         self.proposal = create(Builder('proposal')
@@ -71,6 +73,24 @@ class TestProtocol(FunctionalTestCase):
         browser.find('Generate protocol').click()
         browser.fill({'Target dossier': self.dossier})
         browser.find('Generate').click()
+
+    def test_default_protocol_is_configured_on_commitee_container(self):
+        self.assertEqual(self.sablon_template,
+                         self.committee.get_protocol_template())
+
+    @browsing
+    def test_protocol_template_can_be_configured_per_commitee(self, browser):
+        custom_template = create(
+            Builder('sablontemplate')
+            .within(self.templates)
+            .with_asset_file('sablon_template.docx'))
+
+        browser.login().open(self.committee, view='edit')
+        browser.fill({'Protocol template': custom_template})
+        browser.css('#form-buttons-save').first.click()
+
+        self.assertEqual(custom_template,
+                         self.committee.get_protocol_template())
 
     @browsing
     def test_protocol_can_be_edited(self, browser):


### PR DESCRIPTION
Make sablon templates configurable per `Committee`. This configuration is optional. The templates defined on a `CommitteeContainer` will still be mandatory and act as fallback.