### PR TITLE
Notification overview and viewlet improvements.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- NotificationViewlet: Display message when no unread notifications exist.
+  [phgross]
+
 - Move MyNotifications listing to the PersonalOverview.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Move MyNotifications listing to the PersonalOverview.
+  [phgross]
+
 - Notifications: added some missing translations.
   [phgross]
 

--- a/opengever/activity/browser/configure.zcml
+++ b/opengever/activity/browser/configure.zcml
@@ -14,11 +14,4 @@
       allowed_attributes="read"
       />
 
-  <browser:page
-      for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
-      name="notification_overview"
-      class=".views.NotificationOverview"
-      permission="zope2.View"
-      />
-
 </configure>

--- a/opengever/activity/browser/views.py
+++ b/opengever/activity/browser/views.py
@@ -1,6 +1,4 @@
 from five import grok
-from ftw.tabbedview.browser.tabbed import TabbedView
-from opengever.activity import _
 from opengever.activity import notification_center
 from opengever.activity.browser.listing import NotificationListingTab
 from plone import api
@@ -18,21 +16,6 @@ class NotificationView(BrowserView):
         notification_id = self.request.get('notification_id')
         notification_center().mark_notification_as_read(notification_id)
         return True
-
-
-class NotificationOverview(TabbedView):
-
-    def get_tabs(self):
-        tabs = [
-            {'id': 'mynotifications',
-             'icon': None,
-             'url': '#',
-             'class': None,
-             'title': _('label_my_notifications',
-                        default=u'My notifications')},
-        ]
-
-        return tabs
 
 
 class MyNotifications(NotificationListingTab):

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-28 07:32+0000\n"
+"POT-Creation-Date: 2015-04-28 09:29+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,12 +51,12 @@ msgstr "Benachrichtigungen"
 msgid "label_description"
 msgstr "Beschreibung:"
 
-#. Default: "My notifications"
-#: ./opengever/activity/browser/views.py:31
-msgid "label_my_notifications"
-msgstr "Meine Benachrichtigungen"
-
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:46
+#: ./opengever/activity/viewlets/notification.pt:54
 msgid "label_notifications_overview"
 msgstr "Alle Benachrichtigungen"
+
+#. Default: "No unread notifications"
+#: ./opengever/activity/viewlets/notification.pt:23
+msgid "no_unread_notifications"
+msgstr "Keine ungelesenen Benachrichtigungen"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-28 07:32+0000\n"
+"POT-Creation-Date: 2015-04-28 09:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,11 +41,6 @@ msgstr "Titre"
 msgid "created"
 msgstr ""
 
-#. Default: "Created"
-#: ./opengever/activity/browser/listing.py:59
-msgid "created"
-msgstr ""
-
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt:3
 msgid "heading_notifications"
@@ -56,12 +51,13 @@ msgstr "Notifications"
 msgid "label_description"
 msgstr ""
 
-#. Default: "My notifications"
-#: ./opengever/activity/browser/views.py:31
-msgid "label_my_notifications"
-msgstr "Mes notifications"
-
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:46
+#: ./opengever/activity/viewlets/notification.pt:54
 msgid "label_notifications_overview"
 msgstr ""
+
+#. Default: "No unread notifications"
+#: ./opengever/activity/viewlets/notification.pt:23
+msgid "no_unread_notifications"
+msgstr ""
+

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -41,6 +41,11 @@ msgstr "Titre"
 msgid "created"
 msgstr ""
 
+#. Default: "Created"
+#: ./opengever/activity/browser/listing.py:59
+msgid "created"
+msgstr ""
+
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt:3
 msgid "heading_notifications"
@@ -60,4 +65,3 @@ msgstr "Mes notifications"
 #: ./opengever/activity/viewlets/notification.pt:46
 msgid "label_notifications_overview"
 msgstr ""
-

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-28 07:32+0000\n"
+"POT-Creation-Date: 2015-04-28 09:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,12 +51,12 @@ msgstr ""
 msgid "label_description"
 msgstr ""
 
-#. Default: "My notifications"
-#: ./opengever/activity/browser/views.py:31
-msgid "label_my_notifications"
+#. Default: "All Notifications"
+#: ./opengever/activity/viewlets/notification.pt:54
+msgid "label_notifications_overview"
 msgstr ""
 
