### PR TITLE
Fixed lookup for active TaskTemplateFolders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fixed lookup for active TaskTemplateFolders.
+  [phgross]
+
 - Display my notification tab also for regular users.
   [phgross]
 

--- a/opengever/tasktemplates/browser/form.py
+++ b/opengever/tasktemplates/browser/form.py
@@ -153,7 +153,7 @@ class AddForm(BrowserView):
     def has_active_tasktemplatefolders(self):
         catalog = api.portal.get_tool('portal_catalog')
         brains = catalog(
-            review_state=('tasktemplatefolder-state-active'),
+            review_state=('tasktemplatefolder-state-activ'),
             portal_type='opengever.tasktemplates.tasktemplatefolder')
 
         return bool(brains)

--- a/opengever/tasktemplates/tests/test_form.py
+++ b/opengever/tasktemplates/tests/test_form.py
@@ -25,7 +25,7 @@ class TestAddTaskTemplateForm(FunctionalTestCase):
     @browsing
     def test_stay_on_view_if_active_tasktemplatefolders_exists(self, browser):
         tasktemplatefolder = create(Builder('tasktemplatefolder')
-                                    .in_state('tasktemplatefolder-state-active'))
+                                    .in_state('tasktemplatefolder-state-activ'))
 
         browser.login().open(self.dossier, view='add-tasktemplate')
         self.assertEquals(


### PR DESCRIPTION
The TaskTemplateFolders checks if there any active TaskTemplateFolders, but the review_state had a typo in the catalog query and also in the test.

@lukasgraf @deiferni 

Backport needed: `4.5-stable`