### PR TITLE
Advanced search: Fix translation for filing no help text.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Advanced search: Fix translation for filing no help text.
+  [lgraf]
+
 - Let OGMail inherit from ftw.mail.mail.Mail.
   [deiferni]
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-07-28 16:13+0000\n"
+"POT-Creation-Date: 2015-08-03 14:02+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -227,12 +227,12 @@ msgid "button_submit"
 msgstr "Verschieben"
 
 #. Default: "Contact"
-#: ./opengever/dossier/browser/participants.py:113
+#: ./opengever/dossier/browser/participants.py:114
 msgid "column_contact"
 msgstr "Kontakt"
 
 #. Default: "role_list"
-#: ./opengever/dossier/browser/participants.py:117
+#: ./opengever/dossier/browser/participants.py:118
 msgid "column_rolelist"
 msgstr "Rolle"
 
@@ -349,7 +349,7 @@ msgstr ""
 
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
-msgstr ""
+msgstr "Geben Sie die vollständige Ablagenummer an."
 
 #: ./opengever/dossier/behaviors/dossier.py:107
 msgid "help_filing_prefix"
@@ -520,7 +520,7 @@ msgstr "Verwandte Dossiers"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:86
-#: ./opengever/dossier/browser/participants.py:174
+#: ./opengever/dossier/browser/participants.py:175
 #: ./opengever/dossier/browser/report.py:44
 msgid "label_responsible"
 msgstr "Federführend"
@@ -638,3 +638,4 @@ msgstr "abgelaufen"
 #: ./opengever/dossier/behaviors/participation.py:197
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
+

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-28 16:13+0000\n"
+"POT-Creation-Date: 2015-08-03 14:02+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -223,12 +223,12 @@ msgid "button_submit"
 msgstr "Déplacer"
 
 #. Default: "Contact"
-#: ./opengever/dossier/browser/participants.py:113
+#: ./opengever/dossier/browser/participants.py:114
 msgid "column_contact"
 msgstr "Contacts"
 
 #. Default: "role_list"
-#: ./opengever/dossier/browser/participants.py:117
+#: ./opengever/dossier/browser/participants.py:118
 msgid "column_rolelist"
 msgstr "Rôle"
 
@@ -345,7 +345,7 @@ msgstr ""
 
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
-msgstr ""
+msgstr "Saisir le numéro d'inventaire complet"
 
 #: ./opengever/dossier/behaviors/dossier.py:107
 msgid "help_filing_prefix"
@@ -516,7 +516,7 @@ msgstr "Dossiers liés"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:86
-#: ./opengever/dossier/browser/participants.py:174
+#: ./opengever/dossier/browser/participants.py:175
 #: ./opengever/dossier/browser/report.py:44
 msgid "label_responsible"
 msgstr "Responsable"
@@ -634,3 +634,4 @@ msgstr "Périmé"
 #: ./opengever/dossier/behaviors/participation.py:197
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation"
+

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-28 16:13+0000\n"
+"POT-Creation-Date: 2015-08-03 14:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -226,12 +226,12 @@ msgid "button_submit"
 msgstr ""
 
 #. Default: "Contact"
-#: ./opengever/dossier/browser/participants.py:113
+#: ./opengever/dossier/browser/participants.py:114
 msgid "column_contact"
 msgstr ""
 
 #. Default: "role_list"
-#: ./opengever/dossier/browser/participants.py:117
+#: ./opengever/dossier/browser/participants.py:118
 msgid "column_rolelist"
 msgstr ""
 
@@ -518,7 +518,7 @@ msgstr ""
 
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:86
-#: ./opengever/dossier/browser/participants.py:174
+#: ./opengever/dossier/browser/participants.py:175
 #: ./opengever/dossier/browser/report.py:44
 msgid "label_responsible"
 msgstr ""


### PR DESCRIPTION
Fixes #1120.

Needs to be backported to `4.5-stable`.