### PR TITLE
Redirect back to documents tab instead of trash tab, after trashing documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Redirect to documents tab instead of trash tab, after trashing documents.
+  [phgross]
+
 - Disallow deactivating a dossier which contains not closed tasks.
   [phgross]
 

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -6,16 +6,19 @@ def create_plone_user(portal, userid, password='demo09'):
     acl_users.source_users.addUser(userid, userid, password)
 
 
-def obj2brain(obj):
+def obj2brain(obj, unrestricted=False):
     catalog = getToolByName(obj, 'portal_catalog')
-    query = {'path':
-             {'query': '/'.join(obj.getPhysicalPath()),
-              'depth': 0}}
-    brains = catalog(query)
+    query = {'path': {'query': '/'.join(obj.getPhysicalPath()), 'depth': 0}}
+
+    if unrestricted:
+        brains = catalog.unrestrictedSearchResults(query)
+    else:
+        brains = catalog(query)
+
     if len(brains) == 0:
         raise Exception('Not in catalog: %s' % obj)
-    else:
-        return brains[0]
+
+    return brains[0]
 
 
 def index_data_for(obj):

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -36,7 +36,7 @@ class TestTrash(FunctionalTestCase):
         self.assertTrue(obj2brain(document_b, unrestricted=True).trashed)
 
     @browsing
-    def test_shows_statusmessage_and_redirects_to_trash_tab(self, browser):
+    def test_shows_statusmessage_and_redirects_to_documents_tab(self, browser):
         document = create(Builder('document')
                           .within(self.dossier)
                           .titled(u'Dokum\xe4nt A'))
@@ -48,7 +48,7 @@ class TestTrash(FunctionalTestCase):
         self.assertEquals([u'the object Dokum\xe4nt A trashed'],
                           info_messages())
         self.assertEquals(
-            'http://nohost/plone/dossier-1#trash', browser.url)
+            'http://nohost/plone/dossier-1#documents', browser.url)
 
     @browsing
     def test_redirect_back_and_shows_message_when_no_items_is_selected(self, browser):

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -119,12 +119,8 @@ class TrashView(grok.View):
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 
-        if trashed:
-            return self.request.RESPONSE.redirect(
-                '%s#trash' % self.context.absolute_url())
-        else:
-            return self.request.RESPONSE.redirect(
-                '%s#documents' % self.context.absolute_url())
+        return self.request.RESPONSE.redirect(
+            '{}#documents'.format(self.context.absolute_url()))
 
     def render(self):
         super(TrashView).render()


### PR DESCRIPTION
Fixes #511.

Additionally I've completely reworked the trash tests, using `ftw.builder` and `ftw.testbrowser`.

@deiferni @lukasgraf  