### PR TITLE
OGDSUpdater: Enforce uniqueness of user and group IDs on application side.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- OGDSUpdater: Enforce uniqueness of user and group IDs on application side.
+  [lgraf]
+
 - Add internationalization support to the activity model.
 
   - Implement translatable activity columns with the help of SQLAlchemy i18n.

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -85,6 +85,12 @@ class OGDSUpdater(grok.Adapter):
         session = create_session()
         return session.query(User).filter_by(userid=userid).first()
 
+    def get_sql_group(self, groupid):
+        """Returns the OGDS group object identified by `groupid`.
+        """
+        session = create_session()
+        return session.query(Group).filter_by(groupid=groupid).first()
+
     def user_exists(self, userid):
         """Checks whether the OGDS user identified by `userid` exists or not.
         """
@@ -154,7 +160,7 @@ class OGDSUpdater(grok.Adapter):
                     session.add(user)
                 else:
                     # Get the existing user
-                    user = session.query(User).filter_by(userid=userid).first()
+                    user = self.get_sql_user(userid)
 
                 # Iterate over all SQL columns and update their values
                 columns = User.__table__.columns
@@ -220,8 +226,7 @@ class OGDSUpdater(grok.Adapter):
                     session.add(group)
                 else:
                     # Get the existing group
-                    group = session.query(Group).filter_by(
-                        groupid=groupid).first()
+                    group = self.get_sql_group(groupid)
 
                 # Iterate over all SQL columns and update their values
                 columns = Group.__table__.columns

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -17,10 +17,10 @@ import logging
 import time
 
 
-NO_UID_MSG = "User '%s' has no 'uid' attribute."
-NO_UID_AD_MSG = "User '%s' has none of the attributes %s - skipping."
-USER_NOT_FOUND_LDAP = "Referenced user %s not found in LDAP, ignoring!"
-USER_NOT_FOUND_SQL = "Referenced user %s not found in SQL, ignoring!"
+NO_UID_MSG = "User '{}' has no 'uid' attribute."
+NO_UID_AD_MSG = "User '{}' has none of the attributes {} - skipping."
+USER_NOT_FOUND_LDAP = "Referenced user {} not found in LDAP, ignoring!"
+USER_NOT_FOUND_SQL = "Referenced user {} not found in SQL, ignoring!"
 
 AD_UID_KEYS = ['userid', 'sAMAccountName', 'windows_login_name']
 
@@ -64,7 +64,7 @@ def sync_ogds(plone, users=True, groups=True):
         updater.import_groups()
 
     elapsed = time.clock() - start
-    logger.info("Done in %.0f seconds." % elapsed)
+    logger.info("Done in {:0.1f} seconds.".format(elapsed))
 
     logger.info("Updating LDAP SYNC importstamp...")
     set_remote_import_stamp(plone)
@@ -152,8 +152,8 @@ class OGDSUpdater(grok.Adapter):
 
                 # Skip users with uid longer than SQL 'userid' column
                 if len(userid) > USER_ID_LENGTH:
-                    logger.warn("Skipping user '%s' - "
-                                "userid too long!" % userid)
+                    logger.warn("Skipping user '{}' - "
+                                "userid too long!".format(userid))
                     continue
 
                 if not self.user_exists(userid):
@@ -169,7 +169,8 @@ class OGDSUpdater(grok.Adapter):
                         # (casing, whitespace, ...) that may not be considered
                         # different by the SQL backend's unique constraint.
                         # We therefore enforce uniqueness ourselves.
-                        logger.warn("Skipping duplicate user '%s'..." % userid)
+                        logger.warn(
+                            "Skipping duplicate user '{}'!".format(userid))
                         continue
 
                 # Iterate over all SQL columns and update their values
@@ -195,7 +196,7 @@ class OGDSUpdater(grok.Adapter):
 
                 # Set the user active
                 user.active = True
-                logger.info("Imported user '%s'" % userid)
+                logger.info("Imported user '{}'".format(userid))
             session.flush()
 
     def import_groups(self):
@@ -226,8 +227,8 @@ class OGDSUpdater(grok.Adapter):
 
                 # Skip groups with groupid longer than SQL 'groupid' column
                 if len(groupid) > GROUP_ID_LENGTH:
