### PR TITLE
Meeting Auflistung: start/end Spalten überarbeitet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fix MeetingListing: default sort_index, disalbe sorting for time columns.
+  [phgross]
+
 - Include collective.usernamelogger in core dependencies.
   [lgraf]
 

--- a/opengever/meeting/browser/committeetabs.py
+++ b/opengever/meeting/browser/committeetabs.py
@@ -12,7 +12,7 @@ class Meetings(MeetingListingTab):
 
     selection = ViewPageTemplateFile("templates/no_selection.pt")
 
-    sort_on = 'start'
+    sort_on = 'start_datetime'
 
     enabled_actions = []
     major_actions = []

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-26 15:46+0000\n"
+"POT-Creation-Date: 2015-06-12 12:53+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,7 +31,7 @@ msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
 #. Default: "Add Member"
-#: ./opengever/meeting/browser/members.py:42
+#: ./opengever/meeting/browser/members.py:45
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
@@ -177,7 +177,7 @@ msgstr "Ausgangslage"
 msgid "Legal basis"
 msgstr "Rechtsgrundlage"
 
-#: ./opengever/meeting/browser/members_templates/member.pt:41
+#: ./opengever/meeting/browser/templates/member.pt:41
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
@@ -194,7 +194,7 @@ msgid "Please select at least one field for the excerpt."
 msgstr "Bitte wählen Sie mindestens einen Feld für den Protokollauszug aus."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
-#: ./opengever/meeting/model/meeting.py:151
+#: ./opengever/meeting/model/meeting.py:152
 msgid "Pre-Protocol"
 msgstr "Vorprotokoll"
 
@@ -211,7 +211,7 @@ msgstr "Vorprotokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 msgid "Pre-protocol template"
 msgstr "Vorlage Vorprotokoll"
 
-#: ./opengever/meeting/browser/members_templates/member.pt:19
+#: ./opengever/meeting/browser/templates/member.pt:19
 msgid "Properties"
 msgstr "Eigenschaften"
 
@@ -226,11 +226,11 @@ msgid "Proposed action"
 msgstr "Antrag"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:89
-#: ./opengever/meeting/model/meeting.py:154
+#: ./opengever/meeting/model/meeting.py:155
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:157
+#: ./opengever/meeting/model/meeting.py:158
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
@@ -311,12 +311,12 @@ msgid "button_submit_documents"
 msgstr "Dokumente einreichen"
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:73
 msgid "close"
 msgstr "Schliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/meeting.py:63
 msgid "closed"
 msgstr "geschlossen"
 
@@ -326,7 +326,7 @@ msgid "column_comittee"
 msgstr "Kommission"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:27
+#: ./opengever/meeting/tabs/meetinglisting.py:30
 msgid "column_date"
 msgstr "Datum"
 
@@ -345,15 +345,15 @@ msgstr "Bis"
 msgid "column_email"
 msgstr "E-Mail"
 
-#. Default: "End Time"
-#: ./opengever/meeting/tabs/meetinglisting.py:38
-msgid "column_end_time"
-msgstr "Bis (Uhrzeit)"
-
 #. Default: "Firstname"
 #: ./opengever/meeting/tabs/memberlisting.py:25
 msgid "column_firstname"
 msgstr "Vorname"
+
+#. Default: "From"
+#: ./opengever/meeting/tabs/meetinglisting.py:34
+msgid "column_from"
+msgstr "Bis"
 
 #. Default: "Initial Position"
 #: ./opengever/meeting/tabs/proposallisting.py:45
@@ -366,7 +366,7 @@ msgid "column_lastname"
 msgstr "Nachname"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:31
+#: ./opengever/meeting/tabs/meetinglisting.py:27
 msgid "column_location"
 msgstr "Standort"
 
@@ -385,11 +385,6 @@ msgstr "Antrag"
 msgid "column_role"
 msgstr "Rolle"
 
-#. Default: "Start Time"
-#: ./opengever/meeting/tabs/meetinglisting.py:34
-msgid "column_start_time"
-msgstr "Von (Uhrzeit)"
-
 #. Default: "State"
 #: ./opengever/meeting/tabs/proposallisting.py:37
 msgid "column_state"
