### PR TITLE
Add sablon template tab and some bugfixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,18 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Add sablon-template tab on template dossiers.
+  [deiferni]
+
+- No longer show sablon templates in navigation.
+  [deiferni]
+
+- Fix downloading protocol-previews in safari.
+  [deiferni]
+
+- Fix downloading sablong templates in template dossier.
+  [deiferni]
+
 - Optimize member and membership view:
 
   - Added Membership listing to MemberView.

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -1,46 +1,15 @@
-from Acquisition import aq_inner, aq_parent
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from plone.app.dexterity.behaviors.metadata import MetadataBase
-from plone.dexterity.interfaces import IDexterityContent
-from plone.dexterity.interfaces import IDexterityFTI
 from plone.namedfile.utils import get_contenttype
-from plone.rfc822.interfaces import IPrimaryField
-from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.interfaces import ISiteRoot
 from urllib import quote
 from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import IValue
 from z3c.form.value import ComputedValue
-from zope.component import adapts
 from zope.component import getMultiAdapter
-from zope.component import getUtility
-from zope.interface import implements
-from zope.schema import getFieldsInOrder
 import re
 import zope.schema.vocabulary
-
-
-class PrimaryFieldInfo(object):
-    """Helper class that determines the primary field of a schema.
-    See http://groups.google.com/group/dexterity-development/browse_thread/thread/1f244caa7425b814
-    """
-    # XXX: Remove as soon as this gets implemented in dexterity
-    implements(IPrimaryFieldInfo)
-    adapts(IDexterityContent)
-
-    def __init__(self, context):
-        self.context = context
-        fti = getUtility(IDexterityFTI, name=context.portal_type)
-        self.schema = fti.lookupSchema()
-        primary = [
-            (name, field) for name, field in getFieldsInOrder(self.schema)
-            if IPrimaryField.providedBy(field)]
-        if len(primary) != 1:
-            raise TypeError('Could not adapt', context, IPrimaryFieldInfo)
-        self.fieldname, self.field = primary[0]
-
-    @property
-    def value(self):
-        return self.field.get(self.schema(self.context))
 
 
 def create_simple_vocabulary(options, message_factory):

--- a/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -191,6 +191,9 @@ msgstr "Dokumente"
 msgid "reports"
 msgstr "Arbeitsrapporte"
 
+msgid "sablontemplates"
+msgstr "Sablon Vorlagen"
+
 msgid "sharing"
 msgstr "Info"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -191,6 +191,9 @@ msgstr "Documents"
 msgid "reports"
 msgstr "Rapports de travail"
 
+msgid "sablontemplates"
+msgstr ""
+
 msgid "sharing"
 msgstr "Info"
 

--- a/opengever/base/locales/ftw.tabbedview.pot
+++ b/opengever/base/locales/ftw.tabbedview.pot
@@ -220,3 +220,6 @@ msgstr ""
 
 msgid "memberships"
 msgstr ""
+
+msgid "sablontemplates"
+msgstr ""

--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4201</version>
+  <version>4300</version>
 </metadata>

--- a/opengever/base/profiles/default/propertiestool.xml
+++ b/opengever/base/profiles/default/propertiestool.xml
@@ -2,7 +2,6 @@
 <object name="portal_properties" meta_type="Plone Properties Tool">
 
     <object name="navtree_properties" meta_type="Plone Property Sheet">
-
         <property name="metaTypesNotToList" type="lines">
             <element value="ATBooleanCriterion"/>
             <element value="ATCurrentAuthorCriterion"/>
@@ -32,13 +31,13 @@
             <element value="opengever.contact.contact"/>
             <element value="opengever.document.document"/>
             <element value="opengever.inbox.forwarding"/>
+            <element value="opengever.meeting.sablontemplate"/>
             <element value="opengever.task.task"/>
             <element value="opengever.tasktemplates.tasktemplate"/>
             <element value="opengever.tasktemplates.tasktemplatefolder"/>
         </property>
-
     </object>
-    
+
     <object name="site_properties" meta_type="Plone Property Sheet">
         <property name="icon_visibility" type="string">enabled</property>
     </object>

--- a/opengever/base/tests/test_paste_items.py
+++ b/opengever/base/tests/test_paste_items.py
@@ -22,7 +22,7 @@ class TestPasteItems(FunctionalTestCase):
 
         browser.open(contactfolder)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(['Sharing'], actions)
