### PR TITLE
Made featureflags (activity, meeting) more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Made featureflags (activity, meeting) more robust.
+  [phgross]
+
 - Fixed sql task synchronisation when task gets moved.
   [phgross]
 

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -5,14 +5,19 @@ from opengever.activity.mail import PloneNotificationMailer
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
+from zope.interface import Interface
 
 
 _ = MessageFactory("opengever.activity")
 
 
 def is_activity_feature_enabled():
-    registry = getUtility(IRegistry)
-    return registry.forInterface(IActivitySettings).is_feature_enabled
+    try:
+        registry = getUtility(IRegistry)
+        return registry.forInterface(IActivitySettings).is_feature_enabled
+
+    except KeyError, AttributeError:
+        return False
 
 
 def notification_center():

--- a/opengever/meeting/__init__.py
+++ b/opengever/meeting/__init__.py
@@ -8,6 +8,9 @@ _ = MessageFactory('opengever.meeting')
 
 
 def is_meeting_feature_enabled():
-    registry = getUtility(IRegistry)
-    settings = registry.forInterface(IMeetingSettings)
-    return settings.is_feature_enabled
+    try:
+        registry = getUtility(IRegistry)
+        return registry.forInterface(IMeetingSettings).is_feature_enabled
+
+    except KeyError, AttributeError:
+        return  False


### PR DESCRIPTION
Calling the feature_flag methods (`is_activity_feature_enabled` etc.) should not fail if the corresponding registry entry is missing and only return False instead.

Fixes #909 


@lukasgraf please have a look ... 