### PR TITLE
Add ftw.mail to development packages.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -11,6 +11,7 @@ development-packages =
   plone.formwidget.autocomplete
   ftw.datepicker
   opengever.ogds.models
+  ftw.mail
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Adds `ftw.mail` to development packages in order to get the fix from 4teamwork/ftw.mail#32

@phgross @deiferni 