### PR TITLE
Fix tests for opengever.ogds.base.

### DIFF
--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -79,8 +79,7 @@ class TestActorLookup(FunctionalTestCase):
 
         self.assertEquals(
             u'<a href="http://nohost/plone/blahbla-foo-b-onmouseover-alert-foo-click-me-b">'
-            'Blahbla Foo <b>click me!</b> (h@example.com)'
-            '</a>',
+            'Blahbla Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (h@example.com)</a>',
             actor.get_link())
 
 


### PR DESCRIPTION
As mentioned in https://github.com/4teamwork/opengever.core/pull/1183 `opengever.ogds.base` were not executed by CI and contain failing tests. This PR addresses this issue.