### PR TITLE
Verbesserungen Benachrichtigungssystem

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- My Notification: disable sorting for type, title and actor column.
+  [phgross]
+
 - Fixed order in dossiers factory menu.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Notification viewlet: added tooltip to the "mark as read" link.
+  [phgross]
+
 - Notification viewlet: sort notification chronologic, newest at the top.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Notification viewlet: sort notification chronologic, newest at the top.
+  [phgross]
+
 - My Notification: disable sorting for type, title and actor column.
   [phgross]
 

--- a/opengever/activity/browser/listing.py
+++ b/opengever/activity/browser/listing.py
@@ -46,15 +46,18 @@ class NotificationListingTab(BaseListingTab):
     columns = (
         {'column': 'kind',
          'column_title': _(u'column_kind', default=u'Kind'),
-         'transform': translated_kind},
+         'transform': translated_kind,
+         'sortable': False},
 
         {'column': 'title',
          'column_title': _(u'column_title', default=u'Title'),
-         'transform': resolve_notification_link},
+         'transform': resolve_notification_link,
+         'sortable': False},
 
         {'column': 'actor_id',
          'column_title': _(u'column_Actor', default=u'Actor'),
-         'transform': readable_actor},
+         'transform': readable_actor,
+         'sortable': False},
 
         {'column': 'created',
          'column_title': _(u'created', default=u'Created'),

--- a/opengever/activity/browser/listing.py
+++ b/opengever/activity/browser/listing.py
@@ -8,8 +8,6 @@ from opengever.activity.browser import resolve_notification_url
 from opengever.ogds.base.actor import Actor
 from opengever.tabbedview.browser.base import BaseListingTab
 from plone import api
-from zope.globalrequest import getRequest
-from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -29,10 +27,6 @@ def readable_date(item, date):
         item.activity.created, long_format=True)
 
 
-def translated_kind(item, value):
-    return translate(item.activity.kind, domain='plone', context=getRequest())
-
-
 class INotificationTableSourceConfig(ITableSourceConfig):
     """Marker interface for notification table source configs."""
 
