### PR TITLE
Aufgaben Frist konfigurierbar implementiert.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Make task default deadline timedelta configurable per installation.
+  [phgross]
+
 - Remove unused copy-related-documents-to-inbox view.
   [deiferni]
 

--- a/opengever/task/interfaces.py
+++ b/opengever/task/interfaces.py
@@ -38,6 +38,10 @@ class ITaskSettings(Interface):
 
     crop_length = schema.Int(title=u"Crop length", default=20)
 
+    deadline_timedelta = schema.Int(
+        title=u'Default timedelta in days for the deadline offset.',
+        default=5)
+
     unidirectional_by_reference = schema.List(
         title=u'Task Types Unidirectional by Reference',
         description=u'',

--- a/opengever/task/profiles/default/metadata.xml
+++ b/opengever/task/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-  <version>4300</version>
+  <version>4500</version>
 </metadata>

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -21,11 +21,13 @@ from opengever.ogds.base.utils import ogds_service
 from opengever.task import _
 from opengever.task import util
 from opengever.task.activities import TaskAddedActivity
+from opengever.task.interfaces import ITaskSettings
 from opengever.task.validators import NoCheckedoutDocsValidator
 from plone import api
 from plone.dexterity.content import Container
 from plone.directives import form, dexterity
 from plone.indexer.interfaces import IIndexer
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import _mergedLocalRoles
 from Products.CMFCore.utils import getToolByName
@@ -358,9 +360,10 @@ class Task(Container):
 
 
 @form.default_value(field=ITask['deadline'])
-def deadlineDefaultValue(data):
-    # To get hold of the folder, do: context = data.context
-    return datetime.today() + timedelta(5)
+def deadline_default_value(data):
+    registry = getUtility(IRegistry)
+    proxy = registry.forInterface(ITaskSettings)
+    return datetime.today() + timedelta(days=proxy.deadline_timedelta)
 
 
 @form.default_value(field=ITask['responsible_client'])

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -312,13 +312,13 @@ class Task(Container):
         return get_containing_dossier(self)
 
     def get_containing_dossier_title(self):
-        #get the containing_dossier value directly with the indexer
+        # get the containing_dossier value directly with the indexer
         catalog = getToolByName(self, 'portal_catalog')
         return getMultiAdapter(
             (self, catalog), IIndexer, name='containing_dossier')()
 
     def get_containing_subdossier(self):
-        #get the containing_dossier value directly with the indexer
+        # get the containing_dossier value directly with the indexer
         catalog = getToolByName(self, 'portal_catalog')
         return getMultiAdapter(
             (self, catalog), IIndexer, name='containing_subdossier')()
@@ -335,8 +335,8 @@ class Task(Container):
             return (None, None,)
 
     def get_principals(self):
-        # index the principal which have View permission. This is according to the
-        # allowedRolesAndUsers index but it does not car of global roles.
+        # index the principal which have View permission. This is according to
+        # the allowedRolesAndUsers index but it does not car of global roles.
         allowed_roles = rolesForPermissionOn(View, self)
         principals = []
         for principal, roles in _mergedLocalRoles(self).items():

--- a/opengever/task/upgrades/configure.zcml
+++ b/opengever/task/upgrades/configure.zcml
@@ -130,4 +130,13 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4300 -> 4500 -->
+    <upgrade-step:importProfile
+        title="Add ITaskSetting.deadline_timedelta record to registry."
+        profile="opengever.task:default"
+        source="4300"
+        destination="4500"
+        directory="profiles/4500"
+        />
+
 </configure>

--- a/opengever/task/upgrades/profiles/4500/registry.xml
+++ b/opengever/task/upgrades/profiles/4500/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <record interface="opengever.task.interfaces.ITaskSettings" field="deadline_timedelta">
+    <value>5</value>
+  </record>
+</registry>


### PR DESCRIPTION
Die Frist ist neu über die Registry konfigurierbar, standardmässig wird immer noch der `heutige Tag + 5 Tage` vorgeschlagen.

 Closes #721

@deiferni 