### PR TITLE
Add macro enabled office mimetypes to MTR

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,9 @@ Changelog
   to get changes from https://github.com/plone/plone.formwidget.namedfile/pull/9
   [lgraf]
 
+- Add macro enabled office mimetypes to MTR.
+  [lgraf]
+
 - Update versions of opengever.core dependencies.
   [lgraf]
 

--- a/opengever/document/__init__.py
+++ b/opengever/document/__init__.py
@@ -3,6 +3,9 @@ import mimetypes
 
 _ = MessageFactory('opengever.document')
 
+# For the common MS office formats, see
+# http://blogs.msdn.com/b/vsofficedeveloper/archive/2008/05/08/office-2007-open-xml-mime-types.aspx
+
 # MindJet MindManager
 mimetypes.add_type('application/vnd.mindjet.mindmanager', '.mmap')
 
@@ -48,8 +51,21 @@ mimetypes.add_type('application/vnd.ms-excel', '.xlw')
 # MS Excel Spreadsheet (OOXML)
 mimetypes.add_type('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '.xlsx')
 
+# MS Excel Spreadsheet (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-excel.sheet.macroEnabled.12', '.xlsm')
+
 # MS Excel Template (OOXML)
 mimetypes.add_type('application/vnd.openxmlformats-officedocument.spreadsheetml.template', '.xltx')
+
+# MS Excel Template (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-excel.template.macroEnabled.12', '.xltm')
+
+# MS Excel Addin (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-excel.addin.macroEnabled.12', '.xlam')
+
+# MS Excel Spreadsheet (Binary, Macro Enabled)
+mimetypes.add_type('application/vnd.ms-excel.sheet.binary.macroEnabled.12', '.xlsb')
+
 
 # MS Word
 mimetypes.add_type('application/msword', '.doc')
@@ -59,8 +75,14 @@ mimetypes.add_type('application/msword', '.dot')
 # MS Word Document (OOXML)
 mimetypes.add_type('application/vnd.openxmlformats-officedocument.wordprocessingml.document', '.docx')
 
+# MS Word Document (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-word.document.macroEnabled.12', '.docm')
+
 # MS Word Template (OOXML)
 mimetypes.add_type('application/vnd.openxmlformats-officedocument.wordprocessingml.template', '.dotx')
+
+# MS Word Template (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-word.template.macroEnabled.12', '.dotm')
 
 # MS Powerpoint
 mimetypes.add_type('application/vnd.ms-powerpoint', '.ppt')
@@ -76,3 +98,17 @@ mimetypes.add_type('application/vnd.openxmlformats-officedocument.presentationml
 # MS Powerpoint Template (OOXML)
 mimetypes.add_type('application/vnd.openxmlformats-officedocument.presentationml.template', '.potx')
 
+# MS Powerpoint Slideshow (OOXML)
+mimetypes.add_type('application/vnd.openxmlformats-officedocument.presentationml.slideshow', '.ppsx')
+
+# MS Powerpoint Addin (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-powerpoint.addin.macroEnabled.12', '.ppam')
+
+# MS Powerpoint Presentation (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-powerpoint.presentation.macroEnabled.12', '.pptm')
+
+# MS Powerpoint Template (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-powerpoint.presentation.macroEnabled.12', '.potm')
+
+# MS Powerpoint Slideshow (Macro Enabled)
+mimetypes.add_type('application/vnd.ms-powerpoint.slideshow.macroEnabled.12', '.ppsm')

--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4502</version>
+  <version>4503</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/opengever/policy/base/profiles/mimetype/metadata.xml
+++ b/opengever/policy/base/profiles/mimetype/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>4501</version>
+</metadata>

--- a/opengever/policy/base/profiles/mimetype/mimetypes.xml
+++ b/opengever/policy/base/profiles/mimetype/mimetypes.xml
@@ -76,6 +76,27 @@
            icon_path="icon_dokument_excel.gif"
            mimetypes="application/vnd.openxmlformats-officedocument.spreadsheetml.template" />
 
+ <mimetype name="Microsoft Excel Spreadsheet (Macro Enabled)"
+           binary="True"
+           extensions="xlsm"
+           globs="*.xlsm"
+           icon_path="icon_dokument_excel.gif"
+           mimetypes="application/vnd.ms-excel.sheet.macroEnabled.12" />
+
+ <mimetype name="Microsoft Excel Template (Macro Enabled)"
+           binary="True"
+           extensions="xltm"
+           globs="*.xltm"
+           icon_path="icon_dokument_excel.gif"
+           mimetypes="application/vnd.ms-excel.template.macroEnabled.12" />
+
+ <mimetype name="Microsoft Excel Addin (Macro Enabled)"
+           binary="True"
+           extensions="xlam"
+           globs="*.xlam"
+           icon_path="icon_dokument_excel.gif"
+           mimetypes="application/vnd.ms-excel.addin.macroEnabled.12" />
+
  <!-- MS Word -->
  <mimetype name="Microsoft Word Document"
            binary="True"
@@ -97,6 +118,20 @@
            globs="*.dotx"
            icon_path="icon_dokument_word.gif"
            mimetypes="application/vnd.openxmlformats-officedocument.wordprocessingml.template" />
+
+ <mimetype name="Microsoft Word Document (Macro Enabled)"
+           binary="True"
+           extensions="docm"
+           globs="*.docm"
+           icon_path="icon_dokument_word.gif"
+           mimetypes="application/vnd.ms-word.document.macroEnabled.12" />
+
+ <mimetype name="Microsoft Word Template (Macro Enabled)"
+           binary="True"
+           extensions="dotm"
+           globs="*.dotm"
+           icon_path="icon_dokument_word.gif"
+           mimetypes="application/vnd.ms-word.template.macroEnabled.12" />
 
 
  <!-- MS Powerpoint -->
@@ -123,6 +158,41 @@
            globs="*.potx"
            icon_path="icon_dokument_powerpoint.gif"
            mimetypes="application/vnd.openxmlformats-officedocument.presentationml.template" />
+
+ <mimetype name="Microsoft PowerPoint Slideshow (OOXML)"
+           binary="True"
+           extensions="ppsx"
+           globs="*.ppsx"
+           icon_path="icon_dokument_powerpoint.gif"
+           mimetypes="application/vnd.openxmlformats-officedocument.presentationml.slideshow" />
+
+ <mimetype name="Microsoft PowerPoint Addin (Macro Enabled)"
+           binary="True"
+           extensions="ppam"
+           globs="*.ppam"
+           icon_path="icon_dokument_powerpoint.gif"
+           mimetypes="application/vnd.ms-powerpoint.addin.macroEnabled.12" />
+
+ <mimetype name="Microsoft PowerPoint Presentation (Macro Enabled)"
+           binary="True"
+           extensions="pptm"
+           globs="*.pptm"
+           icon_path="icon_dokument_powerpoint.gif"
+           mimetypes="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
+
+ <mimetype name="Microsoft PowerPoint Template (Macro Enabled)"
+           binary="True"
+           extensions="potm"
+           globs="*.potm"
+           icon_path="icon_dokument_powerpoint.gif"
+           mimetypes="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
+
+ <mimetype name="Microsoft PowerPoint Slideshow (Macro Enabled)"
+           binary="True"
+           extensions="ppsm"
+           globs="*.ppsm"
+           icon_path="icon_dokument_powerpoint.gif"
+           mimetypes="application/vnd.ms-powerpoint.slideshow.macroEnabled.12" />
 
  <!-- MS Visio -->
  <mimetype name="Microsoft Visio document"

--- a/opengever/policy/base/upgrades/configure.zcml
+++ b/opengever/policy/base/upgrades/configure.zcml
@@ -99,4 +99,14 @@
       directory="profiles/4502"
       />
 
+  <!-- 4502 -> 4503 -->
+  <genericsetup:upgradeStep
+      title="Add macro enabled office mimetypes to MTR, update getIcon metadata of affected documents"
+      description="Initialize opengever.policy.base:mimetype profile version, add macro enabled office mimetypes to MTR and upgrade getIcon metadata"
+      source="4502"
+      destination="4503"
+      handler="opengever.policy.base.upgrades.to4503.AddMacroEnabledOfficeMimetypes"
+      profile="opengever.policy.base:default"
+      />
+
 </configure>

--- a/opengever/policy/base/upgrades/to4503.py
+++ b/opengever/policy/base/upgrades/to4503.py
@@ -1,0 +1,31 @@
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class AddMacroEnabledOfficeMimetypes(UpgradeStep):
+
+    def __call__(self):
+        # Install the opengever.policy.base:mimetype profile.
+        # This initializes the previously unset profile version and
+        # registers the newly added macro enabled office mimetypes.
+        self.setup_install_profile('profile-opengever.policy.base:mimetype')
+        self._update_document_metadata()
+
+    def _update_document_metadata(self):
+        """Update the getIcon metadata on documents.
+        """
+        catalog = api.portal.get_tool('portal_catalog')
+        brains = catalog.unrestrictedSearchResults(
+            portal_type='opengever.document.document')
+
+        # A getIcon value of 'application.png' indicates that the mimetype
+        # coulnd't be resolved for this document - only consider these
+        brains = filter(lambda b: b.getIcon == 'application.png', brains)
+
+        msg = 'Reindexing getIcon metadata for documents'
+        with ProgressLogger(msg, brains) as step:
+            for brain in brains:
+                catalog.reindexObject(
+                    brain.getObject(), idxs=['getIcon'], update_metadata=1)
+                step()


### PR DESCRIPTION
This PR adds the **macro enabled office MIME types** (according to [Office 2007 File Format MIME Types](http://blogs.msdn.com/b/vsofficedeveloper/archive/2008/05/08/office-2007-open-xml-mime-types.aspx)) to the mimetypes registry.

- Initializes `opengever.policy.base:mimetype` profile version (was previously missing a `metadata.xml`)
- Adds new macro enabled types to MTR
- Includes upgrade step that reindexes `getIcon` metadata for all (potentially) affected documents