@@ -402,13 +397,18 @@ msgstr "Status"
 msgid "column_title"
 msgstr "Titel"
 
+#. Default: "To"
+#: ./opengever/meeting/tabs/meetinglisting.py:39
+msgid "column_to"
+msgstr "Von"
+
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:106
+#: ./opengever/meeting/model/proposal.py:108
 msgid "decide"
 msgstr "Beschliessen"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:91
+#: ./opengever/meeting/model/proposal.py:93
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -423,7 +423,7 @@ msgid "form_label_update_preprotocol"
 msgstr "Vorprotokoll aktualisieren"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:61
+#: ./opengever/meeting/model/meeting.py:62
 msgid "held"
 msgstr "Durchgeführt"
 
@@ -454,7 +454,7 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:70
+#: ./opengever/meeting/model/meeting.py:71
 msgid "hold meeting"
 msgstr "Sitzung durchführen"
 
@@ -465,7 +465,7 @@ msgstr "Zieldossier"
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:38
-#: ./opengever/meeting/browser/members_templates/member.pt:49
+#: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:34
 msgid "label_committee"
 msgstr "Kommission"
@@ -481,14 +481,14 @@ msgid "label_current_members"
 msgstr "Aktuelle Mitglieder"
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/members_templates/member.pt:50
 #: ./opengever/meeting/browser/memberships.py:28
+#: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "Von"
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/members_templates/member.pt:51
 #: ./opengever/meeting/browser/memberships.py:33
+#: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Bis"
 
@@ -505,7 +505,7 @@ msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/members_templates/member.pt:62
+#: ./opengever/meeting/browser/templates/member.pt:62
 msgid "label_edit"
 msgstr "Bearbeiten"
 
@@ -515,8 +515,8 @@ msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/browser/members.py:32
-#: ./opengever/meeting/browser/members_templates/member.pt:32
+#: ./opengever/meeting/browser/members.py:35
+#: ./opengever/meeting/browser/templates/member.pt:32
 msgid "label_email"
 msgstr "E-Mail"
 
@@ -531,8 +531,8 @@ msgid "label_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Firstname"
-#: ./opengever/meeting/browser/members.py:22
-#: ./opengever/meeting/browser/members_templates/member.pt:28
+#: ./opengever/meeting/browser/members.py:25
+#: ./opengever/meeting/browser/templates/member.pt:28
 msgid "label_firstname"
 msgstr "Vorname"
 
@@ -547,8 +547,8 @@ msgid "label_last_meeting"
 msgstr "Letzte Sitzung:"
 
 #. Default: "Lastname"
-#: ./opengever/meeting/browser/members.py:27
-#: ./opengever/meeting/browser/members_templates/member.pt:24
+#: ./opengever/meeting/browser/members.py:30
+#: ./opengever/meeting/browser/templates/member.pt:24
 msgid "label_lastname"
 msgstr "Nachname"
 
@@ -603,13 +603,13 @@ msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/members_templates/member.pt:66
+#: ./opengever/meeting/browser/templates/member.pt:66
 msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/members_templates/member.pt:52
 #: ./opengever/meeting/browser/memberships.py:42
+#: ./opengever/meeting/browser/templates/member.pt:52
 msgid "label_role"
 msgstr "Rolle"
 
@@ -702,8 +702,8 @@ msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:60
-#: ./opengever/meeting/model/proposal.py:86
+#: ./opengever/meeting/model/meeting.py:61
+#: ./opengever/meeting/model/proposal.py:88
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -713,37 +713,37 @@ msgid "pre_protocol"
 msgstr "Vorprotokoll"
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:60
+#: ./opengever/meeting/model/proposalhistory.py:61
 msgid "proposal_history_label_created"
 msgstr "Erstellt durch ${user}"
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:140
+#: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_decided"
 msgstr "Antrag beschlossen durch ${user}"
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:112
+#: ./opengever/meeting/model/proposalhistory.py:113
 msgid "proposal_history_label_document_submitted"
 msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:126
+#: ./opengever/meeting/model/proposalhistory.py:127
 msgid "proposal_history_label_document_updated"
 msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:99
