### PR TITLE
Update versions of opengever.core dependencies

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Update versions of opengever.core dependencies.
+  [lgraf]
+
 - TransitionControllers: Rebuild special handling for administrators,
   move agency check for administrators to each transition guard.
   [phgross]

--- a/sources.cfg
+++ b/sources.cfg
@@ -12,6 +12,7 @@ development-packages =
   ftw.datepicker
   z3c.saconfig
   opengever.ogds.models
+  collective.vdexvocabulary
 
 auto-checkout = ${buildout:development-packages}
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -10,6 +10,8 @@ development-packages =
   ftw.inflator
   plone.formwidget.autocomplete
   ftw.datepicker
+  z3c.saconfig
+  opengever.ogds.models
 
 auto-checkout = ${buildout:development-packages}
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -6,15 +6,13 @@ versions = versions
 
 [versions]
 # development pinnings
-collective.recipe.omelette = 0.12
-ipdb = 0.4
-ipython = 0.10.2
-iw.debug = 0.3
-mr.developer = 1.21
+collective.recipe.omelette = 0.16
 collective.z3cinspector = 1.1
-profilestats = 1.0.2
-pyprof2calltree = 1.1.0
-mocker = 1.1.1
+i18ndude = 3.4.0
+mr.developer = 1.33
+pyflakes = 0.9.1
+z3c.dependencychecker = 1.11
+zptlint = 0.2.4
 
 # zope.testrunner 4.4.5 has changed the testing layer ordering
 # which causes test isolation problems with PloneTestCase layers


### PR DESCRIPTION
This PR updates the version pinnings for `opengever.core` dependencies and uses packages from source that don't have a required release out yet.

Requires https://github.com/4teamwork/opengever.ogds.models/pull/31 to be merged first.