### PR TITLE
Fix ftw.mail.inbound.createMailInContainer monkey patch

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fix ftw.mail.inbound.createMailInContainer monkey patch so it
+  sets message.contentType to unicode, not str (see ftw.mail#33).
+  [lgraf]
+
 - Reintroduce a monkey patch for NamedDataConverter.toFieldValue after
   pinning down plone.formwidget.namedfile back to 1.0.7. The patch ensures
   hat mime-types sent by the browser are ignored.

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -199,7 +199,7 @@ def createMailInContainer(container, message):
     schema = fti.lookupSchema()
     field_type = getFields(schema)['message']._type
     message_value = field_type(data=message,
-                       contentType=u'message/rfc822', filename=u'message.eml')
+                       contentType='message/rfc822', filename=u'message.eml')
     # create mail object
     content = createContent('ftw.mail.mail', message=message_value)
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -6,6 +6,7 @@ development-packages =
   opengever.maintenance
   collective.js.timeago
   plonetheme.teamraum
+  ftw.mail
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
so it sets `message.contentType` to `unicode`, not `str` (see 4teamwork/ftw.mail#33).

Needs backport to `4.5-stable`