### PR TITLE
No longer display an empty tab 'additional' on the forwarding edit page.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- No longer display an empty tab 'additional' on the forwarding edit page.
+  [deiferni]
+
 - Fix an issue with the open taks report action, make sure it displayed again.
   [deiferni]
 

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -27,6 +27,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <browser:page
+      for="opengever.inbox.forwarding.IForwarding"
+      name="edit"
+      class=".forwarding.ForwardingEditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
   <profilehook:hook
       profile="opengever.inbox:default"
       handler=".hooks.installed"

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -65,3 +65,14 @@ class TestForwarding(FunctionalTestCase):
         fieldsets = browser.css('form#form fieldset')
         self.assertEqual(1, len(fieldsets))
         self.assertEqual('Common', fieldsets.first.css('legend').first.text)
+
+    @browsing
+    def test_forwarding_edit_form_does_not_render_empty_fieldset_additional(self, browser):
+        forwarding = create(Builder('forwarding').within(self.inbox))
+
+        self.grant('Manager')
+        browser.login().open(forwarding, view='edit')
+
+        fieldsets = browser.css('form#form fieldset')
+        self.assertEqual(1, len(fieldsets))
+        self.assertEqual('Common', fieldsets.first.css('legend').first.text)


### PR DESCRIPTION
Analog zur add-view.

Closes #1124.
Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).