### PR TITLE
Display submitted-to proposals (and document version) on document overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Display submitted-to proposals (and document version) on document overview.
+  Include a link that allows updating outdated documents.
+  [deiferni]
+
 - Add form to manually generate custom excerpts and store them in a dossier.
   [deiferni]
 

--- a/opengever/document/browser/overview_templates/overview.pt
+++ b/opengever/document/browser/overview_templates/overview.pt
@@ -3,13 +3,46 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="opengever.document">
 <body>
-    <table class="vertical listing">
+  <tal:block tal:define="css_width python:99/2;">
 
+    <div tal:attributes="class string:boxGroup; style string:width:${css_width}%">
+    <table class="vertical listing">
         <tr tal:repeat="row view/get_metadata_rows">
             <th tal:content="row/label">Label</th>
             <td tal:content="structure row/content">Content</td>
         </tr>
+      </table>
+    </div>
 
-    </table>
+    <div tal:attributes="class string:boxGroup; style string:width:${css_width}%">
+      <div id="proposals_box" class="box">
+        <tal:condition tal:condition="view/display_submitted_documents">
+          <h2 i18n:translate="">Submitted with</h2>
+
+          <tal:documents tal:repeat="submitted_document view/submitted_documents">
+            <tal:block tal:define="is_outdated python: view.is_outdated(submitted_document)">
+
+              <div class="proposal" tal:condition="not: is_outdated">
+                <span tal:content="structure python: submitted_document.proposal.get_link()"></span>
+              </div>
+              <div class="propsoal outdated" tal:condition="is_outdated">
+                <div tal:content="structure python: submitted_document.proposal.get_link()"></div>
+                <div tal:content="python: view.render_submitted_version(submitted_document)"></div>
+                <div tal:content="python: view.render_current_document_version()"></div>
+                <a tal:attributes="href python: view.get_update_document_url(submitted_document);
+                                   class python: 'overdue' if is_outdated else ''"
+                   i18n:translate=""
+                  >
+                  Update document in proposal
+                </a>
+              </div>
+
+            </tal:block>
+          </tal:documents>
+        </tal:condition>
+      </div>
+    </div>
+
+  </tal:block>
 </body>
 </html>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-04-20 09:47+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -76,6 +76,10 @@ msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
 msgid "Create Task"
 msgstr "Aufgabe erstellen"
 
+#: ./opengever/document/browser/overview.py:170
+msgid "Current version: ${version}"
+msgstr "Aktuelle Version: ${version}"
+
 #: ./opengever/document/profiles/default/types/opengever.document.document.xml
 msgid "Document"
 msgstr "Dokument"
@@ -103,6 +107,14 @@ msgstr "Als E-Mail versenden"
 msgid "Submit additional documents"
 msgstr "Dokumente nachreichen"
 
+#: ./opengever/document/browser/overview.py:166
+msgid "Submitted version: ${version}"
+msgstr "Eingereichte Version: ${version}"
+
+#: ./opengever/document/browser/overview_templates/overview.pt:20
+msgid "Submitted with"
+msgstr "Eingereicht bei"
+
 #: ./opengever/document/browser/download.py:39
 #: ./opengever/document/browser/edit.py:81
 msgid "The Document ${title} has no File"
@@ -111,6 +123,10 @@ msgstr "Das Dokument ${title} enthält keine Datei."
 #: ./opengever/document/browser/edit.py:113
 msgid "The Document is allready checked out by: ${userid}"
 msgstr "Das Dokument ist bereits von ${userid} ausgecheckt."
+
+#: ./opengever/document/browser/overview_templates/overview.pt:32
+msgid "Update document in proposal"
+msgstr "Eingereichte Version aktualisieren"
 
 #: ./opengever/document/browser/edit.py:59
 msgid "You are not authorized to edit the document ${title}"
@@ -284,7 +300,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:123
+#: ./opengever/document/browser/overview.py:125
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr "Ausgecheckt"
@@ -300,7 +316,7 @@ msgid "label_checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:119
+#: ./opengever/document/browser/overview.py:121
 msgid "label_creator"
 msgstr "Ersteller"
 
@@ -341,7 +357,7 @@ msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:125
+#: ./opengever/document/browser/overview.py:127
 #: ./opengever/document/document.py:60
 msgid "label_file"
 msgstr "Datei"
@@ -357,7 +373,7 @@ msgid "label_keywords"
 msgstr "Schlagworte"
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py:84
 msgid "label_no"
 msgstr "Nein"
 
