### PR TITLE
Dossier-Übersicht: abgeschlossene Aufgaben nicht mehr anzeigen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Only show pending states on dossier overview.
+  [deiferni]
+
 - Tasktemplate form: Redirects back to dossier and show statusmessage
   if no active tasktemplatefolders are registered.
   [phgross]

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -68,6 +68,7 @@ class DossierOverview(BoxesViewMixin, grok.View, OpengeverTab):
 
     def tasks(self):
         return Task.query.by_container(self.context, get_current_admin_unit())\
+                         .in_pending_state()\
                          .order_by(desc('modified')).limit(5).all()
 
     def documents(self):

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -59,6 +59,22 @@ class TestOverview(FunctionalTestCase):
             ['Task x'])
 
     @browsing
+    def test_task_box_items_are_filtered_by_pending_state(self, browser):
+        create(Builder('task')
+               .within(self.dossier)
+               .in_state('task-state-open')
+               .titled(u'Task open'))
+        create(Builder('task')
+               .within(self.dossier)
+               .in_state('task-state-tested-and-closed')
+               .titled(u'Task closed'))
+
+        browser.login().open(self.dossier, view='tabbedview_view-overview')
+        self.assertSequenceEqual(
+            browser.css('#newest_tasksBox li:not(.moreLink) a').text,
+            ['Task open'])
+
+    @browsing
     def test_participant_labels_are_displayed(self, browser):
         browser.login().open(self.dossier, view='tabbedview_view-overview')
         self.assertEqual(

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -81,5 +81,8 @@ class TaskQuery(BaseQuery):
             '{}/'.format(task.physical_path)))
         return query
 
+    def in_pending_state(self):
+        return self.filter(Task.review_state.in_(Task.PENDING_STATES))
+
 
 Task.query_cls = TaskQuery

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -1,4 +1,5 @@
 from opengever.base.oguid import Oguid
+from opengever.globalindex.model.task import Task
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.query import BaseQuery
 from plone import api
@@ -10,26 +11,26 @@ class TaskQuery(BaseQuery):
         """Returns query which List all tasks where the given user,
         his userid, is responsible. It queries all admin units.
         """
-        return self.filter(self._attribute('responsible') == userid)
+        return self.filter(Task.responsible == userid)
 
     def users_issued_tasks(self, userid):
         """Returns query which list all tasks where the given user
         is the issuer. It queries all admin units.
         """
-        return self.filter(self._attribute('issuer') == userid)
+        return self.filter(Task.issuer == userid)
 
     def by_assigned_org_unit(self, org_unit):
         """Returns all tasks assigned to the given orgunit."""
-        return self.filter(self._attribute('assigned_org_unit') == org_unit.id())
+        return self.filter(Task.assigned_org_unit == org_unit.id())
 
     def by_issuing_org_unit(self, org_unit):
         """Returns all tasks issued by the given orgunit."""
-        return self.filter(self._attribute('issuing_org_unit') == org_unit.id())
+        return self.filter(Task.issuing_org_unit == org_unit.id())
 
     def all_issued_tasks(self, admin_unit):
         """List all tasks from the current_admin_unit.
         """
-        return self.filter(self._attribute('admin_unit_id') == admin_unit.id())
+        return self.filter(Task.admin_unit_id == admin_unit.id())
 
     by_admin_unit = all_issued_tasks
 
@@ -58,24 +59,27 @@ class TaskQuery(BaseQuery):
     def by_ids(self, task_ids):
         """Returns all tasks whos task_ids are listed in `task_ids`.
         """
-        return self.filter(self._attribute('task_id').in_(task_ids)).all()
+        return self.filter(Task.task_id.in_(task_ids)).all()
 
     def by_container(self, container, admin_unit):
         url_tool = api.portal.get_tool(name='portal_url')
         path = '/'.join(url_tool.getRelativeContentPath(container))
 
         return self.by_admin_unit(admin_unit)\
-                   .filter(self._attribute('physical_path').like(path + '%'))
+                   .filter(Task.physical_path.like(path + '%'))
 
     def by_brain(self, brain):
         relative_content_path = '/'.join(brain.getPath().split('/')[2:])
         return self.by_admin_unit(get_current_admin_unit())\
-                   .filter(self._attribute('physical_path')==relative_content_path).one()
+                   .filter(Task.physical_path==relative_content_path).one()
 
     def subtasks_by_task(self, task):
         """Queries all subtask of the given task sql object."""
         query = self.filter(
-            self._attribute('admin_unit_id') == task.admin_unit_id)
-        query = query.filter(self._attribute('physical_path').startswith(
+            Task.admin_unit_id == task.admin_unit_id)
+        query = query.filter(Task.physical_path.startswith(
             '{}/'.format(task.physical_path)))
         return query
+
+
+Task.query_cls = TaskQuery

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -4,7 +4,6 @@ from opengever.base.model import Base
 from opengever.base.model import Session
 from opengever.base.oguid import Oguid
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
-from opengever.globalindex.model.query import TaskQuery
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
@@ -33,8 +32,6 @@ from zope.i18n import translate
 
 class Task(Base):
     """docstring for Task"""
-
-    query_cls = TaskQuery
 
     MAX_TITLE_LENGTH = 256
     MAX_BREADCRUMB_LENGTH = 512

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -44,6 +44,13 @@ class Task(Base):
 
     OPEN_STATES = ['task-state-open', 'forwarding-state-open']
 
+    PENDING_STATES = ['task-state-open',
+                      'task-state-in-progress',
+                      'task-state-resolved',
+                      'task-state-rejected',
+                      'forwarding-state-open',
+                      'forwarding-state-refused']
+
     __tablename__ = 'tasks'
     __table_args__ = (UniqueConstraint('admin_unit_id', 'int_id'), {})
 

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -38,6 +38,14 @@ class TestTaskQueries(TestCase):
         self.session.add(task)
         return task
 
+    def test_in_pending_state_returns_only_pending_tasks(self):
+        task1 = self.task(1, 'xx', review_state='task-state-open')
+        task2 = self.task(2, 'yy', review_state='task-state-resolved')
+        task3 = self.task(3, 'zz', review_state='task-state-cancelled')
+
+        self.assertItemsEqual(
+            [task1, task2], Task.query.in_pending_state().all())
+
     def test_users_tasks_lists_only_tasks_assigned_to_current_user(self):
         task1 = self.task(1, 'rr', responsible='hugo.boss')
         task2 = self.task(2, 'bd', responsible='tommy.hilfiger')

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -56,15 +56,6 @@ class GlobalTaskListingTab(grok.View, OpengeverTab,
     select_all_template = ViewPageTemplateFile('select_all_globaltasks.pt')
     selection = ViewPageTemplateFile("selection_tasks.pt")
 
-    open_states = [
-            'task-state-open',
-            'task-state-in-progress',
-            'task-state-resolved',
-            'task-state-rejected',
-            'forwarding-state-open',
-            'forwarding-state-refused',
-        ]
-
     state_filter_name = 'task_state_filter'
     state_filter_available = True
 
@@ -178,9 +169,6 @@ class GlobalTaskTableSource(SqlTableSource):
 
     def extend_query_with_statefilter(self, query):
         """When a state filter is active,
-        we add a filter which select just the open tasks"""
+        we add a filter which selects just the pending tasks"""
 
-        query = query.filter(
-            Task.review_state.in_(self.config.open_states))
-
-        return query
+        return query.in_pending_state()


### PR DESCRIPTION
Dieser PR passt die Dossier Übersicht an so, dass nur noch pendente Aufgaben in der Auflistung gelistet werden.

Needs backporting to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).

Closes #1127