### PR TITLE
DocumentsTab: Make sure author and subdossier title are HTML escaped

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Documents Tab: Make sure document_author is HTML escaped.
+  [lgraf]
+
 - Added upgradestep wich cleanup no longer existing interfaces from the zc.relation
   catalog's interfaces_flattened mapping, to avoid pickling erros (see #1091).
   [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Documents Tab: Make sure link text in "containing subdossier" column
+  is HTML escaped.
+  [lgraf]
+
 - Documents Tab: Make sure document_author is HTML escaped.
   [lgraf]
 

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -3,9 +3,11 @@ from ftw.builder import create
 from ftw.testing import MockTestCase
 from mocker import ANY
 from opengever.base.behaviors.utils import set_attachment_content_disposition
+from opengever.base.utils import escape_html
 from opengever.base.utils import find_parent_dossier
 from opengever.testing import FunctionalTestCase
 from plone.namedfile.file import NamedFile
+from unittest2 import TestCase
 from urllib import quote
 
 
@@ -107,3 +109,22 @@ class TestFindParentDossier(FunctionalTestCase):
         document = create(Builder('document'))
         with self.assertRaises(ValueError):
             find_parent_dossier(document)
+
+
+class TestEscapeHTML(TestCase):
+
+    def test_escapes_lt_and_gt(self):
+        text = 'Foo <Bar> Baz'
+        self.assertEquals('Foo &lt;Bar&gt; Baz', escape_html(text))
+
+    def test_escapes_double_quotes(self):
+        text = 'Foo "Bar" Baz'
+        self.assertEquals('Foo &quot;Bar&quot; Baz', escape_html(text))
+
+    def test_escapes_apostrophes(self):
+        text = "Foo 'Bar' Baz"
+        self.assertEquals('Foo &apos;Bar&apos; Baz', escape_html(text))
+
+    def test_escapes_ampersand(self):
+        text = "Foo &Bar& Baz"
+        self.assertEquals('Foo &amp;Bar&amp; Baz', escape_html(text))

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -5,6 +5,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from xml.sax.saxutils import escape
 from zope.component import getMultiAdapter
 import App.config
 import os
@@ -138,3 +139,16 @@ def get_hostname(request):
     host = host.split(":")[0].lower()
 
     return host
+
+
+def escape_html(text):
+    """HTML escape a given string.
+
+    See: https://wiki.python.org/moin/EscapingHtml
+    """
+    # escape() and unescape() takes care of &, < and >, but not quotes
+    html_escape_table = {
+        '"': "&quot;",
+        "'": "&apos;"
+    }
+    return escape(text, html_escape_table)

--- a/opengever/dossier/tests/test_documents_tab.py
+++ b/opengever/dossier/tests/test_documents_tab.py
@@ -16,7 +16,7 @@ class TestDocumentsTab(FunctionalTestCase):
         self.subdossier = create(
             Builder('dossier')
             .within(self.dossier)
-            .titled(u'S\xfcbdossier'))
+            .titled(u'S\xfcbdossier <Foo> Bar'))
         self.document = create(Builder('document').within(self.subdossier))
 
     @browsing
@@ -25,7 +25,8 @@ class TestDocumentsTab(FunctionalTestCase):
 
         browser.css('table.listing').first.css('a.subdossierLink')
         link = browser.css('table.listing').first.css('a.subdossierLink').first
-        self.assertEqual(u'S\xfcbdossier', link.text)
+        # Title should be HTML escaped and encoded properly
+        self.assertEqual(u'S\xfcbdossier &lt;Foo&gt; Bar', link.innerHTML)
 
         link.click()
         self.assertEqual(browser.url, self.subdossier.absolute_url())

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -12,6 +12,7 @@ from opengever.tabbedview import _
 from opengever.tabbedview.browser.base import OpengeverTab
 from opengever.tabbedview.browser.listing import CatalogListingView
 from opengever.tabbedview.browser.tasklisting import GlobalTaskListingTab
+from opengever.tabbedview.helper import escape_html_transform
 from opengever.tabbedview.helper import external_edit_link
 from opengever.tabbedview.helper import linked
 from opengever.tabbedview.helper import linked_document_subdossier
