### PR TITLE
Subdossier aus Documents-Tab verlinken

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Display a link to the containing subdossier on a dossier's document tab.
+  [deiferni]
+
 - Bump plone.formwidget.namedfile and remove corresponding monkeypatch in order
   to get changes from https://github.com/plone/plone.formwidget.namedfile/pull/9
   [lgraf]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -1,0 +1,26 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.task.task import ITask
+from plone.dexterity.content import Item
+
+
+class BaseDocument(Item):
+
+    def get_parent_dossier(self):
+        """Return the document's parent dossier.
+
+        A parent dossier is available for documents in a dossier/subdossier
+        or for documents in a task.
+
+        No parent dossier is available for documents in an inbox, in a
+        forwarding or inside a proposal. In that case this method returns None.
+
+        """
+        parent = aq_parent(aq_inner(self))
+        if IDossierMarker.providedBy(parent):
+            return parent
+        if ITask.providedBy(parent):
+            return parent.get_containing_dossier()
+
+        return None

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -1,11 +1,23 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from opengever.base.browser.helper import get_css_class
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.task.task import ITask
+from plone import api
 from plone.dexterity.content import Item
 
 
 class BaseDocument(Item):
+    """Abstract base class for document-ish content types."""
+
+    removed_state = None
+    active_state = None
+
+    remove_transition = None
+    restore_transition = None
+
+    def css_class(self):
+        return get_css_class(self)
 
     def get_parent_dossier(self):
         """Return the document's parent dossier.
@@ -24,3 +36,19 @@ class BaseDocument(Item):
             return parent.get_containing_dossier()
 
         return None
+
+    @property
+    def is_removed(self):
+        return api.content.get_state(obj=self) == self.removed_state
+
+    def related_items(self):
+        raise NotImplementedError
+
+    def checked_out_by(self):
+        raise NotImplementedError
+
+    def is_checked_out(self):
+        raise NotImplementedError
+
+    def get_current_version(self):
+        raise NotImplementedError

--- a/opengever/document/browser/redirect_to_parent_dossier.py
+++ b/opengever/document/browser/redirect_to_parent_dossier.py
@@ -1,0 +1,17 @@
+from five import grok
+from opengever.document.behaviors import IBaseDocument
+
+
+class RedirectToParentDossier(grok.View):
+    """Redirects to the containing subdossier of a document.
+    """
+    grok.context(IBaseDocument)
+    grok.name('redirect_to_parent_dossier')
+    grok.require('zope2.View')
+
+    def render(self):
+        dossier = self.context.get_parent_dossier()
+        if not dossier:
+            return ''
+
+        return self.request.RESPONSE.redirect(dossier.absolute_url())

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -2,7 +2,6 @@ from Acquisition import aq_inner, aq_parent
 from collective import dexteritytextindexer
 from five import grok
 from ftw.mail.interfaces import IEmailAddress
-from opengever.base.browser.helper import get_css_class
 from opengever.document import _
 from opengever.document.base import BaseDocument
 from opengever.document.behaviors.related_docs import IRelatedDocuments
@@ -111,27 +110,15 @@ class Document(BaseDocument):
     removed_state = 'document-state-removed'
     active_state = 'document-state-draft'
 
+    remove_transition = 'document-transition-remove'
+    restore_transition = 'document-transition-restore'
+
     # disable file preview creation when modifying or creating document
     buildPreview = False
 
     def surrender(self, relative_to_portal=1):
         return super(Document, self).getIcon(
             relative_to_portal=relative_to_portal)
-
-    def css_class(self):
-        return get_css_class(self)
-
-    @property
-    def remove_transition(self):
-        return 'document-transition-remove'
-
-    @property
-    def restore_transition(self):
-        return 'document-transition-restore'
-
-    @property
-    def is_removed(self):
-        return api.content.get_state(obj=self) == Document.removed_state
 
     def related_items(self):
         relations = IRelatedDocuments(self).relatedItems

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -4,6 +4,7 @@ from five import grok
 from ftw.mail.interfaces import IEmailAddress
 from opengever.base.browser.helper import get_css_class
 from opengever.document import _
+from opengever.document.base import BaseDocument
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -11,7 +12,6 @@ from opengever.meeting.proposal import ISubmittedProposal
 from opengever.task.task import ITask
 from plone import api
 from plone.autoform import directives as form_directives
-from plone.dexterity.content import Item
 from plone.directives import form
 from plone.namedfile.field import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
@@ -105,7 +105,7 @@ validator.WidgetValidatorDiscriminators(
 grok.global_adapter(UploadValidator)
 
 
-class Document(Item):
+class Document(BaseDocument):
 
     # document state's
     removed_state = 'document-state-removed'

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -214,6 +214,23 @@ class TestDocument(FunctionalTestCase):
 
         self.assertEqual(1, document.get_current_version())
 
+    def test_get_parent_dossier_returns_direct_parent_for_dossiers(self):
+        dossier = create(Builder('dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+        document = create(Builder('document').within(dossier))
+        document_sub = create(Builder('document').within(subdossier))
+
+        self.assertEqual(dossier, document.get_parent_dossier())
+        self.assertEqual(subdossier, document_sub.get_parent_dossier())
+
+    def test_get_parent_dossier_returns_tasks_dossier(self):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').within(dossier))
+        subtask = create(Builder('task').within(task))
+        document = create(Builder('document').within(subtask))
+
+        self.assertEqual(dossier, document.get_parent_dossier())
+
 
 class TestDocumentDefaultValues(FunctionalTestCase):
 

--- a/opengever/dossier/tests/test_documents_tab.py
+++ b/opengever/dossier/tests/test_documents_tab.py
@@ -1,0 +1,31 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestDocumentsTab(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDocumentsTab, self).setUp()
+
+        self.root = create(Builder('repository_root'))
+        self.repo = create(Builder('repository').within(self.root))
+
+        self.dossier = create(Builder('dossier'))
+        self.subdossier = create(
+            Builder('dossier')
+            .within(self.dossier)
+            .titled(u'S\xfcbdossier'))
+        self.document = create(Builder('document').within(self.subdossier))
+
+    @browsing
+    def test_containing_subdossiers_are_linked(self, browser):
+        browser.login().visit(self.dossier, view='tabbedview_view-documents')
+
+        browser.css('table.listing').first.css('a.subdossierLink')
+        link = browser.css('table.listing').first.css('a.subdossierLink').first
+        self.assertEqual(u'S\xfcbdossier', link.text)
+
+        link.click()
+        self.assertEqual(browser.url, self.subdossier.absolute_url())

--- a/opengever/inbox/inbox.py
+++ b/opengever/inbox/inbox.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.inbox import _
 from opengever.ogds.base.utils import ogds_service

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -9,13 +9,13 @@ from ftw.mail.mail import IMail
 from opengever.base import _ as base_mf
 from opengever.base.browser.helper import get_css_class
 from opengever.base.model import create_session
+from opengever.document.base import BaseDocument
 from opengever.document.behaviors import metadata as ogmetadata
 from opengever.dossier import _
 from opengever.ogds.models.user import User
 from plone import api
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform.interfaces import IFormFieldProvider
-from plone.dexterity.content import Item
 from plone.directives import form, dexterity
 from plone.supermodel.interfaces import FIELDSETS_KEY
 from plone.supermodel.model import Fieldset
@@ -62,7 +62,7 @@ class IOGMail(form.Schema):
 alsoProvides(IOGMail, IFormFieldProvider)
 
 
-class OGMail(Item):
+class OGMail(BaseDocument):
     """Opengever specific mail class."""
 
     # mail state's

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -7,13 +7,11 @@ from ftw.mail import _ as ftw_mf
 from ftw.mail import utils
 from ftw.mail.mail import IMail
 from opengever.base import _ as base_mf
-from opengever.base.browser.helper import get_css_class
 from opengever.base.model import create_session
 from opengever.document.base import BaseDocument
 from opengever.document.behaviors import metadata as ogmetadata
 from opengever.dossier import _
 from opengever.ogds.models.user import User
-from plone import api
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form, dexterity
@@ -69,6 +67,9 @@ class OGMail(BaseDocument):
     removed_state = 'mail-state-removed'
     active_state = 'mail-state-active'
 
+    remove_transition = 'mail-transition-remove'
+    restore_transition = 'mail-transition-restore'
+
     @property
     def msg(self):
         """ returns an email.Message instance
