### PR TITLE
Add logging to the task SQL synchronisation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add logging to the task SQL synchronisation.
+  [phgross]
+
 - Also log object oids in csrf logs.
   [deiferni]
 


### PR DESCRIPTION
The logging should help to detect problems with incorrectly synched or not even registered tasks.

@lukasgraf 

Needs-Backport: `4.5-stable`