### PR TITLE
Harmonize SQL column lengths

### DIFF
--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -1,6 +1,7 @@
 from opengever.activity.model.notification import Notification
 from opengever.base.model import Base
 from opengever.base.model import UTCDateTime
+from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -31,7 +32,7 @@ class Activity(Base):
     activity_id = Column('id', Integer, Sequence("activities_id_seq"),
                          primary_key=True)
     kind = Column(String(255), nullable=False)
-    actor_id = Column(String(255), nullable=False)
+    actor_id = Column(String(USER_ID_LENGTH), nullable=False)
     title = Column(String(512), nullable=False)
     summary = Column(String(512), nullable=False)
     description = Column(Text)

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -30,7 +30,7 @@ class Activity(Base):
 
     activity_id = Column('id', Integer, Sequence("activities_id_seq"),
                          primary_key=True)
-    kind = Column(String(50), nullable=False)
+    kind = Column(String(255), nullable=False)
     actor_id = Column(String(255), nullable=False)
     title = Column(String(512), nullable=False)
     summary = Column(String(512), nullable=False)

--- a/opengever/activity/model/resource.py
+++ b/opengever/activity/model/resource.py
@@ -2,6 +2,7 @@ from opengever.activity.model.watcher import Watcher
 from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
+from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -38,7 +39,7 @@ class Resource(Base):
     resource_id = Column('id', Integer, Sequence('resources_id_seq'),
                          primary_key=True)
 
-    admin_unit_id = Column(String(30), index=True, nullable=False)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), index=True, nullable=False)
     int_id = Column(Integer, index=True, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
 

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -1,4 +1,5 @@
 from opengever.base.model import Base
+from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -21,7 +22,7 @@ class Watcher(Base):
 
     watcher_id = Column('id', Integer, Sequence('watchers_id_seq'),
                         primary_key=True)
-    user_id = Column(String(255), nullable=False, unique=True)
+    user_id = Column(String(USER_ID_LENGTH), nullable=False, unique=True)
 
     def __repr__(self):
         return '<Watcher {}>'.format(repr(self.user_id))

--- a/opengever/activity/profiles/default/metadata.xml
+++ b/opengever/activity/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4303</version>
+  <version>4304</version>
 </metadata>

--- a/opengever/activity/upgrades/configure.zcml
+++ b/opengever/activity/upgrades/configure.zcml
@@ -47,4 +47,14 @@
         profile="opengever.activity:default"
         />
 
+    <!-- 4303 -> 4304 -->
+    <genericsetup:upgradeStep
+        title="Increase lengths for several VARCHAR columns in 'activity' models"
+        description=""
+        source="4303"
+        destination="4304"
+        handler="opengever.activity.upgrades.to4304.IncreaseActivityColumnLengths"
+        profile="opengever.activity:default"
+        />
+
 </configure>

--- a/opengever/activity/upgrades/to4304.py
+++ b/opengever/activity/upgrades/to4304.py
@@ -1,0 +1,21 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+class IncreaseActivityColumnLengths(SchemaMigration):
+    """Increase lengths for several VARCHAR columns for 'activity' models in
+    preparation for factoring out common column lengths to constants.
+    """
+
+    profileid = 'opengever.activity'
+    upgradeid = 4304
+
+    def migrate(self):
+        self.increase_activity_kind_length()
+
+    def increase_activity_kind_length(self):
+        self.op.alter_column('activities',
+                             'kind',
+                             type_=String(255),
+                             existing_nullable=False,
+                             existing_type=String(50))

--- a/opengever/contact/contact.py
+++ b/opengever/contact/contact.py
@@ -1,6 +1,7 @@
 from collective import dexteritytextindexer
 from five import grok
 from opengever.contact import _
+from opengever.ogds.models import EMAIL_LENGTH
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
 from plone.dexterity.content import Item
@@ -109,12 +110,14 @@ class IContact(form.Schema):
         title = _(u'label_email', default=u'email'),
         description = _(u'help_email', default=u''),
         required = False,
+        max_length=EMAIL_LENGTH,
         )
 
     email2 = schema.TextLine(
         title = _(u'label_email2', default=u'Email 2'),
         description = _('help_email2', default=u''),
         required = False,
+        max_length=EMAIL_LENGTH,
         )
 
     url = schema.URI(

--- a/opengever/contact/contact.py
+++ b/opengever/contact/contact.py
@@ -2,6 +2,7 @@ from collective import dexteritytextindexer
 from five import grok
 from opengever.contact import _
 from opengever.ogds.models import FIRSTNAME_LENGTH
+from opengever.ogds.models import LASTNAME_LENGTH
 from plone.dexterity.content import Item
 from plone.directives import dexterity
 from plone.directives import form
@@ -75,6 +76,7 @@ class IContact(form.Schema):
         title = _(u'label_lastname', default=u'Lastname'),
         description = _(u'help_lastname', default=u''),
         required = True,
+        max_length=LASTNAME_LENGTH,
         )
 
     dexteritytextindexer.searchable('firstname')

