### PR TITLE
Unify definition of auto-incrementing SQL columns.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Unify definition of of auto-incrementing SQL columns.
+  Add explicit Sequence to enable of auto-increment for oracle. Also make
+  server-side tables/sequences consistent with other model definitions for
+  Postgres.
+  [deiferni]
+
 - Drop Owner from the workflows of the following content-types: document, contact, dossier,
   templatedossier, forwarding, inbox, mail, repository, repositoryroot, task.
   [deiferni]

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -8,6 +8,7 @@ from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
 import datetime
 import pytz
 
@@ -27,7 +28,8 @@ class Activity(Base):
 
     __tablename__ = 'activities'
 
-    activity_id = Column('id', Integer, primary_key=True)
+    activity_id = Column('id', Integer, Sequence("activities_id_seq"),
+                         primary_key=True)
     kind = Column(String(50), nullable=False)
     actor_id = Column(String(255), nullable=False)
     title = Column(String(512), nullable=False)

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -6,6 +6,7 @@ from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
 
 
 class NotificationQuery(BaseQuery):
@@ -20,7 +21,8 @@ class Notification(Base):
 
     __tablename__ = 'notifications'
 
-    notification_id = Column('id', Integer, primary_key=True)
+    notification_id = Column('id', Integer, Sequence('notifications_id_seq'),
+                             primary_key=True)
 
     watcher_id = Column(Integer, ForeignKey('watchers.id'))
     watcher = relationship("Watcher", backref="notifications")

--- a/opengever/activity/model/resource.py
+++ b/opengever/activity/model/resource.py
@@ -11,6 +11,7 @@ from sqlalchemy import Table
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import composite
 from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
 
 
 class ResourceQuery(BaseQuery):
@@ -34,7 +35,8 @@ class Resource(Base):
     __tablename__ = 'resources'
     __table_args__ = (UniqueConstraint('admin_unit_id', 'int_id'), {})
 
-    resource_id = Column('id', Integer, primary_key=True)
+    resource_id = Column('id', Integer, Sequence('resources_id_seq'),
+                         primary_key=True)
 
     admin_unit_id = Column(String(30), index=True, nullable=False)
     int_id = Column(Integer, index=True, nullable=False)

--- a/opengever/activity/model/settings.py
+++ b/opengever/activity/model/settings.py
@@ -4,6 +4,7 @@ from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
+from sqlalchemy.schema import Sequence
 
 
 class NotificationDefaultQuery(BaseQuery):
@@ -25,7 +26,9 @@ class NotificationDefault(Base):
 
     __tablename__ = 'notification_defaults'
 
-    notification_default_id = Column('id', Integer, primary_key=True)
+    notification_default_id = Column('id', Integer,
+                                     Sequence('notification_defaults_id_seq'),
+                                     primary_key=True)
 
     kind = Column(String(50), nullable=False, unique=True)
     mail_notification = Column(Boolean, nullable=False, default=False)

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -3,6 +3,7 @@ from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
+from sqlalchemy.schema import Sequence
 
 
 class WatcherQuery(BaseQuery):
@@ -18,7 +19,8 @@ class Watcher(Base):
 
     __tablename__ = 'watchers'
 
-    watcher_id = Column('id', Integer, primary_key=True)
+    watcher_id = Column('id', Integer, Sequence('watchers_id_seq'),
+                        primary_key=True)
     user_id = Column(String(255), nullable=False, unique=True)
 
     def __repr__(self):

--- a/opengever/activity/profiles/default/metadata.xml
+++ b/opengever/activity/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4302</version>
+  <version>4303</version>
 </metadata>

--- a/opengever/activity/upgrades/configure.zcml
+++ b/opengever/activity/upgrades/configure.zcml
@@ -37,4 +37,14 @@
         profile="opengever.activity:default"
         />
 
+    <!-- 4302 -> 4303 -->
+    <genericsetup:upgradeStep
+        title="Use correct sequence declarations for auto-increment primary keys."
+        description=""
+        source="4302"
+        destination="4303"
+        handler="opengever.activity.upgrades.to4303.DropPsqlServerDefaults"
+        profile="opengever.activity:default"
+        />
+
 </configure>

--- a/opengever/activity/upgrades/to4303.py
+++ b/opengever/activity/upgrades/to4303.py
@@ -1,0 +1,49 @@
+from opengever.core.upgrade import SchemaMigration
+
+
+class DropPsqlServerDefaults(SchemaMigration):
+    """Unify definition of autoincrementing SQL columns.
+
+    Add explicit Sequence to enable autoincremet for oracle.
+
+    Make server-side tables/sequences consistent with other model definitions
+    that have been created with Sequence. This migration only applies to a
+    Postgres DBMS.
+
+    """
+    profileid = 'opengever.activity'
+    upgradeid = 4303
+
+    def migrate(self):
+        self.drop_psql_server_defaults()
+
+    def drop_psql_server_defaults(self):
+        if not self.is_postgres:
+            return
+
+        # First remove sequence owner table/column. This also asserts that the
+        # specified sequence exists - our updated model relies on postregs'
+        # auto-naming.
+        self._remove_sequence_owner('activities_id_seq')
+        self._remove_sequence_owner('notifications_id_seq')
+        self._remove_sequence_owner('resources_id_seq')
+        self._remove_sequence_owner('notification_defaults_id_seq')
+        self._remove_sequence_owner('watchers_id_seq')
+
+        # Drop server-default that executes auto-increment.
+        self._remove_server_default('activities')
+        self._remove_server_default('notifications')
+        self._remove_server_default('resources')
+        self._remove_server_default('notification_defaults')
+        self._remove_server_default('watchers')
+
+    def _remove_sequence_owner(self, sequence_name):
+        self.op.execute(
+            'ALTER SEQUENCE {} OWNED BY NONE'.format(sequence_name))
+
+    def _remove_server_default(self, table_name):
+        self.op.alter_column(
+            table_name=table_name,
+            column_name='id',
+            server_default=None,
+        )


### PR DESCRIPTION
Add explicit Sequence to enable of auto-incrementing for oracle. Also make
server-side tables/sequences consistent with other model definitions for
Postgres.

Closes #927.