### PR TITLE
Autosizing textareas im Add und Edit Formular von Anträgen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Autosizing textareas in the add and edit form of proposals.
+  [phgross]
+
 - OGDS Sync: Clear memberships from groups_users association table before
   importing them, so that memberships from groups that have been deleted in
   LDAP get removed from OGDS. Also deactivate groups that have been removed

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -4,6 +4,10 @@
 
   $(function() {
 
+    // autosizing textareas when add or editing a proposal
+    $('body.template-opengever-meeting-proposal textarea').autosize();
+    $('body.template-edit.portaltype-opengever-meeting-proposal textarea').autosize();
+
     var viewlet = $("#opengever_meeting_meeting");
 
     var listMessages = function(messages) {


### PR DESCRIPTION
Vorher:
<img width="896" alt="bildschirmfoto 2015-07-21 um 08 36 35" src="https://cloud.githubusercontent.com/assets/485755/8794438/22afa606-2f84-11e5-8f3c-955ef51b8160.png">

Nachher:
<img width="881" alt="bildschirmfoto 2015-07-21 um 08 36 05" src="https://cloud.githubusercontent.com/assets/485755/8794439/22afe22e-2f84-11e5-9854-c6de40f2686a.png">

Fixes #941 

@lukasgraf @deiferni Bitte reviewen oder wollen wir das autosize plugin für alle Textfelder in Formularen verwenden?  