### PR TITLE
Feld erlaubte Spezialdossiers mit Checkbox Widget darstellen.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Use checkbox widget to select addable dossier types on a repository folder.
+  [deiferni]
+
 - Display a link to the containing subdossier on a dossier's document tab.
   [deiferni]
 

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -34,7 +34,6 @@ class IRepositoryFolderSchema(form.Schema):
             ],
         )
 
-    #form.omitted('title')
     form.order_before(effective_title='*')
     effective_title = schema.TextLine(
         title=_(u'Title'),

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -11,6 +11,7 @@ from plone.directives import dexterity
 from plone.directives import form
 from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zope import schema
 from zope.component import queryUtility
 from zope.interface import implements
@@ -80,14 +81,15 @@ class IRepositoryFolderSchema(form.Schema):
         required=False,
         )
 
+    form.widget(addable_dossier_types=CheckBoxFieldWidget)
     addable_dossier_types = schema.List(
         title=_(u'label_addable_dossier_types',
                 default=u'Addable dossier types'),
         description=_(u'help_addable_dossier_types',
                       default=u'Select all additional dossier types which '
                       'should be addable in this repository folder.'),
-        value_type=schema.Choice(vocabulary=u'opengever.repository.'
-                                 u'RestrictedAddableDossiersVocabulary'),
+        value_type=schema.Choice(
+            vocabulary=u'opengever.repository.RestrictedAddableDossiersVocabulary'),
         required=False)
 
 


### PR DESCRIPTION
Dieser PR ersetzt das Widget für das Feld *Erlaubte Spezialdossiers* einer Ordnungsposition. Das default-widget ist relativ hässlich und schlecht bedienbar. Neu schaut das so aus:

![screen shot 2015-06-24 at 13 58 38](https://cloud.githubusercontent.com/assets/736583/8329389/655b48d6-1a79-11e5-9030-bce020978fc4.png)

Zum Vergleich das alte Widget:

![screen shot 2015-06-24 at 14 03 38](https://cloud.githubusercontent.com/assets/736583/8329439/d78e68b6-1a79-11e5-9493-d7b2202e4588.png)

Closes #954.