### PR TITLE
Restrict allowed dossier meeting content in ConstrainTypesDecider.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Restrict allowed dossier meeting content in ConstrainTypesDecider.
+  [deiferni]
+
 - Add initial policy template support and a simple SAAS policy template.
   [deiferni]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Migrate templatedossiers classes from Container to custom DossierContainer subclass.
+  [deiferni]
+
 - Restrict allowed dossier meeting content in ConstrainTypesDecider.
   [deiferni]
 

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -8,6 +8,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IConstrainTypeDecider
 from opengever.dossier.interfaces import IDossierContainerTypes
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.base.actor import Actor
 from opengever.task import OPEN_TASK_STATES
 from opengever.task.task import ITask
@@ -262,6 +263,10 @@ class DefaultConstrainTypeDecider(grok.MultiAdapter):
         for const_ctype, const_depth, const_ftype in mapping:
             if const_ctype == container_type and const_ftype == factory_type:
                 return depth < const_depth or const_depth == 0
+
+        if factory_type in [u'opengever.meeting.proposal',
+                            u'opengever.meeting.sablontemplate']:
+            return is_meeting_feature_enabled()
         return True
 
     @property

--- a/opengever/dossier/menu.py
+++ b/opengever/dossier/menu.py
@@ -2,7 +2,6 @@ from five import grok
 from opengever.base.menu import FilteredPostFactoryMenu
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.meeting import is_meeting_feature_enabled
 from zope.interface import Interface
 
 
@@ -13,9 +12,6 @@ class DossierPostFactoryMenu(FilteredPostFactoryMenu):
         factory_id = factory.get('id')
         if factory_id == u'ftw.mail.mail':
             return True
-        if factory_id in [u'opengever.meeting.proposal',
-                          u'opengever.meeting.sablontemplate', ]:
-            return not is_meeting_feature_enabled()
 
         return False
 

--- a/opengever/dossier/profiles/default/metadata.xml
+++ b/opengever/dossier/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-    <version>4302</version>
+    <version>4303</version>
 </metadata>

--- a/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
@@ -20,7 +20,7 @@
     <property name="schema">opengever.dossier.templatedossier.ITemplateDossier</property>
 
     <!-- class used for content items -->
-    <property name="klass">plone.dexterity.content.Container</property>
+    <property name="klass">opengever.dossier.templatedossier.TemplateDossier</property>
 
     <!-- add permission -->
     <property name="add_permission">opengever.dossier.AddTemplateDossier</property>

--- a/opengever/dossier/templatedossier/__init__.py
+++ b/opengever/dossier/templatedossier/__init__.py
@@ -1,4 +1,5 @@
-from opengever.dossier.templatedossier.interfaces import ITemplateDossier
+from opengever.dossier.templatedossier.interfaces import ITemplateDossier  # keep!
+from opengever.dossier.templatedossier.templatedossier import TemplateDossier  # keep!
 from plone import api
 
 

--- a/opengever/dossier/templatedossier/templatedossier.py
+++ b/opengever/dossier/templatedossier/templatedossier.py
@@ -1,0 +1,5 @@
+from opengever.dossier.base import DossierContainer
+
+
+class TemplateDossier(DossierContainer):
+    """Base class for template dossiers."""

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -1,11 +1,11 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentmenu.menu import FactoriesMenu
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.mail.behaviors import ISendableDocsContainer
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
 from Products.CMFCore.utils import getToolByName
-from Products.CMFCore.Expression import createExprContext
 
 
 class TestDossier(FunctionalTestCase):
@@ -94,3 +94,27 @@ class TestDossier(FunctionalTestCase):
     def get_factory_menu_items(self, obj):
         menu = FactoriesMenu(obj)
         return menu.getMenuItems(self.dossier, self.dossier.REQUEST)
+
+    def test_default_addable_types(self):
+        self.grant('Contributor')
+        self.assertItemsEqual(
+            ['opengever.document.document', 'ftw.mail.mail',
+             'opengever.dossier.businesscasedossier', 'opengever.task.task'],
+            [fti.id for fti in self.dossier.allowedContentTypes()])
+
+
+class TestMeetingFeatureTypes(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestMeetingFeatureTypes, self).setUp()
+        self.dossier = create(Builder('dossier'))
+
+    def test_meeting_feature_enabled_addable_types(self):
+        self.grant('Contributor')
+        self.assertItemsEqual(
+            ['opengever.document.document', 'ftw.mail.mail',
+             'opengever.dossier.businesscasedossier', 'opengever.task.task',
+             'opengever.meeting.proposal'],
+            [fti.id for fti in self.dossier.allowedContentTypes()])

--- a/opengever/dossier/upgrades/configure.zcml
+++ b/opengever/dossier/upgrades/configure.zcml
@@ -168,4 +168,23 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4302 -> 4303 -->
+    <genericsetup:upgradeStep
+        title="Migrate template dossier class."
+        description=""
+        source="4302"
+        destination="4303"
+        handler="opengever.dossier.upgrades.to4303.MigrateTemplateDossierClass"
+        profile="opengever.dossier:default"
+        />
+
+    <genericsetup:registerProfile
+        name="4303"
+        title="opengever.dossier: upgrade profile 4303"
+        description=""
+        directory="profiles/4303"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/opengever/dossier/upgrades/profiles/4303/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/upgrades/profiles/4303/types/opengever.dossier.templatedossier.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="opengever.dossier.templatedossier" meta_type="Dexterity FTI"
+        i18n:domain="opengever.dossier" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <property name="klass">opengever.dossier.templatedossier.TemplateDossier</property>
+
+</object>

--- a/opengever/dossier/upgrades/to4303.py
+++ b/opengever/dossier/upgrades/to4303.py
@@ -1,0 +1,27 @@
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.templatedossier import TemplateDossier
+from plone import api
+from zope.event import notify
+from zope.lifecycleevent import ObjectModifiedEvent
+
+
+class MigrateTemplateDossierClass(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile('profile-opengever.dossier.upgrades:4303')
+        self.migrate_template_dossiers()
+
+    def migrate_template_dossiers(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        brains = catalog.unrestrictedSearchResults(
+            portal_type='opengever.dossier.templatedossier')
+
+        with ProgressLogger('Migrating templatedossier class', brains) as step:
+            for brain in brains:
+                self.migrate_object(brain.getObject())
+                step()
+
+    def migrate_object(self, obj):
+        self.migrate_class(obj, TemplateDossier)
+        notify(ObjectModifiedEvent(obj))


### PR DESCRIPTION
Currently meeting types only get filtered in the add menu, but they are still in the allowedContentTypes and can be added through url-guessing. This PR changes this behaviour and allows or restricts meeting content in dossiers based on whether the meeting feature is enabled.

Closes #907.