### PR TITLE
Macro-Expression verbessern & Cleanup

### DIFF
--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -88,7 +88,7 @@
                   </tal:sql>
                 </li>
 
-                <li class="moreLink" tal:condition="box/href">
+                <li class="moreLink" tal:condition="exists: box/href">
                   <a tal:attributes="href string:#${box/href}"
                      i18n:translate="">
                   show all</a>

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -50,20 +50,6 @@ class TestDossier(FunctionalTestCase):
         tabs = [action['title'] for action in actions]
         return tabs
 
-    def assert_additional_attributes_overview_box_labels(self, expected, obj):
-        overview = obj.restrictedTraverse('tabbedview_view-overview')
-        additional_widgets = overview.additional_attributes()
-
-        self.assertEquals(
-            expected, [widget.label for widget in additional_widgets])
-
-    def assert_additional_attributes_overview_box_values(self, expected, obj):
-        overview = obj.restrictedTraverse('tabbedview_view-overview')
-        additional_widgets = overview.additional_attributes()
-
-        self.assertEquals(
-            expected, [widget.value for widget in additional_widgets])
-
     def assert_tabbedview_tabs_for_obj(self, expected_tabs, obj):
         self.assertEquals(expected_tabs,
                           self._get_active_tabbedview_tab_titles(obj))


### PR DESCRIPTION
- Die Macro-expression sollte `exists:` brauchen da man nur auf die Existenz überprüfen will
- Zwei Methoden entfernen, die nicht mehr gebraucht werden

*changelog sollte nicht nötig sein*