### PR TITLE
Disable copy action in task listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Disable copy action in task listings.
+  [phgross]
+
 - Enable doc-properties for examplecontent and add example template file with doc-properties.
   [deiferni]
 

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -257,7 +257,6 @@ class Tasks(GlobalTaskListingTab):
         'change_state',
         'pdf_taskslisting',
         'move_items',
-        'copy_items',
         'export_tasks',
     ]
 


### PR DESCRIPTION
Aufgaben sollten nicht kopiert werden können.

![bildschirmfoto 2015-05-20 um 19 18 36](https://cloud.githubusercontent.com/assets/485755/7732056/48d7035e-ff25-11e4-8c04-c5846aa08990.png)

@lukasgraf bitte reviewen.


