### PR TITLE
Verhindern, dass Aktivitäten doppelt registriert werden.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,15 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Activity: Prevent generating duplicated activities when:
+
+  - Reassigning tasks
+  - Adding subtasks (Plone action-menu)
+  - Delegating tasks (Workflow)
+  - Modifying a deadline
+
+  [deiferni]
+
 - Migrate activity schema, use text for summary column.
   [deiferni]
 

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -294,3 +294,6 @@ msgstr "Deaktivieren"
 msgid "tasktemplatefolder-transition-inactiv-activ"
 msgstr "Aktivieren"
 
+msgid "transition-add-document"
+msgstr "Dokument hinzugefügt"
+

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -294,3 +294,6 @@ msgstr "Déactiver"
 msgid "tasktemplatefolder-transition-inactiv-activ"
 msgstr "Activer"
 
+msgid "transition-add-document"
+msgstr ""
+

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -243,6 +243,9 @@ msgstr ""
 msgid "task-transition-resolved-tested-and-closed"
 msgstr ""
 
+msgid "transition-add-document"
+msgstr ""
+
 msgid "task-state-cancelled"
 msgstr ""
 

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -122,6 +122,8 @@ class TaskTransitionActivity(TaskActivity):
     """Activity which represents a transition task transition change.
     """
 
+    IGNORED_TRANSITIONS = ['transition-add-subtask']
+
     def __init__(self, context, response):
         self.context = context
         self.request = self.context.REQUEST
@@ -145,6 +147,12 @@ class TaskTransitionActivity(TaskActivity):
     @property
     def description(self):
         return self.response.text
+
+    def record(self):
+        if self.transition in self.IGNORED_TRANSITIONS:
+            return
+
+        return super(TaskTransitionActivity, self).record()
 
 
 class TaskReassignActivity(TaskTransitionActivity):

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -9,11 +9,13 @@ from zope.i18n import translate
 
 
 class TaskActivity(object):
-    """The TaskActivity class is a representation for every activity which can be done with or
-    on a task. It provides every needed attribute/methods to record the activity
-    in the notification center.
-    """
+    """Abstract base class for all task-related activities.
 
+    The TaskActivity class is a representation for every activity which can
+    be done with or on a task. It provides every needed attribute/methods to
+    record the activity in the notification center.
+
+    """
     def __init__(self, context, request, parent):
         self.context = context
         self.request = request
@@ -122,7 +124,10 @@ class TaskTransitionActivity(TaskActivity):
     """Activity which represents a transition task transition change.
     """
 
-    IGNORED_TRANSITIONS = ['transition-add-subtask']
+    IGNORED_TRANSITIONS = [
+        'transition-add-subtask',
+        'task-transition-reassign'
+    ]
 
     def __init__(self, context, response):
         self.context = context
@@ -149,10 +154,13 @@ class TaskTransitionActivity(TaskActivity):
         return self.response.text
 
     def record(self):
-        if self.transition in self.IGNORED_TRANSITIONS:
+        if self._is_ignored_transition():
             return
 
         return super(TaskTransitionActivity, self).record()
+
+    def _is_ignored_transition(self):
+        return self.transition in self.IGNORED_TRANSITIONS
 
 
 class TaskReassignActivity(TaskTransitionActivity):
@@ -176,3 +184,6 @@ class TaskReassignActivity(TaskTransitionActivity):
         change = self.response.get_change('responsible')
         self.center.remove_watcher_from_resource(self.context,
                                                  change.get('before'))
+
+    def _is_ignored_transition(self):
+        return False

--- a/opengever/task/browser/delegate/utils.py
+++ b/opengever/task/browser/delegate/utils.py
@@ -1,3 +1,4 @@
+from opengever.task.activities import TaskAddedActivity
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
 from plone.dexterity.utils import iterSchemata
@@ -72,4 +73,8 @@ def create_subtask(task, data):
 
             setattr(repr, name, value)
 
