### PR TITLE
CSRF: Allow _dav_writelocks to be initialized on context.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.4.1 (unreleased)
 ------------------
 
+- CSRF: Allow _dav_writelocks to be initialized on context.
+  [lgraf]
+
 - Also assign navigation portlet to 'kontakte' in example content.
   Change navigation toplevel to 1. Also include hooks to setup navigation in policy template.
   [deiferni]

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -111,11 +111,17 @@ class OGProtectTransform(ProtectTransform):
         if IPloneSiteRoot.providedBy(getSite()):
             unprotected_write(getToolByName(getSite(), 'portal_memberdata')._members)
 
+        context = self.getContext()
+
         # always allow writes to context's annotations.
-        context = self.request.PARENTS[0]
         if IAnnotatable.providedBy(context):
             annotations = IAnnotations(context)
             unprotected_write(annotations)
             if CONTEXT_ASSIGNMENT_KEY in annotations:
                 # also allow writes to context portlet assignments
                 unprotected_write(annotations[CONTEXT_ASSIGNMENT_KEY])
+
+        # Allow _dav_writelocks to be initialized
+        # see webdav/Lockable.py:64
+        if hasattr(context, '_dav_writelocks'):
+            unprotected_write(context._dav_writelocks)


### PR DESCRIPTION
On certain occasions, `context._dav_writelocks` is lazily initialized with an empty `PersistentMapping` that causes a change to the transaction - see [`webdav/Lockable.py:64`](https://github.com/zopefoundation/Zope/blob/master/src/webdav/Lockable.py#L62-L67)

This PR therefore globally unprotects writes to `context._dav_writelocks`.

Additionally, it contains a "sneaky backport" of @83e173 from #982 which uses the proper way to access the context in `_global_unprotect()`.

@phgross @deiferni 
