### PR TITLE
Added upgradestep wich cleanup zc.relation catalogs interface mapping.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Added upgradestep wich cleanup no longer existing interfaces from the zc.relation
+  catalog's interfaces_flattened mapping, to avoid pickling erros (see #1091).
+  [phgross]
+
 - Adapt SchemaMigration.is_oracle() check so it also recognizes the
   'oracle+cx_oracle' dialect.
   [lgraf]

--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4501</version>
+  <version>4502</version>
 </metadata>

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -303,4 +303,14 @@
         directory="profiles/4501"
         />
 
+    <!-- 4501 -> 4502 -->
+    <genericsetup:upgradeStep
+        title="Remove no longer existing interfaces from relations catalog interface mapping."
+        source="4501"
+        destination="4502"
+        handler="opengever.base.upgrades.to4502.CleanupRelationsCatalog"
+        profile="opengever.base:default"
+        />
+
+
 </configure>

--- a/opengever/base/upgrades/to4502.py
+++ b/opengever/base/upgrades/to4502.py
@@ -1,0 +1,23 @@
+from ftw.upgrade import UpgradeStep
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+
+
+TO_REMOVE = ['plone.directives.form.schema.Schema',
+             'plone.app.kss.interfaces.IPortalObject']
+
+
+class CleanupRelationsCatalog(UpgradeStep):
+
+    def __call__(self):
+        self.relations_catalog = getUtility(ICatalog)
+
+        for iface_name in TO_REMOVE:
+            self.cleanup_interface(iface_name, 'to_interfaces_flattened')
+            self.cleanup_interface(iface_name, 'from_interfaces_flattened')
+
+    def cleanup_interface(self, iface_name, mapping_key):
+        for iface in self.relations_catalog._name_TO_mapping[mapping_key].keys():
+            if '{}.{}'.format(iface.__module__, iface.__name__) == iface_name:
+                del self.relations_catalog._name_TO_mapping[mapping_key][iface]
+                break


### PR DESCRIPTION
The upgradestep removes no longer existing interfaces from zc.relations catalog's interfaces_flattened mapping, to avoid pickling erros (fixes #1091).

@lukasgraf 