### PR TITLE
Add policy template support and a simple SAAS policy template.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,19 @@ Converts repository configuration from old format (repository.csv) to new format
     bin/zopepy scripts/convert_csv_repository_to_xlsx.py <path to repository csv file> <path for new xlsx file>
 
 
+Creating policies
+-----------------
+A script to semi-automatically create policies is provided as ``bin/create-policy``. The script runs in interactive mode and generates policies based on the questions asked. Policies are stored in the source directory ``src``.
+
+Policy templates are avilable from the ``opengever.policytemplates`` package. At the time of writing there is only one policy template for simple SAAS policies.
+
+Once a new policy has been generated the following things need to be added manually:
+
+- an initial repository (as excel file)
+- initial template files, if required
+- initial sablon templates, if required
+- Some more complex confiuration options like retention periods and multiple inboxes/template folders
+
 
 Tests
 -----

--- a/development.cfg
+++ b/development.cfg
@@ -27,6 +27,8 @@ user = zopemaster:admin
 eggs +=
     plonetheme.teamraum
     opengever.maintenance
+# make sure to build mr.bob console script
+    mr.bob
     ${buildout:ogds-db-driver}
 
 zcml-additional =
@@ -69,4 +71,3 @@ cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build
 recipe = collective.recipe.scriptgen
 cmd = python
 arguments = parts/omelette/ftw/mail/mta2plone.py http://127.0.0.1:${instance:http-address}/mandant1/mail-inbound
-

--- a/development.cfg
+++ b/development.cfg
@@ -27,8 +27,6 @@ user = zopemaster:admin
 eggs +=
     plonetheme.teamraum
     opengever.maintenance
-# make sure to build mr.bob console script
-    mr.bob
     ${buildout:ogds-db-driver}
 
 zcml-additional =

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Add initial policy template support and a simple SAAS policy template.
+  [deiferni]
+
 - Made featureflags (activity, meeting) more robust.
   [phgross]
 

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -129,6 +129,10 @@ class ReferenceFormatterVocabulary(grok.GlobalUtility):
         return SimpleVocabulary(terms)
 
 
+DEFAULT_FORMATTER = 'dotted'
+DEFAULT_PREFIX_STARTING_POINT = u'1'
+
+
 class IReferenceNumberSettings(Interface):
 
     formatter = schema.Choice(
@@ -136,12 +140,12 @@ class IReferenceNumberSettings(Interface):
         description=u'Select one of the registered'
         'IReferenceNumberFormatter adapter',
         source='opengever.base.ReferenceFormatterVocabulary',
-        default='dotted')
+        default=DEFAULT_FORMATTER)
 
     reference_prefix_starting_point = schema.TextLine(
         title=u"Starting Point for reference_number prefixs",
         description=u"Used as default when creating the first item on a level.",
-        default=u"1")
+        default=DEFAULT_PREFIX_STARTING_POINT)
 
 
 class ISequenceNumber(Interface):

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -44,12 +44,15 @@ class IDocumentType(Interface):
     )
 
 
+PRESERVED_AS_PAPER_DEFAULT = True
+
+
 class IDocumentSettings(Interface):
     """Registry interface with general document settings."""
 
     preserved_as_paper_default = schema.Bool(
         title=u"Client default for preserved_as_paper",
-        default=True,
+        default=PRESERVED_AS_PAPER_DEFAULT,
     )
 
 

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -4,6 +4,9 @@ from zope.component.interfaces import IObjectEvent
 from zope.interface import Interface
 
 
+DEFAULT_DOSSIER_DEPTH = 1
+
+
 class IDossierContainerTypes(Interface):
     """A type for collaborative spaces."""
 
@@ -19,7 +22,7 @@ class IDossierContainerTypes(Interface):
         title=u'Maximum dossier depth',
         description=u'Maximum nesting depth of dossiers and subdossiers.\
             If set to 0, no subdossiers can be created.',
