### PR TITLE
Added missing translation for the filingnumber search field.

### DIFF
--- a/opengever/dossier/filing/advanced_search.py
+++ b/opengever/dossier/filing/advanced_search.py
@@ -1,5 +1,5 @@
 from five import grok
-from opengever.advancedsearch import _
+from opengever.dossier import _
 from opengever.advancedsearch.advanced_search import AdvancedSearchForm
 from opengever.advancedsearch.advanced_search import IAdvancedSearch
 from opengever.dossier.filing.interfaces import IFilingNumberActivatedLayer

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-07-06 06:40+0000\n"
+"POT-Creation-Date: 2015-07-28 16:13+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -100,7 +100,7 @@ msgstr "Neuste Aufgaben"
 msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
 
-#: ./opengever/dossier/archive.py:53
+#: ./opengever/dossier/archive.py:54
 msgid "Not all required fields are filled"
 msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 
@@ -149,7 +149,7 @@ msgstr "Das Dossier wurde aktiviert."
 msgid "The Dossier has been deactivated"
 msgstr "Das Dossier wurde storniert."
 
-#: ./opengever/dossier/archive.py:268
+#: ./opengever/dossier/archive.py:271
 msgid "The Dossier has been resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen"
 
@@ -161,15 +161,15 @@ msgstr "Das Dossier ${dossier} hat ein ungültiges Enddatum."
 msgid "The dossier has been succesfully resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 
-#: ./opengever/dossier/archive.py:239
+#: ./opengever/dossier/archive.py:242
 msgid "The filing number has been given"
 msgstr "Die Ablagenummer wurde vergeben."
 
-#: ./opengever/dossier/archive.py:68
+#: ./opengever/dossier/archive.py:69
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date})."
 
-#: ./opengever/dossier/archive.py:86
+#: ./opengever/dossier/archive.py:89
 msgid "The given value is not a valid Year"
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
@@ -193,7 +193,7 @@ msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier storniert ist."
 
-#: ./opengever/dossier/archive.py:168
+#: ./opengever/dossier/archive.py:171
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."
 
@@ -210,12 +210,12 @@ msgid "button_add"
 msgstr "Erstellen"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:212
+#: ./opengever/dossier/archive.py:215
 msgid "button_archive"
 msgstr "Speichern"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:271
+#: ./opengever/dossier/archive.py:274
 #: ./opengever/dossier/behaviors/participation.py:167
 #: ./opengever/dossier/move_items.py:125
 msgid "button_cancel"
@@ -250,7 +250,7 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in den Zielordner eingefügt werden: ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:63
+#: ./opengever/dossier/archive.py:64
 msgid "error_enddate"
 msgstr "Enddatum erforderlich"
 
@@ -266,7 +266,7 @@ msgid "fieldset_filing"
 msgstr "Ablage"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:155
+#: ./opengever/dossier/archive.py:158
 msgid "filing_action"
 msgstr "Aktion"
 
@@ -297,18 +297,18 @@ msgid "filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:134
+#: ./opengever/dossier/archive.py:137
 #: ./opengever/dossier/behaviors/dossier.py:106
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:149
+#: ./opengever/dossier/archive.py:152
 msgid "filing_year"
 msgstr "Ablage Jahr"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:204
+#: ./opengever/dossier/archive.py:207
 msgid "heading_archive_form"
 msgstr "Dossier ablegen"
 
@@ -338,7 +338,7 @@ msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 msgid "help_destination"
 msgstr "Live Search: Durchsuchen Sie diesen Mandanten"
 
-#: ./opengever/dossier/archive.py:144
+#: ./opengever/dossier/archive.py:147
 #: ./opengever/dossier/behaviors/dossier.py:74
 msgid "help_end"
 msgstr ""
@@ -449,7 +449,7 @@ msgid "label_email_address"
 msgstr "E-Mail"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:143
+#: ./opengever/dossier/archive.py:146
 #: ./opengever/dossier/behaviors/dossier.py:73
 #: ./opengever/dossier/browser/report.py:40
 msgid "label_end"
@@ -469,7 +469,7 @@ msgstr "Ablagenummer"
 #. Default: "Filing number"
 #: ./opengever/dossier/filing/advanced_search.py:15
 msgid "label_filing_number"
-msgstr ""
+msgstr "Ablagenummer"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:170
@@ -587,7 +587,7 @@ msgstr "Es sind nicht alle Dokumente eingecheckt"
 msgid "not all task are closed"
 msgstr "Es sind nicht alle Aufgaben abgeschlossen"
 
-#: ./opengever/dossier/archive.py:33
+#: ./opengever/dossier/archive.py:34
 msgid "only resolve, set filing no later"
 msgstr "Nur abschliessen (keine Ablagenummer vergeben)"
 
@@ -595,19 +595,19 @@ msgstr "Nur abschliessen (keine Ablagenummer vergeben)"
 msgid "required"
 msgstr "erforderlich"
 
