### PR TITLE
Let RetentionPeriodValidator respect the is_restricted flag now

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fixed bug in retention_period:
+  The RetentionPeriodValidator respect the is_restricted flag now.
+  [phgross]
+
 - Remove expired locks before creating new locks to avoid integrity-errors
   during database flushes.
   [deiferni]

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -105,15 +105,20 @@ def validate_children(folder, event):
     utils.overrides_child(folder, event, aq_fields, ILifeCycleMarker)
 
 
-# RETENTION PERIOD
-class IntLowerEqualThanParentValidator(validator.SimpleFieldValidator):
+class RetentionPeriodValidator(validator.SimpleFieldValidator):
+
+    def is_restricted(self):
+        return _is_retention_period_restricted()
 
     def validate(self, value):
-        super(IntLowerEqualThanParentValidator, self).validate(value)
+        super(RetentionPeriodValidator, self).validate(value)
 
         # should not be negative
         if int(value) < 0:
             raise schema.interfaces.TooSmall()
+
+        if not self.is_restricted():
+            return
 
         # get parent value
         #XXX CHANGED FROM PATH_TRANSLATED TO PATH_INFO because the test
@@ -146,7 +151,6 @@ class IntLowerEqualThanParentValidator(validator.SimpleFieldValidator):
             raise schema.interfaces.TooBig()
 
 
-# RETENTION PERIOD
 class IntGreaterEqualThanParentValidator(validator.SimpleFieldValidator):
 
     def validate(self, value):
@@ -203,7 +207,7 @@ def _get_retention_period_options(vocabulary):
     return options
 
 
-def _is_retention_period_restricted(vocabulary):
+def _is_retention_period_restricted(*args, **kwargs):
     registry = getUtility(IRegistry)
     retention_period_settings = registry.forInterface(IRetentionPeriodRegister)
     return retention_period_settings.is_restricted
@@ -271,11 +275,6 @@ form.default_value(field=ILifeCycle['custody_period'])(
         default=30,
     )
 )
-
-
-# Validator
-class RetentionPeriodValidator(IntLowerEqualThanParentValidator):
-    pass
 
 
 validator.WidgetValidatorDiscriminators(

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -105,52 +105,6 @@ def validate_children(folder, event):
     utils.overrides_child(folder, event, aq_fields, ILifeCycleMarker)
 
 
-class RetentionPeriodValidator(validator.SimpleFieldValidator):
-
-    def is_restricted(self):
-        return _is_retention_period_restricted()
-
-    def validate(self, value):
-        super(RetentionPeriodValidator, self).validate(value)
-
-        # should not be negative
-        if int(value) < 0:
-            raise schema.interfaces.TooSmall()
-
-        if not self.is_restricted():
-            return
-
-        # get parent value
-        #XXX CHANGED FROM PATH_TRANSLATED TO PATH_INFO because the test
-        # don't work
-        if '++add++' in self.request.get('PATH_INFO', object()):
-            obj = self.context
-        else:
-            obj = self.context.aq_inner.aq_parent
-
-        parent_value = -1
-        while parent_value < 0 and not ISiteRoot.providedBy(obj):
-            cf_obj = queryAdapter(obj, ILifeCycle)
-
-            if cf_obj:
-                try:
-                    parent_value = int(self.field.get(cf_obj))
-                except AttributeError:
-                    pass
-                except TypeError:
-                    parent_value = 0
-
-            try:
-                obj = obj.aq_inner.aq_parent
-
-            except AttributeError:
-                return
-
-        # should not be bigger than parent
-        if parent_value > - 1 and int(value) > parent_value:
-            raise schema.interfaces.TooBig()
-
-
 class IntGreaterEqualThanParentValidator(validator.SimpleFieldValidator):
 
     def validate(self, value):
@@ -275,6 +229,52 @@ form.default_value(field=ILifeCycle['custody_period'])(
         default=30,
     )
 )
+
+
+class RetentionPeriodValidator(validator.SimpleFieldValidator):
+
+    def is_restricted(self):
+        return _is_retention_period_restricted()
+
+    def validate(self, value):
+        super(RetentionPeriodValidator, self).validate(value)
+
+        # should not be negative
+        if int(value) < 0:
+            raise schema.interfaces.TooSmall()
+
+        if not self.is_restricted():
+            return
+
+        # get parent value
+        #XXX CHANGED FROM PATH_TRANSLATED TO PATH_INFO because the test
+        # don't work
+        if '++add++' in self.request.get('PATH_INFO', object()):
+            obj = self.context
+        else:
+            obj = self.context.aq_inner.aq_parent
+
+        parent_value = -1
+        while parent_value < 0 and not ISiteRoot.providedBy(obj):
+            cf_obj = queryAdapter(obj, ILifeCycle)
+
+            if cf_obj:
+                try:
+                    parent_value = int(self.field.get(cf_obj))
+                except AttributeError:
+                    pass
+                except TypeError:
+                    parent_value = 0
+
+            try:
+                obj = obj.aq_inner.aq_parent
+
+            except AttributeError:
+                return
+
+        # should not be bigger than parent
+        if parent_value > - 1 and int(value) > parent_value:
+            raise schema.interfaces.TooBig()
 
 
 validator.WidgetValidatorDiscriminators(


### PR DESCRIPTION
The `retention_period` flag was ignored by the RetentionPeriodValidator, this PR fixes #1175.

Because the super class `IntLowerEqualThanParentValidator` is only used by the RetentionPeriodValidator I've dropped the super class, so I can include the is_restricted check directly in the validator.

The complete functionality should be reworked and simplified, but that's not a bugfix thing :wink: 

@deiferni @lukasgraf 

Needs Backport: `4.5-stable`