@@ -82,7 +83,8 @@ class Documents(OpengeverCatalogListingTab):
 
         {'column': 'document_author',
          'column_title': _('label_document_author', default="Document Author"),
-         'sort_index': 'sortable_author'},
+         'sort_index': 'sortable_author',
+         'transform': escape_html_transform},
 
         {'column': 'document_date',
          'column_title': _('label_document_date', default="Document Date"),

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -136,10 +136,10 @@ def linked_document_subdossier(item, value):
         return ''
 
     url = "{}/redirect_to_parent_dossier".format(item.getURL())
-    link_title = escape_html(subdossier_title)
+    title = escape_html(subdossier_title)
 
     link = '<a href="{}" title="{}" class="subdossierLink">{}</a>'.format(
-        url, link_title, subdossier_title)
+        url, title, title)
 
     transforms = api.portal.get_tool('portal_transforms')
     return transforms.convertTo('text/x-html-safe', link).getData()

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -373,3 +373,9 @@ def translated_string(domain='plone'):
         return translate(
             value, context=getRequest(), domain=domain)
     return _translate
+
+
+def escape_html_transform(item, value):
+    if value is None:
+        return value
+    return escape_html(value)

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -1,6 +1,7 @@
 from ftw.mail.utils import get_header
 from opengever.base import _ as base_mf
 from opengever.base.browser.helper import get_css_class
+from opengever.base.utils import escape_html
 from opengever.base.utils import get_hostname
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.document import Document
@@ -18,9 +19,7 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-import cgi
 import pkg_resources
-
 
 try:
     pkg_resources.get_distribution('opengever.pdfconverter')
@@ -137,7 +136,7 @@ def linked_document_subdossier(item, value):
         return ''
 
     url = "{}/redirect_to_parent_dossier".format(item.getURL())
-    link_title = cgi.escape(subdossier_title, quote=True)
+    link_title = escape_html(subdossier_title)
 
     link = '<a href="{}" title="{}" class="subdossierLink">{}</a>'.format(
         url, link_title, subdossier_title)
@@ -169,8 +168,8 @@ def linked(item, value):
     link_title = " > ".join(t for t in breadcrumb_titles)
 
     # Make sure all data used in the HTML snippet is properly escaped
-    link_title = cgi.escape(link_title, quote=True)
-    value = cgi.escape(value, quote=True)
+    link_title = escape_html(link_title)
+    value = escape_html(value)
 
     link = '<a class="rollover-breadcrumb %s" href="%s" title="%s">%s</a>' % (
         css_class, url_method(), link_title, value)
@@ -243,7 +242,7 @@ def _linked_document_with_tooltip(item, value, trashed=False, removed=False):
 
     # Make sure all data used in the HTML snippet is properly escaped
     for k, v in data.items():
-        data[k] = cgi.escape(v, quote=True)
+        data[k] = escape_html(v)
 
     tooltip_links = []
 

--- a/opengever/tabbedview/tests/test_document_helper.py
+++ b/opengever/tabbedview/tests/test_document_helper.py
@@ -2,12 +2,12 @@ from ftw.dictstorage.interfaces import IDictStorage
 from ftw.testing import MockTestCase
 from lxml import etree
 from mocker import ANY
+from opengever.base.utils import escape_html
 from opengever.document.document import Document
 from opengever.tabbedview.helper import linked_document_with_tooltip
 from opengever.tabbedview.helper import linked_trashed_document_with_tooltip
 from pyquery import PyQuery
 from zope.interface import Interface
-import cgi
 
 
 ITEM_TITLE = u'lorem ipsum <with tags>'
@@ -16,7 +16,7 @@ ITEM_TITLE = u'lorem ipsum <with tags>'
 def link(href='#', text=''):
     """Helper method to create a link element to be used in tests.
     """
-    text = cgi.escape(text)
+    text = escape_html(text)
     lnk = PyQuery('<a href="%s">%s</a>' % (href, text))[0]
     return lnk
 


### PR DESCRIPTION
Die Spalten `document_author` und `containing_subdossier` können Zeichen enthalten, die in HTML escaped werden müssen. Dieser PR führt eine wiederverwendbare Funktion `escape_html` in `og.base.utils` ein, ersetzt alle bisherigen Verwendungen von `cgi.escape`, und escaped sowohl den `document_author` wie auch den Link-Text im `containing_subdossier`.

Fixes #1096