### PR TITLE
Add regression test for task type translations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Add regression test for task type translations.
+  [lgraf]
+
 - Activity: Prevent generating duplicated activities when:
 
   - Reassigning tasks


### PR DESCRIPTION
This test makes sure that the VDEX vocabulary backed task types are correctly translated.

@phgross 