### PR TITLE
Dossier Referenzen in der Dossier-Übersicht darstellen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Add additional reference box in the dossier overview.
+  [phgross]
+
 - No longer overwrite mail metadata when it is already set.
   [deiferni]
 

--- a/opengever/base/tests/test_relations.py
+++ b/opengever/base/tests/test_relations.py
@@ -1,0 +1,53 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+
+
+class TestRelations(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRelations, self).setUp()
+        self.dossier_a = create(Builder('dossier').titled(u'Dossier A'))
+
+    @browsing
+    def test_relation_gets_added_in_zc_catalog_when_dossier_is_added(self, browser):
+        browser.login().open(self.portal,
+                             view='++add++opengever.dossier.businesscasedossier')
+        browser.fill({'Title': 'Dossier B with relations',
+                      'Responsible': TEST_USER_ID,
+                      'Related Dossier': [self.dossier_a]})
+        browser.find('Save').click()
+
+        rel_catalog = getUtility(ICatalog)
+        intids = getUtility(IIntIds)
+        relations = [rel for rel in rel_catalog.findRelations(
+            {'to_id': intids.getId(self.dossier_a)})]
+
+        self.assertEqual(1, len(relations))
+        self.assertEqual(intids.getId(self.dossier_a), relations[0].to_id)
+        self.assertEqual(intids.getId(browser.context), relations[0].from_id)
+
+    @browsing
+    def test_relation_catalog_gets_upated_when_dossier_is_updated(self, browser):
+        self.dossier_b = create(Builder('dossier')
+                                .having(responsible=TEST_USER_ID)
+                                .titled(u'Dossier B'))
+        browser.login().open(self.dossier_b, view='edit')
+        browser.fill({'Title': 'Dossier B with relations',
+                      'Responsible': TEST_USER_ID,
+                      'Related Dossier': [self.dossier_a]})
+        browser.find('Save').click()
+
+        rel_catalog = getUtility(ICatalog)
+        intids = getUtility(IIntIds)
+        relations = [rel for rel in rel_catalog.findRelations(
+            {'to_id': intids.getId(self.dossier_a)})]
+
+        self.assertEqual(1, len(relations))
+        self.assertEqual(intids.getId(self.dossier_a), relations[0].to_id)
+        self.assertEqual(intids.getId(self.dossier_b), relations[0].from_id)

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-06-10 10:11+0000\n"
+"POT-Creation-Date: 2015-06-26 08:35+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -43,7 +43,7 @@ msgstr "Report konnte nicht generiert werden."
 msgid "Delete"
 msgstr "Beteiligung löschen"
 
-#: ./opengever/dossier/browser/overview.py:44
+#: ./opengever/dossier/browser/overview.py:52
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -88,11 +88,11 @@ msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossi
 msgid "Move Items"
 msgstr "Elemente verschieben"
 
-#: ./opengever/dossier/browser/overview.py:42
+#: ./opengever/dossier/browser/overview.py:50
 msgid "Newest documents"
 msgstr "Neuste Dokumente"
 
-#: ./opengever/dossier/browser/overview.py:37
+#: ./opengever/dossier/browser/overview.py:42
 msgid "Newest tasks"
 msgstr "Neuste Aufgaben"
 
@@ -108,7 +108,7 @@ msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 msgid "Not found the templatedossier"
 msgstr "Es sind keine Vorlagen vorhanden."
 
-#: ./opengever/dossier/browser/overview.py:39
+#: ./opengever/dossier/browser/overview.py:44
 msgid "Participants"
 msgstr "Beteiligte"
 
@@ -429,7 +429,7 @@ msgid "label_container_type"
 msgstr "Behältnis-Art"
 
 #. Default: "Creator"
-#: ./opengever/dossier/templatedossier/form.py:130
+#: ./opengever/dossier/templatedossier/form.py:132
 msgid "label_creator"
 msgstr "Erstellt von"
 
@@ -481,8 +481,13 @@ msgstr "Früheres Aktenzeichen"
 msgid "label_keywords"
 msgstr "Schlagworte"
 
+#. Default: "Linked Dossiers"
+#: ./opengever/dossier/browser/overview.py:46
+msgid "label_linked_dossiers"
+msgstr "Verlinkte Dossiers"
+
 #. Default: "Modified"
-#: ./opengever/dossier/templatedossier/form.py:133
+#: ./opengever/dossier/templatedossier/form.py:135
 msgid "label_modified"
 msgstr "Zuletzt Bearbeitet"
 
@@ -554,7 +559,7 @@ msgstr "Vorlage"
 
 #. Default: "title"
 #: ./opengever/dossier/browser/report.py:33
-#: ./opengever/dossier/templatedossier/form.py:126
+#: ./opengever/dossier/templatedossier/form.py:128
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:30
 msgid "label_title"
 msgstr "Titel"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-10 10:11+0000\n"
+"POT-Creation-Date: 2015-06-26 08:35+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,7 +41,7 @@ msgstr "Impossible de générer l'affichage"
 msgid "Delete"
 msgstr "Effacer la participation"
 
-#: ./opengever/dossier/browser/overview.py:44
+#: ./opengever/dossier/browser/overview.py:52
 msgid "Description"
 msgstr "Description"
 
@@ -86,11 +86,11 @@ msgstr "Il n'est pas possible d'ouvrir un sous-dossier, le dossier principale do
 msgid "Move Items"
 msgstr "Déplacer l'élément"
 
-#: ./opengever/dossier/browser/overview.py:42
+#: ./opengever/dossier/browser/overview.py:50
 msgid "Newest documents"
 msgstr "Derniers documents"
 
