### PR TITLE
Fix a typo in an opengever.activity models column name.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.4.1 (unreleased)
 ------------------
 
+- Fix a typo in an opengever.activity models column name.
+  [deiferni]
+
 - Use short language codes "DE" and "FR" in language selector.
   [deiferni]
 

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -27,7 +27,7 @@ class Notification(Base):
     watcher_id = Column(Integer, ForeignKey('watchers.id'))
     watcher = relationship("Watcher", backref="notifications")
 
-    activiy_id = Column(Integer, ForeignKey('activities.id'))
+    activity_id = Column(Integer, ForeignKey('activities.id'))
     activity = relationship("Activity", backref="notifications")
 
     read = Column(Boolean(), default=False, nullable=False)

--- a/opengever/activity/profiles/default/metadata.xml
+++ b/opengever/activity/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4304</version>
+  <version>4400</version>
 </metadata>

--- a/opengever/activity/upgrades/configure.zcml
+++ b/opengever/activity/upgrades/configure.zcml
@@ -57,4 +57,14 @@
         profile="opengever.activity:default"
         />
 
+    <!-- 4304 -> 4400 -->
+    <genericsetup:upgradeStep
+        title="Fix typo in column name."
+        description=""
+        source="4304"
+        destination="4400"
+        handler="opengever.activity.upgrades.to4400.RenameActivityForeignKey"
+        profile="opengever.activity:default"
+        />
+
 </configure>

--- a/opengever/activity/upgrades/to4400.py
+++ b/opengever/activity/upgrades/to4400.py
@@ -1,0 +1,23 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Integer
+
+
+class RenameActivityForeignKey(SchemaMigration):
+
+    profileid = 'opengever.activity'
+    upgradeid = 4400
+
+    def migrate(self):
+        self.rename_notification_foreign_key()
+
+    def rename_notification_foreign_key(self):
+        fk_name = self.get_foreign_key_name('notifications', 'activiy_id')
+
+        self.op.drop_constraint(fk_name, 'notifications', type_='foreignkey')
+        self.op.alter_column('notifications',
+                             'activiy_id',
+                             new_column_name='activity_id',
+                             existing_nullable=True,
+                             existing_type=Integer)
+        self.op.create_foreign_key(fk_name, 'notifications', 'activities',
+                                   ['activity_id'], ['id'])


### PR DESCRIPTION
Tested migration *master -> deif-fix-activity-typo* and confirmed working an MySQL, PostgreSQL and Oracle.

Fixes #969