### PR TITLE
Use datetime formatter to display deadline label.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Use datetime formatter to display deadline label.
+  [deiferni]
+
 - Add upgrade-step to fix 'document_author' and 'title' for mails with
   incorrectly decoded header values.
   [lgraf]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import relation
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 from sqlalchemy.sql import functions
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 
 
@@ -201,17 +202,18 @@ class Task(Base):
             translate(self.review_state, domain='plone',
                       context=api.portal.get().REQUEST))
 
-    def get_deadline_label(self):
+    def get_deadline_label(self, format="medium"):
         if not self.deadline:
             return u''
 
         if self.is_overdue:
-            label = '<span class="overdue">{}</span>'
+            label = u'<span class="overdue">{}</span>'
         else:
-            label = '<span>{}</span>'
+            label = u'<span>{}</span>'
 
-        return label.format(
-            self.deadline.strftime('%d.%m.%Y'))
+        formatter = getRequest().locale.dates.getFormatter("date", format)
+        formatted_date = formatter.format(self.deadline)
+        return label.format(formatted_date.strip())
 
     def _date_to_zope_datetime(self, date):
         if not date:

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -85,7 +85,7 @@ class Overview(DisplayForm, OpengeverTab):
             },
             {
                 'label': _(u"label_deadline", default=u"Deadline"),
-                'value': task.get_deadline_label(),
+                'value': task.get_deadline_label(format="long"),
                 'is_html': True,
             },
             {

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -109,7 +109,7 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertSequenceEqual(
             ['Aufgabe', 'Dossier', 'Text blabla', 'To comment',
-             'task-state-open', '01.01.2010', self.user.label(),
+             'task-state-open', 'January 1, 2010', self.user.label(),
              self.user.label(), ''],
             table_data
         )


### PR DESCRIPTION
Also allow to specify if long or medium format should be used.

Closes #1110.