### PR TITLE
Inbox-Übersicht render-Probleme beheben.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fix Inbox Overview: Fix error while rendering overview. Also refactor
+  boxes for inbox/dossier overview, introduce generic macro and mixin, remove inheritance.
+  [deiferni]
+
 - Task overview: Hide responsible info in subtask, maintask, successor and predecessor
   listing.
   [phgross]

--- a/opengever/base/browser/boxes_view.py
+++ b/opengever/base/browser/boxes_view.py
@@ -1,4 +1,5 @@
 from opengever.base.browser.helper import get_css_class
+from opengever.globalindex.model.task import Task
 from opengever.globalindex.utils import indexed_task_link_helper
 from Products.ZCatalog.interfaces import ICatalogBrain
 from z3c.form.interfaces import IFieldWidget
@@ -16,11 +17,14 @@ class BoxesViewMixin(object):
 
     def get_type(self, item):
         """differ the object typ and return the type as string"""
+
         if isinstance(item, dict):
             return 'dict'
         elif ICatalogBrain.providedBy(item):
             return 'brain'
         elif IFieldWidget.providedBy(item):
             return 'widget'
+        elif isinstance(item, Task):
+            return 'globalindex_task'
         else:
-            return 'sqlalchemy_object'
+            raise ValueError("Unknown item type: {!r}".format(item))

--- a/opengever/base/browser/boxes_view.py
+++ b/opengever/base/browser/boxes_view.py
@@ -1,6 +1,7 @@
 from opengever.base.browser.helper import get_css_class
 from opengever.globalindex.utils import indexed_task_link_helper
 from Products.ZCatalog.interfaces import ICatalogBrain
+from z3c.form.interfaces import IFieldWidget
 
 
 class BoxesViewMixin(object):
@@ -19,5 +20,7 @@ class BoxesViewMixin(object):
             return 'dict'
         elif ICatalogBrain.providedBy(item):
             return 'brain'
+        elif IFieldWidget.providedBy(item):
+            return 'widget'
         else:
             return 'sqlalchemy_object'

--- a/opengever/base/browser/boxes_view.py
+++ b/opengever/base/browser/boxes_view.py
@@ -1,0 +1,23 @@
+from opengever.base.browser.helper import get_css_class
+from opengever.globalindex.utils import indexed_task_link_helper
+from Products.ZCatalog.interfaces import ICatalogBrain
+
+
+class BoxesViewMixin(object):
+
+    def render_globalindex_task(self, item):
+        return indexed_task_link_helper(item, item.title)
+
+    def get_item_css_classes(self, item):
+        """Return all css classes for item.
+        """
+        return " ".join(["rollover-breadcrumb", get_css_class(item)])
+
+    def get_type(self, item):
+        """differ the object typ and return the type as string"""
+        if isinstance(item, dict):
+            return 'dict'
+        elif ICatalogBrain.providedBy(item):
+            return 'brain'
+        else:
+            return 'sqlalchemy_object'

--- a/opengever/base/browser/gever_macros.py
+++ b/opengever/base/browser/gever_macros.py
@@ -1,0 +1,13 @@
+from five import grok
+from zope.interface import Interface
+
+
+class View(grok.View):
+    grok.context(Interface)
+    grok.require('zope2.View')
+    grok.name('gever-macros')
+
+    template = grok.PageTemplateFile('templates/gever-macros.pt')
+
+    def __getitem__(self, key):
+        return self.template._template.macros[key]

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -1,0 +1,86 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="opengever.base"
+      tal:omit-tag="">
+  <head>
+  </head>
+
+  <body>
+
+    <tal:comment replace="nothing">
+    Render overview boxes in a generic way. Can display brains, dicts or sqlalchemy objects.
+    Currently will assume than an sqlalchemy-object is a task.
+
+    css_width: a number indicating the width percentage.
+    base_index: optional, it not defined will take 0 as default.
+    </tal:comment>
+
+    <metal:define define-macro="overview_boxes">
+
+      <tal:block tal:repeat="boxes groups" tal:define="base_index base_index | python: 0">
+      <div tal:define="repeat_index repeat/boxes/index;
+                       box_id python: base_index + repeat_index;"
+           tal:attributes="class string:boxGroup boxGroup${box_id};
+                           style string:width:${css_width}%">
+        <div tal:repeat="box boxes" class="box" tal:attributes="id string:${box/id}Box">
+          <h2 i18n:translate="" tal:content="box/label|box/id"></h2>
+
+          <tal:box tal:condition="python: not hasattr(box.get('content'), '__iter__')">
+            <tal:item  tal:condition="box/content">
+              <span tal:content="box/content" />
+            </tal:item>
+            <tal:item tal:condition="not: box/content">
+              <span i18n:translate="" >No content</span>
+            </tal:item>
+          </tal:box>
+
+          <tal:box tal:condition="python: hasattr(box.get('content'), '__iter__')">
+            <tal:items define="items box/content">
+              <ul tal:condition="items">
+                <li tal:repeat="item items">
+
+                  <!-- item is a brain -->
+                  <tal:brain tal:condition="python: view.get_type(item) == 'brain'">
+                    <a href="" tal:attributes="href item/getURL|nothing;
+                                               title item/alt|nothing;
+                                               class python:view.get_item_css_classes(item)" tal:omit-tag="not: item/getURL|nothing">
+                    <span tal:content="item/Title" /></a>
+                  </tal:brain>
+
+                  <!-- item is a dict (Documents and participants) -->
+                  <tal:dict tal:condition="python: view.get_type(item) == 'dict'">
+                    <a href=""
+                       tal:attributes="href item/getURL|nothing;
+                                       title item/alt|nothing;
+                                       class python:'rollover-breadcrumb %s' % (item.get('css_class'))"
+                       tal:omit-tag="not: item/getURL|nothing">
+                    <span tal:content="item/Title" /></a>
+                  </tal:dict>
+
+                  <!-- SQLAlchemy Objects (Tasks from GlobalIndex)-->
+                  <tal:sql tal:condition="python: view.get_type(item) == 'sqlalchemy_object'">
+                    <div tal:replace="structure python:view.render_globalindex_task(item)" />
+                  </tal:sql>
+                </li>
+
+                <li class="moreLink">
+                  <a
+                      tal:attributes="href python: box.get('href', None) and '#%s' % box.get('href') or '#%s' % box.get('id')"
+                      i18n:translate="">
+                  show all</a>
+                </li>
+              </ul>
+              <span tal:condition="not: items" i18n:translate="">No content</span>
+            </tal:items>
+          </tal:box>
+
+        </div>
+      </div>
+      </tal:block>
+
+    </metal:define>
+
+  </body>
+</html>

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -88,10 +88,9 @@
                   </tal:sql>
                 </li>
 
