### PR TITLE
Korrektur der Sortierung im dossier FactoryMenu

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fixed order in dossiers factory menu.
+  [phgross]
+
 - No longer use plone's text/x-html-safe for simple markup fragments, use
   escape_html instead.
   No longer inherit from DisplayForm in task-overview, use grok.View instead.

--- a/opengever/base/menu.py
+++ b/opengever/base/menu.py
@@ -38,9 +38,10 @@ def order_factories(context, factories):
 
 
 class FilteredPostFactoryMenu(grok.MultiAdapter):
-    """Build a filtered factory menu.
+    """Build a customized factory menu by allowing factories to be filtered and
+    renamed.
 
-    Concrete filtering can be implemented by subclasses.
+    Concrete filtering / renaming can be implemented by subclasses.
     """
 
     grok.adapts(Interface, Interface)
@@ -51,11 +52,22 @@ class FilteredPostFactoryMenu(grok.MultiAdapter):
         self.request = request
 
     def is_filtered(self, factory):
+        """Allows a subclass to determine whether a factory should be filtered
+        (omitted) or not.
+        """
         return False
+
+    def rename(self, factory):
+        """Lets a subclass rename a factory entry if necessary, and return the
+        modified factory.
+        """
+        return factory
 
     def __call__(self, factories):
         filtered_factories = []
         for factory in factories:
+            factory = self.rename(factory)
+
             if not self.is_filtered(factory):
                 filtered_factories.append(factory)
 

--- a/opengever/dossier/menu.py
+++ b/opengever/dossier/menu.py
@@ -8,17 +8,16 @@ from zope.interface import Interface
 class DossierPostFactoryMenu(FilteredPostFactoryMenu):
     grok.adapts(IDossierMarker, Interface)
 
+    def __init__(self, context, request):
+        super(DossierPostFactoryMenu, self).__init__(context, request)
+
+    def rename(self, factory):
+        if factory.get('id') == u'opengever.dossier.businesscasedossier':
+            factory['title'] = _(u'Subdossier')
+
+        return factory
+
     def is_filtered(self, factory):
         factory_id = factory.get('id')
         if factory_id == u'ftw.mail.mail':
             return True
-
-        return False
-
-    def __call__(self, factories):
-        factories = super(DossierPostFactoryMenu, self).__call__(factories)
-        for factory in factories:
-            if factory.get('id') == u'opengever.dossier.businesscasedossier':
-                factory['title'] = _(u'Subdossier')
-
-        return factories

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -83,6 +83,19 @@ class TestDossier(FunctionalTestCase):
         self.assertNotIn('ftw.mail.mail',
                          [item.get('id') for item in menu_items])
 
+    def test_factory_menu_sorting(self):
+        menu = FactoriesMenu(self.dossier)
+        menu_items = menu.getMenuItems(self.dossier, self.dossier.REQUEST)
+
+        self.assertEquals(
+            [u'Document',
+             'document_with_template',
+             u'Task',
+             'Add task from template',
+             u'Subdossier',
+             u'Add Participant'],
+            [item.get('title') for item in menu_items])
+
     def test_subdossier_add_form_is_called_add_subdossier(self):
         add_form = self.dossier.unrestrictedTraverse(
             '++add++{}'.format(self.portal_type))


### PR DESCRIPTION
Die im commit c721c6610e0a3df3661c75ff835125af2a7753f7 implementierte `FilterPostFactoryMenu` Sortierung hat für das Dossier Menü nicht korrekt funktioniert, da die Subdossier Aktion erst nach dem Super call umbenannt wurde.

Ich habe deshalb eine zusätzliche Funktion `rename` implementiert.

@lukasgraf 

Backport: `4.5-stable`
Note: Diese Anpassung muss auch für alle `opengever.zug` Spezial Dossier's gemacht werden.
