### PR TITLE
Doppeltes akzeptieren/zuweisen von Tasks verhindern.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Prevent that tasks/forwardings can be accepted/assigned twice.
+  This problem occurred with tasks/forwardings distributed over two (or more) admin-units.
+  [deiferni]
+
 - Allow deadline modification also for issuing_org_unit agency members.
   [phgross]
 

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -108,7 +108,7 @@ class Task(Base):
     def id(self):
         return self.task_id
 
-    def can_be_accepted(self):
+    def is_open(self):
         return self.review_state in self.OPEN_STATES
 
     @property

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -44,6 +44,8 @@ class Task(Base):
                                   'task-state-resolved',
                                   'forwarding-state-closed']
 
+    OPEN_STATES = ['task-state-open', 'forwarding-state-open']
+
     __tablename__ = 'tasks'
     __table_args__ = (UniqueConstraint('admin_unit_id', 'int_id'), {})
 
@@ -105,6 +107,9 @@ class Task(Base):
     @property
     def id(self):
         return self.task_id
+
+    def can_be_accepted(self):
+        return self.review_state in self.OPEN_STATES
 
     @property
     def issuer_actor(self):

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -65,7 +65,7 @@ def accept_forwarding_with_successor(
 
     # the predessecor (the forwarding on the remote client)
     predecessor = Task.query.by_oguid(predecessor_oguid)
-    if not predecessor.can_be_accepted():
+    if not predecessor.is_open():
         raise CannotAcceptTaskException('Forwarding has already been accepted')
 
     # transport the remote forwarding to the inbox or actual yearfolder
@@ -184,7 +184,7 @@ def assign_forwarding_to_dossier(
         context, forwarding_oguid, dossier, response_text):
 
     forwarding = Task.query.by_oguid(forwarding_oguid)
-    if not forwarding.can_be_accepted():
+    if not forwarding.is_open():
         raise CannotAssignForwardingException(
             'Forwarding has already been accepted')
 
@@ -238,7 +238,7 @@ def assign_forwarding_to_dossier(
 
 def accept_task_with_successor(dossier, predecessor_oguid, response_text):
     predecessor = Task.query.by_oguid(predecessor_oguid)
-    if not predecessor.can_be_accepted():
+    if not predecessor.is_open():
         raise CannotAcceptTaskException('Task has already been accepted')
 
     # Transport the original task (predecessor) to this dossier. The new

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -12,6 +12,7 @@ from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import _
 from opengever.task.adapters import IResponseContainer
 from opengever.task.exceptions import CannotAcceptTaskException
+from opengever.task.exceptions import CannotAssignForwardingException
 from opengever.task.exceptions import TaskRemoteRequestError
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import ITaskDocumentsTransporter
@@ -180,9 +181,12 @@ def accept_forwarding_with_successor(
 
 
 def assign_forwarding_to_dossier(
-    context, forwarding_oguid, dossier, response_text):
+        context, forwarding_oguid, dossier, response_text):
 
     forwarding = Task.query.by_oguid(forwarding_oguid)
+    if not forwarding.can_be_accepted():
+        raise CannotAssignForwardingException(
+            'Forwarding has already been accepted')
 
     forwarding_obj = context.unrestrictedTraverse(
         forwarding.physical_path.encode('utf-8'))

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -12,6 +12,7 @@ from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import _
 from opengever.task.adapters import IResponseContainer
 from opengever.task.exceptions import CannotAcceptTaskException
+from opengever.task.exceptions import TaskRemoteRequestError
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import ITaskDocumentsTransporter
 from opengever.task.interfaces import IYearfolderStorer
@@ -153,9 +154,9 @@ def accept_forwarding_with_successor(
                                 data=request_data)
 
     if response.read().strip() != 'OK':
-        raise Exception('Adding the response and changing the '
-                        'workflow state on the predecessor forwarding '
-                        'failed.')
+        raise TaskRemoteRequestError(
+            'Adding the response and changing the workflow state on the '
+            'predecessor forwarding failed.')
 
     if dossier:
         # Update watchers for created successor forwarding and task
@@ -283,9 +284,9 @@ def accept_task_with_successor(dossier, predecessor_oguid, response_text):
                                 data=request_data)
 
     if response.read().strip() != 'OK':
-        raise Exception('Adding the response and changing the '
-                        'workflow state on the predecessor task '
-                        'failed.')
+        raise TaskRemoteRequestError(
+            'Adding the response and changing the workflow state on the '
+            'predecessor task failed.')
 
     # Connect the predecessor and the successor task. This needs to be done
     # that late for preventing a deadlock because of the locked tasks table.

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -11,6 +11,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import _
 from opengever.task.adapters import IResponseContainer
+from opengever.task.exceptions import CannotAcceptTaskException
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import ITaskDocumentsTransporter
 from opengever.task.interfaces import IYearfolderStorer
@@ -62,6 +63,8 @@ def accept_forwarding_with_successor(
 
     # the predessecor (the forwarding on the remote client)
     predecessor = Task.query.by_oguid(predecessor_oguid)
+    if not predecessor.can_be_accepted():
+        raise CannotAcceptTaskException('Forwarding has already been accepted')
 
     # transport the remote forwarding to the inbox or actual yearfolder
     transporter = Transporter()
@@ -229,8 +232,9 @@ def assign_forwarding_to_dossier(
 
 
 def accept_task_with_successor(dossier, predecessor_oguid, response_text):
-
     predecessor = Task.query.by_oguid(predecessor_oguid)
+    if not predecessor.can_be_accepted():
+        raise CannotAcceptTaskException('Task has already been accepted')
 
     # Transport the original task (predecessor) to this dossier. The new
     # response and task change is not yet done and will be done later. This

--- a/opengever/task/exceptions.py
+++ b/opengever/task/exceptions.py
@@ -6,5 +6,9 @@ class CannotAcceptTaskException(TaskException):
     pass
 
 
+class CannotAssignForwardingException(TaskException):
+    pass
+
+
 class TaskRemoteRequestError(TaskException):
     pass

--- a/opengever/task/exceptions.py
+++ b/opengever/task/exceptions.py
@@ -4,3 +4,7 @@ class TaskException(Exception):
 
 class CannotAcceptTaskException(TaskException):
     pass
+
+
+class TaskRemoteRequestError(TaskException):
+    pass

--- a/opengever/task/exceptions.py
+++ b/opengever/task/exceptions.py
@@ -1,0 +1,6 @@
+class TaskException(Exception):
+    """Base exception class for custom task exceptions."""
+
+
+class CannotAcceptTaskException(TaskException):
+    pass

--- a/opengever/task/tests/test_accept.py
+++ b/opengever/task/tests/test_accept.py
@@ -1,4 +1,3 @@
-from Products.CMFCore.utils import getToolByName
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -9,11 +8,15 @@ from opengever.globalindex.model.task import Task
 from opengever.ogds.base import utils
 from opengever.task.adapters import IResponseContainer
 from opengever.task.browser.accept.utils import accept_forwarding_with_successor
+from opengever.task.browser.accept.utils import accept_task_with_successor
+from opengever.task.exceptions import CannotAcceptTaskException
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.tests.data import DOCUMENT_EXTRACTION, FORWARDING_EXTRACTION
+from opengever.testing import FunctionalTestCase
 from opengever.testing import OPENGEVER_INTEGRATION_TESTING
-from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 import unittest2
@@ -28,6 +31,30 @@ class FakeResponse(object):
 
     def read(self):
         return self.result
+
+
+class TestAcceptTask(FunctionalTestCase):
+
+    def test_cannot_accept_task_twice(self):
+        dossier = create(Builder('dossier').titled(u'Dosssier A'))
+        predecessor = create(Builder('task')
+                             .in_state('task-state-in-progress')
+                             .within(dossier))
+
+        with self.assertRaises(CannotAcceptTaskException):
+            accept_task_with_successor(
+                dossier, predecessor.oguid.id, 'msg')
+
+    def test_cannot_accept_forwarding_twice(self):
+        inbox = create(Builder('inbox').titled(u'Inbox'))
+        forwarding = create(Builder('forwarding')
+                            .within(inbox)
+                            .in_state('forwarding-state-closed '))
+
+        with self.assertRaises(CannotAcceptTaskException):
+            accept_forwarding_with_successor(
+                inbox, forwarding.oguid.id, 'msg')
+
 
 class TestTaskAccepting(MockTestCase):
 

--- a/opengever/task/tests/test_assign_to_dossier.py
+++ b/opengever/task/tests/test_assign_to_dossier.py
@@ -3,6 +3,8 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.task.browser.accept.utils import assign_forwarding_to_dossier
+from opengever.task.exceptions import CannotAssignForwardingException
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 
@@ -32,6 +34,17 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         self.repo_folder = create(Builder('repository')
                                   .titled('Repo A')
                                   .within(self.repo_root))
+
+    def test_cannot_assign_forwarding_twice(self):
+        dossier = create(Builder('dossier').titled(u'Dosssier A'))
+        inbox = create(Builder('inbox').titled(u'Inbox'))
+        forwarding = create(Builder('forwarding')
+                            .within(inbox)
+                            .in_state('forwarding-state-closed '))
+
+        with self.assertRaises(CannotAssignForwardingException):
+            assign_forwarding_to_dossier(
+                inbox, forwarding.oguid.id, dossier, 'msg')
 
     @browsing
     def test_assign_to_new_dossier(self, browser):


### PR DESCRIPTION
Dieser PR führt eine zusätzliche Überprüfung beim Ändern des Taks/Forwarding status ein. Dabei wird überprüft, dass sich Task/Forwarding in einem validen Anfangszustand befinden.

Fixes #943.