### PR TITLE
Öffentlichkeitsstatus Formular auch bei Dokumenten innerhalb von Aufgaben darstellen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Show public_trial edit-form link also for documents inside tasks.
+  [phgross]
+
 - Set mail filename from title when creating/updating mails.
   The mail filename is now always set automatically as a normalized form of title.
   [deiferni]

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -1,6 +1,4 @@
 from AccessControl import getSecurityManager
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from five import grok
 from opengever.base import _ as ogbmf
 from opengever.base.browser import edit_public_trial
@@ -14,11 +12,12 @@ from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.model import SubmittedDocument
 from opengever.ogds.base.actor import Actor
 from opengever.tabbedview.browser.base import OpengeverTab
+from plone import api
 from plone.directives.dexterity import DisplayForm
-from Products.CMFCore.utils import getToolByName
 from z3c.form.browser.checkbox import SingleCheckBoxWidget
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import queryMultiAdapter
+
 
 try:
     from opengever.pdfconverter.behaviors.preview import IPreviewMarker
@@ -236,10 +235,7 @@ class Overview(DisplayForm, OpengeverTab):
         except (AssertionError, ValueError):
             return False
 
-        wftool = getToolByName(self.context, 'portal_workflow')
-        state = wftool.getInfoFor(aq_parent(aq_inner(self.context)),
-                                  'review_state')
-
+        state = api.content.get_state(self.context.get_parent_dossier())
         return can_edit and state in DOSSIER_STATES_CLOSED
 
     def get_download_copy_tag(self):

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -197,6 +197,24 @@ class TestDocumentOverview(FunctionalTestCase):
             'Public trial edit link should be visible.')
 
     @browsing
+    def test_modify_public_trial_is_visible_on_closed_dossier_inside_a_task(self, browser):
+        dossier = create(Builder('dossier')
+                         .within(self.repo_folder)
+                         .in_state('dossier-state-resolved'))
+        task = create(Builder('task')
+                      .within(dossier)
+                      .in_state('task-state-tested-and-closed'))
+        document = create(Builder('document')
+                          .within(task)
+                          .with_dummy_content())
+
+        browser.login().visit(document, view='tabbedview_view-overview')
+
+        self.assertTrue(
+            browser.css('#form-widgets-IClassification-public_trial-edit-link'),
+            'Public trial edit link should be visible.')
+
+    @browsing
     def test_submitted_documents_hidden_when_feature_disabled(self, browser):
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee').within(container))


### PR DESCRIPTION
Ich habe die Überprüfung `show_modfiy_public_trial_link` in der Dokumenten Overview korrigiert. Sie ging fälschlicherweise davon aus, dass das Parent eines Dokuments immer ein Dossier ist. Deshalb wurde für Aufgaben fälschlicherweise kein Öffentlichkeitsstatus Formular dargestellt.

Fixes #965.

@lukasgraf @deiferni 