### PR TITLE
CSRF: Add view to enable and disable CSRF tracing monkey patches.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- CSRF: Add view to enable and disable CSRF tracing monkey patches.
+  [lgraf]
+
 - Use supertabular* to render multi-page tables instead of longtable to
   fix an issue with tables breaking pages too late.
   [deiferni]

--- a/opengever/debug/browser/manage_csrf_tracing.py
+++ b/opengever/debug/browser/manage_csrf_tracing.py
@@ -1,0 +1,244 @@
+from collections import namedtuple
+from datetime import datetime
+from datetime import timedelta
+from five import grok
+from opengever.base.protect import OGProtectTransform
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.statusmessages.interfaces import IStatusMessage
+from ZODB.Connection import Connection
+from ZODB.POSException import ConflictError
+from ZODB.utils import u64
+import inspect
+import logging
+import threading
+import traceback
+
+
+log = logging.getLogger('opengever.debug')
+
+
+# References to original methods - used to restore them when "unpatching"
+_orig_register_func = Connection.register
+_orig_build_csrf_report_func = OGProtectTransform._build_csrf_report
+
+# Module global to store traceback (and OID) on DB write. This will be
+# used when building the CSRF report
+_tb_for_last_db_write = None
+
+# Monkey-patches expire after a timeout (in minutes) and remove themselves
+DEFAULT_PATCH_TIMEOUT = 60
+_patches_expire_at = None
+
+# Locks to make writing to module globals thread-safe
+expires_lock = threading.RLock()
+tb_lock = threading.RLock()
+
+
+# Lightweight object to keep a formatted traceback and associated info around
+AnnotatedTraceback = namedtuple(
+    'AnnotatedTraceback', ['oid', 'filename', 'line_no', 'extracted_tb'])
+
+
+def _build_csrf_report_with_tb(self, env):
+    """Patched version of _build_csrf_report that also logs the traceback
+    """
+    revert_patches_if_expired()
+
+    for line in _orig_build_csrf_report_func(self, env):
+        yield line
+
+    instruction = _tb_for_last_db_write
+    if instruction is not None:
+        yield format_instruction(instruction)
+
+
+def register_patched_to_trace(self, obj):
+    """Patched version of ZODB.Connection.Connection.register to trace
+    DB writes and collect stack traces.
+
+    CAUTION: This will be called for every change to a persistent object,
+    be very careful here!
+    """
+    revert_patches_if_expired()
+
+    _orig_register_func(self, obj)
+    try:
+        save_stacktrace(obj)
+    except ConflictError:
+        raise
+    except Exception, e:
+        log.warn('Error when trying to save stacktrace: {}'.format(str(e)))
+
+
+def revert_patches_if_expired():
+    if datetime.now() >= _patches_expire_at:
+        log.info("CSRF tracing patches have expired. Reverting...")
+        _unpatch_register()
+        _unpatch_build_csrf_report()
+
+
+def save_stacktrace(obj):
+    """Stores an `AnnotatedTraceback` object that contains a formatted stack
+    trace for the current frame and the OID of the object that has been
+    modified for possible logging at a later point in time.
+    """
+    global _tb_for_last_db_write
+
+    tb_limit = 20
+    current_frame = inspect.currentframe()
+
+    # Outer two frames are in this module, so they're not interesting
+    frame = current_frame.f_back.f_back
+
+    filename = frame.f_code.co_filename
+    line_no = frame.f_lineno
+    extracted_tb = traceback.extract_stack(frame, limit=tb_limit)
+    oid = hex(u64(obj._p_oid))
+    instruction = AnnotatedTraceback(oid, filename, line_no, extracted_tb)
+
+    # Write the traceback to the module global (in a thread-safe way)
+    with tb_lock:
+        _tb_for_last_db_write = instruction
+
+    # Avoid leaking frames
+    del current_frame
+    del frame
+
+
+def format_instruction(instruction):
+    """Render the information from an `AnnotatedTraceback` object (file name,
+    line number and formatted traceback) and an OID for display.
+    """
+    output = ['\n']
+    msg = 'DB write to obj with OID {oid} from code ' \
+          'in "{filename}", line {line_no}!'
+    msg = msg.format(**instruction._asdict())
+    output.append("=" * len(msg))
+    output.append(msg)
+    output.append("=" * len(msg))
+    output.append(''.join(traceback.format_list(instruction.extracted_tb)))
+    return '\n'.join(output)
+
+
+def _patch_register():
+    assert _orig_register_func != register_patched_to_trace
+    Connection.register = register_patched_to_trace
+    log.info("Patched ZODB.Connection.Connection.register")
+
+
+def _patch_build_csrf_report():
+    from opengever.base.protect import OGProtectTransform
+    assert _orig_build_csrf_report_func != _build_csrf_report_with_tb
+    OGProtectTransform._build_csrf_report = _build_csrf_report_with_tb
+    log.info("Patched OGProtectTransform._build_csrf_report")
+
+
+def _unpatch_register():
+    assert _orig_register_func != register_patched_to_trace
+    Connection.register = _orig_register_func
+    log.info("Reverted patch for ZODB.Connection.Connection.register")
+
+
+def _unpatch_build_csrf_report():
+    from opengever.base.protect import OGProtectTransform
+    assert _orig_build_csrf_report_func != _build_csrf_report_with_tb
+    OGProtectTransform._build_csrf_report = _orig_build_csrf_report_func
+    log.info("Reverted patch for OGProtectTransform._build_csrf_report")
+
+
+def _is_patched(func, orig_func):
+    if func != orig_func:
+        patched_func_name = func.func_name
+        return (True, patched_func_name)
+    return (False, '')
+
+
+class ManageCSRFTracing(grok.View):
+    """This view allows to enable CSRF tracing, which will monkey patch
+    the method for object registration on the ZODB connection in order to
+    save a stack trace at the point a persistent object has been registered
+    (i.e. changed for the first time in a transaction).
+
+    Activating CSRF tracing will patch two methods: register() on the ZODB
+    connection and _build_csrf_report() on our own OGProtectTransform. The
+    patch to register() will save a formatted stack trace to a module global
+    every time a persistent object is modified for the first time in a
+    transaction. This will then allow the patched _build_csrf_report() to
+    include that stored stack trace in the CSRF incident log if a CSRF
+    confirmation dialog is triggered.
+
+    Those patches can also be reverted from this view: The respective methods
+    will then be restored to their original state.
+
+    Additionally, there is a timeout after which the patches will expire, and
+    remove themselves the next time they're called.
+    """
+
+    grok.name('manage-csrf-tracing')
+    grok.context(IPloneSiteRoot)
+    grok.require('cmf.ManagePortal')
+
+    def __call__(self):
+        action = self.request.form.get('submit')
+        timeout = int(self.request.form.get('timeout', DEFAULT_PATCH_TIMEOUT))
+
+        if action == 'Activate':
+            self._activate_csrf_tracing(timeout)
+
+        elif action == 'Deactivate':
+            self._deactivate_csrf_tracing()
+
+        # Allow for suggesting a timeout value via query string
+        self._suggested_timeout = None
+        suggested_timeout = self.request.form.get('timeout')
+        if suggested_timeout is not None:
+            self._suggested_timeout = int(suggested_timeout)
+
+        return super(ManageCSRFTracing, self).__call__()
+
+    def _activate_csrf_tracing(self, timeout):
+        global _patches_expire_at
+
+        log.info("Activating CSRF tracing...")
+        with expires_lock:
+            _patches_expire_at = datetime.now() + timedelta(minutes=timeout)
+
+        _patch_register()
+        _patch_build_csrf_report()
+        msg = u'CSRF tracing has been activated!'
+        IStatusMessage(self.request).addStatusMessage(msg, 'warning')
+        log.info(msg)
+
+    def _deactivate_csrf_tracing(self):
+        log.info("Deactivating CSRF tracing...")
+        _unpatch_register()
+        _unpatch_build_csrf_report()
+        msg = u'CSRF tracing has been deactivated!'
+        IStatusMessage(self.request).addStatusMessage(msg, 'info')
+        log.info(msg)
+
+    def default_timeout(self):
+        if self._suggested_timeout is not None:
+            return self._suggested_timeout
+        return DEFAULT_PATCH_TIMEOUT
+
+    def patching_status(self):
+        for name, func, orig_func in (
+            ('ZODB.Connection.Connection.register',
+             Connection.register,
+             _orig_register_func),
+            ('opengever.base.protect.OGProtectTransform._build_csrf_report',
+             OGProtectTransform._build_csrf_report,
+             _orig_build_csrf_report_func)):
+            patched, patched_name = _is_patched(func, orig_func)
+            yield dict(name=name, patched_name=patched_name, patched=patched)
+
+    def is_patched(self):
+        return any(status['patched'] for status in self.patching_status())
+
+    def current_expires(self):
+        return _patches_expire_at
+
+    def documentation(self):
+        doc = self.__doc__
+        return doc.replace('\n\n', '<br/><br/>')