@@ -46,7 +40,7 @@ class NotificationListingTab(BaseListingTab):
     columns = (
         {'column': 'kind',
          'column_title': _(u'column_kind', default=u'Kind'),
-         'transform': translated_kind,
+         'transform': lambda item, value: item.activity.label,
          'sortable': False},
 
         {'column': 'title',

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -121,6 +121,8 @@ class NotificationCenter(object):
         if only_unread:
             query = query.filter(Notification.is_read == False)
 
+        query = query.join(
+            Notification.activity).order_by(desc(Activity.created))
         return query.limit(limit).all()
 
     def mark_notification_as_read(self, notification_id):

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-07 08:37+0000\n"
+"POT-Creation-Date: 2015-08-17 14:30+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:56
+#: ./opengever/activity/browser/listing.py:58
 msgid "column_Actor"
 msgstr "Akteur"
 
@@ -28,12 +28,12 @@ msgid "column_kind"
 msgstr "Typ"
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:52
+#: ./opengever/activity/browser/listing.py:53
 msgid "column_title"
 msgstr "Titel"
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:60
+#: ./opengever/activity/browser/listing.py:63
 msgid "created"
 msgstr "Erstellt"
 
@@ -47,13 +47,18 @@ msgstr "Benachrichtigungen"
 msgid "label_details"
 msgstr "Details:"
 
+#. Default: "Mark as read"
+#: ./opengever/activity/viewlets/notification.pt:32
+msgid "label_mark_as_read"
+msgstr "Als gelesen markieren"
+
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:54
+#: ./opengever/activity/viewlets/notification.pt:55
 msgid "label_notifications_overview"
 msgstr "Alle Benachrichtigungen"
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
-#: ./opengever/activity/center.py:190
+#: ./opengever/activity/center.py:192
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht oder nur zum Teil ausgelöst."
 

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-07 08:37+0000\n"
+"POT-Creation-Date: 2015-08-17 14:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:56
+#: ./opengever/activity/browser/listing.py:58
 msgid "column_Actor"
 msgstr "Acteur"
 
@@ -28,12 +28,12 @@ msgid "column_kind"
 msgstr "Type"
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:52
+#: ./opengever/activity/browser/listing.py:53
 msgid "column_title"
 msgstr "Titre"
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:60
+#: ./opengever/activity/browser/listing.py:63
 msgid "created"
 msgstr ""
 
@@ -47,13 +47,18 @@ msgstr "Notifications"
 msgid "label_details"
 msgstr ""
 
+#. Default: "Mark as read"
+#: ./opengever/activity/viewlets/notification.pt:32
+msgid "label_mark_as_read"
+msgstr ""
+
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:54
+#: ./opengever/activity/viewlets/notification.pt:55
 msgid "label_notifications_overview"
 msgstr ""
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
-#: ./opengever/activity/center.py:190
+#: ./opengever/activity/center.py:192
 msgid "msg_error_not_notified"
 msgstr ""
 

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-08-07 08:37+0000\n"
+"POT-Creation-Date: 2015-08-17 14:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.activity\n"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:56
+#: ./opengever/activity/browser/listing.py:58
 msgid "column_Actor"
 msgstr ""
 
@@ -28,12 +28,12 @@ msgid "column_kind"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:52
+#: ./opengever/activity/browser/listing.py:53
 msgid "column_title"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:60
+#: ./opengever/activity/browser/listing.py:63
 msgid "created"
 msgstr ""
 
@@ -47,13 +47,18 @@ msgstr ""
 msgid "label_details"
 msgstr ""
 
+#. Default: "Mark as read"
+#: ./opengever/activity/viewlets/notification.pt:32
+msgid "label_mark_as_read"
+msgstr ""
+
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:54
+#: ./opengever/activity/viewlets/notification.pt:55
 msgid "label_notifications_overview"
 msgstr ""
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
-#: ./opengever/activity/center.py:190
+#: ./opengever/activity/center.py:192
 msgid "msg_error_not_notified"
 msgstr ""
 

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -76,12 +76,12 @@ class TestMyNotifications(FunctionalTestCase):
             [{'Actor': u'B\xf6ss Hugo (hugo.boss)',
               'Created': api.portal.get_localized_time(
                   self.activity_1.created, long_format=True),
-              'Kind': u'task-added',
+              'Kind': u'Aufgabe hinzugef\xfcgt',
               'Title': u'Kennzahlen 2014 \xfcbertragen'},
              {'Actor': u'M\xfcller Peter (peter.mueller)',
               'Created': api.portal.get_localized_time(
                   self.activity_2.created, long_format=True),
-              'Kind': u'task-transition-open-in-progress',
+              'Kind': u'Aufgabe akzeptiert',
               'Title': u'Kennzahlen 2014 \xfcbertragen'}],
             browser.css('.listing').first.dicts())
 

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -268,11 +268,11 @@ class TestNotificationHandling(ActivityTestCase):
         hugos_notifications = self.center.get_users_notifications('hugo')
 
         self.assertEquals(
-            [self.activity_1, self.activity_2, self.activity_4],
+            [self.activity_4, self.activity_2, self.activity_1],
             [notification.activity for notification in peters_notifications])
 
         self.assertEquals(
-            [self.activity_1, self.activity_2, self.activity_3],
+            [self.activity_3, self.activity_2, self.activity_1],
             [notification.activity for notification in hugos_notifications])
 
     def test_get_users_notifications_only_unread_parameter(self):

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -29,7 +29,8 @@
             tal:attributes="data-notification-id notification/id">
 
           <div class="buttons">
-            <a href="#" class="mark_as_read" tal:condition="not: notification/read"></a>
+            <a href="#" class="mark_as_read" title="Mark as read"
+               tal:condition="not: notification/read" i18n:attributes="title label_mark_as_read"></a>
           </div>
 
           <div class="item-content">

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -35,12 +35,12 @@
           <div class="item-content">
             <div>
               <div class="item-header">
+                <span class="item-type" tal:content="notification/label" />
                 <span class="item-creation">
                   <span class="timeago relativetime"
                         tal:attributes="title notification/created"
                         tal:content="notification/created" />
                 </span>
-                <span class="item-type" tal:content="notification/label" />
               </div>
               <a class="item-location" href="#"
                  tal:attributes="href notification/link"
@@ -50,7 +50,7 @@
           </div>
         </li>
 
-        <li class="notification-item">
+        <li class="notification-item show_all">
           <a href="#" class="all_link" tal:attributes="href view/overview_url"
              i18n:translate="label_notifications_overview">
             All Notifications

--- a/opengever/inbox/activities.py
+++ b/opengever/inbox/activities.py
@@ -1,5 +1,6 @@
 from opengever.ogds.base.actor import Actor
-from opengever.task import _
+from opengever.inbox import _
+from opengever.task import _ as tmf
 from opengever.task.activities import TaskAddedActivity
 from plone import api
 from Products.CMFPlone import PloneMessageFactory
@@ -16,16 +17,21 @@ class ForwardingAddedActivity(TaskAddedActivity):
     @property
     def summary(self):
         actor = Actor.lookup(self.context.Creator())
-        msg = _('label_forwarding_added', u'New forwarding added by ${user}',
+        msg = _('msg_forwarding_added', u'New forwarding added by ${user}',
                 mapping={'user': actor.get_label(with_principal=False)})
         return self.translate_to_all_languages(msg)
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(
+            _('label_forwarding_added', u'Forwarding added'))
 
     def collect_description_data(self, language):
         """Returns a list with [label, value] pairs.
         """
         return [
-            [_('label_task_title', u'Task title'), self.context.title],
-            [_('label_deadline', u'Deadline'),
+            [tmf('label_task_title', u'Task title'), self.context.title],
+            [tmf('label_deadline', u'Deadline'),
              api.portal.get_localized_time(str(self.context.deadline))],
-            [_('label_text', u'Text'), self.context.text]
+            [tmf('label_text', u'Text'), self.context.text]
         ]

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-10 10:11+0000\n"
+"POT-Creation-Date: 2015-08-17 15:01+0000\n"
 "PO-Revision-Date: 2015-03-30 08:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/inbox/browser/overview.py:38
+#: ./opengever/inbox/browser/overview.py:41
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -51,50 +51,45 @@ msgid "current_inbox_not_available"
 msgstr "Sie sind nicht dazu berechtigt auf den Eingangskorb der/des ${current_org_unit} zuzugreifen."
 
 #. Default: "Error: Please select at least one document to forward"
-#: ./opengever/inbox/forwarding.py:112
+#: ./opengever/inbox/forwarding.py:116
 msgid "error_no_document_selected"
 msgstr "Fehler: Bitte wählen Sie mindestens ein Dokument aus das weitergeleitet werden soll"
 
 #. Default: "Common"
-#: ./opengever/inbox/inbox.py:18
+#: ./opengever/inbox/inbox.py:16
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Forwarding"
-#: ./opengever/inbox/forwarding.py:83
+#: ./opengever/inbox/forwarding.py:87
 msgid "forwarding_task_type"
 msgstr "Weiterleitung"
 
-#: ./opengever/inbox/inbox.py:24
+#: ./opengever/inbox/inbox.py:22
 msgid "help_inbox_group"
 msgstr "Diese Gruppe wird berechtigt, wenn dem Eingangskorb eine Aufgabe zugewiesen wird."
 
-#: ./opengever/inbox/forwarding.py:52
+#: ./opengever/inbox/forwarding.py:56
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person bzw. den Eingangskorb des oben gewählten Mandanten aus."
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:30
+#: ./opengever/inbox/browser/overview.py:31
 msgid "label_assigned_inbox_tasks"
 msgstr "Erhaltene Aufgaben"
 
-#. Default: "Deadline"
-#: ./opengever/inbox/activities.py:29
-msgid "label_deadline"
-msgstr "Frist"
-
-#. Default: "New forwarding added by ${user}"
-#: ./opengever/inbox/activities.py:19
+#. Default: "Forwarding added"
+#: ./opengever/inbox/activities.py:27
 msgid "label_forwarding_added"
-msgstr "Neue Weiterleitung hinzugefügt durch ${user}"
+msgstr "Weiterleitung hinzugefügt"
 
 #. Default: "Inbox Group"
-#: ./opengever/inbox/inbox.py:23
+#: ./opengever/inbox/inbox.py:21
 msgid "label_inbox_group"
 msgstr "Eingangskorb Gruppe"
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:34
+#: ./opengever/inbox/browser/overview.py:36
 msgid "label_issued_inbox_tasks"
 msgstr "Erteilte Aufgaben"
 
@@ -109,19 +104,14 @@ msgid "label_refuse_forwarding"
 msgstr "Weiterleitung ablehnen"
 
 #. Default: "Responsible"
-#: ./opengever/inbox/forwarding.py:51
+#: ./opengever/inbox/forwarding.py:55
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
-#. Default: "Task title"
-#: ./opengever/inbox/activities.py:27
-msgid "label_task_title"
-msgstr "Aufgabentitel"
-
-#. Default: "Text"
-#: ./opengever/inbox/activities.py:31
-msgid "label_text"
-msgstr "Text"
+#. Default: "New forwarding added by ${user}"
+#: ./opengever/inbox/activities.py:20
+msgid "msg_forwarding_added"
+msgstr "Neue Weiterleitung hinzugefügt durch ${user}"
 
 #. Default: "Assign Forwarding"
 #: ./opengever/inbox/browser/assign.py:34
@@ -137,4 +127,3 @@ msgstr "Weiterleitung abschliessen"
 #: ./opengever/inbox/yearfolder.py:39
 msgid "yearfolder_title"
 msgstr "Abgeschlossen ${year}"
-

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-10 10:11+0000\n"
+"POT-Creation-Date: 2015-08-17 15:01+0000\n"
 "PO-Revision-Date: 2014-11-03 14:10+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/inbox/browser/overview.py:38
+#: ./opengever/inbox/browser/overview.py:41
 msgid "Documents"
 msgstr "Documents"
 
@@ -51,50 +51,45 @@ msgid "current_inbox_not_available"
 msgstr "Vous n'avez pas accès à la boîte de réception de ${current_org_unit}"
 
 #. Default: "Error: Please select at least one document to forward"
-#: ./opengever/inbox/forwarding.py:112
+#: ./opengever/inbox/forwarding.py:116
 msgid "error_no_document_selected"
 msgstr "Erreur: Choisissez au minimum un document à transmettre."
 
 #. Default: "Common"
-#: ./opengever/inbox/inbox.py:18
+#: ./opengever/inbox/inbox.py:16
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Forwarding"
-#: ./opengever/inbox/forwarding.py:83
+#: ./opengever/inbox/forwarding.py:87
 msgid "forwarding_task_type"
 msgstr "Transmission"
 
-#: ./opengever/inbox/inbox.py:24
+#: ./opengever/inbox/inbox.py:22
 msgid "help_inbox_group"
 msgstr "Ce goupe est autorisé, dès qu'une tâche est attribuée à la boîte de réception."
 
-#: ./opengever/inbox/forwarding.py:52
+#: ./opengever/inbox/forwarding.py:56
 msgid "help_responsible"
 msgstr "Choix de la personne responsable ou la boîte de réception du client mentionné ci-dessus."
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:30
+#: ./opengever/inbox/browser/overview.py:31
 msgid "label_assigned_inbox_tasks"
 msgstr "Tâches reçues"
 
-#. Default: "Deadline"
-#: ./opengever/inbox/activities.py:29
-msgid "label_deadline"
-msgstr ""
-
-#. Default: "New forwarding added by ${user}"
-#: ./opengever/inbox/activities.py:19
+#. Default: "Forwarding added"
+#: ./opengever/inbox/activities.py:27
 msgid "label_forwarding_added"
 msgstr ""
 
 #. Default: "Inbox Group"
-#: ./opengever/inbox/inbox.py:23
+#: ./opengever/inbox/inbox.py:21
 msgid "label_inbox_group"
 msgstr "Boîte de réception Groupe"
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:34
+#: ./opengever/inbox/browser/overview.py:36
 msgid "label_issued_inbox_tasks"
 msgstr "Tâches attribuées"
 
@@ -109,18 +104,13 @@ msgid "label_refuse_forwarding"
 msgstr "Refuser le transfert"
 
 #. Default: "Responsible"
-#: ./opengever/inbox/forwarding.py:51
+#: ./opengever/inbox/forwarding.py:55
 msgid "label_responsible"
 msgstr "Mandataire"
 
-#. Default: "Task title"
-#: ./opengever/inbox/activities.py:27
-msgid "label_task_title"
-msgstr ""
-
-#. Default: "Text"
-#: ./opengever/inbox/activities.py:31
-msgid "label_text"
+#. Default: "New forwarding added by ${user}"
+#: ./opengever/inbox/activities.py:20
+msgid "msg_forwarding_added"
 msgstr ""
 
 #. Default: "Assign Forwarding"

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-06-10 10:11+0000\n"
+"POT-Creation-Date: 2015-08-17 15:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.inbox\n"
 
-#: ./opengever/inbox/browser/overview.py:38
+#: ./opengever/inbox/browser/overview.py:41
 msgid "Documents"
 msgstr ""
 
@@ -54,50 +54,45 @@ msgid "current_inbox_not_available"
 msgstr ""
 
 #. Default: "Error: Please select at least one document to forward"
-#: ./opengever/inbox/forwarding.py:112
+#: ./opengever/inbox/forwarding.py:116
 msgid "error_no_document_selected"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/inbox/inbox.py:18
+#: ./opengever/inbox/inbox.py:16
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Forwarding"
-#: ./opengever/inbox/forwarding.py:83
+#: ./opengever/inbox/forwarding.py:87
 msgid "forwarding_task_type"
 msgstr ""
 
-#: ./opengever/inbox/inbox.py:24
+#: ./opengever/inbox/inbox.py:22
 msgid "help_inbox_group"
 msgstr ""
 
-#: ./opengever/inbox/forwarding.py:52
+#: ./opengever/inbox/forwarding.py:56
 msgid "help_responsible"
 msgstr ""
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:30
+#: ./opengever/inbox/browser/overview.py:31
 msgid "label_assigned_inbox_tasks"
 msgstr ""
 
-#. Default: "Deadline"
-#: ./opengever/inbox/activities.py:29
-msgid "label_deadline"
-msgstr ""
-
-#. Default: "New forwarding added by ${user}"
-#: ./opengever/inbox/activities.py:19
+#. Default: "Forwarding added"
+#: ./opengever/inbox/activities.py:27
 msgid "label_forwarding_added"
 msgstr ""
 
 #. Default: "Inbox Group"
-#: ./opengever/inbox/inbox.py:23
+#: ./opengever/inbox/inbox.py:21
 msgid "label_inbox_group"
 msgstr ""
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:34
+#: ./opengever/inbox/browser/overview.py:36
 msgid "label_issued_inbox_tasks"
 msgstr ""
 
@@ -112,18 +107,13 @@ msgid "label_refuse_forwarding"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/inbox/forwarding.py:51
+#: ./opengever/inbox/forwarding.py:55
 msgid "label_responsible"
 msgstr ""
 
-#. Default: "Task title"
-#: ./opengever/inbox/activities.py:27
-msgid "label_task_title"
-msgstr ""
-
-#. Default: "Text"
-#: ./opengever/inbox/activities.py:31
-msgid "label_text"
+#. Default: "New forwarding added by ${user}"
+#: ./opengever/inbox/activities.py:20
+msgid "msg_forwarding_added"
 msgstr ""
 
 #. Default: "Assign Forwarding"


### PR DESCRIPTION
"Meine Benachrichtigungen"
  - Sortierung in der "Meine Benachrichtigungen" für alle Spalten bis auf "created" deaktiviert.
  - Label anstatt Kind darstellen verwenden

Benachrichtungs viewlet:
 - Benachrichtigungen werden nun chronologisch, das neuste zuoberst aufgelistet.
 - Tooltip beim "Als gelesen markieren" Link
 - Struktur für einfacheres Styling angepasst (siehe https://github.com/4teamwork/plonetheme.teamraum/pull/348)

Übersetzung für `ForwardingAdded` Activity hinzugefügt.


@lukasgraf @deiferni 