### PR TITLE
Protocol visual improvements.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Implement scrollspy.
+  [Kevin Bieri]
+
+- Re-designed protocol view.
+  [Kevin Bieri]
+
 - Fixed wrongly displayed document_actions in task overview.
   [phgross]
 

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -12,80 +12,134 @@
         <div id="opengever_meeting_protocol">
           <metal:use use-macro="context/@@ploneform-macros/titlelessform">
 
-            <metal:block fill-slot="actions">
+            <metal:block fill-slot="fields">
+             <div class="agenda_items">
+                <metal:block tal:repeat="protocol view/get_agenda_items">
+                  <metal:block tal:define="name protocol/name">
 
-              <metal:block tal:repeat="protocol view/get_agenda_items">
-              <metal:block tal:define="name protocol/name">
+                    <h2 class="protocol_title" tal:content="protocol/get_title"></h2>
 
-                <h2 class="protocol_title" tal:content="protocol/get_title"></h2>
+                    <metal:block tal:condition="protocol/has_proposal">
+                        <label tal:attributes="for string:${name}.legal_basis:record"
+                               i18n:translate="">
+                               Legal basis
+                        </label>
+                        <textarea class="textarea-widget text-field"
+                                  tal:attributes="name string:${name}.legal_basis:record;
+                                                  id string:${name}.legal_basis:record"
+                                  tal:content="protocol/legal_basis"/>
 
-                <metal:block tal:condition="protocol/has_proposal">
-                    <label tal:attributes="for string:${name}.legal_basis:record"
+                        <label tal:attributes="for string:${name}.initial_position:record"
+                               i18n:translate="">
+                               Initial position
+                        </label>
+                        <textarea class="textarea-widget text-field"
+                                  tal:attributes="name string:${name}.initial_position:record;
+                                                  id string:${name}.initial_position:record"
+                                  tal:content="protocol/initial_position"/>
+
+                        <label tal:attributes="for string:${name}.proposed_action:record"
+                               i18n:translate="">
+                               Proposed action
+                        </label>
+                        <textarea class="textarea-widget text-field"
+                                  tal:attributes="name string:${name}.proposed_action:record;
+                                                  id string:${name}.proposed_action:record"
+                                  tal:content="protocol/proposed_action"/>
+
+                        <label tal:attributes="for string:${name}.considerations:record"
+                               i18n:translate="">
+                               Considerations
+                        </label>
+                        <textarea class="textarea-widget text-field"
+                                  tal:attributes="name string:${name}.considerations:record;
+                                                  id string:${name}.considerations:record"
+                                  tal:content="protocol/considerations"/>
+                    </metal:block>
+
+                    <label tal:attributes="for string:${name}.discussion:record"
                            i18n:translate="">
-                           Legal basis
+                           Discussion
                     </label>
                     <textarea class="textarea-widget text-field"
-                              tal:attributes="name string:${name}.legal_basis:record;
-                                              id string:${name}.legal_basis:record"
-                              tal:content="protocol/legal_basis"/>
+                              tal:attributes="name string:${name}.discussion:record;
+                                              id string:${name}.discussion:record"
+                              tal:content="protocol/discussion"/>
 
-                    <label tal:attributes="for string:${name}.initial_position:record"
-                           i18n:translate="">
-                           Initial position
+                    <label tal:attributes="for string:${name}.decision:record"
+                           i18n:translate="label_decision">
+                           Decision
                     </label>
                     <textarea class="textarea-widget text-field"
-                              tal:attributes="name string:${name}.initial_position:record;
-                                              id string:${name}.initial_position:record"
-                              tal:content="protocol/initial_position"/>
+                              tal:attributes="name string:${name}.decision:record;
+                                              id string:${name}.decision:record"
+                              tal:content="protocol/decision"/>
 
-                    <label tal:attributes="for string:${name}.proposed_action:record"
-                           i18n:translate="">
-                           Proposed action
-                    </label>
-                    <textarea class="textarea-widget text-field"
-                              tal:attributes="name string:${name}.proposed_action:record;
-                                              id string:${name}.proposed_action:record"
-                              tal:content="protocol/proposed_action"/>
-
-                    <label tal:attributes="for string:${name}.considerations:record"
-                           i18n:translate="">
-                           Considerations
-                    </label>
-                    <textarea class="textarea-widget text-field"
-                              tal:attributes="name string:${name}.considerations:record;
-                                              id string:${name}.considerations:record"
-                              tal:content="protocol/considerations"/>
+                  </metal:block>
                 </metal:block>
 