-                <li class="moreLink">
-                  <a
-                      tal:attributes="href python: box.get('href', None) and '#%s' % box.get('href') or '#%s' % box.get('id')"
-                      i18n:translate="">
+                <li class="moreLink" tal:condition="python: box.get('href', None)">
+                  <a tal:attributes="href python: '#{}'.format(box.get('href'))"
+                     i18n:translate="">
                   show all</a>
                 </li>
               </ul>

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -42,7 +42,23 @@
               <ul tal:condition="items">
                 <li tal:repeat="item items">
 
-                  <!-- item is a brain -->
+                  <tal:comment replace="nothing">
+                    Item is a widget:
+                  </tal:comment>
+                  <tal:brain tal:condition="python: view.get_type(item) == 'widget'">
+                    <tal:cond tal:condition="item/label">
+                      <span tal:content="structure item/label" />
+                      <span>: </span>
+                      <span tal:content="structure item/render" />
+                    </tal:cond>
+                    <tal:cond tal:condition="not: item/label">
+                      <span tal:content="structure item/render" />
+                    </tal:cond>
+                  </tal:brain>
+
+                  <tal:comment replace="nothing">
+                    Item is a brain:
+                  </tal:comment>
                   <tal:brain tal:condition="python: view.get_type(item) == 'brain'">
                     <a href="" tal:attributes="href item/getURL|nothing;
                                                title item/alt|nothing;
@@ -50,7 +66,10 @@
                     <span tal:content="item/Title" /></a>
                   </tal:brain>
 
-                  <!-- item is a dict (Documents and participants) -->
+
+                  <tal:comment replace="nothing">
+                    Item is a dict (Documents and participants):
+                  </tal:comment>
                   <tal:dict tal:condition="python: view.get_type(item) == 'dict'">
                     <a href=""
                        tal:attributes="href item/getURL|nothing;
@@ -60,7 +79,10 @@
                     <span tal:content="item/Title" /></a>
                   </tal:dict>
 
-                  <!-- SQLAlchemy Objects (Tasks from GlobalIndex)-->
+
+                  <tal:comment replace="nothing">
+                    SQLAlchemy Objects (Tasks from GlobalIndex):
+                  </tal:comment>
                   <tal:sql tal:condition="python: view.get_type(item) == 'sqlalchemy_object'">
                     <div tal:replace="structure python:view.render_globalindex_task(item)" />
                   </tal:sql>

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -19,7 +19,8 @@
 
     <metal:define define-macro="overview_boxes">
 
-      <tal:block tal:repeat="boxes groups" tal:define="base_index base_index | python: 0">
+      <tal:block tal:repeat="boxes view/boxes"
+                 tal:define="base_index base_index | python: 0">
       <div tal:define="repeat_index repeat/boxes/index;
                        box_id python: base_index + repeat_index;"
            tal:attributes="class string:boxGroup boxGroup${box_id};

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -88,8 +88,8 @@
                   </tal:sql>
                 </li>
 
-                <li class="moreLink" tal:condition="python: box.get('href', None)">
-                  <a tal:attributes="href python: '#{}'.format(box.get('href'))"
+                <li class="moreLink" tal:condition="box/href">
+                  <a tal:attributes="href string:#${box/href}"
                      i18n:translate="">
                   show all</a>
                 </li>

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -83,7 +83,7 @@
                   <tal:comment replace="nothing">
                     SQLAlchemy Objects (Tasks from GlobalIndex):
                   </tal:comment>
-                  <tal:sql tal:condition="python: view.get_type(item) == 'sqlalchemy_object'">
+                  <tal:sql tal:condition="python: view.get_type(item) == 'globalindex_task'">
                     <div tal:replace="structure python:view.render_globalindex_task(item)" />
                   </tal:sql>
                 </li>

--- a/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -200,6 +200,9 @@ msgstr "Info"
 msgid "subdossiers"
 msgstr "Subdossiers"
 
+msgid "submittedproposals"
+msgstr "Anträge"
+
 msgid "tasks"
 msgstr "Aufgaben"
 
@@ -223,7 +226,4 @@ msgstr "Papierkorb"
 
 msgid "users"
 msgstr "OGDS"
-
-msgid "submittedproposals"
-msgstr "Anträge"
 

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-22 08:24+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -21,6 +21,10 @@ msgstr ""
 #: ./opengever/base/profiles/default/actions.xml
 msgid "Copy Items"
 msgstr "Kopieren"
+
+#: ./opengever/base/browser/templates/gever-macros.pt:36
+msgid "No content"
+msgstr "Keine Inhalte"
 
 #: ./opengever/base/viewlets/download.py:26
 msgid "No file in in this version"
@@ -357,6 +361,10 @@ msgstr "Haben Sie nicht gefunden, wonach Sie gesucht haben? Die ${advanced_searc
 msgid "search_results_advanced_link"
 msgstr "erweiterte Suche"
 
+#: ./opengever/base/browser/templates/gever-macros.pt:70
+msgid "show all"
+msgstr "Alle anzeigen"
+
 #. Default: "Confirming User Action."
 #: ./opengever/base/browser/confirm.pt:14
 msgid "title_confirming_user_action"
@@ -372,3 +380,4 @@ msgstr "Nicht geprüft"
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr "Nicht klassifiziert"
+

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -77,6 +77,12 @@ msgstr "Metadaten bearbeiten"
 msgid "Give Filing Number"
 msgstr "Ablagenummer vergeben"
 
+msgid "Meeting"
+msgstr "Sitzung"
+
+msgid "Membership"
+msgstr "Mitgliedschaft"
+
 msgid "Modify deadline"
 msgstr "Frist ändern"
 
@@ -288,8 +294,3 @@ msgstr "Deaktivieren"
 msgid "tasktemplatefolder-transition-inactiv-activ"
 msgstr "Aktivieren"
 
-msgid "Meeting"
-msgstr "Sitzung"
-
-msgid "Membership"
-msgstr "Mitgliedschaft"

--- a/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -200,6 +200,9 @@ msgstr "Info"
 msgid "subdossiers"
 msgstr "Sous-dossiers"
 
+msgid "submittedproposals"
+msgstr "Propositions"
+
 msgid "tasks"
 msgstr "Tâches"
 
@@ -223,7 +226,4 @@ msgstr "Corbeille"
 
 msgid "users"
 msgstr "OGDS"
-
-msgid "submittedproposals"
-msgstr "Propositions"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-22 08:24+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,10 @@ msgstr ""
 #: ./opengever/base/profiles/default/actions.xml
 msgid "Copy Items"
 msgstr "Copier"
+
+#: ./opengever/base/browser/templates/gever-macros.pt:36
+msgid "No content"
+msgstr "Pas de contenu"
 
 #: ./opengever/base/viewlets/download.py:26
 msgid "No file in in this version"
@@ -353,6 +357,10 @@ msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search}
 #: ./opengever/base/browser/search.pt:61
 msgid "search_results_advanced_link"
 msgstr "Recherche avancée"
+
+#: ./opengever/base/browser/templates/gever-macros.pt:70
+msgid "show all"
+msgstr "Tout afficher"
 
 #. Default: "Confirming User Action."
 #: ./opengever/base/browser/confirm.pt:14

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -77,6 +77,12 @@ msgstr "Modifier les méta-données"
 msgid "Give Filing Number"
 msgstr "Attribuer un numéro d'inventaire"
 
