### PR TITLE
Fixed and update opengever.activity translations

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Notifications: added some missing translations.
+  [phgross]
+
 - Fix displaying agenda-item numbers. Make number optional and don't
   display it when no number is set (i.e. for paragraphs).
   [deiferni]

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-04-28 07:32+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,7 +46,17 @@ msgstr "Erstellt"
 msgid "heading_notifications"
 msgstr "Benachrichtigungen"
 
+#. Default: "Description:"
+#: ./opengever/activity/mail_templates/notification.pt:21
+msgid "label_description"
+msgstr "Beschreibung:"
+
 #. Default: "My notifications"
 #: ./opengever/activity/browser/views.py:31
 msgid "label_my_notifications"
 msgstr "Meine Benachrichtigungen"
+
+#. Default: "All Notifications"
+#: ./opengever/activity/viewlets/notification.pt:46
+msgid "label_notifications_overview"
+msgstr "Alle Benachrichtigungen"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-04-28 07:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,8 +46,18 @@ msgstr ""
 msgid "heading_notifications"
 msgstr "Notifications"
 
+#. Default: "Description:"
+#: ./opengever/activity/mail_templates/notification.pt:21
+msgid "label_description"
+msgstr ""
+
 #. Default: "My notifications"
 #: ./opengever/activity/browser/views.py:31
 msgid "label_my_notifications"
 msgstr "Mes notifications"
+
+#. Default: "All Notifications"
+#: ./opengever/activity/viewlets/notification.pt:46
+msgid "label_notifications_overview"
+msgstr ""
 

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-04-28 07:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,8 +46,18 @@ msgstr ""
 msgid "heading_notifications"
 msgstr ""
 
+#. Default: "Description:"
+#: ./opengever/activity/mail_templates/notification.pt:21
+msgid "label_description"
+msgstr ""
+
 #. Default: "My notifications"
 #: ./opengever/activity/browser/views.py:31
 msgid "label_my_notifications"
+msgstr ""
+
+#. Default: "All Notifications"
+#: ./opengever/activity/viewlets/notification.pt:46
+msgid "label_notifications_overview"
 msgstr ""
 

--- a/opengever/activity/mail_templates/notification.pt
+++ b/opengever/activity/mail_templates/notification.pt
@@ -18,7 +18,7 @@
     <a href="" tal:content="options/title" tal:attributes="href options/link"></a>
     <p tal:content="structure options/summary" />
 
-    <p>Description:</p>
+    <p i18n:translate="label_description">Description:</p>
     <span tal:replace="structure options/description" />
 
     <br />

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -43,8 +43,9 @@
           </div>
         </li>
         <li class="notification-item">
-          <a href="#" class="all_link" tal:attributes="href view/overview_url">
-            Notifications Overview
+          <a href="#" class="all_link" tal:attributes="href view/overview_url"
+             i18n:translate="label_notifications_overview">
+            All Notifications
           </a>
         </li>
       </ul>

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -1,4 +1,5 @@
 from opengever.activity import notification_center
+from opengever.base.utils import get_preferred_language_code
 from opengever.ogds.base.actor import Actor
 from opengever.task import _
 from opengever.task.response_description import ResponseDescription
@@ -102,13 +103,13 @@ class TaskAddedActivity(TaskActivity):
             [self.translate(_('label_deadline', u'Deadline')),
              api.portal.get_localized_time(str(self.context.deadline))],
             [self.translate(_('label_task_type', u'Task Type')),
-             self.context.get_task_type_label()],
+             self.context.get_task_type_label(
+                 language=get_preferred_language_code())],
             [self.translate(_('label_dossier_title', u'Dossier title')),
              self.parent.title],
             [self.translate(_('label_text', u'Text')),
              self.context.text]
         ]
-
 
     def before_recording(self):
         self.center.add_watcher_to_resource(self.context,


### PR DESCRIPTION
 - Added missing translations.
 - Make sure the `tasktype` in the activity description is translated.

@lukasgraf please have a look ... 
