### PR TITLE
Remove c.vdexvocabulary from dev-packages after releasing 0.2.1.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -12,7 +12,6 @@ development-packages =
   ftw.datepicker
   z3c.saconfig
   opengever.ogds.models
-  collective.vdexvocabulary
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
`collective.vdexvocabulary` was used from source in @d9f88a4064 but has now been released as `0.2.1`  (and pinned in https://github.com/4teamwork/kgs/commit/add1b442eea0ab2907268596b1fa630458414c1a), so we can remove it from development packages again.