### PR TITLE
Add upgrade-step to fix 'document_author' and 'title' for mails with incorrectly decoded header values.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Add upgrade-step to fix 'document_author' and 'title' for mails with
+  incorrectly decoded header values.
+  [lgraf]
+
 - Move submitted with proposals list to its own document overview
   table row.
   [deiferni]

--- a/opengever/mail/profiles/default/metadata.xml
+++ b/opengever/mail/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4500</version>
+  <version>4501</version>
   <dependencies>
     <dependency>profile-ftw.mail:default</dependency>
   </dependencies>

--- a/opengever/mail/upgrades/configure.zcml
+++ b/opengever/mail/upgrades/configure.zcml
@@ -178,4 +178,14 @@
         profile="opengever.mail:default"
         />
 
+    <!-- 4500 -> 4501 -->
+    <genericsetup:upgradeStep
+        title="Fix 'document_author' and 'title' for mails with incorrectly decoded header values"
+        description=""
+        source="4500"
+        destination="4501"
+        handler="opengever.mail.upgrades.to4501.FixMailsWithIncorrectlyDecodedHeaderValues"
+        profile="opengever.mail:default"
+        />
+
 </configure>

--- a/opengever/mail/upgrades/to4501.py
+++ b/opengever/mail/upgrades/to4501.py
@@ -1,0 +1,83 @@
+from ftw.mail.utils import ENCODED_WORD_WITHOUT_LWSP
+from ftw.mail.utils import get_header
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from plone import api
+import logging
+
+
+log = logging.getLogger('ftw.upgrade')
+
+
+def looks_incorrectly_decoded(text):
+    """Determine whether a field value looks like a raw header value that
+    `decode_header` failed to decode.
+    """
+    return bool(ENCODED_WORD_WITHOUT_LWSP.search(text))
+
+
+def fix_field_value(mail, field_name, header_name):
+    """Try to fix a possibly incorrectly decoded value in a field by:
+    - Checking whether it looks like a raw, undecoded header
+    - Checking whether it is exactly the same as the corresponding raw header
+      value (which means is hasn't been edited by a user)
+    - If both of the above are true, re-decode it by fetching it from the
+      original message again using `get_header`
+    - If the new value is different, update it on the object, reindex the
+      necessary indexes, and sync the filename to the title again if needed.
+    """
+    updated = False
+    value = getattr(mail, field_name)
+    if looks_incorrectly_decoded(value) and value == mail.msg[header_name]:
+        new_value = get_header(mail.msg, header_name)
+
+        # safe_decode_headers returns UTF8, Dexterity wants unicode
+        new_value = new_value.decode('utf-8')
+
+        if value != new_value:
+            log.info("Fixing '{}' for mail {} ({} -> {})".format(
+                field_name, mail.absolute_url(), repr(value), repr(new_value)))
+            setattr(mail, field_name, new_value)
+            if field_name == 'title':
+                mail.update_filename()
+            updated = True
+
+    return updated
+
+
+def fix_document_author(mail):
+    updated = fix_field_value(mail, 'document_author', 'From')
+    if updated:
+        return ['document_author',
+                'SearchableText',
+                'sortable_author']
+    return []
+
+
+def fix_title(mail):
+    updated = fix_field_value(mail, 'title', 'Subject')
+    if updated:
+        return ['Title',
+                'SearchableText',
+                'sortable_title',
+                'breadcrumb_titles']
+    return []
+
+
+class FixMailsWithIncorrectlyDecodedHeaderValues(UpgradeStep):
+
+    def __call__(self):
+        catalog = api.portal.get_tool('portal_catalog')
+
+        objects = self.catalog_unrestricted_search(
+            {'portal_type': 'ftw.mail.mail'}, full_objects=True)
+
+        info = 'Fixing mails with incorrectly decoded text'
+        for mail in ProgressLogger(info, objects):
+
+            need_reindexing = set()
+            need_reindexing.update(fix_document_author(mail))
+            need_reindexing.update(fix_title(mail))
+
+            if need_reindexing:
+                catalog.reindexObject(mail, idxs=need_reindexing)


### PR DESCRIPTION
Fixes the `document_author` and  `title` fields on the mail objects.

The upgrade-step tries to fix a possibly incorrectly decoded value in a field by

- Checking whether it looks like a raw, undecoded header
- Checking whether it is exactly the same as the corresponding raw header
  value (which means is hasn't been edited by a user)
- If both of the above are true, re-decode it by fetching it from the
  original message again using `get_header`
- If the new value is different, update it on the object, reindex the
  necessary indexes, and sync the filename to the title again if needed.