### PR TITLE
Fix redirect loops when transaction is modified on @@confirm-action view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- CSRF: Also allow writes to context portlet assignments.
+  [lgraf]
+
 - CSRF: Detect redirect loops on @@confirm-action view and
   break them if necessary.
   [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- CSRF: Detect redirect loops on @@confirm-action view and
+  break them if necessary.
+  [lgraf]
+
 - CSRF: Rollback transaction on @@confirm-action view to avoid
   creating redirect loops.
   [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- CSRF: Rollback transaction on @@confirm-action view to avoid
+  creating redirect loops.
+  [lgraf]
+
 - Expanded/Collapsed triangle style for helptext-trigger.
   [Kevin Bieri]
 

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -1,4 +1,5 @@
 from plone import api
+from plone.portlets.constants import CONTEXT_ASSIGNMENT_KEY
 from plone.protect.auto import ProtectTransform
 from plone.protect.interfaces import IDisableCSRFProtection
 from Products.CMFCore.utils import getToolByName
@@ -113,4 +114,8 @@ class OGProtectTransform(ProtectTransform):
         # always allow writes to context's annotations.
         context = self.request.PARENTS[0]
         if IAnnotatable.providedBy(context):
-            unprotected_write(IAnnotations(context))
+            annotations = IAnnotations(context)
+            unprotected_write(annotations)
+            if CONTEXT_ASSIGNMENT_KEY in annotations:
+                # also allow writes to context portlet assignments
+                unprotected_write(annotations[CONTEXT_ASSIGNMENT_KEY])


### PR DESCRIPTION
On current `master` the first request after installing `ftw.footer` results in a redirect loop on most views, including the Plone site root.

This is because the context portlet assignments in the context's annotations gets modified (not the annotations themselves, those are already whitelisted). Because the respective viewlet also gets rendered on the `@@confirm-action` view, this causes the transaction to be modified on the `@@confirm-action` view, which triggers another confirmation, etc.. The results is is a redirect loop that the browser eventually needs to detect and cancel.

This PR addresses three things:
- It fixes the current **trigger** for the problem, which are **context portlet assignments**. Those are now whitelisted globally for writes.
- It **rolls back the transaction** (if modified) on the `@@confirm-action` view. There should not be any modifications in the transaction anyway on this view, if there are this is a symptom of a deeper problem - so take the secure approach and discard the modification.
- It adds a method to **detect redirect loops** as a last line of defense. Though with the change above "this should never happen" ™.

I did test all these changes in isolation from each other - so every single one does prevent redirect loops on its own.

One might argue that it would even be better to raise an exception if `_redirect_loop_detected()` - this is a last resort, shouldn't happen, and if it still does, should fail in an obvious (but safe) way - but raising exceptions in a transform chain doesn't work well (leads to garbled, half-styled output).

@jone @deiferni @phgross 