--- a/opengever/debug/browser/manage_csrf_tracing_templates/managecsrftracing.pt
+++ b/opengever/debug/browser/manage_csrf_tracing_templates/managecsrftracing.pt
@@ -1,0 +1,79 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="opengever.debug">
+<head>
+  <metal:head metal:fill-slot="head_slot">
+  <title>Manage CSRF Tracing</title>
+  <style>
+    td.patched {background-color: DarkOrange;}
+    td.not-patched {background-color: LimeGreen;}
+    blockquote {max-width: 45em}
+  </style>
+  </metal:head>
+</head>
+
+<body>
+  <metal:block fill-slot="top_slot" tal:define="dummy python:request.set('disable_border',1)" />
+
+  <metal:main fill-slot="main">
+
+    <tal:main-macro metal:define-macro="main">
+
+      <div tal:replace="structure provider:plone.abovecontenttitle" />
+      <h1 class="documentFirstHeading">Manage CSRF tracing</h1>
+
+      <div tal:replace="structure provider:plone.abovecontentbody" />
+
+        <h2>Current Status</h2>
+
+        <table class="listing">
+          <tr tal:repeat="status view/patching_status">
+            <td><pre tal:content="status/name"></pre></td>
+            <td tal:content="python: status['patched'] and 'patched' or 'not patched'"
+                tal:attributes="class python: status['patched'] and 'patched' or 'not-patched'"></td>
+          </tr>
+        </table>
+
+        <tal:expires tal:condition="view/is_patched">
+          <br />
+          <strong>Current patches will expire at:</strong>
+          <span tal:content="view/current_expires"></span>
+          <br />
+        </tal:expires>
+        <br />
+
+      <form method="post" class="rowlike" id="form">
+
+        <tal:activate tal:condition="not:view/is_patched">
+          <div class="field">
+            <label for="timeout" class="horizontal">Timeout (minutes)
+              <span class="required horizontal">&nbsp;</span>
+            </label>
+            <span class="formHelp">Timeout after which monkey patches will expire and remove themselves (in minutes)</span>
+            <input name="timeout" type="text" value="60" class="text-widget required int-field" tal:attributes="value view/default_timeout"/>
+          </div>
+          <input name="submit" type="submit" value="Activate" />
+        </tal:activate>
+
+        <tal:deactivate tal:condition="view/is_patched">
+          <input name="submit" type="submit" value="Deactivate" />
+        </tal:deactivate>
+
+      </form>
+
+      <br />
+      <blockquote class="discreet" tal:content="structure view/documentation"></blockquote>
+
+      <div class="visualClear"><!----></div>
+      <div tal:replace="structure provider:plone.belowcontentbody" />
+      <div class="visualClear"><!----></div>
+    </tal:main-macro>
+
+  </metal:main>
+
+</body>
+</html>


