### PR TITLE
Monkey patch a fix from plone.formwidget.namedfile 1.0.11.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Monkey patch NamedDataConverter.toFieldValue to make sure that mime-types
+  sent by the browser are ignored.
+  [deiferni]
+
 - Improve notification center's error_handling.
   Catch exception during dispatching a notification separately.
   [phgross]

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -352,3 +352,49 @@ def nullupgrade(context):
 
 marmoset_patch(betas.to43rc1, nullupgrade)
 LOGGER.info('Marmoset patched plone.app.upgrade.v43.betas.to43rc1')
+
+
+# --------
+# Monkeypatch `NamedDataConverter.toFieldValue`. This adds the changes
+# introduced in the following pull-request:
+# https://github.com/plone/plone.formwidget.namedfile/pull/9/files.
+# Unfortunately we can't use the released version with above changes due to
+# an issue with validating file uploads, see:
+# https://github.com/4teamwork/opengever.core/issues/1153.
+
+from plone.formwidget.namedfile.converter import NamedDataConverter
+from plone.namedfile.interfaces import INamed
+from plone.namedfile.utils import safe_basename
+
+
+def toFieldValue(self, value):
+
+    if value is None or value == '':
+        return self.field.missing_value
+
+    if INamed.providedBy(value):
+        return value
+    elif isinstance(value, FileUpload):
+
+        filename = safe_basename(value.filename)
+
+        if filename is not None and not isinstance(filename, unicode):
+            # Work-around for
+            # https://bugs.launchpad.net/zope2/+bug/499696
+            filename = filename.decode('utf-8')
+
+        value.seek(0)
+        data = value.read()
+        if data or filename:
+            return self.field._type(data=data, filename=filename)
+        else:
+            return self.field.missing_value
+
+    else:
+        return self.field._type(data=str(value))
+
+
+NamedDataConverter.toFieldValue = toFieldValue
+LOGGER.info(
+    'Monkey patched '
+    'plone.formwidget.namedfile.converter.NamedDataConverter.toFieldValue')


### PR DESCRIPTION
We reverted pinning of plone.formwidget.namedfile to plone default, 1.0.7 since
there are problems with the newer version, see #1153.

Now we need to make sure that mime-types sent by the browser are ignored since
they are unrelibale. Instead we want to let the server guess the uploaded
file's mimetype.

Closes #1153.
Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).