### PR TITLE
Fristverlängerung auch für Stellvertreter erlauben.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Allow deadline modification also for issuing_org_unit agency members.
+  [phgross]
+
 - Monkey patch http_server.compute_timezone_for_log in order to fix
   DST bug in timezone calculation for Z2 logs.
   [lgraf]

--- a/opengever/task/browser/modify_deadline.py
+++ b/opengever/task/browser/modify_deadline.py
@@ -104,15 +104,6 @@ class ModifyDeadlineFormView(layout.FormWrapper, grok.View):
     __call__ = layout.FormWrapper.__call__
 
 
-class DeadlineModifierController(grok.View):
-    grok.context(ITask)
-    grok.name('is_deadline_modification_allowed')
-    # grok.require('zope.Public')
-
-    def render(self):
-        return IDeadlineModifier(self.context).is_modify_allowed()
-
-
 class RemoteDeadlineModifier(grok.View):
     grok.context(ITask)
     grok.name('remote_deadline_modifier')

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -8,6 +8,7 @@ from opengever.task.browser.modify_deadline import ModifyDeadlineFormView
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.util import get_documents_of_task
+from plone import api
 from plone.protect.utils import addTokenToUrl
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
@@ -609,6 +610,12 @@ class Conditions(object):
     @property
     def is_responsible(self):
         return self.task.responsible_actor.corresponds_to(self.current_user)
+
+    @property
+    def is_administrator(self):
+        current = api.user.get_current()
+        return bool(current.has_role('Administrator') or
+                    current.has_role('Manager'))
 
     @property
     def is_issuing_orgunit_agency_member(self):

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -151,7 +151,8 @@ class TaskTransitionController(BrowserView):
 
     @guard('task-transition-modify-deadline')
     def modify_deadline_guard(self, conditions, include_agency):
-        return IDeadlineModifier(self.context).is_modify_allowed()
+        return IDeadlineModifier(self.context).is_modify_allowed(
+            include_agency=include_agency)
 
     @action('task-transition-modify-deadline')
     def modify_deadline_action(self, transition):

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -242,6 +242,11 @@ class Task(Container):
     def oguid(self):
         return Oguid(get_current_admin_unit().id(), self.int_id)
 
+    @property
+    def is_editable(self):
+        current_state = api.content.get_state(self)
+        return current_state in ['task-state-open', 'task-state-in-progress']
+
     def get_issuer_label(self):
         return self.get_sql_object().get_issuer_label()
 

--- a/opengever/task/tests/test_actionmenu_viewlet.py
+++ b/opengever/task/tests/test_actionmenu_viewlet.py
@@ -35,7 +35,8 @@ class TestActionmenuViewlet(FunctionalTestCase):
             browser.css('ul.regular_buttons a').text)
 
         self.assertEquals(
-            ['task-transition-open-cancelled',
+            ['task-transition-modify-deadline',
+             'task-transition-open-cancelled',
              'task-transition-open-tested-and-closed'],
             browser.css('dl.agency_buttons ul a').text)
 


### PR DESCRIPTION
Neu können nun auch Mitglieder der Eingangskorb-Gruppe des Auftraggeber Mandanten, stellvertretend die Frist ändern. 

Zudem wird nun auch die Aktion `Frist ändern` korrekt im Stellvertreter DropDown dargestellt, falls die Aktion nur Aufgrund Stellvertreter-Berechtigung möglich ist.

![bildschirmfoto 2015-06-15 um 15 03 55](https://cloud.githubusercontent.com/assets/485755/8160418/c89626b6-136f-11e5-810e-d2a2c4a8ac30.png)

Closes #996.

@lukasgraf @deiferni 