### PR TITLE
Fix Upgrade-Step that updates lexicon: Affected indexes need to be cleared first

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fix Upgrade-Step that updates lexicon: The affected indexes need to be
+  cleared first before rebuilding them, otherwise the lexicon might not get
+  updated properly.
+  [lgraf]
+
 - Add logging to the task SQL synchronisation.
   [phgross]
 

--- a/opengever/policy/base/upgrades/to4504.py
+++ b/opengever/policy/base/upgrades/to4504.py
@@ -30,4 +30,7 @@ class ExecuteDelayedPloneUpgrade(UpgradeStep):
         catalog = api.portal.get_tool('portal_catalog')
         for index in catalog.Indexes.objectValues():
             if IZCTextIndex.providedBy(index):
-                self.catalog_rebuild_index(index.getId())
+                index_id = index.getId()
+                # Clear index first to make sure lexicon gets updated properly
+                catalog.manage_clearIndex([index_id])
+                self.catalog_rebuild_index(index_id)


### PR DESCRIPTION
Our deferred version of the upgrade step removed the `catalog.manage_clearIndex([index_id])` [that the `plone.app.upgrade` upgrade step does](https://github.com/plone/plone.app.upgrade/blob/741f9e5996f12dff31189a0abed917b22769056a/plone/app/upgrade/v43/alphas.py#L65).

This leads to cases where the Plone Lexicon used by the `ZCTextIndexes` isn't rebuilt correctly.

Needs-Backport: `4.5-stable`