### PR TITLE
Fix upgrades for PostgreSQL/MySQL

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,15 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Fix upgrades for PostgreSQL/MySQL:
+
+  - Fix opengever.policy.base upgrades, limit created tables to installed package.
+  - Add idempotent MySQL implementations for creating/dropping indices and dropping tables.
+  - Drop unnecessary/broken statements from migrations.
+  - Drop a temporary table after the migration is finished.
+
+  [deiferni]
+
 - Fixed userdetails icons for group listings.
   [phgross]
 

--- a/opengever/activity/model/__init__.py
+++ b/opengever/activity/model/__init__.py
@@ -2,3 +2,12 @@ from opengever.activity.model.activity import Activity
 from opengever.activity.model.notification import Notification
 from opengever.activity.model.resource import Resource
 from opengever.activity.model.watcher import Watcher
+
+
+tables = [
+    'activities',
+    'notifications',
+    'resource_watchers',
+    'resources',
+    'watchers',
+]

--- a/opengever/base/model.py
+++ b/opengever/base/model.py
@@ -9,6 +9,11 @@ BASE.session = Session
 Base = query_base(Session)
 
 
+def get_tables(table_names):
+    tables = Base.metadata.tables
+    return [tables.get(table_name) for table_name in table_names]
+
+
 def create_session():
     """Returns a new sql session bound to the defined named scope.
     """

--- a/opengever/base/tests/test_database_table_declarations.py
+++ b/opengever/base/tests/test_database_table_declarations.py
@@ -1,0 +1,21 @@
+from opengever.activity.model import tables as activity_tables
+from opengever.base.model import Base
+from opengever.globalindex.model import tables as globalindex_tables
+from opengever.meeting.model import tables as meeting_tables
+from unittest2 import TestCase
+
+
+class TestDatabaseTableDeclarations(TestCase):
+    """Test that tables in metadata are in sync with manual table definitions.
+
+    When this test fails it most likely means that you defined new database
+    model classes or secondary tables but forgot to add them to the manual
+    table list in its corresponding model package.
+
+    The manual table list is necessary for certain upgrade steps to work
+    correctly.
+
+    """
+    def test_package_table_definitions_are_correct(self):
+        expected_tables = meeting_tables + activity_tables + globalindex_tables
+        self.assertItemsEqual(expected_tables, Base.metadata.tables.keys())

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -179,9 +179,14 @@ class IdempotentOperations(Operations):
             *args, **kwargs)
 
     @metadata_operation
-    def drop_table(self, *args, **kwargs):
-        return super(IdempotentOperations, self).drop_table(
-            *args, **kwargs)
+    def drop_table(self, name, **kw):
+        if self._get_table(name) is None:
+            logger.log(logging.INFO,
+                       "Skipping drop table '{0}', table no longer exist"
+                       .format(name))
+            return
+
+        return super(IdempotentOperations, self).drop_table(name, **kw)
 
     @metadata_operation
     def create_index(self, name, table_name, columns, schema=None,

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -184,14 +184,30 @@ class IdempotentOperations(Operations):
             *args, **kwargs)
 
     @metadata_operation
-    def create_index(self, *args, **kwargs):
+    def create_index(self, name, table_name, columns, schema=None,
+                     unique=False, quote=None, **kw):
+        if self._has_index(name, table_name):
+            logger.log(logging.INFO,
+                       "Skipping create index '{0}' for table '{1}', "
+                       "index already exists."
+                       .format(name, table_name))
+            return
+
         return super(IdempotentOperations, self).create_index(
-            *args, **kwargs)
+            name, table_name, columns,
+            schema=schema, unique=unique, quote=quote, **kw)
 
     @metadata_operation
-    def drop_index(self, *args, **kwargs):
+    def drop_index(self, name, table_name=None, schema=None):
+        if not self._has_index(name, table_name):
+            logger.log(logging.INFO,
+                       "Skipping drop index '{0}' for table '{1}', "
+                       "index no longer exists."
+                       .format(name, table_name))
+            return
+
         return super(IdempotentOperations, self).drop_index(
-            *args, **kwargs)
+            name, table_name=table_name, schema=schema)
 
 
 class DeactivatedFKConstraint(object):

