### PR TITLE
Remove expired locks before creating new locks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Remove expired locks before creating new locks to avoid integrity-errors
+  during database flushes.
+  [deiferni]
+
 - CSRF: Add view to enable and disable CSRF tracing monkey patches.
   [lgraf]
 

--- a/opengever/locking/lockable.py
+++ b/opengever/locking/lockable.py
@@ -50,14 +50,14 @@ class SQLLockable(object):
         If children is True, child objects will be locked as well.
         """
 
+        self.clear_expired_locks()
+
         lock = Lock(object_id=self.object_id,
                     object_type=self.object_type,
                     creator=api.user.get_current().getId(),
                     lock_type=self.searialize_lock_type(lock_type))
-
         self.session.add(lock)
 
-        self.clear_expired_locks()
 
     def refresh_lock(self, lock_type=STEALABLE_LOCK):
         if not self.locked():

--- a/opengever/locking/tests/test_lockable.py
+++ b/opengever/locking/tests/test_lockable.py
@@ -158,3 +158,15 @@ class TestSQLLockable(FunctionalTestCase):
         self.assertEquals(1, len(locks))
         self.assertNotIn(lock_1, locks)
         self.assertNotIn(lock_2, locks)
+
+    def test_lock_creation_removes_expired_locks_for_same_object(self):
+        expired_lock = create(
+            Builder('lock')
+            .of_obj(self.wrapper)
+            .having(time=utcnow_tz_aware() - timedelta(seconds=1000)))
+
+        ILockable(self.wrapper).lock()
+
+        locks = Lock.query.all()
+        self.assertEquals(1, len(locks))
+        self.assertNotIn(expired_lock, locks)


### PR DESCRIPTION
This avoids integrity-errors during database flushes when locking the
same object for which expired locks are cleaned.

Fixes #1212.