-        default=1
+        default=DEFAULT_DOSSIER_DEPTH
     )
 
     type_prefixes = schema.List(

--- a/opengever/mail/interfaces.py
+++ b/opengever/mail/interfaces.py
@@ -4,11 +4,14 @@ from zope.interface import Interface, Attribute
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
+DEFAULT_MAIL_MAX_SIZE = 5
+
+
 class ISendDocumentConf(Interface):
     max_size = schema.Int(
         title=u'max_size',
         description=u'Maximal Size (MB) of the Attachment',
-        default=5,
+        default=DEFAULT_MAIL_MAX_SIZE,
     )
 
     documents_as_links_default = schema.Bool(

--- a/opengever/policytemplates/cli.py
+++ b/opengever/policytemplates/cli.py
@@ -1,0 +1,54 @@
+import argparse
+import sys
+
+
+class CreatePolicyCLI(object):
+    """Command Line Interface that will by available through the
+    bin/create-policy script in the development buildout directory.
+
+    For now it's a simple wrapper around bin/mrbob.
+    """
+
+    def __init__(self, args):
+        self.args = args
+
+    def run(self):
+        options = self._parse_args()
+        mrbob = 'bin/mrbob'
+        target_dir = 'src/'
+
+        cmdline = mrbob
+        if options.verbose:
+            cmdline += ' -v'
+        cmdline += ' -O %s' % target_dir
+        cmdline += ' opengever.policytemplates:policy_template'
+
+        # os.system, because it's friday afternoon and I can't be bothered to
+        # figure out subprocess.call()'s usage for the 42nd time. IOW: Fuck it.
+        os.system(cmdline)
+        print "Done."
+
+    def _parse_args(self):
+        prog = sys.argv[0]
+
+        # Top level parser
+        parser = argparse.ArgumentParser(prog=prog)
+
+        # Global arguments
+        parser.add_argument(
+            '-v',
+            '--verbose',
+            action='store_true',
+            help='Be very verbose.')
+
+        return parser.parse_args()
+
+
+def main():
+    args = sys.argv
+    cli = CreatePolicyCLI(args)
+    cli.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/policytemplates/cli.py
+++ b/opengever/policytemplates/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import mrbob.cli
 import sys
 
 
@@ -14,19 +15,19 @@ class CreatePolicyCLI(object):
 
     def run(self):
         options = self._parse_args()
-        mrbob = 'bin/mrbob'
-        target_dir = 'src/'
 
-        cmdline = mrbob
+        args = []
         if options.verbose:
-            cmdline += ' -v'
-        cmdline += ' -O %s' % target_dir
-        cmdline += ' opengever.policytemplates:policy_template'
+            args.append('-v')
 
-        # os.system, because it's friday afternoon and I can't be bothered to
-        # figure out subprocess.call()'s usage for the 42nd time. IOW: Fuck it.
-        os.system(cmdline)
-        print "Done."
+        target_dir = 'src/'
+        args.append('-O')
+        args.append(target_dir)
+
+        template = 'opengever.policytemplates:policy_template'
+        args.append(template)
+
+        sys.exit(mrbob.cli.main(args=args))
 
     def _parse_args(self):
         prog = sys.argv[0]
@@ -45,9 +46,7 @@ class CreatePolicyCLI(object):
 
 
 def main():
-    args = sys.argv
-    cli = CreatePolicyCLI(args)
-    cli.run()
+    CreatePolicyCLI(sys.argv).run()
 
 
 if __name__ == '__main__':

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -2,6 +2,7 @@ from mrbob.hooks import to_integer
 from mrbob.hooks import validate_choices
 from opengever.base.interfaces import DEFAULT_FORMATTER
 from opengever.base.interfaces import DEFAULT_PREFIX_STARTING_POINT
+from opengever.dossier.interfaces import DEFAULT_DOSSIER_DEPTH
 from opengever.repository.interfaces import DEFAULT_REPOSITORY_DEPTH
 import os
 
@@ -11,7 +12,10 @@ def init_defaults(configurator, question):
     question."""
 
     configurator.defaults.update({
-        'setup.maximum_repository_dept': DEFAULT_REPOSITORY_DEPTH,
+        'setup.maximum_dossier_depth': DEFAULT_DOSSIER_DEPTH,
+        'setup.maximum_repository_depth': DEFAULT_REPOSITORY_DEPTH,
+        'setup.reference_number_formatter': DEFAULT_FORMATTER,
+        'setup.reference_prefix_starting_point': DEFAULT_PREFIX_STARTING_POINT,
     })
 
 
@@ -63,30 +67,50 @@ def post_base_domain(configurator, question, answer):
 
 
 def post_nof_templates(configurator, question, answer):
+    if not answer:
+        return ''
+
     answer = to_integer(configurator, question, answer)
     configurator.variables['include_templates'] = bool(answer)
     return answer
 
 
 def post_maximum_repository_depth(configurator, question, answer):
+    if not answer:
+        return ''
+
     answer = to_integer(configurator, question, answer)
     if answer == DEFAULT_REPOSITORY_DEPTH:
-        return None
+        return ''
 
     return answer
 
 
 def post_reference_prefix_starting_point(configurator, question, answer):
     if answer == DEFAULT_PREFIX_STARTING_POINT:
-        return None
+        return ''
 
     return answer
 
 
 def post_reference_number_formatter(configurator, question, answer):
+    if not answer:
+        return ''
+
     answer = validate_choices(configurator, question, answer)
     if answer == DEFAULT_FORMATTER:
-        return None
+        return ''
+
+    return answer
+
+
+def post_maximum_dossier_depth(configurator, question, answer):
+    if not answer:
+        return ''
+
+    answer = to_integer(configurator, question, answer)
+    if answer == DEFAULT_DOSSIER_DEPTH:
+        return ''
 
     return answer
 

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -31,6 +31,8 @@ def post_package_name(configurator, question, answer):
         'adminunit.abbreviation': answer,
         'adminunit.id': answer,
     })
+    configurator.variables['package.name_capitalized'] = answer.capitalize()
+    configurator.variables['package.name_upper'] = answer.upper()
     return answer
 
 

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -1,4 +1,7 @@
 from mrbob.hooks import to_integer
+from mrbob.hooks import validate_choices
+from opengever.base.interfaces import DEFAULT_FORMATTER
+from opengever.base.interfaces import DEFAULT_PREFIX_STARTING_POINT
 from opengever.repository.interfaces import DEFAULT_REPOSITORY_DEPTH
 import os
 
@@ -68,6 +71,21 @@ def post_nof_templates(configurator, question, answer):
 def post_maximum_repository_depth(configurator, question, answer):
     answer = to_integer(configurator, question, answer)
     if answer == DEFAULT_REPOSITORY_DEPTH:
+        return None
+
+    return answer
+
+
+def post_reference_prefix_starting_point(configurator, question, answer):
+    if answer == DEFAULT_PREFIX_STARTING_POINT:
+        return None
+
+    return answer
+
+
+def post_reference_number_formatter(configurator, question, answer):
+    answer = validate_choices(configurator, question, answer)
+    if answer == DEFAULT_FORMATTER:
         return None
 
     return answer

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -3,6 +3,7 @@ from mrbob.hooks import validate_choices
 from opengever.base.interfaces import DEFAULT_FORMATTER
 from opengever.base.interfaces import DEFAULT_PREFIX_STARTING_POINT
 from opengever.dossier.interfaces import DEFAULT_DOSSIER_DEPTH
+from opengever.mail.interfaces import DEFAULT_MAIL_MAX_SIZE
 from opengever.repository.interfaces import DEFAULT_REPOSITORY_DEPTH
 import os
 
@@ -13,6 +14,7 @@ def init_defaults(configurator, question):
 
     configurator.defaults.update({
         'setup.maximum_dossier_depth': DEFAULT_DOSSIER_DEPTH,
+        'setup.maximum_mail_size': DEFAULT_MAIL_MAX_SIZE,
         'setup.maximum_repository_depth': DEFAULT_REPOSITORY_DEPTH,
         'setup.reference_number_formatter': DEFAULT_FORMATTER,
         'setup.reference_prefix_starting_point': DEFAULT_PREFIX_STARTING_POINT,
@@ -110,6 +112,17 @@ def post_maximum_dossier_depth(configurator, question, answer):
 
     answer = to_integer(configurator, question, answer)
     if answer == DEFAULT_DOSSIER_DEPTH:
+        return ''
+
+    return answer
+
+
+def post_maximum_mail_size(configurator, question, answer):
+    if not answer:
+        return ''
+
+    answer = to_integer(configurator, question, answer)
+    if answer == DEFAULT_MAIL_MAX_SIZE:
         return ''
 
     return answer

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -1,7 +1,9 @@
+from mrbob.hooks import to_boolean
 from mrbob.hooks import to_integer
 from mrbob.hooks import validate_choices
 from opengever.base.interfaces import DEFAULT_FORMATTER
 from opengever.base.interfaces import DEFAULT_PREFIX_STARTING_POINT
+from opengever.document.interfaces import PRESERVED_AS_PAPER_DEFAULT
 from opengever.dossier.interfaces import DEFAULT_DOSSIER_DEPTH
 from opengever.mail.interfaces import DEFAULT_MAIL_MAX_SIZE
 from opengever.repository.interfaces import DEFAULT_REPOSITORY_DEPTH
@@ -16,6 +18,7 @@ def init_defaults(configurator, question):
         'setup.maximum_dossier_depth': DEFAULT_DOSSIER_DEPTH,
         'setup.maximum_mail_size': DEFAULT_MAIL_MAX_SIZE,
         'setup.maximum_repository_depth': DEFAULT_REPOSITORY_DEPTH,
+        'setup.preserved_as_paper': PRESERVED_AS_PAPER_DEFAULT,
         'setup.reference_number_formatter': DEFAULT_FORMATTER,
         'setup.reference_prefix_starting_point': DEFAULT_PREFIX_STARTING_POINT,
     })
@@ -123,6 +126,17 @@ def post_maximum_mail_size(configurator, question, answer):
 
     answer = to_integer(configurator, question, answer)
     if answer == DEFAULT_MAIL_MAX_SIZE:
+        return ''
+
+    return answer
+
+
+def post_preserved_as_paper(configurator, question, answer):
+    if not answer:
+        return ''
+
+    answer = to_boolean(configurator, question, answer)
+    if answer == PRESERVED_AS_PAPER_DEFAULT:
         return ''
 
     return answer

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -1,0 +1,75 @@
+from mrbob.hooks import to_integer
+import os
+
+
+def post_package_name(configurator, question, answer):
+    configurator.defaults.update({
+        'package.url': 'https://github.com/4teamwork/opengever.{}'.format(
+            answer),
+        'adminunit.abbreviation': answer,
+        'adminunit.id': answer,
+    })
+    return answer
+
+
+def post_package_title(configurator, question, answer):
+    configurator.defaults.update({
+        'adminunit.title': answer,
+    })
+    return answer
+
+
+def post_adminunit_title(configurator, question, answer):
+    configurator.defaults.update({
+        'orgunit.title': answer,
+    })
+    return answer
+
+
+def post_adminunit_abbreviation(configurator, question, answer):
+    configurator.defaults.update({
+        'package.name': answer,
+        'adminunit.id': answer,
+        'deployment.ldap_ou': 'OpenGever{}'.format(answer.capitalize()),
+        'deployment.rolemanager_group': 'og_{}_leitung'.format(answer),
+        'orgunit.users_group': 'og_{}_benutzer'.format(answer),
+        'orgunit.inbox_group': 'og_{}_sekretariat'.format(answer),
+        'orgunit.id': answer
+    })
+    return answer
+
+
+def post_base_domain(configurator, question, answer):
+    configurator.defaults.update({
+        'adminunit.site_url': 'https://{}'.format(answer),
+        'adminunit.public_url': 'https://{}'.format(answer),
+        'deployment.mail_domain': answer,
+        'deployment.mail_from_address': 'info@{}'.format(answer),
+    })
+    return answer
+
+
+def post_nof_templates(configurator, question, answer):
+    answer = to_integer(configurator, question, answer)
+    configurator.variables['include_templates'] = bool(answer)
+    return answer
+
+
+def post_render(configurator):
+    if not configurator.variables['include_templates']:
+        _delete_templates_files(configurator)
+
+
+def _delete_templates_files(configurator):
+    package_name = configurator.variables['package.name']
+    content_path = os.path.join(
+        configurator.target_directory,
+        'opengever.{}'.format(package_name),
+        'opengever',
+        package_name,
+        'profiles',
+        'default_content',
+        'opengever_content')
+
+    os.remove(os.path.join(content_path, '02-templates.json'))
+    os.rmdir(os.path.join(content_path, 'templates'))

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -1,5 +1,15 @@
 from mrbob.hooks import to_integer
+from opengever.repository.interfaces import DEFAULT_REPOSITORY_DEPTH
 import os
+
+
+def init_defaults(configurator, question):
+    """Could not find another hook to init stuff, so we abuse the first
+    question."""
+
+    configurator.defaults.update({
+        'setup.maximum_repository_dept': DEFAULT_REPOSITORY_DEPTH,
+    })
 
 
 def post_package_name(configurator, question, answer):
@@ -52,6 +62,14 @@ def post_base_domain(configurator, question, answer):
 def post_nof_templates(configurator, question, answer):
     answer = to_integer(configurator, question, answer)
     configurator.variables['include_templates'] = bool(answer)
+    return answer
+
+
+def post_maximum_repository_depth(configurator, question, answer):
+    answer = to_integer(configurator, question, answer)
+    if answer == DEFAULT_REPOSITORY_DEPTH:
+        return None
+
     return answer
 
 

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -135,7 +135,7 @@ def post_preserved_as_paper(configurator, question, answer):
     if not answer:
         return ''
 
-    answer = to_boolean(configurator, question, answer)
+    answer = to_boolean(configurator, question, str(answer))
     if answer == PRESERVED_AS_PAPER_DEFAULT:
         return ''
 

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -64,7 +64,28 @@ deployment.mail_domain.required = True
 deployment.mail_from_address.question = Mail from address
 deployment.mail_from.address.required = True
 
+setup.enable_tree_favorites.question = Enable tree favorites
+setup.enable_tree_favorites.required = True
+setup.enable_tree_favorites.default = False
+setup.enable_tree_favorites.post_ask_hook = mrbob.hooks:to_boolean
+
+setup.enable_activity_feature.question = Enable activity feature
+setup.enable_activity_feature.required = True
+setup.enable_activity_feature.default = False
+setup.enable_activity_feature.post_ask_hook = mrbob.hooks:to_boolean
+
+setup.enable_meeting_feature.question = Enable meeting feature
+setup.enable_meeting_feature.required = True
+setup.enable_meeting_feature.default = False
+setup.enable_meeting_feature.post_ask_hook = mrbob.hooks:to_boolean
+
+setup.enable_docproperty_feature.question = Enable docproperty feature
+setup.enable_docproperty_feature.required = True
+setup.enable_docproperty_feature.default = False
+setup.enable_docproperty_feature.post_ask_hook = mrbob.hooks:to_boolean
+
 setup.nof_templates.question = Number of initial templates
+setup.nof_templates.default = 0
 setup.nof_templates.post_ask_question = opengever.policytemplates.hooks:post_nof_templates
 
 setup.maximum_repository_depth.question = Maximum repository depth

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -78,3 +78,6 @@ setup.reference_number_formatter.choices = dotted;grouped_by_three;no_client_id_
 setup.reference_number_formatter.choices_case_sensitive = yes
 setup.reference_number_formatter.choices_delimiter = ;
 setup.reference_number_formatter.post_ask_question = opengever.policytemplates.hooks:post_reference_number_formatter
+
+setup.maximum_dossier_depth.question = Maximum dossier depth
+setup.maximum_dossier_depth.post_ask_question =  opengever.policytemplates.hooks:post_maximum_dossier_depth

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -68,6 +68,13 @@ setup.nof_templates.question = Number of initial templates
 setup.nof_templates.post_ask_question = opengever.policytemplates.hooks:post_nof_templates
 
 setup.maximum_repository_depth.question = Maximum repository depth
-setup.maximum_repository_depth.required = True
 setup.maximum_repository_depth.post_ask_question = opengever.policytemplates.hooks:post_maximum_repository_depth
 
+setup.reference_prefix_starting_point.question = Reference prefix starting point
+setup.reference_prefix_starting_point.post_ask_question = opengever.policytemplates.hooks:post_reference_prefix_starting_point
+
+setup.reference_number_formatter.question = Reference number formatter
+setup.reference_number_formatter.choices = dotted;grouped_by_three;no_client_id_dotted
+setup.reference_number_formatter.choices_case_sensitive = yes
+setup.reference_number_formatter.choices_delimiter = ;
+setup.reference_number_formatter.post_ask_question = opengever.policytemplates.hooks:post_reference_number_formatter

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -80,4 +80,7 @@ setup.reference_number_formatter.choices_delimiter = ;
 setup.reference_number_formatter.post_ask_question = opengever.policytemplates.hooks:post_reference_number_formatter
 
 setup.maximum_dossier_depth.question = Maximum dossier depth
-setup.maximum_dossier_depth.post_ask_question =  opengever.policytemplates.hooks:post_maximum_dossier_depth
+setup.maximum_dossier_depth.post_ask_question = opengever.policytemplates.hooks:post_maximum_dossier_depth
+
+setup.maximum_mail_size.question = Maximum mail size
+setup.maximum_mail_size.post_ask_question = opengever.policytemplates.hooks:post_maximum_mail_size

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -1,4 +1,66 @@
+[template]
+post_render = opengever.policytemplates.hooks:post_render
+
 [questions]
-policy.name.question = Policy name
-policy.name.help = 2nd part of package name
-policy.name.required = True
+package.title.question = Package title
+package.title.required = True
+package.title.post_ask_question = opengever.policytemplates.hooks:post_package_title
+
+package.name.question = Package name
+package.name.help = 2nd part of package name: opengever.[package_name]
+package.name.required = True
+package.name.post_ask_question = opengever.policytemplates.hooks:post_package_name
+
+package.url.question = Package url
+package.url.required = True
+
+base.domain.question = Domain
+base.domain.required = True
+base.domain.post_ask_question = opengever.policytemplates.hooks:post_base_domain
+
+adminunit.title.question = AdminUnit title
+adminunit.title.required = True
+adminunit.title.post_ask_question = opengever.policytemplates.hooks:post_adminunit_title
+
+adminunit.abbreviation.question = AdminUnit abbreviation
+adminunit.abbreviation.required = True
+adminunit.abbreviation.post_ask_question = opengever.policytemplates.hooks:post_adminunit_abbreviation
+
+adminunit.id.question = AdminUnit id
+adminunit.id.required = True
+
+adminunit.public_url.question = AdminUnit public_url
+adminunit.public_url.required = True
+
+adminunit.site_url.question = AdminUnit site_url
+adminunit.site_url.required = True
+
+adminunit.ip.question = AdminUnit ip
+adminunit.ip.required = True
+
+orgunit.title.question = OrgUnit title
+orgunit.title.required = True
+
+orgunit.id.question = OrgUnit id
+orgunit.id.required = True
+
+orgunit.users_group.question = Users group
+orgunit.users_group.required = True
+
+orgunit.inbox_group.question = Inbox group
+orgunit.inbox_group.required = True
+
+deployment.ldap_ou.question = LDAP ou name
+deployment.ldap_ou.required = True
+
+deployment.rolemanager_group.question = Rolemanager group
+deployment.rolemanager_group.required = True
+
+deployment.mail_domain.question = Mail domain
+deployment.mail_domain.required = True
+
+deployment.mail_from_address.question = Mail from address
+deployment.mail_from.address.required = True
+
+setup.nof_templates.question = Number of initial templates
+setup.nof_templates.post_ask_question = opengever.policytemplates.hooks:post_nof_templates

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -4,16 +4,17 @@ post_render = opengever.policytemplates.hooks:post_render
 [questions]
 package.title.pre_ask_question = opengever.policytemplates.hooks:init_defaults
 
-package.title.question = Package title
+package.title.question = Package title (e.g.: OneGovGever - customer foo)
+package.title.help = Used as deployment title and package title in readme and setup.py.
 package.title.required = True
 package.title.post_ask_question = opengever.policytemplates.hooks:post_package_title
 
-package.name.question = Package name
-package.name.help = 2nd part of package name: opengever.[package_name]
+package.name.question = Package name (opengever.PACKAGE_NAME)
+package.name.help = 2nd part of package name: opengever.PACKAGE_NAME
 package.name.required = True
 package.name.post_ask_question = opengever.policytemplates.hooks:post_package_name
 
-package.url.question = Package url
+package.url.question = Package URL
 package.url.required = True
 
 base.domain.question = Domain
@@ -37,7 +38,7 @@ adminunit.public_url.required = True
 adminunit.site_url.question = AdminUnit site_url
 adminunit.site_url.required = True
 
-adminunit.ip.question = AdminUnit ip
+adminunit.ip.question = AdminUnit IP
 adminunit.ip.required = True
 
 orgunit.title.question = OrgUnit title
@@ -94,7 +95,7 @@ setup.maximum_repository_depth.post_ask_question = opengever.policytemplates.hoo
 setup.reference_prefix_starting_point.question = Reference prefix starting point
 setup.reference_prefix_starting_point.post_ask_question = opengever.policytemplates.hooks:post_reference_prefix_starting_point
 
-setup.reference_number_formatter.question = Reference number formatter
+setup.reference_number_formatter.question = Reference number formatter (dotted|grouped_by_three|no_client_id_dotted)
 setup.reference_number_formatter.choices = dotted;grouped_by_three;no_client_id_dotted
 setup.reference_number_formatter.choices_case_sensitive = yes
 setup.reference_number_formatter.choices_delimiter = ;
@@ -103,8 +104,8 @@ setup.reference_number_formatter.post_ask_question = opengever.policytemplates.h
 setup.maximum_dossier_depth.question = Maximum dossier depth
 setup.maximum_dossier_depth.post_ask_question = opengever.policytemplates.hooks:post_maximum_dossier_depth
 
-setup.maximum_mail_size.question = Maximum mail size
+setup.maximum_mail_size.question = Maximum mail size (MB)
 setup.maximum_mail_size.post_ask_question = opengever.policytemplates.hooks:post_maximum_mail_size
 
-setup.preserved_as_paper.question = Preserved as paper
+setup.preserved_as_paper.question = "Preserved as paper" default
 setup.preserved_as_paper.post_ask_question = opengever.policytemplates.hooks:post_preserved_as_paper

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -1,0 +1,4 @@
+[questions]
+policy.name.question = Policy name
+policy.name.help = 2nd part of package name
+policy.name.required = True

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -105,3 +105,6 @@ setup.maximum_dossier_depth.post_ask_question = opengever.policytemplates.hooks:
 
 setup.maximum_mail_size.question = Maximum mail size
 setup.maximum_mail_size.post_ask_question = opengever.policytemplates.hooks:post_maximum_mail_size
+
+setup.preserved_as_paper.question = Preserved as paper
+setup.preserved_as_paper.post_ask_question = opengever.policytemplates.hooks:post_preserved_as_paper

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -2,6 +2,8 @@
 post_render = opengever.policytemplates.hooks:post_render
 
 [questions]
+package.title.pre_ask_question = opengever.policytemplates.hooks:init_defaults
+
 package.title.question = Package title
 package.title.required = True
 package.title.post_ask_question = opengever.policytemplates.hooks:post_package_title
@@ -64,3 +66,8 @@ deployment.mail_from.address.required = True
 
 setup.nof_templates.question = Number of initial templates
 setup.nof_templates.post_ask_question = opengever.policytemplates.hooks:post_nof_templates
+
+setup.maximum_repository_depth.question = Maximum repository depth
+setup.maximum_repository_depth.required = True
+setup.maximum_repository_depth.post_ask_question = opengever.policytemplates.hooks:post_maximum_repository_depth
+

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/.gitignore
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/.gitignore
@@ -1,0 +1,16 @@
+*.egg-info
+*.mo
+*.pyc
+.installed.cfg
+.mr.developer.cfg
+bin/
+build/
+buildout.cfg
+coverage/
+develop-eggs/
+dist/
+eggs/
+parts/
+src/
+var/
+.DS_Store

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/MANIFEST.in
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/MANIFEST.in
@@ -1,0 +1,7 @@
+recursive-include opengever *
+recursive-include docs *
+include *.rst
+include *.txt
+global-exclude *.pyc
+global-exclude ._*
+global-exclude *.mo

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/README.rst.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/README.rst.bob
@@ -1,0 +1,8 @@
+opengever.{{{package.name}}}:
+=============================
+
+The policy/customization package for {{{package.title}}}
+
+Customizations:
+---------------
+

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/bootstrap.py
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/bootstrap.py
@@ -1,0 +1,178 @@
+##############################################################################
+#
+# Copyright (c) 2006 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Bootstrap a buildout-based project
+
+Simply run this script in a directory containing a buildout.cfg.
+The script accepts buildout command-line options, so you can
+use the -c option to specify an alternate configuration file.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+from optparse import OptionParser
+
+tmpeggs = tempfile.mkdtemp()
+
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep 
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("-v", "--version", help="use a specific zc.buildout version")
+
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+
+
+options, args = parser.parse_args()
+
+######################################################################
+# load/install setuptools
+
+try:
+    if options.allow_site_packages:
+        import setuptools
+        import pkg_resources
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions 
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'. 
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+cmd = [sys.executable, '-c',
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+requirement = 'zc.buildout'
+version = options.version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        for part in parsed_version:
+            if (part[:1] == '*') and (part not in _final_parts):
+                return False
+        return True
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
+
+ws.add_entry(tmpeggs)
+ws.require(requirement)
+import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
+shutil.rmtree(tmpeggs)

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
@@ -6,8 +6,6 @@ extends =
   http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
 {{% endif %}}
 
-include-policy = opengever.{{{package.name}}}
-
 ogds-db-name = opengever{{{package.name}}}
 
 [instance]
@@ -21,8 +19,6 @@ zcml-additional =
     <configure
         xmlns="http://namespaces.zope.org/zope"
         xmlns:db="http://namespaces.zope.org/db">
-
-        <include package="${buildout:include-policy}" />
 
         <include package="z3c.saconfig" file="meta.zcml" />
 

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
@@ -1,0 +1,42 @@
+[buildout]
+extends =
+  test-plone-4-2-x.cfg
+  https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+  http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
+
+include-policy = opengever.{{{package.name}}}
+
+ogds-db-name = opengever{{{package.name}}}
+
+[instance]
+zserver-threads = 4
+user = zopemaster:admin
+eggs +=
+    opengever.core
+    psycopg2
+
+zcml-additional =
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:db="http://namespaces.zope.org/db">
+
+        <include package="${buildout:include-policy}" />
+
+        <include package="z3c.saconfig" file="meta.zcml" />
+
+        <db:engine name="opengever.db"
+          url="postgresql+psycopg2:///${buildout:ogds-db-name}" pool_recycle="3600" />
+        <db:session name="opengever" engine="opengever.db" />
+
+    </configure>
+
+zope-conf-additional =
+    datetime-format international
+
+    <product-config opengever.core>
+        ogds_log_file ${buildout:directory}/var/log/ogds-update.log
+    </product-config>
+
+environment-vars +=
+    IS_DEVELOPMENT_MODE True
+    SABLON_BIN ${buildout:sablon-executable}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
@@ -2,7 +2,9 @@
 extends =
   test-plone-4-2-x.cfg
   https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+{{% if setup.enable_meeting_feature %}}
   http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
+{{% endif %}}
 
 include-policy = opengever.{{{package.name}}}
 
@@ -39,4 +41,6 @@ zope-conf-additional =
 
 environment-vars +=
     IS_DEVELOPMENT_MODE True
+{{% if setup.enable_meeting_feature %}}
     SABLON_BIN ${buildout:sablon-executable}
+{{% endif %}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/docs/HISTORY.txt
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/docs/HISTORY.txt
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+
+1.0 (unreleased)
+----------------
+
+- Initial release

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/feedcenter.ini
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/feedcenter.ini
@@ -1,0 +1,2 @@
+[jenkins]
+public = false

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
@@ -38,6 +38,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="ldap"
+      title="opengever.{{{package.name}}}:ldap"
+      description="LDAP profile for {{{package.title}}}."
+      directory="profiles/ldap"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
   <!-- deployments -->
   <opengever:registerDeployment
       title="OneGov GEVER {{{package.title}}}"

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
@@ -8,8 +8,6 @@
     xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <meta:provides feature="opengever.{{{package.name}}}" />
-
   <grok:grok package="." />
 
   <include package=".upgrades" />

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
@@ -1,0 +1,60 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:grok="http://namespaces.zope.org/grok"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:meta="http://namespaces.zope.org/meta"
+    xmlns:opengever="http://namespaces.zope.org/opengever"
+    xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <meta:provides feature="opengever.{{{package.name}}}" />
+
+  <grok:grok package="." />
+
+  <include package=".upgrades" />
+
+  <genericsetup:registerProfile
+      name="default"
+      title="opengever.{{{package.name}}}:default"
+      description="Policy for {{{package.title}}}"
+      directory="profiles/default"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="default_content"
+      title="opengever.{{{package.name}}}:default_content"
+      description="Default content for {{{package.title}}}."
+      directory="profiles/default_content"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="units"
+      title="opengever.{{{package.name}}}:units"
+      description="Units content for {{{package.title}}}."
+      directory="profiles/units"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <!-- deployments -->
+  <opengever:registerDeployment
+      title="OneGov GEVER {{{package.title}}}"
+      policy_profile="opengever.{{{package.name}}}:default"
+      additional_profiles="opengever.{{{package.name}}}:units
+                           opengever.{{{package.name}}}:default_content"
+      admin_unit_id="{{{adminunit.id}}}"
+      rolemanager_group="{{{deployment.rolemanager_group}}}"
+      is_default="True"
+      mail_domain="{{{deployment.mail_domain}}}"
+      mail_from_address="{{{deployment.mail_from_address}}}"
+      />
+
+  <opengever:registerLDAP
+      title="OneGov GEVER {{{package.title}}} LDAP"
+      ldap_profile="opengever.{{{package.name}}}:ldap"
+      is_default="True"
+      />
+
+</configure>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/metadata.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<metadata>
+    <version>1</version>
+    <dependencies>
+      <dependency>profile-opengever.policy.base:default</dependency>
+      <dependency>profile-plonetheme.teamraum:gever</dependency>
+      <dependency>profile-opengever.policy.base:mimetype</dependency>
+      <dependency>profile-ftw.tika:default</dependency>
+    </dependencies>
+</metadata>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/portlets.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/portlets.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<portlets>
+  <assignment name="options" category="context" key="/"
+              manager="ftw.footer.column2" type="plone.portlet.static.Static"
+              visible="True">
+    <property
+        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/dokumentation/installation-des-external-editors-unter-windows"&gt;External Editor (Windows)&lt;/a&gt;&lt;br /&gt;&lt;span&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/die-wichtigsten-module-von-onegov-gever/direktes-bearbeiten/#external-editor-unter-os-x"&gt;External Editor (Mac)&lt;/a&gt;&lt;/span&gt;&lt;/p&gt;</property>
+    <property name="more_url"/>
+    <property name="omit_border">False</property>
+    <property name="header">Optionen</property>
+    <property name="footer"/>
+  </assignment>
+
+  <assignment name="documentation" category="context" key="/"
+              manager="ftw.footer.column3" type="plone.portlet.static.Static"
+              visible="True">
+    <property
+        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/dokumentation"&gt;Benutzerhandbuch&lt;/a&gt;&lt;br /&gt;&lt;a class="external-link" href="http://feedback.onegov.ch"&gt;Feedback Forum&lt;/a&gt;&lt;/p&gt;</property>
+    <property name="more_url"/>
+    <property name="omit_border">False</property>
+    <property name="header">Dokumentation</property>
+    <property name="footer"/>
+  </assignment>
+
+  <assignment name="about_gever" category="context" key="/"
+              manager="ftw.footer.column1" type="plone.portlet.static.Static"
+              visible="True">
+    <property
+        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/die-wichtigsten-module-von-onegov-gever"&gt;Funktionen&lt;/a&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;a class="external-link" href="https://github.com/4teamwork/opengever.core"&gt;Quellcode&lt;/a&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;a class="external-link" href="https://jenkins.4teamwork.ch"&gt;Software Tests&lt;/a&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/aktuell/onegov-gever-release-3.0"&gt;Release 3.0&lt;/a&gt;&lt;/p&gt;</property>
+    <property name="more_url"/>
+    <property name="omit_border">False</property>
+    <property name="header">Über OneGov GEVER</property>
+    <property name="footer"/>
+  </assignment>
+
+  <assignment name="contact" category="context" key="/"
+              manager="ftw.footer.column4" type="plone.portlet.static.Static"
+              visible="True">
+    <property
+        name="text">&lt;p&gt;&lt;strong&gt;4teamwork AG&lt;/strong&gt;&lt;br /&gt;Engehaldenstrasse 53&lt;br /&gt;3012 Bern&lt;br /&gt;&lt;a class="external-link" href="http://www.4teamwork.ch"&gt;www.4teamwork.ch&lt;/a&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;span&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;strong&gt;Support&lt;br /&gt;&lt;/strong&gt;&lt;span&gt;031 511 04 04&lt;br /&gt;&lt;a class="mail-link" href="mailto:support@4teamwork.ch"&gt;support@4temwork.ch&lt;/a&gt;&lt;/span&gt;&lt;/p&gt;</property>
+    <property name="more_url"/>
+    <property name="omit_border">False</property>
+    <property name="header">Kontakt</property>
+    <property name="footer"/>
+  </assignment>
+</portlets>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -4,28 +4,28 @@
   <record name="opengever.portlets.tree.enable_favorites">
       <value>True</value>
   </record>
-{{% endif %}}
 
+{{% endif %}}
 {{% if setup.enable_activity_feature %}}
   <record interface="opengever.activity.interfaces.IActivitySettings" field="is_feature_enabled">
     <field type="plone.registry.field.Bool" />
     <value>True</value>
   </record>
-{{% endif %}}
 
+{{% endif %}}
 {{% if setup.enable_meeting_feature %}}
   <record interface="opengever.meeting.interfaces.IMeetingSettings" field="is_feature_enabled">
     <field type="plone.registry.field.Bool" />
     <value>True</value>
   </record>
-{{% endif %}}
 
+{{% endif %}}
 {{% if setup.enable_docproperty_feature %}}
   <records interface="opengever.dossier.interfaces.ITemplateDossierProperties">
     <value key="create_doc_properties">True</value>
   </records>
-{{% endif %}}
 
+{{% endif %}}
   <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration">
     <value key="current_unit_id">{{{adminunit.id}}}</value>
   </records>
@@ -38,8 +38,8 @@
   <records interface="opengever.repository.interfaces.IRepositoryFolderRecords">
     <value key="maximum_repository_depth">{{setup.maximum_repository_depth}}</value>
   </records>
-{{% endif %}}
 
+{{% endif %}}
 {{% if setup.reference_number_formatter or setup.reference_prefix_starting_point %}}
   <records interface="opengever.base.interfaces.IReferenceNumberSettings">
   {{% if setup.reference_number_formatter %}}
@@ -49,18 +49,18 @@
     <value key="reference_prefix_starting_point">{{{setup.reference_prefix_starting_point}}}</value>
   {{% endif %}}
   </records>
-{{% endif %}}
 
+{{% endif %}}
 {{% if setup.maximum_dossier_depth %}}
   <records interface="opengever.dossier.interfaces.IDossierContainerTypes">
     <value key="maximum_dossier_depth">{{{setup.maximum_dossier_depth}}}</value>
   </records>
-{{% endif %}}
 
+{{% endif %}}
 {{% if setup.maximum_mail_size %}}
   <records interface="opengever.mail.interfaces.ISendDocumentConf">
     <value key="max_size">{{{setup.maximum_mail_size}}}</value>
   </records>
-{{% endif %}}
 
+{{% endif %}}
 </registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -63,4 +63,10 @@
   </records>
 
 {{% endif %}}
+{{% if setup.preserved_as_paper != '' %}}
+  <records interface="opengever.document.interfaces.IDocumentSettings">
+      <value key="preserved_as_paper_default">{{{setup.preserved_as_paper}}}</value>
+  </records>
+
+{{% endif %}}
 </registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -14,5 +14,15 @@
   </records>
 {{% endif %}}
 
+{{% if setup.reference_number_formatter or setup.reference_prefix_starting_point %}}
+  <records interface="opengever.base.interfaces.IReferenceNumberSettings">
+  {{% if setup.reference_number_formatter %}}
+    <value key="formatter">{{{setup.reference_number_formatter}}}}</value>
+  {{% endif %}}
+  {{% if setup.setup.reference_prefix_starting_point %}}
+    <value key="reference_prefix_starting_point">{{{setup.reference_prefix_starting_point}}}</value>
+  {{% endif %}}
+  </records>
+{{% endif %}}
 
 </registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -25,4 +25,10 @@
   </records>
 {{% endif %}}
 
+{{% if setup.maximum_dossier_depth %}}
+  <records interface="opengever.dossier.interfaces.IDossierContainerTypes">
+    <value key="maximum_dossier_depth">{{{setup.maximum_dossier_depth}}}</value>
+  </records>
+{{% endif %}}
+
 </registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -1,0 +1,10 @@
+<registry>
+
+  <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration">
+    <value key="current_unit_id">{{{adminunit.id}}}</value>
+  </records>
+
+  <records interface="opengever.latex.interfaces.ILaTeXSettings">
+    <value key="location">{{{adminunit.title}}}</value>
+  </records>
+</registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -7,4 +7,12 @@
   <records interface="opengever.latex.interfaces.ILaTeXSettings">
     <value key="location">{{{adminunit.title}}}</value>
   </records>
+
+{{% if setup.maximum_repository_depth %}}
+  <records interface="opengever.repository.interfaces.IRepositoryFolderRecords">
+    <value key="maximum_repository_depth">{{setup.maximum_repository_depth}}</value>
+  </records>
+{{% endif %}}
+
+
 </registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -31,4 +31,10 @@
   </records>
 {{% endif %}}
 
+{{% if setup.maximum_mail_size %}}
+  <records interface="opengever.mail.interfaces.ISendDocumentConf">
+    <value key="max_size">{{{setup.maximum_mail_size}}}</value>
+  </records>
+{{% endif %}}
+
 </registry>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -1,5 +1,31 @@
 <registry>
 
+{{% if setup.enable_tree_favorites %}}
+  <record name="opengever.portlets.tree.enable_favorites">
+      <value>True</value>
+  </record>
+{{% endif %}}
+
+{{% if setup.enable_activity_feature %}}
+  <record interface="opengever.activity.interfaces.IActivitySettings" field="is_feature_enabled">
+    <field type="plone.registry.field.Bool" />
+    <value>True</value>
+  </record>
+{{% endif %}}
+
+{{% if setup.enable_meeting_feature %}}
+  <record interface="opengever.meeting.interfaces.IMeetingSettings" field="is_feature_enabled">
+    <field type="plone.registry.field.Bool" />
+    <value>True</value>
+  </record>
+{{% endif %}}
+
+{{% if setup.enable_docproperty_feature %}}
+  <records interface="opengever.dossier.interfaces.ITemplateDossierProperties">
+    <value key="create_doc_properties">True</value>
+  </records>
+{{% endif %}}
+
   <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration">
     <value key="current_unit_id">{{{adminunit.id}}}</value>
   </records>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/metadata.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+    <version>1</version>
+</metadata>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/01-initial-structure.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/01-initial-structure.json.bob
@@ -1,0 +1,56 @@
+[
+    {
+        "_path": "eingangskorb",
+        "_type": "opengever.inbox.inbox",
+        "title": "Eingangskorb",
+        "responsible_org_unit": "{{{orgunit.id}}}",
+        "_ac_local_roles": {
+          "{{{orgunit.inbox_group}}}": [
+            "Reader",
+            "Editor",
+            "Contributor"
+          ]
+        }
+    },
+    {
+        "_path": "vorlagen",
+        "_type": "opengever.dossier.templatedossier",
+        "title": "Vorlagen",
+        "_ac_local_roles": {
+            "{{{orgunit.users_group}}}": [
+                "Reader"
+            ],
+            "{{{orgunit.inbox_group}}}": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ],
+            "{{{deployment.rolemanager_group}}}": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ]
+        }
+    },
+    {
+        "_path": "kontakte",
+        "_type": "opengever.contact.contactfolder",
+        "title": "Kontakte",
+        "_transitions": "publish",
+        "_ac_local_roles": {
+            "{{{orgunit.users_group}}}": [
+                "Reader"
+            ],
+            "{{{orgunit.inbox_group}}}": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ],
+            "{{{deployment.rolemanager_group}}}": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ]
+        }
+    }
+]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/01-initial-structure.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/01-initial-structure.json.bob
@@ -24,11 +24,6 @@
                 "Contributor",
                 "Editor",
                 "Reader"
-            ],
-            "{{{deployment.rolemanager_group}}}": [
-                "Contributor",
-                "Editor",
-                "Reader"
             ]
         }
     },
@@ -42,11 +37,6 @@
                 "Reader"
             ],
             "{{{orgunit.inbox_group}}}": [
-                "Contributor",
-                "Editor",
-                "Reader"
-            ],
-            "{{{deployment.rolemanager_group}}}": [
                 "Contributor",
                 "Editor",
                 "Reader"

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/02-templates.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/02-templates.json.bob
@@ -1,0 +1,11 @@
+[
+{{% for template in range(setup.nof_templates) %}}
+    {
+        "_path": "/vorlagen/template-{{{loop.index}}}",
+        "_type": "opengever.document.document",
+        "title": "EDIT ME",
+        "file:file": "templates/EDIT ME"
+    }{{% if not loop.last %}}{,{{% endif %}}
+{{% endfor %}}
+
+]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/02-templates.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/02-templates.json.bob
@@ -5,7 +5,7 @@
         "_type": "opengever.document.document",
         "title": "EDIT ME",
         "file:file": "templates/EDIT ME"
-    }{{% if not loop.last %}}{,{{% endif %}}
+    }{{% if not loop.last %}},{{% endif %}}
 {{% endfor %}}
 
 ]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/ldap/ldap_plugin.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/ldap/ldap_plugin.xml.bob
@@ -1,7 +1,7 @@
 <?xml version="1.0"  ?>
 <ldapplugins>
 
-        <ldapplugin title="{{{package.title}}} LDAP" id="ldap" meta_type="Plone LDAP plugin" update="False">
+        <ldapplugin title="{{{package.name}}} LDAP" id="ldap" meta_type="Plone LDAP plugin" update="False">
             <cache value="RAMCache"/>
             <interface value="IAuthenticationPlugin"/>
             <interface value="ICredentialsResetPlugin"/>
@@ -14,7 +14,7 @@
             <interface value="IUserEnumerationPlugin"/>
             <interface value="IUserManagement"/>
             <plugin_property id="prefix" type="string" mode="w" value=""/>
-            <plugin_property id="title" type="string" mode="wd" value="{{{package.title}}} LDAP"/>
+            <plugin_property id="title" type="string" mode="wd" value="{{{package.name}}} LDAP"/>
             <property id="_login_attr" type="str">
                 <item value="uid"/>
             </property>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/ldap/ldap_plugin.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/ldap/ldap_plugin.xml.bob
@@ -1,0 +1,117 @@
+<?xml version="1.0"  ?>
+<ldapplugins>
+
+        <ldapplugin title="{{{package.title}}} LDAP" id="ldap" meta_type="Plone LDAP plugin" update="False">
+            <cache value="RAMCache"/>
+            <interface value="IAuthenticationPlugin"/>
+            <interface value="ICredentialsResetPlugin"/>
+            <interface value="IGroupEnumerationPlugin"/>
+            <interface value="IGroupIntrospection"/>
+            <interface value="IGroupManagement"/>
+            <interface value="IGroupsPlugin"/>
+            <interface value="IPropertiesPlugin"/>
+            <interface value="IUserAdderPlugin"/>
+            <interface value="IUserEnumerationPlugin"/>
+            <interface value="IUserManagement"/>
+            <plugin_property id="prefix" type="string" mode="w" value=""/>
+            <plugin_property id="title" type="string" mode="wd" value="{{{package.title}}} LDAP"/>
+            <property id="_login_attr" type="str">
+                <item value="uid"/>
+            </property>
+            <property id="_uid_attr" type="str">
+                <item value="uid"/>
+            </property>
+            <property id="_rdnattr" type="str">
+                <item value="cn"/>
+            </property>
+            <property id="users_base" type="str">
+                <item value="ou=Users,ou={{{deployment.ldap_ou}}},dc=4teamwork,dc=ch"/>
+            </property>
+            <property id="users_scope" type="int">
+                <item value="2"/>
+            </property>
+            <property id="_local_groups" type="bool">
+                <item value="False"/>
+            </property>
+            <property id="_implicit_mapping" type="int">
+                <item value="0"/>
+            </property>
+            <property id="groups_base" type="str">
+                <item value="ou=Groups,ou={{{deployment.ldap_ou}}},dc=4teamwork,dc=ch"/>
+            </property>
+            <property id="groups_scope" type="int">
+                <item value="2"/>
+            </property>
+            <property id="_binduid" type="str">
+                <item value="REPLACEME"/>
+            </property>
+            <property id="_bindpwd" type="str">
+                <item value="REPLACEME"/>
+            </property>
+            <property id="_binduid_usage" type="int">
+                <item value="1"/>
+            </property>
+            <property id="read_only" type="bool">
+                <item value="False"/>
+            </property>
+            <property id="_user_objclasses" type="list">
+                <item value="inetOrgPerson"/>
+                <item value="organizationalPerson"/>
+                <item value="person"/>
+            </property>
+            <property id="_extra_user_filter" type="str">
+                <item value=""/>
+            </property>
+            <property id="_pwd_encryption" type="str">
+                <item value="SHA"/>
+            </property>
+            <property id="_roles" type="list">
+              <item value="Authenticated" />
+            </property>
+            <schema>
+                <attr id="mail">
+                    <item id="public_name" value="email"/>
+                    <item id="binary" value="False"/>
+                    <item id="ldap_name" value="mail"/>
+                    <item id="friendly_name" value="Email address"/>
+                    <item id="multivalued" value="False"/>
+                </attr>
+                <attr id="cn">
+                    <item id="public_name" value="fullname"/>
+                    <item id="binary" value="False"/>
+                    <item id="ldap_name" value="cn"/>
+                    <item id="friendly_name" value="Canonical Name"/>
+                    <item id="multivalued" value="False"/>
+                </attr>
+                <attr id="sn">
+                    <item id="public_name" value="lastname"/>
+                    <item id="binary" value="False"/>
+                    <item id="ldap_name" value="sn"/>
+                    <item id="friendly_name" value="Last Name"/>
+                    <item id="multivalued" value="False"/>
+                </attr>
+                <attr id="uid">
+                    <item id="public_name" value="userid"/>
+                    <item id="binary" value="False"/>
+                    <item id="ldap_name" value="uid"/>
+                    <item id="friendly_name" value="User id"/>
+                    <item id="multivalued" value="False"/>
+                </attr>
+                <attr id="givenName">
+                    <item id="public_name" value="firstname"/>
+                    <item id="binary" value="False"/>
+                    <item id="ldap_name" value="givenName"/>
+                    <item id="friendly_name" value="First name"/>
+                    <item id="multivalued" value="False"/>
+                </attr>
+            </schema>
+            <server update="False" delete="False">
+                <item id="host" value="ldap.4teamwork.ch" type="str"/>
+                <item id="op_timeout" value="-1" type="int"/>
+                <item id="protocol" value="ldaps" type="str"/>
+                <item id="port" value="636" type="str"/>
+                <item id="conn_timeout" value="5" type="int"/>
+            </server>
+        </ldapplugin>
+
+</ldapplugins>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/units/metadata.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/units/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+    <version>1</version>
+</metadata>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/units/unit_creation/admin_units.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/units/unit_creation/admin_units.json.bob
@@ -1,0 +1,10 @@
+[
+  {
+    "unit_id": "{{{adminunit.id}}}",
+    "title": "{{{adminunit.title}}}",
+    "ip_address": "{{{adminunit.ip}}}",
+    "site_url": "{{{adminunit.site_url}}}",
+    "public_url": "{{{adminunit.public_url}}}",
+    "abbreviation": "{{{adminunit.abbreviation}}}"
+  }
+]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/units/unit_creation/org_units.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/units/unit_creation/org_units.json.bob
@@ -1,0 +1,8 @@
+[
+  {
+    "inbox_group_id": "{{{orgunit.inbox_group}}}",
+    "users_group_id": "{{{orgunit.users_group}}}",
+    "admin_unit_id": "{{{adminunit.id}}}",
+    "unit_id": "{{{orgunit.id}}}",
+    "title": "{{{orgunit.title}}}"}
+]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/testing.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/testing.py.bob
@@ -1,0 +1,25 @@
+from ftw.builder.testing import set_builder_session_factory
+from opengever.core.testing import functional_session_factory
+from opengever.core.testing import OPENGEVER_FIXTURE
+from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import PloneSandboxLayer
+import opengever.{{{package.name}}}
+
+
+class {{{package.name_capitalized}}}FunctionalLayer(PloneSandboxLayer):
+
+    defaultBases = (OPENGEVER_FIXTURE, )
+
+    def setUpZope(self, app, configurationContext):
+        self.loadZCML('configure.zcml', package=opengever.{{{package.name}}})
+
+    def setUpPloneSite(self, portal):
+        applyProfile(portal, 'opengever.{{{package.name}}}:default')
+
+
+OPENGEVER_{{{package.name_upper}}}_FIXTURE = {{{package.name_capitalized}}}FunctionalLayer()
+OPENGEVER_{{{package.name_upper}}}_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(OPENGEVER_{{{package.name_upper}}}_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
+    name="opengever-{{{package.name}}}:functional")

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/tests/test_setup.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/tests/test_setup.py.bob
@@ -1,0 +1,11 @@
+from opengever.testing import FunctionalTestCase
+from opengever.{{{package.name}}}.testing import OPENGEVER_{{{package.name_upper}}}_FUNCTIONAL_TESTING
+
+
+class Test{{{package.name_capitalized}}}Setup(FunctionalTestCase):
+
+    layer = OPENGEVER_{{{package.name_upper}}}_FUNCTIONAL_TESTING
+
+    def test_smoke_setup_works(self):
+        """If this test fails your default profile is f***ed."""
+        pass

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/upgrades/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/upgrades/configure.zcml.bob
@@ -1,0 +1,9 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    i18n_domain="opengever.{{{package.name}}}">
+
+    <include package="ftw.upgrade" file="meta.zcml" />
+
+</configure>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/__init__.py
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/__init__.py
@@ -1,0 +1,6 @@
+# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/setup.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/setup.py.bob
@@ -1,0 +1,58 @@
+from setuptools import setup, find_packages
+import os
+
+version = '1.0.0.dev0'
+
+
+tests_require = [
+    'ftw.builder',
+    'ftw.testbrowser',
+    'ftw.testing',
+    'plone.app.testing',
+]
+
+
+setup(name='opengever.{{{package.name}}}',
+      version=version,
+      description="policy and customization package for {{{package.name}}}",
+      long_description=open("README.rst").read() + "\n" + \
+          open(os.path.join("docs", "HISTORY.txt")).read(),
+      # Get more strings from
+      # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+      classifiers=[
+        "Framework :: Plone",
+        "Framework :: Zope2",
+        "Framework :: Zope3",
+        "Programming Language :: Python",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        ],
+      keywords='opengever {{{package.name}}}',
+      author='4teamwork AG',
+      author_email='mailto:info@4teamwork.ch',
+      maintainer='4teamwork AG',
+      url='{{{package.url}}}',
+      license='GPL2',
+      packages=find_packages(exclude=['ez_setup']),
+      namespace_packages=['opengever', ],
+      include_package_data=True,
+      zip_safe=False,
+      install_requires=[
+        'setuptools',
+        'z3c.autoinclude',
+        'opengever.core',
+        'plonetheme.teamraum',
+        'ftw.tika',
+        'ftw.upgrade',
+        # We not depend directly on ftw.inflator to avoid ConfigurationConflictError.
+        # 'ftw.inflator',
+
+        # -*- Extra requirements: -*-
+        ],
+      tests_require=tests_require,
+      extras_require=dict(tests=tests_require),
+      entry_points="""
+      # -*- Entry points: -*-
+      [z3c.autoinclude.plugin]
+      target = plone
+      """,
+      )

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/test-plone-4-2-x.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/test-plone-4-2-x.cfg.bob
@@ -1,0 +1,21 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/authentication.cfg
+    https://raw.github.com/4teamwork/opengever.core/master/sources.cfg
+    https://raw.github.com/4teamwork/opengever.core/master/versions.cfg
+
+parts += test
+
+development-packages +=
+    opengever.core
+
+versions = versions
+
+package-name = opengever.{{{package.name}}}
+
+find-links +=
+    http://downloads.4teamwork.ch/simple
+
+[versions]
+opengever.{{{package.name}}} =

--- a/opengever/repository/interfaces.py
+++ b/opengever/repository/interfaces.py
@@ -1,6 +1,8 @@
 from zope import schema
 from zope.interface import Interface
 
+DEFAULT_REPOSITORY_DEPTH = 3
+
 
 class IRepositoryFolder(Interface):
     """Marker Interface for content type Repository Folder
@@ -12,4 +14,4 @@ class IRepositoryFolderRecords(Interface):
     """
 
     maximum_repository_depth = schema.Int(title=u'Maximum Repository Depth',
-                                          default=3)
+                                          default=DEFAULT_REPOSITORY_DEPTH)

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(name='opengever.core',
         'ftw.tooltip',
         'ftw.upgrade',
         'ftw.zipexport',
+        'mr.bob',
         'ooxml_docprops',
         'opengever.ogds.models',
         'ordereddict',
@@ -143,5 +144,8 @@ setup(name='opengever.core',
 
       [izug.basetheme]
       version = opengever.core
+
+      [console_scripts]
+      create-policy = opengever.policytemplates.cli:main
       """,
       )


### PR DESCRIPTION
This PR adds a script to generate policies from a template ``bin/create-policy``. policy templates. The script is interactive and generates policies in the ``src`` folder.

It also adds one policy template with SAAS customers in mind.