-#: ./opengever/dossier/archive.py:35
+#: ./opengever/dossier/archive.py:36
 msgid "resolve and set a new filing no"
 msgstr "Abschliessen und Ablagenummer neu vergeben"
 
-#: ./opengever/dossier/archive.py:32
+#: ./opengever/dossier/archive.py:33
 msgid "resolve and set filing no"
 msgstr "Abschliessen und Ablagenummer vergeben"
 
-#: ./opengever/dossier/archive.py:34
+#: ./opengever/dossier/archive.py:35
 msgid "resolve and take the existing filing no"
 msgstr "Abschliessen und die existierende Ablagenummer verwenden"
 
-#: ./opengever/dossier/archive.py:36
+#: ./opengever/dossier/archive.py:37
 msgid "set a filing no"
 msgstr "Ablagenummer vergeben"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-06 06:40+0000\n"
+"POT-Creation-Date: 2015-07-28 16:13+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,7 +98,7 @@ msgstr "Dernières tâches"
 msgid "No Subdossiers"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:53
+#: ./opengever/dossier/archive.py:54
 msgid "Not all required fields are filled"
 msgstr "Manque des champs obligatoires"
 
@@ -145,7 +145,7 @@ msgstr "Le dossier a été activé."
 msgid "The Dossier has been deactivated"
 msgstr "Le dossier a été annulé."
 
-#: ./opengever/dossier/archive.py:268
+#: ./opengever/dossier/archive.py:271
 msgid "The Dossier has been resolved"
 msgstr "Dossier a été fermé avec succès"
 
@@ -157,15 +157,15 @@ msgstr "La date du dossier ${dossier} n'est pas valable."
 msgid "The dossier has been succesfully resolved"
 msgstr "Le dossier a été fermé avec succès"
 
-#: ./opengever/dossier/archive.py:239
+#: ./opengever/dossier/archive.py:242
 msgid "The filing number has been given"
 msgstr "Le numéro d'inventaire va être attribué"
 
-#: ./opengever/dossier/archive.py:68
+#: ./opengever/dossier/archive.py:69
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou égale à la date la plus récente de l'objet contenu."
 
-#: ./opengever/dossier/archive.py:86
+#: ./opengever/dossier/archive.py:89
 msgid "The given value is not a valid Year"
 msgstr "L'année de dépôt attribuée n'est pas valable"
 
@@ -189,7 +189,7 @@ msgstr "Le sous-dossier a été fermé avec succès"
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Ce sous-dossier ne peut pas être réactivé parce que le dossier prinicipal a été annulé."
 
-#: ./opengever/dossier/archive.py:168
+#: ./opengever/dossier/archive.py:171
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution de numéro d'inventaire, tous les champs sont obligatoires"
 
@@ -206,12 +206,12 @@ msgid "button_add"
 msgstr "Etablir"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:212
+#: ./opengever/dossier/archive.py:215
 msgid "button_archive"
 msgstr "Enregistrer"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:271
+#: ./opengever/dossier/archive.py:274
 #: ./opengever/dossier/behaviors/participation.py:167
 #: ./opengever/dossier/move_items.py:125
 msgid "button_cancel"
@@ -246,7 +246,7 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Pas d'objet déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi : ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:63
+#: ./opengever/dossier/archive.py:64
 msgid "error_enddate"
 msgstr "Date de clôture obligatoire"
 
@@ -262,7 +262,7 @@ msgid "fieldset_filing"
 msgstr "Classeur"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:155
+#: ./opengever/dossier/archive.py:158
 msgid "filing_action"
 msgstr "Action"
 
@@ -293,18 +293,18 @@ msgid "filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:134
+#: ./opengever/dossier/archive.py:137
 #: ./opengever/dossier/behaviors/dossier.py:106
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:149
+#: ./opengever/dossier/archive.py:152
 msgid "filing_year"
 msgstr "Année de dépôt"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:204
+#: ./opengever/dossier/archive.py:207
 msgid "heading_archive_form"
 msgstr "Classer le dossier"
 
@@ -334,7 +334,7 @@ msgstr "Type de conteneur du dossier imprimé"
 msgid "help_destination"
 msgstr "Recherche en direct: Recherche de ce client"
 
-#: ./opengever/dossier/archive.py:144
+#: ./opengever/dossier/archive.py:147
 #: ./opengever/dossier/behaviors/dossier.py:74
 msgid "help_end"
 msgstr ""
@@ -445,7 +445,7 @@ msgid "label_email_address"
 msgstr "Email"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:143
+#: ./opengever/dossier/archive.py:146
 #: ./opengever/dossier/behaviors/dossier.py:73
 #: ./opengever/dossier/browser/report.py:40
 msgid "label_end"
@@ -465,7 +465,7 @@ msgstr "Numéro d'inventaire"
 #. Default: "Filing number"
 #: ./opengever/dossier/filing/advanced_search.py:15
 msgid "label_filing_number"
