### PR TITLE
Author eines Mails nur überschreiben, wenn noch nicht gesetzt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- No longer overwrite mail metadata when it is already set.
+  [deiferni]
+
 - Fixed message type (warning) when resubmitting an already submitted document.
   [phgross]
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -184,7 +184,8 @@ def initialize_metadata(mail, event):
 
     mail_metadata.receipt_date = date.today()
 
-    mail_metadata.document_author = get_author_by_email(mail)
+    if not mail_metadata.document_author:
+        mail_metadata.document_author = get_author_by_email(mail)
     mail.reindexObject(idxs=['document_date',
                              'document_author',
                              'receipt_date'])

--- a/opengever/mail/tests/__init__.py
+++ b/opengever/mail/tests/__init__.py
@@ -1,0 +1,4 @@
+from pkg_resources import resource_string
+
+
+MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')

--- a/opengever/mail/tests/test_generate_mail_id.py
+++ b/opengever/mail/tests/test_generate_mail_id.py
@@ -1,10 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
-from pkg_resources import resource_string
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 class TestGenerateMailIdAndSequentialNumber(FunctionalTestCase):

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -1,12 +1,13 @@
-from collective.dexteritytextindexer.interfaces import \
-    IDynamicTextIndexExtender
+from collective.dexteritytextindexer.interfaces import IDynamicTextIndexExtender
 from ftw.mail.mail import IMail
 from ftw.testing import MockTestCase
-from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
-from opengever.mail.indexer import checked_out
-from zope.component import getAdapters, getAdapter
-from zope.interface import Interface
 from grokcore.component.testing import grok
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import ISequenceNumber
+from opengever.mail.indexer import checked_out
+from zope.component import getAdapter
+from zope.component import getAdapters
+from zope.interface import Interface
 
 
 class TestMailIndexers(MockTestCase):

--- a/opengever/mail/tests/test_mail_byline.py
+++ b/opengever/mail/tests/test_mail_byline.py
@@ -14,8 +14,7 @@ class TestMailByline(TestBylineBase):
 
         self.mail = create(Builder('mail')
                            .with_message(MAIL_DATA)
-                           .having(start=date(2013, 11, 6),
-                                   document_date=date(2013, 11, 5)))
+                           .having(start=date(2013, 11, 6)))
         self.browser.open(self.mail.absolute_url())
 
     def test_document_byline_start_date(self):

--- a/opengever/mail/tests/test_mail_byline.py
+++ b/opengever/mail/tests/test_mail_byline.py
@@ -2,10 +2,7 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.tests.byline_base_test import TestBylineBase
-from pkg_resources import resource_string
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
+from opengever.mail.tests import MAIL_DATA
 
 
 class TestMailByline(TestBylineBase):

--- a/opengever/mail/tests/test_mail_byline.py
+++ b/opengever/mail/tests/test_mail_byline.py
@@ -15,8 +15,7 @@ class TestMailByline(TestBylineBase):
         self.mail = create(Builder('mail')
                            .with_message(MAIL_DATA)
                            .having(start=date(2013, 11, 6),
-                                   document_date=date(2013, 11, 5),
-                                   document_author='hugo.boss'))
+                                   document_date=date(2013, 11, 5)))
         self.browser.open(self.mail.absolute_url())
 
     def test_document_byline_start_date(self):

--- a/opengever/mail/tests/test_mail_classification.py
+++ b/opengever/mail/tests/test_mail_classification.py
@@ -6,14 +6,11 @@ from opengever.base.behaviors.classification import IClassificationSettings
 from opengever.base.behaviors.classification import PRIVACY_LAYER_NO
 from opengever.base.behaviors.classification import PUBLIC_TRIAL_PRIVATE
 from opengever.base.behaviors.classification import PUBLIC_TRIAL_UNCHECKED
+from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
-from pkg_resources import resource_string
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 class TestMailMetadata(FunctionalTestCase):

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.testbrowser import browsing
+from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_string
 from plone.app.testing import TEST_USER_ID
@@ -9,7 +10,6 @@ from zope.annotation import IAnnotations
 from zope.i18n import translate
 
 
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 MAIL_DATA_LF = resource_string('opengever.mail.tests', 'mail_lf.txt')
 MAIL_DATA_CRLF = resource_string('opengever.mail.tests', 'mail_crlf.txt')
 

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -7,17 +7,14 @@ from opengever.document.behaviors import metadata
 from opengever.document.interfaces import IDocumentSettings
 from opengever.mail.mail import extract_email
 from opengever.mail.mail import get_author_by_email
+from opengever.mail.tests import MAIL_DATA
 from opengever.mail.tests.utils import get_header_date
 from opengever.testing import FunctionalTestCase
 from opengever.testing.sql import create_ogds_user
-from pkg_resources import resource_string
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
 from zope.component import getUtility
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 def get_preserved_as_paper_default():

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -3,6 +3,7 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail import inbound
+from ftw.testbrowser import browser
 from opengever.document.behaviors import metadata
 from opengever.document.interfaces import IDocumentSettings
 from opengever.mail.mail import extract_email
@@ -134,6 +135,24 @@ class TestMailMetadataWithQuickupload(TestMailMetadataWithBuilder):
                          portal_type='ftw.mail.mail')
         mail = result['success']
         return mail