--- a/opengever/contact/contact.py
+++ b/opengever/contact/contact.py
@@ -1,16 +1,13 @@
-from five import grok
-
-from zope import schema
 from collective import dexteritytextindexer
+from five import grok
+from opengever.contact import _
+from opengever.ogds.models import FIRSTNAME_LENGTH
 from plone.dexterity.content import Item
+from plone.directives import dexterity
 from plone.directives import form
 from plone.indexer import indexer
 from plone.namedfile.field import NamedImage
-
-
-from opengever.contact import _
-
-from plone.directives import dexterity
+from zope import schema
 
 
 class IContact(form.Schema):
@@ -85,6 +82,7 @@ class IContact(form.Schema):
         title = _(u'label_firstname', default=u'Firstname'),
         description = _(u'help_firstname', default=u''),
         required = True,
+        max_length=FIRSTNAME_LENGTH,
         )
 
     company = schema.TextLine(

--- a/opengever/globalindex/model/__init__.py
+++ b/opengever/globalindex/model/__init__.py
@@ -1,3 +1,5 @@
+WORKFLOW_STATE_LENGTH = 255
+
 tables = [
     'task_principals',
     'tasks',

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -3,6 +3,7 @@ from DateTime import DateTime as ZopeDateTime
 from opengever.base.model import Base
 from opengever.base.model import Session
 from opengever.base.oguid import Oguid
+from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.globalindex.model.query import TaskQuery
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -54,10 +55,10 @@ class Task(Base):
     oguid = composite(Oguid, admin_unit_id, int_id)
 
     title = Column(String(MAX_TITLE_LENGTH))
-    text = Column(Text)
+    text = Column(Text())
     breadcrumb_title = Column(String(MAX_BREADCRUMB_LENGTH))
     physical_path = Column(String(256))
-    review_state = Column(String(255))
+    review_state = Column(String(WORKFLOW_STATE_LENGTH))
     icon = Column(String(50))
 
     responsible = Column(String(USER_ID_LENGTH), index=True)

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -7,6 +7,7 @@ from opengever.globalindex.model.query import TaskQuery
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models import UNIT_ID_LENGTH
 from plone import api
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -46,7 +47,7 @@ class Task(Base):
 
     task_id = Column("id", Integer, Sequence("task_id_seq"), primary_key=True)
 
-    admin_unit_id = Column(String(30), index=True, nullable=False)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), index=True, nullable=False)
     int_id = Column(Integer, index=True, nullable=False)
 
     oguid = composite(Oguid, admin_unit_id, int_id)
@@ -76,8 +77,10 @@ class Task(Base):
     completed = Column(Date)
 
     # XXX shit, this should be ...org_unit_ID
