### PR TITLE
Add debug view to trigger a plone.protect confirmation dialog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add debug view to trigger a plone.protect confirmation dialog.
+  [lgraf]
+
 - Also display a members role in a meeting's protocol.
   [deiferni]
 

--- a/opengever/debug/browser/trigger_csrf.py
+++ b/opengever/debug/browser/trigger_csrf.py
@@ -1,0 +1,19 @@
+from five import grok
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+
+
+class TriggerCSRF(grok.View):
+    """A view to trigger a plone.protect confirmation dialog.
+    """
+
+    grok.name('trigger-csrf')
+    grok.context(IPloneSiteRoot)
+    grok.require('cmf.ManagePortal')
+
+    def __call__(self):
+        plone = self.context
+
+        # Cause a write in a GET request
+        plone.some_fancy_attribute = True
+
+        return super(TriggerCSRF, self).__call__()

--- a/opengever/debug/browser/trigger_csrf_templates/triggercsrf.pt
+++ b/opengever/debug/browser/trigger_csrf_templates/triggercsrf.pt
@@ -1,0 +1,25 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="opengever.debug">
+<head>
+</head>
+
+<body>
+
+<metal:main fill-slot="main">
+
+    <tal:main-macro metal:define-macro="main">
+
+    <div>
+      <p>Confirmation dialog for CSRF protection should have been triggered.</p>
+    </div>
+
+    </tal:main-macro>
+</metal:main>
+
+</body>
+</html>

--- a/opengever/debug/configure.zcml
+++ b/opengever/debug/configure.zcml
@@ -1,0 +1,8 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:grok="http://namespaces.zope.org/grok"
+           xmlns:i18n="http://namespaces.zope.org/i18n"
+           i18n_domain="opengever.debug">
+
+    <grok:grok package="." />
+
+</configure>


### PR DESCRIPTION
Adds a debug view `@@trigger-csrf` (on Plone Site, with `ManagePortal` permission) that triggers a `plone.protect` confirmation dialog.