### PR TITLE
Add detailed logging for CSRF incidents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add detailed logging for CSRF incidents.
+  [lgraf]
+
 - Fix missing journal entry due to CSRF when downloading copy or
   pdf-preview of a document from document overview.
   [deiferni]


### PR DESCRIPTION
This change introduces detailed **logging for CSRF incidents** (cases where the user is shown the `@@confirm-action` dialog).

- Logging enabled by default, but can be disabled by setting the `CSRF_LOG_ENABLED` environment variable to something falsy.
- Logs are automatically rotated and retained for 7 days by default. This age can be configured via the `CSRF_LOG_MAX_AGE` environment variable (in minutes).

There will be one log file created per incident, and the log filename will contain the timestamp and the user name.

For now, the following information is dumped:
- Original **URL** that caused the CSRF protection to fire
- The **`HTTP_REFERER`**, if present
- The **username** of the user that issued the request
- The contents of **`_registered_objects`** (which equals the persistent objects that have been changed)
- The list of **references** to those objects. There are collected using `gc.get_referrers()`
- The contents of **`REQUEST.__dict__`**, minus the response and auth headers

Once the detailed single-file incident report has been written, a message including the filename will be logged in the main event log.

Example:

```
2015-09-01T00:09:07 WARNING opengever.base.protect CSRF incident has been logged to /full/path/to/var/log/csrf-2015-09-01_00-09-07-someuser.log
```

Example Report (abridged):

```
2015-09-01T00:09:07.491060   CSRF incident at http://localhost:8080/fd/@@trigger-csrf
2015-09-01T00:09:07.491060   ================================================================================
2015-09-01T00:09:07.491060

2015-09-01T00:09:07.491060   User:
2015-09-01T00:09:07.491060   --------------------------------------------------------------------------------
2015-09-01T00:09:07.491060   someuser
2015-09-01T00:09:07.491060

2015-09-01T00:09:07.491060   HTTP_REFERER:
2015-09-01T00:09:07.491060   --------------------------------------------------------------------------------
2015-09-01T00:09:07.491060   http://localhost:8080/fd/@@some-view
2015-09-01T00:09:07.491060

2015-09-01T00:09:07.491060   _registered_objects:
2015-09-01T00:09:07.491060   --------------------------------------------------------------------------------
2015-09-01T00:09:07.491060   [<PloneSite at fd>]
2015-09-01T00:09:07.491060

2015-09-01T00:09:07.491060   References to registered objects:
2015-09-01T00:09:07.491060   --------------------------------------------------------------------------------
2015-09-01T00:09:07.491060   Object: <PloneSite at fd>
2015-09-01T00:09:07.491060   Referrers:
[[<PloneSite at fd>],
 <frame object at 0x1117ee050>,
 <PloneSite at /fd>,
 <persistent.PickleCache object at 0x10aba3f50>,
 <... long list of referrers ...>,
]

2015-09-01T00:09:07.491060   Request:
{'_steps': ['fd', '@@trigger-csrf'],
 'environ': {'CONNECTION_TYPE': 'keep-alive',
             'GATEWAY_INTERFACE': 'CGI/1.1',
             'HTTP_ACCEPT': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
             'MORE STUFF': '....'},
 'form': {}}
2015-09-01T00:09:07.491060   --------------------------------------------------------------------------------
``` 

