### PR TITLE
Configure visible language codes in language selector viewlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.4.1 (unreleased)
 ------------------
 
+- Use short language codes "DE" and "FR" in language selector.
+  [deiferni]
+
 - Display a nested dossier-navigation on the dossier overview page. Display the navigation
   starting at the current dossier's root dossier. Don't display the navigation when no
   subdossiers are available.

--- a/opengever/base/__init__.py
+++ b/opengever/base/__init__.py
@@ -1,5 +1,7 @@
+from plone.i18n.locales import languages
 from zope.i18nmessageid import MessageFactory
 import csv
+
 
 _ = MessageFactory('opengever.base')
 
@@ -14,3 +16,9 @@ class OpenGeverCSVDialect(csv.excel):
 
 
 csv.register_dialect(u'OpenGeverCSV', OpenGeverCSVDialect)
+
+
+# configure visible language codes. Unfortunately this cannot be done in a .po
+# file.
+languages._combinedlanguagelist['de-ch']['native'] = u'DE'
+languages._combinedlanguagelist['fr-ch']['native'] = u'FR'

--- a/opengever/base/tests/test_selector.py
+++ b/opengever/base/tests/test_selector.py
@@ -9,29 +9,30 @@ class TestLanguageSelectorMenu(FunctionalTestCase):
     def setUp(self):
         super(TestLanguageSelectorMenu, self).setUp()
         tool = api.portal.get_tool('portal_languages')
-        tool.addSupportedLanguage('de')
-        tool.addSupportedLanguage('fr')
-        tool.setDefaultLanguage('de')
+        tool.use_combined_language_codes = True
+        tool.addSupportedLanguage('de-ch')
+        tool.addSupportedLanguage('fr-ch')
+        tool.setDefaultLanguage('de-ch')
 
         transaction.commit()
 
     @browsing
     def test_list_all_available_languages(self, browser):
         browser.login().open(self.portal)
-        self.assertEquals(['English', 'Deutsch', u'Fran\xe7ais'],
+        self.assertEquals(['English', 'DE', 'FR'],
                           browser.css('dl#portal-languageselector dd li').text)
 
     @browsing
     def test_title_contains_current_language(self, browser):
         browser.login().open(self.portal)
         title = browser.css('dl#portal-languageselector dt').first
-        self.assertEquals('Deutsch', title.text)
+        self.assertEquals('DE', title.text)
 
     @browsing
     def test_current_language_is_marked_as_currentLanguage(self, browser):
         browser.login().open(self.portal)
         self.assertEquals(
-            ['Deutsch'],
+            ['DE'],
             browser.css('dl#portal-languageselector dd li.currentLanguage').text)
 
     @browsing

--- a/opengever/examplecontent/profiles/default/portal_languages.xml
+++ b/opengever/examplecontent/profiles/default/portal_languages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <object>
   <supported_langs>
-    <element value="fr"/>
+    <element value="fr-ch"/>
     <element value="de-ch"/>
   </supported_langs>
 </object>


### PR DESCRIPTION
Plone does not display translated languages for combine language codes. This PR configures them globally on module level.

![screen shot 2015-06-02 at 17 13 50](https://cloud.githubusercontent.com/assets/736583/7939357/ed47f90a-094a-11e5-97df-0d79475de8b4.png)

We want to move the language selector to another place anyway, so this should be only a temporary configuration.
