### PR TITLE
Fix creating policies from template

### DIFF
--- a/opengever/base/pathfinder.py
+++ b/opengever/base/pathfinder.py
@@ -1,0 +1,39 @@
+from App.config import DefaultConfiguration
+import App.config
+import os
+
+
+class PathFinder(object):
+    """Helper class to provide various Zope2 Instance related paths that are
+    otherwise cumbersome to access.
+    """
+
+    def __init__(self):
+        self._assert_proper_configuration()
+        self._instance_home = os.environ['INSTANCE_HOME']
+        self._client_home = os.environ['CLIENT_HOME']
+
+    def _assert_proper_configuration(self):
+        cfg = App.config._config
+        if cfg is None or isinstance(cfg, DefaultConfiguration):
+            raise RuntimeError(
+                "Zope is not configured properly yet, refusing "
+                "operate on paths that might be wrong!")
+
+    @property
+    def var(self):
+        """Path to {buildout}/var
+        """
+        return os.path.normpath(os.path.join(self._client_home, '..'))
+
+    @property
+    def var_log(self):
+        """Path to {buildout}/var/log
+        """
+        return os.path.join(self.var, 'log')
+
+    @property
+    def buildout(self):
+        """Path to {buildout}
+        """
+        return os.path.normpath(os.path.join(self.var, '..'))

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -1,6 +1,6 @@
 from copy import copy
 from datetime import datetime
-from opengever.base.utils import PathFinder
+from opengever.base.pathfinder import PathFinder
 from plone import api
 from plone.portlets.constants import CONTEXT_ASSIGNMENT_KEY
 from plone.protect.auto import ProtectTransform

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -1,14 +1,11 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from App.config import DefaultConfiguration
-from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.interfaces import IDossierMarker
 from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from xml.sax.saxutils import escape
 from zope.component import getMultiAdapter
-import App.config
-import os
 
 
 def language_cache_key(method, context, request):
@@ -78,40 +75,7 @@ def get_preferred_language_code():
     return language_code.split('-')[0]
 
 
-class PathFinder(object):
-    """Helper class to provide various Zope2 Instance related paths that are
-    otherwise cumbersone to access.
-    """
 
-    def __init__(self):
-        self._assert_proper_configuration()
-        self._instance_home = os.environ['INSTANCE_HOME']
-        self._client_home = os.environ['CLIENT_HOME']
-
-    def _assert_proper_configuration(self):
-        cfg = App.config._config
-        if cfg is None or isinstance(cfg, DefaultConfiguration):
-            raise RuntimeError(
-                "Zope is not configured properly yet, refusing "
-                "operate on paths that might be wrong!")
-
-    @property
-    def var(self):
-        """Path to {buildout}/var
-        """
-        return os.path.normpath(os.path.join(self._client_home, '..'))
-
-    @property
-    def var_log(self):
-        """Path to {buildout}/var/log
-        """
-        return os.path.join(self.var, 'log')
-
-    @property
-    def buildout(self):
-        """Path to {buildout}
-        """
-        return os.path.normpath(os.path.join(self.var, '..'))
 
 
 def get_hostname(request):

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -2,7 +2,7 @@ from five import grok
 from ldap import NO_SUCH_OBJECT
 from logging.handlers import TimedRotatingFileHandler
 from opengever.base.model import create_session
-from opengever.base.utils import PathFinder
+from opengever.base.pathfinder import PathFinder
 from opengever.ogds.base.interfaces import ILDAPSearch
 from opengever.ogds.base.interfaces import IOGDSUpdater
 from opengever.ogds.base.sync.import_stamp import set_remote_import_stamp

--- a/opengever/policytemplates/cli.py
+++ b/opengever/policytemplates/cli.py
@@ -14,11 +14,8 @@ class CreatePolicyCLI(object):
         self.args = args
 
     def run(self):
-        options = self._parse_args()
-
+        options, remainder = self._parse_args()
         args = []
-        if options.verbose:
-            args.append('-v')
 
         target_dir = 'src/'
         args.append('-O')
@@ -27,22 +24,18 @@ class CreatePolicyCLI(object):
         template = 'opengever.policytemplates:policy_template'
         args.append(template)
 
+        if remainder:
+            args.extend(remainder)
+
         sys.exit(mrbob.cli.main(args=args))
 
     def _parse_args(self):
-        prog = sys.argv[0]
+        prog = self.args.pop(0)
 
         # Top level parser
         parser = argparse.ArgumentParser(prog=prog)
 
-        # Global arguments
-        parser.add_argument(
-            '-v',
-            '--verbose',
-            action='store_true',
-            help='Be very verbose.')
-
-        return parser.parse_args()
+        return parser.parse_known_args(args=self.args)
 
 
 def main():


### PR DESCRIPTION
There was an error with cyclic imports during policy creation. This PR fixes that issue by moving a class to its own module from which it can be imported separately.

It also changes the `create_client` script to always pass remaining arguments to the template engine (mr.bob).