### PR TITLE
Make mail upgradesteps (to4500, to4501) more defensive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Make mail upgradesteps (to4500, to4501) more defensive.
+  [phgross]
+
 - ReferenceNumberPrefixAdpater: Fix conditions for lazily initialising
   PersistentMappings in annotations.
   [lgraf]

--- a/opengever/mail/upgrades/to4500.py
+++ b/opengever/mail/upgrades/to4500.py
@@ -1,5 +1,9 @@
 from ftw.upgrade import ProgressLogger
 from ftw.upgrade import UpgradeStep
+from ZODB.POSException import ConflictError
+import logging
+
+logger = logging.getLogger('ftw.upgrade')
 
 
 class UpgradeMailMessageFilename(UpgradeStep):
@@ -9,4 +13,10 @@ class UpgradeMailMessageFilename(UpgradeStep):
             {'portal_type': 'ftw.mail.mail'}, full_objects=True)
 
         for mail in ProgressLogger('Migrate mail message filename', objects):
-            mail.update_filename()
+            try:
+                mail.update_filename()
+            except ConflictError:
+                raise
+            except Exception, e:
+                logger.warn("Updating object {0} failed: {1}".format(
+                    mail.absolute_url(), str(e)))


### PR DESCRIPTION
Make upgradesteps `UpgradeMailMessageFilename` and `FixMailsWithIncorrectlyDecodedHeaderValues` more defensive to avoid trouble douring upgrades caused by mails with a wrong class (ftw.mail.mail.Mail instead of OGMail).

Backport-needed: `4.5-stable`

@lukasgraf @deiferni 