+#: ./opengever/meeting/model/proposalhistory.py:100
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Von der Traktandenliste der Sitzung ${meeting} entfernt durch ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:85
+#: ./opengever/meeting/model/proposalhistory.py:86
 msgid "proposal_history_label_scheduled"
 msgstr "Geplant für die Sitzung ${meeting} durch ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:72
+#: ./opengever/meeting/model/proposalhistory.py:73
 msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"
 
@@ -759,22 +759,22 @@ msgstr "Protokollauszug"
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:114
-#: ./opengever/meeting/model/proposal.py:102
+#: ./opengever/meeting/model/proposal.py:104
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:90
+#: ./opengever/meeting/model/proposal.py:92
 msgid "scheduled"
 msgstr "Traktandiert"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/proposal.py:102
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:88
+#: ./opengever/meeting/model/proposal.py:90
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -784,7 +784,6 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:104
+#: ./opengever/meeting/model/proposal.py:106
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
-

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-26 15:46+0000\n"
+"POT-Creation-Date: 2015-06-12 12:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,7 +31,7 @@ msgid "Add Meeting"
 msgstr "Ajouter la séance"
 
 #. Default: "Add Member"
-#: ./opengever/meeting/browser/members.py:42
+#: ./opengever/meeting/browser/members.py:45
 msgid "Add Member"
 msgstr "Ajouter le membre"
 
@@ -177,7 +177,7 @@ msgstr "Situation initiale"
 msgid "Legal basis"
 msgstr "Base légale"
 
-#: ./opengever/meeting/browser/members_templates/member.pt:41
+#: ./opengever/meeting/browser/templates/member.pt:41
 msgid "Memberships"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgid "Please select at least one field for the excerpt."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
-#: ./opengever/meeting/model/meeting.py:151
+#: ./opengever/meeting/model/meeting.py:152
 msgid "Pre-Protocol"
 msgstr "Pré-procès-verbal"
 
@@ -211,7 +211,7 @@ msgstr "Pré-procès-verbal pour la séance ${title} actualisé avec succès"
 msgid "Pre-protocol template"
 msgstr ""
 
-#: ./opengever/meeting/browser/members_templates/member.pt:19
+#: ./opengever/meeting/browser/templates/member.pt:19
 msgid "Properties"
 msgstr "Propriétés"
 
@@ -226,11 +226,11 @@ msgid "Proposed action"
 msgstr "Action proposée"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:89
-#: ./opengever/meeting/model/meeting.py:154
+#: ./opengever/meeting/model/meeting.py:155
 msgid "Protocol"
 msgstr "Procès-verbal"
 
-#: ./opengever/meeting/model/meeting.py:157
+#: ./opengever/meeting/model/meeting.py:158
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -311,12 +311,12 @@ msgid "button_submit_documents"
 msgstr "Soumettre les documents"
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:73
 msgid "close"
 msgstr "Fermer"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/meeting.py:63
 msgid "closed"
 msgstr "Fermé"
 
@@ -326,7 +326,7 @@ msgid "column_comittee"
 msgstr "Commission"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:27
+#: ./opengever/meeting/tabs/meetinglisting.py:30
 msgid "column_date"
 msgstr "Date"
 
@@ -345,15 +345,15 @@ msgstr "Jusqu'à"
 msgid "column_email"
 msgstr "Email"
 
-#. Default: "End Time"
-#: ./opengever/meeting/tabs/meetinglisting.py:38
-msgid "column_end_time"
-msgstr "Jusqu'à (heure)"
-
 #. Default: "Firstname"
 #: ./opengever/meeting/tabs/memberlisting.py:25
 msgid "column_firstname"
 msgstr "Prénom"
+
+#. Default: "From"
+#: ./opengever/meeting/tabs/meetinglisting.py:34
+msgid "column_from"
+msgstr "De"
 
 #. Default: "Initial Position"
 #: ./opengever/meeting/tabs/proposallisting.py:45
@@ -366,7 +366,7 @@ msgid "column_lastname"
 msgstr "Nom"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:31
+#: ./opengever/meeting/tabs/meetinglisting.py:27
 msgid "column_location"
 msgstr "Site"
 
@@ -385,11 +385,6 @@ msgstr "Proposition"
 msgid "column_role"
 msgstr "Rôle"
 
