### PR TITLE
Disable CSRF protection for remote requests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Disable CSRF protection for remote requests.
+  [phgross]
+
 - Made dispatchers configurable per installation.
   [phgross]
 

--- a/opengever/ogds/base/Extensions/plugins.py
+++ b/opengever/ogds/base/Extensions/plugins.py
@@ -1,5 +1,6 @@
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.ogds.base.utils import ogds_service
+from plone.protect.interfaces import IDisableCSRFProtection
 from zope.interface import alsoProvides
 
 
@@ -35,6 +36,7 @@ def authenticate_credentials(self, credentials):
     #split client.ip_address because they could be a comme seperated list
     if admin_unit and ip in admin_unit.ip_address.split(','):
         activate_request_layer(self.REQUEST, IInternalOpengeverRequestLayer)
+        activate_request_layer(self.REQUEST, IDisableCSRFProtection)
         return uid, login
     return None
 

--- a/opengever/ogds/base/tests/test_plugin.py
+++ b/opengever/ogds/base/tests/test_plugin.py
@@ -1,9 +1,10 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.ogds.base.Extensions.plugins import authenticate_credentials
 from opengever.ogds.base.Extensions.plugins import extract_user
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.testing import FunctionalTestCase
-from ftw.builder import create
-from ftw.builder import Builder
+from plone.protect.interfaces import IDisableCSRFProtection
 
 
 class TestRemoteAuthenticationPlugin(FunctionalTestCase):
@@ -51,6 +52,19 @@ class TestRemoteAuthenticationPlugin(FunctionalTestCase):
 
         self.assertTrue(
             IInternalOpengeverRequestLayer.providedBy(self.portal.REQUEST))
+
+    def test_after_successfully_credentials_authentication_the_request_provides_the_disable_csrf_protection_layer(self):
+        ip = '192.168.1.233'
+        create(Builder('admin_unit')
+               .id('client1')
+               .having(title=u'Client1', ip_address=ip))
+
+        self.set_params_for_remote_request(client_ip=ip)
+
+        creds = extract_user(self.portal, self.portal.REQUEST)
+        authenticate_credentials(self.portal, creds)
+
+        self.assertTrue(IDisableCSRFProtection.providedBy(self.portal.REQUEST))
 
     def test_credentials_authentication_works_also_with_a_coma_sepereted_list(self):
         """The plugin should also work with a client with a comma


### PR DESCRIPTION
Remote Requests werden nur für intern (zwischen zwei GEVER Mandanten) für die mandantenübergreifende Zusammenarbeit verwendet. Solche Requests werden über unser PAS Plugin authentisiert, CSRF Protection ist deshalb für solche Requests nicht notwendig. Fixes #924.

@deiferni @lukasgraf 