### PR TITLE
Implement notification handling for predecessor/successor pairs

### DIFF
--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -126,27 +126,35 @@ class PloneNotificationCenter(NotificationCenter):
     which provides some helper methods for easier access directly from plone.
     """
 
+    def _get_oguid_for(self, item):
+        """Helper which returns a oguid for a given item. If the item is
+        already an oguid, this oguid is returned."""
+
+        if not isinstance(item, Oguid):
+            return Oguid.for_object(item)
+        return item
+
     def add_watcher_to_resource(self, obj, actorid):
         actor = Actor.lookup(actorid)
-        oguid = Oguid.for_object(obj)
+        oguid = self._get_oguid_for(obj)
         for representative in actor.representatives():
             super(PloneNotificationCenter, self).add_watcher_to_resource(
                 oguid, representative.userid)
 
     def remove_watcher_from_resource(self, obj, userid):
-        oguid = Oguid.for_object(obj)
+        oguid = self._get_oguid_for(obj)
         super(PloneNotificationCenter, self).remove_watcher_from_resource(
             oguid, userid)
 
     def add_activity(self, obj, kind, title, summary, actor_id,
                      description=u''):
-        oguid = Oguid.for_object(obj)
+        oguid = self._get_oguid_for(obj)
 
         return super(PloneNotificationCenter, self).add_activity(
             oguid, kind, title, summary, actor_id, description=description)
 
     def get_watchers(self, obj):
-        oguid = Oguid.for_object(obj)
+        oguid = self._get_oguid_for(obj)
         return super(PloneNotificationCenter, self).get_watchers(oguid)
 
     def get_current_users_notifications(self, only_unread=False, limit=None):

--- a/opengever/base/tests/test_download_viewlet.py
+++ b/opengever/base/tests/test_download_viewlet.py
@@ -24,6 +24,7 @@ class TestDownloadViewlet(FunctionalTestCase):
 
     def test_with_file(self):
         test_doc = create(Builder("document")
+                          .without_default_title()
                           .attach_file_containing("lorem ipsum", name=u"foobar.txt"))
 
         response = self.download(test_doc)

--- a/opengever/document/tests/test_download.py
+++ b/opengever/document/tests/test_download.py
@@ -94,7 +94,7 @@ class TestDocumentDownloadConfirmation(FunctionalTestCase):
         super(TestDocumentDownloadConfirmation, self).setUp()
         self.grant('Manager')
         login(self.portal, TEST_USER_NAME)
-        self.document = create(Builder("document"))
+        self.document = create(Builder("document").titled(u'A letter for you'))
 
         file_ = NamedBlobFile('bla bla', filename=u'test.txt')
         self.document.file = file_
@@ -113,8 +113,7 @@ class TestDocumentDownloadConfirmation(FunctionalTestCase):
 
         browser.login().open(self.document, view='file_download_confirmation')
         self.assertIn(
-            u'The Document {0} has no File'.format(self.document.Title()),
-            browser.contents)
+            u'The Document A letter for you has no File', browser.contents)
 
     def test_download_confirmation_view_for_download(self):
         self.browser.open(

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -17,6 +17,7 @@ class TestDocumentIntegration(FunctionalTestCase):
         login(self.portal, TEST_USER_NAME)
         self.document = create(Builder("document")
                                .attach_file_containing(u"bla bla", name=u"test.txt")
+                               .without_default_title()
                                .having(digitally_available=True,
                                        keywords=()))
 

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -263,7 +263,7 @@ class TestOverviewMeetingFeatures(FunctionalTestCase):
         browser.find('Submit Document').click()
 
         self.assertEqual(
-            ['A new submitted version of document None has been created'],
+            [u'A new submitted version of document Testdokum\xe4nt has been created'],
             info_messages())
         self.assertSubmittedDocumentCreated(
             self.proposal, self.document, submitted_version=1)

--- a/opengever/document/tests/test_title_filename_syncer.py
+++ b/opengever/document/tests/test_title_filename_syncer.py
@@ -9,6 +9,7 @@ class TestTitleFilenameSyncer(FunctionalTestCase):
 
     def test_infer_title_from_filename(self):
         document = create(Builder("document")
+                          .without_default_title()
                           .attach_file_containing(u"blup", name=u'T\xf6st.txt'))
         self.assertEqual(document.title, u'T\xf6st')
         self.assertEqual(document.file.filename, u'tost.txt')

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -80,7 +80,10 @@ class TestSendDocument(FunctionalTestCase):
 
     def test_send_documents(self):
         dossier = create(Builder("dossier"))
-        documents = [create(Builder("document").within(dossier).with_dummy_content()), ]
+        documents = [create(Builder("document")
+                            .within(dossier)
+                            .without_default_title()
+                            .with_dummy_content()), ]
         mail = self.send_documents(dossier, documents)
 
         self.assertEquals(TEST_FORM_DATA.get('subject'), mail.get('Subject'),

--- a/opengever/meeting/tests/test_download_sablon_template.py
+++ b/opengever/meeting/tests/test_download_sablon_template.py
@@ -12,6 +12,7 @@ class TestSablonTemplateDownloadView(FunctionalTestCase):
         self.dossier = create(Builder('templatedossier'))
         self.template = create(
             Builder('sablontemplate')
+            .without_default_title()
             .attach_file_containing("blub blub", name=u't\xf6st.txt')
             .within(self.dossier))
 

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -35,16 +35,19 @@ class TestMeetingView(FunctionalTestCase):
             .with_asset_file('excerpt_template.docx'))
 
         self.preprotocol = create(Builder('document')
+                                  .titled(u'Pre protocol')
                                   .attach_file_containing(u"preprotocol",
                                                           u"preprotocol.docx")
                                   .within(self.dossier))
 
         self.protocol = create(Builder('document')
+                               .titled(u'Protocol')
                                .attach_file_containing(u"protocol",
                                                        u"protocol.docx")
                                .within(self.dossier))
 
         self.excerpt = create(Builder('document')
+                              .titled(u'Excerpt')
                               .attach_file_containing(u"excerpt",
                                                       u"excerpt.docx")
                               .within(self.dossier))
@@ -171,31 +174,31 @@ class TestMeetingView(FunctionalTestCase):
     @browsing
     def test_generated_preprotocol_exists(self, browser):
         browser.login().open(MeetingList.url_for(self.committee, self.meeting))
-        self.assertEquals('preprotocol', browser.css(".protocol > a")[0].text)
+        self.assertEquals('Pre protocol', browser.css(".protocol > a")[0].text)
         self.assertEquals(self.preprotocol.absolute_url(), browser.css(".protocol > a")[0].get('href'))
 
     @browsing
     def test_generated_protocol_exists(self, browser):
         browser.login().open(MeetingList.url_for(self.committee, self.meeting))
-        self.assertEquals('protocol', browser.css(".protocol > a")[1].text)
+        self.assertEquals('Protocol', browser.css(".protocol > a")[1].text)
         self.assertEquals(self.protocol.absolute_url(), browser.css(".protocol > a")[1].get('href'))
 
     @browsing
     def test_generated_exceprts_exists(self, browser):
         browser.login().open(MeetingList.url_for(self.committee, self.meeting))
-        self.assertEquals('excerpt', browser.css(".excerpts a").first.text)
+        self.assertEquals('Excerpt', browser.css(".excerpts a").first.text)
         self.assertEquals(self.excerpt.absolute_url(), browser.css(".excerpts a").first.get('href'))
 
     @browsing
     def test_generated_proposal_exceprt_exists(self, browser):
         browser.login().open(MeetingList.url_for(self.committee, self.meeting))
-        self.assertEquals('excerpt', browser.css(".summary > a").first.text)
+        self.assertEquals('Excerpt', browser.css(".summary > a").first.text)
         self.assertEquals(self.excerpt.absolute_url(), browser.css(".summary > a").first.get('href'))
 
     @browsing
     def test_proposal_attachement_exists(self, browser):
         browser.login().open(MeetingList.url_for(self.committee, self.meeting))
-        self.assertEquals('attachement', browser.css(".attachements a").first.text)
+        self.assertEquals(u'Testdokum\xe4nt', browser.css(".attachements a").first.text)
 
     @browsing
     def test_proposal_attachement_link_exists(self, browser):

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -183,6 +183,11 @@ def assign_forwarding_to_dossier(
 
     successor_tc_task = ISuccessorTaskController(task)
 
+    # Add issuer and responsible to the watchers of the newly created task
+    center = notification_center()
+    center.add_watcher_to_resource(task, task.responsible)
+    center.add_watcher_to_resource(task, task.issuer)
+
     # copy documents and map the intids
     intids_mapping = _copy_documents_from_forwarding(forwarding_obj, task)
 

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -1,4 +1,6 @@
 from five import grok
+from opengever.activity import notification_center
+from opengever.base.oguid import Oguid
 from opengever.base.request import dispatch_request
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
@@ -236,6 +238,12 @@ def accept_task_with_successor(dossier, predecessor_oguid, response_text):
     response_transporter.get_responses(predecessor.admin_unit_id,
                                        predecessor.physical_path,
                                        intids_mapping=intids_mapping)
+
+    # Move current responsible from predecessor task to successor
+    center = notification_center()
+    center.remove_watcher_from_resource(Oguid.parse(predecessor_oguid),
+                                        successor.responsible)
+    center.add_watcher_to_resource(successor, successor.responsible)
 
     # First "accept" the successor task..
     accept_task_with_response(successor, response_text)

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -98,6 +98,16 @@ def accept_forwarding_with_successor(
                                        predecessor.physical_path,
                                        intids_mapping=intids_mapping)
 
+    # Remove current responsible from predecessor and add issuer
+    # and responsible to successor's watcher.
+    center = notification_center()
+    center.remove_watcher_from_resource(Oguid.parse(predecessor_oguid),
+                                        successor_forwarding.responsible)
+    center.add_watcher_to_resource(successor_forwarding,
+                                   successor_forwarding.responsible)
+    center.add_watcher_to_resource(successor_forwarding,
+                                   successor_forwarding.issuer)
+
     # if a dossier is given means that a successor task must
     # be created in a new or a existing dossier
     if dossier:
@@ -145,7 +155,12 @@ def accept_forwarding_with_successor(
                         'failed.')
 
     if dossier:
-        # when a successor task exists, we close also the successor forwarding
+        # Update watchers for created successor forwarding and task
+        center = notification_center()
+        center.remove_watcher_from_resource(successor_forwarding, task.responsible)
+        center.add_watcher_to_resource(task, task.responsible)
+
+        # When a successor task exists, we close also the successor forwarding
         change_task_workflow_state(
             successor_forwarding,
             'forwarding-transition-accept',

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -1,10 +1,11 @@
 from Acquisition import aq_inner, aq_parent
-from Products.CMFCore.interfaces import IActionSucceededEvent
 from datetime import date
 from five import grok
+from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from plone.dexterity.interfaces import IDexterityContent
+from Products.CMFCore.interfaces import IActionSucceededEvent
 from zope.app.container.interfaces import IObjectAddedEvent
 
 
@@ -25,6 +26,11 @@ def create_subtask_response(context, event):
     parent = aq_parent(aq_inner(context))
 
     if ITask.providedBy(parent):
+        # If the the added object is a subtask we have to make sure
+        # that the subtask is already synced to the globalindex
+        if ITask.providedBy(context) and not context.get_sql_object():
+            TaskSqlSyncer(context, event).sync()
+
         # add a response with a link to the object
         add_simple_response(parent, added_object=context)
 

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner, aq_parent
 from datetime import date
 from five import grok
+from opengever.document.document import IDocumentSchema
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
@@ -24,15 +25,21 @@ def create_subtask_response(context, event):
         return
 
     parent = aq_parent(aq_inner(context))
-
     if ITask.providedBy(parent):
-        # If the the added object is a subtask we have to make sure
-        # that the subtask is already synced to the globalindex
-        if ITask.providedBy(context) and not context.get_sql_object():
-            TaskSqlSyncer(context, event).sync()
+        if ITask.providedBy(context):
+            transition = 'transition-add-subtask'
+
+            # If the the added object is a subtask we have to make sure
+            # that the subtask is already synced to the globalindex
+            if not context.get_sql_object():
+                TaskSqlSyncer(context, event).sync()
+
+        elif IDocumentSchema.providedBy(context):
+            transition = 'transition-add-document'
 
         # add a response with a link to the object
-        add_simple_response(parent, added_object=context)
+        add_simple_response(parent, added_object=context,
+                            transition=transition)
 
 
 @grok.subscribe(ITask, IActionSucceededEvent)

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -2,9 +2,11 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testing.mailing import Mailing
 from opengever.activity import notification_center
 from opengever.activity.model import Activity
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
+from opengever.task.browser.accept.utils import accept_task_with_successor
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 
@@ -242,3 +244,50 @@ class TestTaskReassignActivity(TestTaskActivites):
         self.assertItemsEqual(
             ['peter.meier', 'hugo.boss'],
             [watcher.user_id for watcher in watchers])
+
+
+class TestSuccesssorHandling(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
+
+    def setUp(self):
+        super(TestSuccesssorHandling, self).setUp()
+
+        # we need to setup the mock mailhost to avoid problems when using
+        # transaction savepoints
+        Mailing(self.portal).set_up()
+
+        create(Builder('ogds_user')
+               .id('peter.meier')
+               .assign_to_org_units([self.org_unit]))
+        create(Builder('ogds_user')
+               .id('james.meier')
+               .assign_to_org_units([self.org_unit]))
+        create(Builder('ogds_user')
+               .id('hugo.boss')
+               .assign_to_org_units([self.org_unit]))
+
+        self.center = notification_center()
+        self.dossier = create(Builder('dossier').titled(u'Dosssier A'))
+        self.predecessor = create(Builder('task')
+                                  .having(responsible='peter.meier',
+                                          issuer='james.meier'))
+
+        self.center.add_watcher_to_resource(self.predecessor, 'peter.meier')
+        self.center.add_watcher_to_resource(self.predecessor, 'hugo.boss')
+        self.center.add_watcher_to_resource(self.predecessor, 'james.meier')
+
+    def tearDown(self):
+        super(TestSuccesssorHandling, self).tearDown()
+        Mailing(self.layer['portal']).tear_down()
+
+    def test_when_accepting_task_with_successor_responsible_watcher_gets_moved_from_predecessor_to_successsor(self):
+        successor = accept_task_with_successor(
+            self.dossier, self.predecessor.oguid.id, 'Ok.')
+
+        predecessors_watcher = [watcher.user_id for watcher in
+                                self.center.get_watchers(self.predecessor)]
+        successors_watcher = [watcher.user_id for watcher in
+                              self.center.get_watchers(successor)]
+        self.assertItemsEqual(['hugo.boss', 'james.meier'], predecessors_watcher)
+        self.assertEquals(['peter.meier'], successors_watcher)

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -144,6 +144,40 @@ class TestTaskActivites(FunctionalTestCase):
             'Test User (test_user_1_)</a>', activity.summary)
         self.assertEquals(u'nicht dring\xe4nd', activity.description)
 
+    @browsing
+    def test_adding_a_subtask_notifies_watchers(self, browser):
+        task = create(Builder('task')
+                      .titled(u'Abkl\xe4rung Fall Meier')
+                      .having(responsible=u'hugo.boss',
+                              deadline=date(2015, 03, 01))
+                      .in_state('task-state-in-progress'))
+
+        browser.login().open(task, view='++add++opengever.task.task')
+        browser.fill({'Title': u'Abkl\xe4rung Fall Meier',
+                      'Responsible': 'hugo.boss',
+                      'Issuer': u'hugo.boss',
+                      'Task Type': 'comment',
+                      'Text': 'Lorem ipsum'})
+        browser.css('#form-buttons-save').first.click()
+
+        activity = Activity.query.first()
+        self.assertEquals(u'transition-add-subtask', activity.kind)
+
+    @browsing
+    def test_adding_a_document_notifies_watchers(self, browser):
+        task = create(Builder('task')
+                      .titled(u'Abkl\xe4rung Fall Meier')
+                      .having(responsible=u'hugo.boss',
+                              deadline=date(2015, 03, 01))
+                      .in_state('task-state-in-progress'))
+
+        browser.login().open(task, view='++add++opengever.document.document')
+        browser.fill({'Title': u'Letter to peter'})
+        browser.css('#form-buttons-save').first.click()
+
+        activity = Activity.query.first()
+        self.assertEquals(u'transition-add-document', activity.kind)
+
 
 class TestTaskReassignActivity(TestTaskActivites):
 

--- a/opengever/task/tests/test_indexer.py
+++ b/opengever/task/tests/test_indexer.py
@@ -5,33 +5,21 @@ from opengever.testing import create_ogds_user
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
 from opengever.testing import obj2brain
-from plone.app.testing import login
-from plone.app.testing import TEST_USER_NAME
 
 
 class TestTaskIndexers(FunctionalTestCase):
 
     def setUp(self):
         super(TestTaskIndexers, self).setUp()
-        self.portal.portal_types['opengever.task.task'].global_allow = True
 
         create(Builder('org_unit')
                .with_default_groups()
                .id('client2')
                .having(title='Client2', admin_unit=self.admin_unit))
 
-        self.grant('Contributor', 'Editor', 'Manager')
-        login(self.portal, TEST_USER_NAME)
-
         self.task = create(Builder("task")
                            .titled("Test task 1")
                            .having(task_type='comment'))
-
-        self.subtask = create(Builder("task").within(self.task)
-                                             .titled("Test task 1")
-                                             .having(task_type='comment'))
-        self.doc1 = create(Builder("document").titled(u"Doc One"))
-        self.doc2 = create(Builder("document").titled(u"Doc Two"))
 
     def test_date_of_completion(self):
         self.assertEquals(
@@ -57,6 +45,10 @@ class TestTaskIndexers(FunctionalTestCase):
             obj2brain(self.task).assigned_client, 'client2')
 
     def test_is_subtask(self):
+        self.subtask = create(Builder("task").within(self.task)
+                                             .titled("Test task 1")
+                                             .having(task_type='comment'))
+
         self.assertFalse(obj2brain(self.task).is_subtask)
 
         self.assertTrue(obj2brain(self.subtask).is_subtask)

--- a/opengever/task/tests/test_statesyncer.py
+++ b/opengever/task/tests/test_statesyncer.py
@@ -1,337 +1,153 @@
-from AccessControl.SecurityManagement import newSecurityManager
-from AccessControl.users import SimpleUser
-from ftw.testing import MockTestCase
-from ftw.testing.layer import ComponentRegistryLayer
-from grokcore.component.testing import grok
-from mocker import ANY, ARGS, KWARGS
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.ogds.base.Extensions.plugins import activate_request_layer
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.task.adapters import IResponseContainer
-from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import IWorkflowStateSyncer
-from opengever.task.statesyncer import SyncTaskWorkflowStateReceiveView
-from opengever.task.task import ITask
+from opengever.testing import FunctionalTestCase
+from plone import api
+from plone.app.testing import TEST_USER_ID
 from zExceptions import Forbidden
-from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.component import getMultiAdapter
-from zope.interface import Interface
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
 remote_viewname = '@@sync-task-workflow-state-receive'
 
 
-class TestWorkflowStateSyncer(MockTestCase):
-
-    remote_requests = []
+class TestWorkflowStateSyncer(FunctionalTestCase):
 
     def setUp(self):
         super(TestWorkflowStateSyncer, self).setUp()
-        grok('opengever.task.statesyncer')
-        grok('opengever.task.adapters')
+        activate_request_layer(self.portal.REQUEST,
+                               IInternalOpengeverRequestLayer)
 
-    def test_get_tasks_to_sync(self):
-        context = self.providing_stub([ITask])
-        request = self.stub()
+    def test_sync_state_change_on_successor_to_predecessor(self):
+        predecessor = create(Builder('task').in_state('task-state-resolved'))
+        successor = create(Builder('task').successor_from(predecessor))
 
-        pred1 = self.providing_stub([ITask])
-        self.expect(pred1.task_type).result(u'forwarding_task_type')
-        pred2 = self.providing_stub([ITask])
-        self.expect(pred2.task_type).result(u'other_task_type')
-        succ1 = self.providing_stub([ITask])
-        succ2 = self.providing_stub([ITask])
+        syncer = getMultiAdapter((successor, successor.REQUEST),
+                                 IWorkflowStateSyncer)
+        syncer.change_remote_tasks_workflow_state(
+            'task-transition-resolved-in-progress',
+            text=u'Please extend chapter 2.4')
 
-        stc = self.stub()
-        self.mock_adapter(stc, ISuccessorTaskController, [Interface])
+        self.assertEquals('task-state-in-progress',
+                          api.content.get_state(predecessor))
 
-        self.expect(stc(context)).result(stc)
-        self.expect(stc.get_successors()).result([succ1, succ2])
+    def test_sync_state_change_on_predecessor_to_successor(self):
+        predecessor = create(Builder('task').in_state('task-state-resolved'))
+        successor = create(Builder('task')
+                           .in_state('task-state-resolved')
+                           .successor_from(predecessor))
 
-        with self.mocker.order():
-            self.expect(stc.get_predecessor(None)).result(None)
-            self.expect(stc.get_predecessor(None)).result(pred1)
-            self.expect(stc.get_predecessor(None)).result(pred2)
+        syncer = getMultiAdapter((predecessor, predecessor.REQUEST),
+                                 IWorkflowStateSyncer)
+        syncer.change_remote_tasks_workflow_state(
+            'task-transition-resolved-in-progress',
+            text=u'Please extend chapter 2.4.')
 
-        self.replay()
+        self.assertEquals('task-state-in-progress',
+                          api.content.get_state(successor))
 
-        syncer = getMultiAdapter(
-            (context, request), IWorkflowStateSyncer)
+    def test_forwarding_predecessors_are_ignored(self):
+        forwarding = create(Builder('forwarding')
+                            .in_state('forwarding-state-closed'))
+        successor = create(Builder('task')
+                           .in_state('task-state-resolved')
+                           .successor_from(forwarding))
 
-        # not a transition to sync
-        self.assertEquals([], syncer.get_tasks_to_sync(
-            'task-transition-cancelled-open'))
+        syncer = getMultiAdapter((successor, successor.REQUEST),
+                                 IWorkflowStateSyncer)
+        syncer.change_remote_tasks_workflow_state(
+            'task-transition-resolved-in-progress',
+            text=u'Please extend chapter 2.4.')
 
-        # no predecessor
-        self.assertEquals([succ1, succ2], syncer.get_tasks_to_sync(
-            'task-transition-resolved-in-progress'))
-
-        # forwarding as predecessor
-        self.assertEquals([succ1, succ2], syncer.get_tasks_to_sync(
-            'task-transition-resolved-in-progress'))
-
-        self.assertEquals([pred2, succ1, succ2], syncer.get_tasks_to_sync(
-            'task-transition-resolved-in-progress'))
-
-    def test_change_remote_tasks_workflow_state(self):
-        context = self.providing_stub([ITask])
-        request = self.stub()
-
-        pred = self.providing_stub([ITask])
-        self.expect(pred.task_type).result(u'other_task_type')
-        self.expect(pred.admin_unit_id).result(u'client1')
-        self.expect(pred.physical_path).result(u'path1')
-        succ1 = self.providing_stub([ITask])
-        self.expect(succ1.admin_unit_id).result(u'client2')
-        self.expect(succ1.physical_path).result(u'path2')
-
-        stc = self.stub()
-        self.mock_adapter(stc, ISuccessorTaskController, [Interface])
-        self.expect(stc(context)).result(stc)
-        self.expect(stc.get_successors()).result([succ1])
-        self.expect(stc.get_predecessor(None)).result(pred)
-        dispatch_request = self.mocker.replace(
-                'opengever.base.request.dispatch_request')
-
-        ok_response = self.stub()
-        self.expect(ok_response.read().strip()).result('OK')
-        self.expect(dispatch_request(
-                u'client2',
-                '@@sync-task-workflow-state-receive',
-                u'path1',
-                data={
-                    'responsible_client': '',
-                    'text': 'Simple Answer text',
-                    'transition': 'task-transition-resolved-in-progress',
-                    'responsible': ''})).result(ok_response).count(0, None)
-
-        self.expect(dispatch_request(
-                u'client2',
-                '@@sync-task-workflow-state-receive',
-                u'path2',
-                data={
-                    'responsible_client': '',
-                    'text': 'Simple Answer text',
-                    'transition': 'task-transition-resolved-in-progress',
-                    'responsible': ''})).result(ok_response).count(0, None)
-
-        fail_response = self.stub()
-        self.expect(fail_response.read().strip()).result('Exception')
-
-        self.expect(dispatch_request(
-                u'client1',
-                '@@sync-task-workflow-state-receive',
-                u'path1',
-                data={
-                    'responsible_client': '',
-                    'text': 'FAILING',
-                    'transition': 'task-transition-resolved-tested-and-closed',
-                    'responsible': ''})).result(fail_response).count(0, None)
-
-        self.expect(dispatch_request(ARGS, KWARGS)).result(ok_response)
-
-        self.replay()
-
-        syncer = getMultiAdapter(
-            (context, request), IWorkflowStateSyncer)
-
-        self.assertEquals(
-            syncer.change_remote_tasks_workflow_state(
-                'task-transition-resolved-in-progress',
-                u'Simple Answer text'),
-            [pred, succ1])
-
-        with self.assertRaises(Exception):
-            self.assertEquals(
-                syncer.change_remote_tasks_workflow_state(
-                    'task-transition-resolved-tested-and-closed',
-                    u'FAILING'),
-                [pred, succ1]
-                )
+        self.assertEquals('forwarding-state-closed',
+                          api.content.get_state(forwarding))
 
 
-class StateSyncerZCMLLayer(ComponentRegistryLayer):
+class TestSyncerReceiveView(FunctionalTestCase):
 
     def setUp(self):
-        super(StateSyncerZCMLLayer, self).setUp()
+        super(TestSyncerReceiveView, self).setUp()
+        create(Builder('ogds_user').id('hugo.boss'))
 
-        from zope.annotation.interfaces import IAnnotations
-        from zope.annotation.attribute import AttributeAnnotations
-        from zope.component import provideAdapter
-        provideAdapter(AttributeAnnotations,
-                       provides=IAnnotations,
-                       adapts=[IAttributeAnnotatable])
+    def prepare_request(self, task, **kwargs):
+        for key, value in kwargs.items():
+            task.REQUEST.set(key, value)
 
-        grok('opengever.task.statesyncer')
-        grok('opengever.task.adapters')
-        grok('opengever.task.localroles')
+        activate_request_layer(task.REQUEST, IInternalOpengeverRequestLayer)
 
-STATE_SYNCER_ZCML_LAYER = StateSyncerZCMLLayer()
-
-
-class TestSyncTaskWorkflowStateReceiveView(MockTestCase):
-
-    layer = STATE_SYNCER_ZCML_LAYER
-    remote_requests = []
-
-    def test_remote_view(self):
-        task = self.providing_stub([ITask, IAttributeAnnotatable])
-        self.expect(task.Type()).result('opengever.task.task')
-
-        # worfklow_tool
-        wft = self.stub()
-        self.mock_tool(wft, 'portal_workflow')
-
-        with self.mocker.order():
-            wft.getInfoFor(task, 'review_state').result(
-                'task-state-resolved')
-            wft.getInfoFor(task, 'review_state').result(
-                'task-state-in-progress')
-
-        wft.doActionFor(task, u'task-transition-resolved-in-progress')
-        wft.getTitleForStateOnType(
-            ANY, 'opengever.task.task').result('Resolved')
-
-        user = SimpleUser('hanspeter', '', ('manage', ), [])
-        newSecurityManager(self.create_dummy(), user)
-
-        # request
-        request = self.stub_request(
-            interfaces=[IInternalOpengeverRequestLayer, ],
-            stub_response=False)
-        getter = self.stub()
-        self.expect(request.get).result(getter)
-        self.expect(getter('text')).result(u'Simpletext')
-        self.expect(getter('responsible')).result(None)
-        self.expect(getter('responsible_client')).result(None)
-        self.expect(getter('transition')).result(
-            u'task-transition-resolved-in-progress')
-
-        #response
-        response = self.stub_response(request=request)
-        self.expect(response.setHeader("Content-type", "text/plain"))
-
-        self.replay()
-
-        # NORMAL TRANSITION
-        # first request
-        view = SyncTaskWorkflowStateReceiveView(task, request)
-        view()
-
-        # second request should do nothing
-        view = SyncTaskWorkflowStateReceiveView(task, request)
-        view()
-
-        self.assertEquals(len(IResponseContainer(task)), 1)
-        self.assertEquals(IResponseContainer(task)[0].text, u'Simpletext')
-        self.assertEquals(len(IResponseContainer(task)[0].changes), 1)
-        self.assertEquals(IResponseContainer(task)[0].creator, 'hanspeter')
-
-    def test_reassign_remote_view(self):
-
-        task = self.providing_stub([ITask, IAttributeAnnotatable])
-        self.expect(task.Type()).result('opengever.task.task')
-        self.expect(task.responsible).result('old_responsible')
-        task.responsible = 'hugo.boss'
-
-        # worfklow_tool
-        wft = self.stub()
-        self.mock_tool(wft, 'portal_workflow')
-
-        with self.mocker.order():
-            wft.getInfoFor(task, 'review_state').result(
-                'task-state-resolved')
-            wft.getInfoFor(task, 'review_state').result(
-                'task-state-in-progress')
-
-        wft.doActionFor(task, u'task-transition-reassign')
-        wft.getTitleForStateOnType(
-            ANY, 'opengever.task.task').result('Resolved')
-
-        user = SimpleUser('hanspeter', '', ('manage', ), [])
-        newSecurityManager(self.create_dummy(), user)
-
-        # reassign request
-        reassign_request = self.stub_request(
-            interfaces=[IInternalOpengeverRequestLayer, ],
-            stub_response=False)
-        getter = self.stub()
-        self.expect(reassign_request.get).result(getter)
-        self.expect(getter('text')).result(u'Simpletext')
-        self.expect(getter('responsible')).result('hugo.boss')
-        self.expect(getter('responsible_client')).result('client1')
-        self.expect(getter('transition')).result(
-            u'task-transition-reassign')
-
-        # reassign respone
-        response = self.stub_response(request=reassign_request)
-        self.expect(response.setHeader("Content-type", "text/plain"))
-
-        # an ObjectModifiedEvent should be notified to update the local roles
-        handler = self.stub()
-        self.mock_handler(handler, [IObjectModifiedEvent])
-        self.expect(handler(ANY)).result(True)
-
-        self.replay()
-
-        # REASSIGN TRANSITION
-        # first request
-        view = SyncTaskWorkflowStateReceiveView(task, reassign_request)
-        view()
-
-        self.assertEquals(IResponseContainer(task)[0].text, u'Simpletext')
-        self.assertEquals(len(IResponseContainer(task)), 1)
-
-    def test_forbidden(self):
-        task = self.providing_stub([ITask, IAttributeAnnotatable])
-        request = self.stub_request()
-        getter = self.stub()
-        self.expect(request.get).result(getter)
-
-        self.replay()
+    def test_receive_view_raise_forbidden_for_none_internal_requests(self):
+        task = create(Builder('task'))
 
         with self.assertRaises(Forbidden):
-            SyncTaskWorkflowStateReceiveView(task, request)()
+            task.unrestrictedTraverse(remote_viewname)()
 
-    def test_test_and_closed_sync(self):
-        """The responsible value None is given in string (remote_request)
-        the responsible should not be set."""
+    def test_changes_workflow_state(self):
+        task = create(Builder('task').in_state('task-state-in-progress'))
 
-        task = self.providing_stub([ITask, IAttributeAnnotatable])
-        self.expect(task.Type()).result('opengever.task.task')
+        self.prepare_request(task, text=u'I am done!',
+                             transition= 'task-transition-in-progress-resolved')
+        task.unrestrictedTraverse(remote_viewname)()
 
-        # request
-        request = self.stub_request(
-            interfaces=[IInternalOpengeverRequestLayer, ],
-            stub_response=False)
-        getter = self.stub()
-        self.expect(request.get).result(getter)
-        self.expect(getter('text')).result(u'Closing text')
-        self.expect(getter('responsible')).result('None')
-        self.expect(getter('responsible_client')).result('None')
-        self.expect(getter('transition')).result(
-            u'task-transition-tested-and-closed')
+        self.assertEquals('task-state-resolved', api.content.get_state(task))
 
-        #response
-        response = self.stub_response(request=request)
-        self.expect(response.setHeader("Content-type", "text/plain"))
+    def test_returns_ok_response_if_update_was_successfull(self):
+        task = create(Builder('task').in_state('task-state-in-progress'))
 
-        # worfklow_tool
-        wft = self.stub()
-        self.mock_tool(wft, 'portal_workflow')
+        self.prepare_request(task, text=u'I am done!',
+                             transition= 'task-transition-in-progress-resolved')
+        response = task.unrestrictedTraverse(remote_viewname)()
 
-        with self.mocker.order():
-            wft.getInfoFor(task, 'review_state').result(
-                'task-state-in-progress')
-            wft.getInfoFor(task, 'review_state').result(
-                'task-state-tested-and-closed')
+        self.assertEquals('OK', response)
 
-        wft.doActionFor(task, u'task-transition-tested-and-closed')
-        wft.getTitleForStateOnType(
-            ANY, 'opengever.task.task').result('Closed')
+    def test_second_call_is_ignored_but_returns_ok_response(self):
+        task = create(Builder('task').in_state('task-state-in-progress'))
 
-        self.replay()
+        self.prepare_request(task, text=u'I am done!',
+                             transition= 'task-transition-in-progress-resolved')
+        task.unrestrictedTraverse(remote_viewname)()
 
-        view = SyncTaskWorkflowStateReceiveView(task, request)
-        view()
+        response = task.unrestrictedTraverse(remote_viewname)()
+        self.assertEquals('OK', response)
 
-        self.assertEquals(IResponseContainer(task)[0].text, u'Closing text')
-        self.assertEquals(len(IResponseContainer(task)), 1)
+    def test_does_not_reset_responsible_if_no_new_value_is_given(self):
+        task = create(Builder('task')
+                      .in_state('task-state-in-progress'))
+
+        self.prepare_request(task, text=u'I am done!',
+                             transition= 'task-transition-in-progress-resolved')
+        task.unrestrictedTraverse(remote_viewname)()
+
+        self.assertEquals('client1', task.responsible_client)
+        self.assertEquals(TEST_USER_ID, task.responsible)
+
+    def test_updates_responsible_if_new_value_is_given(self):
+        task = create(Builder('task')
+                      .in_state('task-state-in-progress'))
+
+        self.prepare_request(task, text=u'I am done!',
+                             transition='task-transition-reassign',
+                             responsible='hugo.boss',
+                             responsible_client='afi')
+        task.unrestrictedTraverse(remote_viewname)()
+
+        self.assertEquals('afi', task.responsible_client)
+        self.assertEquals('hugo.boss', task.responsible)
+
+    def test_adds_corresponding_response(self):
+        task = create(Builder('task').in_state('task-state-in-progress'))
+
+        self.prepare_request(task, text=u'\xe4\xe4hhh I am done!',
+                             transition='task-transition-in-progress-resolved')
+        task.unrestrictedTraverse(remote_viewname)()
+
+        response = IResponseContainer(task)[-1]
+        self.assertEquals('task-transition-in-progress-resolved', response.transition)
+        self.assertEquals(u'\xe4\xe4hhh I am done!', response.text)
+        self.assertEquals(TEST_USER_ID, response.creator)
+        self.assertEquals([{'before': 'task-state-in-progress',
+                            'after': 'task-state-resolved',
+                            'id': 'review_state',
+                            'name': u'Issue state'}], response.changes)

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -126,9 +126,9 @@ class TestTaskIntegration(FunctionalTestCase):
                          .within(maintask)
                          .titled('maintask'))
 
-        responses = IResponseContainer(maintask)
-        self.assertEquals(
-            responses[-1].added_object.to_id, intids.getId(subtask))
+        response = IResponseContainer(maintask)[-1]
+        self.assertEquals(intids.getId(subtask), response.added_object.to_id)
+        self.assertEquals('transition-add-subtask', response.transition)
 
     def test_adding_a_subtask_via_remote_request_does_not_add_response_to_main_task(self):
         maintask = create(Builder('task').titled('maintask'))
@@ -148,6 +148,17 @@ class TestTaskIntegration(FunctionalTestCase):
         maintask.REQUEST.set('X-CREATING-SUCCESSOR', True)
         create(Builder('task').within(maintask).titled('subtask'))
         self.assertEquals(0, len(IResponseContainer(maintask)))
+
+    def test_adding_a_document_add_response_on_main_task(self):
+        intids = getUtility(IIntIds)
+        maintask = create(Builder('task').titled('maintask'))
+        document = create(Builder('document')
+                          .within(maintask)
+                          .titled('Letter to Peter'))
+
+        response = IResponseContainer(maintask)[-1]
+        self.assertEquals(intids.getId(document), response.added_object.to_id)
+        self.assertEquals('transition-add-document', response.transition)
 
 
 class TestDossierSequenceNumber(FunctionalTestCase):

--- a/opengever/task/tests/test_workflow.py
+++ b/opengever/task/tests/test_workflow.py
@@ -107,6 +107,7 @@ class TestTaskWorkflow(FunctionalTestCase):
                       .in_state('task-state-tested-and-closed'))
 
         document = create(Builder('document')
+                          .titled(u'Letter for Peter')
                           .within(task))
 
         self.browser.open('%s/edit' % (document.absolute_url()))
@@ -124,7 +125,9 @@ class TestTaskWorkflow(FunctionalTestCase):
                       .having(issuer=TEST_USER_ID, responsible=TEST_USER_ID)
                       .in_state('task-state-tested-and-closed'))
 
-        document = create(Builder('document').within(task))
+        document = create(Builder('document')
+                          .titled(u'Letter for Peter')
+                          .within(task))
 
         self.wf_tool.doActionFor(dossier, 'dossier-transition-resolve')
         transaction.commit()

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -1,6 +1,7 @@
 from collective.elephantvocabulary import wrap_vocabulary
 from five import grok
 from opengever.task import _
+from opengever.task.activities import TaskTransitionActivity
 from persistent.list import PersistentList
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as PMF
@@ -15,7 +16,6 @@ from zope.schema.vocabulary import SimpleVocabulary
 import AccessControl
 import opengever.task
 import types
-
 
 CUSTOM_INITIAL_VERSION_MESSAGE = 'custom_inital_version_message'
 TASK_TYPE_CATEGORIES = ['unidirectional_by_reference',
@@ -137,6 +137,7 @@ def add_simple_response(task, text='', field_changes=None, added_object=None,
 
     notify(ObjectModifiedEvent(task))
 
+    TaskTransitionActivity(task, response).record()
     return response
 
 

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -157,7 +157,7 @@ def change_task_workflow_state(task, transition, **kwargs):
     after = wftool.getInfoFor(task, 'review_state')
     after = wftool.getTitleForStateOnType(after, task.Type())
 
-    response = add_simple_response(task, **kwargs)
+    response = add_simple_response(task, transition=transition, **kwargs)
     response.add_change('review_state', _(u'Issue state'),
                         before, after)
     response.transition = transition

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -41,8 +41,16 @@ class DocumentBuilder(DexterityBuilder):
     checked_out = None
     _trashed = False
 
+    def __init__(self, session):
+        super(DocumentBuilder, self).__init__(session)
+        self.arguments['title'] = u'Testdokum\xe4nt'
+
     def with_dummy_content(self):
         self.attach_file_containing("Test data")
+        return self
+
+    def without_default_title(self):
+        self.arguments.pop('title')
         return self
 
     def with_asset_file(self, filename):


### PR DESCRIPTION
Das Benachrichtigungssystem soll auch Predecessor/Successor Paare richtig behandeln. Das heisst das die Benutzer jeweils auf die Richtige Seite des Paares landen. Grundsätzlich gilt: Der Auftraggeber wird auf den Predecessor, der Auftragnehmer auf den Successor verlinkt.

Damit wir nicht für alle Aktivitäten, eine spezielle Behandlung für AdminUnit übergreifende Aufgaben implementieren müssen, werden nur die die Watchers von Predecessor/Successor Paare entsprechend angepasst.

**AdminUnit übergreifende Aufgaben:**
 * Der Auftraggeber überwacht nach wie vor den Predecessor.
 * Der Auftragnehmer überwacht neu nur noch den Successor.

**Weiterleitung einem Dossier zuweisen:**
 * Der Auftraggeber und Auftragnehmer überwachen die neu erstellte Aufgabe
 * Die Watchers der Weiterleitung werden nicht angepasst, da es dort eh zu keinem Statuswechsel und demnach auch zu keiner Aktivität mehr kommt.

**AdminUnit übergreifende Weiterleitung akzeptieren:**
 * Der Auftraggeber der ursprünglichen Weiterleitung überwacht nach wie vor den Predecessor.
 * Der Auftragnehmer überwacht nur noch die kopierte Weiterleitung.
 * Der neue Auftraggeber überwacht die kopierte Weiterleitung. (der Auftraggeber wird ja auf die aktuelle Eingangskorb Gruppe übertragen).

**AdminUnit übergreifende Weiterleitung akzeptieren und direkt einem Dossier zuweisen:**
* Kopierte Weiterleitung
 * Der Auftraggeber der ursprünglichen Weiterleitung überwacht nach wie vor den Predecessor.
 * Der Auftragnehmer überwacht nur noch die kopierte Weiterleitung.
 * Der neue Auftraggeber überwacht die kopierte Weiterleitung. (der Auftraggeber wird ja auf die aktuelle Eingangskorb Gruppe übertragen).
* Kopierte Aufgabe
 * Der Auftraggeber und Auftragnehmer überwachen die neu erstellte Aufgabe
 * Die Watchers der Weiterleitung werden nicht angepasst, da es dort eh zu keinem Statuswechsel und demnach auch zu keiner Aktivität mehr kommt.

@lukasgraf bitte reviewen