+msgid "Meeting"
+msgstr "Séance"
+
+msgid "Membership"
+msgstr ""
+
 msgid "Modify deadline"
 msgstr "Changer le délai"
 
@@ -288,8 +294,3 @@ msgstr "Déactiver"
 msgid "tasktemplatefolder-transition-inactiv-activ"
 msgstr "Activer"
 
-msgid "Meeting"
-msgstr "Séance"
-
-msgid "Membership"
-msgstr ""

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-22 08:24+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,10 @@ msgstr ""
 
 #: ./opengever/base/profiles/default/actions.xml
 msgid "Copy Items"
+msgstr ""
+
+#: ./opengever/base/browser/templates/gever-macros.pt:36
+msgid "No content"
 msgstr ""
 
 #: ./opengever/base/viewlets/download.py:26
@@ -351,6 +355,10 @@ msgstr ""
 #. Default: "Advanced Search"
 #: ./opengever/base/browser/search.pt:61
 msgid "search_results_advanced_link"
+msgstr ""
+
+#: ./opengever/base/browser/templates/gever-macros.pt:70
+msgid "show all"
 msgstr ""
 
 #. Default: "Confirming User Action."

--- a/opengever/base/tests/test_unit_boxes_view.py
+++ b/opengever/base/tests/test_unit_boxes_view.py
@@ -1,0 +1,42 @@
+from opengever.base.browser.boxes_view import BoxesViewMixin
+from opengever.globalindex.model.task import Task
+from Products.ZCatalog.CatalogBrains import AbstractCatalogBrain
+from unittest2 import TestCase
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.widget import Widget
+from zope.interface import alsoProvides
+
+
+class MockBrain(AbstractCatalogBrain):
+    __record_schema__ = {}
+
+
+class TestUnitBoxesView(TestCase):
+
+    def setUp(self):
+        super(TestUnitBoxesView, self).setUp()
+
+        self.view = BoxesViewMixin()
+
+    def test_get_type_dict(self):
+        self.assertEqual('dict', self.view.get_type(dict()))
+
+    def test_get_type_brain(self):
+        self.assertEqual('brain', self.view.get_type(MockBrain()))
+
+    def test_get_type_widget(self):
+        mock_widget = Widget(None)
+        alsoProvides(mock_widget, IFieldWidget)
+
+        self.assertEqual('widget', self.view.get_type(mock_widget))
+
+    def test_get_type_task(self):
+        self.assertEqual('globalindex_task',
+                         self.view.get_type(Task(123, 'foo')))
+
+    def test_invalid_value_raises(self):
+        class Foo(object):
+            pass
+
+        with self.assertRaises(ValueError):
+            self.view.get_type(Foo())

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -36,7 +36,7 @@ class DossierOverview(BoxesViewMixin, grok.View, OpengeverTab):
                 dict(id='newest_tasks', content=self.tasks(),
                      href='tasks', label=_("Newest tasks")),
                 dict(id='participants', content=self.sharing(),
-                     label=_("Participants")),
+                     href='participants', label=_("Participants")),
             ], [
                 dict(id='newest_documents', content=self.documents(),
                      href='documents', label=_("Newest documents")),

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -1,19 +1,19 @@
 from five import grok
+from opengever.base.browser.boxes_view import BoxesViewMixin
 from opengever.base.browser.helper import get_css_class
+from opengever.dossier import _
 from opengever.dossier import _ as _dossier
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossierMarker, IDossier
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.globalindex.model.task import Task
-from opengever.globalindex.utils import indexed_task_link_helper
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.tabbedview.browser.base import OpengeverTab
-from Products.ZCatalog.interfaces import ICatalogBrain
 from sqlalchemy import desc
 
 
-class DossierOverview(grok.View, OpengeverTab):
+class DossierOverview(BoxesViewMixin, grok.View, OpengeverTab):
 
     show_searchform = False
 
@@ -33,13 +33,17 @@ class DossierOverview(grok.View, OpengeverTab):
     def boxes(self):
         return [
             [
-                dict(id='newest_tasks', content=self.tasks(), href='tasks'),
-                dict(id='participants', content=self.sharing()), ],
-            [
+                dict(id='newest_tasks', content=self.tasks(),
+                     href='tasks', label=_("Newest tasks")),
+                dict(id='participants', content=self.sharing(),
+                     label=_("Participants")),
+            ], [
                 dict(id='newest_documents', content=self.documents(),
-                     href='documents'),
-                dict(id='description', content=self.description), ]
+                     href='documents', label=_("Newest documents")),
+                dict(id='description', content=self.description,
+                     label=_("Description")),
             ]
+        ]
 
     def is_subdossier_navigation_available(self):
         main_dossier = self.context.get_main_dossier()
@@ -101,26 +105,3 @@ class DossierOverview(grok.View, OpengeverTab):
 
     def description(self):
         return self.context.description
-
-    def render_globalindex_task(self, item):
-        return indexed_task_link_helper(item, item.title)
-
-    def get_css_class(self, item):
-        """Return the css classes
-        """
-        return "%s %s" % (
-            "rollover-breadcrumb", self._get_css_icon_class(item))
-
-    def _get_css_icon_class(self, item):
-        """Return the rigth css-class for the icon.
-        """
-        return get_css_class(item)
-
-    def get_type(self, item):
-        """differ the object typ and return the type as string"""
-        if isinstance(item, dict):
-            return 'dict'
-        elif ICatalogBrain.providedBy(item):
-            return 'brain'
-        else:
-            return 'sqlalchemy_object'

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -1,7 +1,6 @@
 <!--TODO: refactor using viewlets-->
 <tal:block i18n:domain="opengever.dossier"
-           tal:define="groups view/boxes;
-                       css_width python:99/3;
+           tal:define="css_width python:99/3;
                        base_index python: 1">
 
   <div class="boxGroup boxGroup0" tal:attributes="style string:width:${css_width}%">

--- a/opengever/dossier/browser/overview_templates/overview.pt
+++ b/opengever/dossier/browser/overview_templates/overview.pt
@@ -1,6 +1,8 @@
 <!--TODO: refactor using viewlets-->
 <tal:block i18n:domain="opengever.dossier"
-           tal:define="groups view/boxes; css_width python:99/3">
+           tal:define="groups view/boxes;
+                       css_width python:99/3;
+                       base_index python: 1">
 
   <div class="boxGroup boxGroup0" tal:attributes="style string:width:${css_width}%">
     <div class="box" id="subdossiersBox">
@@ -29,65 +31,6 @@
     </div>
   </div>
 
