### PR TITLE
Add debug helpers to assist in debugging plone.protect issues.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Add debug helpers to assist in debugging plone.protect issues.
+  [lgraf]
+
 - Improve exception handling.
   Remove bare excepts and only catch Exception when possible. Also make sure to
   always re-raise ConflictError.

--- a/opengever/debug/protect.py
+++ b/opengever/debug/protect.py
@@ -1,0 +1,115 @@
+"""Helpers to assist in debugging issues around plone.protect
+"""
+
+from collections import namedtuple
+from functools import partial
+import sys
+import traceback
+import ZODB
+
+
+original_trace_func = None
+
+
+Instruction = namedtuple(
+    'Instruction', ['filename', 'line_no', 'extracted_tb'])
+
+
+class TraceObjectRegistrations(object):
+    """
+    Context manager that traces and displays calls to a ZODB
+    connection's `register()` method.
+
+    These calls will effectively indicate a DB write, and displaying them
+    for an operation that isn't supposed to cause a DB write can help in
+    debugging problems with plone.protect's automatic CSRF protection.
+
+    Once a call to `register()` is intercepted, a message indicating this
+    and the corresponding stack trace are displayed.
+
+    :param limit: Maximum depth of the displayed stack trace
+
+    Usage:
+
+    >>> with TraceObjectRegistrations(tb_limit=5):
+    ...     something_that_writes_but_shouldnt()
+
+    """
+
+    def __init__(self, tb_limit=10):
+        self.tb_limit = tb_limit
+
+    def __enter__(self):
+        trace_func = partial(_trace_obj_registration_calls, self.tb_limit)
+        set_trace(trace_func)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        remove_trace()
+
+
+def set_trace(trace_func):
+    """Registers a call trace function which will be called for every
+    function call, and keeps a reference to any previously set trace function
+    in order to be able to restore it.
+    """
+    global original_trace
+
+    original_trace = sys.gettrace()
+    sys.settrace(trace_func)
+
+
+def remove_trace():
+    """Restores the original trace function (if there was one).
+    """
+    global original_trace
+
+    sys.settrace(original_trace_func)
+
+
+def _trace_obj_registration_calls(tb_limit, frame, event, arg):
+    """Call trace function to intercept any calls to a ZODB
+    connection's .register() method (which effectively indicates a DB write).
+
+    (This function needs to be partially applied first in order to have the
+    proper 3 argument signature to be used as a trace function)
+    """
+    if event != 'call':
+        return
+
+    co = frame.f_code
+    func_name = co.co_name
+
+    # We only want to trace calls to .register() on a
+    # ZODB.Connection.Connection or any of its subclasses.
+
+    if func_name != 'register':
+        return
+
+    frame_self = frame.f_locals.get('self')
+    if frame_self is None:
+        return
+
+    if not issubclass(frame_self.__class__, ZODB.Connection.Connection):
+        return
+
+    filename = frame.f_code.co_filename
+    line_no = frame.f_lineno
+    extracted_tb = traceback.extract_stack(frame, limit=tb_limit)
+    instruction = Instruction(filename, line_no, extracted_tb)
+
+    # At this point we can be reasonably certain that we're in
+    # `register(self, obj)` - so we try to get a reference to the object
+    # that's being registered to print a more helpful message
+    obj = frame.f_locals.get('obj')
+
+    _display_intercepted_call(obj, instruction)
+
+
+def _display_intercepted_call(obj, instruction):
+    msg = 'DB write to {obj} from code in "{filename}", line {line_no}!'
+    msg = msg.format(obj=obj, **instruction._asdict())
+    print "=" * len(msg)
+    print msg
+    print "=" * len(msg)
+    print ''.join(traceback.format_list(instruction.extracted_tb))


### PR DESCRIPTION
This PR introduces a context manager `TraceObjectRegistrations` that will intercept and log all calls to the [`register()` method](https://github.com/zopefoundation/ZODB/blob/master/src/ZODB/Connection.py#L973-L991) on `ZODB.Connection.Connection` or any of its subclasses.

This will indicate a change to a persistent object, and can therefore be used to track down what code exactly causes an unexpected DB write in situations where a `plone.protect` confirmation page appears for a legitimate action.

The context manager works by [registering a trace function](https://docs.python.org/2/library/sys.html#sys.settrace) that traces all calls to `register()`. Once a call is intercepted, a message indicating this and the corresponding stack trace are displayed. Because there is no need to use a local line tracing function, the performance impact is minimal.

##### Usage

```python
>>> with TraceObjectRegistrations(tb_limit=5):
...     something_that_writes_but_shouldnt()
``` 

##### Example Output

```pytb
===============================================================================================
DB write from code in "ZODB3-3.10.5-py2.7-macosx-10.4-x86_64.egg/ZODB/Connection.py", line 961!
===============================================================================================
  File ".../ftw/dictstorage/base.py", line 28, in __getitem__
    return self.storage[key]
  File ".../ftw/dictstorage/base.py", line 28, in __getitem__
    return self.storage[key]
  File ".../ftw/tabbedview/statestorage.py", line 87, in storage
    ann[key] = PersistentDict()
  File ".../zope/annotation/attribute.py", line 70, in __setitem__
    annotations[key] = value
  File ".../ZODB/Connection.py", line 961, in register
    def register(self, obj):

aborting transaction due to no CSRF protection on url http://.../tabbedview_view-versions
```

##### Limitations
- Only the **first change** to particular persistent object inside a sub-transaction (up to the next savepoint) will cause `register()` to be called. Therefore, if multiple changes to the same object happen, only the first modification will be logged.
- Trace functions are registered **per-thread**. I haven't addressed this yet, but I'm not even sure if we need to: The thread that runs the operation causing a write will also execute the context manager that registers and unregisters the trace, so all should be good.
- Invoking **PDB** using `pdb.set_trace()` after entering the context manger, but before leaving it, will result in our trace function being removed, and therefore no DB writes will be logged any more. This is because PDB doesn't save and restore any previous trace functions.
- `conn._registered_objects` is what `plone.protect.auto` is looking at. From what I've seen and understand, there should be *no* code anywhere that directly adds to `_registered_objects` except `register()` on `ZODB.Connection.Connection` or any of its subclasses (`commit()  and `abort()` will obviously clear it, but that's of no interest to us for this purpose).

@deiferni @phgross