### PR TITLE
VersionsTab: Use getHistoryMetadata() instead of getHistory() for better performance

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- VersionsTab: Use getHistoryMetadata() instead of getHistory() to avoid
+  fetching the actual versioned objects and hence improve performance.
+  [lgraf]
+
 - Prevent a silently ignored key error in our PAS IAuthenticationPlugin
   for internal requests.
   [lgraf]


### PR DESCRIPTION
VersionsTab: Use `getHistoryMetadata()` instead of `getHistory()` to avoid fetching the actual versioned objects and hence improve performance.

Iterating over the `LazyHistory` returned by `getHistory()` will cause a `retrieve()` for every version iterated over, causing the entire versioned object to be constructed, and therefore results in poor performance.

This change instead uses `getHistoryMetadata()`, which returns a [`ShadowHistory`](https://github.com/plone/Products.CMFEditions/blob/16391ecc2b4905cd286e448143b259f985e451f4/Products/CMFEditions/ZVCStorageTool.py#L784-L947) instance. The APIs for using `LazyHistory` and `ShadowHistory` are entirely different (`ShadowHistory` doesn't support iteration), that's why it's not just a method call that needed to be changed.

IMHO needs a backport to `4.5-stable`

@phgross @deiferni 