-#. Default: "Start Time"
-#: ./opengever/meeting/tabs/meetinglisting.py:34
-msgid "column_start_time"
-msgstr "De (Heure)"
-
 #. Default: "State"
 #: ./opengever/meeting/tabs/proposallisting.py:37
 msgid "column_state"
@@ -402,13 +397,18 @@ msgstr "Etat"
 msgid "column_title"
 msgstr "Titre"
 
+#. Default: "To"
+#: ./opengever/meeting/tabs/meetinglisting.py:39
+msgid "column_to"
+msgstr "Jusqu'à"
+
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:106
+#: ./opengever/meeting/model/proposal.py:108
 msgid "decide"
 msgstr "Décider"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:91
+#: ./opengever/meeting/model/proposal.py:93
 msgid "decided"
 msgstr "Décidé"
 
@@ -423,7 +423,7 @@ msgid "form_label_update_preprotocol"
 msgstr "Actualiser le pré-procès-verbal"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:61
+#: ./opengever/meeting/model/meeting.py:62
 msgid "held"
 msgstr "Tenu"
 
@@ -454,7 +454,7 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:70
+#: ./opengever/meeting/model/meeting.py:71
 msgid "hold meeting"
 msgstr "Tenir séance"
 
@@ -465,7 +465,7 @@ msgstr "Dossier de destination"
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:38
-#: ./opengever/meeting/browser/members_templates/member.pt:49
+#: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:34
 msgid "label_committee"
 msgstr "Commission"
@@ -481,14 +481,14 @@ msgid "label_current_members"
 msgstr "Membres actuels"
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/members_templates/member.pt:50
 #: ./opengever/meeting/browser/memberships.py:28
+#: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "De"
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/members_templates/member.pt:51
 #: ./opengever/meeting/browser/memberships.py:33
+#: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Jusqu'à"
 
@@ -505,7 +505,7 @@ msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/members_templates/member.pt:62
+#: ./opengever/meeting/browser/templates/member.pt:62
 msgid "label_edit"
 msgstr ""
 
@@ -515,8 +515,8 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/browser/members.py:32
-#: ./opengever/meeting/browser/members_templates/member.pt:32
+#: ./opengever/meeting/browser/members.py:35
+#: ./opengever/meeting/browser/templates/member.pt:32
 msgid "label_email"
 msgstr "Email"
 
@@ -531,8 +531,8 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/meeting/browser/members.py:22
-#: ./opengever/meeting/browser/members_templates/member.pt:28
+#: ./opengever/meeting/browser/members.py:25
+#: ./opengever/meeting/browser/templates/member.pt:28
 msgid "label_firstname"
 msgstr "Prénom"
 
@@ -547,8 +547,8 @@ msgid "label_last_meeting"
 msgstr "Dernière séance:"
 
 #. Default: "Lastname"
-#: ./opengever/meeting/browser/members.py:27
-#: ./opengever/meeting/browser/members_templates/member.pt:24
+#: ./opengever/meeting/browser/members.py:30
+#: ./opengever/meeting/browser/templates/member.pt:24
 msgid "label_lastname"
 msgstr "Nom"
 
@@ -603,13 +603,13 @@ msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/members_templates/member.pt:66
+#: ./opengever/meeting/browser/templates/member.pt:66
 msgid "label_remove"
 msgstr ""
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/members_templates/member.pt:52
 #: ./opengever/meeting/browser/memberships.py:42
+#: ./opengever/meeting/browser/templates/member.pt:52
 msgid "label_role"
 msgstr "Rôle"
 
@@ -702,8 +702,8 @@ msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:60
-#: ./opengever/meeting/model/proposal.py:86
+#: ./opengever/meeting/model/meeting.py:61
+#: ./opengever/meeting/model/proposal.py:88
 msgid "pending"
 msgstr "En modification"
 
