### PR TITLE
Activity Upgrade-Step flicken

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fix activity upgrade steps, don't rely on potentially dangerous imports
+  from model but duplicate necessary information.
+  [deiferni]
+
 - Make `author_cache_key` also discriminate on hostname.
   This is required because this cache key is used to cache generated
   URLs, which are dependent on the hostname that is used to access the

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -12,7 +12,8 @@ from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
-from sqlalchemy_i18n import Translatable, translation_base
+from sqlalchemy_i18n import Translatable
+from sqlalchemy_i18n import translation_base
 import datetime
 import pytz
 
@@ -37,7 +38,7 @@ class Activity(Base, Translatable):
     locale = DEFAULT_LOCALE
 
     id = Column('id', Integer, Sequence("activities_id_seq"),
-                         primary_key=True)
+                primary_key=True)
     kind = Column(String(255), nullable=False)
     actor_id = Column(String(USER_ID_LENGTH), nullable=False)
     created = Column(UTCDateTime(timezone=True), default=utcnow_tz_aware)
@@ -69,7 +70,7 @@ class ActivityTranslation(translation_base(Activity)):
 
     __tablename__ = 'activities_translation'
 
-    title = Column('title', Text)
-    label = Column('label', Text)
-    summary = Column('summary', Text)
-    description = Column('description', Text)
+    title = Column(Text)
+    label = Column(Text)
+    summary = Column(Text)
+    description = Column(Text)

--- a/opengever/activity/upgrades/to4501.py
+++ b/opengever/activity/upgrades/to4501.py
@@ -1,7 +1,8 @@
-from opengever.base.model import Base
-from opengever.base.model import create_session
-from opengever.base.model import get_tables
 from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import Text
 from sqlalchemy.sql.expression import column
 from sqlalchemy.sql.expression import table
 
@@ -20,10 +21,20 @@ class AddI18nSupportForActivities(SchemaMigration):
         self.remove_non_translated_columns()
 
     def add_activity_translations_table(self):
-        Base.metadata.create_all(
-            create_session().bind,
-            tables=get_tables(['activities_translation']),
-            checkfirst=True)
+        self.op.create_table(
+            'activities_translation',
+            Column("id", Integer, primary_key=True, autoincrement=False),
+            Column("locale", String(10), primary_key=True),
+            Column('title', Text),
+            Column('label', Text),
+            Column('summary', Text),
+            Column('description', Text),
+        )
+        self.op.create_foreign_key(
+            'activities_trnsltn_id_fkey',
+            'activities_translation', 'activities',
+            ['id'], ['id'],
+            ondelete='CASCADE')
 
     def migrate_data(self):
         activities_table = table(


### PR DESCRIPTION
Dieser PR behebt ein potentielles Problem mit den activity upgrades. Es wurden versehentlich Modell-Definitionen aus dem Modell importiert, anstatt wie für Upgrade-Steps korrekt, dupliziert.

Konkret geht es um übersetzte Activities. Die Mapper zum Übersetzen werden teilweise von einem 3rdParty Produkt (https://github.com/kvesteri/sqlalchemy-i18n) generiert. Für den Upgrade-Step wurde die generierte Tabelle aus DB analysiert und als upgrade umgesetzt.

Weiteres:
- Entfernung Parameter Column-Name weil unnötig (Konsistent mit anderen Modelldefinitionen)
- PEP8