### PR TITLE
Pendenzenliste Action darstellen, wenn nötig.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fix an issue with the open taks report action, make sure it displayed again.
+  [deiferni]
+
 - Disable inline validation.
   [phgross]
 

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -56,7 +56,6 @@ class TestMyNotifications(FunctionalTestCase):
             'peter.mueller',
             {'en': None})
 
-
     @browsing
     def test_lists_only_notifications_of_current_user(self, browser):
         browser.login().open(self.portal,
@@ -81,7 +80,7 @@ class TestMyNotifications(FunctionalTestCase):
               'Title': 'Kennzahlen 2014 erfassen'},
              {'Actor': 'Mueller Peter (peter.mueller)',
               'Created': api.portal.get_localized_time(
-                  self.activity_1.created, long_format=True),
+                  self.activity_2.created, long_format=True),
               'Kind': 'task-transition-open-in-progress',
               'Title': 'Kennzahlen 2014 erfassen'}],
             browser.css('.listing').first.dicts())

--- a/opengever/latex/opentaskreport.py
+++ b/opengever/latex/opentaskreport.py
@@ -173,5 +173,9 @@ class OpenTaskReportPDFAllowed(grok.View):
     grok.require('zope2.View')
 
     def render(self):
-        inbox = get_current_org_unit().inbox()
-        return ogds_service().fetch_current_user() in inbox.assigned_users()
+        return is_open_task_report_allowed()
+
+
+def is_open_task_report_allowed():
+    inbox = get_current_org_unit().inbox()
+    return ogds_service().fetch_current_user() in inbox.assigned_users()

--- a/opengever/latex/opentaskreport.py
+++ b/opengever/latex/opentaskreport.py
@@ -17,6 +17,7 @@ from opengever.task.helper import task_type_helper
 from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy.sql.expression import asc
+from zExceptions import Unauthorized
 from zope.interface import Interface
 
 
@@ -40,8 +41,10 @@ class OpenTaskReportPDFView(grok.View, ExportPDFView):
     grok.require('zope2.View')
 
     def render(self):
-        provide_request_layer(self.request, IOpenTaskReportLayer)
+        if not is_open_task_report_allowed():
+            raise Unauthorized()
 
+        provide_request_layer(self.request, IOpenTaskReportLayer)
         return ExportPDFView.__call__(self)
 
 

--- a/opengever/latex/tests/test_opentaskreport.py
+++ b/opengever/latex/tests/test_opentaskreport.py
@@ -14,6 +14,7 @@ from opengever.latex.testing import LATEX_ZCML_LAYER
 from opengever.testing import create_plone_user
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import login
+from zExceptions import Unauthorized
 from zope.component import adaptedBy
 from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
@@ -131,6 +132,11 @@ class TestOpenTaskReport(FunctionalTestCase):
     @browsing
     def test_smoke_open_task_report_view_allowed(self, browser):
         browser.login().open(view='pdf-open-task-report')
+
+    @browsing
+    def test_open_task_report_view_not_allowed_raises_unauthorized(self, browser):
+        with self.assertRaises(Unauthorized):
+            browser.login('hans.meier').open(view='pdf-open-task-report')
 
     def test_task_report_is_only_available_for_current_inbox_users(self):
         self.assertTrue(

--- a/opengever/latex/tests/test_opentaskreport.py
+++ b/opengever/latex/tests/test_opentaskreport.py
@@ -11,7 +11,6 @@ from opengever.latex import opentaskreport
 from opengever.latex.layouts.default import DefaultLayout
 from opengever.latex.opentaskreport import IOpenTaskReportLayer
 from opengever.latex.testing import LATEX_ZCML_LAYER
-from opengever.testing import create_plone_user
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import login
 from zExceptions import Unauthorized
@@ -35,21 +34,6 @@ class TestOpenTaskReportPDFView(MockTestCase):
 
         self.assertTrue(isinstance(
                         view, opentaskreport.OpenTaskReportPDFView))
-
-    def test_render_adds_browser_layer(self):
-        context = request = self.create_dummy()
-
-        view = self.mocker.patch(
-            opentaskreport.OpenTaskReportPDFView(context, request))
-
-        self.expect(view.allow_alternate_output()).result(False)
-        self.expect(view.export())
-
-        self.replay()
-
-        view.render()
-        self.assertTrue(opentaskreport.IOpenTaskReportLayer.providedBy(
-                        request))
 
 
 class TestOpenTaskReportLaTeXView(MockTestCase):
@@ -113,6 +97,11 @@ class TestOpenTaskReport(FunctionalTestCase):
         layout = DefaultLayout(self.task, self.task.REQUEST, PDFBuilder())
         self.opentaskreport = getMultiAdapter(
             (self.task, self.task.REQUEST, layout), ILaTeXView)
+
+    @browsing
+    def test_render_adds_browser_layer(self, browser):
+        browser.login().open(view='pdf-open-task-report')
+        self.assertTrue(IOpenTaskReportLayer.providedBy(self.request))
 
     @browsing
     def test_open_task_report_action_visible_for_user_with_correct_group(self, browser):

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -3,6 +3,7 @@ from five import grok
 from ftw.tabbedview.browser.tabbed import TabbedView
 from opengever.activity import is_activity_feature_enabled
 from opengever.globalindex.model.task import Task
+from opengever.latex.opentaskreport import is_open_task_report_allowed
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import ogds_service
@@ -68,6 +69,13 @@ class PersonalOverview(TabbedView):
             repo_url = repos[0].getURL()
             return self.request.RESPONSE.redirect(repo_url)
         else:
+            if is_open_task_report_allowed():
+                # Somehow if only the pdf-open-task-report action is available
+                # plone's `showEditableBorder` assumes that the edit-bar should
+                # be hidden.
+                # So we have to force the edit bar if the user can generate an
+                # open task report.
+                api.portal.get().REQUEST.set('enable_border', True)
             return self.template(self)
 
     def personal_overview_title(self):


### PR DESCRIPTION
Dieser PR behebt ein Problem mit der Pendenzenliste Action und stellt sicher, dass die Action immer angezeigt wird, wenn der Benutzer in der Inbox Gruppe ist.

Desweiteren wird die View, die das PDF zurückgibt auch mit einem Check, der diese Rechte überprüft, geschützt.

Fixes #1128.
Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).