### PR TITLE
Verbesserung und Vereinheitlichung des Mail Icons.

### DIFF
--- a/opengever/mail/browser/templates/file.pt
+++ b/opengever/mail/browser/templates/file.pt
@@ -3,8 +3,7 @@
 
   <tal:file tal:condition="context/message">
     <!-- icon, filename, size -->
-    <span tal:attributes="class view/get_css_class"></span>
-    <span tal:define="filename view/w/message/filename">
+    <span tal:attributes="class view/get_css_class" tal:define="filename view/w/message/filename">
       <span class="filename" tal:content="filename">Filename</span>
       <span class="discreet">
         &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100 KB</span>

--- a/sources.cfg
+++ b/sources.cfg
@@ -5,6 +5,7 @@ extensions = mr.developer
 development-packages =
   opengever.maintenance
   collective.js.timeago
+  plonetheme.teamraum
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Kleine Anpassung an der Struktur des Mail "file-widgets", um die Darstellung des Mail-Icons zu verbessern. Siehe https://github.com/4teamwork/plonetheme.teamraum/pull/329

@lukasgraf 

----
Benötigt einen Backport nach `4.5-stable` 