### PR TITLE
Hide foreign part of predecessor/successor pairs in the opentaskreport.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Hide foreign part of predecessor/successor pairs in the opentaskreport listings.
+  [phgross]
+
 - Validate task title length.
   [deiferni]
 

--- a/opengever/latex/opentaskreport.py
+++ b/opengever/latex/opentaskreport.py
@@ -79,7 +79,7 @@ class OpenTaskReportLaTeXView(grok.MultiAdapter, MakoLaTeXView):
         query = query.filter(
             or_(
                 and_(Task.predecessor == None, Task.successors == None),
-                Task.assigned_org_unit == get_current_org_unit().id()))
+                Task.admin_unit_id == get_current_org_unit().id()))
 
         return query
 


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.zug/issues/205 (inkl. genauere Beschreibung der Problematik)

@deiferni @lukasgraf 

Backport: `4.5-stable`