@@ -84,21 +85,6 @@ class OGMail(BaseDocument):
                 data = data.replace(temp_msg['Subject'], fixed_subject)
             return email.message_from_string(data)
         return MIMEText('')
-
-    @property
-    def remove_transition(self):
-        return 'mail-transition-remove'
-
-    @property
-    def restore_transition(self):
-        return 'mail-transition-restore'
-
-    @property
-    def is_removed(self):
-        return api.content.get_state(obj=self) == self.removed_state
-
-    def css_class(self):
-        return get_css_class(self)
 
     def related_items(self):
         """Mail does not support relatedItems"""

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -13,9 +13,11 @@ from opengever.tabbedview.browser.base import OpengeverTab
 from opengever.tabbedview.browser.listing import CatalogListingView
 from opengever.tabbedview.browser.tasklisting import GlobalTaskListingTab
 from opengever.tabbedview.helper import external_edit_link
+from opengever.tabbedview.helper import linked
+from opengever.tabbedview.helper import linked_document_subdossier
 from opengever.tabbedview.helper import linked_document_with_tooltip
 from opengever.tabbedview.helper import linked_trashed_document_with_tooltip
-from opengever.tabbedview.helper import readable_ogds_author, linked
+from opengever.tabbedview.helper import readable_ogds_author
 from opengever.tabbedview.helper import readable_ogds_user
 from opengever.tabbedview.helper import workflow_state
 from opengever.tabbedview.interfaces import IStateFilterTableSourceConfig
