### PR TITLE
Make annotation initialisation plone.protect aware.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- CSRF: unprotect initializing annotations and sequence numbers.
+  [deiferni]
+
 - Fixed bug in retention_period:
   The RetentionPeriodValidator respect the is_restricted flag now.
   [phgross]

--- a/opengever/base/overrides.zcml
+++ b/opengever/base/overrides.zcml
@@ -29,4 +29,10 @@
       permission="zope.Public"
       />
 
+<adapter
+    for="zope.annotation.interfaces.IAttributeAnnotatable"
+    provides="zope.annotation.interfaces.IAnnotations"
+    factory=".protect.ProtectAwareAttributeAnnotations"
+    />
+
 </configure>

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -42,7 +42,6 @@ def unprotected_write(obj):
         unprotected_write(getattr(obj.obj, '__annotations__', None))
         return obj
 
-    LOG.debug('Disable CSRF protection for {}'.format(repr(obj)))
     _get_unprotected_objects().append(obj)
     return obj
 

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -1,3 +1,4 @@
+from BTrees.OOBTree import OOBTree
 from copy import copy
 from datetime import datetime
 from opengever.base.utils import PathFinder
@@ -232,3 +233,22 @@ class OGProtectTransform(ProtectTransform):
         # see webdav/Lockable.py:64
         if hasattr(context, '_dav_writelocks'):
             unprotected_write(context._dav_writelocks)
+
+
+class ProtectAwareAttributeAnnotations(AttributeAnnotations):
+    """Zope AttributeAnnotations lazily intializes annotations.
+
+    When annotations are initialized on an object we need to unprotect that
+    object.
+    """
+
+    def __setitem__(self, key, value):
+        try:
+            annotations = self.obj.__annotations__
+        except AttributeError:
+            # unprotect new annotations since they will be written
+            annotations = unprotected_write(OOBTree())
+            # unprotect obj for which we initialize annotations
+            unprotected_write(self.obj).__annotations__ = annotations
+
+        annotations[key] = value

--- a/opengever/base/sequence.py
+++ b/opengever/base/sequence.py
@@ -56,11 +56,11 @@ class DefaultSequenceNumberGenerator(grok.Adapter):
         ann = unprotected_write(IAnnotations(portal))
         if SEQUENCE_NUMBER_ANNOTATION_KEY not in ann.keys():
             ann[SEQUENCE_NUMBER_ANNOTATION_KEY] = unprotected_write(PersistentDict())
-        map = unprotected_write(ann.get(SEQUENCE_NUMBER_ANNOTATION_KEY))
-        if key not in map:
-            map[key] = Increaser(0)
+        mapping = unprotected_write(ann.get(SEQUENCE_NUMBER_ANNOTATION_KEY))
+        if key not in mapping:
+            mapping[key] = Increaser(0)
         # increase
-        inc = map[key]
+        inc = mapping[key]
         unprotected_write(inc).set(inc() + 1)
-        map[key] = inc
+        mapping[key] = inc
         return inc()

--- a/opengever/base/sequence.py
+++ b/opengever/base/sequence.py
@@ -56,11 +56,11 @@ class DefaultSequenceNumberGenerator(grok.Adapter):
         ann = unprotected_write(IAnnotations(portal))
         if SEQUENCE_NUMBER_ANNOTATION_KEY not in ann.keys():
             ann[SEQUENCE_NUMBER_ANNOTATION_KEY] = unprotected_write(PersistentDict())
-        map = ann.get(SEQUENCE_NUMBER_ANNOTATION_KEY)
+        map = unprotected_write(ann.get(SEQUENCE_NUMBER_ANNOTATION_KEY))
         if key not in map:
             map[key] = Increaser(0)
         # increase
         inc = map[key]
-        inc.set(inc() + 1)
+        unprotected_write(inc).set(inc() + 1)
         map[key] = inc
         return inc()

--- a/opengever/base/tests/test_protect.py
+++ b/opengever/base/tests/test_protect.py
@@ -1,0 +1,26 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+import transaction
+
+
+class TestProtect(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestProtect, self).setUp()
+        repo_root = create(Builder('repository_root'))
+        repo_folder = create(Builder('repository').within(repo_root))
+        self.dossier = create(Builder('dossier').within(repo_folder))
+        self.document = create(Builder('document').within(self.dossier))
+
+    @browsing
+    def test_initializes_annotations_without_csrf_confirmation(self, browser):
+        browser.login().open(self.document)
+        self.assertEquals(self.document.absolute_url(), browser.url)
+
+        del self.document.__annotations__
+        transaction.commit()
+
+        browser.login().open(self.document)
+        self.assertEquals(self.document.absolute_url(), browser.url)


### PR DESCRIPTION
With this PR initialising annotations in a GET request no longer displays a CSRF confirmation page.

Needs backport to `4.5-stable`.

Closes https://github.com/4teamwork/opengever.zug/issues/203.