### PR TITLE
SqlTableSource: Wrap `sort_on` in a ColumnClause when extending query with ordering

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
+- SqlTableSource: Wrap `sort_on` with a ColumnClause when extending
+  query with ordering in order to allow SQLAlchemy to properly
+  quote column identifiers depending on the dialect (see #957).
+  [lgraf]
+
 - Meeting SchemaMigrations: Made some upgrades Oracle compatible.
   [phgross]
 

--- a/opengever/tabbedview/browser/sqltablelisting.py
+++ b/opengever/tabbedview/browser/sqltablelisting.py
@@ -4,6 +4,7 @@ from ftw.table.interfaces import ITableSource, ITableSourceConfig
 from sqlalchemy import or_
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql.expression import asc, desc
+from sqlalchemy.sql.expression import column
 from zope.interface import Interface
 
 
@@ -34,9 +35,16 @@ class SqlTableSource(grok.MultiAdapter, BaseTableSource):
         """
 
         if self.config.sort_on:
+            sort_on = self.config.sort_on
+            # Don't plug column names as literal strings into an order_by
+            # clause, but use a ColumnClause instead to allow SQLAlchemy to
+            # properly quote the identifier name depending on the dialect
+            if isinstance(sort_on, basestring):
+                sort_on = column(sort_on)
+
             order_f = self.config.sort_reverse and desc or asc
 
-            query = query.order_by(order_f(self.config.sort_on))
+            query = query.order_by(order_f(sort_on))
 
         return query
 


### PR DESCRIPTION
This allows SQLAlchemy to properly quote column identifiers depending on the dialect (see #957).

While this fixes the immediate problem regarding ordering in table listings, we still should avoid using reserved keywords as identifiers, therefore I'm still leaving #957 open.

@phgross @deiferni