-  <tal:block tal:repeat="boxes groups">
-  <div tal:define="repeat_index repeat/boxes/index;
-                   box_id python: repeat_index + 1;"
-       tal:attributes="class string:boxGroup boxGroup${box_id};
-                       style string:width:${css_width}%">
-    <div tal:repeat="box boxes" class="box" tal:attributes="id string:${box/id}Box">
-      <h2 i18n:translate="" tal:content="box/label|box/id"></h2>
-
-      <tal:box tal:condition="python: not hasattr(box.get('content'), '__iter__')">
-        <tal:item  tal:condition="box/content">
-          <span tal:content="box/content" />
-        </tal:item>
-        <tal:item tal:condition="not: box/content">
-          <span i18n:translate="no_content" />
-        </tal:item>
-      </tal:box>
-
-      <tal:box tal:condition="python: hasattr(box.get('content'), '__iter__')">
-        <tal:items define="items box/content">
-          <ul tal:condition="items">
-            <li tal:repeat="item items">
-
-              <!-- item is a brain -->
-              <tal:brain tal:condition="python: view.get_type(item) == 'brain'">
-                <a href="" tal:attributes="href item/getURL|nothing;
-                                           title item/alt|nothing;
-                                           class python:view.get_css_class(item)" tal:omit-tag="not: item/getURL|nothing">
-                <span tal:content="item/Title" /></a>
-              </tal:brain>
-
-              <!-- item is a dict (Documents and participants) -->
-              <tal:dict tal:condition="python: view.get_type(item) == 'dict'">
-                <a href=""
-                   tal:attributes="href item/getURL|nothing;
-                                   title item/alt|nothing;
-                                   class python:'rollover-breadcrumb %s' % (item.get('css_class'))"
-                   tal:omit-tag="not: item/getURL|nothing">
-                <span tal:content="item/Title" /></a>
-              </tal:dict>
-
-              <!-- SQLAlchemy Objects (Tasks from GlobalIndex)-->
-              <tal:sql tal:condition="python: view.get_type(item) == 'sqlalchemy_object'">
-                <div tal:replace="structure python:view.render_globalindex_task(item)" />
-              </tal:sql>
-            </li>
-
-            <li class="moreLink">
-              <a
-                  tal:attributes="href python: box.get('href', None) and '#%s' % box.get('href') or '#%s' % box.get('id')"
-                  i18n:translate="">
-              show all</a>
-            </li>
-          </ul>
-          <span tal:condition="not: items" i18n:translate="no_content" />
-        </tal:items>
-      </tal:box>
-
-    </div>
-  </div>
-  </tal:block>
+  <metal:use use-macro="context/@@gever-macros/overview_boxes" />
 
 </tal:block>

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-05-28 12:08+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -43,11 +43,15 @@ msgstr "Report konnte nicht generiert werden."
 msgid "Delete"
 msgstr "Beteiligung löschen"
 
+#: ./opengever/dossier/browser/overview.py:44
+msgid "Description"
+msgstr "Beschreibung"
+
 #: ./opengever/dossier/move_items.py:96
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr "Dokument ${name} ist mit einer Aufgabe verbunden, bitte Aufgabe verschieben."
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:7
+#: ./opengever/dossier/browser/overview_templates/overview.pt:8
 msgid "Dossier structure"
 msgstr "Dossier-Struktur"
 
@@ -84,7 +88,15 @@ msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossi
 msgid "Move Items"
 msgstr "Elemente verschieben"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:26
+#: ./opengever/dossier/browser/overview.py:42
+msgid "Newest documents"
+msgstr "Neuste Dokumente"
+
+#: ./opengever/dossier/browser/overview.py:37
+msgid "Newest tasks"
+msgstr "Neuste Aufgaben"
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:27
 msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
 
@@ -95,6 +107,10 @@ msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 #: ./opengever/dossier/templatedossier/form.py:103
 msgid "Not found the templatedossier"
 msgstr "Es sind keine Vorlagen vorhanden."
+
+#: ./opengever/dossier/browser/overview.py:39
+msgid "Participants"
+msgstr "Beteiligte"
 
 #. Default: "Project Dossier"
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
@@ -224,9 +240,6 @@ msgstr "Rolle"
 #: ./opengever/dossier/templatedossier/form.py:28
 msgid "create_document_with_template"
 msgstr "Dokument aus Vorlage erstellen"
-
-msgid "description"
-msgstr "Beschreibung"
 
 msgid "documents"
 msgstr "Dokumente"
@@ -552,16 +565,6 @@ msgstr "Titel"
 msgid "label_workflow_state"
 msgstr "Status"
 
-msgid "newest_documents"
-msgstr "Neuste Dokumente"
-
-msgid "newest_tasks"
-msgstr "Neuste Aufgaben"
-
-#: ./opengever/dossier/browser/overview_templates/overview.pt:45
-msgid "no_content"
-msgstr "Keine Inhalte"
-
 #: ./opengever/dossier/resolve.py:11
 msgid "not all documents and tasks are stored in a subdossier"
 msgstr "Es sind nicht alle Dokumente und Aufgaben in Subdossiers abgelegt."
@@ -577,9 +580,6 @@ msgstr "Es sind nicht alle Aufgaben abgeschlossen"
 #: ./opengever/dossier/archive.py:33
 msgid "only resolve, set filing no later"
 msgstr "Nur abschliessen (keine Ablagenummer vergeben)"
-
-msgid "participants"
-msgstr "Beteiligte"
 
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:23
 msgid "required"
@@ -603,10 +603,6 @@ msgstr "Ablagenummer vergeben"
 
 msgid "sharing"
 msgstr "Beteiligungen"
-
-#: ./opengever/dossier/browser/overview_templates/overview.pt:79
-msgid "show all"
-msgstr "Alle anzeigen"
 
 msgid "subdossiers"
 msgstr "Subdossiers"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-28 12:08+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,11 +41,15 @@ msgstr "Impossible de générer l'affichage"
 msgid "Delete"
 msgstr "Effacer la participation"
 
+#: ./opengever/dossier/browser/overview.py:44
+msgid "Description"
+msgstr "Description"
+
 #: ./opengever/dossier/move_items.py:96
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr "Document ${name} est lié avec une tâche, déplacer la tâche, svp."
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:7
+#: ./opengever/dossier/browser/overview_templates/overview.pt:8
 msgid "Dossier structure"
 msgstr ""
 
@@ -82,7 +86,15 @@ msgstr "Il n'est pas possible d'ouvrir un sous-dossier, le dossier principale do
 msgid "Move Items"
 msgstr "Déplacer l'élément"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:26
+#: ./opengever/dossier/browser/overview.py:42
+msgid "Newest documents"
+msgstr "Derniers documents"
+
+#: ./opengever/dossier/browser/overview.py:37
+msgid "Newest tasks"
+msgstr "Dernières tâches"
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:27
 msgid "No Subdossiers"
 msgstr ""
 
@@ -93,6 +105,10 @@ msgstr "Manque des champs obligatoires"
 #: ./opengever/dossier/templatedossier/form.py:103
 msgid "Not found the templatedossier"
 msgstr "Pas de modèles disponible"
+
+#: ./opengever/dossier/browser/overview.py:39
+msgid "Participants"
+msgstr "Participants"
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
 msgid "Project Dossier"
