### PR TITLE
Use `UnicodeCoercingText` TypeDecorator for all `Text` columns

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Use `UnicodeCoercingText` type for all previous `Text` columns.
+  This makes sure we always get `unicode` back from Text columns,
+  whether the backend is Oracle, PostgreSQL or MySQL.
+  Depends on opengever.ogds.models >= 2.3.1.
+  [lgraf]
+
 - Use an admin-unit's public url to generate urls to resolve notifications.
   [deiferni]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- MyNotifications: Make `resolve_notification_link` not mix unicode and str
+  in string formatting by explicitly decoding the URL from ascii.
+  [lgraf]
+
 - Use `UnicodeCoercingText` type for all previous `Text` columns.
   This makes sure we always get `unicode` back from Text columns,
   whether the backend is Oracle, PostgreSQL or MySQL.

--- a/opengever/activity/browser/listing.py
+++ b/opengever/activity/browser/listing.py
@@ -16,7 +16,7 @@ from zope.interface import Interface
 
 def resolve_notification_link(item, value):
     return u'<a href="{}">{}</a>'.format(
-        resolve_notification_url(item),
+        resolve_notification_url(item).decode('ascii'),
         item.activity.title)
 
 

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -5,11 +5,11 @@ from opengever.base.model import SUPPORTED_LOCALES
 from opengever.base.model import UTCDateTime
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
+from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
-from sqlalchemy import Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 from sqlalchemy_i18n import Translatable
@@ -70,7 +70,7 @@ class ActivityTranslation(translation_base(Activity)):
 
     __tablename__ = 'activities_translation'
 
-    title = Column(Text)
-    label = Column(Text)
-    summary = Column(Text)
-    description = Column(Text)
+    title = Column(UnicodeCoercingText)
+    label = Column(UnicodeCoercingText)
+    summary = Column(UnicodeCoercingText)
+    description = Column(UnicodeCoercingText)

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -13,12 +13,12 @@ class TestMyNotifications(FunctionalTestCase):
     def setUp(self):
         super(TestMyNotifications, self).setUp()
 
-        create(Builder('ogds_user').having(userid='peter.mueller',
-                                           firstname='Peter',
-                                           lastname='Mueller'))
-        create(Builder('ogds_user').having(userid='hugo.boss',
-                                           firstname='Hugo',
-                                           lastname='Boss'))
+        create(Builder('ogds_user').having(userid=u'peter.mueller',
+                                           firstname=u'Peter',
+                                           lastname=u'M\xfcller'))
+        create(Builder('ogds_user').having(userid=u'hugo.boss',
+                                           firstname=u'Hugo',
+                                           lastname=u'B\xf6ss'))
 
         self.center = NotificationCenter()
         self.test_user = create(Builder('watcher')
@@ -33,28 +33,28 @@ class TestMyNotifications(FunctionalTestCase):
 
         self.activity_1 = self.center.add_activity(
             Oguid('fd', '123'),
-            'task-added',
-            {'en': 'Kennzahlen 2014 erfassen'},
-            {'en': 'Task added'},
-            {'en': 'Task bla added by Hugo'},
+            u'task-added',
+            {'de': u'Kennzahlen 2014 \xfcbertragen'},
+            {'de': u'Aufgabe hinzugef\xfcgt'},
+            {'de': u'Neue Aufgabe hinzugef\xfcgt durch Hugo B\xf6ss'},
             'hugo.boss',
-            {'en': None}).get('activity')
+            {'de': None}).get('activity')
         self.activity_2 = self.center.add_activity(
             Oguid('fd', '123'),
-            'task-transition-open-in-progress',
-            {'en': 'Kennzahlen 2014 erfassen'},
-            {'en': 'Task accepted'},
-            {'en': 'Task bla accepted by Peter'},
+            u'task-transition-open-in-progress',
+            {'de': u'Kennzahlen 2014 \xfcbertragen'},
+            {'de': u'Aufgabe akzeptiert'},
+            {'de': u'Aufgabe akzeptiert durch Hugo B\xf6ss'},
             'peter.mueller',
-            {'en': None}).get('activity')
+            {'de': None}).get('activity')
         self.activity_3 = self.center.add_activity(
             Oguid('fd', '456'),
-            'task-added',
-            {'en': 'Kennzahlen 2014 erfassen'},
-            {'en': 'Task added'},
-            {'en': 'Task foo added by peter'},
+            u'task-added',
+            {'de': u'Kennzahlen 2014 \xfcbertragen'},
+            {'de': u'Aufgabe hinzugef\xfcgt'},
+            {'de': u'Neue Aufgabe hinzugef\xfcgt durch Peter M\xfcller'},
             'peter.mueller',
-            {'en': None}).get('activity')
+            {'de': None}).get('activity')
 
     @browsing
     def test_lists_only_notifications_of_current_user(self, browser):