@@ -713,37 +713,37 @@ msgid "pre_protocol"
 msgstr "Pré-procès-verbal"
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:60
+#: ./opengever/meeting/model/proposalhistory.py:61
 msgid "proposal_history_label_created"
 msgstr "Créé par ${user}"
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:140
+#: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_decided"
 msgstr ""
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:112
+#: ./opengever/meeting/model/proposalhistory.py:113
 msgid "proposal_history_label_document_submitted"
 msgstr "Document ${title} soumis en version ${version} par ${user}"
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:126
+#: ./opengever/meeting/model/proposalhistory.py:127
 msgid "proposal_history_label_document_updated"
 msgstr "Document soumis ${title} actualisé en version ${version} par ${user}"
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:99
+#: ./opengever/meeting/model/proposalhistory.py:100
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Enlevé de l'ordre du jour de la séance ${meeting} par ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:85
+#: ./opengever/meeting/model/proposalhistory.py:86
 msgid "proposal_history_label_scheduled"
 msgstr "Prévu pour la séance ${meeting} par ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:72
+#: ./opengever/meeting/model/proposalhistory.py:73
 msgid "proposal_history_label_submitted"
 msgstr "Soumis par ${user}"
 
@@ -759,22 +759,22 @@ msgstr ""
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:114
-#: ./opengever/meeting/model/proposal.py:102
+#: ./opengever/meeting/model/proposal.py:104
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:90
+#: ./opengever/meeting/model/proposal.py:92
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/proposal.py:102
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:88
+#: ./opengever/meeting/model/proposal.py:90
 msgid "submitted"
 msgstr "Soumis"
 
@@ -784,7 +784,6 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:104
+#: ./opengever/meeting/model/proposal.py:106
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
-

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-05-26 15:46+0000\n"
+"POT-Creation-Date: 2015-06-12 12:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,7 +31,7 @@ msgid "Add Meeting"
 msgstr ""
 
 #. Default: "Add Member"
-#: ./opengever/meeting/browser/members.py:42
+#: ./opengever/meeting/browser/members.py:45
 msgid "Add Member"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "Legal basis"
 msgstr ""
 
-#: ./opengever/meeting/browser/members_templates/member.pt:41
+#: ./opengever/meeting/browser/templates/member.pt:41
 msgid "Memberships"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgid "Please select at least one field for the excerpt."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
-#: ./opengever/meeting/model/meeting.py:151
+#: ./opengever/meeting/model/meeting.py:152
 msgid "Pre-Protocol"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "Pre-protocol template"
 msgstr ""
 
-#: ./opengever/meeting/browser/members_templates/member.pt:19
+#: ./opengever/meeting/browser/templates/member.pt:19
 msgid "Properties"
 msgstr ""
 
@@ -226,11 +226,11 @@ msgid "Proposed action"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:89
-#: ./opengever/meeting/model/meeting.py:154
+#: ./opengever/meeting/model/meeting.py:155
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:157
+#: ./opengever/meeting/model/meeting.py:158
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -311,12 +311,12 @@ msgid "button_submit_documents"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:73
 msgid "close"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/meeting.py:63
 msgid "closed"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgid "column_comittee"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:27
+#: ./opengever/meeting/tabs/meetinglisting.py:30
 msgid "column_date"
 msgstr ""
 
@@ -345,14 +345,14 @@ msgstr ""
 msgid "column_email"
 msgstr ""
 
-#. Default: "End Time"
-#: ./opengever/meeting/tabs/meetinglisting.py:38
-msgid "column_end_time"
-msgstr ""
-
 #. Default: "Firstname"
 #: ./opengever/meeting/tabs/memberlisting.py:25
 msgid "column_firstname"
+msgstr ""
+
+#. Default: "From"
+#: ./opengever/meeting/tabs/meetinglisting.py:34
+msgid "column_from"
 msgstr ""
 
 #. Default: "Initial Position"
@@ -366,7 +366,7 @@ msgid "column_lastname"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:31
+#: ./opengever/meeting/tabs/meetinglisting.py:27
 msgid "column_location"
 msgstr ""
 
@@ -385,11 +385,6 @@ msgstr ""
 msgid "column_role"
 msgstr ""
 
-#. Default: "Start Time"
-#: ./opengever/meeting/tabs/meetinglisting.py:34
-msgid "column_start_time"
-msgstr ""
-
 #. Default: "State"
 #: ./opengever/meeting/tabs/proposallisting.py:37
 msgid "column_state"
@@ -402,13 +397,18 @@ msgstr ""
 msgid "column_title"
 msgstr ""
 
