### PR TITLE
Use an admin-unit's public url to generate urls to resolve notifications.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Use an admin-unit's public url to generate urls to resolve notifications.
+  [deiferni]
+
 - Fix ftw.mail.inbound.createMailInContainer monkey patch so it
   sets message.contentType to unicode, not str (see ftw.mail#33).
   [lgraf]

--- a/opengever/activity/browser/__init__.py
+++ b/opengever/activity/browser/__init__.py
@@ -1,7 +1,7 @@
-from plone import api
+from opengever.ogds.base.utils import get_current_admin_unit
 
 
 def resolve_notification_url(notification):
     return "{}/@@resolve_notification?notification_id={}".format(
-        api.portal.get().absolute_url(),
+        get_current_admin_unit().public_url,
         notification.notification_id)

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -63,8 +63,8 @@ class TestMyNotifications(FunctionalTestCase):
 
         links = [link.get('href') for link in browser.css('.listing a')]
         self.assertEquals(
-            ['http://nohost/plone/@@resolve_notification?notification_id=1',
-             'http://nohost/plone/@@resolve_notification?notification_id=2'],
+            ['http://example.com/@@resolve_notification?notification_id=1',
+             'http://example.com/@@resolve_notification?notification_id=2'],
             links)
 
     @browsing
@@ -95,5 +95,5 @@ class TestMyNotifications(FunctionalTestCase):
 
         self.assertEquals('Kennzahlen 2014 erfassen', link.text)
         self.assertEquals(
-            'http://nohost/plone/@@resolve_notification?notification_id=1',
+            'http://example.com/@@resolve_notification?notification_id=1',
             link.get('href'))

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -76,6 +76,6 @@ class TestEmailNotification(FunctionalTestCase):
         mail = email.message_from_string(Mailing(self.portal).pop())
         html_part = mail.get_payload()[0].as_string()
 
-        link = '<a href=3D"http://nohost/plone/@@resolve_notification?notification_id=\n=3D1">Test Task</a>'
+        link = '<a href=3D"http://example.com/@@resolve_notification?notification_id=3D=\n1">Test Task</a>'
 
         self.assertIn(link, html_part)

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -100,7 +100,7 @@ class TestNotificationViewlet(FunctionalTestCase):
         browser.login().open()
         link = browser.css('dl.notificationsMenu .item-content a').first
         self.assertEquals(
-            'http://nohost/plone/@@resolve_notification?notification_id=1',
+            'http://example.com/@@resolve_notification?notification_id=1',
             link.get('href'))
 
     @browsing

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -16,7 +16,7 @@ class TestResolveNotificationView(FunctionalTestCase):
         notification = create(Builder('notification').id('123'))
         url = resolve_notification_url(notification)
         self.assertEquals(
-            'http://nohost/plone/@@resolve_notification?notification_id=123',
+            'http://example.com/@@resolve_notification?notification_id=123',
             url)
 
     @browsing

--- a/opengever/examplecontent/profiles/default/unit_creation/admin_units.json
+++ b/opengever/examplecontent/profiles/default/unit_creation/admin_units.json
@@ -3,8 +3,8 @@
     "unit_id": "fd",
     "title": "Finanzdepartement",
     "ip_address": "127.0.0.1",
-    "site_url": "http://localhost:8080/admin1",
-    "public_url": "http://localhost:8080/admin1",
+    "site_url": "http://localhost:8080/fd",
+    "public_url": "http://localhost:8080/fd",
     "abbreviation": "FD"
   }
 ]


### PR DESCRIPTION
Fixes #1163.
Needs backport to [4.5-stable](https://github.com/4teamwork/opengever.core/tree/4.5-stable).