+        self.assertSequenceEqual(['Export as Zip', 'Sharing'], actions)
 
     @browsing
     def test_paste_action_not_displayed_for_templatedossier(self, browser):
@@ -36,7 +36,8 @@ class TestPasteItems(FunctionalTestCase):
 
         browser.open(templatedossier)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(['Properties', 'Sharing'], actions)
+        self.assertSequenceEqual(
+            ['Export as Zip', 'Properties', 'Sharing'], actions)
 
     @browsing
     def test_paste_action_not_displayed_for_mails(self, browser):
@@ -49,7 +50,8 @@ class TestPasteItems(FunctionalTestCase):
 
         browser.open(mail)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(['Properties', 'save attachments'], actions)
+        self.assertSequenceEqual(
+            ['Export as Zip', 'Properties', 'save attachments'], actions)
 
     def test_pasting_copied_document_into_dossier_succeeds(self):
         dossier = create(Builder('dossier'))

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -258,4 +258,13 @@
         directory="profiles/4201"
         />
 
+    <!-- 4201 -> 4300 -->
+    <upgrade-step:importProfile
+        title="No longer show sablon templates in navigation"
+        profile="opengever.base:default"
+        source="4201"
+        destination="4300"
+        directory="profiles/4300"
+        />
+
 </configure>

--- a/opengever/base/upgrades/profiles/4300/propertiestool.xml
+++ b/opengever/base/upgrades/profiles/4300/propertiestool.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="navtree_properties" meta_type="Plone Property Sheet">
+        <property name="metaTypesNotToList" type="lines" purge="False">
+            <element value="opengever.meeting.sablontemplate"/>
+        </property>
+    </object>
+</object>
+

--- a/opengever/base/viewlets/download.py
+++ b/opengever/base/viewlets/download.py
@@ -1,8 +1,8 @@
 from five import grok
 from opengever.base import _
-from opengever.base.behaviors.utils import PrimaryFieldInfo
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from plone.app.versioningbehavior.behaviors import IVersioningSupport
+from plone.dexterity.primary import PrimaryFieldInfo
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
 

--- a/opengever/base/viewlets/download.py
+++ b/opengever/base/viewlets/download.py
@@ -1,10 +1,10 @@
-from Products.CMFCore.utils import getToolByName
-from Products.statusmessages.interfaces import IStatusMessage
 from five import grok
 from opengever.base import _
 from opengever.base.behaviors.utils import PrimaryFieldInfo
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from plone.app.versioningbehavior.behaviors import IVersioningSupport
+from Products.CMFCore.utils import getToolByName
+from Products.statusmessages.interfaces import IStatusMessage
 
 
 class DownloadFileVersion(grok.View):

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -172,6 +172,7 @@ class OpengeverFixture(PloneSandboxLayer):
         applyProfile(portal, 'plone.formwidget.autocomplete:default')
         applyProfile(portal, 'plone.formwidget.contenttree:default')
         applyProfile(portal, 'ftw.contentmenu:default')
+        applyProfile(portal, 'ftw.zipexport:default')
 
     def createMemberFolder(self, portal):
         # Create a Members folder.

--- a/opengever/dossier/menu.py
+++ b/opengever/dossier/menu.py
@@ -13,7 +13,8 @@ class DossierPostFactoryMenu(FilteredPostFactoryMenu):
         factory_id = factory.get('id')
         if factory_id == u'ftw.mail.mail':
             return True
-        if factory_id == u'opengever.meeting.proposal':
+        if factory_id in [u'opengever.meeting.proposal',
+                          u'opengever.meeting.sablontemplate', ]:
             return not is_meeting_feature_enabled()
 
         return False

--- a/opengever/dossier/profiles/default/metadata.xml
+++ b/opengever/dossier/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-    <version>4300</version>
+    <version>4301</version>
 </metadata>

--- a/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
@@ -70,6 +70,11 @@
         <permission value="View"/>
     </action>
 
+    <action title="Sablon Templates" action_id="sablontemplates" category="tabbedview-tabs"
+            condition_expr="object/@@is_meeting_feature_enabled" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
     <action title="Tasktemplate Folders" action_id="tasktemplatefolders"
             category="tabbedview-tabs"
             condition_expr="" url_expr="string:#" visible="True">

