### PR TITLE
Vorlagen bei der Vorlagenauswahl alphabetisch sortieren.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Sort available templates alphabetically when creating a document from template.
+  [deiferni]
+
 - No longer link templates on the view that creates documents from templates.
   [deiferni]
 

--- a/opengever/dossier/templatedossier/form.py
+++ b/opengever/dossier/templatedossier/form.py
@@ -116,7 +116,9 @@ class TemplateDocumentFormView(grok.View):
         templates = catalog(
             path=dict(
                 depth=-1, query=self.templatedossier_path),
-            portal_type="opengever.document.document")
+            portal_type="opengever.document.document",
+            sort_on='sortable_title',
+            sort_order='ascending')
 
         generator = getUtility(ITableGenerator, 'ftw.tablegenerator')
         columns = (

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -64,6 +64,32 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
         self.assertEqual('', entry['comments'])
 
     @browsing
+    def test_templates_are_sorted_alphabetically_ascending(self, browser):
+        create(Builder('document')
+               .titled('AAA Template')
+               .within(self.templatedossier)
+               .with_dummy_content()
+               .with_modification_date(datetime(2010, 12, 28)))
+
+        browser.login().open(self.dossier, view='document_with_template')
+        self.assertEquals(
+            [{'': '',
+              'Creator': 'test_user_1_',
+              'Modified': '28.12.2010',
+              'title': 'AAA Template'},
+
+             {'': '',
+              'Creator': 'test_user_1_',
+              'Modified': '28.12.2012',
+              'title': 'Template A'},
+
+             {'': '',
+              'Creator': 'test_user_1_',
+              'Modified': '28.12.2012',
+              'title': 'Template B'}],
+            browser.css('table.listing').first.dicts())
+
+    @browsing
     def test_form_list_all_templates(self, browser):
         browser.login().open(self.dossier, view='document_with_template')
         self.assertEquals(


### PR DESCRIPTION
Dieser PR stellt sicher, dass die Vorlagen auf der `document_with_template ` View alphabetisch aufsteigend sortiert werden. 

Closes #745.