### PR TITLE
Display dossier-navigation on dossier overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 4.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Display a nested dossier-navigation on the dossier overview page. Display the navigation
+  starting at the current dossier's root dossier. Don't display the navigation when no
+  subdossiers are available.
+  [deiferni]
 
 
 4.4.0 (2015-06-01)

--- a/opengever/base/tests/test_navigation.py
+++ b/opengever/base/tests/test_navigation.py
@@ -80,10 +80,3 @@ class TestNavigation(FunctionalTestCase):
         yield
         after = value_callback()
         self.assertNotEqual(before, after, msg)
-
-    def assert_json_equal(self, expected, got, msg=None):
-        pretty = {'sort_keys': True, 'indent': 4, 'separators': (',', ': ')}
-        expected_json = json.dumps(expected, **pretty)
-        got_json = json.dumps(got, **pretty)
-        self.maxDiff = None
-        self.assertMultiLineEqual(expected_json, got_json, msg)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -94,6 +94,9 @@ class DossierContainer(Container):
         else:
             return True
 
+    def has_subdossiers(self):
+        return len(self.get_subdossiers()) > 0
+
     def get_subdossiers(self, sort_on='created',
                         sort_order='ascending',
                         review_state=None,

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -68,7 +68,7 @@ class DossierContainer(Container):
                 break
         return depth
 
-    def get_root_dossier(self):
+    def get_main_dossier(self):
         """Return the root dossier for the current dossier.
 
         The root dossier is the dossier that has a repo-folder as its parent

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -68,6 +68,22 @@ class DossierContainer(Container):
                 break
         return depth
 
+    def get_root_dossier(self):
+        """Return the root dossier for the current dossier.
+
+        The root dossier is the dossier that has a repo-folder as its parent
+        and thus forms the root of the local dossier hierarchy.
+
+        """
+        obj = self
+        prev = self
+        while IDossierMarker.providedBy(obj):
+            prev = obj
+            obj = aq_parent(aq_inner(obj))
+            if IPloneSiteRoot.providedBy(obj):
+                break
+        return prev
+
     def show_subdossier(self):
         registry = queryUtility(IRegistry)
         reg_proxy = registry.forInterface(IDossierContainerTypes)

--- a/opengever/dossier/browser/configure.zcml
+++ b/opengever/dossier/browser/configure.zcml
@@ -18,4 +18,11 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <browser:page
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      name="dossier_navigation.json"
+      class=".navigation.JSONNavigation"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/dossier/browser/navigation.py
+++ b/opengever/dossier/browser/navigation.py
@@ -1,0 +1,42 @@
+from opengever.base.browser.navigation import make_tree_by_url
+from Products.Five import BrowserView
+import json
+from plone import api
+
+
+class JSONNavigation(BrowserView):
+    """Return a JSON-navigation structure for a dossier (context) and its
+    subdossiers.
+
+    The navigation starts at the current context, i.e. the dossier.
+
+    """
+    def __call__(self):
+        response = self.request.response
+        response.setHeader('Content-Type', 'application/json')
+        response.setHeader('X-Theme-Disabled', 'True')
+        response.enableHTTPCompression(REQUEST=self.request)
+
+        return self.json()
+
+    def json(self):
+        return json.dumps(self._tree())
+
+    def _context_as_node(self):
+        return {'text': self.context.title,
+                'description': self.context.description,
+                'url': self.context.absolute_url(),
+                'uid': api.content.get_uuid(obj=self.context)}
+
+    def _tree(self):
+        subdossier_nodes = map(self._brain_to_node,
+                               self.context.get_subdossiers())
+        nodes = [self._context_as_node()] + subdossier_nodes
+
+        return make_tree_by_url(nodes)
+
+    def _brain_to_node(self, brain):
+        return {'text': brain.Title,
+                'description': brain.Description,
+                'url': brain.getURL(),
+                'uid': brain.UID}

--- a/opengever/dossier/browser/navigation.py
+++ b/opengever/dossier/browser/navigation.py
@@ -29,8 +29,9 @@ class JSONNavigation(BrowserView):
                 'uid': api.content.get_uuid(obj=self.context)}
 
     def _tree(self):
-        subdossier_nodes = map(self._brain_to_node,
-                               self.context.get_subdossiers())
+        subdossier_nodes = map(
+            self._brain_to_node,
+            self.context.get_subdossiers(sort_on='sortable_title'))
         nodes = [self._context_as_node()] + subdossier_nodes
 
         return make_tree_by_url(nodes)

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -31,24 +31,15 @@ class DossierOverview(grok.View, OpengeverTab):
             sort_order='reverse')
 
     def boxes(self):
-        if not self.context.show_subdossier():
-            items = [
-                [dict(id='newest_tasks', content=self.tasks(), href='tasks'),
-                 ],
-                [dict(id='participants', content=self.sharing()), ],
-                [dict(id='newest_documents', content=self.documents(),
-                      href='documents'),
-                 dict(id='description', content=self.description), ]
-                ]
-        else:
-            items = [
-                [dict(id='subdossiers', content=self.subdossiers()),
-                 dict(id='participants', content=self.sharing()), ],
-                [dict(id='newest_tasks', content=self.tasks(), href='tasks')],
-                [dict(id='newest_documents', content=self.documents(),
-                      href='documents'),
-                 dict(id='description', content=self.description), ], ]
-        return items
+        return [
+            [
+                dict(id='newest_tasks', content=self.tasks(), href='tasks'),
+                dict(id='participants', content=self.sharing()), ],
+            [
+                dict(id='newest_documents', content=self.documents(),
+                     href='documents'),
+                dict(id='description', content=self.description), ]
+            ]
 
     def navigation_json_url(self):
         root_dossier = self.context.get_root_dossier()

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -50,6 +50,10 @@ class DossierOverview(grok.View, OpengeverTab):
                  dict(id='description', content=self.description), ], ]
         return items
 
+    def navigation_json_url(self):
+        root_dossier = self.context.get_root_dossier()
+        return root_dossier.absolute_url() + '/dossier_navigation.json'
+
     def subdossiers(self):
         return self.context.get_subdossiers(
             sort_on='modified', sort_order='reverse',

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -42,12 +42,12 @@ class DossierOverview(grok.View, OpengeverTab):
             ]
 
     def is_subdossier_navigation_available(self):
-        root_dossier = self.context.get_root_dossier()
-        return root_dossier.has_subdossiers()
+        main_dossier = self.context.get_main_dossier()
+        return main_dossier.has_subdossiers()
 
     def navigation_json_url(self):
-        root_dossier = self.context.get_root_dossier()
-        return root_dossier.absolute_url() + '/dossier_navigation.json'
+        return '/dossier_navigation.json'.format(
+            self.context.get_main_dossier().absolute_url())
 
     def subdossiers(self):
         return self.context.get_subdossiers(

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -41,6 +41,10 @@ class DossierOverview(grok.View, OpengeverTab):
                 dict(id='description', content=self.description), ]
             ]
 
+    def is_subdossier_navigation_available(self):
+        root_dossier = self.context.get_root_dossier()
+        return root_dossier.has_subdossiers()
+
     def navigation_json_url(self):
         root_dossier = self.context.get_root_dossier()
         return root_dossier.absolute_url() + '/dossier_navigation.json'

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -1,5 +1,20 @@
 <!--TODO: refactor using viewlets-->
 <tal:block i18n:domain="opengever.dossier" tal:define="groups view/boxes; css_width python:99/len(groups)">
+
+    <div id="dossier-tree"
+      tal:define="context_url context/absolute_url"
+      tal:attributes="data-dossier-navigation-url python:context_url + '/dossier_navigation.json';
+                      data-context-url context_url;">
+        <ul class="filetree">
+            <img src="spinner.gif" class="spinner"/>
+        </ul>
+    </div>
+
+    <script type="text/javascript"
+      tal:define="navroot context/@@plone_portal_state/navigation_root_url"
+      tal:attributes="src string:${navroot}/++resource++opengever.dossier.resources/init_tree.js">
+    </script>
+
   <div tal:repeat="boxes groups" tal:attributes="class string:boxGroup boxGroup${repeat/boxes/index}; style string:width:${css_width}%">
     <div tal:repeat="box boxes" class="box" tal:attributes="id string:${box/id}Box">
       <h2 i18n:translate="" tal:content="box/label|box/id"></h2>

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -1,21 +1,32 @@
 <!--TODO: refactor using viewlets-->
-<tal:block i18n:domain="opengever.dossier" tal:define="groups view/boxes; css_width python:99/len(groups)">
+<tal:block i18n:domain="opengever.dossier"
+           tal:define="groups view/boxes; css_width python:99/3">
 
-    <div id="dossier-tree"
-      tal:define="context_url context/absolute_url"
-      tal:attributes="data-dossier-navigation-url view/navigation_json_url;
-                      data-context-url context_url;">
+  <div class="boxGroup boxGroup0" tal:attributes="style string:width:${css_width}%">
+
+    <div class="box" id="subdossiersBox">
+      <h2 i18n:translate="">Dossier-Struktur</h2>
+      <div id="dossier-tree"
+           tal:attributes="data-dossier-navigation-url view/navigation_json_url;
+                           data-context-url context_url;"
+           tal:define="context_url context/absolute_url">
         <ul class="filetree">
-            <img src="spinner.gif" class="spinner"/>
+          <img src="spinner.gif" class="spinner"/>
         </ul>
+      </div>
     </div>
+  </div>
 
-    <script type="text/javascript"
-      tal:define="navroot context/@@plone_portal_state/navigation_root_url"
-      tal:attributes="src string:${navroot}/++resource++opengever.dossier.resources/init_tree.js">
-    </script>
+  <script type="text/javascript"
+    tal:define="navroot context/@@plone_portal_state/navigation_root_url"
+    tal:attributes="src string:${navroot}/++resource++opengever.dossier.resources/init_tree.js">
+  </script>
 
-  <div tal:repeat="boxes groups" tal:attributes="class string:boxGroup boxGroup${repeat/boxes/index}; style string:width:${css_width}%">
+  <tal:block tal:repeat="boxes groups">
+  <div tal:define="repeat_index repeat/boxes/index;
+                   box_id python: repeat_index + 1;"
+       tal:attributes="class string:boxGroup boxGroup${box_id};
+                       style string:width:${css_width}%">
     <div tal:repeat="box boxes" class="box" tal:attributes="id string:${box/id}Box">
       <h2 i18n:translate="" tal:content="box/label|box/id"></h2>
 
@@ -70,4 +81,6 @@
 
     </div>
   </div>
+  </tal:block>
+
 </tal:block>

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -3,7 +3,7 @@
 
     <div id="dossier-tree"
       tal:define="context_url context/absolute_url"
-      tal:attributes="data-dossier-navigation-url python:context_url + '/dossier_navigation.json';
+      tal:attributes="data-dossier-navigation-url view/navigation_json_url;
                       data-context-url context_url;">
         <ul class="filetree">
             <img src="spinner.gif" class="spinner"/>

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -5,7 +5,7 @@
   <div class="boxGroup boxGroup0" tal:attributes="style string:width:${css_width}%">
 
     <div class="box" id="subdossiersBox">
-      <h2 i18n:translate="">Dossier-Struktur</h2>
+      <h2 i18n:translate="">Dossier structure</h2>
       <div id="dossier-tree"
            tal:attributes="data-dossier-navigation-url view/navigation_json_url;
                            data-context-url context_url;"

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -3,24 +3,31 @@
            tal:define="groups view/boxes; css_width python:99/3">
 
   <div class="boxGroup boxGroup0" tal:attributes="style string:width:${css_width}%">
-
     <div class="box" id="subdossiersBox">
       <h2 i18n:translate="">Dossier structure</h2>
-      <div id="dossier-tree"
-           tal:attributes="data-dossier-navigation-url view/navigation_json_url;
-                           data-context-url context_url;"
-           tal:define="context_url context/absolute_url">
-        <ul class="filetree">
-          <img src="spinner.gif" class="spinner"/>
-        </ul>
-      </div>
+
+      <tal:block tal:condition="view/is_subdossier_navigation_available">
+        <div id="dossier-tree"
+             tal:attributes="data-dossier-navigation-url view/navigation_json_url;
+                             data-context-url context_url;"
+             tal:define="context_url context/absolute_url">
+          <ul class="filetree">
+            <img src="spinner.gif" class="spinner"/>
+          </ul>
+        </div>
+
+        <script type="text/javascript"
+          tal:define="navroot context/@@plone_portal_state/navigation_root_url"
+          tal:attributes="src string:${navroot}/++resource++opengever.dossier.resources/init_tree.js">
+        </script>
+      </tal:block>
+
+      <tal:block tal:condition="not: view/is_subdossier_navigation_available">
+        <span i18n:translate="" >No Subdossiers</span>
+      </tal:block>
+
     </div>
   </div>
-
-  <script type="text/javascript"
-    tal:define="navroot context/@@plone_portal_state/navigation_root_url"
-    tal:attributes="src string:${navroot}/++resource++opengever.dossier.resources/init_tree.js">
-  </script>
 
   <tal:block tal:repeat="boxes groups">
   <div tal:define="repeat_index repeat/boxes/index;

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -1,15 +1,19 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:vdex="http://namespaces.zope.org/vdex"
-    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="opengever.dossier">
 
   <grok:grok package="." />
 
   <vdex:vocabulary directory="vdexvocabs" />
+
+  <browser:resourceDirectory
+      name="opengever.dossier.resources" directory="resources" />
 
   <include package=".viewlets" />
   <include package=".upgrades" />

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-05-28 10:28+0000\n"
+"POT-Creation-Date: 2015-05-28 12:08+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -47,7 +47,7 @@ msgstr "Beteiligung löschen"
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr "Dokument ${name} ist mit einer Aufgabe verbunden, bitte Aufgabe verschieben."
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+#: ./opengever/dossier/browser/overview_templates/overview.pt:7
 msgid "Dossier structure"
 msgstr "Dossier-Struktur"
 
@@ -83,6 +83,10 @@ msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossi
 #: ./opengever/dossier/profiles/default/actions.xml
 msgid "Move Items"
 msgstr "Elemente verschieben"
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:26
+msgid "No Subdossiers"
+msgstr "Keine Subdossiers"
 
 #: ./opengever/dossier/archive.py:53
 msgid "Not all required fields are filled"
@@ -554,7 +558,7 @@ msgstr "Neuste Dokumente"
 msgid "newest_tasks"
 msgstr "Neuste Aufgaben"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:38
+#: ./opengever/dossier/browser/overview_templates/overview.pt:45
 msgid "no_content"
 msgstr "Keine Inhalte"
 
@@ -600,7 +604,7 @@ msgstr "Ablagenummer vergeben"
 msgid "sharing"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:72
+#: ./opengever/dossier/browser/overview_templates/overview.pt:79
 msgid "show all"
 msgstr "Alle anzeigen"
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-05-28 10:28+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -46,6 +46,10 @@ msgstr "Beteiligung löschen"
 #: ./opengever/dossier/move_items.py:96
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr "Dokument ${name} ist mit einer Aufgabe verbunden, bitte Aufgabe verschieben."
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+msgid "Dossier structure"
+msgstr "Dossier-Struktur"
 
 #: ./opengever/dossier/resolve.py:80
 msgid "Dossiers successfully reactivated."
@@ -93,7 +97,7 @@ msgstr "Es sind keine Vorlagen vorhanden."
 msgid "Project Dossier"
 msgstr "Projektdossier"
 
-#: ./opengever/dossier/menu.py:26
+#: ./opengever/dossier/menu.py:22
 msgid "Subdossier"
 msgstr "Subdossier"
 
@@ -104,6 +108,10 @@ msgstr "Vorlagendossier"
 #. Default: "expired"
 msgid "Templates"
 msgstr "Vorlagen"
+
+#: ./opengever/dossier/deactivate.py:64
+msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
+msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
 
 #: ./opengever/dossier/deactivate.py:46
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
@@ -546,7 +554,7 @@ msgstr "Neuste Dokumente"
 msgid "newest_tasks"
 msgstr "Neuste Aufgaben"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:12
+#: ./opengever/dossier/browser/overview_templates/overview.pt:38
 msgid "no_content"
 msgstr "Keine Inhalte"
 
@@ -592,7 +600,7 @@ msgstr "Ablagenummer vergeben"
 msgid "sharing"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:46
+#: ./opengever/dossier/browser/overview_templates/overview.pt:72
 msgid "show all"
 msgstr "Alle anzeigen"
 
@@ -620,3 +628,4 @@ msgstr "abgelaufen"
 #: ./opengever/dossier/behaviors/participation.py:197
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
+

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-05-28 10:28+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,10 @@ msgstr "Effacer la participation"
 #: ./opengever/dossier/move_items.py:96
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr "Document ${name} est lié avec une tâche, déplacer la tâche, svp."
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+msgid "Dossier structure"
+msgstr ""
 
 #: ./opengever/dossier/resolve.py:80
 msgid "Dossiers successfully reactivated."
@@ -90,7 +94,7 @@ msgstr "Pas de modèles disponible"
 msgid "Project Dossier"
 msgstr "Dossier du projet"
 
-#: ./opengever/dossier/menu.py:26
+#: ./opengever/dossier/menu.py:22
 msgid "Subdossier"
 msgstr "Sous-dossier"
 
@@ -100,6 +104,10 @@ msgstr "Dossier des modèles"
 
 msgid "Templates"
 msgstr "Modèles"
+
+#: ./opengever/dossier/deactivate.py:64
+msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
+msgstr ""
 
 #: ./opengever/dossier/deactivate.py:46
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
@@ -542,7 +550,7 @@ msgstr "Derniers documents"
 msgid "newest_tasks"
 msgstr "Dernières tâches"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:12
+#: ./opengever/dossier/browser/overview_templates/overview.pt:38
 msgid "no_content"
 msgstr "Pas de contenu"
 
@@ -588,7 +596,7 @@ msgstr "Attribuer numéro d'inventaire"
 msgid "sharing"
 msgstr "Participations enlevées"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:46
+#: ./opengever/dossier/browser/overview_templates/overview.pt:72
 msgid "show all"
 msgstr "Tout afficher"
 
@@ -616,3 +624,4 @@ msgstr "Périmé"
 #: ./opengever/dossier/behaviors/participation.py:197
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation"
+

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-28 10:28+0000\n"
+"POT-Creation-Date: 2015-05-28 12:08+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgstr "Effacer la participation"
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr "Document ${name} est lié avec une tâche, déplacer la tâche, svp."
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+#: ./opengever/dossier/browser/overview_templates/overview.pt:7
 msgid "Dossier structure"
 msgstr ""
 
@@ -81,6 +81,10 @@ msgstr "Il n'est pas possible d'ouvrir un sous-dossier, le dossier principale do
 #: ./opengever/dossier/profiles/default/actions.xml
 msgid "Move Items"
 msgstr "Déplacer l'élément"
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:26
+msgid "No Subdossiers"
+msgstr ""
 
 #: ./opengever/dossier/archive.py:53
 msgid "Not all required fields are filled"
@@ -550,7 +554,7 @@ msgstr "Derniers documents"
 msgid "newest_tasks"
 msgstr "Dernières tâches"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:38
+#: ./opengever/dossier/browser/overview_templates/overview.pt:45
 msgid "no_content"
 msgstr "Pas de contenu"
 
@@ -596,7 +600,7 @@ msgstr "Attribuer numéro d'inventaire"
 msgid "sharing"
 msgstr "Participations enlevées"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:72
+#: ./opengever/dossier/browser/overview_templates/overview.pt:79
 msgid "show all"
 msgstr "Tout afficher"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-28 10:28+0000\n"
+"POT-Creation-Date: 2015-05-28 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,7 +48,7 @@ msgstr ""
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+#: ./opengever/dossier/browser/overview_templates/overview.pt:7
 msgid "Dossier structure"
 msgstr ""
 
@@ -83,6 +83,10 @@ msgstr ""
 
 #: ./opengever/dossier/profiles/default/actions.xml
 msgid "Move Items"
+msgstr ""
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:26
+msgid "No Subdossiers"
 msgstr ""
 
 #: ./opengever/dossier/archive.py:53
@@ -552,7 +556,7 @@ msgstr ""
 msgid "newest_tasks"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:38
+#: ./opengever/dossier/browser/overview_templates/overview.pt:45
 msgid "no_content"
 msgstr ""
 
@@ -598,7 +602,7 @@ msgstr ""
 msgid "sharing"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:72
+#: ./opengever/dossier/browser/overview_templates/overview.pt:79
 msgid "show all"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-05-28 10:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,10 @@ msgstr ""
 
 #: ./opengever/dossier/move_items.py:96
 msgid "Document ${name} is connected to a Task. Please move the Task."
+msgstr ""
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+msgid "Dossier structure"
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:80
@@ -93,7 +97,7 @@ msgstr ""
 msgid "Project Dossier"
 msgstr ""
 
-#: ./opengever/dossier/menu.py:26
+#: ./opengever/dossier/menu.py:22
 msgid "Subdossier"
 msgstr ""
 
@@ -102,6 +106,10 @@ msgid "Template Dossier"
 msgstr ""
 
 msgid "Templates"
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py:64
+msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py:46
@@ -544,7 +552,7 @@ msgstr ""
 msgid "newest_tasks"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:12
+#: ./opengever/dossier/browser/overview_templates/overview.pt:38
 msgid "no_content"
 msgstr ""
 
@@ -590,7 +598,7 @@ msgstr ""
 msgid "sharing"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:46
+#: ./opengever/dossier/browser/overview_templates/overview.pt:72
 msgid "show all"
 msgstr ""
 

--- a/opengever/dossier/resources/init_tree.js
+++ b/opengever/dossier/resources/init_tree.js
@@ -1,0 +1,32 @@
+$(function() {
+  var tree_container = $('#dossier-tree');
+
+  function find_parent_node_for_url(tree, url) {
+    if (!url) {
+      return null;
+    }
+
+    var node = tree.findBy({'url': url});
+    if (node) {
+      return node;
+    }
+    return find_parent_node_for_url(tree, url.slice(0, url.lastIndexOf('/')));
+  }
+
+  function render_tree(tree_data) {
+    navtree = make_tree(tree_data);
+    tree_container.html('');
+    navtree.render(tree_container);
+    navtree.selectCurrent(find_parent_node_for_url(
+              navtree, tree_container.data('context-url')));
+  };
+
+  $.ajax({
+    dataType: 'json',
+    url: tree_container.data('dossier-navigation-url'),
+    cache: false,
+    success: function(data) {
+      render_tree(data);
+    }
+  });
+});

--- a/opengever/dossier/resources/init_tree.js
+++ b/opengever/dossier/resources/init_tree.js
@@ -14,12 +14,27 @@ $(function() {
   }
 
   function render_tree(tree_data) {
-    navtree = make_tree(tree_data);
-    tree_container.html('');
-    navtree.render(tree_container);
+    var navtree = make_tree(tree_data, {
+      components: [new BusinessCaseDossierIconLinks()]
+    });
+    var tree_root = tree_container.find('>ul');
+
+    tree_root.html('');
+    navtree.render(tree_root);
     navtree.selectCurrent(find_parent_node_for_url(
               navtree, tree_container.data('context-url')));
   };
+
+  BusinessCaseDossierIconLinks = function() {
+    var self = {
+      listen: function(tree) {
+        $(tree).bind('tree:link-created', function(event, node, link) {
+          link.addClass('contenttype-opengever-dossier-businesscasedossier');
+        });
+      }
+    };
+    return self;
+  }
 
   $.ajax({
     dataType: 'json',

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -30,6 +30,19 @@ class TestDossier(FunctionalTestCase):
         self.assertEqual(self.dossier, sub1.get_root_dossier())
         self.assertEqual(self.dossier, sub2.get_root_dossier())
 
+    def test_falsy_has_subdossiers(self):
+        self.assertFalse(self.dossier.has_subdossiers())
+
+    def test_truthy_has_subdossiers(self):
+        create(Builder(self.builder_id).within(self.dossier))
+        self.assertTrue(self.dossier.has_subdossiers())
+
+    def test_truthy_has_subdossiers_closed_dossiers(self):
+        create(Builder(self.builder_id)
+               .within(self.dossier)
+               .in_state('dossier-state-resolved'))
+        self.assertTrue(self.dossier.has_subdossiers())
+
     def _get_active_tabbedview_tab_titles(self, obj):
         types_tool = getToolByName(self.portal, 'portal_types')
         actions = types_tool.listActionInfos(

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -20,6 +20,16 @@ class TestDossier(FunctionalTestCase):
     def create_test_dossier(self):
         return create(Builder(self.builder_id))
 
+    def test_get_root_dossier_returns_self_when_is_already_root(self):
+        self.assertEqual(self.dossier, self.dossier.get_root_dossier())
+
+    def test_get_root_dossier_returns_root_for_nested_dossiers(self):
+        sub1 = create(Builder(self.builder_id).within(self.dossier))
+        sub2 = create(Builder(self.builder_id).within(sub1))
+
+        self.assertEqual(self.dossier, sub1.get_root_dossier())
+        self.assertEqual(self.dossier, sub2.get_root_dossier())
+
     def _get_active_tabbedview_tab_titles(self, obj):
         types_tool = getToolByName(self.portal, 'portal_types')
         actions = types_tool.listActionInfos(

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -20,15 +20,15 @@ class TestDossier(FunctionalTestCase):
     def create_test_dossier(self):
         return create(Builder(self.builder_id))
 
-    def test_get_root_dossier_returns_self_when_is_already_root(self):
-        self.assertEqual(self.dossier, self.dossier.get_root_dossier())
+    def test_get_main_dossier_returns_self_when_is_already_root(self):
+        self.assertEqual(self.dossier, self.dossier.get_main_dossier())
 
-    def test_get_root_dossier_returns_root_for_nested_dossiers(self):
+    def test_get_main_dossier_returns_main_for_nested_dossiers(self):
         sub1 = create(Builder(self.builder_id).within(self.dossier))
         sub2 = create(Builder(self.builder_id).within(sub1))
 
-        self.assertEqual(self.dossier, sub1.get_root_dossier())
-        self.assertEqual(self.dossier, sub2.get_root_dossier())
+        self.assertEqual(self.dossier, sub1.get_main_dossier())
+        self.assertEqual(self.dossier, sub2.get_main_dossier())
 
     def test_falsy_has_subdossiers(self):
         self.assertFalse(self.dossier.has_subdossiers())

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -1,0 +1,36 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone.uuid.interfaces import IUUID
+
+
+class TestNavigation(FunctionalTestCase):
+
+    @browsing
+    def test_dossier_navigation_json_is_valid(self, browser):
+        root = create(Builder('repository_root'))
+        folder = create(Builder('repository').within(root))
+        root_dossier = create(Builder('dossier')
+                              .titled(u'Root')
+                              .having(description=u'The root dossier')
+                              .within(folder))
+        subdossier = create(Builder('dossier')
+                            .titled(u'Subdossier')
+                            .having(description=u'The sub-dossier')
+                            .within(root_dossier))
+
+        browser.login().visit(root_dossier, view='dossier_navigation.json')
+        self.assert_json_equal(
+            [{"text": "Root",
+              "description": "The root dossier",
+              "uid": IUUID(root_dossier),
+              "url": root_dossier.absolute_url(),
+              "nodes": [{"text": "Subdossier",
+                         "description": "The sub-dossier",
+                         "nodes": [],
+                         "uid": IUUID(subdossier),
+                         "url": subdossier.absolute_url(),
+                         }],
+              }],
+            browser.json)

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -11,9 +11,9 @@ class TestNavigation(FunctionalTestCase):
         super(TestNavigation, self).setUp()
         self.root = create(Builder('repository_root'))
         self.folder = create(Builder('repository').within(self.root))
-        self.root_dossier = create(Builder('dossier')
-                                   .titled(u'Root')
-                                   .having(description=u'The root dossier')
+        self.main_dossier = create(Builder('dossier')
+                                   .titled(u'Main')
+                                   .having(description=u'The main dossier')
                                    .within(self.folder))
 
     @browsing
@@ -21,15 +21,15 @@ class TestNavigation(FunctionalTestCase):
         subdossier = create(Builder('dossier')
                             .titled(u'Subdossier')
                             .having(description=u'The sub-dossier')
-                            .within(self.root_dossier))
+                            .within(self.main_dossier))
 
-        browser.login().visit(self.root_dossier,
+        browser.login().visit(self.main_dossier,
                               view='dossier_navigation.json')
         self.assert_json_equal(
-            [{"text": "Root",
-              "description": "The root dossier",
-              "uid": IUUID(self.root_dossier),
-              "url": self.root_dossier.absolute_url(),
+            [{"text": "Main",
+              "description": "The main dossier",
+              "uid": IUUID(self.main_dossier),
+              "url": self.main_dossier.absolute_url(),
               "nodes": [{"text": "Subdossier",
                          "description": "The sub-dossier",
                          "nodes": [],
@@ -44,20 +44,20 @@ class TestNavigation(FunctionalTestCase):
         sub1 = create(Builder('dossier')
                       .titled(u'XXX')
                       .having(description=u'The XXX sub-dossier')
-                      .within(self.root_dossier))
+                      .within(self.main_dossier))
 
         sub2 = create(Builder('dossier')
                       .titled(u'AAA')
                       .having(description=u'The AAA sub-dossier')
-                      .within(self.root_dossier))
+                      .within(self.main_dossier))
 
-        browser.login().visit(self.root_dossier,
+        browser.login().visit(self.main_dossier,
                               view='dossier_navigation.json')
         self.assert_json_equal(
-            [{"text": "Root",
-              "description": "The root dossier",
-              "uid": IUUID(self.root_dossier),
-              "url": self.root_dossier.absolute_url(),
+            [{"text": "Main",
+              "description": "The main dossier",
+              "uid": IUUID(self.main_dossier),
+              "url": self.main_dossier.absolute_url(),
               "nodes": [{"text": "AAA",
                          "description": "The AAA sub-dossier",
                          "nodes": [],

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -7,30 +7,68 @@ from plone.uuid.interfaces import IUUID
 
 class TestNavigation(FunctionalTestCase):
 
+    def setUp(self):
+        super(TestNavigation, self).setUp()
+        self.root = create(Builder('repository_root'))
+        self.folder = create(Builder('repository').within(self.root))
+        self.root_dossier = create(Builder('dossier')
+                                   .titled(u'Root')
+                                   .having(description=u'The root dossier')
+                                   .within(self.folder))
+
     @browsing
     def test_dossier_navigation_json_is_valid(self, browser):
-        root = create(Builder('repository_root'))
-        folder = create(Builder('repository').within(root))
-        root_dossier = create(Builder('dossier')
-                              .titled(u'Root')
-                              .having(description=u'The root dossier')
-                              .within(folder))
         subdossier = create(Builder('dossier')
                             .titled(u'Subdossier')
                             .having(description=u'The sub-dossier')
-                            .within(root_dossier))
+                            .within(self.root_dossier))
 
-        browser.login().visit(root_dossier, view='dossier_navigation.json')
+        browser.login().visit(self.root_dossier,
+                              view='dossier_navigation.json')
         self.assert_json_equal(
             [{"text": "Root",
               "description": "The root dossier",
-              "uid": IUUID(root_dossier),
-              "url": root_dossier.absolute_url(),
+              "uid": IUUID(self.root_dossier),
+              "url": self.root_dossier.absolute_url(),
               "nodes": [{"text": "Subdossier",
                          "description": "The sub-dossier",
                          "nodes": [],
                          "uid": IUUID(subdossier),
                          "url": subdossier.absolute_url(),
+                         }],
+              }],
+            browser.json)
+
+    @browsing
+    def test_dossiers_are_sorted_by_title(self, browser):
+        sub1 = create(Builder('dossier')
+                      .titled(u'XXX')
+                      .having(description=u'The XXX sub-dossier')
+                      .within(self.root_dossier))
+
+        sub2 = create(Builder('dossier')
+                      .titled(u'AAA')
+                      .having(description=u'The AAA sub-dossier')
+                      .within(self.root_dossier))
+
+        browser.login().visit(self.root_dossier,
+                              view='dossier_navigation.json')
+        self.assert_json_equal(
+            [{"text": "Root",
+              "description": "The root dossier",
+              "uid": IUUID(self.root_dossier),
+              "url": self.root_dossier.absolute_url(),
+              "nodes": [{"text": "AAA",
+                         "description": "The AAA sub-dossier",
+                         "nodes": [],
+                         "uid": IUUID(sub2),
+                         "url": sub2.absolute_url(),
+                         },
+                        {"text": "XXX",
+                         "description": "The XXX sub-dossier",
+                         "nodes": [],
+                         "uid": IUUID(sub1),
+                         "url": sub1.absolute_url(),
                          }],
               }],
             browser.json)

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -20,60 +20,6 @@ class TestOverview(FunctionalTestCase):
                                       responsible='hugo.boss'))
 
     @browsing
-    def test_subdossier_box_items_are_limited_to_five_sort_by_modified(self, browser):
-        for i in range(1, 6):
-            create(Builder('dossier')
-                   .within(self.dossier)
-                   .with_modification_date(DateTime(2012, 3, 7) + i)
-                   .titled(u'Dossier %s' % i))
-        create(Builder('dossier')
-               .within(self.dossier)
-               .with_modification_date(DateTime(2010, 1, 1))
-               .titled(u'Dossier 6'))
-
-        browser.login().open(self.dossier, view='tabbedview_view-overview')
-        self.assertSequenceEqual(
-            ['Dossier 5', 'Dossier 4', 'Dossier 3', 'Dossier 2', 'Dossier 1'],
-            browser.css('#subdossiersBox li:not(.moreLink) a').text)
-
-    @browsing
-    def test_subdossier_box_only_list_open_dossiers(self, browser):
-        create(Builder('dossier').within(self.dossier)
-               .titled(u'Dossier Open')
-               .in_state('dossier-state-active'))
-
-        create(Builder('dossier').within(self.dossier)
-               .titled(u'Dossier Inactive')
-               .in_state('dossier-state-inactive'))
-
-        create(Builder('dossier').within(self.dossier)
-               .titled(u'Dossier Resolved')
-               .in_state('dossier-state-resolved'))
-
-        browser.login().open(self.dossier, view='tabbedview_view-overview')
-        self.assertItemsEqual(
-            ['Dossier Open'],
-            browser.css('#subdossiersBox li:not(.moreLink) a').text)
-
-    @browsing
-    def test_main_dossier_displays_subdossier_box_but_subdossier_does_not(self, browser):
-        subdossier = create(Builder('dossier')
-                            .within(self.dossier)
-                            .titled(u'Subdossier'))
-
-        browser.login().open(self.dossier, view='tabbedview_view-overview')
-        box_titles = browser.css('div.box h2').text
-        self.assertItemsEqual(['subdossiers', 'participants', 'newest_tasks',
-                               'newest_documents', 'description'],
-                              box_titles)
-
-        browser.open(subdossier, view='tabbedview_view-overview')
-        box_titles = browser.css('div.box h2').text
-        self.assertItemsEqual(['participants', 'newest_tasks',
-                               'newest_documents', 'description'],
-                              box_titles)
-
-    @browsing
     def test_description_box_is_displayed(self, browser):
         browser.login().open(self.dossier, view='tabbedview_view-overview')
         self.assertEqual(u'Hie hesch e beschribig',

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -17,6 +17,7 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.i18n import translate
+import json
 import transaction
 import unittest2
 
@@ -153,3 +154,10 @@ class FunctionalTestCase(TestCase):
                          submitted_document_model.submitted_version)
         self.assertEqual(proposal.load_model(),
                          submitted_document_model.proposal)
+
+    def assert_json_equal(self, expected, got, msg=None):
+        pretty = {'sort_keys': True, 'indent': 4, 'separators': (',', ': ')}
+        expected_json = json.dumps(expected, **pretty)
+        got_json = json.dumps(got, **pretty)
+        self.maxDiff = None
+        self.assertMultiLineEqual(expected_json, got_json, msg)


### PR DESCRIPTION
Stiles are provided in a separate PR, see: https://github.com/4teamwork/plonetheme.teamraum/pull/308

![subdossier-nav](https://cloud.githubusercontent.com/assets/736583/7937709/00e81f0c-0942-11e5-9a6d-3711021a98eb.png)

Display a nested dossier-navigation on the dossier overview page. Display the navigation starting at the current dossier's root dossier. Don't display the navigation when no subdossiers are available.