### PR TITLE
Use correct geometry setup for landscape pdfs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Use correct geometry setup for landscape pdfs.
+  [deiferni]
+
 - Fixed translation of PDF Preview button in document's tooltip.
   [phgross]
 

--- a/opengever/latex/layouts/default.py
+++ b/opengever/latex/layouts/default.py
@@ -31,10 +31,7 @@ class DefaultLayout(CustomizableLayout, grok.MultiAdapter):
         self.use_package('babel', 'ngerman', append_options=False)
         self.use_package('fancyhdr')
 
-        self.use_package('geometry', 'left=35mm')
-        self.use_package('geometry', 'right=10mm')
-        self.use_package('geometry', 'top=55mm')
-        self.use_package('geometry', 'bottom=10.5mm')
+        self.use_package_geometry()
 
         self.use_package('graphicx')
         self.use_package('lastpage')
@@ -50,6 +47,12 @@ class DefaultLayout(CustomizableLayout, grok.MultiAdapter):
 
         if self.show_logo:
             self.add_raw_template_file('gever_logo.jpeg')
+
+    def use_package_geometry(self):
+        self.use_package('geometry', 'left=35mm')
+        self.use_package('geometry', 'right=10mm')
+        self.use_package('geometry', 'top=55mm')
+        self.use_package('geometry', 'bottom=10.5mm')
 
     def get_render_arguments(self):
         owner = self.get_owner()

--- a/opengever/latex/layouts/landscape.py
+++ b/opengever/latex/layouts/landscape.py
@@ -13,3 +13,9 @@ class LandscapeLayout(DefaultLayout):
     def __init__(self, context, request, builder):
         super(LandscapeLayout, self).__init__(context, request, builder)
         self.show_contact = False
+
+    def use_package_geometry(self):
+        self.use_package('geometry', 'top=35mm')
+        self.use_package('geometry', 'right=10.5mm')
+        self.use_package('geometry', 'bottom=10.5mm')
+        self.use_package('geometry', 'left=10.5mm')


### PR DESCRIPTION
Make better use of the full a4 landscape paper width:
![screen shot 2015-08-05 at 14 44 50](https://cloud.githubusercontent.com/assets/736583/9085831/8f48cd26-3b80-11e5-91ba-aa0181673552.png)

Fixes #1125.

Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).