### PR TITLE
Drop limitation of notifications and make notification viewlet scrollable instead.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Drop limitation of notifications and make notification viewlet scrollable instead.
+  [phgross]
+
 - Notification viewlet: added tooltip to the "mark as read" link.
   [phgross]
 

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -103,16 +103,6 @@ class TestNotificationViewlet(FunctionalTestCase):
             browser.css('.item-content .item-summary').text)
 
     @browsing
-    def test_notifications_is_limited_to_ten_latest(self, browser):
-        for i in range(13):
-            create(Builder('notification')
-                   .having(activity=self.activity_a, watcher=self.test_watcher))
-
-        browser.login().open()
-        notifications = browser.css('.notification-item a.item-location')
-        self.assertEquals(10, len(notifications))
-
-    @browsing
     def test_notifications_are_linked_to_resolve_notification_view(self, browser):
         create(Builder('notification')
                .having(activity=self.activity_c, watcher=self.test_watcher))

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -18,7 +18,7 @@
     </dt>
 
     <dd class="actionMenuContent notificationsMenuContent">
-      <ul>
+      <ul class="notifications">
         <li class="no-content" tal:condition="not: num_unread" >
           <div class="item-content" i18n:translate="no_unread_notifications">
             No unread notifications
@@ -51,6 +51,8 @@
           </div>
         </li>
 
+      </ul>
+      <ul>
         <li class="notification-item show_all">
           <a href="#" class="all_link" tal:attributes="href view/overview_url"
              i18n:translate="label_notifications_overview">

--- a/opengever/activity/viewlets/notification.py
+++ b/opengever/activity/viewlets/notification.py
@@ -28,7 +28,7 @@ class NotificationViewlet(common.ViewletBase):
         if not self.notifications:
             center = notification_center()
             self.notifications = center.get_current_users_notifications(
-                only_unread=True, limit=10)
+                only_unread=True)
 
         return self.notifications
 


### PR DESCRIPTION
Das Notification Viewlet hat aktuell nur die 10 neusten Einträge dargestellt. Diese Limitierung macht aber bei der aktuellen Darstellung schlicht keinen Sinn. 

Deshalb werden neu alle Notifications dargestellt, und das Notification Viewlet ist stattdessen scrollable.

![bildschirmfoto 2015-08-18 um 16 59 55](https://cloud.githubusercontent.com/assets/485755/9333535/9876476c-45ca-11e5-869d-2fcc0198bb31.png)
![bildschirmfoto 2015-08-18 um 16 59 01](https://cloud.githubusercontent.com/assets/485755/9333534/986e6a4c-45ca-11e5-91ff-926505002e99.png)

Styling: im separater PR im `plonetheme.teamraum`
Backport: `4.5-stable`


@lukasgraf @deiferni 