### PR TITLE
Mail-Titel als Dateiname verwenden.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,7 +371,7 @@ mail:
 
 ``cat testmail.eml | bin/test-inbound-mail``
 
-The script assumes you got an instance running on port ``${instance:http-address}``, a GEVER client called ``mandant1`` and an omelette with ``ftw.mail`` in it installed. It will then feed the mail from stdin to
+The script assumes you got an instance running on port ``${instance:http-address}``, a GEVER client called ``fd`` and an omelette with ``ftw.mail`` in it installed. It will then feed the mail from stdin to
 the ``ftw.mail`` inbound view, like Postfix would.
 
 

--- a/development.cfg
+++ b/development.cfg
@@ -68,4 +68,4 @@ cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build
 # Usage: cat testmail.eml | bin/test-inbound-mail
 recipe = collective.recipe.scriptgen
 cmd = python
-arguments = parts/omelette/ftw/mail/mta2plone.py http://127.0.0.1:${instance:http-address}/mandant1/mail-inbound
+arguments = parts/omelette/ftw/mail/mta2plone.py http://127.0.0.1:${instance:http-address}/fd/mail-inbound

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Set mail filename from title when creating/updating mails.
+  The mail filename is now always set automatically as a normalized form of title.
+  [deiferni]
+
 - Set focus on first form field.
   [phgross]
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -15,11 +15,13 @@ from opengever.ogds.models.user import User
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form, dexterity
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.supermodel.interfaces import FIELDSETS_KEY
 from plone.supermodel.model import Fieldset
 from sqlalchemy import func
 from z3c.form.interfaces import DISPLAY_MODE
 from zope import schema
+from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import Interface, alsoProvides
@@ -106,6 +108,14 @@ class OGMail(BaseDocument):
 
         return 0
 
+    def update_filename(self):
+        if not self.message:
+            return
+
+        normalizer = getUtility(IIDNormalizer)
+        normalized_subject = normalizer.normalize(self.title)
+        self.message.filename = u'{}.eml'.format(normalized_subject)
+
 
 class OGMailBase(metadata.MetadataBase):
 
@@ -139,6 +149,8 @@ def initalize_title(mail, event):
 
         IOGMail(mail).title = value
         mail.title = value
+
+    mail.update_filename()
 
 
 # XXX: The following two methods will be obselet if the ContactInformation

--- a/opengever/mail/profiles/default/metadata.xml
+++ b/opengever/mail/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4300</version>
+  <version>4500</version>
   <dependencies>
     <dependency>profile-ftw.mail:default</dependency>
   </dependencies>

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -26,7 +26,7 @@ class TestMailDownloadCopy(FunctionalTestCase):
             'status': '200 Ok',
             'content-length': str(len(browser.contents)),
             'content-type': 'message/rfc822',
-            'content-disposition': 'attachment; filename="testmail.eml"'},
+            'content-disposition': 'attachment; filename="die-burgschaft.eml"'},
             browser.headers)
 
     @browsing

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -27,7 +27,7 @@ class TestOverview(FunctionalTestCase):
                   ['creator', 'Test User (test_user_1_)'],
                   ['Description', ''],
                   ['Foreign Reference', ''],
-                  ['Original message', u'testmail.eml \u2014 1 KB Download copy'],
+                  ['Original message', u'die-burgschaft.eml \u2014 1 KB Download copy'],
                   ['Digital Available', 'yes'],
                   ['Preserved as paper', 'yes'],
                   ['Date of receipt', date_format_helper(date.today())],

