### PR TITLE
Traktanden müssen während dem Durchführen der Sitzung editierbar bleiben. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Remove edit restrictions, let meetings be editable until they are closed.
+  [deiferni]
+
 - Remove pre-protocols, they are now the same as protocols.
   [deiferni]
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -136,9 +136,6 @@ class MeetingView(BrowserView):
     def url_delete_agenda_item(self, agenda_item):
         return DeleteAgendaItem.url_for(self.context, self.model, agenda_item)
 
-    def is_protocol_editable(self):
-        return self.model.is_protocol_editable()
-
     def get_protocol_document(self):
         if self.model.protocol_document:
             return self.model.protocol_document.resolve_document()

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -124,7 +124,7 @@
           <table id="agenda_items">
               <tbody>
                   <tr tal:repeat="agenda_item view/agenda_items" tal:attributes="data-uid agenda_item/agenda_item_id; class python: agenda_item.get_css_class()">
-                      <td class="sortable_handle" tal:condition="not:meeting/is_protocol_editable"></td>
+                      <td class="sortable_handle" tal:condition="meeting/is_editable"></td>
                       <td class="number" tal:content="agenda_item/number"></td>
                       <td class="title">
                         <span>

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -118,10 +118,7 @@ class Meeting(Base):
         return 'contenttype-opengever-meeting-meeting'
 
     def is_editable(self):
-        return self.get_state() == self.STATE_PENDING
-
-    def is_protocol_editable(self):
-        return self.get_state() == self.STATE_HELD
+        return self.get_state() in (self.STATE_PENDING, self.STATE_HELD)
 
     def has_protocol_document(self):
         return self.protocol_document is not None

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -73,8 +73,9 @@ class TestAgendaItem(FunctionalTestCase):
         self.assertTrue(agenda_item.is_paragraph)
 
     @browsing
-    def test_text_and_paragraph_agenda_item_disabled_for_held_meetings(self, browser):
+    def test_text_and_paragraph_agenda_item_disabled_for_closed_meetings(self, browser):
         self.meeting.execute_transition('pending-held')
+        self.meeting.execute_transition('held-closed')
         transaction.commit()
 
         url = ScheduleText.url_for(self.committee, self.meeting)
@@ -102,8 +103,9 @@ class TestAgendaItem(FunctionalTestCase):
         self.assertFalse(agenda_item.is_paragraph)
 
     @browsing
-    def test_proposal_agenda_item_disabled_for_held_meetings(self, browser):
+    def test_proposal_agenda_item_disabled_for_closed_meetings(self, browser):
         self.meeting.execute_transition('pending-held')
+        self.meeting.execute_transition('held-closed')
         proposal = self.setup_proposal()
         proposal_model = proposal.load_model()
         transaction.commit()
@@ -127,10 +129,11 @@ class TestAgendaItem(FunctionalTestCase):
         self.assertEqual(0, len(meeting.agenda_items))
 
     @browsing
-    def test_agenda_item_deletion_disabled_for_held_meetings(self, browser):
+    def test_agenda_item_deletion_disabled_for_closed_meetings(self, browser):
         agenda_item = create(Builder('agenda_item').having(
             meeting=self.meeting))
         self.meeting.execute_transition('pending-held')
+        self.meeting.execute_transition('held-closed')
         transaction.commit()
 
         url = DeleteAgendaItem.url_for(

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -92,6 +92,7 @@ class TestMeeting(FunctionalTestCase):
                                  start=datetime(2013, 1, 1),
                                  location='There',))
         meeting.execute_transition('pending-held')
+        meeting.execute_transition('held-closed')
         transaction.commit()
 
         with self.assertRaises(Unauthorized):

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -25,6 +25,8 @@ class TestUnitMeeting(TestCase):
     def test_is_editable(self):
         self.assertTrue(self.meeting.is_editable())
         self.meeting.workflow_state = 'held'
+        self.assertTrue(self.meeting.is_editable())
+        self.meeting.workflow_state = 'closed'
         self.assertFalse(self.meeting.is_editable())
 
     def test_has_protocol_document(self):


### PR DESCRIPTION
Dieser PR entfernt Einschränkungen beim Bearbeiten und erlaubt edits auch noch während dem Durchführen einer Sitzung.

Closes #1072.