### PR TITLE
Fix missing agendaitem title in sablon templates.

### DIFF
--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -26,13 +26,12 @@ Der gro\u0308sste Aufwandposten ist wie in den vergangenen Jahren mit CHF 3,050 
 
 Es sind Investitionsvorhaben von CHF 1\u2018288\u2018700.00 geplant.'''
 
-PROPOSED_ACTION_3 = '''Der Kirchgemeinderat stellt der Kirchgemeindeversammlung den Antrag,
+PROPOSED_ACTION_3 = u'''Der Kirchgemeinderat stellt der Kirchgemeindeversammlung den Antrag,
 
 1. den Voranschlag 2015 mit einem Ausgabenu\u0308berschuss von CHF 613\u2018000.00 zu genehmigen.
-
 2. den Steuerfuss auf 0.210 Einheiten zu belassen.'''
 
-INITIAL_POSITION_4 = u'''Die Versammlung hat am 6. Juni 2012 einen Verpflichtungskredit von Fr. 144'600.00 fu\u0308r die Revision genehmigt. Nach mehr als 30 Jahren seit der letzten grossen Revision, wo in der Regel alle 20 Jahre sollte durchgefu\u0308hrt werden, hat sich diese aufgedra\u0308ngt.
+INITIAL_POSITION_4 = u'''Die Versammlung hat am 6. Juni 2012 einen Verpflichtungskredit von Fr. 144\u2018600.00 fu\u0308r die Revision genehmigt. Nach mehr als 30 Jahren seit der letzten grossen Revision, wo in der Regel alle 20 Jahre sollte durchgefu\u0308hrt werden, hat sich diese aufgedra\u0308ngt.
 
 Wa\u0308hrend den Revisionsarbeiten hat sich herausgestellt, dass zusa\u0308tzlich Arbeiten durchgef\xfchrt werden m\xfcssen.Diese zusa\u0308tzlichen Arbeiten gleichzeitig mit der Revision durchzufu\u0308hren, erschien als sinnvoll. Im letzten Jahr hat deshalb der Besondere Verwalter gestu\u0308tzt auf die einverlangten Offerten einen Nachkredit von rund Fr. 10'000.00 genehmigt. Dies lag betragsma\u0308ssig in seiner Kompetenz.
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -57,7 +57,7 @@ class AgendaItem(Base):
         data = {
             'number': self.number,
             'description': self.description,
-            'title': self.title,
+            'title': self.get_title(),
         }
         if include_initial_position:
             data['markdown:initial_position'] = self._sanitize_text(

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.meeting.protocol import PreProtocolData
+from opengever.testing import FunctionalTestCase
+
+
+class TestProtocolJsonData(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestProtocolJsonData, self).setUp()
+        self.proposal = create(
+            Builder('proposal_model')
+            .having(title=u'Proposal',
+                    initial_position=u'Initial',
+                    legal_basis=u'Legal!',
+                    proposed_action=u'Yep',
+                    considerations=u'We should think about it'))
+        self.committee = create(Builder('committee_model'))
+        self.meeting = create(Builder('meeting').having(
+            committee=self.committee,
+            start=datetime(2010, 1, 1)))
+
+        self.agenda_item_proposal = create(
+            Builder('agenda_item').having(
+                proposal=self.proposal,
+                meeting=self.meeting,
+                discussion=u'Hmm',
+                decision=u'Do it'))
+        self.agend_item_text = create(
+            Builder('agenda_item').having(
+                title=u'Free Text',
+                meeting=self.meeting,
+                discussion=u'Blah',
+                decision=u'Done',))
+
+    def test_protocol_json(self):
+        data = PreProtocolData(self.meeting).data
+        self.assertEqual(
+            {'agenda_items': [
+                {'description': u'Proposal',
+                 'markdown:considerations': u'We should think about it',
+                 'markdown:decision': u'Do it',
+                 'markdown:discussion': u'Hmm',
+                 'markdown:initial_position': u'Initial',
+                 'markdown:legal_basis': u'Legal!',
+                 'markdown:proposed_action': u'Yep',
+                 'number': None,
+                 'title': u'Proposal'},
+                {'description': u'Free Text',
+                 'markdown:considerations': None,
+                 'markdown:decision': u'Done',
+                 'markdown:discussion': u'Blah',
+                 'markdown:initial_position': None,
+                 'markdown:legal_basis': None,
+                 'markdown:proposed_action': None,
+                 'number': None,
+                 'title': u'Free Text'}],
+             'mandant': {'name': u'Client1'},
+             'meeting': {'date': u'Jan 01, 2010',
+                         'end_time': '',
+                         'start_time': u'12:00 AM'},
+             'participants': {'members': [], 'other': []},
+             'protocol': {'type': u'Pre-Protocol'}},
+            data
+         )


### PR DESCRIPTION
This PR fixes missing agendaitem titles in sablon templates for agendaitems that are attached to a protocol.

It also fixes an issue with initial meeting content where an invalid template was created from non-unicode text.

*I think a changelog entry is not not necessary since recently introduced additions are fixed*