--- a/opengever/mail/tests/test_message_filename_initialized.py
+++ b/opengever/mail/tests/test_message_filename_initialized.py
@@ -1,0 +1,43 @@
+from collective.quickupload.interfaces import IQuickUploadFileFactory
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.mail import inbound
+from ftw.testbrowser import browsing
+from opengever.mail.tests import MAIL_DATA
+from opengever.testing import FunctionalTestCase
+
+
+class TestMessageFilenameInitialized(FunctionalTestCase):
+
+    def test_message_filename_initialized_with_builder(self):
+        mail = create(Builder("mail").with_message(MAIL_DATA))
+        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+
+    def test_message_filename_initialized_with_quickupload(self):
+        dossier = create(Builder("dossier"))
+        factory = IQuickUploadFileFactory(dossier)
+
+        result = factory(filename='mail.eml',
+                         title='',  # ignored by adapter
+                         description='Description',  # ignored by adapter
+                         content_type='message/rfc822',
+                         data=MAIL_DATA,
+                         portal_type='ftw.mail.mail')
+        mail = result['success']
+        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+
+    def test_message_filename_initialzed_with_inboud_mail(self):
+        dossier = create(Builder("dossier"))
+        mail = inbound.createMailInContainer(dossier, MAIL_DATA)
+        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+
+    @browsing
+    def test_message_filename_initialized_on_addview(self, browser):
+        dossier = create(Builder("dossier"))
+        browser.login().open(dossier, view='++add++ftw.mail.mail')
+        browser.fill({
+            'Raw Message': (MAIL_DATA, 'mail.eml', 'message/rfc822')
+        }).submit()
+
+        mail = browser.context
+        self.assertEquals('die-burgschaft.eml', mail.message.filename)

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -76,3 +76,14 @@ class TestOGMailAddition(FunctionalTestCase):
 
         self.assertFalse(mail_a.is_removed)
         self.assertTrue(mail_b.is_removed)
+
+    def test_update_filename_does_not_fail_for_mails_without_message(self):
+        mail = create(Builder("mail").titled('Foo'))
+        mail.title = u'Foo B\xe4r'
+        mail.update_filename()
+
+    def test_update_filename_sets_normalized_filename(self):
+        mail = create(Builder('mail').with_dummy_message())
+        mail.title = u'Foo B\xe4r'
+        mail.update_filename()
+        self.assertEqual(u'foo-bar.eml', mail.message.filename)

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -132,7 +132,7 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
         mails = [create(Builder("mail").within(dossier).with_dummy_message()), ]
 
         mail = self.send_documents(dossier, mails)
-        self.assert_attachment(mail, 'testmail.eml', 'message/rfc822')
+        self.assert_attachment(mail, 'no-subject.eml', 'message/rfc822')
 
         attachment = mail.get_payload()[1].get_payload()[0]
         self.assertIn(

--- a/opengever/mail/tests/test_subscribers.py
+++ b/opengever/mail/tests/test_subscribers.py
@@ -1,0 +1,24 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestSubscribers(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestSubscribers, self).setUp()
+
+        self.root = create(Builder('repository_root'))
+        self.repo = create(Builder('repository').within(self.root))
+        self.dossier = create(Builder('dossier').within(self.repo))
+
+    @browsing
+    def test_modifying_title_updates_filename(self, browser):
+        mail = create(
+            Builder('mail').within(self.dossier).with_dummy_message())
+
+        browser.login().open(mail, view='edit')
+        browser.fill({'Title': 'My new mail Title'}).submit()
+
+        self.assertEqual(u'my-new-mail-title.eml', mail.message.filename)

--- a/opengever/mail/upgrades/configure.zcml
+++ b/opengever/mail/upgrades/configure.zcml
@@ -168,4 +168,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4300 -> 4500 -->
+    <genericsetup:upgradeStep
+        title="Update message filename from title."
+        description=""
+        source="4300"
+        destination="4500"
+        handler="opengever.mail.upgrades.to4500.UpgradeMailMessageFilename"
+        profile="opengever.mail:default"
+        />
+
 </configure>

--- a/opengever/mail/upgrades/to4500.py
+++ b/opengever/mail/upgrades/to4500.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+
+
+class UpgradeMailMessageFilename(UpgradeStep):
+
+    def __call__(self):
+        objects = self.catalog_unrestricted_search(
+            {'portal_type': 'ftw.mail.mail'}, full_objects=True)
+
+        for mail in ProgressLogger('Migrate mail message filename', objects):
+            mail.update_filename()

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -200,6 +200,7 @@ class MailBuilder(DexterityBuilder):
             trasher = ITrashable(obj)
             trasher.trash()
 
+        obj.update_filename()
         super(MailBuilder, self).after_create(obj)
 
     def set_missing_values_for_empty_fields(self, obj):


### PR DESCRIPTION
Dieser PR ändert das Verhalten des Mail-Filenames. Bisher war das Verhalten folgendermassen:
- Beim Mail-In wurde hardcoded der Filename `message.eml` vergeben.
- Beim QuickUpload wurde der Dateiname übernommen.

Neu wird der filename immer automatisch aus dem Titel abgeleitet und gesetzt. Er entspricht der normalisierten Form des Titels:

```
Subject: Die Bürgschaft
Filename: die-burgschaft.eml
```

Damit wird auch automatisch der Titel des Mails als Dateiname beim Zipexport verwendet.

Closes #534.