### PR TITLE
Add CreatorMigrator that migrates creators for Dexterity objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.5.0 (unreleased)
 ------------------
 
+- Add CreatorMigrator that migrates creators for Dexterity objects.
+  (to be used with ftw.usermigration).
+  [lgraf]
+
 - Added activity support for tasktemplates.
   [phgross]
 

--- a/opengever/usermigration/creator.py
+++ b/opengever/usermigration/creator.py
@@ -1,0 +1,91 @@
+"""
+Helper for migrating creators on Dexterity objects.
+"""
+
+from opengever.usermigration.exceptions import UserMigrationException
+from plone import api
+from zope.component import getMultiAdapter
+import logging
+
+
+logger = logging.getLogger('opengever.usermigration')
+
+
+class CreatorMigrator(object):
+
+    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+        self.portal = portal
+        self.principal_mapping = principal_mapping
+
+        if mode != 'move':
+            raise NotImplementedError(
+                "CreatorMigrator only supports 'move' mode as of yet")
+        self.mode = mode
+
+        self.strict = strict
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.acl_users = api.portal.get_tool('acl_users')
+
+    def _get_objects(self):
+        brains = self.catalog.unrestrictedSearchResults()
+        for brain in brains:
+            yield brain.getObject()
+
+    def _verify_user(self, userid):
+        pas_search = getMultiAdapter((self.portal, self.portal.REQUEST),
+                                     name='pas_search')
+        users = pas_search.searchUsers(id=userid)
+        if len(users) < 1:
+            msg = "User '{}' not found in acl_users!".format(userid)
+            if self.strict:
+                raise UserMigrationException(msg)
+            else:
+                logger.warn(msg)
+
+    def _migrate_creators(self, obj):
+        if not hasattr(obj, 'creators'):
+            return [], []
+
+        changed = False
+        moved = []
+        modified_idxs = set()
+        path = '/'.join(obj.getPhysicalPath())
+
+        new_creators = []
+        for old_userid in obj.creators:
+            if old_userid in self.principal_mapping:
+                new_userid = self.principal_mapping[old_userid]
+                logger.info("Migrating creator(s) for {} ({} -> {})".format(
+                    path, old_userid, new_userid))
+                self._verify_user(new_userid)
+                new_creators.append(new_userid)
+                moved.append((path, old_userid, new_userid))
+                modified_idxs.update(['listCreators', 'Creator'])
+                changed = True
+            else:
+                new_creators.append(old_userid)
+        if changed:
+            obj.creators = tuple(new_creators)
+
+        return list(modified_idxs), moved
+
+    def migrate(self):
+        creators_moved = []
+
+        objects = self._get_objects()
+        for obj in objects:
+            modified_idxs = []
+
+            # Migrate creators
+            idxs, moved = self._migrate_creators(obj)
+            modified_idxs.extend(idxs)
+            creators_moved.extend(moved)
+            if modified_idxs:
+                self.catalog.reindexObject(obj, idxs=modified_idxs)
+
+        results = {
+            'creators': {
+                'moved': creators_moved, 'copied': [], 'deleted': []},
+        }
+
+        return results

--- a/opengever/usermigration/tests/test_creator_migrator.py
+++ b/opengever/usermigration/tests/test_creator_migrator.py
@@ -1,0 +1,94 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import create_plone_user
+from opengever.testing import FunctionalTestCase
+from opengever.testing import index_data_for
+from opengever.testing.helpers import obj2brain
+from opengever.usermigration.creator import CreatorMigrator
+from opengever.usermigration.exceptions import UserMigrationException
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_NAME
+
+
+class TestCreatorMigrator(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCreatorMigrator, self).setUp()
+        self.portal = self.layer['portal']
+        self.catalog = api.portal.get_tool('portal_catalog')
+
+        create_plone_user(self.portal, 'old.user')
+        setRoles(self.portal, 'old.user', ['Reader', 'Contributor'])
+
+        create_plone_user(self.portal, 'new.user')
+        setRoles(self.portal, 'new.user', ['Reader', 'Contributor'])
+
+        self.login(user_id='old.user')
+        self.dossier = create(Builder('dossier')
+                              .titled(u'Testdossier'))
+
+        self.doc = create(Builder('document')
+                          .within(self.dossier))
+
+        self.login(user_id=TEST_USER_NAME)
+
+    def test_creators_get_migrated(self):
+        migrator = CreatorMigrator(
+            self.portal, {'old.user': 'new.user'}, 'move')
+        migrator.migrate()
+        self.assertEquals(('new.user',), self.dossier.creators)
+        self.assertEquals(('new.user',), self.doc.creators)
+
+    def test_uppercase_creator_accessor_works_after_migration(self):
+        migrator = CreatorMigrator(
+            self.portal, {'old.user': 'new.user'}, 'move')
+        migrator.migrate()
+        self.assertEquals('new.user', self.dossier.Creator())
+        self.assertEquals('new.user', self.doc.Creator())
+
+    def test_creator_index_gets_updated(self):
+        migrator = CreatorMigrator(
+            self.portal, {'old.user': 'new.user'}, 'move')
+        migrator.migrate()
+
+        # Index should be up to date
+        self.assertEquals('new.user',
+                          index_data_for(self.dossier).get('Creator'))
+        self.assertEquals('new.user',
+                          index_data_for(self.doc).get('Creator'))
+
+        # Metadata should be up to date
+        self.assertEquals(('new.user', ), obj2brain(self.dossier).listCreators)
+        self.assertEquals(('new.user', ), obj2brain(self.doc).listCreators)
+
+        self.assertEquals('new.user', obj2brain(self.dossier).Creator)
+        self.assertEquals('new.user', obj2brain(self.doc).Creator)
+
+    def test_raises_if_strict_and_user_doesnt_exist(self):
+        migrator = CreatorMigrator(
+            self.portal, {'old.user': 'doesnt.exist'}, 'move')
+
+        with self.assertRaises(UserMigrationException):
+            migrator.migrate()
+
+    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
+        migrator = CreatorMigrator(
+            self.portal, {'old.user': 'doesnt.exist'}, 'move', strict=False)
+
+        migrator.migrate()
+        self.assertEquals(('doesnt.exist', ), self.dossier.creators)
+        self.assertEquals(('doesnt.exist', ), self.doc.creators)
+
+    def test_returns_proper_results_for_moving_creator(self):
+        migrator = CreatorMigrator(
+            self.portal, {'old.user': 'new.user'}, 'move')
+        results = migrator.migrate()
+
+        self.assertEquals(
+            [
+                ('/plone/dossier-1', 'old.user', 'new.user'),
+                ('/plone/dossier-1/document-1', 'old.user', 'new.user'),
+            ],
+            results['creators']['moved']
+        )


### PR DESCRIPTION
Adds a `CreatorMigrator` that migrates creators for Dexterity objects - to be used with `ftw.usermigration`.