@@ -99,7 +101,8 @@ class Documents(OpengeverCatalogListingTab):
          'transform': readable_ogds_user},
 
         {'column': 'containing_subdossier',
-         'column_title': _('label_subdossier', default="Subdossier"), },
+         'column_title': _('label_subdossier', default="Subdossier"),
+         'transform': linked_document_subdossier},
 
         {'column': 'public_trial',
          'column_title': _('label_public_trial', default="Public Trial"),

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from ftw.mail.utils import get_header
 from opengever.base import _ as base_mf
 from opengever.base.browser.helper import get_css_class
@@ -6,14 +8,16 @@ from opengever.document.document import Document
 from opengever.mail.mail import OGMail
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import ogds_service
+from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import ram
+from plone.uuid.interfaces import IUUID
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFPlone import PloneMessageFactory as pmf
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
-from zope.component.hooks import getSite
 from zope.component import getMultiAdapter
 from zope.component import getUtility
+from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 import cgi
@@ -118,6 +122,21 @@ def _breadcrumbs_from_item(item):
         breadcrumb_titles.append(title)
 
     return breadcrumb_titles
+
+
+def linked_document_subdossier(item, value):
+    subdossier_title = item.containing_subdossier
+    if not subdossier_title:
+        return ''
+
+    url = "{}/redirect_to_parent_dossier".format(item.getURL())
+    link_title = cgi.escape(subdossier_title, quote=True)
+
+    link = '<a href="{}" title="{}" class="subdossierLink">{}</a>'.format(
+        url, link_title, subdossier_title)
+
+    transforms = api.portal.get_tool('portal_transforms')
+    return transforms.convertTo('text/x-html-safe', link).getData()
 
 
 def linked(item, value):


### PR DESCRIPTION
Wir haben uns entschieden das Problem mit einer Redirect-View zu lösen.
Dieser PR führt zudem eine gemeinsame Superklasse für `Document` und `Mail` ein.

![screen shot 2015-06-22 at 17 08 54](https://cloud.githubusercontent.com/assets/736583/8300753/671c8c9e-1988-11e5-8586-0006a8d272c0.png)

Closes #510
