### PR TITLE
CSRF tracing: Fix parameter name collision between actual and suggested timeout

### DIFF
--- a/opengever/debug/browser/manage_csrf_tracing.py
+++ b/opengever/debug/browser/manage_csrf_tracing.py
@@ -190,7 +190,7 @@ class ManageCSRFTracing(grok.View):
 
         # Allow for suggesting a timeout value via query string
         self._suggested_timeout = None
-        suggested_timeout = self.request.form.get('timeout')
+        suggested_timeout = self.request.form.get('suggested_timeout')
         if suggested_timeout is not None:
             self._suggested_timeout = int(suggested_timeout)
 


### PR DESCRIPTION
I mistakenly used the same name `timeout` for both the **actual** timeout to be set (when submitting the form via `POST`) and the **suggested** timeout (query string parameter when first calling the view, just influencing the form default).

Because the query string parameter stays in the URL, they both get submitted when the form is `POST`ed, leading to Zope parsing them as a list and

```pytb
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module opengever.debug.browser.manage_csrf_tracing, line 183, in __call__
TypeError: int() argument must be a string or a number, not 'list'
```

With this change, the view should then obviously be invoked as `@@manage-csrf-tracing?suggested_timeout=700`

*(No changelog entry because the feature currently doesn't work as advertised in the existing changelog)*

Should probably be backported to `4.5-stable`.