--- a/opengever/globalindex/model/__init__.py
+++ b/opengever/globalindex/model/__init__.py
@@ -1,0 +1,4 @@
+tables = [
+    'task_principals',
+    'tasks',
+]

--- a/opengever/meeting/model/__init__.py
+++ b/opengever/meeting/model/__init__.py
@@ -8,3 +8,18 @@ from opengever.meeting.model.member import Member
 from opengever.meeting.model.membership import Membership
 from opengever.meeting.model.proposal import Proposal
 from opengever.meeting.model.submitteddocument import SubmittedDocument
+
+
+tables = [
+    'agendaitems',
+    'committees',
+    'generateddocuments',
+    'meeting_excerpts',
+    'meeting_participants',
+    'meetings',
+    'members',
+    'memberships',
+    'proposalhistory',
+    'proposals',
+    'submitteddocuments',
+]

--- a/opengever/meeting/upgrades/to4216.py
+++ b/opengever/meeting/upgrades/to4216.py
@@ -26,13 +26,10 @@ class CreateGeneratedDocument(SchemaMigration):
             Column("generated_document_type", String(100), nullable=False),
         )
 
-        if not self.op._has_index('ix_generated_document_unique',
-                                  'generateddocuments'):
-
-            self.op.create_index(
-                'ix_generated_document_unique',
-                'generateddocuments',
-                ['admin_unit_id', 'int_id'])
+        self.op.create_index(
+            'ix_generated_document_unique',
+            'generateddocuments',
+            ['admin_unit_id', 'int_id'])
 
     def create_meeting_columns(self):
         self.op.add_column(

--- a/opengever/meeting/upgrades/to4302.py
+++ b/opengever/meeting/upgrades/to4302.py
@@ -4,7 +4,6 @@ from sqlalchemy import Date
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
-from sqlalchemy.schema import CreateSequence
 from sqlalchemy.schema import Sequence
 from sqlalchemy.sql.expression import column
 from sqlalchemy.sql.expression import table
@@ -35,9 +34,6 @@ class AddMembershipIdColumn(SchemaMigration):
             Column("member_id", Integer, ForeignKey('members.id')),
             Column("role", String(256))
         )
-
-        if not self.is_mysql:
-            self.op.execute(CreateSequence(Sequence("membership_id_seq")))
 
         self.op.create_unique_constraint(
             'ix_membership_unique',

--- a/opengever/policy/base/upgrades/to4200.py
+++ b/opengever/policy/base/upgrades/to4200.py
@@ -1,5 +1,8 @@
 from ftw.upgrade import UpgradeStep
-from opengever.base import model
+from opengever import meeting
+from opengever.base.model import Base
+from opengever.base.model import create_session
+from opengever.base.model import get_tables
 
 
 class InstallMeeting(UpgradeStep):
@@ -19,4 +22,7 @@ class InstallMeeting(UpgradeStep):
         care of that.
 
         """
-        model.Base.metadata.create_all(model.Session().bind, checkfirst=True)
+        Base.metadata.create_all(
+            create_session().bind,
+            get_tables(meeting.model.tables),
+            checkfirst=True)

--- a/opengever/policy/base/upgrades/to4201.py
+++ b/opengever/policy/base/upgrades/to4201.py
@@ -1,5 +1,8 @@
 from ftw.upgrade import UpgradeStep
-from opengever.base import model
+from opengever import activity
+from opengever.base.model import Base
+from opengever.base.model import create_session
+from opengever.base.model import get_tables
 
 
 class InstallActivity(UpgradeStep):
@@ -18,5 +21,7 @@ class InstallActivity(UpgradeStep):
         If it is installed on an new plone-site `opengever.base.hooks` takes
         care of that.
         """
-
-        model.Base.metadata.create_all(model.Session().bind, checkfirst=True)
+        Base.metadata.create_all(
+            create_session().bind,
+            tables=get_tables(activity.model.tables),
+            checkfirst=True)


### PR DESCRIPTION
This PR addresses the following migration issues:
  - Fix opengever.policy.base upgrades, limit created tables to installed package.
  - Add idempotent MySQL implementations for creating/dropping indices and dropping tables.
  - Drop unnecessary/broken statements from migrations.
  - Drop a temporary table after the migration is finished.