### PR TITLE
Fix invalid variable name in policy template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fix invalid variable name in policy template.
+  (Reference to setup.setup....)
+  [lgraf]
+
 - Improve the representation of the searchresults and the searchform.
   [phgross]
 

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -41,7 +41,7 @@
   {{% if setup.reference_number_formatter %}}
     <value key="formatter">{{{setup.reference_number_formatter}}}}</value>
   {{% endif %}}
-  {{% if setup.setup.reference_prefix_starting_point %}}
+  {{% if setup.reference_prefix_starting_point %}}
     <value key="reference_prefix_starting_point">{{{setup.reference_prefix_starting_point}}}</value>
   {{% endif %}}
   </records>


### PR DESCRIPTION
`registry.xml` contained a reference to `setup.setup.reference_prefix_starting_point` (`setup` twice).