### PR TITLE
Fehlende franz. Übersetzung für Checkin ohne Kommentar hinzugefügt

### DIFF
--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -459,5 +459,4 @@ msgstr "Avec commentaire"
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
-msgstr ""
-
+msgstr "Sans commentaire"


### PR DESCRIPTION
![bildschirmfoto_2015-07-03_um_08_40_45](https://cloud.githubusercontent.com/assets/485755/8493832/7ace2a8e-215f-11e5-9df6-eb429f4f4909.png)

Muss auf den Release 3.3.x backportet werden.