### PR TITLE
Disable inline validation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Disable inline validation.
+  [phgross]
+
 - Dossier WF: Allow 'Copy or Move' for Dossiers in closed states:
   This is necessary to be able to copy documents from closed dossiers.
   [lgraf]

--- a/opengever/policy/base/profiles/default/jsregistry.xml
+++ b/opengever/policy/base/profiles/default/jsregistry.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript id="inline_validation.js" enabled="False" />
+
+</object>

--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4504</version>
+  <version>4505</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/opengever/policy/base/upgrades/configure.zcml
+++ b/opengever/policy/base/upgrades/configure.zcml
@@ -119,4 +119,13 @@
       profile="opengever.policy.base:default"
       />
 
+  <!-- 4504 -> 4505 -->
+  <upgrade-step:importProfile
+      title="Disable inline validation."
+      profile="opengever.policy.base:default"
+      source="4504"
+      destination="4505"
+      directory="profiles/4505"
+      />
+
 </configure>

--- a/opengever/policy/base/upgrades/profiles/4505/jsregistry.xml
+++ b/opengever/policy/base/upgrades/profiles/4505/jsregistry.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript id="inline_validation.js" enabled="False" />
+
+</object>


### PR DESCRIPTION
Because of several problems in particularly with `invariants`, we decided to disable the inline validation for now.

Fixes #1137 

Backport needed: `4.5-stable`