-                    logger.warn("Skipping group '%s' - "
-                                "groupid too long!" % groupid)
+                    logger.warn("Skipping group '{}' - "
+                                "groupid too long!".format(groupid))
                     continue
 
                 if not self.group_exists(groupid):
@@ -243,7 +244,8 @@ class OGDSUpdater(grok.Adapter):
                         # (casing, whitespace, ...) that may not be considered
                         # different by the SQL backend's unique constraint.
                         # We therefore enforce uniqueness ourselves.
-                        logger.warn("Skipping duplicate group '%s'..." % groupid)
+                        logger.warn(
+                            "Skipping duplicate group '{}'!".format(groupid))
                         continue
 
                 # Iterate over all SQL columns and update their values
@@ -265,7 +267,7 @@ class OGDSUpdater(grok.Adapter):
                 contained_users = []
                 group_members = ldap_util.get_group_members(info)
 
-                logger.info("Importing group '%s'..." % groupid)
+                logger.info("Importing group '{}'...".format(groupid))
                 for user_dn in group_members:
                     try:
                         ldap_user = ldap_util.entry_by_dn(user_dn)
@@ -276,7 +278,7 @@ class OGDSUpdater(grok.Adapter):
 
                         if not ldap_util.is_ad:
                             if 'userid' not in user_info:
-                                logger.warn(NO_UID_MSG % user_dn)
+                                logger.warn(NO_UID_MSG.format(user_dn))
                                 continue
                             userid = user_info['userid']
                         else:
@@ -289,8 +291,8 @@ class OGDSUpdater(grok.Adapter):
                                     break
                             if not uid_found:
                                 # No suitable UID found, skip this user
-                                logger.warn(NO_UID_AD_MSG % (user_dn,
-                                                             AD_UID_KEYS))
+                                logger.warn(NO_UID_AD_MSG.format(
+                                    user_dn, AD_UID_KEYS))
                                 continue
 
                         if isinstance(userid, list):
@@ -302,18 +304,20 @@ class OGDSUpdater(grok.Adapter):
                         try:
                             user = self.get_sql_user(userid)
                         except NoResultFound:
-                            logger.warn(USER_NOT_FOUND_SQL % userid)
+                            logger.warn(USER_NOT_FOUND_SQL.format(userid))
                             continue
                         except MultipleResultsFound:
                             # Duplicate user - skip (see above).
-                            logger.warn("Skipping duplicate user '%s'..." % userid)
+                            logger.warn(
+                                "Skipping duplicate user '{}'!".format(userid))
                             continue
 
                         contained_users.append(user)
-                        logger.info("Importing user '%s' "
-                                    "into group '%s'..." % (userid, groupid))
+                        logger.info(
+                            "Importing user '{}' into group '{}'...".format(
+                                userid, groupid))
                     except NO_SUCH_OBJECT:
-                        logger.warn(USER_NOT_FOUND_LDAP % user_dn)
+                        logger.warn(USER_NOT_FOUND_LDAP.format(user_dn))
                 group.users = contained_users
                 session.flush()
                 logger.info("Done.")


### PR DESCRIPTION
With this PR we enforce **uniqueness of user and group IDs** on application side.

If for example a user exists in LDAP twice, with two slightly different spellings of the supposedly unique user ID (casing, trailing whitespace), then a `UNIQUE` constraint in `SQL` may or may not consider those spellings equal, depending on the backend.

If it *doesn't* consider them equal, and allows the `INSERT` of the second user, then this leads to problems when using a case insensitive collation on the session: A `WHERE userid='john'` clause in an `UPDATE` statement will both match `'john'` and `'JOHN'`, and the update would therefore change both users even though it should only affect the one identified by the primary key value. SQLAlchemy detects this and raises

```
StaleDataError: UPDATE statement on table 'users' expected to update 1 row(s); 2 were matched.
```

Creating case-insensitive `UNIQUE` constraints in a cross-database way is non-trivial, we therefore enforce uniqueness on the application side.

Fixes 4teamwork/opengever.zug#112