-    issuing_org_unit = Column(String(30), index=True, nullable=False)
-    assigned_org_unit = Column(String(30), index=True, nullable=False)
+    issuing_org_unit = Column(
+        String(UNIT_ID_LENGTH), index=True, nullable=False)
+    assigned_org_unit = Column(
+        String(UNIT_ID_LENGTH), index=True, nullable=False)
 
     predecessor_id = Column(Integer, ForeignKey('tasks.id'))
     successors = relationship(

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -55,11 +55,11 @@ class Task(Base):
     text = Column(Text)
     breadcrumb_title = Column(String(MAX_BREADCRUMB_LENGTH))
     physical_path = Column(String(256))
-    review_state = Column(String(50))
+    review_state = Column(String(255))
     icon = Column(String(50))
 
-    responsible = Column(String(32), index=True)
-    issuer = Column(String(32), index=True)
+    responsible = Column(String(255), index=True)
+    issuer = Column(String(255), index=True)
 
     task_type = Column(String(50), index=True)
     is_subtask = Column(Boolean(), default=False)

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -8,6 +8,7 @@ from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import UNIT_ID_LENGTH
+from opengever.ogds.models import USER_ID_LENGTH
 from plone import api
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -59,8 +60,8 @@ class Task(Base):
     review_state = Column(String(255))
     icon = Column(String(50))
 
-    responsible = Column(String(255), index=True)
-    issuer = Column(String(255), index=True)
+    responsible = Column(String(USER_ID_LENGTH), index=True)
+    issuer = Column(String(USER_ID_LENGTH), index=True)
 
     task_type = Column(String(50), index=True)
     is_subtask = Column(Boolean(), default=False)
@@ -306,7 +307,7 @@ class Task(Base):
 class TaskPrincipal(Base):
     __tablename__ = 'task_principals'
 
-    principal = Column(String(255), primary_key=True)
+    principal = Column(String(USER_ID_LENGTH), primary_key=True)
     task_id = Column(Integer, ForeignKey('tasks.id'),
                      primary_key=True)
 

--- a/opengever/globalindex/profiles/default/metadata.xml
+++ b/opengever/globalindex/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4004</version>
+  <version>4301</version>
 </metadata>

--- a/opengever/globalindex/upgrades/configure.zcml
+++ b/opengever/globalindex/upgrades/configure.zcml
@@ -84,4 +84,14 @@
         directory="profiles/4004"
         />
 
+    <!-- 4004 -> 4301 -->
+    <genericsetup:upgradeStep
+        title="Increase lengths for several VARCHAR columns in GlobalIndex"
+        description=""
+        source="4004"
+        destination="4301"
+        handler="opengever.globalindex.upgrades.to4301.IncreaseGlobalIndexColumnLengths"
+        profile="opengever.globalindex:default"
+        />
+
 </configure>

--- a/opengever/globalindex/upgrades/to4301.py
+++ b/opengever/globalindex/upgrades/to4301.py
@@ -1,0 +1,40 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+class IncreaseGlobalIndexColumnLengths(SchemaMigration):
+    """Increase lengths for several VARCHAR columns in GlobalIndex in
+    preparation for factoring out common column lengths to constants.
+    """
+
+    profileid = 'opengever.globalindex'
+    upgradeid = 4301
+
+    def migrate(self):
+        self.increase_task_review_state_length()
+        self.increase_task_responsible_length()
+        self.increase_task_issuer_length()
+
+    def increase_task_review_state_length(self):
+        # Match WORKFLOW_STATE_LENGTH
+        self.op.alter_column('tasks',
+                             'review_state',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))
+
+    def increase_task_responsible_length(self):
+        # Match USER_ID_LENGTH
+        self.op.alter_column('tasks',
+                             'responsible',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(32))
+
+    def increase_task_issuer_length(self):
+        # Match USER_ID_LENGTH
+        self.op.alter_column('tasks',
+                             'issuer',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(32))

--- a/opengever/meeting/browser/members.py
+++ b/opengever/meeting/browser/members.py
@@ -4,6 +4,7 @@ from opengever.meeting.form import ModelAddForm
 from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Member
 from opengever.ogds.models import FIRSTNAME_LENGTH
