### PR TITLE
Anstatt Referenznummern für Vorlagendossiers Dossier-Titel darstellen.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- No longer generate reference numbers for templatedossiers.
+  Also Cleanup old generated reference numbers.
+  [deiferni]
+
 - No longer display an empty tab 'additional' on the forwarding edit page.
   [deiferni]
 

--- a/opengever/dossier/profiles/default/metadata.xml
+++ b/opengever/dossier/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-    <version>4501</version>
+    <version>4502</version>
 </metadata>

--- a/opengever/dossier/reference.py
+++ b/opengever/dossier/reference.py
@@ -3,6 +3,7 @@ from five import grok
 from opengever.base.interfaces import IReferenceNumber, IReferenceNumberPrefix
 from opengever.base.reference import BasicReferenceNumber
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.templatedossier import ITemplateDossier
 
 
 class DossierReferenceNumber(BasicReferenceNumber):
@@ -18,3 +19,15 @@ class DossierReferenceNumber(BasicReferenceNumber):
         prefix = IReferenceNumberPrefix(parent).get_number(self.context)
 
         return prefix or ''
+
+
+class TemplateDossierReferenceNumber(BasicReferenceNumber):
+    """ Reference number for template dossiers.
+    """
+    grok.provides(IReferenceNumber)
+    grok.context(ITemplateDossier)
+
+    ref_type = 'dossier'
+
+    def get_local_number(self):
+        return self.context.title

--- a/opengever/dossier/tests/test_upgrades.py
+++ b/opengever/dossier/tests/test_upgrades.py
@@ -1,0 +1,21 @@
+from opengever.dossier.upgrades.to4502 import drop_old_refnumber_from_annotations
+from opengever.testing import FunctionalTestCase
+from zope.annotation.interfaces import IAnnotations
+
+
+class TestDropTemplateDossierReferenceNumber(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDropTemplateDossierReferenceNumber, self).setUp()
+        annotations = IAnnotations(self.portal)
+        annotations['dossier_reference_mapping'] = 'Foo'
+        annotations['reference_numbers'] = 'Bar'
+        annotations['reference_prefix'] = 'Qux'
+
+    def test_drop_refnumbers_from_annotations(self):
+        drop_old_refnumber_from_annotations()
+
+        annotations = IAnnotations(self.portal)
+        self.assertNotIn('dossier_reference_mapping', annotations)
+        self.assertNotIn('reference_numbers', annotations)
+        self.assertNotIn('reference_prefix', annotations)

--- a/opengever/dossier/upgrades/configure.zcml
+++ b/opengever/dossier/upgrades/configure.zcml
@@ -225,4 +225,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4501 -> 4502 -->
+    <genericsetup:upgradeStep
+        title="No longer generate reference numbers for template dossiers."
+        description=""
+        source="4501"
+        destination="4502"
+        handler="opengever.dossier.upgrades.to4502.DropTemplateDossierReferenceNumber"
+        profile="opengever.dossier:default"
+        />
+
 </configure>

--- a/opengever/dossier/upgrades/to4502.py
+++ b/opengever/dossier/upgrades/to4502.py
@@ -1,0 +1,32 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+from zope.annotation.interfaces import IAnnotations
+
+
+DOSSIER_KEY = 'dossier_reference_mapping'
+CHILD_REF_KEY = 'reference_numbers'
+PREFIX_REF_KEY = 'reference_prefix'
+
+
+class DropTemplateDossierReferenceNumber(UpgradeStep):
+    """Drop the no longer needed referencenumbers for template dossiers from
+    the plone site.
+
+    They are stored in the site's annotations under the key
+    'dossier_reference_mapping'.
+
+    Also cleanup potential leftovers from a previous reference number
+    migration. Previously refernce numbers were not stored type-specific but
+    directly as annotation keys with the keys 'reference_numbers' and
+    'reference_prefix'.
+
+    """
+    def __call__(self):
+        drop_old_refnumber_from_annotations()
+
+
+def drop_old_refnumber_from_annotations():
+    annotations = IAnnotations(api.portal.get())
+    for key in [DOSSIER_KEY, CHILD_REF_KEY, PREFIX_REF_KEY]:
+        if key in annotations:
+            del annotations[key]


### PR DESCRIPTION
Die Referenznummer für das Vorlagendossier macht eigentlich keinen Sinn. Zudem gibts es Probleme mit nicht vollständig generierten Referenznummern. Dieser PR nutzt die Gelegenheit um die Referenznummern für Vorlagendossiers zu entfernen. Stattdessen wir neu der Titel des Vorlagendossiers als Referenznummer angezeigt.

Fixes #1136.
Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).