### PR TITLE
No longer allow reverting document versions while documents are checked out.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- No longer allow reverting document versions while documents are checked out.
+  [deiferni]
+
 - Remove expired locks before creating new locks to avoid integrity-errors
   during database flushes.
   [deiferni]


### PR DESCRIPTION
This PR no longer allows reverts while a document is checked out. This avoids nasty race-conditions where theoretically users could overwrite their files and lose content.
Also disable links to revert as follows:

![screen shot 2015-09-08 at 14 15 05](https://cloud.githubusercontent.com/assets/736583/9734533/0e5ceebc-5634-11e5-9be6-9c567034bd1c.png)


Closes #1204.

Needs backport to `4.5-stable`.