@@ -73,16 +73,16 @@ class TestMyNotifications(FunctionalTestCase):
                              view='tabbedview_view-mynotifications')
 
         self.assertEquals(
-            [{'Actor': 'Boss Hugo (hugo.boss)',
+            [{'Actor': u'B\xf6ss Hugo (hugo.boss)',
               'Created': api.portal.get_localized_time(
                   self.activity_1.created, long_format=True),
-              'Kind': 'task-added',
-              'Title': 'Kennzahlen 2014 erfassen'},
-             {'Actor': 'Mueller Peter (peter.mueller)',
+              'Kind': u'task-added',
+              'Title': u'Kennzahlen 2014 \xfcbertragen'},
+             {'Actor': u'M\xfcller Peter (peter.mueller)',
               'Created': api.portal.get_localized_time(
                   self.activity_2.created, long_format=True),
-              'Kind': 'task-transition-open-in-progress',
-              'Title': 'Kennzahlen 2014 erfassen'}],
+              'Kind': u'task-transition-open-in-progress',
+              'Title': u'Kennzahlen 2014 \xfcbertragen'}],
             browser.css('.listing').first.dicts())
 
     @browsing
@@ -93,7 +93,7 @@ class TestMyNotifications(FunctionalTestCase):
         row = browser.css('.listing tr')[1]
         link = row.css('a').first
 
-        self.assertEquals('Kennzahlen 2014 erfassen', link.text)
+        self.assertEquals(u'Kennzahlen 2014 \xfcbertragen', link.text)
         self.assertEquals(
             'http://example.com/@@resolve_notification?notification_id=1',
             link.get('href'))

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -9,6 +9,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
+from opengever.ogds.models.types import UnicodeCoercingText
 from plone import api
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -17,7 +18,6 @@ from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
-from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref
@@ -62,7 +62,7 @@ class Task(Base):
     oguid = composite(Oguid, admin_unit_id, int_id)
 
     title = Column(String(MAX_TITLE_LENGTH))
-    text = Column(Text())
+    text = Column(UnicodeCoercingText())
     breadcrumb_title = Column(String(MAX_BREADCRUMB_LENGTH))
     physical_path = Column(String(256))
     review_state = Column(String(WORKFLOW_STATE_LENGTH))

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -1,11 +1,11 @@
 from opengever.base.model import Base
 from opengever.base.model import create_session
+from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
-from sqlalchemy import Text
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
@@ -23,7 +23,7 @@ class AgendaItem(Base):
     proposal = relationship("Proposal", uselist=False,
                             backref=backref('agenda_item', uselist=False))
 
-    title = Column(Text)
+    title = Column(UnicodeCoercingText)
     number = Column('item_number', String(16))
     is_paragraph = Column(Boolean, nullable=False, default=False)
     sort_order = Column(Integer, nullable=False, default=0)
@@ -31,8 +31,8 @@ class AgendaItem(Base):
     meeting_id = Column(Integer, ForeignKey('meetings.id'), nullable=False)
     meeting = relationship("Meeting")
 
-    discussion = Column(Text)
-    decision = Column(Text)
+    discussion = Column(UnicodeCoercingText)
+    decision = Column(UnicodeCoercingText)
 
     def update(self, request):
         """Update with changed data."""

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -7,6 +7,7 @@ from opengever.meeting.model.query import MeetingQuery
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
+from opengever.ogds.models.types import UnicodeCoercingText
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from sqlalchemy import Column
@@ -15,7 +16,6 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Table
-from sqlalchemy import Text
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
@@ -91,7 +91,7 @@ class Meeting(Base):
     secretary = relationship(
         'Member', primaryjoin="Member.member_id==Meeting.secretary_id")
     secretary_id = Column(Integer, ForeignKey('members.id'))
-    other_participants = Column(Text)
+    other_participants = Column(UnicodeCoercingText)
     participants = relationship('Member',
                                 secondary=meeting_participants,
                                 backref='meetings')

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -11,12 +11,12 @@ from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import UNIT_ID_LENGTH
+from opengever.ogds.models.types import UnicodeCoercingText
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
-from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import composite
@@ -76,14 +76,14 @@ class Proposal(Base):
 
     title = Column(String(256), nullable=False)
     workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False)
-    legal_basis = Column(Text)
-    initial_position = Column(Text)
-    proposed_action = Column(Text)
+    legal_basis = Column(UnicodeCoercingText)
+    initial_position = Column(UnicodeCoercingText)
+    proposed_action = Column(UnicodeCoercingText)
 
-    considerations = Column(Text)
-    publish_in = Column(Text)
-    disclose_to = Column(Text)
-    copy_for_attention = Column(Text)
+    considerations = Column(UnicodeCoercingText)
+    publish_in = Column(UnicodeCoercingText)
+    disclose_to = Column(UnicodeCoercingText)
+    copy_for_attention = Column(UnicodeCoercingText)
 
     committee_id = Column(Integer, ForeignKey('committees.id'))
     committee = relationship('Committee', backref='proposals')

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,6 +7,7 @@ development-packages =
   collective.js.timeago
   plonetheme.teamraum
   ftw.mail
+  opengever.ogds.models
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Use the `UnicodeCoercingText` TypeDecorator introduced in 4teamwork/opengever.ogds.models#33 for all `Text` columns.

This makes sure we always get `unicode` back from `Text` columns, even with Oracle as the backend.

Fixes #1154.

Depends on `opengever.ogds.models >= 2.3.1` (hence the failing tests).

Needs backport to `4.5-stable`.

@phgross @deiferni 