--- a/opengever/dossier/templatedossier/tabs.py
+++ b/opengever/dossier/templatedossier/tabs.py
@@ -45,6 +45,36 @@ class TemplateDossierDocuments(Documents):
     ]
 
 
+class TemplateDossierSablonTemplates(Documents):
+    grok.context(ITemplateDossier)
+    grok.name('tabbedview_view-sablontemplates')
+
+    types = ['opengever.meeting.sablontemplate']
+
+    depth = 1
+
+    @property
+    def columns(self):
+        return drop_columns(
+            super(TemplateDossierSablonTemplates, self).columns)
+
+    @property
+    def enabled_actions(self):
+        return filter(
+            lambda x: x not in self.disabled_actions,
+            super(TemplateDossierSablonTemplates, self).enabled_actions)
+
+    disabled_actions = [
+        'cancel',
+        'checkin',
+        'checkout',
+        'create_task',
+        'move_items',
+        'send_as_email',
+        'submit_additional_documents',
+    ]
+
+
 class TemplateDossierTrash(Trash):
     grok.context(ITemplateDossier)
 

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -271,6 +271,7 @@ DOCUMENT_TAB = 'tabbedview_view-documents'
 TRASH_TAB = 'tabbedview_view-trash'
 JOURNAL_TAB = 'tabbedview_view-journal'
 INFO_TAB = 'tabbedview_view-sharing'
+SABLONTEMPLATES_TAB = 'tabbedview_view-sablontemplates'
 
 
 class TestTemplateDossierListings(FunctionalTestCase):
@@ -318,6 +319,28 @@ class TestTemplateDossierListings(FunctionalTestCase):
         create(Builder('document').within(subdossier))
 
         view = self.templatedossier.unrestrictedTraverse(DOCUMENT_TAB)
+        view.update()
+
+        self.assertEquals([document_a],
+                          [brain.getObject() for brain in view.contents])
+
+    def test_enabled_actions_are_limited_in_sablontemplates_tab(self):
+        view = self.templatedossier.unrestrictedTraverse(SABLONTEMPLATES_TAB)
+        self.assertEquals(['checkin_with_comment',
+                           'checkin_without_comment',
+                           'trashed',
+                           'copy_items',
+                           'zip_selected'],
+                          view.enabled_actions)
+
+    def test_sablontemplates_tab_lists_only_documents_directly_beneath(self):
+        subdossier = create(Builder('templatedossier')
+                            .within(self.templatedossier))
+        document_a = create(Builder('sablontemplate')
+                            .within(self.templatedossier))
+        create(Builder('sablontemplate').within(subdossier))
+
+        view = self.templatedossier.unrestrictedTraverse(SABLONTEMPLATES_TAB)
         view.update()
 
         self.assertEquals([document_a],

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -6,6 +6,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ooxml_docprops import read_properties
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.dossier.docprops import TemporaryDocFile
 from opengever.dossier.interfaces import ITemplateDossierProperties
 from opengever.dossier.templatedossier import get_template_dossier
@@ -238,6 +239,24 @@ class TestTemplateDossier(FunctionalTestCase):
 
     @browsing
     def test_addable_types(self, browser):
+        templatedossier = create(Builder('templatedossier'))
+        browser.login().open(templatedossier)
+
+        self.assertEquals(
+            ['Document', 'TaskTemplateFolder', 'Template Dossier'],
+            factoriesmenu.addable_types())
+
+
+class TestTemplateDossierMeetingEnabled(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestTemplateDossierMeetingEnabled, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_addable_types_with_meating_feature(self, browser):
         templatedossier = create(Builder('templatedossier'))
         browser.login().open(templatedossier)
 

--- a/opengever/dossier/upgrades/configure.zcml
+++ b/opengever/dossier/upgrades/configure.zcml
@@ -139,4 +139,14 @@
         directory="profiles/4300"
         />
 
+    <!-- 4300 -> 4301 -->
+    <genericsetup:upgradeStep
+        title="Display sablon-template tab for template-dossiers."
+        description=""
+        source="4300"
+        destination="4301"
+        handler="opengever.dossier.upgrades.to4301.AddSablonTemplatesTab"
+        profile="opengever.dossier:default"
+        />
+
 </configure>

--- a/opengever/dossier/upgrades/to4301.py
+++ b/opengever/dossier/upgrades/to4301.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddSablonTemplatesTab(UpgradeStep):
+
+    def __call__(self):
+        self.actions_add_type_action(
+            'opengever.dossier.templatedossier',
+            after='documents',
+            action_id='sablontemplates',
+            **{'title': 'Sablon Templates',
+               'action': 'string:#',
+               'category': 'tabbedview-tabs',
+               'condition': 'object/@@is_meeting_feature_enabled',
+               'link_target': '',
+               'visible': True,
+               'permissions': ('View', )})

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -62,7 +62,7 @@ class GenerateExcerpt(AutoExtensibleForm, EditForm):
             response.setHeader('X-Theme-Disabled', 'True')
             response.setHeader('Content-Type', MIME_DOCX)
             response.setHeader("Content-Disposition",
-                               "attachment; filename='{}'".format(filename))
+                               'attachment; filename="{}"'.format(filename))
             return sablon.file_data
 
     @button.buttonAndHandler(_('Cancel', default=u'Cancel'), name='cancel')

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -69,7 +69,7 @@ class DownloadGeneratedPreProtocol(BrowserView):
         response.setHeader('X-Theme-Disabled', 'True')
         response.setHeader('Content-Type', MIME_DOCX)
         response.setHeader("Content-Disposition",
-                           "attachment; filename='{}'".format(filename))
+                           'attachment; filename="{}"'.format(filename))
         return sablon.file_data
 
 

