### PR TITLE
Templates nicht mehr verlinken.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- No longer link templates on the view that creates documents from templates.
+  [deiferni]
+
 - Use checkbox widget to select addable dossier types on a repository folder.
   [deiferni]
 

--- a/opengever/dossier/templatedossier/form.py
+++ b/opengever/dossier/templatedossier/form.py
@@ -5,7 +5,7 @@ from opengever.base.interfaces import IRedirector
 from opengever.dossier import _
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.templatedossier import get_template_dossier
-from opengever.tabbedview.helper import linked
+from opengever.tabbedview.helper import document_with_icon
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getUtility
@@ -125,7 +125,7 @@ class TemplateDocumentFormView(grok.View):
             {'column': 'Title',
              'column_title': _(u'label_title', default=u'title'),
              'sort_index': 'sortable_title',
-             'transform': linked},
+             'transform': document_with_icon},
             {'column': 'Creator',
              'column_title': _(u'label_creator', default=u'Creator'),
              'sort_index': 'document_author'},

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -107,12 +107,6 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
             browser.css('table.listing').first.dicts())
 
     @browsing
-    def test_template_titles_are_linked(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.find('Template B').click()
-        self.assertEquals(self.template_b, browser.context)
-
-    @browsing
     def test_cancel_redirects_to_the_dossier(self, browser):
         browser.login().open(self.dossier, view='document_with_template')
         browser.find('Cancel').click()

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -172,6 +172,14 @@ def linked(item, value):
     return wrapper
 
 
+def document_with_icon(item, value):
+    icon = '<span class="{}"></span><span>{}</span>'.format(
+        get_css_class(item), value)
+
+    transforms = api.portal.get_tool('portal_transforms')
+    return transforms.convertTo('text/x-html-safe', icon).getData()
+
+
 def linked_document_with_tooltip(item, value):
     """Wrapper method for the _linked_document_with_tooltip method
     for normal not trashed documents and mails."""


### PR DESCRIPTION
Dieser PR entfernt den Link zur Vorlage auf der `document_with_template` View.

![screen shot 2015-06-25 at 09 24 50](https://cloud.githubusercontent.com/assets/736583/8349316/10a4014a-1b1c-11e5-809f-331b9a614671.png)

Closes #739.