### PR TITLE
Dokumentansicht: Inhaltsbereich zur Hälfte limitiert

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Move submitted with proposals list to its own document overview
+  table row.
+  [deiferni]
+
 - Add authentication token also to the file and pdf version download link.
   [phgross]
 

--- a/opengever/document/browser/overview_templates/overview.pt
+++ b/opengever/document/browser/overview_templates/overview.pt
@@ -2,47 +2,13 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="opengever.document">
+
 <body>
-  <tal:block tal:define="css_width python:99/2;">
-
-    <div tal:attributes="class string:boxGroup; style string:width:${css_width}%">
-    <table class="vertical listing">
-        <tr tal:repeat="row view/get_metadata_rows">
-            <th tal:content="row/label">Label</th>
-            <td tal:content="structure row/content">Content</td>
-        </tr>
-      </table>
-    </div>
-
-    <div tal:attributes="class string:boxGroup; style string:width:${css_width}%">
-      <div id="proposals_box" class="box">
-        <tal:condition tal:condition="view/display_submitted_documents">
-          <h2 i18n:translate="">Submitted with</h2>
-
-          <tal:documents tal:repeat="submitted_document view/submitted_documents">
-            <tal:block tal:define="is_outdated python: view.is_outdated(submitted_document)">
-
-              <div class="proposal" tal:condition="not: is_outdated">
-                <span tal:content="structure python: submitted_document.proposal.get_link()"></span>
-              </div>
-              <div class="propsoal outdated" tal:condition="is_outdated">
-                <div tal:content="structure python: submitted_document.proposal.get_link()"></div>
-                <div tal:content="python: view.render_submitted_version(submitted_document)"></div>
-                <div tal:content="python: view.render_current_document_version()"></div>
-                <a tal:attributes="href python: view.get_update_document_url(submitted_document);
-                                   class python: 'overdue' if is_outdated else ''"
-                   i18n:translate=""
-                  >
-                  Update document in proposal
-                </a>
-              </div>
-
-            </tal:block>
-          </tal:documents>
-        </tal:condition>
-      </div>
-    </div>
-
-  </tal:block>
+  <table class="vertical listing">
+    <tr tal:repeat="row view/get_metadata_rows">
+      <th tal:content="row/label">Label</th>
+      <td tal:content="structure row/content">Content</td>
+    </tr>
+  </table>
 </body>
 </html>

--- a/opengever/document/browser/templates/submitted_with.pt
+++ b/opengever/document/browser/templates/submitted_with.pt
@@ -1,0 +1,30 @@
+<div i18n:domain="opengever.document" id="proposals_box">
+  <tal:documents tal:repeat="submitted_document view/submitted_documents">
+    <tal:block tal:define="is_outdated python: view.is_outdated(submitted_document)">
+
+      <div class="proposal" tal:condition="not: is_outdated">
+        <span tal:content="structure python: submitted_document.proposal.get_link()"></span>
+      </div>
+      <div class="propsoal" tal:condition="is_outdated">
+        <div>
+          <span tal:content="structure python: submitted_document.proposal.get_link()"></span>
+          <span class="discreet">
+            —
+            <div tal:replace="python: view.render_submitted_version(submitted_document)"></div>
+            —
+            <div tal:replace="python: view.render_current_document_version()"></div>
+          </span>
+        </div>
+        <div class="updateActions">
+          <a tal:attributes="href python: view.get_update_document_url(submitted_document);
+                             class python: 'outdated' if is_outdated else ''"
+             i18n:translate=""
+            >
+            Update document in proposal
+          </a>
+        </div>
+      </div>
+
+    </tal:block>
+  </tal:documents>
+</div>

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -8,8 +8,8 @@ from opengever.document import _ as ogdmf
 from opengever.document.browser.overview import CustomRow
 from opengever.document.browser.overview import FieldRow
 from opengever.document.browser.overview import Overview
+from opengever.document.browser.overview import TemplateRow
 from opengever.mail import _
-from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import instance
 from Products.CMFCore.utils import getToolByName
@@ -64,6 +64,9 @@ class PreviewTab(ftwView):
 class OverviewTab(Overview):
     grok.context(IMail)
 
+    # override template lookup, its realive to this file
+    file_template = ViewPageTemplateFile('templates/file.pt')
+
     def get_metadata_config(self):
         return [
             FieldRow('title'),
@@ -74,9 +77,9 @@ class OverviewTab(Overview):
                       label=ogdmf('label_creator', default='creator')),
             FieldRow('IDocumentMetadata.description'),
             FieldRow('IDocumentMetadata.foreign_reference'),
-            CustomRow(self.render_file_widget,
-                      label=_('label_org_message',
-                              default='Original message')),
+            TemplateRow(self.file_template,
+                        label=_('label_org_message',
+                                default='Original message')),
             FieldRow('IDocumentMetadata.digitally_available'),
             FieldRow('IDocumentMetadata.preserved_as_paper'),
             FieldRow('IDocumentMetadata.receipt_date'),
@@ -84,12 +87,8 @@ class OverviewTab(Overview):
             FieldRow('IRelatedDocuments.relatedItems'),
             FieldRow('IClassification.classification'),
             FieldRow('IClassification.privacy_layer'),
-            CustomRow(self.render_public_trial_with_edit_link,
-                      label=ogbmf('label_public_trial',
-                                  default='Public Trial')),
+            TemplateRow(self.public_trial_template,
+                        label=ogbmf('label_public_trial',
+                                    default='Public Trial')),
             FieldRow('IClassification.public_trial_statement'),
         ]
-
-    def render_file_widget(self):
-        template = ViewPageTemplateFile('templates/file.pt')
-        return template(self)


### PR DESCRIPTION
Dieser PR verschiebt meeting Elemente in eine eigene Box, so dass der Inahltsbereich für Dokumente nicht mehr halbiert wird.

![screen shot 2015-07-29 at 11 30 11](https://cloud.githubusercontent.com/assets/736583/8954669/7fd8d9ce-35e7-11e5-9899-3190ae515342.png)

Closes #1103.