### PR TITLE
Extend logging of task SQL synchronisation, with tasks modification date.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Extend logging of task SQL synchronisation, with tasks modification date.
+  [phgross]
+
 - CSRF: unprotect initializing annotations and sequence numbers.
   [deiferni]
 

--- a/opengever/globalindex/handlers/task.py
+++ b/opengever/globalindex/handlers/task.py
@@ -72,8 +72,11 @@ class TaskSqlSyncer(object):
 
         task = self.get_sql_task()
         task.sync_with(self.obj)
-        logger.info('Task {!r} has been successfully synchronized '
-                    'to globalindex ({!r}).'.format(self.obj, task))
+        logger.info('Task {!r} (modified:{}) has been successfully synchronized '
+                    'to globalindex ({!r}).'.format(
+                        self.obj,
+                        self.obj.modified().asdatetime().replace(tzinfo=None),
+                        task))
 
 
 def sync_task(obj, event):


### PR DESCRIPTION
So it's possible to ensure, that the plone object which was used for the synchronisation (see https://github.com/4teamwork/opengever.core/blob/master/opengever/globalindex/handlers/task.py#L82) was up-to-date.

@deiferni 