### PR TITLE
Korrektur ComponentLookupError in der CancelDocument View

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fixed ComponentLookupError in CancelDocument view, when mails are selected,
+  show error statusmessage instead.
+  [phgross]
+
 - Show public_trial edit-form link also for documents inside tasks.
   [phgross]
 

--- a/opengever/document/checkout/cancel.py
+++ b/opengever/document/checkout/cancel.py
@@ -1,9 +1,11 @@
-from Products.CMFCore.utils import getToolByName
-from Products.statusmessages.interfaces import IStatusMessage
 from five import grok
+from ftw.mail.mail import IMail
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
+from plone import api
+from Products.CMFCore.utils import getToolByName
+from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
 from zope.interface import Interface
 
@@ -20,7 +22,6 @@ class CancelDocuments(grok.View):
     grok.name('cancel_document_checkouts')
 
     def render(self):
-
         # check whether we have paths or not
         paths = self.request.get('paths')
 
@@ -64,6 +65,14 @@ class CancelDocuments(grok.View):
     def cancel(self, obj):
         """Cancels a single document checkout.
         """
+        if IMail.providedBy(obj):
+            msg = _(u'msg_cancel_checkout_on_mail_not_possible',
+                    default=u'Could not cancel checkout on document ${title}, '
+                    'mails does not support the checkin checkout process.',
+                    mapping={'title': obj.Title().decode('utf-8')})
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+            return
 
         # check out the document
         manager = getMultiAdapter((obj, self.request),

--- a/opengever/document/checkout/cancel.py
+++ b/opengever/document/checkout/cancel.py
@@ -4,8 +4,6 @@ from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone import api
-from Products.CMFCore.utils import getToolByName
-from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
 from zope.interface import Interface
 
@@ -28,8 +26,8 @@ class CancelDocuments(grok.View):
         # using "paths" is mandantory on any objects except for a document
         if not paths and not IDocumentSchema.providedBy(self.context):
             msg = _(u'You have not selected any documents')
-            IStatusMessage(self.request).addStatusMessage(
-                msg, type='error')
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
 
             # we assume the request came from the tabbed_view "documents"
             # tab on the dossier
@@ -38,7 +36,7 @@ class CancelDocuments(grok.View):
 
         elif paths:
             # lookup the objects to be handled using the catalog
-            catalog = getToolByName(self.context, 'portal_catalog')
+            catalog = api.portal.get_tool('portal_catalog')
             objects = []
             for path in paths:
                 query = dict(path={'query': path, 'depth': 0})
@@ -82,12 +80,13 @@ class CancelDocuments(grok.View):
         if not manager.is_cancel_allowed():
             msg = _(u'Could not cancel checkout on document ${title}',
                     mapping=dict(title=obj.Title().decode('utf-8')))
-            IStatusMessage(self.request).addStatusMessage(msg, type='error')
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
 
         else:
             manager.cancel()
-
             # notify the user
             msg = _(u'Cancel checkout: ${title}',
                     mapping={'title': obj.Title().decode('utf-8')})
-            IStatusMessage(self.request).addStatusMessage(msg, type='info')
+            api.portal.show_message(
+                message=msg, request=self.request, type='info')

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-04-20 09:47+0000\n"
+"POT-Creation-Date: 2015-07-01 11:57+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -23,7 +23,7 @@ msgstr "Das Dokument kann momentan nicht bearbeitet werden, es ist gesperrt."
 msgid "Cancel"
 msgstr "Widerrufen"
 
-#: ./opengever/document/checkout/cancel.py:82
+#: ./opengever/document/checkout/cancel.py:88
 msgid "Cancel checkout: ${title}"
 msgstr "Checkout abgebrochen für ${title}"
 
@@ -51,7 +51,7 @@ msgstr "Ohne Kommentar einchecken"
 msgid "Checkout"
 msgstr "Auschecken"
 
-#: ./opengever/document/checkout/cancel.py:74
+#: ./opengever/document/checkout/cancel.py:80
 msgid "Could not cancel checkout on document ${title}"
 msgstr "Das Auschecken des Dokuments ${title} konnte nicht widerrufen werden."
 
@@ -88,7 +88,7 @@ msgstr "Dokument"
 msgid "Don't show this message again."
 msgstr "Diese Meldung nicht mehr anzeigen."
 
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:18
+#: ./opengever/document/browser/templates/logout_overlay.pt:19
 msgid "Logout"
 msgstr "GEVER verlassen"
 
@@ -132,14 +132,14 @@ msgstr "Eingereichte Version aktualisieren"
 msgid "You are not authorized to edit the document ${title}"
 msgstr "Sie sind nicht berechtigt, das Dokument ${title} zu bearbeiten."
 
-#: ./opengever/document/checkout/cancel.py:29
+#: ./opengever/document/checkout/cancel.py:28
 #: ./opengever/document/checkout/checkin.py:197
 #: ./opengever/document/checkout/checkout.py:33
 msgid "You have not selected any documents"
 msgstr "Sie haben keine Dokumente ausgewählt."
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:3
+#: ./opengever/document/browser/templates/logout_overlay.pt:3
 msgid "alert_not_checked_in_documents"
 msgstr "Sie haben noch ausgecheckte Dokumente. Wollen Sie OneGov GEVER wirklich verlassen?"
 
@@ -154,7 +154,7 @@ msgid "button_checkin"
 msgstr "Einchecken"
 
 #. Default: "copy of"
-#: ./opengever/document/subscribers.py:75
+#: ./opengever/document/subscribers.py:76
 msgid "copy_of"
 msgstr "Kopie von"
 
@@ -169,19 +169,19 @@ msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:91
+#: ./opengever/document/document.py:90
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py:67
 msgid "error_title_or_file_required"
 msgstr "Ein Titel oder eine Datei muss angegeben werden."
 
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:27
 #: ./opengever/document/behaviors/related_docs.py:38
-#: ./opengever/document/document.py:44
+#: ./opengever/document/document.py:43
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -243,7 +243,7 @@ msgid "help_document_type"
 msgstr ""
 
 #. Default: ""
-#: ./opengever/document/document.py:61
+#: ./opengever/document/document.py:60
 msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
@@ -311,7 +311,7 @@ msgid "label_checkin_journal_comment"
 msgstr "Journal-Kommentar"
 
 #. Default: "Edit Document"
-#: ./opengever/document/browser/overview_templates/file.pt:37
+#: ./opengever/document/browser/templates/file.pt:36
 msgid "label_checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
@@ -352,13 +352,13 @@ msgstr "Herunterladen"
 #. Default: "Download copy"
 #: ./opengever/document/browser/download.py:134
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/overview_templates/file.pt:53
+#: ./opengever/document/browser/templates/file.pt:52
 msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
 #. Default: "File"
 #: ./opengever/document/browser/overview.py:127
-#: ./opengever/document/document.py:60
+#: ./opengever/document/document.py:59
 msgid "label_file"
 msgstr "Datei"
 
@@ -382,7 +382,7 @@ msgid "label_ok"
 msgstr "OK"
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/overview_templates/file.pt:23
+#: ./opengever/document/browser/templates/file.pt:22
 msgid "label_pdf_preview"
 msgstr "PDF Vorschau"
 
@@ -427,7 +427,7 @@ msgid "label_thumbnail"
 msgstr "Kurzbild"
 
 #. Default: "Title"
-#: ./opengever/document/document.py:54
+#: ./opengever/document/document.py:53
 msgid "label_title"
 msgstr "Titel"
 
@@ -441,13 +441,18 @@ msgstr "Ja"
 msgid "message_checkout_info"
 msgstr "Dieses Dokument wurde von ${creator} ausgecheckt."
 
+#. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
+#: ./opengever/document/checkout/cancel.py:67
+msgid "msg_cancel_checkout_on_mail_not_possible"
+msgstr "Das Dokument `${title}` konnte nicht ausgecheckt werden, da Mails den Checkin/Checkout Prozess nicht unterstützen."
+
 #. Default: "No file"
-#: ./opengever/document/browser/overview_templates/file.pt:60
+#: ./opengever/document/browser/templates/file.pt:59
 msgid "no_file"
 msgstr "Keine Datei"
 
 #. Default: "Following documents are checked out:"
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:8
+#: ./opengever/document/browser/templates/logout_overlay.pt:8
 msgid "overview_not_checked_in_documents"
 msgstr "Folgende Dokumente sind ausgecheckt:"
 
@@ -465,4 +470,3 @@ msgstr "Mit Kommentar"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Ohne Kommentar"
-

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-20 09:47+0000\n"
+"POT-Creation-Date: 2015-07-01 11:57+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgstr "Impossible de modifier le document en ce moment car il est verrouillé."
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ./opengever/document/checkout/cancel.py:82
+#: ./opengever/document/checkout/cancel.py:88
 msgid "Cancel checkout: ${title}"
 msgstr "Annuler le checkout pour  ${title}"
 
@@ -49,7 +49,7 @@ msgstr "Checkin sans commentaire"
 msgid "Checkout"
 msgstr "Checkout"
 
-#: ./opengever/document/checkout/cancel.py:74
+#: ./opengever/document/checkout/cancel.py:80
 msgid "Could not cancel checkout on document ${title}"
 msgstr "Checkout du document ${title} inabouti"
 
@@ -86,7 +86,7 @@ msgstr "Document"
 msgid "Don't show this message again."
 msgstr "Ne plus afficher ce message."
 
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:18
+#: ./opengever/document/browser/templates/logout_overlay.pt:19
 msgid "Logout"
 msgstr "Quitter GEVER"
 
@@ -129,14 +129,14 @@ msgstr ""
 msgid "You are not authorized to edit the document ${title}"
 msgstr "Vous n'avez pas les droits de modifier le document ${title}"
 
-#: ./opengever/document/checkout/cancel.py:29
+#: ./opengever/document/checkout/cancel.py:28
 #: ./opengever/document/checkout/checkin.py:197
 #: ./opengever/document/checkout/checkout.py:33
 msgid "You have not selected any documents"
 msgstr "Vous n'avez  sélectionné aucun document"
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:3
+#: ./opengever/document/browser/templates/logout_overlay.pt:3
 msgid "alert_not_checked_in_documents"
 msgstr "Vous avez encore des documents en checkout! Voulez-vous quand même quitter Gever ?"
 
@@ -151,7 +151,7 @@ msgid "button_checkin"
 msgstr "Checkin"
 
 #. Default: "copy of"
-#: ./opengever/document/subscribers.py:75
+#: ./opengever/document/subscribers.py:76
 msgid "copy_of"
 msgstr "Copie de"
 
@@ -166,19 +166,19 @@ msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:91
+#: ./opengever/document/document.py:90
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py:67
 msgid "error_title_or_file_required"
 msgstr "Un titre ou un fichier est requis."
 
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:27
 #: ./opengever/document/behaviors/related_docs.py:38
-#: ./opengever/document/document.py:44
+#: ./opengever/document/document.py:43
 msgid "fieldset_common"
 msgstr "En général"
 
@@ -237,7 +237,7 @@ msgstr "Date de création du document"
 msgid "help_document_type"
 msgstr ""
 
-#: ./opengever/document/document.py:61
+#: ./opengever/document/document.py:60
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
@@ -301,7 +301,7 @@ msgid "label_checkin_journal_comment"
 msgstr "Commentaire de l'historique"
 
 #. Default: "Edit Document"
-#: ./opengever/document/browser/overview_templates/file.pt:37
+#: ./opengever/document/browser/templates/file.pt:36
 msgid "label_checkout_and_edit"
 msgstr "Checkout / Modifier"
 
@@ -342,13 +342,13 @@ msgstr "Télécharger"
 #. Default: "Download copy"
 #: ./opengever/document/browser/download.py:134
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/overview_templates/file.pt:53
+#: ./opengever/document/browser/templates/file.pt:52
 msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
 #. Default: "File"
 #: ./opengever/document/browser/overview.py:127
-#: ./opengever/document/document.py:60
+#: ./opengever/document/document.py:59
 msgid "label_file"
 msgstr "Fichier"
 
@@ -372,7 +372,7 @@ msgid "label_ok"
 msgstr "Ok"
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/overview_templates/file.pt:23
+#: ./opengever/document/browser/templates/file.pt:22
 msgid "label_pdf_preview"
 msgstr "Aucun résultat trouvé"
 
@@ -417,7 +417,7 @@ msgid "label_thumbnail"
 msgstr "Vignette"
 
 #. Default: "Title"
-#: ./opengever/document/document.py:54
+#: ./opengever/document/document.py:53
 msgid "label_title"
 msgstr "Titre"
 
@@ -431,13 +431,18 @@ msgstr "Oui"
 msgid "message_checkout_info"
 msgstr "Ce document a un checkout de ${creator}"
 
+#. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
+#: ./opengever/document/checkout/cancel.py:67
+msgid "msg_cancel_checkout_on_mail_not_possible"
+msgstr ""
+
 #. Default: "No file"
-#: ./opengever/document/browser/overview_templates/file.pt:60
+#: ./opengever/document/browser/templates/file.pt:59
 msgid "no_file"
 msgstr "Aucun fichier trouvé"
 
 #. Default: "Following documents are checked out:"
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:8
+#: ./opengever/document/browser/templates/logout_overlay.pt:8
 msgid "overview_not_checked_in_documents"
 msgstr "Les documents suivants sont en checkout:"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-20 09:47+0000\n"
+"POT-Creation-Date: 2015-07-01 11:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./opengever/document/checkout/cancel.py:82
+#: ./opengever/document/checkout/cancel.py:88
 msgid "Cancel checkout: ${title}"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Checkout"
 msgstr ""
 
-#: ./opengever/document/checkout/cancel.py:74
+#: ./opengever/document/checkout/cancel.py:80
 msgid "Could not cancel checkout on document ${title}"
 msgstr ""
 
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Don't show this message again."
 msgstr ""
 
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:18
+#: ./opengever/document/browser/templates/logout_overlay.pt:19
 msgid "Logout"
 msgstr ""
 
@@ -132,14 +132,14 @@ msgstr ""
 msgid "You are not authorized to edit the document ${title}"
 msgstr ""
 
-#: ./opengever/document/checkout/cancel.py:29
+#: ./opengever/document/checkout/cancel.py:28
 #: ./opengever/document/checkout/checkin.py:197
 #: ./opengever/document/checkout/checkout.py:33
 msgid "You have not selected any documents"
 msgstr ""
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:3
+#: ./opengever/document/browser/templates/logout_overlay.pt:3
 msgid "alert_not_checked_in_documents"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgid "button_checkin"
 msgstr ""
 
 #. Default: "copy of"
-#: ./opengever/document/subscribers.py:75
+#: ./opengever/document/subscribers.py:76
 msgid "copy_of"
 msgstr ""
 
@@ -169,19 +169,19 @@ msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:91
+#: ./opengever/document/document.py:90
 msgid "error_mail_upload"
 msgstr ""
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py:67
 msgid "error_title_or_file_required"
 msgstr ""
 
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:27
 #: ./opengever/document/behaviors/related_docs.py:38
-#: ./opengever/document/document.py:44
+#: ./opengever/document/document.py:43
 msgid "fieldset_common"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgstr ""
 msgid "help_document_type"
 msgstr ""
 
-#: ./opengever/document/document.py:61
+#: ./opengever/document/document.py:60
 msgid "help_file"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "label_checkin_journal_comment"
 msgstr ""
 
 #. Default: "Edit Document"
-#: ./opengever/document/browser/overview_templates/file.pt:37
+#: ./opengever/document/browser/templates/file.pt:36
 msgid "label_checkout_and_edit"
 msgstr ""
 
@@ -345,13 +345,13 @@ msgstr ""
 #. Default: "Download copy"
 #: ./opengever/document/browser/download.py:134
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/overview_templates/file.pt:53
+#: ./opengever/document/browser/templates/file.pt:52
 msgid "label_download_copy"
 msgstr ""
 
 #. Default: "File"
 #: ./opengever/document/browser/overview.py:127
-#: ./opengever/document/document.py:60
+#: ./opengever/document/document.py:59
 msgid "label_file"
 msgstr ""
 
@@ -375,7 +375,7 @@ msgid "label_ok"
 msgstr ""
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/overview_templates/file.pt:23
+#: ./opengever/document/browser/templates/file.pt:22
 msgid "label_pdf_preview"
 msgstr ""
 
@@ -420,7 +420,7 @@ msgid "label_thumbnail"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/document/document.py:54
+#: ./opengever/document/document.py:53
 msgid "label_title"
 msgstr ""
 
@@ -434,13 +434,18 @@ msgstr ""
 msgid "message_checkout_info"
 msgstr ""
 
+#. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
+#: ./opengever/document/checkout/cancel.py:67
+msgid "msg_cancel_checkout_on_mail_not_possible"
+msgstr ""
+
 #. Default: "No file"
-#: ./opengever/document/browser/overview_templates/file.pt:60
+#: ./opengever/document/browser/templates/file.pt:59
 msgid "no_file"
 msgstr ""
 
 #. Default: "Following documents are checked out:"
-#: ./opengever/document/browser/logout_overlay_templates/logout_overlay.pt:8
+#: ./opengever/document/browser/templates/logout_overlay.pt:8
 msgid "overview_not_checked_in_documents"
 msgstr ""
 

--- a/opengever/document/tests/test_cancel.py
+++ b/opengever/document/tests/test_cancel.py
@@ -1,0 +1,89 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.testing import FunctionalTestCase
+from plone.protect import createToken
+from zope.component import getMultiAdapter
+
+
+class TestCancelDocuments(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCancelDocuments, self).setUp()
+        self.dossier = create(Builder('dossier'))
+
+    def obj2paths(self, objs):
+        return ['/'.join(obj.getPhysicalPath()) for obj in objs]
+
+    def get_manager(self, doc):
+        return getMultiAdapter(
+            (doc, self.portal.REQUEST), ICheckinCheckoutManager)
+
+    @browsing
+    def test_shows_message_if_view_is_called_on_a_dossier_without_passing_paths(self, browser):
+        browser.login().open(self.dossier, view='cancel_document_checkouts')
+        self.assertEquals(['You have not selected any documents'],
+                          error_messages())
+
+    @browsing
+    def test_cancel_checkout_for_document_when_view_is_called_on_a_document(self, browser):
+        doc = create(Builder('document').within(self.dossier).checked_out())
+        browser.login().open(doc, {'_authenticator': createToken()},
+                             view='cancel_document_checkouts', )
+
+        self.assertEquals(None, self.get_manager(doc).get_checked_out_by())
+
+    @browsing
+    def test_cancel_checkout_for_all_selected_documents(self, browser):
+        doc1 = create(Builder('document').within(self.dossier).checked_out())
+        doc2 = create(Builder('document').within(self.dossier).checked_out())
+
+        browser.login().open(self.dossier,
+                             {'paths': self.obj2paths([doc1, doc2]),
+                              '_authenticator': createToken()},
+                             view='cancel_document_checkouts', )
+
+        self.assertEquals(None, self.get_manager(doc1).get_checked_out_by())
+        self.assertEquals(None, self.get_manager(doc2).get_checked_out_by())
+
+    @browsing
+    def test_redirects_to_document_itself_when_view_is_called_on_a_document(self, browser):
+        doc = create(Builder('document').within(self.dossier).checked_out())
+        browser.login().open(doc, {'_authenticator': createToken()},
+                             view='cancel_document_checkouts', )
+
+        self.assertEquals(doc, browser.context)
+        self.assertEquals([u'Cancel checkout: Testdokum\xe4nt'],
+                          info_messages())
+
+    @browsing
+    def test_redirects_to_dossier_when_multiple_documents_are_selected(self, browser):
+        doc1 = create(Builder('document').within(self.dossier).checked_out())
+        doc2 = create(Builder('document')
+                      .within(self.dossier)
+                      .titled(u'Anfrage Baugesuch Herr Meier')
+                      .checked_out())
+
+        browser.login().open(self.dossier,
+                             {'paths': self.obj2paths([doc1, doc2]),
+                              '_authenticator': createToken()},
+                             view='cancel_document_checkouts', )
+
+        self.assertEquals(self.dossier, browser.context)
+        self.assertEquals([u'Cancel checkout: Testdokum\xe4nt',
+                           u'Cancel checkout: Anfrage Baugesuch Herr Meier'],
+                          info_messages())
+
+    @browsing
+    def test_shows_message_when_checkout_cant_be_cancelled(self, browser):
+        doc = create(Builder('document').within(self.dossier))
+
+        browser.login().open(doc, {'_authenticator': createToken()},
+                             view='cancel_document_checkouts', )
+
+        self.assertEquals(
+            [u'Could not cancel checkout on document Testdokum\xe4nt'],
+            error_messages())


### PR DESCRIPTION
Wenn fälschlicherweise Mails für die Aktion `Wiederrufen` selektiert werden, so stellt neu die CancelDocument View eine entsprechende Fehlermeldung dar. (Fixes #530)
![bildschirmfoto 2015-07-01 um 14 07 10](https://cloud.githubusercontent.com/assets/485755/8454041/8345f7ca-1ffa-11e5-908b-de5fc04e0677.png)

Zudem habe ich für die View noch Tests geschrieben und die Plone API konsequent verwendet.

@lukasgraf @deiferni 
