### PR TITLE
Finalize Release 3.3

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -4,12 +4,7 @@ extensions = mr.developer
 
 development-packages =
   opengever.maintenance
-  opengever.ogds.models
-  plonetheme.teamraum
-  ftw.tabbedview
   collective.js.timeago
-  transmogrify.dexterity
-  ftw.inflator
 
 auto-checkout = ${buildout:development-packages}
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    http://kgs.4teamwork.ch/release/opengever/latest
+    http://kgs.4teamwork.ch/release/opengever/develop
 
 versions = versions
 


### PR DESCRIPTION
- Update development-packages after finalizing release 3.3.	
- Use newly created develop kgs in the test buildout (see https://github.com/4teamwork/kgs/pull/74 for more information).

@lukasgraf 

:warning: https://github.com/4teamwork/kgs/pull/74 has to be merged first