### PR TITLE
Darstellung und Inhalt des Benachrichtigungsmail überarbeitet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Improve content and styling of the notification mail.
+  [phgross]
+
 - OGDSUpdater: Enforce uniqueness of user and group IDs on application side.
   [lgraf]
 

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-16 16:16+0000\n"
+"POT-Creation-Date: 2015-07-17 11:04+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,10 +16,6 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-
-#: ./opengever/activity/templates/notification.pt:29
-msgid "View in GEVER"
-msgstr "In GEVER betrachten"
 
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py:56
@@ -47,7 +43,7 @@ msgid "heading_notifications"
 msgstr "Benachrichtigungen"
 
 #. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt:21
+#: ./opengever/activity/templates/notification.pt:19
 msgid "label_details"
 msgstr "Details:"
 
@@ -65,3 +61,8 @@ msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. D
 #: ./opengever/activity/viewlets/notification.pt:23
 msgid "no_unread_notifications"
 msgstr "Keine ungelesenen Benachrichtigungen"
+
+#. Default: "GEVER Task"
+#: ./opengever/activity/mail.py:60
+msgid "subject_prefix"
+msgstr "GEVER Aufgabe"

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-23 18:19+0000\n"
+"POT-Creation-Date: 2015-07-16 16:16+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/activity/templates/notification.pt:27
+#: ./opengever/activity/templates/notification.pt:29
 msgid "View in GEVER"
 msgstr "In GEVER betrachten"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:55
+#: ./opengever/activity/browser/listing.py:56
 msgid "column_Actor"
 msgstr "Akteur"
 
 #. Default: "Kind"
-#: ./opengever/activity/browser/listing.py:47
+#: ./opengever/activity/browser/listing.py:48
 msgid "column_kind"
 msgstr "Typ"
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:51
+#: ./opengever/activity/browser/listing.py:52
 msgid "column_title"
 msgstr "Titel"
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:59
+#: ./opengever/activity/browser/listing.py:60
 msgid "created"
 msgstr "Erstellt"
 
@@ -46,10 +46,10 @@ msgstr "Erstellt"
 msgid "heading_notifications"
 msgstr "Benachrichtigungen"
 
-#. Default: "Description:"
+#. Default: "Details:"
 #: ./opengever/activity/templates/notification.pt:21
-msgid "label_description"
-msgstr "Beschreibung:"
+msgid "label_details"
+msgstr "Details:"
 
 #. Default: "All Notifications"
 #: ./opengever/activity/viewlets/notification.pt:54
@@ -57,7 +57,7 @@ msgid "label_notifications_overview"
 msgstr "Alle Benachrichtigungen"
 
 #. Default: "A problem has occurred during the notification creation. Notification could not be produced."
-#: ./opengever/activity/center.py:166
+#: ./opengever/activity/center.py:179
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht ausgelöst."
 

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-16 16:16+0000\n"
+"POT-Creation-Date: 2015-07-17 11:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,10 +16,6 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-
-#: ./opengever/activity/templates/notification.pt:29
-msgid "View in GEVER"
-msgstr ""
 
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py:56
@@ -47,7 +43,7 @@ msgid "heading_notifications"
 msgstr "Notifications"
 
 #. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt:21
+#: ./opengever/activity/templates/notification.pt:19
 msgid "label_details"
 msgstr ""
 
@@ -64,5 +60,10 @@ msgstr ""
 #. Default: "No unread notifications"
 #: ./opengever/activity/viewlets/notification.pt:23
 msgid "no_unread_notifications"
+msgstr ""
+
+#. Default: "GEVER Task"
+#: ./opengever/activity/mail.py:60
+msgid "subject_prefix"
 msgstr ""
 

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-23 18:19+0000\n"
+"POT-Creation-Date: 2015-07-16 16:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/activity/templates/notification.pt:27
+#: ./opengever/activity/templates/notification.pt:29
 msgid "View in GEVER"
 msgstr ""
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:55
+#: ./opengever/activity/browser/listing.py:56
 msgid "column_Actor"
 msgstr "Acteur"
 
 #. Default: "Kind"