-msgstr ""
+msgstr "Numéro d'inventaire"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:170
@@ -583,7 +583,7 @@ msgstr "Tous les documents n'ont pas le statut checkin"
 msgid "not all task are closed"
 msgstr "Toutes les tâches ne sont pas fermées"
 
-#: ./opengever/dossier/archive.py:33
+#: ./opengever/dossier/archive.py:34
 msgid "only resolve, set filing no later"
 msgstr "Uniquement fermé (numéro d'inventaire non attribué)"
 
@@ -591,19 +591,19 @@ msgstr "Uniquement fermé (numéro d'inventaire non attribué)"
 msgid "required"
 msgstr "Obligatoire"
 
-#: ./opengever/dossier/archive.py:35
+#: ./opengever/dossier/archive.py:36
 msgid "resolve and set a new filing no"
 msgstr "Fermer et attribuer un nouveau numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py:32
+#: ./opengever/dossier/archive.py:33
 msgid "resolve and set filing no"
 msgstr "Fermer et attribuer un numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py:34
+#: ./opengever/dossier/archive.py:35
 msgid "resolve and take the existing filing no"
 msgstr "Fermer et utiliser un numéro d'inventaire existant"
 
-#: ./opengever/dossier/archive.py:36
+#: ./opengever/dossier/archive.py:37
 msgid "set a filing no"
 msgstr "Attribuer numéro d'inventaire"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-06 06:40+0000\n"
+"POT-Creation-Date: 2015-07-28 16:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,7 +101,7 @@ msgstr ""
 msgid "No Subdossiers"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:53
+#: ./opengever/dossier/archive.py:54
 msgid "Not all required fields are filled"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "The Dossier has been deactivated"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:268
+#: ./opengever/dossier/archive.py:271
 msgid "The Dossier has been resolved"
 msgstr ""
 
@@ -160,15 +160,15 @@ msgstr ""
 msgid "The dossier has been succesfully resolved"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:239
+#: ./opengever/dossier/archive.py:242
 msgid "The filing number has been given"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:68
+#: ./opengever/dossier/archive.py:69
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr ""
 
-#: ./opengever/dossier/archive.py:86
+#: ./opengever/dossier/archive.py:89
 msgid "The given value is not a valid Year"
 msgstr ""
 
@@ -192,7 +192,7 @@ msgstr ""
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:168
+#: ./opengever/dossier/archive.py:171
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""
 
@@ -209,12 +209,12 @@ msgid "button_add"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:212
+#: ./opengever/dossier/archive.py:215
 msgid "button_archive"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:271
+#: ./opengever/dossier/archive.py:274
 #: ./opengever/dossier/behaviors/participation.py:167
 #: ./opengever/dossier/move_items.py:125
 msgid "button_cancel"
@@ -249,7 +249,7 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr ""
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:63
+#: ./opengever/dossier/archive.py:64
 msgid "error_enddate"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgid "fieldset_filing"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:155
+#: ./opengever/dossier/archive.py:158
 msgid "filing_action"
 msgstr ""
 
@@ -296,18 +296,18 @@ msgid "filing_number"
 msgstr ""
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:134
+#: ./opengever/dossier/archive.py:137
 #: ./opengever/dossier/behaviors/dossier.py:106
 msgid "filing_prefix"
 msgstr ""
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:149
+#: ./opengever/dossier/archive.py:152
 msgid "filing_year"
 msgstr ""
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:204
+#: ./opengever/dossier/archive.py:207
 msgid "heading_archive_form"
 msgstr ""
 
@@ -337,7 +337,7 @@ msgstr ""
 msgid "help_destination"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:144
+#: ./opengever/dossier/archive.py:147
 #: ./opengever/dossier/behaviors/dossier.py:74
 msgid "help_end"
 msgstr ""
@@ -447,7 +447,7 @@ msgid "label_email_address"
 msgstr ""
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:143
+#: ./opengever/dossier/archive.py:146
 #: ./opengever/dossier/behaviors/dossier.py:73
 #: ./opengever/dossier/browser/report.py:40
 msgid "label_end"
@@ -585,7 +585,7 @@ msgstr ""
 msgid "not all task are closed"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:33
+#: ./opengever/dossier/archive.py:34
 msgid "only resolve, set filing no later"
 msgstr ""
 
@@ -593,19 +593,19 @@ msgstr ""
 msgid "required"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:35
+#: ./opengever/dossier/archive.py:36
 msgid "resolve and set a new filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:32
+#: ./opengever/dossier/archive.py:33
 msgid "resolve and set filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:34
+#: ./opengever/dossier/archive.py:35
 msgid "resolve and take the existing filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:36
+#: ./opengever/dossier/archive.py:37
 msgid "set a filing no"
 msgstr ""
 
@@ -636,3 +636,4 @@ msgstr ""
 #: ./opengever/dossier/behaviors/participation.py:197
 msgid "warning_no_participants_selected"
 msgstr ""
+


### PR DESCRIPTION
The field was wrongly translated with the advancedsearch domain, but the file is inside the opengever.dossier subpackage. I've changed the domain.

Fixes #1101 

@lukasgraf 