### PR TITLE
Display notification tab also for regular users.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Display my notification tab also for regular users.
+  [phgross]
+
 - Don't show paste action for closed dossiers.
   [deiferni]
 

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -110,12 +110,9 @@ class PersonalOverview(TabbedView):
         return tabs
 
     def get_tabs(self):
-        tabs = []
-
+        tabs = self.default_tabs + self.notification_tabs
         if self.is_user_allowed_to_view_additional_tabs():
-            tabs = self.default_tabs + self.notification_tabs + self.admin_tabs
-        else:
-            tabs = self.default_tabs
+            tabs += self.admin_tabs
 
         return tabs
 

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -92,6 +92,18 @@ class TestPersonalOverviewActivitySupport(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 
+
+    def setUp(self):
+        super(TestPersonalOverviewActivitySupport, self).setUp()
+
+        create_plone_user(self.portal, 'hugo.boss')
+        self.hugo = create(Builder('ogds_user')
+                           .having(userid='hugo.boss',
+                                   firstname='Hugo',
+                                   lastname='Boss')
+                           .assign_to_org_units([self.org_unit]))
+        transaction.commit()
+
     @browsing
     def test_notification_tab_is_displayed_when_activity_feature_is_enabled(self, browser):
         browser.login().open(view='personal_overview')
@@ -102,6 +114,13 @@ class TestPersonalOverviewActivitySupport(FunctionalTestCase):
              'My notifications',
              'alltasks',
              'allissuedtasks'],
+            browser.css('li.formTab a').text)
+
+        browser.login(username='hugo.boss', password='demo09').open(
+            view='personal_overview')
+        self.assertEqual(
+            ['mydossiers', 'mydocuments', 'mytasks',
+             'myissuedtasks', 'My notifications'],
             browser.css('li.formTab a').text)
 
 


### PR DESCRIPTION
Wrongly the `My notification` tab only gets added for users wich are allowed to watch additional tabs (inbox_group users).

@deiferni @lukasgraf 

Backport needed: `4.5-stable`