-    return notify(ObjectModifiedEvent(subtask))
+    activity = TaskAddedActivity(subtask, task.REQUEST, task)
+    activity.record()
+
+    notify(ObjectModifiedEvent(subtask))
+    return subtask

--- a/opengever/task/deadline_modifier.py
+++ b/opengever/task/deadline_modifier.py
@@ -1,12 +1,10 @@
 from five import grok
 from opengever.base.request import dispatch_request
-from opengever.task.activities import TaskTransitionActivity
 from opengever.task.browser.transitioncontroller import get_conditions
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
-from plone import api
 from Products.CMFDiffTool.utils import safe_utf8
 from zExceptions import Unauthorized
 from zope.event import notify
@@ -51,7 +49,7 @@ class DeadlineModifier(grok.Adapter):
         self.sync_deadline(new_deadline, text, transition)
 
     def update_deadline(self, new_deadline, text, transition):
-        response = add_simple_response(
+        add_simple_response(
             self.context, text=text,
             field_changes=(
                 (ITask['deadline'], new_deadline),
@@ -59,13 +57,8 @@ class DeadlineModifier(grok.Adapter):
             transition=transition
         )
 
-        self.record_activity(response)
-
         self.context.deadline = new_deadline
         notify(ObjectModifiedEvent(self.context))
-
-    def record_activity(self, response):
-        TaskTransitionActivity(self.context, response).record()
 
     def sync_deadline(self, new_deadline, text, transition):
         sct = ISuccessorTaskController(self.context)

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -2,7 +2,6 @@ from Acquisition import aq_inner, aq_parent
 from datetime import date
 from five import grok
 from opengever.document.behaviors import IBaseDocument
-from opengever.document.document import IDocumentSchema
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -34,7 +34,7 @@ class TestTaskActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.first()
+        activity = Activity.query.one()
         self.assertEquals('task-added', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task added by Test User', activity.summary)
@@ -76,7 +76,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Wird n\xe4chste Woche erledigt.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.first()
+        activity = Activity.query.one()
         self.assertEquals(u'task-transition-open-in-progress', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -98,7 +98,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Wird n\xe4chste Woche erledigt.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.first()
+        activity = Activity.query.one()
         self.assertEquals(u'task-transition-open-in-progress', activity.kind)
         self.assertEquals('hugo.boss', activity.actor_id)
 
@@ -114,7 +114,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Ist erledigt.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.first()
+        activity = Activity.query.one()
         self.assertEquals(u'task-transition-in-progress-resolved', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -137,7 +137,7 @@ class TestTaskActivites(FunctionalTestCase):
             'New Deadline': '03/20/16',
             'Response': u'nicht dring\xe4nd'}).save()
 
-        activity = Activity.query.first()
+        activity = Activity.query.one()
         self.assertEquals(u'task-transition-modify-deadline', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -177,14 +177,21 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Title': u'Letter to peter'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.first()
+        activity = Activity.query.one()
         self.assertEquals(u'transition-add-document', activity.kind)
 
 
-class TestTaskReassignActivity(TestTaskActivites):
+class TestTaskReassignActivity(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 
     def setUp(self):
         super(TestTaskReassignActivity, self).setUp()
+        self.dossier = create(Builder('dossier').titled(u'Dossier XY'))
+        self.hugo = create(Builder('ogds_user')
+                           .id('hugo.boss')
+                           .assign_to_org_units([self.org_unit])
+                           .having(firstname=u'Hugo', lastname=u'Boss'))
 
         create(Builder('ogds_user')
                .id('peter.meier')

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -247,23 +247,27 @@ class TestTaskReassignActivity(FunctionalTestCase):
         self.task = self.add_task(browser)
         self.reassign(browser, 'hugo.boss', u'Bitte Abkl\xe4rungen erledigen.')
 
-        activity = Activity.query.all()[-1]
+        activities = Activity.query.all()
+        self.assertEqual(2, len(activities))
 
-        self.assertEquals(u'task-transition-reassign', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
-        self.assertEquals(u'Reassigned from <a href="http://nohost/plone/@@user-details/james.meier">Meier James (james.meier)</a> to <a href="http://nohost/plone/@@user-details/hugo.boss">Boss Hugo (hugo.boss)</a> by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>', activity.summary)
-        self.assertEquals(u'Bitte Abkl\xe4rungen erledigen.', activity.description)
+        reassign_activity = activities[-1]
+        self.assertEquals(u'task-transition-reassign', reassign_activity.kind)
+        self.assertEquals(u'Abkl\xe4rung Fall Meier', reassign_activity.title)
+        self.assertEquals(u'Reassigned from <a href="http://nohost/plone/@@user-details/james.meier">Meier James (james.meier)</a> to <a href="http://nohost/plone/@@user-details/hugo.boss">Boss Hugo (hugo.boss)</a> by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>', reassign_activity.summary)
+        self.assertEquals(u'Bitte Abkl\xe4rungen erledigen.', reassign_activity.description)
 
     @browsing
     def test_notifies_old_and_new_responsible(self, browser):
         self.task = self.add_task(browser)
         self.reassign(browser, 'hugo.boss', u'Bitte Abkl\xe4rungen erledigen.')
 
-        activity = Activity.query.all()[-1]
+        activities = Activity.query.all()
+        self.assertEqual(2, len(activities))
 
+        reassign_activity = activities[-1]
         self.assertItemsEqual(
             [u'james.meier', u'peter.meier', u'hugo.boss'],
-            [notes.watcher.user_id for notes in activity.notifications])
+            [notes.watcher.user_id for notes in reassign_activity.notifications])
 
     @browsing
     def test_removes_old_responsible_from_watchers_list(self, browser):

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -147,7 +147,7 @@ class TestTaskActivites(FunctionalTestCase):
         self.assertEquals(u'nicht dring\xe4nd', activity.description)
 
     @browsing
-    def test_adding_a_subtask_notifies_watchers(self, browser):
+    def test_adding_a_subtask_creates_activity(self, browser):
         task = create(Builder('task')
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=u'hugo.boss',
@@ -162,8 +162,10 @@ class TestTaskActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.first()
-        self.assertEquals(u'transition-add-subtask', activity.kind)
+        activity = Activity.query.one()
+        self.assertEquals('task-added', activity.kind)
+        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(u'New task added by Test User', activity.summary)
 
     @browsing
     def test_adding_a_document_notifies_watchers(self, browser):

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -182,6 +182,27 @@ class TestTaskActivites(FunctionalTestCase):
         activity = Activity.query.one()
         self.assertEquals(u'transition-add-document', activity.kind)
 
+    @browsing
+    def test_delegate_activity(self, browser):
+        task = create(Builder('task')
+                      .titled(u'Abkl\xe4rung Fall Huber')
+                      .having(responsible=u'hugo.boss',
+                              deadline=date(2015, 07, 01))
+                      .in_state('task-state-in-progress'))
+
+        browser.login().open(task)
+        browser.find('task-transition-delegate').click()
+        # fill responsibles step
+        browser.fill({'Responsibles': ['client1:hugo.boss']})
+        browser.find('Continue').click()
+        # fill medatata step and submit
+        browser.find('Save').click()
+
+        activity = Activity.query.one()
+        self.assertEquals('task-added', activity.kind)
+        self.assertEquals(u'Abkl\xe4rung Fall Huber', activity.title)
+        self.assertEquals(u'New task added by Test User', activity.summary)
+
 
 class TestTaskReassignActivity(FunctionalTestCase):
 


### PR DESCRIPTION
Dieser PR verhindert, dass die folgenden Aktivitäten doppelt registriert/dargestellt werden:
  - Neu zuweisen
  - Unteraufgaben hinzufügen (Plone action-menu)
  - Delegieren tasks (Workflow)
  - Frist ändern

Fixes #1007