### PR TITLE
Let OGMail inherit from ftw.mail.mail.Mail.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Let OGMail inherit from ftw.mail.mail.Mail.
+  [deiferni]
+
 - Also provide information to sablon templater whether an agenda item
   is a paragraph.
   [deiferni]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -4,10 +4,9 @@ from opengever.base.browser.helper import get_css_class
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.task.task import ITask
 from plone import api
-from plone.dexterity.content import Item
 
 
-class BaseDocument(Item):
+class BaseDocumentMixin(object):
     """Abstract base class for document-ish content types."""
 
     removed_state = None

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -3,7 +3,7 @@ from collective import dexteritytextindexer
 from five import grok
 from ftw.mail.interfaces import IEmailAddress
 from opengever.document import _
-from opengever.document.base import BaseDocument
+from opengever.document.base import BaseDocumentMixin
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -11,6 +11,7 @@ from opengever.meeting.proposal import ISubmittedProposal
 from opengever.task.task import ITask
 from plone import api
 from plone.autoform import directives as form_directives
+from plone.dexterity.content import Item
 from plone.directives import form
 from plone.namedfile.field import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
@@ -104,7 +105,7 @@ validator.WidgetValidatorDiscriminators(
 grok.global_adapter(UploadValidator)
 
 
-class Document(BaseDocument):
+class Document(Item, BaseDocumentMixin):
 
     # document state's
     removed_state = 'document-state-removed'

--- a/opengever/mail/profiles/default/metadata.xml
+++ b/opengever/mail/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4501</version>
+  <version>4600</version>
   <dependencies>
     <dependency>profile-ftw.mail:default</dependency>
   </dependencies>

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -123,19 +123,19 @@ class TestOGMailAddition(FunctionalTestCase):
                       .within(self.dossier)
                       .with_asset_message('mail_with_one_mail_attachment.eml'))
 
-        expected_description = {
+        expected_description = ({
             'content-type': 'message/rfc822',
             'filename': 'Inneres Testma\xcc\x88il ohne Attachments.eml',
             'position': 2,
             'size': 930,
-        }
-        self.assertEqual([expected_description], mail.get_attachments())
+        },)
+        self.assertEqual(expected_description, mail.get_attachments())
 
     def test_get_attachments_returns_empty_list_for_mails_without_attachments(self):
         mail = create(Builder('mail')
                       .within(self.dossier)
                       .with_message(MAIL_DATA))
-        self.assertEqual([], mail.get_attachments())
+        self.assertEqual(tuple(), mail.get_attachments())
 
     def test_truthy_has_attachmentes(self):
         mail = create(Builder('mail')

--- a/opengever/mail/upgrades/configure.zcml
+++ b/opengever/mail/upgrades/configure.zcml
@@ -188,4 +188,14 @@
         profile="opengever.mail:default"
         />
 
+    <!-- 4501 -> 4600 -->
+    <genericsetup:upgradeStep
+        title="Initialize ftw.mail caches."
+        description=""
+        source="4501"
+        destination="4600"
+        handler="opengever.mail.upgrades.to4600.InitializeFtwMailCaches"
+        profile="opengever.mail:default"
+        />
+
 </configure>

--- a/opengever/mail/upgrades/to4600.py
+++ b/opengever/mail/upgrades/to4600.py
@@ -1,0 +1,21 @@
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+
+
+class InitializeFtwMailCaches(UpgradeStep):
+
+    def __call__(self):
+        objects = self.catalog_unrestricted_search(
+            {'portal_type': 'ftw.mail.mail'}, full_objects=True)
+
+        for mail in ProgressLogger('Initialize ftw.mail caches', objects):
+            # initialize attributes (lazy attribute loading)
+            mail.Title()
+
+            # initialize cached data
+            mail._message = vars(mail).get('message')
+            mail._update_attachment_infos()
+            mail._reset_header_cache()
+
+            # preserve title, move from 'title' to '_title'
+            mail.title = vars(mail).get('title')


### PR DESCRIPTION
Closes #1037.

Also a migration is needed to:
- initialize ftw.mail caches (headers, attachments)
- rename title attribute from `title` to `_title` to avoid shadowing by properties