### PR TITLE
Notification mail: hide "display" label for activities without a description.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Notification mail: hide "display" label for activities without a description.
+  [phgross]
+
 - Make sure to create an RFC2047 compliant From: or To: header when sending mails.
   (By avoiding encoded-words in angle-addr or addr-spec).
   [lgraf

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -38,11 +38,10 @@
 
     <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
 
-    <p class="details" i18n:translate="label_details">Details:</p>
-    <div>
-      <span tal:replace="structure options/description" />
-    </div>
-
+    <tal:block tal:condition="options/description">
+      <p class="details" i18n:translate="label_details">Details:</p>
+      <div tal:content="structure options/description"></div>
+    </tal:block>
   </body>
 
 </html>


### PR DESCRIPTION
Das Label `Details:` wird nur noch angezeigt wenn es auch wirklich eine Beschreibung gibt.

![bildschirmfoto 2015-08-19 um 13 52 15](https://cloud.githubusercontent.com/assets/485755/9355432/87035d4e-4679-11e5-94ab-be7e16a094a3.png)
![bildschirmfoto 2015-08-19 um 13 51 57 1](https://cloud.githubusercontent.com/assets/485755/9355433/87059942-4679-11e5-95f6-979458d477b5.png)

@deiferni 

Backport: `4.5-stable`