### PR TITLE
Aktenzeichen reindexieren von enthaltenen Objekten wenn der Referencenumber prefix ändert.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Update reference number of contained objects when referencenumber prefix changes.
+  [phgross]
+
 - Improve content and styling of the notification mail.
   [phgross]
 

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -20,6 +20,7 @@ def update_reference_prefixes(obj, event):
 
     if is_reference_number_prefix_changed(event.descriptions):
         catalog = api.portal.get_tool('portal_catalog')
-        children = catalog(path='/'.join(obj.getPhysicalPath()))
+        children = catalog.unrestrictedSearchResults(
+            path='/'.join(obj.getPhysicalPath()))
         for child in children:
             child.getObject().reindexObject(idxs=['reference'])

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -1,0 +1,25 @@
+from five import grok
+from opengever.repository.interfaces import IRepositoryFolder
+from plone import api
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+
+
+def is_reference_number_prefix_changed(descriptions):
+    for desc in descriptions:
+        for attr in desc.attributes:
+            if attr == 'IReferenceNumberPrefix.reference_number_prefix':
+                return True
+    return False
+
+
+@grok.subscribe(IRepositoryFolder, IObjectModifiedEvent)
+def update_reference_prefixes(obj, event):
+    """A eventhandler which reindex all contained objects, if the
+    reference prefix has been changed.
+    """
+
+    if is_reference_number_prefix_changed(event.descriptions):
+        catalog = api.portal.get_tool('portal_catalog')
+        children = catalog(path='/'.join(obj.getPhysicalPath()))
+        for child in children:
+            child.getObject().reindexObject(idxs=['reference'])

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -20,6 +20,9 @@ class TestReferencePrefixUpdating(FunctionalTestCase):
                               .within(self.repository_1_1))
         self.subdossier = create(Builder('dossier').within(self.dossier))
         self.document = create(Builder('document').within(self.subdossier))
+        self.trashed_document = create(Builder('document')
+                                       .trashed()
+                                       .within(self.subdossier))
 
     @browsing
     def test_reference_number_is_updated_in_catalog(self, browser):
@@ -45,3 +48,6 @@ class TestReferencePrefixUpdating(FunctionalTestCase):
                           obj2brain(self.subdossier).reference)
         self.assertEquals('Client1 6.1 / 1.1 / 1',
                           obj2brain(self.document).reference)
+        self.assertEquals(
+            'Client1 6.1 / 1.1 / 2',
+            obj2brain(self.trashed_document, unrestricted=True).reference)

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -1,0 +1,47 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from opengever.testing import obj2brain
+
+
+class TestReferencePrefixUpdating(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestReferencePrefixUpdating, self).setUp()
+        self.repository_root = create(Builder('repository_root'))
+        self.repository_1 = create(Builder('repository')
+                                   .within(self.repository_root)
+                                   .titled(u'Repository A'))
+        self.repository_1_1 = create(Builder('repository')
+                                     .within(self.repository_1)
+                                     .titled(u'Repository A'))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repository_1_1))
+        self.subdossier = create(Builder('dossier').within(self.dossier))
+        self.document = create(Builder('document').within(self.subdossier))
+
+    @browsing
+    def test_reference_number_is_updated_in_catalog(self, browser):
+        self.grant('Manager')
+        browser.login().open(self.repository_1, view='edit')
+        browser.fill({'Reference Prefix': u'6'})
+        browser.find('Save').click()
+
+        self.assertEquals('Client1 6', obj2brain(self.repository_1).reference)
+
+    @browsing
+    def test_reference_number_of_children_is_updated_in_catalog(self, browser):
+        self.grant('Manager')
+        browser.login().open(self.repository_1, view='edit')
+        browser.fill({'Reference Prefix': u'6'})
+        browser.find('Save').click()
+
+        self.assertEquals('Client1 6.1',
+                          obj2brain(self.repository_1_1).reference)
+        self.assertEquals('Client1 6.1 / 1',
+                          obj2brain(self.dossier).reference)
+        self.assertEquals('Client1 6.1 / 1.1',
+                          obj2brain(self.subdossier).reference)
+        self.assertEquals('Client1 6.1 / 1.1 / 1',
+                          obj2brain(self.document).reference)


### PR DESCRIPTION
Dieser PR fügt ein Eventhandler hinzu, welcher überprüft ob der `Aktenzeichen Prefix` Wert verändert wurde. Falls das Präfix geändert wurde, wird die `reference_number` auch bei allen enthaltenen Objekte reindexiert. Fixes #115.

Wie im Issue bereits beschrieben, die Problematik von lang dauernden Requests, z.B. bei Anpassungen an Ordnungspositionen mit viel Inhalt, wird vorerst "ignoriert". 

@lukasgraf 