### PR TITLE
Monkey patch a fix from plone.formwidget.namedfile 1.0.11.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Reintroduce a monkey patch for NamedDataConverter.toFieldValue after
+  pinning down plone.formwidget.namedfile back to 1.0.7. The patch ensures
+  hat mime-types sent by the browser are ignored.
+  [deiferni]
+
 - Improve notification center's error_handling.
   Catch exception during dispatching a notification separately.
   [phgross]

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -251,7 +251,8 @@ LOGGER.info('Monkey patched ftw.mail.inbound.createMailInContainer')
 # To include the fix https://github.com/plone/plone.formwidget.namedfile/pull/9
 # which involves in broken files, when uploading documents with firefox.
 
-# Monkeypath should be removed after updating opengever to plone 4.3.
+# This monkeypatch should be removed after updating to
+# plone.formwidget.namedfile 1.0.11
 from plone.formwidget.namedfile.converter import NamedDataConverter
 from plone.namedfile.interfaces import INamed
 from plone.namedfile.utils import safe_basename
@@ -284,8 +285,9 @@ def toFieldValue(self, value):
 
 
 NamedDataConverter.toFieldValue = toFieldValue
-LOGGER.info('Monkey patched '
-            'plone.formwidget.namedfile.converter.NamedDataConverter.toFieldValue')
+LOGGER.info(
+    'Monkey patched '
+    'plone.formwidget.namedfile.converter.NamedDataConverter.toFieldValue')
 
 
 # --------

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -246,6 +246,49 @@ LOGGER.info('Monkey patched ftw.mail.inbound.createMailInContainer')
 
 
 # --------
+# Monkeypatch for plone.formwidget.namedfile.convert.NamedDataConverter
+
+# To include the fix https://github.com/plone/plone.formwidget.namedfile/pull/9
+# which involves in broken files, when uploading documents with firefox.
+
+# Monkeypath should be removed after updating opengever to plone 4.3.
+from plone.formwidget.namedfile.converter import NamedDataConverter
+from plone.namedfile.interfaces import INamed
+from plone.namedfile.utils import safe_basename
+
+
+def toFieldValue(self, value):
+    if value is None or value == '':
+        return self.field.missing_value
+
+    if INamed.providedBy(value):
+        return value
+    elif isinstance(value, FileUpload):
+
+        filename = safe_basename(value.filename)
+
+        if filename is not None and not isinstance(filename, unicode):
+            # Work-around for
+            # https://bugs.launchpad.net/zope2/+bug/499696
+            filename = filename.decode('utf-8')
+
+        value.seek(0)
+        data = value.read()
+        if data or filename:
+            return self.field._type(data=data, filename=filename)
+        else:
+            return self.field.missing_value
+
+    else:
+        return self.field._type(data=str(value))
+
+
+NamedDataConverter.toFieldValue = toFieldValue
+LOGGER.info('Monkey patched '
+            'plone.formwidget.namedfile.converter.NamedDataConverter.toFieldValue')
+
+
+# --------
 # Monkeypatch `OFS.CopySupport.CopyContainer._verifyObjectPaste`
 # to disable `Delete objects` permission check when moving items
 

--- a/opengever/document/browser/templates/file.pt
+++ b/opengever/document/browser/templates/file.pt
@@ -12,7 +12,8 @@
         <span tal:define="filename view/w/file/filename">
             <span class="filename" tal:content="filename">Filename</span>
             <span class="discreet">
-              &mdash; <span tal:define="sizekb view/w/file/file_size" tal:replace="sizekb">100 KB</span>
+              &mdash; <span tal:define="sizekb view/w/file/file_size" tal:replace="sizekb">100</span>
+              KB
             </span>
         </span>
 

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -31,7 +31,7 @@ class TestDocumentIntegration(FunctionalTestCase):
         browser.login().open(self.document, view='edit')
 
         self.assertEqual(
-            u'document1.doc \u2014 1 KB',
+            u'document1.doc \u2014 0 KB',
             browser.css('.named-file-widget.namedblobfile-field').first.text)
 
         # edit should not be posssible

--- a/opengever/document/widgets/no_download_display.pt
+++ b/opengever/document/widgets/no_download_display.pt
@@ -22,7 +22,7 @@
             tal:condition="python: exists and fieldname">
         <span tal:attributes="class context/css_class"></span>
         <span tal:content="filename">Filename</span>
-        <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100 KB</span></span>
+        <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB</span>
     </span>
     <span tal:condition="not:exists" class="discreet" i18n:translate="no_file">
         No file

--- a/opengever/document/widgets/no_download_input.pt
+++ b/opengever/document/widgets/no_download_input.pt
@@ -29,7 +29,7 @@
         <span tal:attributes="class context/css_class"></span>
         <a class="link-overlay" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
         <span class="discreet"> &mdash;
-            <span tal:define="sizekb view/file_size" tal:replace="sizekb">100 KB</span>
+            <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB
         </span>
     </span>
     <div tal:condition="allow_nochange" style="padding-top: 1em;">

--- a/opengever/mail/browser/templates/file.pt
+++ b/opengever/mail/browser/templates/file.pt
@@ -6,7 +6,8 @@
     <span tal:attributes="class view/get_css_class" tal:define="filename view/w/message/filename">
       <span class="filename" tal:content="filename">Filename</span>
       <span class="discreet">
-        &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100 KB</span>
+        &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100</span>
+        KB
       </span>
     </span>
 


### PR DESCRIPTION
We reverted pinning of plone.formwidget.namedfile to plone default, 1.0.7 since
there are problems with the newer version, see #1153.

This PR reverts the changes introduced in https://github.com/4teamwork/opengever.core/pull/1016.

Now we need to make sure that mime-types sent by the browser are ignored since
they are unrelibale. Instead we want to let the server guess the uploaded
file's mimetype.

Closes #1153.
Needs backport to 4.5-stable.

This PR replaces #1157.