### PR TITLE
Treeportlet: extend caching parameters with current language code.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Treeportlet: extend caching parameters with current language code.
+  [phgross]
+
 - Implement meeting closing:
 
   - Added automatic generation of excerpts for every scheduled proposal.

--- a/opengever/base/browser/navigation.py
+++ b/opengever/base/browser/navigation.py
@@ -1,4 +1,5 @@
 from AccessControl import getSecurityManager
+from opengever.base.utils import get_preferred_language_code
 from pkg_resources import get_distribution
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
@@ -58,6 +59,8 @@ class JSONNavigation(BrowserView):
 
         if self.request.getHeader('Cache-Control') == 'no-cache':
             params.append('nocache=true')
+
+        params.append('language={}'.format(get_preferred_language_code()))
 
         if params:
             url = '{0}?{1}'.format(url, '&'.join(params))

--- a/opengever/base/tests/test_navigation.py
+++ b/opengever/base/tests/test_navigation.py
@@ -21,6 +21,18 @@ class TestNavigation(FunctionalTestCase):
         with self.assert_changes(view.get_caching_url, msg):
             folder.reindexObject()  # changes the modified date
 
+    def test_caching_url_contains_current_language_code(self):
+        root = create(Builder('repository_root'))
+        view = root.restrictedTraverse('navigation.json')
+
+        msg = 'Cache URL did not change after changing language.'
+        with self.assert_changes(view.get_caching_url, msg):
+            root.REQUEST.get('LANGUAGE_TOOL').LANGUAGE = 'fr'
+
+        msg = 'Cache URL did not change after changing language.'
+        with self.assert_changes(view.get_caching_url, msg):
+            root.REQUEST.get('LANGUAGE_TOOL').LANGUAGE = 'de-ch'
+
     @browsing
     def test_json_is_valid(self, browser):
         root = create(Builder('repository_root'))

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -64,3 +64,11 @@ def ok_response(request=None):
 
 def disable_edit_bar():
     api.portal.get().REQUEST.set('disable_border', True)
+
+
+def get_preferred_language_code():
+    ltool = api.portal.get_tool('portal_languages')
+    language_code = ltool.getPreferredLanguage()
+
+    # Special handling for combined languages, but works for regular ones too.
+    return language_code.split('-')[0]


### PR DESCRIPTION
This allows us to display language dependent content in the Treeportlet. As we do for some customers.

@lukasgraf please have a look 