### PR TITLE
Dokumentdatum aktualisieren beim erstellen einer neuen Version (checkin/reverting)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
-- Update document_date to to actual date during checkin.
+- Adjust document_date handling:
+
+  - Update document_date to current date during checkin
+  - Update document_date to version's creation_date when reverting to a version.
+
   [phgross]
 
 - Make sure OGDS sync doesn't fail on user- or group IDs that are too long.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Update document_date to to actual date during checkin.
+  [phgross]
+
 - Make sure OGDS sync doesn't fail on user- or group IDs that are too long.
   Simply skip them and log a warning.
   [lgraf]

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -14,6 +14,7 @@ from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
 from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
+from zope.i18n import translate
 from zope.publisher.interfaces.browser import IBrowserRequest
 
 
@@ -243,8 +244,9 @@ class CheckinCheckoutManager(grok.MultiAdapter):
 
         if create_version:
             # let's create a version
-            comment = _(u'Reverted file to version ${version_id}',
-                        mapping=dict(version_id=version_id))
+            msg = _(u'Reverted file to version ${version_id}',
+                    mapping=dict(version_id=version_id))
+            comment = translate(msg, context=self.request)
             self.repository.save(obj=self.context, comment=comment)
 
         # event

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -1,5 +1,6 @@
 from AccessControl import getSecurityManager, Unauthorized
 from datetime import date
+from datetime import datetime
 from five import grok
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
@@ -241,6 +242,10 @@ class CheckinCheckoutManager(grok.MultiAdapter):
             self.context.file = old_file_copy
         else:
             self.context.file = None
+
+        # update document_date to specific version creation date
+        ts = version.sys_metadata['timestamp']
+        self.context.document_date = datetime.fromtimestamp(ts).date()
 
         if create_version:
             # let's create a version

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -1,4 +1,5 @@
 from AccessControl import getSecurityManager, Unauthorized
+from datetime import date
 from five import grok
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
@@ -9,12 +10,12 @@ from opengever.document.events import ObjectRevertedToVersion
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.trash.trash import ITrashed
 from plone.locking.interfaces import IRefreshableLockable
+from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
 from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
 from zope.publisher.interfaces.browser import IBrowserRequest
 
-from plone.namedfile.file import NamedBlobFile
 
 CHECKIN_CHECKOUT_ANNOTATIONS_KEY = 'opengever.document.checked_out_by'
 
@@ -122,6 +123,9 @@ class CheckinCheckoutManager(grok.MultiAdapter):
         # is the user allowed to checkin?
         if not self.is_checkin_allowed():
             raise Unauthorized
+
+        # update document_date to current date
+        self.context.document_date = date.today()
 
         # create new version in CMFEditions
         self.repository.save(obj=self.context, comment=comment)

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -102,6 +102,8 @@ class TestReverting(FunctionalTestCase):
 
         self.assertEquals(4, len(repo_tool.getHistory(self.document)))
         self.assertEqual(self.document.file.data, version2.object.file.data)
+        self.assertEquals(u'Reverted file to version 2',
+                          repo_tool.retrieve(self.document, 3).comment)
 
     def test_creates_a_new_blob_instance(self):
         self.manager.revert_to_version(2)

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -1,8 +1,10 @@
 from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
+from ftw.testing import freeze
 from opengever.base.interfaces import IRedirector
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -114,6 +116,14 @@ class TestReverting(FunctionalTestCase):
         self.assertNotEqual(
             self.document.file._blob, version2.object.file._blob)
         self.assertNotEqual(self.document.file, version2.object.file)
+
+    def test_resets_document_date_to_reverted_version(self):
+        with freeze(datetime(2015, 01, 28, 12, 00)):
+            self._create_version(self.document, 3)
+
+        self.document.document_date = date(2015, 5, 15)
+        self.manager.revert_to_version(3)
+        self.assertEquals(date(2015, 01, 28), self.document.document_date)
 
     @browsing
     def test_reverting_with_revert_link_in_versions_tab(self, browser):

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -64,6 +64,11 @@ class TestCheckin(FunctionalTestCase):
         self.manager.checkin()
         self.assertFalse(IRefreshableLockable(self.document).locked())
 
+    def test_document_date_is_updated_to_current_date(self):
+        self.manager.checkin()
+
+        self.assertEquals(date.today(), self.document.document_date)
+
 class TestCheckinCheckoutManager(FunctionalTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Neu wird das Dokumentdatum bei jedem erstellen einer Version aktualisiert. Fixes #964 

Beim Checkin: Wird das aktuelle Datum gesetzt. 
Beim Zurücksetzen auf eine Version: Wird das Datum der bestimmten Version verwendet.

 - Ein Upgradestep wird nicht implementiert, da vom Kunden nicht gewünscht.
 - Hab gleich auch die Tests fürs Reverten und Checkin ein wenig optimiert.

@lukasgraf please have a look