-                <label tal:attributes="for string:${name}.discussion:record"
-                       i18n:translate="">
-                       Discussion
-                </label>
-                <textarea class="textarea-widget text-field"
-                          tal:attributes="name string:${name}.discussion:record;
-                                          id string:${name}.discussion:record"
-                          tal:content="protocol/discussion"/>
+                <metal:use use-macro="context/@@ploneform-macros/actions" />
 
-                <label tal:attributes="for string:${name}.decision:record"
-                       i18n:translate="label_decision">
-                       Decision
-                </label>
-                <textarea class="textarea-widget text-field"
-                          tal:attributes="name string:${name}.decision:record;
-                                          id string:${name}.decision:record"
-                          tal:content="protocol/decision"/>
+                <metal:use use-macro="context/@@meeting-macros/disable_kss_inline_validation" />
+              </div>
+            </metal:block>
 
-              </metal:block>
-              </metal:block>
-
-            <metal:use use-macro="context/@@ploneform-macros/actions" />
-
-            <metal:use use-macro="context/@@meeting-macros/disable_kss_inline_validation" />
-
+            <metal:block fill-slot="actions">
+              <div class="metadata">
+                <metal:use use-macro="context/@@ploneform-macros/fields" />
+              </div>
+              <div class="protocol-navigation" id="protocol-navigation">
+                <ul id="scrollspy" class="nav">
+                    <li tal:repeat="protocol view/get_agenda_items">
+                      <metal:block tal:define="name protocol/name">
+                        <a tal:attributes="href string:#${name}" tal:content="protocol/get_title"></a>
+                          <ul class="nav">
+                            <metal:block tal:condition="protocol/has_proposal">
+                              <li>
+                                <a tal:attributes="href string:#${name}-legal_basis"
+                                   i18n:translate="">
+                                   Legal basis
+                                 </a>
+                              </li>
+                              <li>
+                                <a tal:attributes="href string:#${name}-initial_position"
+                                   i18n:translate="">
+                                   Initial position
+                                 </a>
+                              </li>
+                              <li>
+                                <a tal:attributes="href string:#${name}-proposed_action"
+                                   i18n:translate="">
+                                   Proposed action
+                                 </a>
+                              </li>
+                              <li>
+                                <a tal:attributes="href string:#${name}-considerations"
+                                   i18n:translate="">
+                                   Considerations
+                                 </a>
+                              </li>
+                            </metal:block>
+                            <li>
+                              <a tal:attributes="href string:#${name}-discussion"
+                                 i18n:translate="">
+                                 Discussion
+                               </a>
+                            </li>
+                            <li>
+                              <a tal:attributes="href string:#${name}-decision"
+                                 i18n:translate="">
+                                 Decision
+                               </a>
+                            </li>
+                          </ul>
+                        </metal:block>
+                    </li>
+                </ul>
+              </div>
             </metal:block>
 
           </metal:use>
-        </div>
       </metal:content-core>
     </metal:content-core>
 

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -17,68 +17,72 @@
                 <metal:block tal:repeat="protocol view/get_agenda_items">
                   <metal:block tal:define="name protocol/name">
 
-                    <h2 class="protocol_title" tal:content="protocol/get_title"></h2>
+                    <h2 class="protocol_title" tal:attributes="id name" tal:content="protocol/get_title"></h2>
 
                     <metal:block tal:condition="protocol/has_proposal">
-                        <label tal:attributes="for string:${name}.legal_basis:record"
+                        <label tal:attributes="for string:${name}-legal_basis;
+                                               id string:${name}-legal_basis-label"
                                i18n:translate="">
                                Legal basis
                         </label>
                         <textarea class="textarea-widget text-field"
                                   tal:attributes="name string:${name}.legal_basis:record;
-                                                  id string:${name}.legal_basis:record"
+                                                  id string:${name}-legal_basis"
                                   tal:content="protocol/legal_basis"/>
 
