### PR TITLE
Remove p.formwidget.namedfile monkeypatch

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Bump plone.formwidget.namedfile and remove corresponding monkeypatch in order
+  to get changes from https://github.com/plone/plone.formwidget.namedfile/pull/9
+  [lgraf]
+
 - Update versions of opengever.core dependencies.
   [lgraf]
 

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -244,49 +244,6 @@ LOGGER.info('Monkey patched ftw.mail.inbound.createMailInContainer')
 
 
 # --------
-# Monkeypatch for plone.formwidget.namedfile.convert.NamedDataConverter
-
-# To include the fix https://github.com/plone/plone.formwidget.namedfile/pull/9
-# which involves in broken files, when uploading documents with firefox.
-
-# Monkeypath should be removed after updating opengever to plone 4.3.
-from plone.formwidget.namedfile.converter import NamedDataConverter
-from plone.namedfile.interfaces import INamed
-from plone.namedfile.utils import safe_basename
-
-
-def toFieldValue(self, value):
-    if value is None or value == '':
-        return self.field.missing_value
-
-    if INamed.providedBy(value):
-        return value
-    elif isinstance(value, FileUpload):
-
-        filename = safe_basename(value.filename)
-
-        if filename is not None and not isinstance(filename, unicode):
-            # Work-around for
-            # https://bugs.launchpad.net/zope2/+bug/499696
-            filename = filename.decode('utf-8')
-
-        value.seek(0)
-        data = value.read()
-        if data or filename:
-            return self.field._type(data=data, filename=filename)
-        else:
-            return self.field.missing_value
-
-    else:
-        return self.field._type(data=str(value))
-
-
-NamedDataConverter.toFieldValue = toFieldValue
-LOGGER.info('Monkey patched '
-            'plone.formwidget.namedfile.converter.NamedDataConverter.toFieldValue')
-
-
-# --------
 # Monkeypatch `OFS.CopySupport.CopyContainer._verifyObjectPaste`
 # to disable `Delete objects` permission check when moving items
 

--- a/opengever/document/browser/templates/file.pt
+++ b/opengever/document/browser/templates/file.pt
@@ -12,8 +12,7 @@
         <span tal:define="filename view/w/file/filename">
             <span class="filename" tal:content="filename">Filename</span>
             <span class="discreet">
-              &mdash; <span tal:define="sizekb view/w/file/file_size" tal:replace="sizekb">100</span>
-              KB
+              &mdash; <span tal:define="sizekb view/w/file/file_size" tal:replace="sizekb">100 KB</span>
             </span>
         </span>
 

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -31,7 +31,7 @@ class TestDocumentIntegration(FunctionalTestCase):
         browser.login().open(self.document, view='edit')
 
         self.assertEqual(
-            u'document1.doc \u2014 0 KB',
+            u'document1.doc \u2014 1 KB',
             browser.css('.named-file-widget.namedblobfile-field').first.text)
 
         # edit should not be posssible

--- a/opengever/document/widgets/no_download_display.pt
+++ b/opengever/document/widgets/no_download_display.pt
@@ -21,7 +21,7 @@
                       filename_encoded view/filename_encoded;"
             tal:condition="python: exists and fieldname">
         <span tal:content="filename">Filename</span>
-        <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB</span>
+        <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100 KB</span></span>
     </span>
     <span tal:condition="not:exists" class="discreet" i18n:translate="no_file">
         No file

--- a/opengever/document/widgets/no_download_input.pt
+++ b/opengever/document/widgets/no_download_input.pt
@@ -28,7 +28,7 @@
     <span tal:condition="python: exists and action=='nochange'">
         <a class="link-overlay" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
         <span class="discreet"> &mdash;
-            <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB
+            <span tal:define="sizekb view/file_size" tal:replace="sizekb">100 KB</span>
         </span>
     </span>
     <div tal:condition="allow_nochange" style="padding-top: 1em;">

--- a/opengever/mail/browser/templates/file.pt
+++ b/opengever/mail/browser/templates/file.pt
@@ -7,8 +7,7 @@
     <span tal:define="filename view/w/message/filename">
       <span class="filename" tal:content="filename">Filename</span>
       <span class="discreet">
-        &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100</span>
-        KB
+        &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100 KB</span>
       </span>
     </span>
 


### PR DESCRIPTION
Remove `plone.formwidget.namedfile monkeypatch` and perform necessary changes for using `1.0.11` (bumped in https://github.com/4teamwork/kgs/commit/55e74b878b7a0e40dd7ce357390b28d12c021005)  which includes the fix from plone/plone.formwidget.namedfile#9

(`widget/file/file_size` now includes the `KB` suffix, which requires a few changes to our overridden templates. Also, an empty file is now reported as having a size of `1 KB` as opposed to `0 KB` before).

@phgross @deiferni 