-#: ./opengever/activity/browser/listing.py:47
+#: ./opengever/activity/browser/listing.py:48
 msgid "column_kind"
 msgstr "Type"
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:51
+#: ./opengever/activity/browser/listing.py:52
 msgid "column_title"
 msgstr "Titre"
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:59
+#: ./opengever/activity/browser/listing.py:60
 msgid "created"
 msgstr ""
 
@@ -46,9 +46,9 @@ msgstr ""
 msgid "heading_notifications"
 msgstr "Notifications"
 
-#. Default: "Description:"
+#. Default: "Details:"
 #: ./opengever/activity/templates/notification.pt:21
-msgid "label_description"
+msgid "label_details"
 msgstr ""
 
 #. Default: "All Notifications"
@@ -57,7 +57,7 @@ msgid "label_notifications_overview"
 msgstr ""
 
 #. Default: "A problem has occurred during the notification creation. Notification could not be produced."
-#: ./opengever/activity/center.py:166
+#: ./opengever/activity/center.py:179
 msgid "msg_error_not_notified"
 msgstr ""
 

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-16 16:16+0000\n"
+"POT-Creation-Date: 2015-07-17 11:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,10 +16,6 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.activity\n"
-
-#: ./opengever/activity/templates/notification.pt:29
-msgid "View in GEVER"
-msgstr ""
 
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py:56
@@ -47,7 +43,7 @@ msgid "heading_notifications"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt:21
+#: ./opengever/activity/templates/notification.pt:19
 msgid "label_details"
 msgstr ""
 
@@ -64,5 +60,10 @@ msgstr ""
 #. Default: "No unread notifications"
 #: ./opengever/activity/viewlets/notification.pt:23
 msgid "no_unread_notifications"
+msgstr ""
+
+#. Default: "GEVER Task"
+#: ./opengever/activity/mail.py:60
+msgid "subject_prefix"
 msgstr ""
 

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-23 18:19+0000\n"
+"POT-Creation-Date: 2015-07-16 16:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.activity\n"
 
-#: ./opengever/activity/templates/notification.pt:27
+#: ./opengever/activity/templates/notification.pt:29
 msgid "View in GEVER"
 msgstr ""
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:55
+#: ./opengever/activity/browser/listing.py:56
 msgid "column_Actor"
 msgstr ""
 
 #. Default: "Kind"
-#: ./opengever/activity/browser/listing.py:47
+#: ./opengever/activity/browser/listing.py:48
 msgid "column_kind"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:51
+#: ./opengever/activity/browser/listing.py:52
 msgid "column_title"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:59
+#: ./opengever/activity/browser/listing.py:60
 msgid "created"
 msgstr ""
 
@@ -46,9 +46,9 @@ msgstr ""
 msgid "heading_notifications"
 msgstr ""
 
-#. Default: "Description:"
+#. Default: "Details:"
 #: ./opengever/activity/templates/notification.pt:21
-msgid "label_description"
+msgid "label_details"
 msgstr ""
 
 #. Default: "All Notifications"
@@ -57,7 +57,7 @@ msgid "label_notifications_overview"
 msgstr ""
 
 #. Default: "A problem has occurred during the notification creation. Notification could not be produced."
