### PR TITLE
Made Document's tooltip edit_direct link CSRF safe

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Made Document's tooltip edit_direct link CSRF safe, adding the authentication token.
+  [phgross]
+
 - Fixed gever customization of sharing view, for updateSharingInfo.
   [phgross]
 

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -11,6 +11,7 @@ from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import ram
+from plone.protect.utils import addTokenToUrl
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFPlone import PloneMessageFactory as pmf
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
@@ -229,7 +230,7 @@ def _linked_document_with_tooltip(item, value, trashed=False, removed=False):
     data['edit_metadata_label'] = translate(
         pmf(u'Edit metadata'), context=item.REQUEST).encode('utf-8')
 
-    data['edit_direct_link'] = '%s/editing_document' % (data['url'])
+    data['edit_direct_link'] = addTokenToUrl('%s/editing_document' % (data['url']))
     data['edit_direct_label'] = translate(
         pmf(u'Checkout and edit'), context=item.REQUEST).encode('utf-8')
 

--- a/opengever/tabbedview/tests/test_document_helper.py
+++ b/opengever/tabbedview/tests/test_document_helper.py
@@ -7,6 +7,7 @@ from opengever.document.document import Document
 from opengever.tabbedview.helper import linked_document_with_tooltip
 from opengever.tabbedview.helper import linked_trashed_document_with_tooltip
 from pyquery import PyQuery
+from zope.globalrequest import setRequest
 from zope.interface import Interface
 
 
@@ -50,6 +51,10 @@ class LinkTestCase(MockTestCase):
     def setUp(self):
         super(LinkTestCase, self).setUp()
         self.request = self.stub_request()
+        self.expect(self.request.SERVER_URL).result('http://nohost/plone')
+        self.expect(self.request.environ).result({'_auth_token': '123456'})
+        setRequest(self.request)
+
         self.doc_brain = MockBrain(self.request, 'opengever.document.document')
         self.mail_brain = MockBrain(self.request, 'ftw.mail.mail')
         self.user_mock = self.stub()
@@ -171,7 +176,7 @@ class TestTooltipLinkedHelperWithDocuments(TestWithPDFConverter):
     def test_tooltip_link_to_checkout_and_edit_is_available(self):
         self.replay()
         checkout_link = link(
-            href="%s/editing_document" % self.doc_brain.getURL(),
+            href="%s/editing_document?_authenticator=123456" % self.doc_brain.getURL(),
             text="Checkout and edit")
         self.assertTooltipLinkIn(checkout_link, self.markup())
 


### PR DESCRIPTION
This PR adds the authentication token to the edit_direct link, which fixes #1139.

@lukasgraf @deiferni 

Need backport: `4.5-stable`