### PR TITLE
Fix overwriting ploneform-macros

### DIFF
--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -9,20 +9,6 @@
           permission="zope2.View"
           />
 
-    <!-- Fix for bug mentioned in Issue #934 Fehler bei den Falldossiers 1 und 2 BD.ARP
-         https://extranet.4teamwork.ch/projects/opengever-kanton-zug/sprint-backlog/934
-         Remove as soon as this has been fixed in plone.app.z3cform / plone.z3cform
-    -->
-    <browser:page
-        name="ploneform-macros"
-        for="*"
-        layer="opengever.base.interfaces.IOpengeverBaseLayer"
-        class=".ploneform_macros.Macros"
-        template="templates/macros.pt"
-        allowed_interface="zope.interface.common.mapping.IItemMapping"
-        permission="zope.Public"
-        />
-
     <adapter factory=".navtree.OpengeverNavtreeStrategy" />
 
     <browser:page

--- a/opengever/base/overrides.zcml
+++ b/opengever/base/overrides.zcml
@@ -10,4 +10,18 @@
       class=".menu.OGCombinedActionsWorkflowMenu"
       />
 
+  <!-- Fix for bug mentioned in Issue #934 Fehler bei den Falldossiers 1 und 2 BD.ARP
+       https://extranet.4teamwork.ch/projects/opengever-kanton-zug/sprint-backlog/934
+       Remove as soon as this has been fixed in plone.app.z3cform / plone.z3cform
+  -->
+  <browser:page
+      name="ploneform-macros"
+      for="*"
+      layer="plone.app.z3cform.interfaces.IPloneFormLayer"
+      class=".browser.ploneform_macros.Macros"
+      template="browser/templates/macros.pt"
+      allowed_interface="zope.interface.common.mapping.IItemMapping"
+      permission="zope.Public"
+      />
+
 </configure>

--- a/opengever/base/tests/test_ploneform_macros.py
+++ b/opengever/base/tests/test_ploneform_macros.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.testing import FunctionalTestCase
+
+
+class TestRegressionPloneformMacros(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRegressionPloneformMacros, self).setUp()
+
+        self.repository_root = create(Builder('repository_root'))
+        self.repository_folder = create(
+            Builder('repository').within(self.repository_root))
+
+    @browsing
+    def test_error_messages_are_displayed_for_form_groups(self, browser):
+        browser.login()
+
+        # make sure that only title is required
+        # ensure that our assumption is correct, otherwise the regression
+        # test won't work correctly
+        browser.open(self.repository_folder,
+                     view='++add++opengever.dossier.businesscasedossier')
+        browser.fill({'Title': 'foo'})
+        browser.find('Save').click()
+        self.assertEqual(['Item created'], info_messages())
+
+        # actually test that group-errors are displayed correctly
+        browser.open(self.repository_folder,
+                     view='++add++opengever.dossier.businesscasedossier')
+        # fill invalid
+        browser.fill({'Title': 'foo', 'Date of cassation': 'invalid'})
+        browser.find('Save').click()
+        self.assertEqual([], info_messages())
+        self.assertEqual(['There were some errors.'], error_messages())


### PR DESCRIPTION
Currently the `ploneform-macros` view is overwritten to fix a bug with displaying status messages. Unfortunately the overwrite does not work reliably. This PR moves the overwrite to `overrides.zcml` to make sure it works correctly.