### PR DESCRIPTION
The `@@manage-csrf-tracing` view allows to enable **CSRF tracing**, which will monkey patch the method for object registration on the ZODB connection in order to **save a stack trace** at the point a persistent object has been registered (i.e. changed for the first time in a transaction).

Activating CSRF tracing will patch two methods: [`register()` on the ZODB connection](https://github.com/zopefoundation/ZODB/blob/e76c5b0234fff2ce773b875e024a32ba1e07800b/src/ZODB/Connection.py#L973-L991) and `_build_csrf_report()` on our own `OGProtectTransform`. The patch to `register()` will save a formatted stack trace to a module global every time a persistent object is modified for the first time in a transaction. This will then allow the patched `_build_csrf_report()` to include that stored stack trace in the CSRF incident log if a CSRF confirmation dialog is triggered.

![csrf_tracing_inactive](https://cloud.githubusercontent.com/assets/405124/9713980/2435f54c-5555-11e5-9ad3-7e2eddf1e800.png)


Those patches can also be reverted from this view: The respective methods will then be restored to their original state.

Additionally, there is a timeout after which the patches will expire, and remove themselves the next time they're called.

![csrf_tracing_active](https://cloud.githubusercontent.com/assets/405124/9713983/2cc701e2-5555-11e5-979b-45e5abdd4fc1.png)

Example stack trace that ends up in the `csrf-*.log`:

```pytb
================================================================================================
DB write to obj with OID 0x6050 from code in "opengever/debug/browser/trigger_csrf.py", line 17!
================================================================================================
  File "eggs/Zope2-2.13.21-py2.7.egg/ZServer/PubCore/ZServerPublisher.py", line 31, in __init__
    response=b)
  File "eggs/Zope2-2.13.21-py2.7.egg/ZPublisher/Publish.py", line 455, in publish_module
    environ, debug, request, response)
  File "eggs/Zope2-2.13.21-py2.7.egg/ZPublisher/Publish.py", line 249, in publish_module_standard
    response = publish(request, module_name, after_list, debug=debug)
  File "eggs/Zope2-2.13.21-py2.7.egg/ZPublisher/Publish.py", line 138, in publish
    request, bind=1)
  File "eggs/Zope2-2.13.21-py2.7.egg/ZPublisher/mapply.py", line 77, in mapply
    if debug is not None: return debug(object,args,context)
  File "eggs/Zope2-2.13.21-py2.7.egg/ZPublisher/Publish.py", line 48, in call_object
    result=apply(object,args) # Type s<cr> to step into published object.
  File "opengever/debug/browser/trigger_csrf.py", line 17, in __call__
    plone.some_fancy_attribute = True
```

Needs backport to `4.5-stable`

@deiferni 