@@ -220,9 +236,6 @@ msgstr "Rôle"
 #: ./opengever/dossier/templatedossier/form.py:28
 msgid "create_document_with_template"
 msgstr "Créer un document à partir d'un modèle"
-
-msgid "description"
-msgstr "Description"
 
 msgid "documents"
 msgstr "Documents"
@@ -548,16 +561,6 @@ msgstr "Titre"
 msgid "label_workflow_state"
 msgstr "Etat"
 
-msgid "newest_documents"
-msgstr "Derniers documents"
-
-msgid "newest_tasks"
-msgstr "Dernières tâches"
-
-#: ./opengever/dossier/browser/overview_templates/overview.pt:45
-msgid "no_content"
-msgstr "Pas de contenu"
-
 #: ./opengever/dossier/resolve.py:11
 msgid "not all documents and tasks are stored in a subdossier"
 msgstr "Pas de document ni de tâche classés dans le sous-dossier"
@@ -573,9 +576,6 @@ msgstr "Toutes les tâches ne sont pas fermées"
 #: ./opengever/dossier/archive.py:33
 msgid "only resolve, set filing no later"
 msgstr "Uniquement fermé (numéro d'inventaire non attribué)"
-
-msgid "participants"
-msgstr "Participants"
 
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:23
 msgid "required"
@@ -599,10 +599,6 @@ msgstr "Attribuer numéro d'inventaire"
 
 msgid "sharing"
 msgstr "Participations enlevées"
-
-#: ./opengever/dossier/browser/overview_templates/overview.pt:79
-msgid "show all"
-msgstr "Tout afficher"
 
 msgid "subdossiers"
 msgstr "Sous-dossier"

--- a/opengever/dossier/locales/opengever.dossier-manual.pot
+++ b/opengever/dossier/locales/opengever.dossier-manual.pot
@@ -32,22 +32,10 @@ msgstr ""
 msgid "documents"
 msgstr ""
 
-msgid "newest_documents"
-msgstr ""
-
-msgid "newest_tasks"
-msgstr ""
-
 msgid "sharing"
 msgstr ""
 
-msgid "participants"
-msgstr ""
-
 msgid "Add Business Case Dossier"
-msgstr ""
-
-msgid "description"
 msgstr ""
 
 msgid "additional_attributes"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-28 12:08+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,11 +44,15 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+#: ./opengever/dossier/browser/overview.py:44
+msgid "Description"
+msgstr ""
+
 #: ./opengever/dossier/move_items.py:96
 msgid "Document ${name} is connected to a Task. Please move the Task."
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:7
+#: ./opengever/dossier/browser/overview_templates/overview.pt:8
 msgid "Dossier structure"
 msgstr ""
 
@@ -85,7 +89,15 @@ msgstr ""
 msgid "Move Items"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:26
+#: ./opengever/dossier/browser/overview.py:42
+msgid "Newest documents"
+msgstr ""
+
+#: ./opengever/dossier/browser/overview.py:37
+msgid "Newest tasks"
+msgstr ""
+
+#: ./opengever/dossier/browser/overview_templates/overview.pt:27
 msgid "No Subdossiers"
 msgstr ""
 
@@ -95,6 +107,10 @@ msgstr ""
 
 #: ./opengever/dossier/templatedossier/form.py:103
 msgid "Not found the templatedossier"
+msgstr ""
+
+#: ./opengever/dossier/browser/overview.py:39
+msgid "Participants"
 msgstr ""
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
@@ -222,9 +238,6 @@ msgstr ""
 #. Default: "create document with template"
 #: ./opengever/dossier/templatedossier/form.py:28
 msgid "create_document_with_template"
-msgstr ""
-
-msgid "description"
 msgstr ""
 
 msgid "documents"
@@ -550,16 +563,6 @@ msgstr ""
 msgid "label_workflow_state"
 msgstr ""
 
-msgid "newest_documents"
-msgstr ""
-
-msgid "newest_tasks"
-msgstr ""
-
-#: ./opengever/dossier/browser/overview_templates/overview.pt:45
-msgid "no_content"
-msgstr ""
-
 #: ./opengever/dossier/resolve.py:11
 msgid "not all documents and tasks are stored in a subdossier"
 msgstr ""
@@ -574,9 +577,6 @@ msgstr ""
 
 #: ./opengever/dossier/archive.py:33
 msgid "only resolve, set filing no later"
-msgstr ""
-
-msgid "participants"
 msgstr ""
 
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:23
@@ -600,10 +600,6 @@ msgid "set a filing no"
 msgstr ""
 
 msgid "sharing"
-msgstr ""
-
-#: ./opengever/dossier/browser/overview_templates/overview.pt:79
-msgid "show all"
 msgstr ""
 
 msgid "subdossiers"

--- a/opengever/inbox/browser/overview.py
+++ b/opengever/inbox/browser/overview.py
@@ -16,6 +16,9 @@ class InboxOverview(DossierOverview):
     grok.context(IInbox)
     grok.name('tabbedview_view-overview')
 
+    def is_subdossier_navigation_available(self):
+        return False
+
     def boxes(self):
         """Defines the boxes wich are Displayed at the Overview tab"""
 

--- a/opengever/inbox/browser/overview.py
+++ b/opengever/inbox/browser/overview.py
@@ -27,14 +27,17 @@ class InboxOverview(BoxesViewMixin, grok.View, OpengeverTab):
             [
                 dict(id='assigned_inbox_tasks',
                      content=self.assigned_tasks(),
+                     href='assigned_inbox_tasks',
                      label=_(u'label_assigned_inbox_tasks',
                              default='Assigned tasks')),
                 dict(id='issued_inbox_tasks',
+                     href='issued_inbox_tasks',
                      content=self.issued_tasks(),
                      label=_(u'label_issued_inbox_tasks',
                              default='Issued tasks')),
             ], [
                 dict(id='documents',
+                     href='documents',
                      label=_("Documents"),
                      content=self.documents()),
             ]

--- a/opengever/inbox/browser/overview.py
+++ b/opengever/inbox/browser/overview.py
@@ -1,38 +1,44 @@
 from five import grok
+from opengever.base.browser.boxes_view import BoxesViewMixin
 from opengever.base.browser.helper import get_css_class
-from opengever.dossier.browser.overview import DossierOverview
 from opengever.globalindex.model.task import Task
 from opengever.inbox import _
 from opengever.inbox.inbox import IInbox
 from opengever.ogds.base.utils import get_current_org_unit
+from opengever.tabbedview.browser.base import OpengeverTab
 from opengever.task import OPEN_TASK_STATES
 from plone import api
 from sqlalchemy import desc
 
 
-class InboxOverview(DossierOverview):
-    """Displayes the Inbox Overview
-    """
+class InboxOverview(BoxesViewMixin, grok.View, OpengeverTab):
+
+    show_searchform = False
+
     grok.context(IInbox)
     grok.name('tabbedview_view-overview')
