### PR TITLE
Let's see if testrunner 4.4.9 still has problems.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -17,4 +17,4 @@ zptlint = 0.2.4
 # zope.testrunner 4.4.5 has changed the testing layer ordering
 # which causes test isolation problems with PloneTestCase layers
 # which are not isolating properly.
-zope.testrunner = 4.4.4
+zope.testrunner = 4.4.9


### PR DESCRIPTION
:construction: We may also get a performance boost.