### PR TITLE
Prevent a silently ignored key error in our PAS IAuthenticationPlugin for internal requests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Prevent a silently ignored key error in our PAS IAuthenticationPlugin
+  for internal requests.
+  [lgraf]
+
 - Fixed get_parent_dossier getter for document inside a proposal.
   [phgross]
 

--- a/opengever/ogds/base/Extensions/plugins.py
+++ b/opengever/ogds/base/Extensions/plugins.py
@@ -27,7 +27,10 @@ def extract_user(self, request):
 
 # IAuthenticationPlugin.authenticateCredentials
 def authenticate_credentials(self, credentials):
-    uid = credentials['id']
+    uid = credentials.get('id')
+    if uid is None:
+        # Not one of our internal requests
+        return None
     login = credentials['login']
     auid = credentials['auid'].strip()
     ip = credentials['remote_address'].strip()


### PR DESCRIPTION
Our [PAS plugin for authenticating internal requests](https://github.com/4teamwork/opengever.core/blob/46cac2fc9a9d1ff0ee7a17d6646f825d7d4ab9be/opengever/ogds/base/Extensions/plugins.py#L28-L41) often causes a `KeyError` because the extracted credentials usually don't contain `id` for normal requests.

These errors are rarely seen because PAS usually swallows them silently, but they still should be avoided.