### PR TITLE
Fix autocomplete widget tests by using our own layer

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -118,6 +118,7 @@ class OpengeverFixture(PloneSandboxLayer):
             '  <includePlugins package="plone" />'
             '  <includePluginsOverrides package="plone" />'
 
+            '  <include package="opengever.core.tests" file="tests.zcml" />'
             '  <include package="opengever.ogds.base" file="tests.zcml" />'
             '  <include package="opengever.base.tests" file="tests.zcml" />'
             '  <include package="opengever.setup.tests" />'

--- a/opengever/core/tests/test_autocomplete_widget.py
+++ b/opengever/core/tests/test_autocomplete_widget.py
@@ -1,8 +1,7 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.testing import BROWSER_FUNCTIONAL_TESTING
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING
 from plone.app.testing import SITE_OWNER_NAME
 from unittest2 import TestCase
-import os
 import plone.protect.auto
 
 
@@ -12,7 +11,7 @@ class TestOpengeverAutocompleteWidgetForTestbrowser(TestCase):
     of "q" as query parameter and returns different results.
     """
 
-    layer = BROWSER_FUNCTIONAL_TESTING
+    layer = OPENGEVER_FUNCTIONAL_TESTING
 
     def setUp(self):
         plone.protect.auto.CSRF_DISABLED = True
@@ -22,15 +21,15 @@ class TestOpengeverAutocompleteWidgetForTestbrowser(TestCase):
 
     @browsing
     def test_autocomplete_form_fill(self, browser):
-        browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
-        browser.fill({'Payment': 'mastercard'})
+        browser.login(SITE_OWNER_NAME).visit(view='test-user-selection')
+        browser.fill({'Select users': 'hans'})
         browser.find('Submit').click()
-        self.assertEquals({u'payment': [u'mastercard']}, browser.json)
+        self.assertEquals({u'users': [u'hans']}, browser.json)
 
     @browsing
     def test_autocomplete_query(self, browser):
-        browser.login(SITE_OWNER_NAME).visit(view='test-z3cform-shopping')
+        browser.login(SITE_OWNER_NAME).visit(view='test-user-selection')
 
-        self.assertEquals([['cash', 'Cash'],
-                           ['mastercard', 'MasterCard']],
-                          browser.find('Payment').query('ca'))
+        self.assertEquals([[u'hans', u'Hans M\xfcller'],
+                           [u'hugo', u'Hugo Boss']],
+                          browser.find('Select users').query('h'))

--- a/opengever/core/tests/tests.zcml
+++ b/opengever/core/tests/tests.zcml
@@ -1,0 +1,6 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope">
+
+    <include package=".views" />
+
+</configure>

--- a/opengever/core/tests/views/configure.zcml
+++ b/opengever/core/tests/views/configure.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+    <include package="Products.CMFCore"/>
+
+    <browser:page
+        name="test-user-selection"
+        class=".z3cform.UserSelectionView"
+        for="*"
+        permission="cmf.ModifyPortalContent"
+        />
+
+    <utility
+        factory=".z3cform.TestUsersVocabulary"
+        provides="zope.schema.interfaces.IVocabularyFactory"
+        name="test-users-vocabulary"
+        />
+
+</configure>

--- a/opengever/core/tests/views/z3cform.py
+++ b/opengever/core/tests/views/z3cform.py
@@ -1,0 +1,80 @@
+from plone.formwidget.autocomplete.widget import AutocompleteMultiFieldWidget
+from plone.z3cform.layout import FormWrapper
+from z3c.form.button import buttonAndHandler
+from z3c.form.field import Fields
+from z3c.form.form import Form
+from z3c.formwidget.query.interfaces import IQuerySource
+from zope import schema
+from zope.interface import implements
+from zope.interface import Interface
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+import json
+
+
+class TestUsersVocabulary(SimpleVocabulary):
+    implements(IVocabularyFactory, IQuerySource)
+
+    def __init__(self):
+        super(TestUsersVocabulary, self).__init__([
+            SimpleTerm(u'james', u'james', u'James Bond'),
+            SimpleTerm(u'hans', u'hans', u'Hans M\xfcller'),
+            SimpleTerm(u'hugo', u'hugo', u'Hugo Boss')])
+
+    def search(self, query_string):
+        query_string = query_string.lower()
+        for term in self():
+            if query_string in term.title.lower():
+                yield term
+
+    def __call__(self, context=None):
+        return self
+
+
+class IUserSelectionFormSchema(Interface):
+
+    users = schema.List(
+        title=u'Select users',
+        value_type=schema.Choice(
+            vocabulary='test-users-vocabulary'),
+        required=False)
+
+
+class UserSelectionForm(Form):
+    label = u'Select users'
+    ignoreContext = True
+    fields = Fields(IUserSelectionFormSchema)
+
+    def __init__(self, *args, **kwargs):
+        super(UserSelectionForm, self).__init__(*args, **kwargs)
+        self.result_data = None
+
+    def update(self):
+        self.fields['users'].widgetFactory = AutocompleteMultiFieldWidget
+        return super(UserSelectionForm, self).update()
+
+    @buttonAndHandler(u'Submit')
+    def handle_submit(self, action):
+        data, errors = self.extractData()
+        if len(errors) > 0:
+            return
+
+        self.result_data = {}
+        for key, value in data.items():
+            if not value:
+                continue
+
+            self.result_data[key] = value
+
+
+class UserSelectionView(FormWrapper):
+
+    form = UserSelectionForm
+
+    def render(self):
+        if self.form_instance.result_data:
+            self.request.RESPONSE.setHeader('Content-Type', 'application/json')
+            return json.dumps(self.form_instance.result_data)
+        else:
+            return super(UserSelectionView, self).render()


### PR DESCRIPTION
Fix autocomplete widget tests by using our own layer instead of importing from `ftw.testbrowser`.

`ftw.testbrowser.testing` now imports from `plone.app.contenttypes` which we neither have or want). So we just define a form and view in `opengever.core.tests` to the our autocomplete widget against.