-#. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:46
-msgid "label_notifications_overview"
+#. Default: "No unread notifications"
+#: ./opengever/activity/viewlets/notification.pt:23
+msgid "no_unread_notifications"
 msgstr ""

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -60,4 +60,3 @@ msgstr ""
 #: ./opengever/activity/viewlets/notification.pt:46
 msgid "label_notifications_overview"
 msgstr ""
-

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -102,3 +102,15 @@ class TestNotificationViewlet(FunctionalTestCase):
         self.assertEquals(
             'http://nohost/plone/@@resolve_notification?notification_id=1',
             link.get('href'))
+
+    @browsing
+    def test_displays_message_when_no_unread_notifications(self, browser):
+        browser.login().open()
+
+        self.assertEquals(
+            ['No unread notifications', 'All Notifications'],
+            browser.css('dl.notificationsMenu li').text)
+
+        self.assertEquals(
+            'no-content',
+            browser.css('dl.notificationsMenu li').first.get('class'))

--- a/opengever/activity/tests/test_views.py
+++ b/opengever/activity/tests/test_views.py
@@ -8,20 +8,6 @@ from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 
 
-class TestNotificationOverview(FunctionalTestCase):
-
-    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-
-    @browsing
-    def test_tabs(self, browser):
-        browser.login().open(self.portal, view='notification_overview')
-
-        tabs = browser.css('.tabbedview-tabs li.formTab a')
-
-        self.assertEquals(['My notifications'], tabs.text)
-        self.assertEquals('#mynotifications', tabs[0].get('href'))
-
-
 class TestNotificationView(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -3,9 +3,10 @@
   <h5 class="hiddenStructure" i18n:translate="heading_notifications">Notifications</h5>
 
   <dl class="notificationsMenu actionMenu deactivated" id="portal-notifications-selector-menu"
-      tal:attributes="data-read-url view/read_url">
+      tal:attributes="data-read-url view/read_url"
+      tal:define="num_unread view/num_unread">
 
-    <dt class="notificationsMenuHeader actionMenuHeader" tal:define="num_unread view/num_unread">
+    <dt class="notificationsMenuHeader actionMenuHeader">
 
       <a tal:attributes="href string:#"></a>
 
@@ -18,6 +19,12 @@
 
     <dd class="actionMenuContent notificationsMenuContent">
       <ul>
+        <li class="no-content" tal:condition="not: num_unread" >
+          <div class="item-content" i18n:translate="no_unread_notifications">
+            No unread notifications
+          </div>
+        </li>
+
         <li class="notification-item" tal:repeat="notification view/get_notifications"
             tal:attributes="data-notification-id notification/id">
 
@@ -42,6 +49,7 @@
             </div>
           </div>
         </li>
+
         <li class="notification-item">
           <a href="#" class="all_link" tal:attributes="href view/overview_url"
              i18n:translate="label_notifications_overview">

--- a/opengever/activity/viewlets/notification.py
+++ b/opengever/activity/viewlets/notification.py
@@ -52,5 +52,4 @@ class NotificationViewlet(common.ViewletBase):
 
     @property
     def overview_url(self):
-        return '{}/notification_overview'.format(
-            api.portal.get().absolute_url())
+        return '{}/personal_overview#mynotifications'.format(api.portal.get().absolute_url())

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -1,6 +1,7 @@
 from AccessControl import Unauthorized
 from five import grok
 from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.activity import is_activity_feature_enabled
 from opengever.globalindex.model.task import Task
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
@@ -46,7 +47,7 @@ class PersonalOverview(TabbedView):
         {'id': 'mydocuments', 'icon': None, 'url': '#', 'class': None},
         {'id': 'mytasks', 'icon': None, 'url': '#', 'class': None},
         {'id': 'myissuedtasks', 'icon': None, 'url': '#', 'class': None},
-        ]
+    ]
 
     admin_tabs = [
         {'id': 'alltasks', 'icon': None, 'url': '#', 'class': None},
@@ -89,11 +90,26 @@ class PersonalOverview(TabbedView):
                 return True
         return False
 
+    @property
+    def notification_tabs(self):
+        tabs = []
+        if is_activity_feature_enabled():
+            tabs.append(
+                {'id': 'mynotifications',
+                 'title': _('label_my_notifications', default=u'My notifications'),
+                 'icon': None, 'url': '#', 'class': None})
+
+        return tabs
+
     def get_tabs(self):
+        tabs = []
+
         if self.is_user_allowed_to_view_additional_tabs():
-            return self.default_tabs + self.admin_tabs
+            tabs = self.default_tabs + self.notification_tabs + self.admin_tabs
         else:
-            return self.default_tabs
+            tabs = self.default_tabs
+
+        return tabs
 
     def is_user_allowed_to_view_additional_tabs(self):
         """The additional tabs Alltasks and AllIssuedTasks are only shown

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -282,6 +282,11 @@ msgstr "Ende"
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
+#. Default: "My notifications"
+#: ./opengever/tabbedview/browser/personal_overview.py:50
+msgid "label_my_notifications"
+msgstr "Meine Benachrichtigungen"
+
 #. Default: "Public Trial"
 #: ./opengever/tabbedview/browser/tabs.py:105
 msgid "label_public_trial"
@@ -369,7 +374,7 @@ msgid "participants"
 msgstr "Beteiligte"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:79
+#: ./opengever/tabbedview/browser/personal_overview.py:82
 msgid "personal_overview_title"
 msgstr "Persönliche Übersicht: ${user_name}"
 
@@ -441,4 +446,3 @@ msgstr "Titel"
 
 msgid "trash"
 msgstr "Papierkorb"
-

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -274,6 +274,11 @@ msgstr "Fin"
 msgid "label_issuer"
 msgstr "Mandant"
 
+#. Default: "My notifications"
+#: ./opengever/tabbedview/browser/personal_overview.py:50
+msgid "label_my_notifications"
+msgstr ""
+
 #. Default: "Public Trial"
 #: ./opengever/tabbedview/browser/tabs.py:105
 msgid "label_public_trial"
@@ -359,7 +364,7 @@ msgid "participants"
 msgstr "Participants"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:79
+#: ./opengever/tabbedview/browser/personal_overview.py:82
 msgid "personal_overview_title"
 msgstr "Vue d'ensemble personnelle: ${user_name}"
 
@@ -421,4 +426,3 @@ msgstr "Titre"
 
 msgid "trash"
 msgstr "Corbeille"
-

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -275,6 +275,11 @@ msgstr ""
 msgid "label_issuer"
 msgstr ""
 
+#. Default: "My notifications"
+#: ./opengever/tabbedview/browser/personal_overview.py:50
+msgid "label_my_notifications"
+msgstr ""
+
 #. Default: "Public Trial"
 #: ./opengever/tabbedview/browser/tabs.py:105
 msgid "label_public_trial"
@@ -360,7 +365,7 @@ msgid "participants"
 msgstr ""
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:79
+#: ./opengever/tabbedview/browser/personal_overview.py:82
 msgid "personal_overview_title"
 msgstr ""
 
@@ -422,4 +427,3 @@ msgstr ""
 
 msgid "trash"
 msgstr ""
-

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.testing import create_plone_user
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import setRoles
@@ -76,6 +77,31 @@ class TestPersonalOverview(FunctionalTestCase):
             view='personal_overview')
         self.assertEqual(
             ['mydossiers', 'mydocuments', 'mytasks', 'myissuedtasks'],
+            browser.css('li.formTab a').text)
+
+    @browsing
+    def test_notification_tab_is_hidden_when_activity_feature_is_disabled(self, browser):
+        browser.login(username='hugo.boss', password='demo09').open(
+            view='personal_overview')
+        self.assertEqual(
+            ['mydossiers', 'mydocuments', 'mytasks', 'myissuedtasks'],
+            browser.css('li.formTab a').text)
+
+
+class TestPersonalOverviewActivitySupport(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
+
+    @browsing
+    def test_notification_tab_is_displayed_when_activity_feature_is_enabled(self, browser):
+        browser.login().open(view='personal_overview')
+        self.assertEqual(
+            ['mydossiers', 'mydocuments',
+             'mytasks',
+             'myissuedtasks',
+             'My notifications',
+             'alltasks',
+             'allissuedtasks'],
             browser.css('li.formTab a').text)
 
 


### PR DESCRIPTION
Move MyNotifications listing to the PersonalOverview:
![bildschirmfoto 2015-04-28 um 11 33 50](https://cloud.githubusercontent.com/assets/485755/7366707/7dcf8654-ed9a-11e4-817d-87d6f7510433.png)

NotificationViewlet: Display message when no unread notitifications exists:
![bildschirmfoto 2015-04-28 um 11 31 35](https://cloud.githubusercontent.com/assets/485755/7366726/8c032474-ed9a-11e4-8ff9-301873b42bb8.png)

@lukasgraf / @deiferni please have a look ... 

---
Styling will follow in a separate PR in plonetheme.teamraum