+from opengever.ogds.models import LASTNAME_LENGTH
 from plone.directives import form
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -26,7 +27,7 @@ class IMemberModel(form.Schema):
 
     lastname = schema.TextLine(
         title=_(u"label_lastname", default=u"Lastname"),
-        max_length=256,
+        max_length=LASTNAME_LENGTH,
         required=True)
 
     email = schema.TextLine(

--- a/opengever/meeting/browser/members.py
+++ b/opengever/meeting/browser/members.py
@@ -3,6 +3,7 @@ from opengever.meeting import _
 from opengever.meeting.form import ModelAddForm
 from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Member
+from opengever.ogds.models import FIRSTNAME_LENGTH
 from plone.directives import form
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -20,7 +21,7 @@ class IMemberModel(form.Schema):
 
     firstname = schema.TextLine(
         title=_(u"label_firstname", default=u"Firstname"),
-        max_length=256,
+        max_length=FIRSTNAME_LENGTH,
         required=True)
 
     lastname = schema.TextLine(

--- a/opengever/meeting/browser/members.py
+++ b/opengever/meeting/browser/members.py
@@ -3,6 +3,7 @@ from opengever.meeting import _
 from opengever.meeting.form import ModelAddForm
 from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Member
+from opengever.ogds.models import EMAIL_LENGTH
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
 from plone.directives import form
@@ -32,7 +33,7 @@ class IMemberModel(form.Schema):
 
     email = schema.TextLine(
         title=_(u"label_email", default=u"E-Mail"),
-        max_length=256,
+        max_length=EMAIL_LENGTH,
         required=False)
 
 

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -2,6 +2,7 @@ from opengever.base.model import Base
 from opengever.base.oguid import Oguid
 from opengever.meeting.model.query import CommitteeQuery
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models import UNIT_ID_LENGTH
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -21,7 +22,7 @@ class Committee(Base):
     committee_id = Column("id", Integer, Sequence("committee_id_seq"),
                           primary_key=True)
 
-    admin_unit_id = Column(String(30), nullable=False)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
     title = Column(String(256))

--- a/opengever/meeting/model/generateddocument.py
+++ b/opengever/meeting/model/generateddocument.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.base.oguid import Oguid
 from opengever.meeting.model.query import GeneratedDocumentQuery
+from opengever.ogds.models import UNIT_ID_LENGTH
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -25,7 +26,7 @@ class GeneratedDocument(Base):
 
     document_id = Column("id", Integer, Sequence("generateddocument_id_seq"),
                          primary_key=True)
-    admin_unit_id = Column(String(30), nullable=False)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
     generated_version = Column(Integer, nullable=False)

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -81,7 +81,7 @@ class Meeting(Base):
     location = Column(String(256))
     start = Column(DateTime, nullable=False)
     end = Column(DateTime)
-    workflow_state = Column(String(256), nullable=False,
+    workflow_state = Column(String(255), nullable=False,
                             default=workflow.default_state.name)
 
     presidency = relationship(

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from opengever.base.model import Base
+from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model.query import MeetingQuery
@@ -81,7 +82,7 @@ class Meeting(Base):
     location = Column(String(256))
     start = Column(DateTime, nullable=False)
     end = Column(DateTime)
-    workflow_state = Column(String(255), nullable=False,
+    workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False,
                             default=workflow.default_state.name)
 
     presidency = relationship(

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -1,4 +1,5 @@
 from opengever.base.model import Base
+from opengever.ogds.models import FIRSTNAME_LENGTH
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -13,7 +14,7 @@ class Member(Base):
 
     member_id = Column("id", Integer, Sequence("member_id_seq"),
                        primary_key=True)
-    firstname = Column(String(255), nullable=False)
+    firstname = Column(String(FIRSTNAME_LENGTH), nullable=False)
     lastname = Column(String(255), nullable=False)
     fullname = column_property(firstname + " " + lastname)
     email = Column(String(255))

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -1,5 +1,6 @@
 from opengever.base.model import Base
 from opengever.ogds.models import FIRSTNAME_LENGTH
+from opengever.ogds.models import LASTNAME_LENGTH
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -15,7 +16,7 @@ class Member(Base):
     member_id = Column("id", Integer, Sequence("member_id_seq"),
                        primary_key=True)
     firstname = Column(String(FIRSTNAME_LENGTH), nullable=False)
-    lastname = Column(String(255), nullable=False)
+    lastname = Column(String(LASTNAME_LENGTH), nullable=False)
     fullname = column_property(firstname + " " + lastname)
     email = Column(String(255))
 

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -13,10 +13,10 @@ class Member(Base):
 
     member_id = Column("id", Integer, Sequence("member_id_seq"),
                        primary_key=True)
-    firstname = Column(String(256), nullable=False)
-    lastname = Column(String(256), nullable=False)
+    firstname = Column(String(255), nullable=False)
+    lastname = Column(String(255), nullable=False)
     fullname = column_property(firstname + " " + lastname)
-    email = Column(String(256))
+    email = Column(String(255))
 
     def __repr__(self):
         return '<Member {}>'.format(repr(self.fullname))

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -1,4 +1,5 @@
 from opengever.base.model import Base
+from opengever.ogds.models import EMAIL_LENGTH
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
 from plone import api
@@ -18,7 +19,7 @@ class Member(Base):
     firstname = Column(String(FIRSTNAME_LENGTH), nullable=False)
     lastname = Column(String(LASTNAME_LENGTH), nullable=False)
     fullname = column_property(firstname + " " + lastname)
-    email = Column(String(255))
+    email = Column(String(EMAIL_LENGTH))
 
     def __repr__(self):
         return '<Member {}>'.format(repr(self.fullname))

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -68,7 +68,7 @@ class Proposal(Base):
         primaryjoin="GeneratedExcerpt.document_id==Proposal.submitted_excerpt_document_id")
 
     title = Column(String(256), nullable=False)
-    workflow_state = Column(String(256), nullable=False)
+    workflow_state = Column(String(255), nullable=False)
     legal_basis = Column(Text)
     initial_position = Column(Text)
     proposed_action = Column(Text)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -9,6 +9,7 @@ from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models import UNIT_ID_LENGTH
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -43,12 +44,12 @@ class Proposal(Base):
 
     proposal_id = Column("id", Integer, Sequence("proposal_id_seq"),
                          primary_key=True)
-    admin_unit_id = Column(String(30), nullable=False)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
     physical_path = Column(String(256), nullable=False)
 
-    submitted_admin_unit_id = Column(String(30))
+    submitted_admin_unit_id = Column(String(UNIT_ID_LENGTH))
     submitted_int_id = Column(Integer)
     submitted_oguid = composite(
         Oguid, submitted_admin_unit_id, submitted_int_id)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
+from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import proposalhistory
@@ -69,7 +70,7 @@ class Proposal(Base):
         primaryjoin="GeneratedExcerpt.document_id==Proposal.submitted_excerpt_document_id")
 
     title = Column(String(256), nullable=False)
-    workflow_state = Column(String(255), nullable=False)
+    workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False)
     legal_basis = Column(Text)
     initial_position = Column(Text)
     proposed_action = Column(Text)

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from opengever.base.model import Base
 from opengever.meeting import _
 from opengever.ogds.base.actor import Actor
+from opengever.ogds.models import USER_ID_LENGTH
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import DateTime
@@ -28,7 +29,7 @@ class ProposalHistory(Base):
     proposal_id = Column(Integer, ForeignKey('proposals.id'), nullable=False)
     proposal = relationship('Proposal')
     created = Column(DateTime, default=datetime.now, nullable=False)
-    userid = Column(String(255), default=get_current_user_id, nullable=False)
+    userid = Column(String(USER_ID_LENGTH), default=get_current_user_id, nullable=False)
 
     # intended to be used only by DocumentSubmitted/DocumentUpdated
     submitted_document_id = Column(Integer, ForeignKey('submitteddocuments.id'))

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -28,7 +28,7 @@ class ProposalHistory(Base):
     proposal_id = Column(Integer, ForeignKey('proposals.id'), nullable=False)
     proposal = relationship('Proposal')
     created = Column(DateTime, default=datetime.now, nullable=False)
-    userid = Column(String(256), default=get_current_user_id, nullable=False)
+    userid = Column(String(255), default=get_current_user_id, nullable=False)
 
     # intended to be used only by DocumentSubmitted/DocumentUpdated
     submitted_document_id = Column(Integer, ForeignKey('submitteddocuments.id'))

--- a/opengever/meeting/model/submitteddocument.py
+++ b/opengever/meeting/model/submitteddocument.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.base.oguid import Oguid
 from opengever.meeting.model.query import SubmittedDocumentQuery
+from opengever.ogds.models import UNIT_ID_LENGTH
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
@@ -30,14 +31,14 @@ class SubmittedDocument(Base):
 
     document_id = Column("id", Integer, Sequence("submitteddocument_id_seq"),
                          primary_key=True)
-    admin_unit_id = Column(String(30), nullable=False)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
     proposal_id = Column(Integer, ForeignKey('proposals.id'), nullable=False)
     proposal = relationship("Proposal", backref='submitted_documents')
     submitted_version = Column(Integer, nullable=False)
 
-    submitted_admin_unit_id = Column(String(30))
+    submitted_admin_unit_id = Column(String(UNIT_ID_LENGTH))
     submitted_int_id = Column(Integer)
     submitted_oguid = composite(
         Oguid, submitted_admin_unit_id, submitted_int_id)

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4307</version>
+    <version>4308</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -265,4 +265,14 @@
         directory="profiles/4307"
         />
 
+    <!-- 4307 -> 4308 -->
+    <genericsetup:upgradeStep
+        title="Decrease lengths for several VARCHAR columns in 'meeting' models"
+        description=""
+        source="4307"
+        destination="4308"
+        handler="opengever.meeting.upgrades.to4308.DecreaseMeetingColumnLengths"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4308.py
+++ b/opengever/meeting/upgrades/to4308.py
@@ -1,0 +1,67 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+class DecreaseMeetingColumnLengths(SchemaMigration):
+    """Decrease lengths for several VARCHAR columns in 'meeting' models in
+    preparation for factoring out common column lengths to constants.
+    """
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4308
+
+    def migrate(self):
+        self.decrease_meeting_workflow_state_length()
+        self.decrease_member_firstname_length()
+        self.decrease_member_lastname_length()
+        self.decrease_member_email_length()
+        self.decrease_proposal_workflow_state_length()
+        self.decrease_proposalhistory_userid_length()
+
+    def decrease_meeting_workflow_state_length(self):
+        # Match WORKFLOW_STATE_LENGTH
+        self.op.alter_column('meetings',
+                             'workflow_state',
+                             type_=String(255),
+                             existing_nullable=False,
+                             existing_type=String(256))
+
+    def decrease_member_firstname_length(self):
+        # Match FIRSTNAME_LENGTH
+        self.op.alter_column('members',
+                             'firstname',
+                             type_=String(255),
+                             existing_nullable=False,
+                             existing_type=String(256))
+
+    def decrease_member_lastname_length(self):
+        # Match LASTNAME_LENGTH
+        self.op.alter_column('members',
+                             'lastname',
+                             type_=String(255),
+                             existing_nullable=False,
+                             existing_type=String(256))
+
+    def decrease_member_email_length(self):
+        # Match EMAIL_LENGTH
+        self.op.alter_column('members',
+                             'email',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(256))
+
+    def decrease_proposal_workflow_state_length(self):
+        # Match WORKFLOW_STATE_LENGTH
+        self.op.alter_column('proposals',
+                             'workflow_state',
+                             type_=String(255),
+                             existing_nullable=False,
+                             existing_type=String(256))
+
+    def decrease_proposalhistory_userid_length(self):
+        # Match USER_ID_LENGTH
+        self.op.alter_column('proposalhistory',
+                             'userid',
+                             type_=String(255),
+                             existing_nullable=False,
+                             existing_type=String(256))

--- a/opengever/ogds/base/interfaces.py
+++ b/opengever/ogds/base/interfaces.py
@@ -1,3 +1,4 @@
+from opengever.ogds.models import UNIT_ID_LENGTH
 from zope import schema
 from zope.interface import Attribute
 from zope.interface import Interface
@@ -107,7 +108,9 @@ class IAdminUnitConfiguration(Interface):
         title=u'Id of the current Administrative Unit',
         description=u'The id of this administrative unit. It will be \
         mapped to the corresponding adminstrative unit configuration \
-        in the OGDS (Opengever Global Directory Service).', )
+        in the OGDS (Opengever Global Directory Service).',
+        max_length=UNIT_ID_LENGTH,
+    )
 
 
 class ISyncStamp(Interface):