@@ -416,7 +432,7 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:81
+#: ./opengever/document/browser/overview.py:83
 msgid "label_yes"
 msgstr "Ja"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-04-20 09:47+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -74,6 +74,10 @@ msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti"
 msgid "Create Task"
 msgstr "Créer une tâche"
 
+#: ./opengever/document/browser/overview.py:170
+msgid "Current version: ${version}"
+msgstr ""
+
 #: ./opengever/document/profiles/default/types/opengever.document.document.xml
 msgid "Document"
 msgstr "Document"
@@ -100,6 +104,14 @@ msgstr "Envoyer par E-Mail"
 msgid "Submit additional documents"
 msgstr "Soumettre des documents additionnels"
 
+#: ./opengever/document/browser/overview.py:166
+msgid "Submitted version: ${version}"
+msgstr ""
+
+#: ./opengever/document/browser/overview_templates/overview.pt:20
+msgid "Submitted with"
+msgstr ""
+
 #: ./opengever/document/browser/download.py:39
 #: ./opengever/document/browser/edit.py:81
 msgid "The Document ${title} has no File"
@@ -108,6 +120,10 @@ msgstr "Le dodument  ${title} ne contient pas de fichier"
 #: ./opengever/document/browser/edit.py:113
 msgid "The Document is allready checked out by: ${userid}"
 msgstr "Le document a déjà un checkout par  ${userid}"
+
+#: ./opengever/document/browser/overview_templates/overview.pt:32
+msgid "Update document in proposal"
+msgstr ""
 
 #: ./opengever/document/browser/edit.py:59
 msgid "You are not authorized to edit the document ${title}"
@@ -274,7 +290,7 @@ msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:123
+#: ./opengever/document/browser/overview.py:125
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr "Avec checkout"
@@ -290,7 +306,7 @@ msgid "label_checkout_and_edit"
 msgstr "Checkout / Modifier"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:119
+#: ./opengever/document/browser/overview.py:121
 msgid "label_creator"
 msgstr "Créateur"
 
@@ -331,7 +347,7 @@ msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:125
+#: ./opengever/document/browser/overview.py:127
 #: ./opengever/document/document.py:60
 msgid "label_file"
 msgstr "Fichier"
@@ -347,7 +363,7 @@ msgid "label_keywords"
 msgstr "Mots-clés"
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py:84
 msgid "label_no"
 msgstr "Non"
 
@@ -406,7 +422,7 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:81
+#: ./opengever/document/browser/overview.py:83
 msgid "label_yes"
 msgstr "Oui"
 
@@ -438,5 +454,5 @@ msgstr "Avec commentaire"
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
-msgstr "Sans commentaire"
+msgstr ""
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-04-20 09:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,6 +77,10 @@ msgstr ""
 msgid "Create Task"
 msgstr ""
 
+#: ./opengever/document/browser/overview.py:170
+msgid "Current version: ${version}"
+msgstr ""
+
 #: ./opengever/document/profiles/default/types/opengever.document.document.xml
 msgid "Document"
 msgstr ""
@@ -103,6 +107,14 @@ msgstr ""
 msgid "Submit additional documents"
 msgstr ""
 
+#: ./opengever/document/browser/overview.py:166
+msgid "Submitted version: ${version}"
+msgstr ""
+
+#: ./opengever/document/browser/overview_templates/overview.pt:20
+msgid "Submitted with"
+msgstr ""
+
 #: ./opengever/document/browser/download.py:39
 #: ./opengever/document/browser/edit.py:81
 msgid "The Document ${title} has no File"
@@ -110,6 +122,10 @@ msgstr ""
 
 #: ./opengever/document/browser/edit.py:113
 msgid "The Document is allready checked out by: ${userid}"
+msgstr ""
+
+#: ./opengever/document/browser/overview_templates/overview.pt:32
+msgid "Update document in proposal"
 msgstr ""
 
 #: ./opengever/document/browser/edit.py:59
@@ -277,7 +293,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:123
+#: ./opengever/document/browser/overview.py:125
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr ""
@@ -293,7 +309,7 @@ msgid "label_checkout_and_edit"
 msgstr ""
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:119
+#: ./opengever/document/browser/overview.py:121
 msgid "label_creator"
 msgstr ""
 
@@ -334,7 +350,7 @@ msgid "label_download_copy"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:125
+#: ./opengever/document/browser/overview.py:127
 #: ./opengever/document/document.py:60
 msgid "label_file"
 msgstr ""
