### PR TITLE
Validate task title length.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Validate task title length.
+  [deiferni]
+
 - Add detailed logging for CSRF incidents.
   [lgraf]
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -83,6 +83,7 @@ class ITask(form.Schema):
         title=_(u"label_title", default=u"Title"),
         description=_('help_title', default=u""),
         required=True,
+        max_length=256,
         )
 
     form.widget(issuer=AutocompleteFieldWidget)

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.dexterity import erroneous_fields
 from opengever.task.adapters import IResponseContainer
 from opengever.task.interfaces import ITaskSettings
 from opengever.task.response import Response
@@ -55,6 +56,19 @@ class TestTaskIntegration(FunctionalTestCase):
                     .titled('Task 2'))
 
         self.assertEquals([t2.get_sql_object()], view.get_sub_tasks())
+
+    @browsing
+    def test_task_title_length_is_validated(self, browser):
+        dossier = create(Builder('dossier'))
+        browser.login().open(dossier, view='++add++opengever.task.task')
+
+        browser.fill({'Title': 300*'x',
+                      'Task Type': 'To comment',
+                      'Responsible': TEST_USER_ID})
+        browser.find('Save').click()
+
+        self.assertEquals({u'Title': ['Value is too long']},
+                          erroneous_fields())
 
     def test_relateddocuments(self):
         # create document and append it to the relatedItems of the task


### PR DESCRIPTION
This prevents an ugly error being displayed.

Needs backport to `4.5-stable`.

Closes https://github.com/4teamwork/opengever.zug/issues/206