### PR TITLE
Fehlendes Icon im Mail FileWidget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,13 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Fix missing mail icon in mail edit view/properties view.
+  [deiferni]
+
+- Show context mimetype icon in custom no_download namedfile widget
+  mode templates.
+  [deiferni]
+
 - Documents Tab: Make sure link text in "containing subdossier" column
   is HTML escaped.
   [lgraf]

--- a/opengever/document/widgets/no_download_display.pt
+++ b/opengever/document/widgets/no_download_display.pt
@@ -20,6 +20,7 @@
                       filename view/filename;
                       filename_encoded view/filename_encoded;"
             tal:condition="python: exists and fieldname">
+        <span tal:attributes="class context/css_class"></span>
         <span tal:content="filename">Filename</span>
         <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100 KB</span></span>
     </span>

--- a/opengever/document/widgets/no_download_input.pt
+++ b/opengever/document/widgets/no_download_input.pt
@@ -26,6 +26,7 @@
                 action view/action;
                 allow_nochange view/allow_nochange;">
     <span tal:condition="python: exists and action=='nochange'">
+        <span tal:attributes="class context/css_class"></span>
         <a class="link-overlay" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
         <span class="discreet"> &mdash;
             <span tal:define="sizekb view/file_size" tal:replace="sizekb">100 KB</span>

--- a/opengever/mail/browser/configure.zcml
+++ b/opengever/mail/browser/configure.zcml
@@ -21,10 +21,17 @@
     <browser:page
         name="view"
         for="ftw.mail.mail.IMail"
-        class="opengever.base.browser.default_view.OGDefaultView"
+        class=".default_view.MailDefaultView"
         permission="zope2.View"
         layer="opengever.base.interfaces.IOpengeverBaseLayer"
         />
+
+    <browser:page
+          name="edit"
+          for="ftw.mail.mail.IMail"
+          class=".edit.MailEditView"
+          permission="cmf.ModifyPortalContent"
+          />
 
     <browser:page
         for="ftw.mail.mail.IMail"

--- a/opengever/mail/browser/default_view.py
+++ b/opengever/mail/browser/default_view.py
@@ -1,0 +1,17 @@
+from opengever.base.browser.default_view import OGDefaultView
+from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
+
+
+class MailDefaultView(OGDefaultView):
+    """A customized default view for Dexterity content.
+
+    On mails we don't want to display the message widget in DISPLAY mode
+    because then it's possible to download a possibly private working copy
+    of the message.
+    """
+
+    def updateWidgets(self):
+        super(MailDefaultView, self).updateWidgets()
+        field = self.groups[0].fields.get('message')
+        if field:
+            field.mode = NO_DOWNLOAD_DISPLAY_MODE

--- a/opengever/mail/browser/edit.py
+++ b/opengever/mail/browser/edit.py
@@ -1,0 +1,19 @@
+from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
+from plone.dexterity.browser.edit import DefaultEditForm
+from plone.z3cform import layout
+
+
+class MailEditForm(DefaultEditForm):
+    """Custom edit form for mails, which displays a custom edit mode for
+    message.
+    """
+
+    def updateWidgets(self):
+        super(MailEditForm, self).updateWidgets()
+
+        field = self.groups[0].fields.get('message')
+        if field:
+            field.mode = NO_DOWNLOAD_DISPLAY_MODE
+
+
+MailEditView = layout.wrap_form(MailEditForm)


### PR DESCRIPTION
Dieser PR stellt sicher, dass auch das Mail `message` Feld die gleichen custom widget templates benutzt wie das Document `file` Feld. Die templates stellen sicher, dass die `message` nur über die overwiew heruntergeladen werden kann, so wird dies auch journalisiert.

Desweiteren wird neu im widget ein MIME-Type icon neben dem Dateinamen angezeigt.
![screen shot 2015-07-28 at 17 25 36](https://cloud.githubusercontent.com/assets/736583/8935801/e6679b2e-354e-11e5-8e6f-c4cd9d233a16.png)


Closes #1095.