### PR TITLE
Set `coerce_to_unicode` for the CX Oracle dialect to always get unicode from SA

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Make sure we always get unicode from SQLAlchemy for columns values by
+  setting the `coerce_to_unicode` parameter for the cx_Oracle dialect.
+  Necessary for SQLAlchemy >= 0.9.2
+  See http://docs.sqlalchemy.org/en/latest/dialects/oracle.html#unicode)
+  [lgraf]
+
 - OGDS Updater: Fix some unicode errors while logging.
   [lgraf]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Adapt SchemaMigration.is_oracle() check so it also recognizes the
+  'oracle+cx_oracle' dialect.
+  [lgraf]
+
 - Make sure we always get unicode from SQLAlchemy for columns values by
   setting the `coerce_to_unicode` parameter for the cx_Oracle dialect.
   Necessary for SQLAlchemy >= 0.9.2

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -296,7 +296,8 @@ class SchemaMigration(UpgradeStep):
 
     @property
     def is_oracle(self):
-        return self.dialect_name == 'oracle'
+        # Could be 'oracle' or 'oracle+cx_oracle'
+        return 'oracle' in self.dialect_name
 
     @property
     def is_postgres(self):

--- a/opengever/ogds/base/events.py
+++ b/opengever/ogds/base/events.py
@@ -42,8 +42,13 @@ def setup_engine_options(event):
     """
     engine = event.engine
     if engine.name == 'oracle':
-        # the sqlalchemy 0.7 way:
         listen(engine, 'connect', alter_session_on_connect)
+
+        # Make sure we always get unicode from SQLAlchemy for columns values.
+        # Necessary for SQLAlchemy >= 0.9.2. See:
+        # http://docs.sqlalchemy.org/en/latest/dialects/oracle.html#unicode
+        if hasattr(engine.dialect, 'coerce_to_unicode'):
+            engine.dialect.coerce_to_unicode = True
 
     elif engine.name == 'sqlite':
         listen(engine, 'connect', setup_isolation_level_on_connect)


### PR DESCRIPTION
Make sure we always get unicode from SQLAlchemy for columns values by setting the `coerce_to_unicode` parameter for the cx_Oracle dialect. Necessary for `SQLAlchemy >= 0.9.2`

See http://docs.sqlalchemy.org/en/latest/dialects/oracle.html#unicode)