### PR TITLE
Fehlerbehandlung des Benachrichtungssystems verbessert

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 
 4.5.0 (unreleased)
 ------------------
+  
+- Optimize error handling of the NotificationCenter, show statusmessage
+  instead of abort request.
+  [phgross]
 
 - Sort available templates alphabetically when creating a document from template.
   [deiferni]

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-28 09:29+0000\n"
+"POT-Creation-Date: 2015-06-23 18:19+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/activity/mail_templates/notification.pt:27
+#: ./opengever/activity/templates/notification.pt:27
 msgid "View in GEVER"
 msgstr "In GEVER betrachten"
 
@@ -47,7 +47,7 @@ msgid "heading_notifications"
 msgstr "Benachrichtigungen"
 
 #. Default: "Description:"
-#: ./opengever/activity/mail_templates/notification.pt:21
+#: ./opengever/activity/templates/notification.pt:21
 msgid "label_description"
 msgstr "Beschreibung:"
 
@@ -55,6 +55,11 @@ msgstr "Beschreibung:"
 #: ./opengever/activity/viewlets/notification.pt:54
 msgid "label_notifications_overview"
 msgstr "Alle Benachrichtigungen"
+
+#. Default: "A problem has occurred during the notification creation. Notification could not be produced."
+#: ./opengever/activity/center.py:166
+msgid "msg_error_not_notified"
+msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht ausgelöst."
 
 #. Default: "No unread notifications"
 #: ./opengever/activity/viewlets/notification.pt:23

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-28 09:29+0000\n"
+"POT-Creation-Date: 2015-06-23 18:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/activity/mail_templates/notification.pt:27
+#: ./opengever/activity/templates/notification.pt:27
 msgid "View in GEVER"
 msgstr ""
 
@@ -47,13 +47,18 @@ msgid "heading_notifications"
 msgstr "Notifications"
 
 #. Default: "Description:"
-#: ./opengever/activity/mail_templates/notification.pt:21
+#: ./opengever/activity/templates/notification.pt:21
 msgid "label_description"
 msgstr ""
 
 #. Default: "All Notifications"
 #: ./opengever/activity/viewlets/notification.pt:54
 msgid "label_notifications_overview"
+msgstr ""
+
+#. Default: "A problem has occurred during the notification creation. Notification could not be produced."
+#: ./opengever/activity/center.py:166
+msgid "msg_error_not_notified"
 msgstr ""
 
 #. Default: "No unread notifications"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-28 09:29+0000\n"
+"POT-Creation-Date: 2015-06-23 18:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.activity\n"
 
-#: ./opengever/activity/mail_templates/notification.pt:27
+#: ./opengever/activity/templates/notification.pt:27
 msgid "View in GEVER"
 msgstr ""
 
@@ -47,7 +47,7 @@ msgid "heading_notifications"
 msgstr ""
 
 #. Default: "Description:"
-#: ./opengever/activity/mail_templates/notification.pt:21
+#: ./opengever/activity/templates/notification.pt:21
 msgid "label_description"
 msgstr ""
 
@@ -56,7 +56,13 @@ msgstr ""
 msgid "label_notifications_overview"
 msgstr ""
 
+#. Default: "A problem has occurred during the notification creation. Notification could not be produced."
+#: ./opengever/activity/center.py:166
+msgid "msg_error_not_notified"
+msgstr ""
+
 #. Default: "No unread notifications"
 #: ./opengever/activity/viewlets/notification.pt:23
 msgid "no_unread_notifications"
 msgstr ""
+


### PR DESCRIPTION
Anstatt bei einem Fehler während dem Erstellen einer Aktivität bzw. Benachrichtigung den Request abzubrechen, wird neu der Fehler abgefangen und der Benutzer stattdessen mit einer Warnung informiert:
![bildschirmfoto 2015-06-19 um 16 08 06](https://cloud.githubusercontent.com/assets/485755/8255037/73330e24-169d-11e5-8c09-b9c047a2348a.png)

Der Error wird aber trotzdem geloggt, so dass wir via Errbit darüber informiert werden.

Closes #1001.

@lukasgraf @deiferni 
