### PR TITLE
Tasktemplate form: add redirect when no tasktemplatefolder exists.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Tasktemplate form: Redirects back to dossier and show statusmessage
+  if no active tasktemplatefolders are registered.
+  [phgross]
+
 - Advanced search: Fix translation for filing no help text.
   [lgraf]
 

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-08-04 11:47+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -94,7 +94,7 @@ msgid "label_continue"
 msgstr "Weiter"
 
 #. Default: "Created"
-#: ./opengever/tasktemplates/browser/form.py:119
+#: ./opengever/tasktemplates/browser/form.py:121
 msgid "label_created"
 msgstr "Erstelldatum"
 
@@ -147,7 +147,7 @@ msgid "label_text"
 msgstr "Kommentar"
 
 #. Default: "Title"
-#: ./opengever/tasktemplates/browser/form.py:117
+#: ./opengever/tasktemplates/browser/form.py:119
 #: ./opengever/tasktemplates/browser/tasktemplates.py:41
 #: ./opengever/tasktemplates/browser/templatefolders.py:29
 msgid "label_title"
@@ -159,14 +159,19 @@ msgid "label_yes"
 msgstr "Ja"
 
 #. Default: "You have not selected any templates"
-#: ./opengever/tasktemplates/browser/form.py:208
+#: ./opengever/tasktemplates/browser/form.py:230
 msgid "message_no_templates_selected"
 msgstr "Sie haben keine Vorlagen ausgewählt."
 
 #. Default: "tasks created"
-#: ./opengever/tasktemplates/browser/form.py:277
+#: ./opengever/tasktemplates/browser/form.py:307
 msgid "message_tasks_created"
 msgstr "Alle Aufgaben aus gewähltem Standardablauf wurden erstellt."
+
+#. Default: "Currently there are no activetask template folders registered."
+#: ./opengever/tasktemplates/browser/form.py:144
+msgid "msg_no_active_tasktemplatefolders"
+msgstr "Zurzeit sind keine aktiven Standardabläufe hinterlegt."
 
 #. Default: "Yes"
 #: ./opengever/tasktemplates/browser/tasktemplates.py:19

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-08-04 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -94,7 +94,7 @@ msgid "label_continue"
 msgstr "Continuer"
 
 #. Default: "Created"
-#: ./opengever/tasktemplates/browser/form.py:119
+#: ./opengever/tasktemplates/browser/form.py:121
 msgid "label_created"
 msgstr "Date de création"
 
@@ -147,7 +147,7 @@ msgid "label_text"
 msgstr "commentaire"
 
 #. Default: "Title"
-#: ./opengever/tasktemplates/browser/form.py:117
+#: ./opengever/tasktemplates/browser/form.py:119
 #: ./opengever/tasktemplates/browser/tasktemplates.py:41
 #: ./opengever/tasktemplates/browser/templatefolders.py:29
 msgid "label_title"
@@ -159,14 +159,19 @@ msgid "label_yes"
 msgstr "Oui"
 
 #. Default: "You have not selected any templates"
-#: ./opengever/tasktemplates/browser/form.py:208
+#: ./opengever/tasktemplates/browser/form.py:230
 msgid "message_no_templates_selected"
 msgstr "Vous n'avez sélectionné aucun modèle."
 
 #. Default: "tasks created"
-#: ./opengever/tasktemplates/browser/form.py:277
+#: ./opengever/tasktemplates/browser/form.py:307
 msgid "message_tasks_created"
 msgstr "Toutes les tâches du procédé standard ont été créées"
+
+#. Default: "Currently there are no activetask template folders registered."
+#: ./opengever/tasktemplates/browser/form.py:144
+msgid "msg_no_active_tasktemplatefolders"
+msgstr ""
 
 #. Default: "Yes"
 #: ./opengever/tasktemplates/browser/tasktemplates.py:19

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-16 17:18+0000\n"
+"POT-Creation-Date: 2015-08-04 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,7 +97,7 @@ msgid "label_continue"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/tasktemplates/browser/form.py:119
+#: ./opengever/tasktemplates/browser/form.py:121
 msgid "label_created"
 msgstr ""
 
@@ -150,7 +150,7 @@ msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tasktemplates/browser/form.py:117
+#: ./opengever/tasktemplates/browser/form.py:119
 #: ./opengever/tasktemplates/browser/tasktemplates.py:41
 #: ./opengever/tasktemplates/browser/templatefolders.py:29
 msgid "label_title"
@@ -162,13 +162,18 @@ msgid "label_yes"
 msgstr ""
 
 #. Default: "You have not selected any templates"
-#: ./opengever/tasktemplates/browser/form.py:208
+#: ./opengever/tasktemplates/browser/form.py:230
 msgid "message_no_templates_selected"
 msgstr ""
 
 #. Default: "tasks created"
-#: ./opengever/tasktemplates/browser/form.py:277
+#: ./opengever/tasktemplates/browser/form.py:307
 msgid "message_tasks_created"
+msgstr ""
+
+#. Default: "Currently there are no activetask template folders registered."
+#: ./opengever/tasktemplates/browser/form.py:144
+msgid "msg_no_active_tasktemplatefolders"
 msgstr ""
 
 #. Default: "Yes"

--- a/opengever/tasktemplates/tests/test_form.py
+++ b/opengever/tasktemplates/tests/test_form.py
@@ -1,0 +1,34 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
+from opengever.testing import FunctionalTestCase
+
+
+class TestAddTaskTemplateForm(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestAddTaskTemplateForm, self).setUp()
+        self.dossier = create(Builder('dossier'))
+        self.templatedossier = create(Builder('templatedossier'))
+
+    @browsing
+    def test_redirects_back_and_show_statusmessage_when_no_active_tasktemplatefolder_exists(self, browser):
+        tasktemplatefolder = create(Builder('tasktemplatefolder'))
+
+        browser.login().open(self.dossier, view='add-tasktemplate')
+        self.assertEquals(self.dossier.absolute_url(), browser.url)
+        self.assertEquals(
+            ['Currently there are no activetask template folders registered.'],
+            error_messages())
+
+    @browsing
+    def test_stay_on_view_if_active_tasktemplatefolders_exists(self, browser):
+        tasktemplatefolder = create(Builder('tasktemplatefolder')
+                                    .in_state('tasktemplatefolder-state-active'))
+
+        browser.login().open(self.dossier, view='add-tasktemplate')
+        self.assertEquals(
+            '{}/add-tasktemplate'.format(self.dossier.absolute_url()),
+            browser.url)
+        self.assertEquals([], error_messages())


### PR DESCRIPTION
Redirects back to dossier and shows statusmessage if no active tasktemplatefolders are registered.

Fixes #1119 

![bildschirmfoto 2015-08-04 um 13 55 33](https://cloud.githubusercontent.com/assets/485755/9060065/8639b19e-3ab0-11e5-8fb6-fd61ff33461d.png)

@lukasgraf 