-#: ./opengever/dossier/browser/overview.py:37
+#: ./opengever/dossier/browser/overview.py:42
 msgid "Newest tasks"
 msgstr "Dernières tâches"
 
@@ -106,7 +106,7 @@ msgstr "Manque des champs obligatoires"
 msgid "Not found the templatedossier"
 msgstr "Pas de modèles disponible"
 
-#: ./opengever/dossier/browser/overview.py:39
+#: ./opengever/dossier/browser/overview.py:44
 msgid "Participants"
 msgstr "Participants"
 
@@ -425,7 +425,7 @@ msgid "label_container_type"
 msgstr "Type de conteneur"
 
 #. Default: "Creator"
-#: ./opengever/dossier/templatedossier/form.py:130
+#: ./opengever/dossier/templatedossier/form.py:132
 msgid "label_creator"
 msgstr "Créé par"
 
@@ -477,8 +477,13 @@ msgstr "Ancienne numéro référence"
 msgid "label_keywords"
 msgstr "Mots-clés"
 
+#. Default: "Linked Dossiers"
+#: ./opengever/dossier/browser/overview.py:46
+msgid "label_linked_dossiers"
+msgstr ""
+
 #. Default: "Modified"
-#: ./opengever/dossier/templatedossier/form.py:133
+#: ./opengever/dossier/templatedossier/form.py:135
 msgid "label_modified"
 msgstr "Modifié"
 
@@ -550,7 +555,7 @@ msgstr "Modèle"
 
 #. Default: "title"
 #: ./opengever/dossier/browser/report.py:33
-#: ./opengever/dossier/templatedossier/form.py:126
+#: ./opengever/dossier/templatedossier/form.py:128
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:30
 msgid "label_title"
 msgstr "Titre"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-10 10:11+0000\n"
+"POT-Creation-Date: 2015-06-26 08:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:44
+#: ./opengever/dossier/browser/overview.py:52
 msgid "Description"
 msgstr ""
 
@@ -89,11 +89,11 @@ msgstr ""
 msgid "Move Items"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:42
+#: ./opengever/dossier/browser/overview.py:50
 msgid "Newest documents"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:37
+#: ./opengever/dossier/browser/overview.py:42
 msgid "Newest tasks"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Not found the templatedossier"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:39
+#: ./opengever/dossier/browser/overview.py:44
 msgid "Participants"
 msgstr ""
 
@@ -427,7 +427,7 @@ msgid "label_container_type"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/dossier/templatedossier/form.py:130
+#: ./opengever/dossier/templatedossier/form.py:132
 msgid "label_creator"
 msgstr ""
 
@@ -479,8 +479,13 @@ msgstr ""
 msgid "label_keywords"
 msgstr ""
 
+#. Default: "Linked Dossiers"
+#: ./opengever/dossier/browser/overview.py:46
+msgid "label_linked_dossiers"
+msgstr ""
+
 #. Default: "Modified"
-#: ./opengever/dossier/templatedossier/form.py:133
+#: ./opengever/dossier/templatedossier/form.py:135
 msgid "label_modified"
 msgstr ""
 
@@ -552,7 +557,7 @@ msgstr ""
 
 #. Default: "title"
 #: ./opengever/dossier/browser/report.py:33
-#: ./opengever/dossier/templatedossier/form.py:126
+#: ./opengever/dossier/templatedossier/form.py:128
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:30
 msgid "label_title"
 msgstr ""

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -99,3 +99,32 @@ class TestOverview(FunctionalTestCase):
         self.assertEquals(
             ['Foo'],
             browser.css('span.contenttype-opengever-task-task').text)
+
+    @browsing
+    def test_references_box_lists_regular_references(self, browser):
+        browser.login().open(
+            self.portal, view='++add++opengever.dossier.businesscasedossier')
+        browser.fill({'Title': 'Dossier B', 'Related Dossier': [self.dossier]})
+        browser.find('Save').click()
+        dossier_b = browser.context
+
+        browser.open(browser.context, view='tabbedview_view-overview')
+        references = browser.css('#referencesBox a')
+        self.assertEquals(['Testdossier'], references.text)
+        self.assertEquals([self.dossier.absolute_url()],
+                          [link.get('href') for link in references])
+
+
+    @browsing
+    def test_references_box_lists_back_references(self, browser):
+        browser.login().open(
+            self.portal, view='++add++opengever.dossier.businesscasedossier')
+        browser.fill({'Title': 'Dossier B', 'Related Dossier': [self.dossier]})
+        browser.find('Save').click()
+        dossier_b = browser.context
+
+        browser.open(self.dossier, view='tabbedview_view-overview')
+        references = browser.css('#referencesBox a')
+        self.assertEquals(['Dossier B'], references.text)
+        self.assertEquals([dossier_b.absolute_url()],
+                          [link.get('href') for link in references])


### PR DESCRIPTION
Neu werden alle Referenzen, sowohl ausgehende wie auch einkommende, in einer separaten Box in der Dossier Übersicht dargestellt. Closes #841 

![bildschirmfoto_2015-06-26_um_10_37_10](https://cloud.githubusercontent.com/assets/485755/8373719/90c8305c-1bef-11e5-8421-8adadcbb3806.png)

----
Während der Entwicklung bin ich noch auf eine [Bug im plone.app.relationfield](https://github.com/plone/plone.app.relationfield/pull/12) gestossen. Da ich nicht mit einem Backport seitens von Plone rechne, habe ich den Bug mit einem separaten Event Handler im `opengever.base` korrigiert. Wie verzichten vorerst auf einen Upgradestep, welche bestehende Referenzen reindexieren würde, falls troztdem notwendig, kann das einfach zu einem späteren Zeitpunkt nachgeholt werden.