### PR TITLE
Don't show paste action for closed dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Don't show paste action for closed dossiers.
+  [deiferni]
+
 - MyNotifications: Make `resolve_notification_link` not mix unicode and str
   in string formatting by explicitly decoding the URL from ascii.
   [lgraf]

--- a/opengever/base/browser/pasting_allowed.py
+++ b/opengever/base/browser/pasting_allowed.py
@@ -1,5 +1,6 @@
 from five import grok
 from opengever.base.clipboard import Clipboard
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from ZODB.POSException import ConflictError
 from zope.interface import Interface
 
@@ -38,6 +39,12 @@ class IsPastingAllowedView(grok.View):
         # Check whether pasting is allowed at all for the container type
         if self.context.portal_type in self.disabled_types:
             return False
+
+        # XXX implement me in a more object oriented manner, i.e. by
+        # implementing `is_pasting_allowed` for all our content types.
+        if IDossierMarker.providedBy(self.context):
+            if not self.context.is_open():
+                return False
 
         objs = Clipboard(self.request).get_objs()
         if not objs:

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -277,6 +277,28 @@ class TestMoveItemsWithTestbrowser(FunctionalTestCase):
         self.assertIn(task, self.target_dossier.objectValues())
 
     @browsing
+    def test_paste_action_not_visible_for_closed_dossiers(self, browser):
+        resolved_dossier = create(Builder('dossier')
+                                  .in_state('dossier-state-resolved'))
+        document = create(Builder('document').within(self.source_dossier))
+
+        browser.login()
+        # Copy the document
+        paths = ['/'.join(document.getPhysicalPath())]
+        browser.open(
+            self.source_dossier, {'paths:list': paths}, view='copy_items')
+
+        browser.open(self.source_dossier)
+        self.assertIsNotNone(
+            browser.find('Paste'),
+            'Paste should be visible for open dossiers')
+
+        browser.open(resolved_dossier)
+        self.assertIsNone(
+            browser.find('Paste'),
+            'Paste should not be visible for resolved dossiers')
+
+    @browsing
     def test_copy_then_move(self, browser):
         subdossier = create(Builder('dossier').within(self.source_dossier))
         document = create(Builder('document').within(self.source_dossier))


### PR DESCRIPTION
Fixes  #1155.
Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).