### PR TITLE
Meeting SchemaMigrations: Made upgrades Oracle compatible.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- Meeting SchemaMigrations: Made some upgrades Oracle compatible.
+  [phgross]
+
 - Unify definition of of auto-incrementing SQL columns.
   Add explicit Sequence to enable of auto-increment for oracle. Also make
   server-side tables/sequences consistent with other model definitions for

--- a/opengever/meeting/upgrades/to4203.py
+++ b/opengever/meeting/upgrades/to4203.py
@@ -28,10 +28,10 @@ class AddMembershipRole(SchemaMigration):
 
     def make_start_date_primary_oracle(self):
         self.op.execute(
-            "ALTER TABLE MEMBERSHIPS DROP PRIMARY KEY;")
+            "ALTER TABLE MEMBERSHIPS DROP PRIMARY KEY")
         self.op.execute(
             "ALTER TABLE MEMBERSHIPS ADD PRIMARY KEY "
-            "(COMMITTEE_ID, MEMBER_ID, DATE_FROM);")
+            "(COMMITTEE_ID, MEMBER_ID, DATE_FROM)")
 
     def make_start_date_primary(self):
         if self.is_postgres:

--- a/opengever/meeting/upgrades/to4208.py
+++ b/opengever/meeting/upgrades/to4208.py
@@ -29,11 +29,16 @@ class AddSubmittedDocumentsTable(SchemaMigration):
             Column("submitted_physical_path", String(256))
         )
 
-        self.op.create_unique_constraint(
-            'ix_submitted_document_unique_source',
-            'submitteddocuments',
-            ['admin_unit_id', 'int_id', 'proposal_id'])
-        self.op.create_unique_constraint(
-            'ix_submitted_document_unique_target',
-            'submitteddocuments',
-            ['submitted_admin_unit_id', 'submitted_int_id'])
+        # For Oracle compatibility the names of UniqueConstraints have to be
+        # limited to max. 30 chars (see ORA-00972). the constraint will be
+        # added with an valid name in the 4215 Schemamigration
+        # (RenameUniqueConstraints)
+        if not self.is_oracle:
+            self.op.create_unique_constraint(
+                'ix_submitted_document_unique_source',
+                'submitteddocuments',
+                ['admin_unit_id', 'int_id', 'proposal_id'])
+            self.op.create_unique_constraint(
+                'ix_submitted_document_unique_target',
+                'submitteddocuments',
+                ['submitted_admin_unit_id', 'submitted_int_id'])

--- a/opengever/meeting/upgrades/to4215.py
+++ b/opengever/meeting/upgrades/to4215.py
@@ -9,7 +9,11 @@ class RenameUniqueConstraints(SchemaMigration):
     upgradeid = 4215
 
     def migrate(self):
-        self.remove_old_constraints()
+        # If the OGDS backend is oracle, the constraints creation in 4208
+        # has been skipped. See 4208.py for more details.
+        if not self.is_oracle:
+            self.remove_old_constraints()
+
         self.add_new_constraints()
 
     def remove_old_constraints(self):

--- a/opengever/policy/base/upgrades/to4201.py
+++ b/opengever/policy/base/upgrades/to4201.py
@@ -8,11 +8,11 @@ from opengever.base.model import get_tables
 class InstallActivity(UpgradeStep):
 
     def __call__(self):
+        self.create_activity_tables()
         self.setup_install_profile(
             'profile-opengever.activity:default')
         self.setup_install_profile(
             'profile-collective.js.timeago:default')
-        self.create_activity_tables()
 
     def create_activity_tables(self):
         """When installing the activity suppackage via upgrade-step we need


### PR DESCRIPTION
Eine Upgrade auf einer Testinstallation mit Oracle als OGDS DB hat noch einige Probleme bei  Schemamigrationen aufgezeigt. 
Die meisten Probleme traten aufgrund von Oracle Eigenheiten auf:
 * Oracle unterstützt Time als datatype nicht.
 * Namen von Indexes sind auf 30 Zeichen limitiert
 * Unnötige Semicolons in Queries entfernt.

Zudem hat sich auch gezeigt das die Reihenfolge im Acitvity Installation Upgradestep angepasst werden muss, da der Profilehook bereits die Activity Tables benötigt.

@lukasgraf @deiferni bitte reviewn.
 


 