### PR TITLE
Initialize annotations during object creation, to avoid CSRF messages on first object access.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Initalize annotations during object creation, to avoid CSRF messages on
+  first object access.
+  [phgross]
+
 - Move empty template profiles from setup to examplecontent. Create reusable
   Municipality content profile with initial meeting content.
   [phgross, deiferni]

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -1,14 +1,17 @@
 from five import grok
 from OFS.interfaces import IObjectClonedEvent
 from opengever.base import _
+from persistent.mapping import PersistentMapping
 from plone.app.lockingbehavior.behaviors import ILocking
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.interfaces import IEditBegunEvent
 from plone.protect.interfaces import IDisableCSRFProtection
 from Products.PluggableAuthService.interfaces.events import IUserLoggedOutEvent
+from zope.annotation import IAnnotations
 from zope.component.hooks import getSite
 from zope.interface import alsoProvides
 from zope.interface import Interface
+from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 
 
 @grok.subscribe(IDexterityContent, IObjectClonedEvent)
@@ -44,3 +47,24 @@ def disable_plone_protect_when_logging_out(user, event):
     This results in a lot of changes in the database, so we disable CSRF protection.
     """
     alsoProvides(user.REQUEST, IDisableCSRFProtection)
+
+
+@grok.subscribe(IDexterityContent, IObjectCreatedEvent)
+def initialize_annotations(obj, event):
+    """We have to initalize the annotations on every object.
+    To avoid CSRF protection messages on first access of newly created objects,
+    which haven't accessed the annotations during the creation process.
+    Because the PortletAssignment's, for example `ftw.footer` writes the
+    PortletAssignments to the objects annotations.
+
+    So if the annotations haven't been already accessed, the `AttributeAnnotations`
+    mixin will create the `__annotations__` attribute on the object. This means that
+    not the annotations are marked as changed but rather the object itself.
+
+    And the we can't whitelist the object itself, because thats the important part
+    of the CSRF protection.
+    """
+
+    annotations = IAnnotations(obj)
+    annotations['initialized'] = True
+    del annotations['initialized']


### PR DESCRIPTION
We have to initialize the annotations on every object. To avoid CSRF protection messages on first access of newly created objects, which haven't accessed the annotations during the creation process.

Because the PortletAssignments, for example `ftw.footer` portlets, are written to the objects annotations.

So if the annotations haven't been already accessed, the `AttributeAnnotations` mixin will create the `__annotations__` attribute on the object. This means that not the annotations are marked as changed but rather the object itself. And the we can't whitelist the object itself.

@deiferni @jone @lukasgraf 