### PR TITLE
Fixed UnicodeEncodeError in state_label getter of tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fixed UnicodeEncodeError in state_label getter of tasks.
+  [phgross]
+
 - Add debug helpers to assist in debugging plone.protect issues.
   [lgraf]
 

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -196,7 +196,7 @@ class Task(Base):
         return org_unit.prefix_label(actor.get_link())
 
     def get_state_label(self):
-        return "<span class=wf-{}>{}</span>".format(
+        return u"<span class=wf-{}>{}</span>".format(
             self.review_state,
             translate(self.review_state, domain='plone',
                       context=api.portal.get().REQUEST))

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -4,7 +4,9 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import FunctionalTestCase
+from plone import api
 from plone.app.testing import TEST_USER_ID
+import transaction
 
 
 class TestTaskOverview(FunctionalTestCase):
@@ -197,3 +199,19 @@ class TestTaskOverview(FunctionalTestCase):
             ['Predecessor'], browser.css("#predecessor_taskBox div.task").text)
         self.assertSequenceEqual(
             [], browser.css("#successor_tasksBox div.task").text)
+
+
+    @browsing
+    def test_state_is_translated_state_label(self, browser):
+        self.task = create(Builder('task').in_state('task-state-tested-and-closed'))
+
+        # set french as preferred language
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.addSupportedLanguage('fr-ch')
+        lang_tool.setDefaultLanguage('fr-ch')
+        transaction.commit()
+
+        browser.login().open(self.task, view='tabbedview_view-overview')
+
+        self.assertIn(['Etat', u'Ferm\xe9'],
+                      browser.css('table.listing').first.lists())


### PR DESCRIPTION
Beim Darstellen der Aufgabenübersicht wurde ein UnicodeEncoderError geraised, wenn das übersetzte Status Label Non-Ascii Zeichen enthielt, z.B. `Fermé`

Korrektur von https://errbit.4teamwork.ch/apps/524030763838182915000312/problems/55923f5a6d61742183c00100.

@lukasgraf 