-
-    def is_subdossier_navigation_available(self):
-        return False
+    grok.require('zope2.View')
+    grok.template('overview')
 
     def boxes(self):
         """Defines the boxes wich are Displayed at the Overview tab"""
 
-        items = [[dict(id='assigned_inbox_tasks',
-                       content=self.assigned_tasks(),
-                       label=_(u'label_assigned_inbox_tasks',
-                               default='Assigned tasks')),
-                  dict(id='issued_inbox_tasks',
-                       content=self.issued_tasks(),
-                       label=_(u'label_issued_inbox_tasks',
-                               default='Issued tasks')), ],
-                 [dict(id='documents',
-                       content=self.documents()), ]]
-        return items
+        return [
+            [
+                dict(id='assigned_inbox_tasks',
+                     content=self.assigned_tasks(),
+                     label=_(u'label_assigned_inbox_tasks',
+                             default='Assigned tasks')),
+                dict(id='issued_inbox_tasks',
+                     content=self.issued_tasks(),
+                     label=_(u'label_issued_inbox_tasks',
+                             default='Issued tasks')),
+            ], [
+                dict(id='documents',
+                     label=_("documents"),
+                     content=self.documents()),
+            ]
+        ]
 
     def assigned_tasks(self):
         """Returns the 5 last modified open task which are assigned

--- a/opengever/inbox/browser/overview.py
+++ b/opengever/inbox/browser/overview.py
@@ -35,7 +35,7 @@ class InboxOverview(BoxesViewMixin, grok.View, OpengeverTab):
                              default='Issued tasks')),
             ], [
                 dict(id='documents',
-                     label=_("documents"),
+                     label=_("Documents"),
                      content=self.documents()),
             ]
         ]
@@ -73,8 +73,10 @@ class InboxOverview(BoxesViewMixin, grok.View, OpengeverTab):
         query = {'isWorkingCopy': 0,
                  'path': {'depth': 1,
                           'query': '/'.join(self.context.getPhysicalPath())},
-                 'portal_type': ['opengever.document.document',
-                                 'ftw.mail.mail']}
+                 'object_provides': [
+                     'opengever.document.behaviors.IBaseDocument', ],
+                 'sort_on': 'modified',
+                 'sort_order': 'reverse'}
 
         documents = catalog(query)[:10]
         document_list = [{

--- a/opengever/inbox/browser/overview_templates/overview.pt
+++ b/opengever/inbox/browser/overview_templates/overview.pt
@@ -1,0 +1,7 @@
+<!--TODO: refactor using viewlets-->
+<tal:block i18n:domain="opengever.inbox"
+           tal:define="css_width python:99/2">
+
+  <metal:use use-macro="context/@@gever-macros/overview_boxes" />
+
+</tal:block>

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: 2015-03-30 08:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/inbox/browser/overview.py:38
+msgid "Documents"
+msgstr "Dokumente"
 
 #: ./opengever/inbox/profiles/default/actions.xml
 msgid "Forward"
@@ -70,7 +74,7 @@ msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person bzw. den Eingangskorb des oben gewählten Mandanten aus."
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:24
+#: ./opengever/inbox/browser/overview.py:30
 msgid "label_assigned_inbox_tasks"
 msgstr "Erhaltene Aufgaben"
 
@@ -90,7 +94,7 @@ msgid "label_inbox_group"
 msgstr "Eingangskorb Gruppe"
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:28
+#: ./opengever/inbox/browser/overview.py:34
 msgid "label_issued_inbox_tasks"
 msgstr "Erteilte Aufgaben"
 
@@ -133,3 +137,4 @@ msgstr "Weiterleitung abschliessen"
 #: ./opengever/inbox/yearfolder.py:39
 msgid "yearfolder_title"
 msgstr "Abgeschlossen ${year}"
+

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: 2014-11-03 14:10+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/inbox/browser/overview.py:38
+msgid "Documents"
+msgstr "Documents"
 
 #: ./opengever/inbox/profiles/default/actions.xml
 msgid "Forward"
@@ -70,7 +74,7 @@ msgid "help_responsible"
 msgstr "Choix de la personne responsable ou la boîte de réception du client mentionné ci-dessus."
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:24
+#: ./opengever/inbox/browser/overview.py:30
 msgid "label_assigned_inbox_tasks"
 msgstr "Tâches reçues"
 
@@ -90,7 +94,7 @@ msgid "label_inbox_group"
 msgstr "Boîte de réception Groupe"
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:28
+#: ./opengever/inbox/browser/overview.py:34
 msgid "label_issued_inbox_tasks"
 msgstr "Tâches attribuées"
 

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-06-10 10:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.inbox\n"
+
+#: ./opengever/inbox/browser/overview.py:38
+msgid "Documents"
+msgstr ""
 
 #: ./opengever/inbox/profiles/default/actions.xml
 msgid "Forward"
@@ -73,7 +77,7 @@ msgid "help_responsible"
 msgstr ""
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:24
+#: ./opengever/inbox/browser/overview.py:30
 msgid "label_assigned_inbox_tasks"
 msgstr ""
 
@@ -93,7 +97,7 @@ msgid "label_inbox_group"
 msgstr ""
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:28
+#: ./opengever/inbox/browser/overview.py:34
 msgid "label_issued_inbox_tasks"
 msgstr ""
 

--- a/opengever/inbox/tests/test_overview.py
+++ b/opengever/inbox/tests/test_overview.py
@@ -1,6 +1,7 @@
 from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
 from opengever.globalindex.handlers.task import sync_task
 from opengever.testing import FunctionalTestCase
 
@@ -26,6 +27,10 @@ class TestBaseInboxOverview(FunctionalTestCase):
 
 
 class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
+
+    @browsing
+    def test_overview(self, browser):
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
 
     def list_documents_from_the_inbox(self):
         inbox_document = create(Builder('document')

--- a/opengever/inbox/tests/test_overview.py
+++ b/opengever/inbox/tests/test_overview.py
@@ -23,7 +23,6 @@ class TestBaseInboxOverview(FunctionalTestCase):
             Builder('fixture').with_all_unit_setup())
 
         self.inbox = create(Builder('inbox').titled(u'eingangskorb'))
-        self.view = self.inbox.restrictedTraverse('tabbedview_view-overview')
 
 
 class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
@@ -32,28 +31,39 @@ class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
     def test_overview(self, browser):
         browser.login().open(self.inbox, view='tabbedview_view-overview')
 
-    def list_documents_from_the_inbox(self):
-        inbox_document = create(Builder('document')
-                                .titled('inbox document')
-                                .within(self.inbox))
+    @browsing
+    def test_inbox_documents_are_listed(self, browser):
+        create(Builder('document')
+               .titled('inbox document')
+               .within(self.inbox))
         create(Builder('document')
                .titled('portal document')
                .within(self.portal))
 
-        self.assert_documents([inbox_document, ], self.view.documents())
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
 
-    def test_list_only_documents_directly_inside_the_current_inbox(self):
-        inbox_document = create(Builder('document')
-                                .titled('inbox document')
-                                .within(self.inbox))
+        self.assertSequenceEqual(
+            browser.css('#documentsBox li:not(.moreLink) a').text,
+            ['inbox document'])
+
+    @browsing
+    def test_list_only_documents_directly_inside_the_current_inbox(self, browser):
+        create(Builder('document')
+               .titled('inbox document')
+               .within(self.inbox))
         forwarding = create(Builder('forwarding').within(self.inbox))
         create(Builder('document')
                .titled('forwarding document')
                .within(forwarding))
 
-        self.assert_documents([inbox_document, ], self.view.documents())
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
 
-    def test_list_only_documents_in_the_current_inbox(self):
+        self.assertSequenceEqual(
+            browser.css('#documentsBox li:not(.moreLink) a').text,
+            ['inbox document'])
+
+    @browsing
+    def test_list_only_documents_in_the_current_inbox(self, browser):
         sub_inbox_1 = create(Builder('inbox')
                              .within(self.inbox)
                              .having(responsible_org_unit='client1'))
@@ -62,144 +72,163 @@ class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
                              .within(self.inbox)
                              .having(responsible_org_unit='client2'))
 
-        doc1 = create(Builder('document')
-                      .titled('Doc 1').within(sub_inbox_1))
+        create(Builder('document')
+               .titled('Doc 1').within(sub_inbox_1))
         create(Builder('document')
                .titled('Doc 2').within(sub_inbox_2))
 
-        sub_inbox_1_view = sub_inbox_1.restrictedTraverse(
-            'tabbedview_view-overview')
+        browser.login().open(sub_inbox_1, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#documentsBox li:not(.moreLink) a').text,
+            ['Doc 1'])
 
-        self.assert_documents([doc1, ], sub_inbox_1_view.documents())
+    @browsing
+    def test_document_box_items_are_limited_to_ten_and_sorted_by_modified(self, browser):
+        for i in range(1, 11):
+            create(Builder('document')
+                   .within(self.inbox)
+                   .with_modification_date(DateTime(2010, 1, 1) + i)
+                   .titled(u'Document %s' % i))
+        create(Builder('document')
+               .within(self.inbox)
+               .with_modification_date(DateTime(2009, 12, 8))
+               .titled(u'Document 11'))
 
-    def test_document_box_is_limited_to_ten_documents(self):
-        for i in range(15):
-            create(Builder('document').within(self.inbox))
-
-        self.assertEquals(10, len(self.view.documents()))
-
-    def assert_documents(self, expected, value):
-        self.assertEquals(
-            [obj.Title() for obj in expected],
-            [item.get('Title') for item in value])
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#documentsBox li:not(.moreLink) a').text,
+            ['Document 10', 'Document 9', 'Document 8', 'Document 7',
+             'Document 6', 'Document 5', 'Document 4', 'Document 3',
+             'Document 2', 'Document 1'])
 
 
 class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
 
-    def test_list_tasks_and_forwardings_assigned_to_current_inbox_group(self):
-        task = create(Builder('task')
-                      .with_modification_date(DateTime(2014, 1, 1))
-                      .having(responsible='inbox:client1'))
-        forwarding = create(Builder('forwarding')
-                            .with_modification_date(DateTime(2014, 1, 2))
-                            .having(responsible='inbox:client1'))
-        create(Builder('forwarding').having(responsible='inbox:client2'))
+    @browsing
+    def test_list_tasks_and_forwardings_assigned_to_current_inbox_group(self, browser):
+        create(Builder('task')
+               .within(self.inbox)
+               .with_modification_date(DateTime(2014, 1, 1))
+               .having(responsible='inbox:client1')
+               .titled(u'Task x'))
+        create(Builder('forwarding')
+               .within(self.inbox)
+               .with_modification_date(DateTime(2014, 1, 2))
+               .having(responsible='inbox:client1')
+               .titled(u'Forwarding x'))
+        create(Builder('forwarding').having(responsible='inbox:client2')
+                                    .titled(u'Forwarding Invisible'))
 
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
         self.assertEquals(
-            [forwarding.get_sql_object(), task.get_sql_object()],
-            self.view.assigned_tasks())
+            ['Forwarding x', 'Task x'],
+            browser.css('#assigned_inbox_tasksBox li:not(.moreLink) span span').text)
 
-    def test_is_limited_to_five_entries(self):
-        for i in range(10):
+    @browsing
+    def test_task_box_items_are_limited_to_five_and_sorted_by_modified(self, browser):
+        for i in range(1, 6):
             create(Builder('forwarding')
-                   .having(responsible='inbox:client1'))
+                   .within(self.inbox)
+                   .having(responsible='inbox:client1')
+                   .with_modification_date(DateTime(2010, 1, 1) + i)
+                   .titled(u'Task %s' % i))
+        create(Builder('task')
+               .within(self.inbox)
+               .having(responsible='inbox:client1')
+               .with_modification_date(DateTime(2009, 12, 1))
+               .titled(u'Task 6'))
 
-        self.assertEquals(5, len(self.view.assigned_tasks()))
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#assigned_inbox_tasksBox li:not(.moreLink) span span').text,
+            ['Task 5', 'Task 4', 'Task 3', 'Task 2', 'Task 1'])
 
-    def test_lists_only_the_local_one_when_having_predecessor_successor_couples(self):
+    @browsing
+    def test_lists_only_the_local_one_when_having_predecessor_successor_couples(self, browser):
         predecessor = create(Builder('forwarding')
                              .having(responsible='inbox:client2',
-                                     assigned_client='client2'))
-        successor = create(Builder('forwarding')
-                           .having(responsible='inbox:client1',
-                                   assigned_client='client1')
-                           .successor_from(predecessor))
+                                     assigned_client='client2')
+                             .titled(u'Predecessor'))
+        create(Builder('forwarding')
+               .having(responsible='inbox:client1',
+                       assigned_client='client1')
+               .successor_from(predecessor)
+               .titled(u'Successor'))
 
-        self.assertEquals(
-            [successor.get_sql_object()], self.view.assigned_tasks())
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#assigned_inbox_tasksBox li:not(.moreLink) span span').text,
+            ['Successor'])
 
-    def test_list_only_active_tasks(self):
-        active = create(Builder('forwarding')
-                        .having(responsible='inbox:client1'))
+    @browsing
+    def test_list_only_active_tasks(self, browser):
+        create(Builder('forwarding')
+               .having(responsible='inbox:client1')
+               .titled('Active'))
         closed = create(Builder('forwarding')
                         .having(responsible='inbox:client1')
-                        .in_state('forwarding-state-closed'))
+                        .in_state('forwarding-state-closed')
+                        .titled('Closed'))
         sync_task(closed, None)
 
-        self.assertEquals(
-            [active.get_sql_object()],
-            self.view.assigned_tasks())
-
-    def test_is_sorted_on_modification_date_last_modified_first(self):
-        task1 = create(Builder('task')
-                       .with_modification_date(DateTime(2014, 1, 2))
-                       .having(responsible='inbox:client1'))
-
-        task2 = create(Builder('task')
-                       .with_modification_date(DateTime(2014, 1, 1))
-                       .having(responsible='inbox:client1'))
-
-        task3 = create(Builder('task')
-                       .with_modification_date(DateTime(2014, 1, 3))
-                       .having(responsible='inbox:client1'))
-
-        self.assertEquals(
-            [task.get_sql_object() for task in [task3, task1, task2]],
-            self.view.assigned_tasks())
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#assigned_inbox_tasksBox li:not(.moreLink) span span').text,
+            ['Active'])
 
 
 class TestInboxOverviewIssuedInboxTasks(TestBaseInboxOverview):
 
-    def test_list_tasks_and_forwardings_issued_by_current_inbox_group(self):
-        task = create(Builder('task')
-                      .with_modification_date(DateTime(2014, 1, 1))
-                      .within(self.inbox)
-                      .having(issuer='inbox:client1'))
-        forwarding = create(Builder('forwarding')
-                            .with_modification_date(DateTime(2014, 2, 1))
-                            .within(self.inbox)
-                            .having(issuer='inbox:client1'))
-        create(Builder('forwarding').having(issuer='inbox:client2'))
-
-        self.assertEquals(
-            [forwarding.get_sql_object(), task.get_sql_object()],
-            self.view.issued_tasks())
-
-    def test_is_limited_to_five_entries(self):
-        for i in range(10):
-            create(Builder('forwarding')
-                   .within(self.inbox)
-                   .having(issuer='inbox:client1'))
-
-        self.assertEquals(5, len(self.view.issued_tasks()))
-
-    def test_list_only_active_tasks_and_forwardings(self):
-        active = create(Builder('forwarding')
-                        .within(self.inbox)
-                        .having(issuer='inbox:client1'))
-
-        create(Builder('forwarding')
+    @browsing
+    def test_list_tasks_and_forwardings_issued_by_current_inbox_group(self, browser):
+        create(Builder('task')
+               .with_modification_date(DateTime(2014, 1, 1))
                .within(self.inbox)
                .having(issuer='inbox:client1')
-               .in_state('forwarding-state-closed'))
+               .titled('A Task'))
+        create(Builder('forwarding')
+               .with_modification_date(DateTime(2014, 2, 1))
+               .within(self.inbox)
+               .having(issuer='inbox:client1')
+               .titled('A Forwarding'))
+        create(Builder('forwarding').having(issuer='inbox:client2'))
 
-        self.assertEquals(
-            [active.get_sql_object()],
-            self.view.issued_tasks())
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#issued_inbox_tasksBox li:not(.moreLink) span span').text,
+            ['A Forwarding', 'A Task'])
 
-    def test_is_sorted_by_modfied(self):
-        task1 = create(Builder('task')
-                       .with_modification_date(DateTime(2014, 1, 2))
-                       .having(issuer='inbox:client1'))
+    @browsing
+    def test_task_box_items_are_limited_to_five_and_sorted_by_modified(self, browser):
+        for i in range(1, 6):
+            create(Builder('forwarding')
+                   .within(self.inbox)
+                   .having(issuer='inbox:client1')
+                   .with_modification_date(DateTime(2010, 1, 1) + i)
+                   .titled(u'Task %s' % i))
+        create(Builder('task')
+               .within(self.inbox)
+               .having(issuer='inbox:client1')
+               .with_modification_date(DateTime(2009, 12, 1))
+               .titled(u'Task 6'))
 
-        task2 = create(Builder('task')
-                       .with_modification_date(DateTime(2014, 1, 1))
-                       .having(issuer='inbox:client1'))
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#issued_inbox_tasksBox li:not(.moreLink) span span').text,
+            ['Task 5', 'Task 4', 'Task 3', 'Task 2', 'Task 1'])
 
-        task3 = create(Builder('task')
-                       .with_modification_date(DateTime(2014, 1, 3))
-                       .having(issuer='inbox:client1'))
+    @browsing
+    def test_list_only_active_tasks(self, browser):
+        create(Builder('forwarding')
+               .having(issuer='inbox:client1')
+               .titled('Active'))
+        closed = create(Builder('forwarding')
+                        .having(issuer='inbox:client1')
+                        .in_state('forwarding-state-closed')
+                        .titled('Closed'))
+        sync_task(closed, None)
 
-        self.assertEquals(
-            [task.get_sql_object() for task in [task3, task1, task2]],
-            self.view.issued_tasks())
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#issued_inbox_tasksBox li:not(.moreLink) span span').text,
+            ['Active'])

--- a/opengever/inbox/tests/test_overview.py
+++ b/opengever/inbox/tests/test_overview.py
@@ -39,12 +39,15 @@ class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
         create(Builder('document')
                .titled('portal document')
                .within(self.portal))
+        create(Builder('mail')
+               .titled('A mail')
+               .within(self.inbox))
 
         browser.login().open(self.inbox, view='tabbedview_view-overview')
 
         self.assertSequenceEqual(
             browser.css('#documentsBox li:not(.moreLink) a').text,
-            ['inbox document'])
+            ['inbox document', 'A mail'])
 
     @browsing
     def test_list_only_documents_directly_inside_the_current_inbox(self, browser):
@@ -61,26 +64,6 @@ class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
         self.assertSequenceEqual(
             browser.css('#documentsBox li:not(.moreLink) a').text,
             ['inbox document'])
-
-    @browsing
-    def test_list_only_documents_in_the_current_inbox(self, browser):
-        sub_inbox_1 = create(Builder('inbox')
-                             .within(self.inbox)
-                             .having(responsible_org_unit='client1'))
-
-        sub_inbox_2 = create(Builder('inbox')
-                             .within(self.inbox)
-                             .having(responsible_org_unit='client2'))
-
-        create(Builder('document')
-               .titled('Doc 1').within(sub_inbox_1))
-        create(Builder('document')
-               .titled('Doc 2').within(sub_inbox_2))
-
-        browser.login().open(sub_inbox_1, view='tabbedview_view-overview')
-        self.assertSequenceEqual(
-            browser.css('#documentsBox li:not(.moreLink) a').text,
-            ['Doc 1'])
 
     @browsing
     def test_document_box_items_are_limited_to_ten_and_sorted_by_modified(self, browser):


### PR DESCRIPTION
Dieser PR behebt ein Problem beim rendern der Übersicht des Eingangskorbes. Ursache des Problems waren Änderungen an der Dossier-Übersicht von der die Inbox-Übersicht erbt. Dabei ist Verbesserungspotential augefallen, die ersten Probleme wurden mit folgenden vorsichtigen Änderungen angegangen:

* Tests zu ftw.testbrowser tests umgeschrieben damit die View tatsächlich gerendert wird.
* Views entkoppelt, die Inhaltstypen erben nicht voneinander, die Views sollten das daher auch nicht tun.
* Gemeinsames in ein macro und in eine Mixin Klasse ausgelagert
* Macro so angepasst, dass gewisse schon bestehende Kunden-Anpassungen einfacher eingebaut werden können (Support für Widgets)

Fixes #981.