### PR TITLE
Potentiell teuren Plone upgrade-step verzögern.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Delay expensive plone upgrade that installs plone lexicon using I18N
+  Case normalizer.
+  [deiferni]
+
 - Fix activity upgrade steps, don't rely on potentially dangerous imports
   from model but duplicate necessary information.
   [deiferni]

--- a/opengever/base/marmoset_patch.py
+++ b/opengever/base/marmoset_patch.py
@@ -1,0 +1,10 @@
+import inspect
+
+
+def marmoset_patch(old, new, extra_globals={}):
+    g = old.func_globals
+    g.update(extra_globals)
+    c = inspect.getsource(new)
+    exec c in g
+
+    old.func_code = g[new.__name__].func_code

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -16,6 +16,7 @@ For further details see:
 
 from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
+from opengever.base.marmoset_patch import marmoset_patch
 from Products.Five.browser import decode
 from ZODB.POSException import ConflictError
 from ZPublisher.HTTPRequest import FileUpload
@@ -336,3 +337,18 @@ def _verifyObjectPaste(self, object, validate_src=1):
 
 CopyContainer._verifyObjectPaste = _verifyObjectPaste
 LOGGER.info('Monkey patched OFS.CopySupport.CopyContainer._verifyObjectPaste')
+
+
+# --------
+# Marmoset patch `plone.app.upgrade.v43.betas.to43rc1` to delay an expensive
+# upgrade. The upgrade is re-defined as opengever.policy.base.to4504.
+
+
+from plone.app.upgrade.v43 import betas
+
+
+def nullupgrade(context):
+    pass
+
+marmoset_patch(betas.to43rc1, nullupgrade)
+LOGGER.info('Marmoset patched plone.app.upgrade.v43.betas.to43rc1')

--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4503</version>
+  <version>4504</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/opengever/policy/base/upgrades/configure.zcml
+++ b/opengever/policy/base/upgrades/configure.zcml
@@ -109,4 +109,14 @@
       profile="opengever.policy.base:default"
       />
 
+  <!-- 4503 -> 4504 -->
+  <genericsetup:upgradeStep
+      title="Execute delayed Upgrade: plone lexicon using I18N Case normalizer."
+      description=""
+      source="4503"
+      destination="4504"
+      handler="opengever.policy.base.upgrades.to4504.ExecuteDelayedPloneUpgrade"
+      profile="opengever.policy.base:default"
+      />
+
 </configure>

--- a/opengever/policy/base/upgrades/to4504.py
+++ b/opengever/policy/base/upgrades/to4504.py
@@ -1,0 +1,19 @@
+from plone.app.upgrade.utils import loadMigrationProfile
+from plone.app.upgrade.v43.alphas import upgradeToI18NCaseNormalizer
+from ftw.upgrade import UpgradeStep
+
+
+class ExecuteDelayedPloneUpgrade(UpgradeStep):
+    """Redefine a patched plone upgrade step that is expensive.
+
+    This upgrade step reindexes all ZCTextIndex fields. This step may take
+    very long for customers with a lot of data. Thus we disable the default
+    plone upgrade an redefine here to allow separate execution of this step.
+
+    The plone upgrade step is monkey-patched in opengever.base.monkeypatch.
+    """
+
+    def __call__(self):
+        loadMigrationProfile(self.portal_setup,
+                             'profile-plone.app.upgrade.v43:to43rc1')
+        upgradeToI18NCaseNormalizer(self.portal_setup)


### PR DESCRIPTION
Dieser PR deaktiviert einen Plone upgrade-step, der den Suchtext für alle Inhalte neu rechnet.

Grund für das Plone Upgrade ist ein neuer I18N Case normalizer. Da damit der ganze Searchable-Text neu gerechnet wird müssen wir dieses Upgrade aus Zeitgründen später einspielen können. Dazu wird der Plone Upgrade Step mit einer null-methode gepatched. Wir registrieren einen separaten upgradestep in `opengever.policy.base`, der das Upgrade nachholt.