--- a/opengever/meeting/sablontemplate.py
+++ b/opengever/meeting/sablontemplate.py
@@ -2,11 +2,13 @@ from opengever.document.document import Document
 from opengever.document.document import IDocumentSchema
 from opengever.meeting import _
 from os.path import join
+from plone.directives import form
 from plone.namedfile.field import NamedBlobFile
 
 
 class ISablonTemplate(IDocumentSchema):
 
+    form.primary('file')
     file = NamedBlobFile(
         title=_(u'label_sablon_template_file', default='File'),
         required=True,

--- a/opengever/meeting/tests/test_download_sablon_template.py
+++ b/opengever/meeting/tests/test_download_sablon_template.py
@@ -1,0 +1,26 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestSablonTemplateDownloadView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestSablonTemplateDownloadView, self).setUp()
+        self.grant('Manager')
+        self.dossier = create(Builder('templatedossier'))
+        self.template = create(
+            Builder('sablontemplate')
+            .attach_file_containing("blub blub", name=u't\xf6st.txt')
+            .within(self.dossier))
+
+    @browsing
+    def test_download_sablon_template(self, browser):
+        browser.login().open(self.template, view='tabbedview_view-overview')
+        browser.find('Download copy').click()
+        browser.find('label_download').click()
+
+        self.assertEqual('attachment; filename="tost.txt"',
+                         browser.headers['content-disposition'])
+        self.assertEqual("blub blub", browser.contents)

--- a/opengever/repository/tests/test_deletion.py
+++ b/opengever/repository/tests/test_deletion.py
@@ -71,7 +71,8 @@ class TestRepositoryDeletion(FunctionalTestCase):
         create(Builder('dossier').within(self.repository))
         browser.login().open(self.repository)
         self.assertEquals(
-            ['Prefix Manager',
+            ['Export as Zip',
+             'Prefix Manager',
              'Properties',
              'Sharing',
              'repositoryfolder-transition-inactivate'],
@@ -82,6 +83,7 @@ class TestRepositoryDeletion(FunctionalTestCase):
         browser.login().open(self.repository)
         self.assertEquals(
             ['Delete',
+             'Export as Zip',
              'Prefix Manager',
              'Properties',
              'Sharing',

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -296,7 +296,8 @@ class Trash(Documents):
     types = ['opengever.dossier.dossier',
              'opengever.document.document',
              'opengever.task.task',
-             'ftw.mail.mail', ]
+             'ftw.mail.mail',
+             'opengever.meeting.sablontemplate', ]
 
     search_options = {'trashed': True}
 


### PR DESCRIPTION
- Display a separate tab for sablon templates on template-dossiers. Also make sablon templates visible in Trash.
- Drop our implementation of `PrimaryFieldInfo`, i has been implemented in `plone.dextertity` in the meantime.

Also fix #864, #839, #868 and #866.