--- a/opengever/ogds/base/profiles/default/metadata.xml
+++ b/opengever/ogds/base/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-    <version>4006</version>
+    <version>4301</version>
 </metadata>

--- a/opengever/ogds/base/upgrades/configure.zcml
+++ b/opengever/ogds/base/upgrades/configure.zcml
@@ -91,4 +91,14 @@
         profile="opengever.ogds.base:default"
         />
 
+    <!-- 4006 -> 4301 -->
+    <genericsetup:upgradeStep
+        title="Increase lengths for several VARCHAR columns in OGDS"
+        description=""
+        source="4006"
+        destination="4301"
+        handler="opengever.ogds.base.upgrades.to4301.IncreaseOGDSColumnLengths"
+        profile="opengever.ogds.base:default"
+        />
+
 </configure>

--- a/opengever/ogds/base/upgrades/to4301.py
+++ b/opengever/ogds/base/upgrades/to4301.py
@@ -1,0 +1,104 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+class IncreaseOGDSColumnLengths(SchemaMigration):
+    """Increase lengths for several VARCHAR columns in OGDS in preparation
+    for factoring out common column lengths to constants.
+
+    (Upgrade-step for corresponding change in opengever.ogds.models)
+    """
+
+    profileid = 'opengever.ogds.base'
+    upgradeid = 4301
+
+    def migrate(self):
+        self.increase_admin_unit_title_length()
+        self.increase_org_unit_title_length()
+
+        self.increase_user_firstname_length()
+        self.increase_user_lastname_length()
+
+        self.increase_user_directorate_length()
+        self.increase_user_directorate_abbr_length()
+        self.increase_user_department_length()
+        self.increase_user_department_abbr_length()
+
+        self.increase_user_email_length()
+        self.increase_user_email2_length()
+
+    def increase_admin_unit_title_length(self):
+        # Match UNIT_TITLE_LENGTH
+        self.op.alter_column('admin_units',
+                             'title',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(30))
+
+    def increase_org_unit_title_length(self):
+        # Match UNIT_TITLE_LENGTH
+        self.op.alter_column('org_units',
+                             'title',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(30))
+
+    def increase_user_firstname_length(self):
+        # Match FIRSTNAME_LENGTH
+        self.op.alter_column('users',
+                             'firstname',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))
+
+    def increase_user_lastname_length(self):
+        # Match LASTNAME_LENGTH
+        self.op.alter_column('users',
+                             'lastname',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))
+
+    def increase_user_directorate_length(self):
+        self.op.alter_column('users',
+                             'directorate',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))
+
+    def increase_user_directorate_abbr_length(self):
+        self.op.alter_column('users',
+                             'directorate_abbr',
+                             type_=String(50),
+                             existing_nullable=True,
+                             existing_type=String(10))
+
+    def increase_user_department_length(self):
+        self.op.alter_column('users',
+                             'department',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))
+
+    def increase_user_department_abbr_length(self):
+        self.op.alter_column('users',
+                             'department_abbr',
+                             type_=String(50),
+                             existing_nullable=True,
+                             existing_type=String(10))
+
+    def increase_user_email_length(self):
+        # Match EMAIL_LENGTH
+        self.op.alter_column('users',
+                             'email',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))
+
+    def increase_user_email2_length(self):
+        # Match EMAIL_LENGTH
+        self.op.alter_column('users',
+                             'email2',
+                             type_=String(255),
+                             existing_nullable=True,
+                             existing_type=String(50))

