### PR TITLE
RelationCatalog Cleanup Upgradestep Korrektur 

### DIFF
--- a/opengever/base/upgrades/to4502.py
+++ b/opengever/base/upgrades/to4502.py
@@ -15,9 +15,21 @@ class CleanupRelationsCatalog(UpgradeStep):
         for iface_name in TO_REMOVE:
             self.cleanup_to_mapping(iface_name, 'to_interfaces_flattened')
             self.cleanup_to_mapping(iface_name, 'from_interfaces_flattened')
+            self.cleanup_objtokenset(
+                ['from_interfaces_flattened', 'to_interfaces_flattened'])
 
     def cleanup_to_mapping(self, iface_name, mapping_key):
         for iface in self.catalog._name_TO_mapping[mapping_key].keys():
             if '{}.{}'.format(iface.__module__, iface.__name__) == iface_name:
                 del self.catalog._name_TO_mapping[mapping_key][iface]
                 break
+
+    def cleanup_objtokenset(self, attribute_names):
+        for (key, value) in self.catalog._reltoken_name_TO_objtokenset.items():
+            token, name = key
+            if name in attribute_names:
+                broken_values = [iface for iface in value
+                                 if '{}.{}'.format(iface.__module__, iface.__name__) in TO_REMOVE]
+
+                for broken in broken_values:
+                    value.remove(broken)

--- a/opengever/base/upgrades/to4502.py
+++ b/opengever/base/upgrades/to4502.py
@@ -10,14 +10,14 @@ TO_REMOVE = ['plone.directives.form.schema.Schema',
 class CleanupRelationsCatalog(UpgradeStep):
 
     def __call__(self):
-        self.relations_catalog = getUtility(ICatalog)
+        self.catalog = getUtility(ICatalog)
 
         for iface_name in TO_REMOVE:
-            self.cleanup_interface(iface_name, 'to_interfaces_flattened')
-            self.cleanup_interface(iface_name, 'from_interfaces_flattened')
+            self.cleanup_to_mapping(iface_name, 'to_interfaces_flattened')
+            self.cleanup_to_mapping(iface_name, 'from_interfaces_flattened')
 
-    def cleanup_interface(self, iface_name, mapping_key):
-        for iface in self.relations_catalog._name_TO_mapping[mapping_key].keys():
+    def cleanup_to_mapping(self, iface_name, mapping_key):
+        for iface in self.catalog._name_TO_mapping[mapping_key].keys():
             if '{}.{}'.format(iface.__module__, iface.__name__) == iface_name:
-                del self.relations_catalog._name_TO_mapping[mapping_key][iface]
+                del self.catalog._name_TO_mapping[mapping_key][iface]
                 break


### PR DESCRIPTION
Mit dem im Commit 647eddb eingeführten Upgradestep, werden nicht mehr existierende Interfaces im `zc.relation Catalog` persistent gespeicherte Interfaces entfernt, dies aber nur aus dem `_name_TO_mapping`. 

Während dem Testen auf dem roten System, hat sich aber gezeigt das noch eine weitere Korrektur notwendig ist: Für die Korrektur von existierenden Relations muss aber zusätzlich auch das `_reltoken_name_TO_objtokenset` mapping korrigiert werden.

Mit dieser Anpassung sollte nun auch das Verschieben und Kopieren von migrierten Objekten (Plone 4.2 -> 4.3) funktionieren.

@lukasgraf @deiferni  