### PR TITLE
Fixed userdetails icons for group listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Fixed userdetails icons for group listings.
+  [phgross]
+
 - Also manage meeting permissions in dossier workflows.
   [deiferni]
 

--- a/opengever/ogds/base/browser/userdetails_templates/userdetails.pt
+++ b/opengever/ogds/base/browser/userdetails_templates/userdetails.pt
@@ -117,7 +117,7 @@
               <td>
                   <ul class="groups">
                       <li tal:repeat="group groups">
-                        <a class="contenttype-opengever-contact-contactfolder link-overlay" tal:attributes="href string:list_groupmembers?group=${group/groupid}" tal:content="python: group.title or group.groupid"></a>
+                        <a class="group link-overlay" tal:attributes="href string:list_groupmembers?group=${group/groupid}" tal:content="python: group.title or group.groupid"></a>
                       </li>
                   </ul>
               </td>


### PR DESCRIPTION
![bildschirmfoto 2015-04-30 um 09 00 45](https://cloud.githubusercontent.com/assets/485755/7407946/bcd0caf6-ef17-11e4-91b9-6968f76be1a8.png)

According changes in https://github.com/4teamwork/plonetheme.teamraum/pull/302

@lukasgraf please have a look.