### PR TITLE
Message typ (warning) korrigiert, beim Einreichen von bereits eingereichten Dokument-versionen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 
 4.5.0 (unreleased)
 ------------------
-  
+
+- Fixed message type (warning) when resubmitting an already submitted document.
+  [phgross]
+
 - Optimize error handling of the NotificationCenter, show statusmessage
   instead of abort request.
   [phgross]

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -300,7 +300,7 @@ class NullUpdateSubmittedDocumentCommand(object):
             _(u'Document ${title} has already been submitted in that version',
               mapping=dict(title=self.document.title)),
             portal.REQUEST,
-            type='warn')
+            type='warning')
 
 
 class UpdateSubmittedDocumentCommand(object):


### PR DESCRIPTION
Der Message Typ war fälschlicherweise `warn` anstatt `warning`.
![bildschirmfoto_2015-06-29_um_09_08_35](https://cloud.githubusercontent.com/assets/485755/8402784/babd7a06-1e3e-11e5-9022-4a790cab4922.png)

Closes #938 

@deiferni 