### PR TITLE
Improve performance for task overviews

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- No longer use plone's text/x-html-safe for simple markup fragments, use
+  escape_html instead.
+  No longer inherit from DisplayForm in task-overview, use grok.View instead.
+  [deiferni]
+
 - Fixed lookup for active TaskTemplateFolders.
   [phgross]
 

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -3,6 +3,7 @@ from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from lxml.etree import tostring
 from opengever.testing import FunctionalTestCase
 
 
@@ -112,9 +113,10 @@ class TestOverview(FunctionalTestCase):
             [],
             browser.css('span.contenttype-opengever-task-task script'))
 
+        node = browser.css('span.contenttype-opengever-task-task').first
         self.assertEquals(
-            ['Foo'],
-            browser.css('span.contenttype-opengever-task-task').text)
+            '<span class="contenttype-opengever-task-task">Foo &lt;script&gt;alert(\'foo\')&lt;/script&gt;</span>',
+            tostring(node.node))
 
     @browsing
     def test_references_box_lists_regular_references(self, browser):

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -3,6 +3,7 @@ from DateTime import DateTime as ZopeDateTime
 from opengever.base.model import Base
 from opengever.base.model import Session
 from opengever.base.oguid import Oguid
+from opengever.base.utils import escape_html
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -274,10 +275,12 @@ class Task(Base):
         return len(principals & allowed_principals) > 0
 
     def get_link(self, with_state_icon=True, with_responsible_info=True):
+        title = escape_html(self.title)
         admin_unit = self.get_admin_unit()
+
         if not admin_unit:
             return u'<span class="{}">{}</span>'.format(
-                self.get_css_class(), self.title)
+                self.get_css_class(), title)
 
         url = '/'.join((admin_unit.public_url, self.physical_path))
         breadcrumb_titles = u"[{}] > {}".format(
@@ -285,7 +288,7 @@ class Task(Base):
         responsible_info = u' <span class="discreet">({})</span>'.format(
             self.get_responsible_label(linked=False))
         link_content = u'<span class="{}">{}</span>'.format(
-            self.get_css_class(), self.title)
+            self.get_css_class(), title)
 
         # If the target is on a different client we need to make a popup
         if self.admin_unit_id != get_current_admin_unit().id():
@@ -308,9 +311,6 @@ class Task(Base):
             link = self._task_state_wrapper(link)
         else:
             link = u'<span>%s</span>' % (link)
-
-        transformer = api.portal.get_tool('portal_transforms')
-        link = transformer.convertTo('text/x-html-safe', link).getData()
 
         return link
 

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from lxml.cssselect import css_to_xpath
 from lxml.etree import fromstring
+from lxml.etree import tostring
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 
@@ -122,7 +123,9 @@ class TestTaskLinkGeneration(FunctionalTestCase):
             title="Foo <b onmouseover=alert('Wufff!')>click me!</b>")
 
         link_tag = link.xpath(css_to_xpath('a span'))[0]
-        self.assertEquals('Foo ', link_tag.text)
+        self.assertEquals(
+            '<span class="contenttype-opengever-task-task">Foo &lt;b onmouseover=alert(\'Wufff!\')&gt;click me!&lt;/b&gt;</span>',
+            tostring(link_tag))
 
     def test_handles_non_ascii_characters_correctly(self):
         link = self.add_task_and_get_link(title=u'D\xfc it')

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -2,6 +2,7 @@ from five import grok
 from ftw.mail.mail import IMail
 from ftw.table.interfaces import ITableGenerator
 from opengever.base.utils import disable_edit_bar
+from opengever.base.utils import escape_html
 from opengever.mail import _
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -51,10 +52,7 @@ def downloadable_filename_helper(context):
         link = '<a href="%s/get_attachment?position=%s">%s</a>' % (
             context.absolute_url(),
             item.get('position'),
-            filename)
-
-        transformer = api.portal.get_tool('portal_transforms')
-        link = transformer.convertTo('text/x-html-safe', link).getData()
+            escape_html(filename))
         return link
 
     return _helper

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -1,9 +1,9 @@
 from opengever.base.model import Base
 from opengever.base.oguid import Oguid
+from opengever.base.utils import escape_html
 from opengever.meeting.model.query import CommitteeQuery
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import UNIT_ID_LENGTH
-from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -39,9 +39,9 @@ class Committee(Base):
         if not url:
             return ''
 
