### PR TITLE
Fix duplicate activity recordings when a forwarding gets reassigned.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fix duplicate activity recordings when a forwarding gets reassigned.
+  [phgross]
+
 - Fix Upgrade-Step that updates lexicon: The affected indexes need to be
   cleared first before rebuilding them, otherwise the lexicon might not get
   updated properly.

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -154,7 +154,8 @@ class TaskTransitionActivity(TaskActivity):
     IGNORED_TRANSITIONS = [
         'transition-add-subtask',
         'task-transition-reassign',
-        'forwarding-transition-reassign'
+        'forwarding-transition-reassign',
+        'forwarding-transition-reassign-refused',
     ]
 
     def __init__(self, context, response):

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -153,7 +153,8 @@ class TaskTransitionActivity(TaskActivity):
 
     IGNORED_TRANSITIONS = [
         'transition-add-subtask',
-        'task-transition-reassign'
+        'task-transition-reassign',
+        'forwarding-transition-reassign'
     ]
 
     def __init__(self, context, response):


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.zug/issues/200. 

With the PR #1011 the problem of doubled recorded activities gets fixed for tasks, this PR fix the Problem also for forwarding activities wich gets recorded twice.

@lukasgraf @deiferni 

Backport needed: `4.5-stable`