+
+
+class TestMailMetadataWithAddView(TestMailMetadataWithBuilder):
+
+    def create_mail(self):
+        """Add mails over a plone view since builders implement their own
+        instance construction.
+        """
+
+        with browser(self.app):
+            dossier = create(Builder("dossier"))
+            browser.login().open(dossier, view='++add++ftw.mail.mail')
+            browser.fill({
+                'Raw Message': (MAIL_DATA, 'mail.eml', 'message/rfc822')
+            }).submit()
+
+            mail = browser.context
+            return mail
 
 
 class TestMailPreservedAsPaperDefault(FunctionalTestCase):

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -3,12 +3,9 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.mail.mail import get_author_by_email
+from opengever.mail.tests import MAIL_DATA
 from opengever.mail.tests.utils import get_header_date
 from opengever.testing import FunctionalTestCase
-from pkg_resources import resource_string
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 def date_format_helper(dateobj):

--- a/opengever/mail/tests/test_mail_previewtab.py
+++ b/opengever/mail/tests/test_mail_previewtab.py
@@ -1,11 +1,9 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_string
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 class TestPreview(FunctionalTestCase):

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -2,11 +2,8 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.mail.mail import IOGMailMarker
+from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
-from pkg_resources import resource_string
-
-
-MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 class TestOGMailAddition(FunctionalTestCase):

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -35,18 +36,28 @@ class TestOGMailAddition(FunctionalTestCase):
         self.assertEquals(u'hanspeter', mail.title)
         self.assertEquals('hanspeter', mail.Title())
 
-    def test_copy_mail_preserves_author(self):
+    def test_copy_mail_preserves_metadata(self):
         dossier_1 = create(Builder('dossier'))
         dossier_2 = create(Builder('dossier'))
         mail = create(Builder('mail')
                       .within(dossier_1)
-                      .with_message(MAIL_DATA)
-                      .having(document_author='Hanspeter'))
+                      .with_message(MAIL_DATA))
 
+        # can't set this with `having` as it is overwritten by an event handler
+        mail.document_author = 'Hanspeter'
+        mail.document_date = date(2014, 1, 5)
+        mail.receipt_date = date(2014, 10, 1)
+
+        # preserved on initial creation
         self.assertEqual('Hanspeter', mail.document_author)
+        self.assertEqual(date(2014, 1, 5), mail.document_date)
+        self.assertEqual(date(2014, 10, 1), mail.receipt_date)
 
         copy = api.content.copy(source=mail, target=dossier_2)
+        # preserved on copy
         self.assertEqual('Hanspeter', copy.document_author)
+        self.assertEqual(date(2014, 1, 5), copy.document_date)
+        self.assertEqual(date(2014, 10, 1), copy.receipt_date)
 
     def test_mail_is_never_checked_out(self):
         mail = create(Builder("mail").with_dummy_message())

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
 from opengever.mail.mail import IOGMailMarker
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_string
@@ -9,7 +10,6 @@ MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
 
 
 class TestOGMailAddition(FunctionalTestCase):
-    use_browser = True
 
     def test_og_mail_behavior(self):
         mail = create(Builder("mail"))
@@ -27,13 +27,12 @@ class TestOGMailAddition(FunctionalTestCase):
         self.assertEquals(u'Die B\xfcrgschaft', mail.title)
         self.assertEquals('Die B\xc3\xbcrgschaft', mail.Title())
 
-    def test_mail_behavior(self):
+    @browsing
+    def test_mail_behavior(self, browser):
         mail = create(Builder("mail").with_message(MAIL_DATA))
 
-        self.browser.open('%s/edit' % mail.absolute_url())
-        self.browser.getControl(
-            name='form.widgets.IOGMail.title').value = 'hanspeter'
-        self.browser.getControl(name='form.buttons.save').click()
+        browser.login().open(mail, view='edit')
+        browser.fill({'Title': u'hanspeter'}).submit()
 
         self.assertEquals(u'hanspeter', mail.title)
         self.assertEquals('hanspeter', mail.Title())

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from opengever.mail.mail import IOGMailMarker
 from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
+from plone import api
 
 
 class TestOGMailAddition(FunctionalTestCase):
@@ -33,6 +34,19 @@ class TestOGMailAddition(FunctionalTestCase):
 
         self.assertEquals(u'hanspeter', mail.title)
         self.assertEquals('hanspeter', mail.Title())
+
+    def test_copy_mail_preserves_author(self):
+        dossier_1 = create(Builder('dossier'))
+        dossier_2 = create(Builder('dossier'))
+        mail = create(Builder('mail')
+                      .within(dossier_1)
+                      .with_message(MAIL_DATA)
+                      .having(document_author='Hanspeter'))
+
+        self.assertEqual('Hanspeter', mail.document_author)
+
+        copy = api.content.copy(source=mail, target=dossier_2)
+        self.assertEqual('Hanspeter', copy.document_author)
 
     def test_mail_is_never_checked_out(self):
         mail = create(Builder("mail").with_dummy_message())

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -15,7 +15,9 @@ from Products.CMFCore.utils import getToolByName
 from z3c.relationfield.relation import RelationValue
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
+from zope.event import notify
 from zope.intid.interfaces import IIntIds
+from zope.lifecycleevent import ObjectCreatedEvent
 
 
 class DossierBuilder(DexterityBuilder):
@@ -199,6 +201,15 @@ class MailBuilder(DexterityBuilder):
             trasher.trash()
 
         super(MailBuilder, self).after_create(obj)
+
+    def set_missing_values_for_empty_fields(self, obj):
+        """Fire ObjectCreatedEvent (again) to trigger setting of initial
+        attribute values extracted from the message.
+        """
+
+        super(MailBuilder, self).set_missing_values_for_empty_fields(obj)
+
+        notify(ObjectCreatedEvent(obj))
 
 builder_registry.register('mail', MailBuilder)
 


### PR DESCRIPTION
Dieser PR verhindert, dass Mail-Metadaten beim Kopieren automatisch überschrieben werden.

Fixes #922.