### PR TITLE
Activate statefilter for subdossier listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Activate statefilter also in subdossiers listings.
+  [phgross]
+
 - Fixed french translations
   [phgross]
 

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -125,7 +125,17 @@ class Documents(OpengeverCatalogListingTab):
         ]
 
 
-class BaseDossiersTab(OpengeverCatalogListingTab):
+class Dossiers(OpengeverCatalogListingTab):
+    grok.name('tabbedview_view-dossiers')
+
+    implements(IStateFilterTableSourceConfig)
+
+    selection = ViewPageTemplateFile("selection_dossier.pt")
+    template = ViewPageTemplateFile("generic_dossier.pt")
+
+    open_states = DOSSIER_STATES_OPEN
+    state_filter_name = 'dossier_state_filter'
+    state_filter_available = True
 
     object_provides = 'opengever.dossier.behaviors.dossier.IDossierMarker'
 
@@ -175,29 +185,12 @@ class BaseDossiersTab(OpengeverCatalogListingTab):
     major_actions = ['change_state', ]
 
 
-class Dossiers(BaseDossiersTab):
-    """Dossier listing view. Using the base dossier tab configuration
-    and install additonaly a statefilter (active/all)."""
-
-    grok.name('tabbedview_view-dossiers')
-
-    implements(IStateFilterTableSourceConfig)
-
-    selection = ViewPageTemplateFile("selection_dossier.pt")
-
-    template = ViewPageTemplateFile("generic_dossier.pt")
-
-    open_states = DOSSIER_STATES_OPEN
-
-    state_filter_name = 'dossier_state_filter'
-    state_filter_available = True
-
-
-class SubDossiers(BaseDossiersTab):
+class SubDossiers(Dossiers):
     """Listing of all subdossier. Using only the base dossier tab
     configuration (without a statefilter)."""
 
     grok.name('tabbedview_view-subdossiers')
+
     search_options = {'is_subdossier': True}
 
 

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -1,0 +1,49 @@
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+
+
+class TestDossierListing(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDossierListing, self).setUp()
+
+        self.repository = create(Builder('repository'))
+        self.dossier_a = create(Builder('dossier')
+                                .having(responsible=TEST_USER_ID,
+                                        start=date(2015, 02, 10),
+                                        end=date(2015, 02, 22))
+                                .within(self.repository)
+                                .titled(u'Dossier A'))
+        self.dossier_b = create(Builder('dossier')
+                                .within(self.repository)
+                                .titled(u'Dossier B')
+                                .in_state('dossier-state-inactive'))
+        self.dossier_c = create(Builder('dossier')
+                                .within(self.repository)
+                                .titled(u'Dossier C')
+                                .in_state('dossier-state-resolved'))
+
+    @browsing
+    def test_lists_only_active_dossiers_by_default(self, browser):
+        browser.login().open(self.repository, view='tabbedview_view-dossiers')
+
+        table = browser.css('.listing').first
+
+        self.assertEquals([['',
+                            'Reference Number',
+                            'Title',
+                            'Review state',
+                            'Responsible',
+                            'Start',
+                            'End'],
+                           ['',
+                            'Client1 1 / 1',
+                            'Dossier A',
+                            'dossier-state-active',
+                            'Test User (test_user_1_)',
+                            '10.02.2015',
+                            '22.02.2015']], table.lists())


### PR DESCRIPTION
Inheriting from the Dossier tab instead of inherit from the BaseDossiersTab
class, includes the default dossier statefilter.

Fixes #720.

Feature flag is not necessary in my opinion: The idea was given the thumbs up (https://feedback.onegovgever.ch/t/abgeschlossene-subdossier-ausblenden-filterbar-machen/75)

![bildschirmfoto 2015-04-16 um 07 28 01](https://cloud.githubusercontent.com/assets/485755/7174542/27455352-e40a-11e4-88b8-0a47c7556a88.png)