### PR TITLE
Monkey patch http_server.compute_timezone_for_log in order to fix DST bug

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Monkey patch http_server.compute_timezone_for_log in order to fix
+  DST bug in timezone calculation for Z2 logs.
+  [lgraf]
+
 - No longer display emtpy tab 'additional' on forwarding add page.
   [deiferni]
 


### PR DESCRIPTION
This adds a monkey patch for [`ZServer.medusa.http_server.compute_timezone_for_log`](https://github.com/zopefoundation/Zope/blob/2.13/src/ZServer/medusa/http_server.py#L772-L787) (and the module global [`http_server.tz_for_log`](https://github.com/zopefoundation/Zope/blob/2.13/src/ZServer/medusa/http_server.py#L790) where the computation result of that function is saved) in order to fix a DST bug in timezone calculation for Z2 logs.

The original function [tries to use `if time.daylight:`](https://github.com/zopefoundation/Zope/blob/2.13/src/ZServer/medusa/http_server.py#L773) to determine whether it is daylight savings time is currently obeserved or not. However, [`time.daylight`](https://docs.python.org/2/library/time.html#time.daylight) only says whether a a DST timezone is **defined** or not - so if time zone makes a distinction between DST (summer time) and winter time, `time.daylight` is *always* `1`, all year round.

Also see: [Python Issue #7229: Manual entry for time.daylight can be misleading](https://bugs.python.org/issue7229)

Instead, what should be used to determine whether DST is currently being observed is [`time.localtime().tm_isdst`](http://stackoverflow.com/a/2881048/1599111).