### PR TITLE
Make `author_cache_key` also discriminate on hostname

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Make `author_cache_key` also discriminate on hostname.
+  This is required because this cache key is used to cache generated
+  URLs, which are dependent on the hostname that is used to access the
+  system (might be localhost + SSH tunnel).
+  [lgraf]
+
 - Only display link to proposal for documents in repositories.
   [deiferni]
 

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -111,3 +111,30 @@ class PathFinder(object):
         """Path to {buildout}
         """
         return os.path.normpath(os.path.join(self.var, '..'))
+
+
+def get_hostname(request):
+    """Extract hostname in virtual-host-safe manner
+
+    @param request: HTTPRequest object, assumed contains environ dictionary
+
+    @return: Host DNS name, as requested by client. Lowercased, no port part.
+             Return None if host name is not present in HTTP request headers
+             (e.g. unit testing).
+
+    (from docs.plone.org/develop/plone/serving/http_request_and_response.html)
+    """
+
+    if "HTTP_X_FORWARDED_HOST" in request.environ:
+        # Virtual host
+        host = request.environ["HTTP_X_FORWARDED_HOST"]
+    elif "HTTP_HOST" in request.environ:
+        # Direct client request
+        host = request.environ["HTTP_HOST"]
+    else:
+        return None
+
+    # separate to domain name and port sections
+    host = host.split(":")[0].lower()
+
+    return host

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from ftw.mail.utils import get_header
 from opengever.base import _ as base_mf
 from opengever.base.browser.helper import get_css_class
@@ -11,7 +9,6 @@ from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import ram
-from plone.uuid.interfaces import IUUID
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFPlone import PloneMessageFactory as pmf
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
@@ -54,7 +51,7 @@ def task_id_checkbox_helper(item, value):
         'id': item.task_id,
         'value': item.task_id,
         'title': 'Select %s' % item.title,
-        }
+    }
 
     return '<input %s />' % ' '.join(['%s="%s"' % (k, v)
                                       for k, v in sorted(attrs.items())])
@@ -344,7 +341,6 @@ def external_edit_link(item, value):
     with the external_edit mode selected """
     if item.portal_type != 'opengever.document.document':
         return ''
-    #item = hasattr(item, 'aq_explicit') and item.aq_explicit or item
     if hasattr(item, 'getURL'):
         url = item.getURL()
     elif hasattr(item, 'absolute_url'):

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -1,6 +1,7 @@
 from ftw.mail.utils import get_header
 from opengever.base import _ as base_mf
 from opengever.base.browser.helper import get_css_class
+from opengever.base.utils import get_hostname
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.document import Document
 from opengever.mail.mail import OGMail
@@ -58,10 +59,19 @@ def task_id_checkbox_helper(item, value):
 
 
 def author_cache_key(m, i, author):
+    """Cache key that discriminates on the user ID of the provided user
+    (Plone user or string), and the hostname.
+
+    The hostname is required because this cache key is used to cache generated
+    URLs, which are dependent on the hostname that is used to access the
+    system (might be localhost + SSH tunnel).
+    """
+    hostname = get_hostname(getRequest())
     if IPropertiedUser.providedBy(author) or IMemberData.providedBy(author):
-        return author.getId()
+        userid = author.getId()
     else:
-        return author
+        userid = author
+    return (userid, hostname)
 
 
 @ram.cache(author_cache_key)


### PR DESCRIPTION
This is required because this cache key is used to cache generated URLs, which are dependent on the hostname that is used to access the system (might be `localhost` + SSH tunnel).

Fixes #1068