### PR TITLE
Make sure to create an RFC2047 compliant From: or To: header when sending mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Make sure to create an RFC2047 compliant From: or To: header when sending mails.
+  (By avoiding encoded-words in angle-addr or addr-spec).
+  [lgraf
+
 - Fix layout and styling in notification mail also for microsoft outlook.
   [phgross]
 

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -3,15 +3,17 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from opengever.activity.browser import resolve_notification_url
 from opengever.base.model import get_locale
+from opengever.mail.utils import make_addr_header
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ZODB.POSException import ConflictError
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
-import traceback
 import logging
 import sys
+import traceback
+
 
 # because of circular imports, we can't import from opengever.activity
 _ = MessageFactory("opengever.activity")
@@ -62,8 +64,7 @@ class PloneNotificationMailer(object):
         msg = MIMEMultipart('alternative')
 
         actor = ogds_service().fetch_user(notification.activity.actor_id)
-        msg['From'] = Header(u'{} <{}>'.format(actor.fullname(), actor.email),
-                             'utf-8')
+        msg['From'] = make_addr_header(actor.fullname(), actor.email, 'utf-8')
 
         recipient = ogds_service().fetch_user(notification.watcher.user_id)
         msg['To'] = recipient.email

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.mail.utils import get_header
 from ftw.testbrowser import browsing
 from ftw.testing.mailing import Mailing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
@@ -63,7 +64,8 @@ class TestEmailNotification(FunctionalTestCase):
 
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('hugo.boss@example.org', mail.get('To'))
-        self.assertEquals('Test User <test@example.org>', mail.get('From'))
+        self.assertEquals(
+            'Test User <test@example.org>', get_header(mail, 'From'))
 
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -1,3 +1,4 @@
+from datetime import date
 from email import Encoders
 from email.Header import Header
 from email.MIMEBase import MIMEBase
@@ -12,6 +13,7 @@ from opengever.mail import _
 from opengever.mail.behaviors import ISendableDocsContainer
 from opengever.mail.events import DocumentSent
 from opengever.mail.interfaces import ISendDocumentConf
+from opengever.mail.utils import make_addr_header
 from opengever.mail.validators import AddressValidator
 from opengever.mail.validators import DocumentSizeValidator
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -36,7 +38,6 @@ from zope.i18n import translate
 from zope.interface import Interface
 from zope.interface import Invalid
 from zope.interface import invariant
-from datetime import date
 
 
 CHARSET = 'utf-8'
@@ -204,17 +205,16 @@ class SendDocumentForm(form.Form):
                 portal = self.context.portal_url.getPortalObject()
                 sender_address = portal.email_from_address
 
-            mail_from = '%s <%s>' % (
-                    user.label().encode(CHARSET),
-                    sender_address.encode(CHARSET))
-
-            msg['From'] = Header(mail_from, CHARSET)
+            msg['From'] = make_addr_header(
+                user.label(), sender_address, CHARSET)
 
             header_to = Header(','.join(addresses), CHARSET)
             msg['To'] = header_to
 
             # send it
-            mh.send(msg, mfrom=mail_from, mto=','.join(addresses))
+            mfrom = u'{} <{}>'.format(
+                user.label(), sender_address).encode(CHARSET)
+            mh.send(msg, mfrom=mfrom, mto=','.join(addresses))
 
             # Store a copy of the sent mail in dossier
             if data.get('file_copy_in_dossier', False):

--- a/opengever/mail/tests/test_utils.py
+++ b/opengever/mail/tests/test_utils.py
@@ -1,0 +1,27 @@
+from email.header import decode_header
+from opengever.mail.utils import make_addr_header
+import unittest2
+
+
+class TestMakeAddrHeader(unittest2.TestCase):
+
+    def test_encodes_addr_name(self):
+        fullname = u'Fr\xe4nzi M\xfcller'
+        address = 'fraenzi.mueller@example.org'
+        header = make_addr_header(fullname, address)
+        self.assertEquals(
+            [('Fr\xc3\xa4nzi M\xc3\xbcller', 'utf-8'),
+             ('<fraenzi.mueller@example.org>', None)],
+            decode_header(header))
+
+    def test_preserves_addr_spec(self):
+        fullname = u'Fr\xe4nzi M\xfcller'
+        address = 'fraenzi.mueller@example.org'
+        header = make_addr_header(fullname, address)
+        self.assertIn(' <fraenzi.mueller@example.org>', str(header))
+
+    def test_preserves_bails_on_bytestring_names(self):
+        fullname = 'bytestring'
+        address = ''
+        with self.assertRaises(ValueError):
+            make_addr_header(fullname, address)

--- a/opengever/mail/utils.py
+++ b/opengever/mail/utils.py
@@ -1,0 +1,21 @@
+from email.header import make_header
+
+
+def make_addr_header(fullname, address, charset='utf-8'):
+    """Creates an RFC2047 compliant From: or To: header.
+
+    (Makes sure encoded-words are only used for addr-name, but not for
+    angle-addr or addr-spec. See http://tools.ietf.org/html/rfc2047#section-5)
+    """
+
+    if not isinstance(fullname, unicode):
+        raise ValueError("Please pass unicode to make_addr_header()")
+
+    # Implicitely decode as 'ascii' - this should never be an issue for
+    address = unicode(address)
+
+    header = make_header(
+        [(fullname.encode(charset), charset),
+         (u'<{}>'.format(address), None)])
+
+    return header


### PR DESCRIPTION
Bisher wurden in GEVER beim Senden von Mails die `From:` Header falsch codiert.

Angenommen, der Header soll `Lükäs Graf <l.graf@4teamwork.ch>` sein. Wenn man diesen einfach an `Header()` übergibt, wird der komplette String in ein sog. `encoded-word` gepackt:

```
From: =?utf-8?q?Graf_L=C3=BCk=C3=A4s_=3Cl=2Egraf=404teamwork=2Ech=3E?=
```

Laut [RFC2047](http://tools.ietf.org/html/rfc2047#section-5) darf aber die eigentliche E-Mail Adresse nicht encoded werden:

> An `'encoded-word'` MUST NOT appear in any portion of an `'addr-spec'`.

Outlook verschluckt sich daran und stellt den Header nachher so dar:

![encoded_addr_spec](https://cloud.githubusercontent.com/assets/405124/9341519/bc4e633c-45f6-11e5-8ab5-0fa381a94c58.png)

Dieser PR führt darum eine Utility-Funktion `make_addr_header` ein, welcher der Fullname und die Adresse separat übergeben werden, und die das richtige encoding übernimmt, so dass dann ein solcher Header rauskommt:

```
From: =?utf-8?q?Graf_L=C3=BCk=C3=A4s_=28lukas=2Egraf=29?= <l.graf@4teamwork.ch>
```

Dieser wird dann korrekt dargestellt:

![outlook_mail](https://cloud.githubusercontent.com/assets/405124/9341572/006c7a4a-45f7-11e5-928b-8ff64f3b0d75.png)

(Dieser Screenshots belegt auch gerade noch abschliessende Tests mit Outlook für PR #1179 - habe in allen Feldern mindestens einen Umlaut verwendet. Die "Dokument als Mail versenden" Funktion habe ich ebenfalls nochmals von Hand getestet und das `.eml` in Outlook geöffnet).

Needs backport: `4.5-stable`

@phgross   @deiferni 