### PR TITLE
Use supertabular* to render multi-page tables.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Use supertabular* to render multi-page tables instead of longtable to
+  fix an issue with tables breaking pages too late.
+  [deiferni]
+
 - Hide foreign part of predecessor/successor pairs in the opentaskreport listings.
   [phgross]
 

--- a/opengever/latex/templates/opentaskreport.tex
+++ b/opengever/latex/templates/opentaskreport.tex
@@ -6,21 +6,22 @@
 
 % if incoming:
 {
-    \vspace{5mm}
+  \vspace{5mm}
   {\bf Pendenzenkontrolle ${client}: erhaltene Aufgaben}\\%%
   \vspace{\baselineskip}
   \scriptsize
   \noindent
-  \addtolength{\tablewidth}{-20\tabcolsep}
-  \begin{longtable}{p{.01\tablewidth}p{.20\tablewidth}p{.12\tablewidth}p{.23\tablewidth}p{.1\tablewidth}p{.1\tablewidth}p{.1\tablewidth}p{.09\tablewidth}p{.05\tablewidth}}
-    \bfseries Nr & \bfseries Aufgabentitel & \bfseries Aufgabentyp & \bfseries Dossiertitel & \bfseries Aktenzeichen & \bfseries Auftraggeber & \bfseries Auftragnehmer & \bfseries Zu erledigen bis & \bfseries Status \\%%
-    \endhead\hline
+
+  \setlength\extrarowheight{1pt}
+  \tablehead{\bfseries Nr & \bfseries Aufgabentitel & \bfseries Aufgabentyp & \bfseries Dossiertitel & \bfseries Aktenzeichen & \bfseries Auftraggeber & \bfseries Auftragnehmer & \bfseries Zu erledigen bis & \bfseries Status \\ \hline}
+  \begin{supertabular*}{\textwidth}{lp{50mm}p{17mm}p{50mm}lp{25mm}p{25mm}ll}
+  \shrinkheight{20mm}
 
   % for row in incoming:
-    ${row} \\%%
-    \hline
+    ${row} \\ \hline
   % endfor
-  \end{longtable}
+
+  \end{supertabular*}
 }
 % endif
 
@@ -32,15 +33,17 @@
   \vspace{\baselineskip}
   \scriptsize
   \noindent
-  \addtolength{\tablewidth}{-20\tabcolsep}
-  \begin{longtable}{p{.01\tablewidth}p{.20\tablewidth}p{.12\tablewidth}p{.23\tablewidth}p{.1\tablewidth}p{.1\tablewidth}p{.1\tablewidth}p{.09\tablewidth}p{.05\tablewidth}}
-    \bfseries Nr & \bfseries Aufgabentitel & \bfseries Aufgabentyp & \bfseries Dossiertitel & \bfseries Aktenzeichen & \bfseries Auftraggeber & \bfseries Auftragnehmer & \bfseries Zu erledigen bis & \bfseries Status \\%%
-    \endhead\hline
+
+  \setlength\extrarowheight{1pt}
+  \tablehead{\bfseries Nr & \bfseries Aufgabentitel & \bfseries Aufgabentyp & \bfseries Dossiertitel & \bfseries Aktenzeichen & \bfseries Auftraggeber & \bfseries Auftragnehmer & \bfseries Zu erledigen bis & \bfseries Status \\ \hline}
+  \begin{supertabular*}{\textwidth}{lp{50mm}p{17mm}p{50mm}lp{25mm}p{25mm}ll}
+  \shrinkheight{20mm}
+
 
   % for row in outgoing:
-    ${row} \\%%
-    \hline
+    ${row} \\ \hline
   % endfor
-  \end{longtable}
+
+  \end{supertabular*}
 }
 % endif


### PR DESCRIPTION
This PR replaces longtable to with supertabular to fix an issue with tables
breaking pages too late.

Needs backport to `4.5-stable`.

Closes https://github.com/4teamwork/opengever.zug/issues/204.

fixed page break:
![screen shot 2015-09-03 at 14 46 39](https://cloud.githubusercontent.com/assets/736583/9658587/e9977166-524a-11e5-8edb-f7d6c40dde62.png)

previous implementation, broken page breaks:
![screen shot 2015-09-03 at 14 46 18](https://cloud.githubusercontent.com/assets/736583/9658597/f3f3bffc-524a-11e5-9ebd-688a6129506f.png)