+#. Default: "To"
+#: ./opengever/meeting/tabs/meetinglisting.py:39
+msgid "column_to"
+msgstr ""
+
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:106
+#: ./opengever/meeting/model/proposal.py:108
 msgid "decide"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:91
+#: ./opengever/meeting/model/proposal.py:93
 msgid "decided"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgid "form_label_update_preprotocol"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:61
+#: ./opengever/meeting/model/meeting.py:62
 msgid "held"
 msgstr ""
 
@@ -454,7 +454,7 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:70
+#: ./opengever/meeting/model/meeting.py:71
 msgid "hold meeting"
 msgstr ""
 
@@ -465,7 +465,7 @@ msgstr ""
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:38
-#: ./opengever/meeting/browser/members_templates/member.pt:49
+#: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:34
 msgid "label_committee"
 msgstr ""
@@ -481,14 +481,14 @@ msgid "label_current_members"
 msgstr ""
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/members_templates/member.pt:50
 #: ./opengever/meeting/browser/memberships.py:28
+#: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr ""
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/members_templates/member.pt:51
 #: ./opengever/meeting/browser/memberships.py:33
+#: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr ""
 
@@ -505,7 +505,7 @@ msgid "label_documents"
 msgstr ""
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/members_templates/member.pt:62
+#: ./opengever/meeting/browser/templates/member.pt:62
 msgid "label_edit"
 msgstr ""
 
@@ -515,8 +515,8 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/browser/members.py:32
-#: ./opengever/meeting/browser/members_templates/member.pt:32
+#: ./opengever/meeting/browser/members.py:35
+#: ./opengever/meeting/browser/templates/member.pt:32
 msgid "label_email"
 msgstr ""
 
@@ -531,8 +531,8 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/meeting/browser/members.py:22
-#: ./opengever/meeting/browser/members_templates/member.pt:28
+#: ./opengever/meeting/browser/members.py:25
+#: ./opengever/meeting/browser/templates/member.pt:28
 msgid "label_firstname"
 msgstr ""
 
@@ -547,8 +547,8 @@ msgid "label_last_meeting"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/meeting/browser/members.py:27
-#: ./opengever/meeting/browser/members_templates/member.pt:24
+#: ./opengever/meeting/browser/members.py:30
+#: ./opengever/meeting/browser/templates/member.pt:24
 msgid "label_lastname"
 msgstr ""
 
@@ -602,13 +602,13 @@ msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/members_templates/member.pt:66
+#: ./opengever/meeting/browser/templates/member.pt:66
 msgid "label_remove"
 msgstr ""
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/members_templates/member.pt:52
 #: ./opengever/meeting/browser/memberships.py:42
+#: ./opengever/meeting/browser/templates/member.pt:52
 msgid "label_role"
 msgstr ""
 
@@ -701,8 +701,8 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:60
-#: ./opengever/meeting/model/proposal.py:86
+#: ./opengever/meeting/model/meeting.py:61
+#: ./opengever/meeting/model/proposal.py:88
 msgid "pending"
 msgstr ""
 
@@ -712,37 +712,37 @@ msgid "pre_protocol"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:60
+#: ./opengever/meeting/model/proposalhistory.py:61
 msgid "proposal_history_label_created"
 msgstr ""
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:140
+#: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_decided"
 msgstr ""
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:112
+#: ./opengever/meeting/model/proposalhistory.py:113
 msgid "proposal_history_label_document_submitted"
 msgstr ""
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:126
+#: ./opengever/meeting/model/proposalhistory.py:127
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:99
+#: ./opengever/meeting/model/proposalhistory.py:100
 msgid "proposal_history_label_remove_scheduled"
 msgstr ""
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:85
+#: ./opengever/meeting/model/proposalhistory.py:86
 msgid "proposal_history_label_scheduled"
 msgstr ""
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:72
+#: ./opengever/meeting/model/proposalhistory.py:73
 msgid "proposal_history_label_submitted"
 msgstr ""
 
@@ -758,22 +758,22 @@ msgstr ""
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:114
-#: ./opengever/meeting/model/proposal.py:102
+#: ./opengever/meeting/model/proposal.py:104
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:90
+#: ./opengever/meeting/model/proposal.py:92
 msgid "scheduled"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/proposal.py:102
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:88
+#: ./opengever/meeting/model/proposal.py:90
 msgid "submitted"
 msgstr ""
 
