### PR TITLE
Fix layout and styling in notification mail also for microsoft outlook.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fix layout and styling in notification mail also for microsoft outlook.
+  [phgross]
+
 - Drop limitation of notifications and make notification viewlet scrollable instead.
   [phgross]
 

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -3,21 +3,43 @@
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    tal:omit-tag="python: True"
     i18n:domain="opengever.activity">
 
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <title tal:content="structure options/summary"></title>
+    <style>
+      body{
+        font-family: sans-serif;
+        font-size: 85%;
+      }
+
+      .notification_label {
+        padding-bottom: 5px;
+
+      }
+      .label {
+        font-weight: bold;
+        text-align: left;
+        padding-right: 1em;
+        }
+
+      .details {
+        padding-top: 15px;
+        }
+    </style>
+
   </head>
 
   <body>
-    <p <p style="padding-bottom: 5px;" tal:content="structure options/summary" />
+    <p class="notification_label" tal:content="structure options/summary" />
 
-    <a href="" tal:content="options/title" tal:attributes="href options/link"></a>
+    <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
 
-    <p style="padding-top: 15px;" i18n:translate="label_details">Details:</p>
-    <div style="text-align: left;">
+    <p class="details" i18n:translate="label_details">Details:</p>
+    <div>
       <span tal:replace="structure options/description" />
     </div>
 

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -76,6 +76,7 @@ class TestEmailNotification(FunctionalTestCase):
         mail = email.message_from_string(Mailing(self.portal).pop())
         html_part = mail.get_payload()[0].as_string()
 
-        link = '<a href=3D"http://example.com/@@resolve_notification?notification_id=3D=\n1">Test Task</a>'
+        link = '<p><a href=3D"http://example.com/@@resolve_notification' \
+               '?notification_id=\n=3D1">Test Task</a></p>'
 
         self.assertIn(link, html_part)

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -120,7 +120,7 @@ class TaskAddedActivity(TaskActivity):
     def render_description_markup(self, data, language):
         msg = u'<table><tbody>'
         for label, value in data:
-            msg = u'{}<tr><th>{}</th><td>{}</td></tr>'.format(
+            msg = u'{}<tr><td class="label">{}</td><td>{}</td></tr>'.format(
                 msg, self.translate(label, language), value)
 
         return u'{}</tbody></table>'.format(msg)

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -43,11 +43,11 @@ class TestTaskActivites(FunctionalTestCase):
         # dict representation
         self.maxDiff = None
         expected = (u'<table><tbody>'
-                    u'<tr><th>Task title</th><td>Abkl\xe4rung Fall Meier</td></tr>'
-                    u'<tr><th>Deadline</th><td>Feb 13, 2015</td></tr>'
-                    u'<tr><th>Task Type</th><td>To comment</td></tr>'
-                    u'<tr><th>Dossier title</th><td>Dossier XY</td></tr>'
-                    u'<tr><th>Text</th><td>Lorem ipsum</td></tr></tbody></table>')
+                    u'<tr><td class="label">Task title</td><td>Abkl\xe4rung Fall Meier</td></tr>'
+                    u'<tr><td class="label">Deadline</td><td>Feb 13, 2015</td></tr>'
+                    u'<tr><td class="label">Task Type</td><td>To comment</td></tr>'
+                    u'<tr><td class="label">Dossier title</td><td>Dossier XY</td></tr>'
+                    u'<tr><td class="label">Text</td><td>Lorem ipsum</td></tr></tbody></table>')
         self.assertEquals(expected, activity.description)
 
     @browsing


### PR DESCRIPTION
Fixes #1178 .

Zu einem habe ich die HTML Struktur korrigiert und anderseits das Styling in ein separates Style Tag im Header verschoben.

![bildschirmfoto 2015-08-18 um 19 14 53](https://cloud.githubusercontent.com/assets/485755/9337093/6cec2518-45dd-11e5-9c5f-2775c687fffe.png)

@lukasgraf @deiferni 

Backport needed: `4.5-stable`