-                        <label tal:attributes="for string:${name}.initial_position:record"
+                        <label tal:attributes="for string:${name}-initial_position;
+                                               id string:${name}-initial_position-label"
                                i18n:translate="">
                                Initial position
                         </label>
                         <textarea class="textarea-widget text-field"
                                   tal:attributes="name string:${name}.initial_position:record;
-                                                  id string:${name}.initial_position:record"
+                                                  id string:${name}-initial_position"
                                   tal:content="protocol/initial_position"/>
 
-                        <label tal:attributes="for string:${name}.proposed_action:record"
+                        <label tal:attributes="for string:${name}-proposed_action;
+                                               id string:${name}-proposed_action-label"
                                i18n:translate="">
                                Proposed action
                         </label>
                         <textarea class="textarea-widget text-field"
                                   tal:attributes="name string:${name}.proposed_action:record;
-                                                  id string:${name}.proposed_action:record"
+                                                  id string:${name}-proposed_action"
                                   tal:content="protocol/proposed_action"/>
 
-                        <label tal:attributes="for string:${name}.considerations:record"
+                        <label tal:attributes="for string:${name}-considerations;
+                                               id string:${name}-considerations-label"
                                i18n:translate="">
                                Considerations
                         </label>
                         <textarea class="textarea-widget text-field"
                                   tal:attributes="name string:${name}.considerations:record;
-                                                  id string:${name}.considerations:record"
+                                                  id string:${name}-considerations"
                                   tal:content="protocol/considerations"/>
                     </metal:block>
 
-                    <label tal:attributes="for string:${name}.discussion:record"
+                    <label tal:attributes="for string:${name}-discussion;
+                                           id string:${name}-discussion-label"
                            i18n:translate="">
                            Discussion
                     </label>
                     <textarea class="textarea-widget text-field"
                               tal:attributes="name string:${name}.discussion:record;
-                                              id string:${name}.discussion:record"
+                                              id string:${name}-discussion"
                               tal:content="protocol/discussion"/>
 
-                    <label tal:attributes="for string:${name}.decision:record"
+                    <label tal:attributes="for string:${name}-decision;
+                                           id string:${name}-decision-label"
                            i18n:translate="label_decision">
                            Decision
                     </label>
                     <textarea class="textarea-widget text-field"
                               tal:attributes="name string:${name}.decision:record;
-                                              id string:${name}.decision:record"
+                                              id string:${name}-decision"
                               tal:content="protocol/decision"/>
 
                   </metal:block>
                 </metal:block>
-
-                <metal:use use-macro="context/@@ploneform-macros/actions" />
 
                 <metal:use use-macro="context/@@meeting-macros/disable_kss_inline_validation" />
               </div>
@@ -86,7 +90,10 @@
 
             <metal:block fill-slot="actions">
               <div class="metadata">
-                <metal:use use-macro="context/@@ploneform-macros/fields" />
+                <div class="fields">
+                  <metal:use use-macro="context/@@ploneform-macros/fields" />
+                  <metal:use use-macro="context/@@ploneform-macros/actions" />
+                </div>
               </div>
               <div class="protocol-navigation" id="protocol-navigation">
                 <ul id="scrollspy" class="nav">

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -47,10 +47,6 @@
       $(this).parents("tr").toggleClass("expanded");
     };
 