@@ -783,7 +783,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:104
+#: ./opengever/meeting/model/proposal.py:106
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -211,6 +211,21 @@ class Meeting(Base):
     def get_date(self):
         return api.portal.get_localized_time(datetime=self.start)
 
+    def get_start(self):
+        """Returns the start datetime in localized format.
+        """
+        return api.portal.get_localized_time(
+            datetime=self.start, long_format=True)
+
+    def get_end(self):
+        """Returns the end datetime in localized format.
+        """
+        if self.end:
+            return api.portal.get_localized_time(
+                datetime=self.end, long_format=True)
+
+        return None
+
     def get_start_time(self):
         return self._get_localized_time(self.start)
 

--- a/opengever/meeting/tabs/meetinglisting.py
+++ b/opengever/meeting/tabs/meetinglisting.py
@@ -23,21 +23,23 @@ class MeetingListingTab(BaseListingTab):
          'column_title': _(u'column_title', default=u'Title'),
          'transform': lambda item, value: item.get_link()},
 
-        {'column': 'date',
-         'column_title': _(u'column_date', default=u'Date'),
-         'transform': lambda item, value: item.get_date()},
-
         {'column': 'location',
          'column_title': _(u'column_location', default=u'Location')},
 
-        {'column': 'start',
-         'column_title': _(u'column_start_time', default=u'Start Time'),
-         'transform': lambda item, value: item.get_start_time()},
+        {'column': 'start_datetime',
+         'column_title': _(u'column_date', default=u'Date'),
+         'transform': lambda item, value: item.get_date()},
 
-        {'column': 'end',
-         'column_title': _(u'column_end_time', default=u'End Time'),
-         'transform': lambda item, value: item.get_end_time()},
-        )
+        {'column': 'start_time',
+         'column_title': _(u'column_from', default=u'From'),
+         'transform': lambda item, value: item.get_start_time(),
+         'sortable': False},
+
+        {'column': 'end_time',
+         'column_title': _(u'column_to', default=u'To'),
+         'transform': lambda item, value: item.get_end_time(),
+         'sortable': False},
+    )
 
     def get_base_query(self):
         return Meeting.query.filter_by(committee=self.context.load_model())

--- a/opengever/meeting/tests/test_committee_tabs.py
+++ b/opengever/meeting/tests/test_committee_tabs.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from datetime import timedelta
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestCommitteeTabs(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCommitteeTabs, self).setUp()
+
+        self.maxDiff = None
+        self.container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee')
+                                .within(self.container)
+                                .titled(u'Kleiner Burgerrat'))
+        self.committee_model = self.committee.load_model()
+
+        create(Builder('meeting')
+               .having(committee=self.committee_model,
+                       location='Bern',
+                       start=datetime(2015, 01, 01, 12, 00),
+                       end=datetime(2015, 01, 03, 18, 00)))
+
+        create(Builder('meeting')
+               .having(committee=self.committee_model,
+                       location='Bern',
+                       start=datetime(2015, 06, 13, 9, 30)))
+
+    @browsing
+    def test_meeting_listing(self, browser):
+        browser.login().open(self.committee, view='tabbedview_view-meetings')
+
+        table = browser.css('.listing').first
+        self.assertEquals([
+            {'Title': 'Bern, Jan 01, 2015',
+             'Date': 'Jan 01, 2015',
+             'Location': 'Bern',
+             'From': '12:00 PM',
+             'To': '06:00 PM'},
+            {'Title': 'Bern, Jun 13, 2015',
+             'Date': 'Jun 13, 2015',
+             'Location': 'Bern',
+             'From': '09:30 AM',
+             'To': ''}
+        ], table.dicts())


### PR DESCRIPTION
- Default Sortierung korrigiert (fixes #986)
- Keine Sortierung mehr bei Uhrzeit Spalten
- Umbenennen  der Spalten Titel

![bildschirmfoto 2015-06-12 um 15 06 49](https://cloud.githubusercontent.com/assets/485755/8130660/b2ecdc18-1114-11e5-8c02-931fb7967269.png)

@lukas