### PR TITLE
Use clones for headings.

### DIFF
--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -8,6 +8,7 @@ $(document).ready(function() {
   var currentTarget;
 
   if(stickyHeadingInstance) {
+    stickyHeadingInstance.doUpdate(true);
     stickyHeadingInstance.onNoSticky(function() {
       scrollSpy.css("position", "static");
       $(".metadata .fields").css("position", "static");
@@ -17,7 +18,7 @@ $(document).ready(function() {
       scrollSpy.css("position", "fixed");
       $(".metadata .fields").css("position", "fixed");
       if(currentTarget && !currentTarget.hasClass("protocol_title")) {
-        $('html, body').scrollTop(currentTarget.offset().top - (heading.node.height() + 30));
+        $('html, body').scrollTop(currentTarget.offset().top - (heading.clone.height() + 30));
         currentTarget = null;
       }
     });
@@ -44,7 +45,7 @@ $(document).ready(function() {
     var target = $(anchor);
     moveCaretToEnd(target[0]);
     currentTarget = target;
-    $('html, body').scrollTop(target.offset().top);
+    $('html, body').scrollTop(target.offset().top + 1);
   });
 
 });


### PR DESCRIPTION
The offset of the sticky headings are calculated once at startup based
on the DOM elements. When the content is getting higher, the position is
no longer valid because the offset is still referring to the
relative positioned elements. So a clone of each heading is being generated. When scrolling,
just the clone is being positioned relative. The offset is calculated
based on the static positioned original heading which has the correct
offset in the DOM.