### PR TITLE
Fixed gever customization of sharing view, for updateSharingInfo.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fixed gever customization of sharing view, for updateSharingInfo.
+  [phgross]
+
 - Add additional columns publish_in, disclose_to and copy_for_attention
   to proposals, protocols and protocol excerpts.
   [deiferni]

--- a/opengever/sharing/browser/configure.zcml
+++ b/opengever/sharing/browser/configure.zcml
@@ -11,6 +11,15 @@
         />
 
     <browser:page
+        name="updateSharingInfo"
+        for="*"
+        class=".sharing.OpengeverSharingView"
+        attribute="updateSharingInfo"
+        permission="plone.DelegateRoles"
+        layer="opengever.sharing.interfaces.IOpengeverSharing"
+        />
+
+    <browser:page
         name="tabbedview_view-sharing"
         for="*"
         class=".sharing.SharingTab"


### PR DESCRIPTION
The view wich is called per ajax when searching for a principal, is registered as a separate view, therefore we need to overwrite them as well. Fixes #1122 

----
Wie besprochen müssten die `opengever.sharing` Tests komplett überarbeitet werden, da dies aber den Rahmen dieses Bugfixes sprengen würde, enthält der PR kein Test.

@lukasgraf @deiferni 

Backport needed: `4.5-stable`