### PR TITLE
Cleanup development-packages after releasing GEVER 3.4.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -5,14 +5,6 @@ extensions = mr.developer
 development-packages =
   opengever.maintenance
   collective.js.timeago
-  plonetheme.teamraum
-  transmogrify.dexterity
-  ftw.inflator
-  plone.formwidget.autocomplete
-  ftw.datepicker
-  opengever.ogds.models
-  ftw.mail
-  ftw.tabbedview
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Die Packages sind nun released und müssen nicht mehr ausgecheckt werden.

`collective.js.timeago` ist leider noch nicht released worden.

@deiferni or @lukasgraf 