### PR TITLE
Leeres fieldset `Erweitert` für Forwardig nicht mehr darstellen.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- No longer display emtpy tab 'additional' on forwarding add page.
+  [deiferni]
+
 - Fix MeetingListing: default sort_index, disalbe sorting for time columns.
   [phgross]
 

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -53,3 +53,15 @@ class TestForwarding(FunctionalTestCase):
     def test_autocomplete_does_not_raise_notfound(self, browser):
         browser.login().open(self.inbox,
             view='++add++opengever.inbox.forwarding/++widget++issuer/@@autocomplete-search?term=sb')
+
+    @browsing
+    def test_forwarding_add_form_does_not_render_empty_fieldset_additional(self, browser):
+        doc = create(Builder('document').within(self.inbox).titled(u'Doc 1'))
+        data = dict(paths=[doc.getPhysicalPath()])
+
+        browser.login().open(self.inbox, data,
+                             view='++add++opengever.inbox.forwarding')
+
+        fieldsets = browser.css('form#form fieldset')
+        self.assertEqual(1, len(fieldsets))
+        self.assertEqual('Common', fieldsets.first.css('legend').first.text)


### PR DESCRIPTION
Closes #644.