### PR TITLE
Dossier-Titel als defaultvalue für Antragstitel verwenden. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Remove pre-protocols, they are now the same as protocols.
   [deiferni]
 
+- Use dossier title as default title for new proposals.
+  [deiferni]
+
 
 4.5.0 (2015-08-03)
 ------------------

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -19,6 +19,13 @@ from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.interface import implements
 from zope.interface import Interface
+from zope.interface import provider
+from zope.schema.interfaces import IContextAwareDefaultFactory
+
+
+@provider(IContextAwareDefaultFactory)
+def default_title(context):
+    return context.title
 
 
 class IProposalModel(Interface):
@@ -28,6 +35,7 @@ class IProposalModel(Interface):
         title=_(u"label_title", default=u"Title"),
         required=True,
         max_length=256,
+        defaultFactory=default_title
         )
 
     committee = schema.Choice(

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -41,7 +41,9 @@ class TestProposal(FunctionalTestCase):
     def setUp(self):
         super(TestProposal, self).setUp()
         self.repo, self.repo_folder = create(Builder('repository_tree'))
-        self.dossier = create(Builder('dossier').within(self.repo_folder))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repo_folder)
+                              .titled(u'D\xf6ssier'))
 
     def test_proposal_can_be_added(self):
         proposal = create(Builder('proposal').within(self.dossier))
@@ -57,6 +59,13 @@ class TestProposal(FunctionalTestCase):
         title = document.Title()
         browser.fill(
             {'form.widgets.relatedItems.widgets.query': title}).submit()
+
+    @browsing
+    def test_dossier_title_is_default_value_for_proposal_title(self, browser):
+        browser.login()
+        browser.open(self.dossier, view='++add++opengever.meeting.proposal')
+
+        self.assertEqual(u'D\xf6ssier', browser.find('Title').value)
 
     @browsing
     def test_proposal_can_be_created_in_browser(self, browser):


### PR DESCRIPTION
Neu wird beim Erstellen eines Antrags der Dossiertitel als defaultvalue für den Antragstitel verwendet.

Closes #1075.