--- a/opengever/repository/behaviors/responsibleorg.py
+++ b/opengever/repository/behaviors/responsibleorg.py
@@ -1,3 +1,4 @@
+from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.repository import _
 from plone.directives import form
 from zope import schema
@@ -17,6 +18,7 @@ class IResponsibleOrgUnit(form.Schema):
             u'responsible_org_unit',
             default=u'Responsible organisation unit'),
         description=u'',
+        max_length=UNIT_ID_LENGTH,
         required=False,
         )
 

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -1,3 +1,4 @@
+from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.setup.directives import deployment_directive
 from opengever.setup.directives import ldap_directive
@@ -61,15 +62,18 @@ class IDeploymentDirective(Interface):
 
     reader_group = TextLine(
         title=u'Reader group',
-        required=False)
+        required=False,
+        max_length=GROUP_ID_LENGTH)
 
     rolemanager_group = TextLine(
         title=u'Rolemanager group',
-        required=False)
+        required=False,
+        max_length=GROUP_ID_LENGTH)
 
     administrator_group = TextLine(
         title=u'Administrator group',
-        required=False)
+        required=False,
+        max_length=GROUP_ID_LENGTH)
 
 
 def register_ldap(context, **kwargs):

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -1,3 +1,4 @@
+from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.setup.directives import deployment_directive
 from opengever.setup.directives import ldap_directive
 from zope.configuration.fields import Tokens
@@ -38,7 +39,8 @@ class IDeploymentDirective(Interface):
     admin_unit_id = TextLine(
         title=u'AdminUnit ID',
         description=u'AdminUnit corresponding to this plone site',
-        required=True)
+        required=True,
+        max_length=UNIT_ID_LENGTH)
 
     mail_domain = TextLine(
         title=u'Mail domain',


### PR DESCRIPTION
This PR harmonizes column lengths for SQL models within SQL as well as with Plone models by extracting lengths for common column types into constants.

PR https://github.com/4teamwork/opengever.ogds.models/pull/30 needs to be merged first.

(Changelog will be added once review is complete to avoid rebase hell)

Fixes #893.