### PR TITLE
Don't configure current_unit_id in policy templates.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -26,10 +26,6 @@
   </records>
 
 {{% endif %}}
-  <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration">
-    <value key="current_unit_id">{{{adminunit.id}}}</value>
-  </records>
-
   <records interface="opengever.latex.interfaces.ILaTeXSettings">
     <value key="location">{{{adminunit.title}}}</value>
   </records>


### PR DESCRIPTION
This is done automatically by deploy.py and thus an unnecessary duplication.