### PR TITLE
Autofocus automatisch auf's erste Feld legen.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Set focus on first form field.
+  [phgross]
+
 - Add additional reference box in the dossier overview.
   [phgross]
 

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -1,0 +1,4 @@
+$(function() {
+  // set focus on first form field
+  $("form#form input:text:visible, form#form textarea:visible").first().focus();
+});

--- a/opengever/base/profiles/default/jsregistry.xml
+++ b/opengever/base/profiles/default/jsregistry.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
 
-    <javascript cacheable="True" compression="save" cookable="True" expression=""
+    <javascript cacheable="True" compression="safe" cookable="True" expression=""
                 enabled="True" id="++resource++opengever.base/prepoverlay.js" inline="False"
                 insert-after="++resource++plone.app.jquerytools.overlayhelpers.js"
                 />
 
-    <javascript cacheable="True" compression="save" cookable="True" expression=""
+    <javascript cacheable="True" compression="safe" cookable="True" expression=""
                 enabled="True" id="++resource++opengever.base/quickupload.js" inline="False"
                 insert-after="++resource++plone.app.jquery.js"
                 />

--- a/opengever/base/profiles/default/jsregistry.xml
+++ b/opengever/base/profiles/default/jsregistry.xml
@@ -17,4 +17,8 @@
                 expression="" id="++resource++opengever.base/livesearch.js"
                 inline="False"/>
 
+    <javascript cacheable="True" compression="safe" cookable="True" expression=""
+                enabled="True" id="++resource++opengever.base/base.js" inline="False"
+                />
+
 </object>

--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4302</version>
+  <version>4500</version>
 </metadata>

--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4500</version>
+  <version>4501</version>
 </metadata>

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -294,4 +294,13 @@
         directory="profiles/4500"
         />
 
+    <!-- 4500 -> 4501 -->
+    <upgrade-step:importProfile
+        title="Fixed compression type of some opengever.base javascripts."
+        profile="opengever.base:default"
+        source="4500"
+        destination="4501"
+        directory="profiles/4501"
+        />
+
 </configure>

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -285,4 +285,13 @@
         directory="profiles/4302"
         />
 
+    <!-- 4302 -> 4500 -->
+    <upgrade-step:importProfile
+        title="Register base.js, wich includes a script which set focus on first form field."
+        profile="opengever.base:default"
+        source="4302"
+        destination="4500"
+        directory="profiles/4500"
+        />
+
 </configure>

--- a/opengever/base/upgrades/profiles/4500/jsregistry.xml
+++ b/opengever/base/upgrades/profiles/4500/jsregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript cacheable="True" compression="safe" cookable="True" expression=""
+              enabled="True" id="++resource++opengever.base/base.js" inline="False"
+              />
+
+</object>

--- a/opengever/base/upgrades/profiles/4501/jsregistry.xml
+++ b/opengever/base/upgrades/profiles/4501/jsregistry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript compression="safe" id="++resource++opengever.base/prepoverlay.js" />
+  <javascript compression="safe" id="++resource++opengever.base/quickupload.js" />
+
+</object>


### PR DESCRIPTION
Closes #961 .

Wie besprochen habe ich ein generelles Javascript registriert (`base.js`), dies ermöglicht uns kleine Scripts, gesammelt in einem File in der JSRegistry zu registrieren.

@lukasgraf @deiferni 

Zusätzlich habe ich auch gleich den `compression type` von bereits existierenden Javascripts korrigiert, diese hatten fälschlicherweise `save` anstatt `safe` hinterlegt.