@@ -350,7 +366,7 @@ msgid "label_keywords"
 msgstr ""
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py:84
 msgid "label_no"
 msgstr ""
 
@@ -409,7 +425,7 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:81
+#: ./opengever/document/browser/overview.py:83
 msgid "label_yes"
 msgstr ""
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -138,19 +138,26 @@ class Proposal(Base):
             return self.agenda_item.decision
         return None
 
-    def get_link(self):
-        return self._get_link(self.get_admin_unit(), self.physical_path)
+    def get_url(self):
+        return self._get_url(self.get_admin_unit(), self.physical_path)
 
-    def get_submitted_link(self, include_icon=True):
-        return self._get_link(self.get_submitted_admin_unit(),
-                              self.submitted_physical_path,
-                              include_icon=include_icon)
+    def get_submitted_url(self):
+        return self._get_url(self.get_submitted_admin_unit(),
+                             self.submitted_physical_path)
 
-    def _get_link(self, admin_unit, physical_path, include_icon=True):
+    def _get_url(self, admin_unit, physical_path):
         if not (admin_unit and physical_path):
             return ''
-        url = '/'.join((admin_unit.public_url, physical_path))
+        return '/'.join((admin_unit.public_url, physical_path))
 
+    def get_link(self, include_icon=True):
+        return self._get_link(self.get_url(), include_icon=include_icon)
+
+    def get_submitted_link(self, include_icon=True):
+        return self._get_link(self.get_submitted_url(),
+                              include_icon=include_icon)
+
+    def _get_link(self, url, include_icon=True):
         if include_icon:
             link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
                 url, self.title, self.css_class)
@@ -203,3 +210,6 @@ class Proposal(Base):
         session = create_session()
         session.add(
             proposalhistory.RemoveScheduled(proposal=self, meeting=meeting))
+
+    def resolve_proposal(self):
+        return self.oguid.resolve_object()

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
-from opengever.base.oguid import Oguid
 from opengever.base.transport import Transporter
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.exceptions import NoSubmittedDocument
@@ -146,18 +145,3 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         self.assertSequenceEqual(
             ['A new submitted version of document A Document has been created'],
             info_messages())
-
-    def assertSubmittedDocumentCreated(self, proposal, document,
-                                       submitted_version=0):
-        portal = api.portal.get()
-        submitted_document_model = SubmittedDocument.query.get_by_source(
-            proposal, document)
-        submitted_document = portal.restrictedTraverse(
-            submitted_document_model.submitted_physical_path.encode('utf-8'))
-        self.assertIsNotNone(submitted_document_model)
-        self.assertEqual(Oguid.for_object(submitted_document),
-                         submitted_document_model.submitted_oguid)
-        self.assertEqual(submitted_version,
-                         submitted_document_model.submitted_version)
-        self.assertEqual(proposal.load_model(),
-                         submitted_document_model.proposal)

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -1,8 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.oguid import Oguid
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
 from opengever.dossier.interfaces import ITemplateDossierProperties
 from opengever.journal.tests.utils import get_journal_entry
+from opengever.meeting.model import SubmittedDocument
 from opengever.testing import builders  # keep!
 from opengever.testing.browser import OGBrowser
 from plone import api
@@ -134,3 +136,18 @@ class FunctionalTestCase(TestCase):
         browser.handleErrors = False
         browser.addHeader('Authorization', 'Basic %s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD,))
         return browser
+
+    def assertSubmittedDocumentCreated(self, proposal, document,
+                                       submitted_version=0):
+        portal = api.portal.get()
+        submitted_document_model = SubmittedDocument.query.get_by_source(
+            proposal, document)
+        submitted_document = portal.restrictedTraverse(
+            submitted_document_model.submitted_physical_path.encode('utf-8'))
+        self.assertIsNotNone(submitted_document_model)
+        self.assertEqual(Oguid.for_object(submitted_document),
+                         submitted_document_model.submitted_oguid)
+        self.assertEqual(submitted_version,
+                         submitted_document_model.submitted_version)
+        self.assertEqual(proposal.load_model(),
+                         submitted_document_model.proposal)


### PR DESCRIPTION
Also display a link to directly update the document in its proposal when it is
outdated.

![screen shot 2015-04-16 at 17 01 19](https://cloud.githubusercontent.com/assets/736583/7183918/911ce966-e45a-11e4-8814-19eb889ab6d6.png)
