### PR TITLE
Fixed sql task synchronisation when task gets moved.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Fixed sql task synchronisation when task gets moved.
+  [phgross]
+
 - Redirect to documents tab instead of trash tab, after trashing documents.
   [phgross]
 

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from datetime import datetime
 from five import grok
+from opengever.base.interfaces import ISequenceNumber
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -15,6 +16,7 @@ from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 from zope.interface import Interface
@@ -229,6 +231,9 @@ class DossierContainer(Container):
     @property
     def responsible_label(self):
         return self.get_responsible_actor().get_label()
+
+    def get_sequence_number(self):
+        return getUtility(ISequenceNumber).get_number(self)
 
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -53,6 +53,7 @@ def set_former_reference_after_moving(obj, event):
 
 
 @grok.subscribe(IDossierMarker, IObjectAddedEvent)
+@grok.subscribe(IDossierMarker, IObjectMovedEvent)
 def saveReferenceNumberPrefix(obj, event):
     parent = aq_parent(aq_inner(obj))
     prefix_adapter = IReferenceNumberPrefix(parent)

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -94,6 +94,15 @@ class TestDossierContainer(FunctionalTestCase):
             [subdossier],
             self.brains_to_objects(dossier.get_subdossiers(depth=1)))
 
+    def test_sequence_number(self):
+        dossier_1 = create(Builder("dossier"))
+        subdossier = create(Builder("dossier"))
+        dossier_2 = create(Builder("dossier"))
+
+        self.assertEquals(1, dossier_1.get_sequence_number())
+        self.assertEquals(2, subdossier.get_sequence_number())
+        self.assertEquals(3, dossier_2.get_sequence_number())
+
 
 class TestDossierChecks(FunctionalTestCase):
 

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -1,0 +1,14 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.inbox.inbox import IInbox
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+
+
+def get_containing_dossier(obj):
+    while not IPloneSiteRoot.providedBy(obj):
+        if IDossierMarker.providedBy(obj) or IInbox.providedBy(obj):
+            return obj
+        obj = aq_parent(aq_inner(obj))
+
+    return None

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -139,7 +139,7 @@ class Task(Base):
         self.is_subtask = plone_task.get_is_subtask()
         self.sequence_number = plone_task.get_sequence_number()
         self.reference_number = plone_task.get_reference_number()
-        self.containing_dossier = plone_task.get_containing_dossier()
+        self.containing_dossier = plone_task.get_containing_dossier_title()
         self.dossier_sequence_number = plone_task.get_dossier_sequence_number()
         self.assigned_org_unit = plone_task.responsible_client
         self.principals = plone_task.get_principals()

--- a/opengever/inbox/inbox.py
+++ b/opengever/inbox/inbox.py
@@ -37,3 +37,8 @@ class Inbox(Container):
             return ogds_service().fetch_org_unit(org_unit_id)
 
         return None
+
+    def get_sequence_number(self):
+        """The Inbox does not have a sequence number."""
+
+        return None

--- a/opengever/inbox/tests/test_inbox.py
+++ b/opengever/inbox/tests/test_inbox.py
@@ -21,3 +21,8 @@ class TestInbox(FunctionalTestCase):
         inbox = create(Builder('inbox'))
 
         self.assertEqual(None, inbox.get_responsible_org_unit())
+
+    def test_get_sequence_number_returns_none(self):
+        inbox = create(Builder('inbox'))
+
+        self.assertEqual(None, inbox.get_sequence_number())

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -307,6 +307,9 @@ class Task(Container):
         return IReferenceNumber(self).get_number()
 
     def get_containing_dossier(self):
+        return get_containing_dossier(self)
+
+    def get_containing_dossier_title(self):
         #get the containing_dossier value directly with the indexer
         catalog = getToolByName(self, 'portal_catalog')
         return getMultiAdapter(
@@ -319,7 +322,7 @@ class Task(Container):
             (self, catalog), IIndexer, name='containing_subdossier')()
 
     def get_dossier_sequence_number(self):
-        dossier = get_containing_dossier(self)
+        dossier = self.get_containing_dossier()
         if dossier:
             return dossier.get_sequence_number()
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -11,6 +11,7 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.oguid import Oguid
 from opengever.base.source import DossierPathSourceBinder
+from opengever.dossier.utils import get_containing_dossier
 from opengever.globalindex.model.task import Task as TaskModel
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.autocomplete_widget import AutocompleteFieldWidget
@@ -318,30 +319,9 @@ class Task(Container):
             (self, catalog), IIndexer, name='containing_subdossier')()
 
     def get_dossier_sequence_number(self):
-        # the dossier_sequence_number index is required for generating lists
-        # of tasks as PDFs (LaTeX) as defined by the customer.
-        dossier_marker = 'opengever.dossier.behaviors.dossier.IDossierMarker'
-
-        path = self.getPhysicalPath()[:-1]
-
-        portal = getToolByName(self, 'portal_url').getPortalObject()
-        portal_path = '/'.join(portal.getPhysicalPath())
-        catalog = getToolByName(self, 'portal_catalog')
-
-        while path and '/'.join(path) != portal_path:
-            brains = catalog({'path': {'query': '/'.join(path),
-                                       'depth': 0},
-                              'object_provides': dossier_marker})
-
-            if len(brains):
-                if brains[0].sequence_number:
-                    return brains[0].sequence_number
-                else:
-                    return None
-            else:
-                path = path[:-1]
-
-        return None
+        dossier = get_containing_dossier(self)
+        if dossier:
+            return dossier.get_sequence_number()
 
     def get_predecessor_ids(self):
         if self.predecessor:

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -148,3 +148,39 @@ class TestTaskIntegration(FunctionalTestCase):
         maintask.REQUEST.set('X-CREATING-SUCCESSOR', True)
         create(Builder('task').within(maintask).titled('subtask'))
         self.assertEquals(0, len(IResponseContainer(maintask)))
+
+
+class TestDossierSequenceNumber(FunctionalTestCase):
+
+    def test_if_task_is_inside_a_maindossier_is_maindossier_number(self):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').within(dossier))
+
+        self.assertEquals(
+            dossier.get_sequence_number(),
+            task.get_dossier_sequence_number())
+
+    def test_if_task_is_inside_a_subdossier_is_subdossiers_number(self):
+        dossier = create(Builder('dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+        task = create(Builder('task').within(subdossier))
+
+        self.assertEquals(
+            subdossier.get_sequence_number(),
+            task.get_dossier_sequence_number())
+
+    def test_handles_multiple_levels_of_subdossier_correctly(self):
+        dossier = create(Builder('dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+        subsubdossier = create(Builder('dossier').within(subdossier))
+        task = create(Builder('task').within(subsubdossier))
+
+        self.assertEquals(
+            subsubdossier.get_sequence_number(),
+            task.get_dossier_sequence_number())
+
+    def test_its_inboxs_number_for_forwardings(self):
+        inbox = create(Builder('inbox'))
+        task = create(Builder('task').within(inbox))
+
+        self.assertEquals(None, task.get_dossier_sequence_number())


### PR DESCRIPTION
 - Make sure that task's `reference_number` is updated in sql after moving the container: Because we can't control the order of event handlers, we have to sync all containing tasks manually, if the reference number of the dossier or subdossier has changed.
 - Reworked task's `get_dossier_sequence_number` method: Drop magic implementation using the catalog and replaced it with a simple implementation which uses acquisition to get the containing dossier and the `ISequenceNumber` adapter to get the number.

Fixes #802 

@lukasgraf please have a look .. 