-        link = u'<a href="{0}" title="{1}">{1}</a>'.format(url, self.title)
-        transformer = api.portal.get_tool('portal_transforms')
-        return transformer.convertTo('text/x-html-safe', link).getData()
+        link = u'<a href="{0}" title="{1}">{1}</a>'.format(
+            url, escape_html(self.title))
+        return link
 
     def get_url(self, admin_unit=None):
         admin_unit = admin_unit or self.get_admin_unit()

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from opengever.base.model import Base
+from opengever.base.utils import escape_html
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.model import AgendaItem
@@ -260,10 +261,8 @@ class Meeting(Base):
     def get_link(self):
         url = self.get_url()
         link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
-            url, self.get_title(), self.css_class)
-
-        transformer = api.portal.get_tool('portal_transforms')
-        return transformer.convertTo('text/x-html-safe', link).getData()
+            url, escape_html(self.get_title()), self.css_class)
+        return link
 
     def get_url(self):
         admin_unit = self.committee.get_admin_unit()

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -1,8 +1,8 @@
 from opengever.base.model import Base
+from opengever.base.utils import escape_html
 from opengever.ogds.models import EMAIL_LENGTH
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
-from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -35,10 +35,8 @@ class Member(Base):
         title = title or self.fullname
         url = self.get_url(context)
         link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
-            url, title, self.css_class)
-
-        transformer = api.portal.get_tool('portal_transforms')
-        return transformer.convertTo('text/x-html-safe', link).getData()
+            url, escape_html(title), self.css_class)
+        return link
 
     def get_firstname_link(self, context):
         return self.get_link(context, title=self.firstname)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
+from opengever.base.utils import escape_html
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.model import AgendaItem
@@ -168,14 +169,13 @@ class Proposal(Base):
                               include_icon=include_icon)
 
     def _get_link(self, url, include_icon=True):
+        title = escape_html(self.title)
         if include_icon:
             link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
-                url, self.title, self.css_class)
+                url, title, self.css_class)
         else:
-            link = u'<a href="{0}" title="{1}">{1}</a>'.format(url, self.title)
-
-        transformer = api.portal.get_tool('portal_transforms')
-        return transformer.convertTo('text/x-html-safe', link).getData()
+            link = u'<a href="{0}" title="{1}">{1}</a>'.format(url, title)
+        return link
 
     def getPath(self):
         """This method is required by a tabbedview."""

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -21,6 +21,7 @@ For known actor types use:
 
 """
 
+from opengever.base.utils import escape_html
 from opengever.ogds.base import _
 from opengever.ogds.base.browser.userdetails import UserDetails
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -76,7 +77,7 @@ class Actor(object):
 
     def get_link(self, with_icon=False):
         url = self.get_profile_url()
-        label = self.get_label()
+        label = escape_html(self.get_label())
 
         if not url:
             return label
@@ -86,8 +87,6 @@ class Actor(object):
         else:
             link = u'<a href="{}">{}</a>'.format(url, label)
 
-        transformer = api.portal.get_tool('portal_transforms')
-        link = transformer.convertTo('text/x-html-safe', link).getData()
         return link
 
     def corresponds_to(self, user):

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -8,7 +8,6 @@ from opengever.mail.mail import OGMail
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import ogds_service
 from opengever.tabbedview import _
-from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import ram
 from plone.protect.utils import addTokenToUrl
@@ -141,9 +140,7 @@ def linked_document_subdossier(item, value):
 
     link = '<a href="{}" title="{}" class="subdossierLink">{}</a>'.format(
         url, title, title)
-
-    transforms = api.portal.get_tool('portal_transforms')
-    return transforms.convertTo('text/x-html-safe', link).getData()
+    return link
 
 
 def linked(item, value):
@@ -180,11 +177,10 @@ def linked(item, value):
 
 
 def document_with_icon(item, value):
+    value = escape_html(value)
     icon = '<span class="{}"></span><span>{}</span>'.format(
         get_css_class(item), value)
-
-    transforms = api.portal.get_tool('portal_transforms')
-    return transforms.convertTo('text/x-html-safe', icon).getData()
+    return icon
 
 
 def linked_document_with_tooltip(item, value):

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -6,11 +6,10 @@ from opengever.tabbedview.browser.base import OpengeverTab
 from opengever.task import _
 from opengever.task.task import ITask
 from plone import api
-from plone.directives.dexterity import DisplayForm
 from Products.CMFCore.utils import getToolByName
 
 
-class Overview(DisplayForm, OpengeverTab):
+class Overview(grok.View, OpengeverTab):
     grok.context(ITask)
     grok.name('tabbedview_view-overview')
     grok.template('overview')


### PR DESCRIPTION
This PR improves performance for task overviews by:
- No longer inheriting from `DisplayForm`, this skips unnecessary widget preparations. Our data is from an SQL-source.
- No longer use plone transforms to `text/x-html-safe`, they are slow and not really required here since we build short markup fragments. Instead just use `escape_html`.