-    $("#opengever_meeting_protocol textarea").autosize();
-
-    stickyHeading("#opengever_meeting_protocol .protocol_title");
-
     var agendaItemTable = $("#agenda_items"),
       agendaItemStore = $("tbody", agendaItemTable).clone(),
       updateNumbers = function(numbers) {

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -1,0 +1,50 @@
+$(document).ready(function() {
+  var scrollSpy = $("#scrollspy");
+
+  $("#opengever_meeting_protocol textarea").autosize();
+
+  var stickyHeadingInstance = stickyHeading("#opengever_meeting_protocol .protocol_title");
+
+  var currentTarget;
+
+  if(stickyHeadingInstance) {
+    stickyHeadingInstance.onNoSticky(function() {
+      scrollSpy.css("position", "static");
+      $(".metadata .fields").css("position", "static");
+    });
+
+    stickyHeadingInstance.onSticky(function(heading) {
+      scrollSpy.css("position", "fixed");
+      $(".metadata .fields").css("position", "fixed");
+      if(currentTarget && !currentTarget.hasClass("protocol_title")) {
+        $('html, body').scrollTop(currentTarget.offset().top - (heading.node.height() + 30));
+        currentTarget = null;
+      }
+    });
+
+    stickyHeadingInstance.onCollision(function() {
+      scrollSpy.css("position", "fixed");
+      $(".metadata .fields").css("position", "fixed");
+    });
+  }
+
+  function moveCaretToEnd(el) {
+    if (typeof el.selectionStart == "number") {
+        el.selectionStart = el.selectionEnd = el.value.length;
+    } else if (el.createTextRange) {
+        var range = el.createTextRange();
+        range.collapse(false);
+    }
+    el.focus();
+  }
+
+  $("#scrollspy a").click(function(event) {
+    event.preventDefault();
+    var anchor = $(this).attr("href");
+    var target = $(anchor);
+    moveCaretToEnd(target[0]);
+    currentTarget = target;
+    $('html, body').scrollTop(target.offset().top);
+  });
+
+});

--- a/opengever/meeting/browser/resources/sticky_heading.js
+++ b/opengever/meeting/browser/resources/sticky_heading.js
@@ -20,10 +20,20 @@ stickyHeading = function($){
   }
 
   return function(selector) {
-    var headings = $(selector).map(function(i, e){
-      var el = $(e);
-      return { node: el, offset: el.offset().top, height: el.outerHeight()};
-    });
+
+    var didResize = false;
+
+    var headings;
+
+    function mapHeadings() {
+      headings = $(selector).map(function(i, e){
+        var el = $(e);
+        return { node: el, offset: el.offset().top, height: el.outerHeight()};
+      });
+    }
+
+    mapHeadings();
+
     if(headings.length < 1) { return false; }
 
     function findStickyHeading(scrollPositionTop){
@@ -36,7 +46,15 @@ stickyHeading = function($){
       return pastHeadings[pastHeadings.length - 1];
     }
 
+    function onResize() {
+      didResize = true;
+    }
+
     function onScroll() {
+      if(didResize) {
+        mapHeadings();
+        didResize = false;
+      }
       layouter.reset(headings);
       var scrollPositionTop = $(window).scrollTop();
       var stickyHeading = findStickyHeading(scrollPositionTop);
@@ -54,5 +72,6 @@ stickyHeading = function($){
     }
 
     $(window).scroll(onScroll);
+    $(window).resize(onResize);
   }
 }(jQuery);

--- a/opengever/meeting/browser/resources/sticky_heading.js
+++ b/opengever/meeting/browser/resources/sticky_heading.js
@@ -1,21 +1,31 @@
 stickyHeading = function($){
+
+  var onStickyCallback = function() {};
+  var onNoStickyCallback = function() {};
+  var onCollisionCallback = function() {};
+
   var layouter = {
     reset: function(headings){
       $.each(headings, function(i, heading) { heading.node.removeClass('sticky').css('top', 0); });
     },
 
     noSticky: function(scrollPositionTop){
-      // no-op
+      onNoStickyCallback(scrollPositionTop);
     },
 
-    sticky: function(heading, scrollPositionTop){
+    sticky: function(heading, pastHeading, scrollPositionTop){
       heading.node.addClass('sticky');
       heading.node.css('top', scrollPositionTop - heading.offset);
+      if(pastHeading) {
+        this.reset([pastHeading]);
+      }
+      onStickyCallback(heading, scrollPositionTop);
     },
 
     collision: function(fadeOutHeading, fadeInHeading, scrollPositionTop) {
       fadeOutHeading.node.addClass('sticky').css('top', fadeInHeading.offset - fadeOutHeading.offset - fadeOutHeading.height);
       fadeInHeading.node.addClass('sticky');
+      onCollisionCallback(fadeOutHeading, fadeInHeading, scrollPositionTop);
     }
   }
 
@@ -36,14 +46,14 @@ stickyHeading = function($){
 
     if(headings.length < 1) { return false; }
 
-    function findStickyHeading(scrollPositionTop){
+    function findPastHeadings(scrollPositionTop){
       var pastHeadings = [];
       $.each(headings, function(i, heading) {
         if (scrollPositionTop >= heading.offset) {
           pastHeadings.push(heading);
         }
       });
-      return pastHeadings[pastHeadings.length - 1];
+      return pastHeadings;
     }
 
     function onResize() {
@@ -57,14 +67,19 @@ stickyHeading = function($){
       }
       layouter.reset(headings);
       var scrollPositionTop = $(window).scrollTop();
-      var stickyHeading = findStickyHeading(scrollPositionTop);
+      var pastHeadings = findPastHeadings(scrollPositionTop);
 
-      if (stickyHeading) {
-        nextHeading = headings[headings.index(stickyHeading) + 1];
+      if (pastHeadings.length > 0) {
+        var stickyHeading = pastHeadings[pastHeadings.length - 1];
+        var nextHeading = headings[headings.index(stickyHeading) + 1];
+        var pastHeading = null;
+        if(pastHeadings.length > 1) {
+          pastHeading = pastHeadings[pastHeadings.length - 2];
+        }
         if (nextHeading && scrollPositionTop >= nextHeading.offset - stickyHeading.height) {
           layouter.collision(stickyHeading, nextHeading, scrollPositionTop);
         } else {
-          layouter.sticky(stickyHeading, scrollPositionTop);
+          layouter.sticky(stickyHeading, pastHeading, scrollPositionTop);
         }
       } else {
         layouter.noSticky(scrollPositionTop);
@@ -73,5 +88,21 @@ stickyHeading = function($){
 
     $(window).scroll(onScroll);
     $(window).resize(onResize);
+
+    return {
+
+      onSticky: function(callback) {
+        onStickyCallback = callback;
+      },
+
+      onNoSticky: function(callback) {
+        onNoStickyCallback = callback;
+      },
+
+      onCollision: function(callback) {
+        onCollisionCallback = callback;
+      }
+
+    }
   }
 }(jQuery);

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -138,7 +138,7 @@ class AgendaItem(Base):
     def name(self):
         """Currently used as name for input tags in html."""
 
-        return "agenda_item.{}".format(self.agenda_item_id)
+        return "agenda_item-{}".format(self.agenda_item_id)
 
     @property
     def description(self):

--- a/opengever/meeting/profiles/default/jsregistry.xml
+++ b/opengever/meeting/profiles/default/jsregistry.xml
@@ -16,4 +16,9 @@
                 insert-after="++resource++plone.app.jquery.js"
                 />
 
+    <javascript cacheable="True" compression="safe" cookable="True" expression=""
+                enabled="True" id="++resource++opengever.meeting/protocol.js" inline="False"
+                insert-after="++resource++opengever.meeting/sticky_heading.js"
+                />
+
 </object>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4305</version>
+    <version>4306</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -84,7 +84,7 @@ class TestExcerpt(FunctionalTestCase):
             MeetingList.url_for(self.committee, self.meeting))
 
         browser.find('Generate excerpt').click()
-        browser.fill({'agenda_item.1.include:record': True,
+        browser.fill({'agenda_item-1.include:record': True,
                       'Target dossier': self.dossier})
         browser.find('Save').click()
 
@@ -114,7 +114,7 @@ class TestExcerpt(FunctionalTestCase):
         # de-select pre-selected field-checkboxes
         browser.fill({'form.widgets.include_initial_position:list': False,
                       'form.widgets.include_decision:list': False,
-                      'agenda_item.1.include:record': True,
+                      'agenda_item-1.include:record': True,
                       'Target dossier': self.dossier})
         browser.find('Save').click()
 

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -247,4 +247,13 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4305 -> 4306 -->
+    <upgrade-step:importProfile
+        title="Add protocol javascript file."
+        source="4305"
+        destination="4306"
+        profile="opengever.meeting:default"
+        directory="profiles/4306"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4306/jsregistry.xml
+++ b/opengever/meeting/upgrades/profiles/4306/jsregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+    <javascript cacheable="True" compression="safe" cookable="True" expression=""
+                enabled="True" id="++resource++opengever.meeting/protocol.js" inline="False"
+                insert-after="++resource++opengever.meeting/sticky_heading.js"
+                />
+</object>


### PR DESCRIPTION
Implement scrollspy upon sticky headings. Scrollspy provides the ability
to switch between anchors in a huge protocol so the user wont lose the
focus.

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/303