### PR TITLE
Added NullResponseDescription fallback for responses without a transition.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add NullResponseDescription fallback for responses without a transition.
+  This makes the use of the ResponseDescriptions (ResponseViewlet etc.) more robust.
+  [phgross]
+
 - Fix duplicate activity recordings when a forwarding gets reassigned.
   [phgross]
 

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -33,9 +33,7 @@ class ResponseDescription(object):
         description = cls.registry.get(transition)
 
         if not description:
-            raise ValueError(
-                'No response description configured for'
-                'transition {}'.format(transition))
+            description = NullResponseDescription
 
         return description(response)
 
@@ -320,3 +318,17 @@ class DocumentAdded(ResponseDescription):
                  u'Document added to Task')
 
 ResponseDescription.add_description(DocumentAdded)
+
+
+class NullResponseDescription(ResponseDescription):
+    """Fallback description for responses without any transition information.
+    """
+
+    transition = None
+    css_class = 'null-transition'
+
+    def msg(self):
+        return ''
+
+    def label(self):
+        return ''

--- a/opengever/task/tests/test_response_descriptions.py
+++ b/opengever/task/tests/test_response_descriptions.py
@@ -2,8 +2,11 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.task.adapters import IResponseContainer
+from opengever.task.adapters import Response
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
+import transaction
 
 
 class TestResponseDescriptions(FunctionalTestCase):
@@ -265,6 +268,21 @@ class TestResponseDescriptions(FunctionalTestCase):
         self.assertEqual(
             u'Document [No Subject] added by M\xfcller Hans (test_user_1_)',
             self.get_latest_answer(browser))
+
+    @browsing
+    def test_null_fallback(self, browser):
+        # add null response
+        null_response = Response(None)
+        IResponseContainer(self.task).add(null_response)
+        transaction.commit()
+
+        browser.login()
+        self.visit_overview(browser)
+
+        self.assertEqual('answer null-transition',
+                         browser.css('div.answer')[0].get('class'))
+        self.assertEqual('', self.get_latest_answer(browser))
+
 
     # TODO:
     # - Test assigning forwarding to dossier


### PR DESCRIPTION
This makes the use of the ResponseDescriptions (`ResponseViewlet` etc.) more robust.
Although reponses without any transition information should not exists, it's the better option to add this fallback than remove any task history (responses).

Fixes https://errbit.4teamwork.ch/apps/524d6966383818361b00175b/problems/55ed2ad06d61743a31120000

Needs-backport: `4.5-stable`

@lukasgraf @deiferni 