-#: ./opengever/activity/center.py:166
+#: ./opengever/activity/center.py:179
 msgid "msg_error_not_notified"
 msgstr ""
 

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -62,7 +62,6 @@ class PloneNotificationMailer(object):
         template = ViewPageTemplateFile("templates/notification.pt")
         language = self.get_users_language()
         options = {
-            'subject': notification.activity.translations[language].title,
             'title': notification.activity.translations[language].title,
             'label': notification.activity.translations[language].label,
             'summary': notification.activity.translations[language].summary,

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -6,6 +6,11 @@ from opengever.base.model import get_locale
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.i18n import translate
+from zope.i18nmessageid import MessageFactory
+
+# because of circular imports, we can't import from opengever.activity
+_ = MessageFactory("opengever.activity")
 
 
 class PloneNotificationMailer(object):
@@ -44,13 +49,18 @@ class PloneNotificationMailer(object):
 
         recipient = ogds_service().fetch_user(notification.watcher.user_id)
         msg['To'] = recipient.email
-        msg['Subject'] = Header(
-            notification.activity.translations[self.get_users_language()].title, 'utf-8')
+        msg['Subject'] = self.get_subject(notification)
 
         html = self.prepare_html(notification)
         msg.attach(MIMEText(html.encode('utf-8'), 'html', 'utf-8'))
 
         return msg
+
+    def get_subject(self, notification):
+        prefix = translate(_(u'subject_prefix', default=u'GEVER Task'),
+                           context=self.request)
+        title = notification.activity.translations[self.get_users_language()].title
+        return Header(u'{}: {}'.format(prefix, title), 'utf-8')
 
     def get_users_language(self):
         # XXX TODO Right now there is no support to store users preferred

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -8,23 +8,19 @@
 
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title tal:content="options/subject">
-    </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   </head>
 
   <body>
-    <p><b tal:content="options/label"></b></p>
+    <p <p style="padding-bottom: 5px;" tal:content="structure options/summary" />
+
     <a href="" tal:content="options/title" tal:attributes="href options/link"></a>
-    <p tal:content="structure options/summary" />
 
-    <p i18n:translate="label_description">Description:</p>
-    <span tal:replace="structure options/description" />
+    <p style="padding-top: 15px;" i18n:translate="label_details">Details:</p>
+    <div style="text-align: left;">
+      <span tal:replace="structure options/description" />
+    </div>
 
-    <br />
-    <hr />
-    <br />
-    <a href="" i18n:translate="" tal:attributes="href options/link">View in GEVER</a>
   </body>
 
 </html>

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -51,7 +51,7 @@ class TestEmailNotification(FunctionalTestCase):
 
         mail = email.message_from_string(Mailing(self.portal).pop())
 
-        self.assertEquals('Test Task', mail.get('Subject'))
+        self.assertEquals('GEVER Task: Test Task', mail.get('Subject'))
 
     @browsing
     def test_from_and_to_addresses(self, browser):

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -66,7 +66,7 @@ class TestEmailNotification(FunctionalTestCase):
         self.assertEquals('Test User <test@example.org>', mail.get('From'))
 
     @browsing
-    def test_see_on_gever_is_linked_to_resolve_notification_view(self, browser):
+    def test_task_title_is_linked_to_resolve_notification_view(self, browser):
         browser.login().open(self.dossier, view='++add++opengever.task.task')
         browser.fill({'Title': 'Test Task',
                       'Responsible': 'hugo.boss',
@@ -76,7 +76,6 @@ class TestEmailNotification(FunctionalTestCase):
         mail = email.message_from_string(Mailing(self.portal).pop())
         html_part = mail.get_payload()[0].as_string()
 
-        # TODO: better assertion ...
-        expected = '<a href=3D"http://nohost/plone/@@resolve_notification?notification_id=\n=3D1">View in GEVER</a>'
+        link = '<a href=3D"http://nohost/plone/@@resolve_notification?notification_id=\n=3D1">Test Task</a>'
 
-        self.assertIn(expected, html_part)
+        self.assertIn(link, html_part)

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -136,7 +136,8 @@ class TaskAddedActivity(TaskActivity):
              self.context.get_task_type_label(language=language)],
             [_('label_dossier_title', u'Dossier title'),
              self.parent.title],
-            [_('label_text', u'Text'), self.context.text]
+            [_('label_text', u'Text'),
+             self.context.text if self.context.text else u'-' ]
         ]
 
     def before_recording(self):


### PR DESCRIPTION
 * Der Betreff enthält neu den Aufgaben Titel prefixed mit `GEVER Aufgabe`.
 * Die Tabellen Darstellung bei den Details wurde verbessert
 * Wurde keine Aufgaben-Beschreibung angegeben so erscheint nun ein `-` anstatt `None`

Fixes #1000.

![bildschirmfoto 2015-07-17 um 13 20 27](https://cloud.githubusercontent.com/assets/485755/8746144/bf6c11e2-2c86-11e5-83d6-b643ceda6865.png)

@lukasgraf 