### PR TITLE
Add linked commitees + repository-folders and meetings + dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,15 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Link committees to a repository folder and link meetings to meeting-dossiers:
+
+    - Add a new content-type, meeting-dossier.
+    - Link dossier and meeting creation, automatically create a meeting-dossier
+      when a meeting is created.
+    - Automatically generate Protocols into the meeting's dossier.
+
+  [deiferni]
+
 - Extend agenda items in protocol view with numbers.
   [Kevin Bieri]
 

--- a/opengever/base/browser/wizard/interfaces.py
+++ b/opengever/base/browser/wizard/interfaces.py
@@ -22,6 +22,14 @@ class IWizardDataStorage(Interface):
         key -- String key to identify the data set.
         """
 
+    def drop_data(key):
+        """Delete data set (dict) stored under `key` in the storage. If
+        there is no such data set, nothing happens.
+
+        Arguments:
+        key -- String key to identify the data set.
+        """
+
     def update(key, data):
         """Updates the data set stored under `key` with `data` (dict).
 

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -24,11 +24,11 @@ class WizardDataStorage(grok.GlobalUtility):
     def _get_user_storage(self):
         userid = getSecurityManager().getUser().getId()
         data = IAnnotations(getSite())
-        if ANNOTATIONS_KEY not in data.keys():
+        if ANNOTATIONS_KEY not in data:
             data[ANNOTATIONS_KEY] = OOBTree()
 
         storage = data[ANNOTATIONS_KEY]
-        if userid not in storage.keys():
+        if userid not in storage:
             storage.insert(userid, PersistentDict())
 
         return storage.get(userid)
@@ -45,7 +45,7 @@ class WizardDataStorage(grok.GlobalUtility):
         storage = self._get_user_storage()
         self._cleanup_user_storage(storage)
 
-        if key not in storage.keys():
+        if key not in storage:
             storage[key] = PersistentDict()
             storage[key]['__created'] = datetime.now()
 

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -65,6 +65,11 @@ class WizardDataStorage(grok.GlobalUtility):
         del data['__created']
         return data
 
+    def drop_data(self, key):
+        storage = self._get_user_storage()
+        if key in storage:
+            del storage[key]
+
     def update(self, key, data):
         self._get_data(key).update(data)
 

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -41,7 +41,7 @@ class WizardDataStorage(grok.GlobalUtility):
             if data.get('__created') < threshold:
                 del user_storage[key]
 
-    def get_data(self, key):
+    def _get_data(self, key):
         storage = self._get_user_storage()
         self._cleanup_user_storage(storage)
 
@@ -51,18 +51,31 @@ class WizardDataStorage(grok.GlobalUtility):
 
         return storage[key]
 
+    def get_data(self, key):
+        """Return a dict copy of our internal PersistentDict.
+
+        The copy is created to:
+        - avoid exposing the internal timestamp (could be set as attribute of
+          objects created from the data-dict)
+        - avoid passing a reference to our internal data to avoid accidental
+          modifications
+
+        """
+        data = dict(self._get_data(key))
+        del data['__created']
+        return data
+
     def update(self, key, data):
-        self.get_data(key).update(data)
+        self._get_data(key).update(data)
 
     def get(self, key, datakey, default=None):
-        return self.get_data(key).get(datakey, default)
+        return self._get_data(key).get(datakey, default)
 
     def set(self, key, datakey, value):
-        self.get_data(key)[datakey] = value
+        self._get_data(key)[datakey] = value
 
     def push_to_remote_client(self, key, admin_unit_id):
-        data = dict(self.get_data(key))
-        del data['__created']
+        data = self.get_data(key)
 
         req_data = {'data-set': json.dumps(data),
                     'key': key}

--- a/opengever/base/form.py
+++ b/opengever/base/form.py
@@ -1,0 +1,100 @@
+from five import grok
+from plone import api
+from plone.dexterity.i18n import MessageFactory as pd_mf
+from plone.z3cform.layout import FormWrapper
+from zope.component import queryMultiAdapter
+
+
+class WizzardWrappedAddForm(FormWrapper, grok.View):
+    grok.baseclass()
+    grok.require('cmf.AddPortalContent')
+
+    typename = None
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+        ttool = api.portal.get_tool('portal_types')
+        self.fti = ttool.getTypeInfo(self.typename)
+
+        FormWrapper.__init__(self, context, request)
+        grok.View.__init__(self, context, request)
+
+        # Set portal_type name on newly created form instance
+        if self.form_instance is not None and \
+                not getattr(self.form_instance, 'portal_type', None):
+            self.form_instance.portal_type = self.fti.getId()
+
+    @property
+    def form(self):
+        """
+        This form wraps another add form into the wizard. It is
+        important that the original add form is used, since there
+        may be custom things like hidden widgets in updateWidgets(). There
+        are also several ways how a dexterity add form can be customized.
+        Therefore we just get the original add form from the add-view and
+        wrap it with our wizard stuff. See _wrap_form.
+
+        """
+        if getattr(self, '_form', None) is not None:
+            return self._form
+
+        add_view = queryMultiAdapter((self.context, self.request, self.fti),
+                                     name=self.fti.factory)
+        if add_view is None:
+            add_view = queryMultiAdapter((self.context, self.request,
+                                          self.fti))
+
+        self._form = self._wrap_form(add_view.form)
+
+        return self._form
+
+    def _wrap_form(self, parent_form_class):
+        """
+        The original form is passed as `parent_form_class` here and is
+        "extended" with the wizard stuff (different template, passing of
+        values from earlier steps, step configuration etc.). This is done by
+        subclassing the original form and overwriting the buttons, since
+        we need to do our custom stuff.
+
+        """
+        steptitle = pd_mf(u'Add ${name}',
+                          mapping={'name': self.fti.Title()})
+
+        form_class = self._create_form_class(parent_form_class, steptitle)
+
+        form_class.__name__ = 'WizardForm: %s' % parent_form_class.__name__
+        return form_class
+
+    def _create_form_class(self, parent_form_class, steptitle):
+        """Create a custom form class here, e.g.:
+
+        class WrappedForm(BaseWizardStepForm, parent_form_class):
+            step_name = 'add-some-type'
+            step_title = steptitle
+            steps = the_stepd
+
+            @buttonAndHandler(pd_mf(u'Save'), name='save')
+            def handleAdd(self, action):
+                data, errors = self.extractData()
+                if errors:
+                    self.status = self.formErrorsMessage
+                    return
+
+                # crate content type here
+                # ...
+
+                return self.request.RESPONSE.redirect('somewhere')
+
+            @buttonAndHandler(pd_mf(u'Cancel'), name='cancel')
+            def handleCancel(self, action):
+                return self.request.RESPONSE.redirect('somewhere_else')
+
+        return WrappedForm
+
+        """
+        raise NotImplementedError()
+
+    def __call__(self):
+        return FormWrapper.__call__(self)

--- a/opengever/base/oguid.py
+++ b/opengever/base/oguid.py
@@ -1,6 +1,7 @@
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import ogds_service
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
-from opengever.ogds.base.utils import get_current_admin_unit
 
 
 class Oguid(object):
@@ -39,6 +40,24 @@ class Oguid(object):
     def __init__(self, admin_unit_id, int_id):
         self.admin_unit_id = admin_unit_id
         self.int_id = int(int_id) if int_id else None
+
+    def get_url(self):
+        """Return an url to the object represented by this Oguid.
+
+        Resolves the object and returns its absolute_url for objects on the
+        same admin-unit.
+        Returns an url to the resolve_oguid view for objects on foreign
+        admin-units.
+
+        """
+        obj = self.resolve_object()
+        if obj:
+            return obj.absolute_url()
+        admin_unit = ogds_service().fetch_admin_unit(self.admin_unit_id)
+
+        # XXX have some kind ouf routes to avoid cyclic dependecies
+        from opengever.base.browser.resolveoguid import ResolveOGUIDView
+        return ResolveOGUIDView.url_for(self, admin_unit=admin_unit)
 
     def resolve_object(self):
         if self.admin_unit_id != get_current_admin_unit().id():

--- a/opengever/base/tests/test_oguid.py
+++ b/opengever/base/tests/test_oguid.py
@@ -44,3 +44,14 @@ class TestOguidFunctional(FunctionalTestCase):
         oguid = Oguid.for_object(obj)
 
         self.assertEqual('client1:{}'.format(int_id), oguid)
+
+    def test_oguid_get_url_same_admin_unit(self):
+        obj = create(Builder('dossier'))
+        oguid = Oguid.for_object(obj)
+        self.assertEqual(obj.absolute_url(), oguid.get_url())
+
+    def test_oguid_url_different_admin_unit(self):
+        oguid = Oguid('foo', 1234)
+        self.assertEqual(
+            'http://example.com/@@resolve_oguid?oguid=foo:1234',
+            oguid.get_url())

--- a/opengever/base/tests/test_pathbar.py
+++ b/opengever/base/tests/test_pathbar.py
@@ -54,7 +54,8 @@ class TestPathBar(FunctionalTestCase):
         committee = create(Builder('committee').within(container))
         meeting = create(Builder('meeting')
                          .having(committee=committee.load_model(),
-                                 start=datetime(2010, 1, 1)))
+                                 start=datetime(2010, 1, 1))
+                         .link_with(self.dossier))
 
         browser.login().open(meeting.get_url())
         last_link = browser.css('#portal-breadcrumbs a')[-1]

--- a/opengever/base/tests/test_pathbar.py
+++ b/opengever/base/tests/test_pathbar.py
@@ -11,13 +11,15 @@ class TestPathBar(FunctionalTestCase):
         super(TestPathBar, self).setUp()
         self.admin_unit.public_url = 'http://nohost/plone'
 
-        root = create(Builder('repository_root').titled(u'Repository'))
-        repo = create(Builder('repository')
-                      .within(root)
-                      .titled(u'Testposition'))
+        self.root = create(Builder('repository_root').titled(u'Repository'))
+        self.repo = create(Builder('repository')
+                           .within(self.root)
+                           .titled(u'Testposition'))
         self.dossier = create(Builder('dossier')
-                              .within(repo)
+                              .within(self.repo)
                               .titled(u'Dossier 1'))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repo))
 
     @browsing
     def test_first_part_is_org_unit_title(self, browser):
@@ -55,7 +57,7 @@ class TestPathBar(FunctionalTestCase):
         meeting = create(Builder('meeting')
                          .having(committee=committee.load_model(),
                                  start=datetime(2010, 1, 1))
-                         .link_with(self.dossier))
+                         .link_with(self.meeting_dossier))
 
         browser.login().open(meeting.get_url())
         last_link = browser.css('#portal-breadcrumbs a')[-1]

--- a/opengever/base/tests/test_wizard_storage.py
+++ b/opengever/base/tests/test_wizard_storage.py
@@ -40,6 +40,14 @@ class TestAcceptTaskStorageManager(MockTestCase):
         data['foo'] = 'bar'
         self.assertEqual(manager._get_user_storage(), data)
 
+    def test_drop_data(self):
+        manager = storage.WizardDataStorage()
+        manager.get_data('somekey')
+        self.assertTrue('somekey' in manager._get_user_storage())
+
+        manager.drop_data('somekey')
+        self.assertFalse('somekey' in manager._get_user_storage())
+
     def test_get_user_storage_is_per_user(self):
         request = object()
 

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -7,6 +7,7 @@ from ftw.builder import create
 from ftw.builder import session
 from opengever.base.model import create_session
 from opengever.testing import builders  # keep!
+from plone import api
 from plone.portlets.constants import CONTEXT_CATEGORY
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletManager
@@ -65,6 +66,8 @@ class MeetingExampleContentCreator(object):
             'ordnungssystem/ressourcen-und-support/finanzen/planung/finanzplanung/dossier-6')
         self.dossier_equipment = self.site.restrictedTraverse(
             'ordnungssystem/ressourcen-und-support/finanzen/planung/investitionsplanung/dossier-7')
+        self.repository_folder_meeting = self.site.restrictedTraverse(
+            'ordnungssystem/fuehrung/gemeindeversammlung-gemeindeparlament-legislative/versammlungen-sitzungen')
 
         self.document_baumann_1 = self.dossier_baumann['document-2']
         self.document_baumann_2 = self.dossier_baumann['document-3']
@@ -106,25 +109,26 @@ class MeetingExampleContentCreator(object):
                            date_to=date.today() + timedelta(days=512)))
 
     def create_meetings(self):
-        self.meeting = create(Builder('meeting').having(
-            committee=self.committee_assembly_model,
-            location=u'Bern',
-            start=datetime.combine(date.today() + timedelta(days=1), time(10, 0)),
-            end=datetime.combine(date.today() + timedelta(days=1), time(12, 0))
-            )
-        )
+        self.dossier, self.meeting = self.create_meeting(delta=1)
 
         # create future meetings
         for delta in [30, 60, 90, 120]:
-            create(Builder('meeting').having(
-                committee=self.committee_assembly_model,
-                location=u'Bern',
-                start=datetime.combine(date.today() + timedelta(days=delta),
-                                       time(10, 0)),
-                end=datetime.combine(date.today() + timedelta(days=delta),
-                                     time(12, 0))
-                )
-            )
+            self.create_meeting(delta=delta)
+
+    def create_meeting(self, delta):
+        start = datetime.combine(date.today() + timedelta(days=delta), time(10, 0))
+        end = datetime.combine(date.today() + timedelta(days=delta), time(12, 0))
+        dossier = create(Builder('dossier')
+                         .having(title=u'Meeting {}'.format(
+                             api.portal.get_localized_time(start)),)
+                         .within(self.repository_folder_meeting))
+        meeting = create(Builder('meeting')
+                         .having(committee=self.committee_assembly_model,
+                                 location=u'Bern',
+                                 start=start,
+                                 end=end,)
+                         .link_with(dossier))
+        return dossier, meeting
 
     def create_proposals(self):
         proposal1 = create(

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -118,7 +118,7 @@ class MeetingExampleContentCreator(object):
     def create_meeting(self, delta):
         start = datetime.combine(date.today() + timedelta(days=delta), time(10, 0))
         end = datetime.combine(date.today() + timedelta(days=delta), time(12, 0))
-        dossier = create(Builder('dossier')
+        dossier = create(Builder('meeting_dossier')
                          .having(title=u'Meeting {}'.format(
                              api.portal.get_localized_time(start)),)
                          .within(self.repository_folder_meeting))

--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
@@ -10,17 +10,20 @@
             {
                 "_id": "committee-1",
                 "_type": "opengever.meeting.committee",
-                "title": "Kommission für Rechtsfragen"
+                "title": "Kommission für Rechtsfragen",
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/kommission-fuer-rechtsfragen"
             },
             {
                 "_id": "committee-2",
                 "_type": "opengever.meeting.committee",
-                "title": "Rechnungsprüfungskommission"
+                "title": "Rechnungsprüfungskommission",
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/rechnungspruefungskommission"
             },
             {
                 "_id": "committee-3",
                 "_type": "opengever.meeting.committee",
-                "title": "Gemeindeversammlung"
+                "title": "Gemeindeversammlung",
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/gemeindeversammlung-gemeindeparlament-legislative/versammlungen-sitzungen"
             }
 
         ]

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -6,7 +6,7 @@
   <browser:page
       for="opengever.meeting.committee.ICommittee"
       name="add-meeting"
-      class=".meeting.AddMeeting"
+      class=".meeting.AddMeetingWizardStepView"
       permission="zope2.View"
     />
 

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -8,7 +8,6 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
 from z3c.form.form import EditForm
 from z3c.form.interfaces import ActionExecutionError
-from z3c.form.interfaces import IDataConverter
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
 from zope.interface import Invalid
@@ -100,18 +99,19 @@ class GenerateExcerpt(AutoExtensibleForm, EditForm):
         self.model = self.context.model
         self._excerpt_data = None
 
-    def updateWidgets(self):
-        super(GenerateExcerpt, self).updateWidgets()
+    def update(self):
         self.inject_initial_data()
+        super(GenerateExcerpt, self).update()
 
     def inject_initial_data(self):
         if self.request.method != 'GET':
             return
 
         initial_filename = self.model.get_excerpt_title()
-        widget = self.widgets['title']
-        value = IDataConverter(widget).toWidgetValue(initial_filename)
-        widget.value = value
+        self.request['form.widgets.title'] = initial_filename
+
+        dossier = self.model.get_dossier()
+        self.request['form.widgets.dossier'] = ['/'.join(dossier.getPhysicalPath())]
 
     def get_agenda_items(self):
         for agenda_item in self.model.agenda_items:

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -152,7 +152,7 @@ class GenerateExcerpt(AutoExtensibleForm, EditForm):
 
     @button.buttonAndHandler(_('Cancel', default=u'Cancel'), name='cancel')
     def handleCancel(self, action):
-        return self.redirect_to_meetinglist()
+        return self.redirect_to_meeting()
 
     def redirect_to_meeting(self):
         return self.request.RESPONSE.redirect(self.model.get_url())

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -127,7 +127,7 @@ class AddMeetingDossierView(FormWrapper, grok.View):
     grok.name('add-meeting-dossier')
     grok.require('cmf.AddPortalContent')
 
-    typename = 'opengever.dossier.businesscasedossier'
+    typename = 'opengever.meeting.meetingdossier'
 
     def __init__(self, context, request):
         ttool = api.portal.get_tool('portal_types')

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -1,4 +1,9 @@
+from five import grok
 from opengever.base.browser.helper import get_css_class
+from opengever.base.browser.wizard import BaseWizardStepForm
+from opengever.base.browser.wizard.interfaces import IWizardDataStorage
+from opengever.base.model import create_session
+from opengever.base.oguid import Oguid
 from opengever.meeting import _
 from opengever.meeting.browser.meetings.agendaitem import DeleteAgendaItem
 from opengever.meeting.browser.meetings.agendaitem import ScheduleSubmittedProposal
@@ -7,15 +12,25 @@ from opengever.meeting.browser.meetings.agendaitem import UpdateAgendaItemOrder
 from opengever.meeting.browser.meetings.transitions import MeetingTransitionController
 from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.browser.protocol import UpdateProtocol
-from opengever.meeting.form import ModelAddForm
+from opengever.meeting.committee import ICommittee
 from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Meeting
+from opengever.repository.interfaces import IRepositoryFolder
+from plone import api
+from plone.dexterity.i18n import MessageFactory as pd_mf
 from plone.directives import form
+from plone.z3cform.layout import FormWrapper
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import field
+from z3c.form.button import buttonAndHandler
+from z3c.form.field import Fields
+from z3c.form.form import Form
 from z3c.form.interfaces import HIDDEN_MODE
 from zope import schema
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 
 
@@ -41,15 +56,52 @@ class IMeetingModel(form.Schema):
         required=False)
 
 
-class AddMeeting(ModelAddForm):
+ADD_MEETING_STEPS = (
+    ('add-meeting', _(u'Add Meeting')),
+    ('add-meeting-dossier', _(u'Add Dossier for Meeting'))
+)
 
-    schema = IMeetingModel
-    model_class = Meeting
 
+def get_dm_key(committee_oguid=None):
+    """Return the key used to store meeting-data in the wizard-storage."""
+
+    committee_oguid = committee_oguid or get_committee_oguid()
+    return 'create_meeting:{}'.format(committee_oguid)
+
+
+def get_committee_oguid():
+    return Oguid.parse(getRequest().get('committee-oguid'))
+
+
+class AddMeetingWizardStep(BaseWizardStepForm, Form):
+    step_name = 'add-meeting'
     label = _('Add Meeting', default=u'Add Meeting')
+    steps = ADD_MEETING_STEPS
+
+    fields = Fields(IMeetingModel)
+
+    @buttonAndHandler(_(u'button_continue', default=u'Continue'), name='save')
+    def handle_continue(self, action):
+        data, errors = self.extractData()
+        if errors:
+            return
+
+        committee_oguid = Oguid.for_object(self.context)
+
+        dm = getUtility(IWizardDataStorage)
+        dm.update(get_dm_key(committee_oguid), data)
+
+        repository_folder = self.context.repository_folder.to_object
+        return self.request.RESPONSE.redirect(
+            '{}/add-meeting-dossier?committee-oguid={}'.format(
+                repository_folder.absolute_url(), committee_oguid))
+
+    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
 
     def updateWidgets(self):
-        super(AddMeeting, self).updateWidgets()
+        super(AddMeetingWizardStep, self).updateWidgets()
 
         committee_id = self.context.load_model().committee_id
         self.widgets['committee'].mode = HIDDEN_MODE
@@ -57,6 +109,142 @@ class AddMeeting(ModelAddForm):
 
     def nextURL(self):
         return self._created_object.get_url()
+
+
+class AddMeetingWizardStepView(FormWrapper, grok.View):
+    grok.context(ICommittee)
+    grok.name('add-meeting')
+    grok.require('zope2.View')
+    form = AddMeetingWizardStep
+
+    def __init__(self, *args, **kwargs):
+         FormWrapper.__init__(self, *args, **kwargs)
+         grok.View.__init__(self, *args, **kwargs)
+
+
+class AddMeetingDossierView(FormWrapper, grok.View):
+    grok.context(IRepositoryFolder)
+    grok.name('add-meeting-dossier')
+    grok.require('cmf.AddPortalContent')
+
+    typename = 'opengever.dossier.businesscasedossier'
+
+    def __init__(self, context, request):
+        ttool = api.portal.get_tool('portal_types')
+        self.ti = ttool.getTypeInfo(self.typename)
+
+        FormWrapper.__init__(self, context, request)
+        grok.View.__init__(self, context, request)
+
+        # Set portal_type name on newly created form instance
+        if self.form_instance is not None and \
+                not getattr(self.form_instance, 'portal_type', None):
+            self.form_instance.portal_type = self.ti.getId()
+
+    @property
+    def form(self):
+        # This form wraps the dossier add form into the wizard. It is
+        # important that the original dossier add form is used, since there
+        # may be custom things like hidden widgets in updateWidgets(). There
+        # are also several ways how a dexterity add form can be customized.
+        # Therefor we just get the original add form from the add-view and
+        # wrap it with our wizard stuff. See _wrap_form()
+
+        if getattr(self, '_form', None) is not None:
+            return self._form
+
+        add_view = queryMultiAdapter((self.context, self.request, self.ti),
+                                     name=self.ti.factory)
+        if add_view is None:
+            add_view = queryMultiAdapter((self.context, self.request,
+                                          self.ti))
+
+        self._form = self._wrap_form(add_view.form)
+
+        return self._form
+
+    def _wrap_form(self, formclass):
+        # The original form is passed as `formclass` here and is "extended"
+        # with the wizard stuff (different template, passing of values from
+        # earlier steps, step configuration etc.). This is done by
+        # subclassing the original form and overwriting the buttons, since
+        # we need to do our custom stuff instead of the default dossier
+        # creation.
+
+        steptitle = pd_mf(u'Add ${name}',
+                          mapping={'name': self.ti.Title()})
+
+        class WrappedForm(BaseWizardStepForm, formclass):
+            step_name = 'add-meeting-dossier'
+            step_title = steptitle
+            steps = ADD_MEETING_STEPS
+            label = _(u'Add Dossier for Meeting')
+
+            passed_data = ['committee-oguid']
+
+            @buttonAndHandler(pd_mf(u'Save'), name='save')
+            def handleAdd(self, action):
+                # create the dossier
+                data, errors = self.extractData()
+                if errors:
+                    self.status = self.formErrorsMessage
+                    return
+
+                self.create_meeting_dossier(data)
+                meeting = self.create_meeting(get_committee_oguid())
+
+                api.portal.show_message(
+                    u"The meeting and its dossier were created successfully",
+                    request=self.request,
+                    type="info")
+
+                return self.request.RESPONSE.redirect(meeting.get_url())
+
+            @buttonAndHandler(pd_mf(u'Cancel'), name='cancel')
+            def handleCancel(self, action):
+                committee_oguid = get_committee_oguid()
+
+                dm = getUtility(IWizardDataStorage)
+                dm.drop_data(get_dm_key(committee_oguid))
+
+                committee = committee_oguid.resolve_object()
+                return self.request.RESPONSE.redirect(committee.absolute_url())
+
+            def create_meeting_dossier(self, data):
+                obj = self.createAndAdd(data)
+                if obj is not None:
+                    # mark only as finished if we get the new object
+                    self._finishedAdd = True
+                return obj
+
+            def create_meeting(self, committee_oguid):
+                dm = getUtility(IWizardDataStorage)
+                data = dm.get_data(get_dm_key())
+
+                meeting = Meeting(**data)
+                session = create_session()
+                session.add(meeting)
+                session.flush()  # required to create an autoincremented id
+
+                dm.drop_data(get_dm_key())
+                return meeting
+
+        WrappedForm.__name__ = 'WizardForm: %s' % formclass.__name__
+        return WrappedForm
+
+    def __call__(self):
+        title_key = 'form.widgets.IOpenGeverBase.title'
+
+        if title_key not in self.request.form:
+            dm = getUtility(IWizardDataStorage)
+            data = dm.get_data(get_dm_key())
+
+            start_date = api.portal.get_localized_time(datetime=data['start'])
+            default_title = _(u'Meeting on ${date}',
+                              mapping={'date': start_date})
+            self.request.set(title_key, default_title)
+
+        return FormWrapper.__call__(self)
 
 
 class EditMeeting(ModelEditForm):

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -190,8 +190,8 @@ class AddMeetingDossierView(FormWrapper, grok.View):
                     self.status = self.formErrorsMessage
                     return
 
-                self.create_meeting_dossier(data)
-                meeting = self.create_meeting(get_committee_oguid())
+                dossier = self.create_meeting_dossier(data)
+                meeting = self.create_meeting(dossier, get_committee_oguid())
 
                 api.portal.show_message(
                     u"The meeting and its dossier were created successfully",
@@ -217,10 +217,11 @@ class AddMeetingDossierView(FormWrapper, grok.View):
                     self._finishedAdd = True
                 return obj
 
-            def create_meeting(self, committee_oguid):
+            def create_meeting(self, dossier, committee_oguid):
                 dm = getUtility(IWizardDataStorage)
                 data = dm.get_data(get_dm_key())
 
+                data['dossier_oguid'] = Oguid.for_object(dossier)
                 meeting = Meeting(**data)
                 session = create_session()
                 session.add(meeting)

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -150,7 +150,7 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
                 meeting = self.create_meeting(dossier, get_committee_oguid())
 
                 api.portal.show_message(
-                    u"The meeting and its dossier were created successfully",
+                    _(u"The meeting and its dossier were created successfully"),
                     request=self.request,
                     type="info")
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -265,7 +265,7 @@ class MeetingView(BrowserView):
 
     def url_generate_protocol(self):
         if not self.model.has_protocol_document():
-            return GenerateProtocol.url_for(self.context, self.model)
+            return GenerateProtocol.url_for(self.model)
         else:
             return UpdateProtocol.url_for(self.model.protocol_document)
 

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -57,6 +57,12 @@
             <metal:use use-macro="context/@@meeting-macros/workflow_actions" />
           </fieldset>
 
+          <fieldset class="dossier">
+            <legend i18n:translate="">Meeting Dossier</legend>
+            <a tal:attributes="href meeting/get_dossier_url"
+               tal:content="python: meeting.get_dossier().title"></a>
+          </fieldset>
+
           <fieldset class="protocol" tal:define="protocol_document view/get_protocol_document">
             <legend i18n:translate="">Protocol</legend>
             <a tal:condition="protocol_document"

--- a/opengever/meeting/browser/protocol.py
+++ b/opengever/meeting/browser/protocol.py
@@ -2,18 +2,17 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from five import grok
 from opengever.document.document import IDocumentSchema
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting import _
 from opengever.meeting.command import CreateGeneratedDocumentCommand
 from opengever.meeting.command import ProtocolOperations
 from opengever.meeting.command import ReplaceGeneratedDocumentCommand
 from opengever.meeting.command import UpdateGeneratedDocumentCommand
+from opengever.meeting.interfaces import IMeetingDossier
 from opengever.meeting.model import GeneratedProtocol
 from opengever.meeting.model import Meeting
-from opengever.meeting.sources import all_open_dossiers_source
-from opengever.repository.repositoryroot import IRepositoryRoot
 from plone.directives import form
 from plone.directives.form import Schema
+from plone.protect.utils import addTokenToUrl
 from plone.z3cform.layout import FormWrapper
 from z3c.form.browser.radio import RadioFieldWidget
 from z3c.form.button import buttonAndHandler
@@ -21,7 +20,6 @@ from z3c.form.field import Fields
 from z3c.form.form import Form
 from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import INPUT_MODE
-from z3c.relationfield.schema import RelationChoice
 from zExceptions import NotFound
 from zope import schema
 from zope.schema.interfaces import IContextSourceBinder
@@ -29,81 +27,40 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 
-class IChooseDossierSchema(Schema):
-
-    dossier = RelationChoice(
-        title=_(u'label_accept_select_dossier',
-                default=u'Target dossier'),
-        description=_(u'help_accept_select_dossier',
-                      default=u'Select the target dossier where the '
-                               'pre-protocol should be created.'),
-        required=True,
-        source=all_open_dossiers_source)
-
-    # hidden field
-    meeting_id = schema.Int(required=True)
-
-
-class ChooseProtocolDossierForm(Form):
-    fields = Fields(IChooseDossierSchema)
-    ignoreContext = True
-    label = _(u'form_label_generate_protocol',
-              default=u'Generate protocol')
+class GenerateProtocol(grok.View):
+    grok.context(IMeetingDossier)
+    grok.name('generate_protocol')
+    grok.require('cmf.AddPortalContent')
 
     operations = ProtocolOperations()
 
-    def updateWidgets(self):
-        super(ChooseProtocolDossierForm, self).updateWidgets()
+    @classmethod
+    def url_for(cls, meeting):
+        dossier = meeting.get_dossier()
+        url = '{}/@@generate_protocol?meeting-id={}'.format(
+            dossier.absolute_url(), meeting.meeting_id)
+        return addTokenToUrl(url)
 
-        self.widgets['meeting_id'].mode = HIDDEN_MODE
-        if not self.widgets['meeting_id'].value:
-            initial_value = self.request.get('meeting_id', None)
-            self.widgets['meeting_id'].value = initial_value
+    def get_meeting(self):
+        meeting_id = self.request.get('meeting-id')
+        if not meeting_id:
+            raise NotFound
 
-    @buttonAndHandler(_(u'button_generate', default=u'Generate'), name='save')
-    def handle_generate(self, action):
-        data, errors = self.extractData()
-        if not errors:
-            dossier = data['dossier']
-            meeting = Meeting.get(data['meeting_id'])
+        meeting = Meeting.get(meeting_id)
+        if not meeting:
+            raise NotFound
 
-            if not meeting:
-                raise NotFound
-            # XXX permission checks on meeting?
+        return meeting
 
-            command = CreateGeneratedDocumentCommand(
-                dossier, meeting, self.operations)
-            document = command.execute()
-            command.show_message()
-            return self.request.RESPONSE.redirect(document.absolute_url())
+    def render(self):
+        meeting = self.get_meeting()
 
-    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'), name='cancel')
-    def handle_cancel(self, action):
-        data, errors = self.extractData()
-        meeting = Meeting.get(data['meeting_id'])
-        assert meeting, 'invalid form state, missing meeting'
+        command = CreateGeneratedDocumentCommand(
+            self.context, meeting, self.operations)
+        command.execute()
+        command.show_message()
 
         return self.request.RESPONSE.redirect(meeting.get_url())
-
-
-class GenerateProtocol(FormWrapper, grok.View):
-    grok.context(IRepositoryRoot)
-    grok.name('generate_protocol')
-    grok.require('zope2.View')
-
-    form = ChooseProtocolDossierForm
-
-    def __init__(self, *args, **kwargs):
-        FormWrapper.__init__(self, *args, **kwargs)
-        grok.View.__init__(self, *args, **kwargs)
-
-    @classmethod
-    def url_for(cls, context, meeting):
-        root = context.restrictedTraverse(
-            '@@primary_repository_root').get_primary_repository_root()
-
-        return '{}/@@generate_protocol?meeting_id={}'.format(
-            root.absolute_url(), meeting.meeting_id)
 
 
 METHOD_NEW_VERSION = u'new_document_version'
@@ -114,8 +71,8 @@ METHOD_NEW_DOCUMENT = u'new_document'
 def method_vocabulary_factory(document):
     assert IDocumentSchema.providedBy(document), 'context is not a document'
     dossier = aq_parent(aq_inner(document))
-    assert IDossierMarker.providedBy(dossier), ('currently only documents in '
-                                                'dossiers are supported')
+    assert IMeetingDossier.providedBy(dossier), (
+        'currently only documents in meeting-dossiers are supported')
 
     return SimpleVocabulary([
         SimpleTerm(

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -81,10 +81,9 @@ class Committee(ModelContainer):
         committee_model = self.load_model()
         return meeting_service().get_submitted_proposals(committee_model)
 
-    def get_model_create_arguments(self, context):
+    def update_model_create_arguments(self, data, context):
         aq_wrapped_self = self.__of__(context)
-
-        return dict(physical_path=aq_wrapped_self.get_physical_path())
+        data['physical_path'] = aq_wrapped_self.get_physical_path()
 
     def get_physical_path(self):
         url_tool = api.portal.get_tool(name='portal_url')

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -7,6 +7,7 @@ from opengever.meeting.model import Committee as CommitteeModel
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Membership
 from opengever.meeting.service import meeting_service
+from opengever.meeting.sources import repository_folder_source
 from opengever.meeting.sources import sablon_template_source
 from plone import api
 from plone.directives import form
@@ -30,6 +31,15 @@ class ICommittee(form.Schema):
         source=sablon_template_source,
         required=False,
     )
+
+    repository_folder = RelationChoice(
+        title=_(u'Linked repository folder'),
+        description=_(
+            u'label_linked_repository_folder',
+            default=u'Contains automatically generated dossiers and documents '
+                    u'for this committee.'),
+        source=repository_folder_source,
+        required=True)
 
 
 class ICommitteeModel(Interface):

--- a/opengever/meeting/container.py
+++ b/opengever/meeting/container.py
@@ -47,7 +47,7 @@ class ModelContainer(Container):
         # some plone-integration relies on acquisition, thus we need to wrap
         # the just created plone content now.
         aq_wrapped_self = self.__of__(context)
-        data.update(self.get_model_create_arguments(context))
+        self.update_model_create_arguments(data, context)
         model_instance = self.model_class(oguid=oguid, **data)
         session.add(model_instance)
         self._after_model_created(model_instance)
@@ -74,5 +74,5 @@ class ModelContainer(Container):
         notify(ObjectModifiedEvent(self))
         return True
 
-    def get_model_create_arguments(self, context):
-        return {}
+    def update_model_create_arguments(self, data, context):
+        return data

--- a/opengever/meeting/dossier.py
+++ b/opengever/meeting/dossier.py
@@ -1,0 +1,5 @@
+from opengever.dossier.base import DossierContainer
+
+
+class MeetingDossier(DossierContainer):
+    pass

--- a/opengever/meeting/dossier.py
+++ b/opengever/meeting/dossier.py
@@ -1,5 +1,11 @@
+from five import grok
 from opengever.dossier.base import DossierContainer
+from opengever.dossier.behaviors.dossier import AddForm
 
 
 class MeetingDossier(DossierContainer):
     pass
+
+
+class MeetingDossierAddForm(AddForm):
+    grok.name('opengever.meeting.meetingdossier')

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -1,5 +1,6 @@
 from zope import schema
 from zope.interface import Interface
+from plone.directives import form
 
 
 class IMeetingSettings(Interface):
@@ -12,3 +13,7 @@ class IMeetingSettings(Interface):
 
 class IMeetingWrapper(Interface):
     """Marker interface for meeting object wrappers."""
+
+
+class IMeetingDossier(form.Schema):
+    """Marker interface for MeetingDossier"""

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-30 15:13+0000\n"
+"POT-Creation-Date: 2015-10-12 10:07+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,12 +21,16 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:97
 msgid "Add Agenda Item"
 msgstr "Traktandum hinzufügen"
 
+#: ./opengever/meeting/browser/meetings/meeting.py:62
+msgid "Add Dossier for Meeting"
+msgstr "Sitzungsdossier hinzufügen"
+
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:61
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
@@ -44,16 +48,16 @@ msgstr "Mitgliedschaft hinzufügen"
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:123
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:129
 msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:177
+#: ./opengever/meeting/browser/meetings/meeting.py:294
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:136
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:142
 msgid "Attachements"
 msgstr "Anhänge"
 
@@ -66,9 +70,9 @@ msgid "Can't change membership, it overlaps an existing membership from ${date_f
 msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis zum ${date_to} überschneidet."
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:159
-#: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/form.py:50
+#: ./opengever/meeting/browser/meetings/excerpt.py:153
+#: ./opengever/meeting/browser/meetings/protocol.py:175
+#: ./opengever/meeting/form.py:51
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -84,15 +88,15 @@ msgstr "Kommission"
 msgid "Committee Container"
 msgstr "Ordner mit Kommissionen"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:54
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:57
 msgid "Considerations"
 msgstr "Erwägungen"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:75
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:78
 msgid "Decision"
 msgstr "Beschluss"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:65
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
 msgid "Discussion"
 msgstr "Diskussion"
 
@@ -100,11 +104,11 @@ msgstr "Diskussion"
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
 msgid "Download preview"
 msgstr "Vorschau herunterladen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:72
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -116,12 +120,12 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:28
+#: ./opengever/meeting/committee.py:30
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:79
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -129,15 +133,15 @@ msgstr "Protokollauszüge"
 msgid "Export settings"
 msgstr "Export-Einstellungen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
 msgid "Generate"
 msgstr "Generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
 msgid "Generate excerpt"
 msgstr "Protokollauszug generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:152
 msgid "Generated proposal excerpt"
 msgstr "Generierter Protokollauszug"
 
@@ -145,49 +149,63 @@ msgstr "Generierter Protokollauszug"
 msgid "History"
 msgstr "Verlauf"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:46
+#: ./opengever/meeting/browser/meetings/excerpt.py:44
 msgid "Include considerations"
 msgstr "Überlegungen einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:70
+#: ./opengever/meeting/browser/meetings/excerpt.py:68
 msgid "Include copy for attention"
 msgstr "Kopie z.K. einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:58
+#: ./opengever/meeting/browser/meetings/excerpt.py:56
 msgid "Include decision"
 msgstr "Entscheid einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:66
+#: ./opengever/meeting/browser/meetings/excerpt.py:64
 msgid "Include disclose to"
 msgstr "Zu eröffnen an einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:54
+#: ./opengever/meeting/browser/meetings/excerpt.py:52
 msgid "Include discussion"
 msgstr "Diskussion einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:38
+#: ./opengever/meeting/browser/meetings/excerpt.py:36
 msgid "Include initial position"
 msgstr "Ausgangslage einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:42
+#: ./opengever/meeting/browser/meetings/excerpt.py:40
 msgid "Include legal basis"
 msgstr "Rechtsgrundlage einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:50
+#: ./opengever/meeting/browser/meetings/excerpt.py:48
 msgid "Include proposed action"
 msgstr "Antrag einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:62
+#: ./opengever/meeting/browser/meetings/excerpt.py:60
 msgid "Include publish in"
 msgstr "Veröffentlichung im einfügen"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:34
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:37
 msgid "Initial position"
 msgstr "Ausgangslage"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:24
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:27
 msgid "Legal basis"
 msgstr "Rechtsgrundlage"
+
+#: ./opengever/meeting/committee.py:36
+msgid "Linked repository folder"
+msgstr "Ablageposition"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:61
+#: ./opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
+#: ./opengever/meeting/upgrades/profiles/4604/types/opengever.meeting.meetingdossier.xml
+msgid "Meeting Dossier"
+msgstr "Sitzungsdossier"
+
+#: ./opengever/meeting/browser/meetings/meeting.py:199
+msgid "Meeting on ${date}"
+msgstr "Sitzung vom ${date}"
 
 #: ./opengever/meeting/browser/templates/member.pt:41
 msgid "Memberships"
@@ -197,11 +215,11 @@ msgstr "Mitgliedschaften"
 msgid "Metadata"
 msgstr "Metadaten"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:140
+#: ./opengever/meeting/browser/meetings/excerpt.py:134
 msgid "Please select at least one agenda item."
 msgstr "Bitte wählen Sie mindestens ein Traktandum aus."
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:87
+#: ./opengever/meeting/browser/meetings/excerpt.py:85
 msgid "Please select at least one field for the excerpt."
 msgstr "Bitte wählen Sie mindestens einen Feld für den Protokollauszug aus."
 
@@ -215,16 +233,16 @@ msgstr "Eigenschaften"
 msgid "Proposal"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:44
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:47
 msgid "Proposed action"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:61
-#: ./opengever/meeting/model/meeting.py:140
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+#: ./opengever/meeting/model/meeting.py:146
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:143
+#: ./opengever/meeting/model/meeting.py:149
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
@@ -236,7 +254,7 @@ msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:22
+#: ./opengever/meeting/committee.py:24
 #: ./opengever/meeting/committeecontainer.py:13
 msgid "Protocol template"
 msgstr "Vorlage Protokoll"
@@ -247,8 +265,8 @@ msgid "Sablon Template"
 msgstr "Sablon Vorlage"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:127
-#: ./opengever/meeting/browser/meetings/protocol.py:126
+#: ./opengever/meeting/browser/meetings/excerpt.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:164
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Speichern"
@@ -261,6 +279,10 @@ msgstr "Mehr anzeigen"
 msgid "Submitted Proposal"
 msgstr "Eingereichter Antrag"
 
+#: ./opengever/meeting/browser/meetings/meeting.py:153
+msgid "The meeting and its dossier were created successfully"
+msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
+
 #: ./opengever/meeting/browser/submitdocuments.py:179
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
@@ -270,27 +292,32 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:129
+#: ./opengever/meeting/browser/meetings/agendaitem.py:121
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:122
 msgid "as free-text"
 msgstr "Als Traktandum"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:114
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
 msgid "as paragraph"
 msgstr "Als Abschnitt"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/documents/submit.py:94
-#: ./opengever/meeting/browser/protocol.py:80
-#: ./opengever/meeting/browser/submitdocuments.py:81
+#: ./opengever/meeting/browser/meetings/meeting.py:100
+#: ./opengever/meeting/browser/protocol.py:153
 msgid "button_cancel"
 msgstr "Abbrechen"
 
+#. Default: "Continue"
+#: ./opengever/meeting/browser/meetings/meeting.py:84
+msgid "button_continue"
+msgstr "Weiter"
+
 #. Default: "Generate"
-#: ./opengever/meeting/browser/protocol.py:63
+#: ./opengever/meeting/browser/protocol.py:127
 msgid "button_generate"
 msgstr "Erstellen"
 
@@ -305,12 +332,12 @@ msgid "button_submit_documents"
 msgstr "Dokumente einreichen"
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:73
+#: ./opengever/meeting/model/meeting.py:74
 msgid "close"
 msgstr "Schliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/meeting.py:64
 msgid "closed"
 msgstr "geschlossen"
 
@@ -320,7 +347,7 @@ msgid "column_comittee"
 msgstr "Kommission"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:30
+#: ./opengever/meeting/tabs/meetinglisting.py:43
 msgid "column_date"
 msgstr "Datum"
 
@@ -345,7 +372,7 @@ msgid "column_firstname"
 msgstr "Vorname"
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:34
+#: ./opengever/meeting/tabs/meetinglisting.py:47
 msgid "column_from"
 msgstr "Bis"
 
@@ -360,7 +387,7 @@ msgid "column_lastname"
 msgstr "Nachname"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:27
+#: ./opengever/meeting/tabs/meetinglisting.py:40
 msgid "column_location"
 msgstr "Standort"
 
@@ -386,92 +413,82 @@ msgstr "Status"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:23
+#: ./opengever/meeting/tabs/meetinglisting.py:36
 #: ./opengever/meeting/tabs/proposallisting.py:33
 msgid "column_title"
 msgstr "Titel"
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:39
+#: ./opengever/meeting/tabs/meetinglisting.py:52
 msgid "column_to"
 msgstr "Von"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:116
+#: ./opengever/meeting/model/proposal.py:115
 msgid "decide"
 msgstr "Beschliessen"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:101
+#: ./opengever/meeting/model/proposal.py:100
 msgid "decided"
 msgstr "Beschlossen"
 
-#. Default: "Generate protocol"
-#: ./opengever/meeting/browser/protocol.py:50
-msgid "form_label_generate_protocol"
-msgstr "Protokoll erstellen"
+#. Default: "Dossier"
+#: ./opengever/meeting/tabs/meetinglisting.py:57
+msgid "dossier"
+msgstr ""
 
 #. Default: "Update protocol"
-#: ./opengever/meeting/browser/protocol.py:156
+#: ./opengever/meeting/browser/protocol.py:114
 msgid "form_label_update_protocol"
 msgstr "Protokoll aktualisieren"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/meeting.py:63
 msgid "held"
 msgstr "Durchgeführt"
 
-#. Default: "Select the target dossier where the pre-protocol should be created."
-#: ./opengever/meeting/browser/protocol.py:37
-msgid "help_accept_select_dossier"
-msgstr "Wählen Sie das Dossier aus, in welchem das Protokoll abgelegt werden soll."
-
-#: ./opengever/meeting/proposal.py:98
+#: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:86
+#: ./opengever/meeting/proposal.py:96
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:92
+#: ./opengever/meeting/proposal.py:102
 msgid "help_proposed_action"
 msgstr ""
 
 #. Default: "Select the target dossier where the excerpts should be created."
-#: ./opengever/meeting/browser/meetings/excerpt.py:26
+#: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt werden soll."
 
-#: ./opengever/meeting/proposal.py:74
+#: ./opengever/meeting/proposal.py:84
 msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:71
+#: ./opengever/meeting/model/meeting.py:72
 msgid "hold meeting"
 msgstr "Sitzung durchführen"
 
-#. Default: "Target dossier"
-#: ./opengever/meeting/browser/protocol.py:35
-msgid "label_accept_select_dossier"
-msgstr "Zieldossier"
-
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:34
+#: ./opengever/meeting/browser/meetings/meeting.py:42
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:34
+#: ./opengever/meeting/proposal.py:44
 msgid "label_committee"
 msgstr "Kommission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/proposal.py:97
+#: ./opengever/meeting/proposal.py:107
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:105
-#: ./opengever/meeting/proposal.py:64
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:108
+#: ./opengever/meeting/proposal.py:74
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
@@ -493,20 +510,20 @@ msgid "label_date_to"
 msgstr "Bis"
 
 #. Default: "Decision"
-#: ./opengever/meeting/proposal.py:175
+#: ./opengever/meeting/proposal.py:185
 msgid "label_decision"
 msgstr "Beschluss"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:95
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:98
+#: ./opengever/meeting/proposal.py:69
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Documents"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:30
-#: ./opengever/meeting/proposal.py:122
+#: ./opengever/meeting/proposal.py:132
 msgid "label_documents"
 msgstr "Dokumente"
 
@@ -527,7 +544,7 @@ msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:48
+#: ./opengever/meeting/browser/meetings/meeting.py:56
 msgid "label_end"
 msgstr "Ende"
 
@@ -543,7 +560,7 @@ msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/proposal.py:44
+#: ./opengever/meeting/proposal.py:54
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
@@ -559,12 +576,17 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/proposal.py:39
+#: ./opengever/meeting/proposal.py:49
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
+#. Default: "Contains automatically generated dossiers and documents for this committee."
+#: ./opengever/meeting/committee.py:37
+msgid "label_linked_repository_folder"
+msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
+
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:39
+#: ./opengever/meeting/browser/meetings/meeting.py:47
 msgid "label_location"
 msgstr "Standort"
 
@@ -584,33 +606,33 @@ msgid "label_next_meeting"
 msgstr "Nächste Sitzung:"
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py:45
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:36
+#: ./opengever/meeting/browser/meetings/protocol.py:37
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:25
+#: ./opengever/meeting/browser/meetings/protocol.py:26
 msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:242
+#: ./opengever/meeting/proposal.py:252
 msgid "label_proposal"
 msgstr "Antrag"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/proposal.py:49
+#: ./opengever/meeting/proposal.py:59
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:85
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:88
+#: ./opengever/meeting/proposal.py:64
 msgid "label_publish_in"
 msgstr "Veröffentlichung im"
 
@@ -631,24 +653,24 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:30
+#: ./opengever/meeting/browser/meetings/protocol.py:31
 msgid "label_secretary"
 msgstr "Sekretär"
 
 #. Default: "Target dossier"
-#: ./opengever/meeting/browser/meetings/excerpt.py:24
+#: ./opengever/meeting/browser/meetings/excerpt.py:22
 msgid "label_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 msgid "label_start"
 msgstr "Start"
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/meetings/excerpt.py:33
-#: ./opengever/meeting/committee.py:38
-#: ./opengever/meeting/proposal.py:28
+#: ./opengever/meeting/browser/meetings/excerpt.py:31
+#: ./opengever/meeting/committee.py:49
+#: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr "Titel"
 
@@ -663,18 +685,18 @@ msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
 #. Default: "Choose how to update an existing protocol:"
-#: ./opengever/meeting/browser/protocol.py:138
+#: ./opengever/meeting/browser/protocol.py:96
 msgid "label_update_generated_protocol_choose_method"
 msgstr "Wählen Sie wie ein bestehendes Protokoll aktualisiert werden soll:"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:178
+#: ./opengever/meeting/proposal.py:188
 msgid "label_workflow_state"
 msgstr "Status"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
-#: ./opengever/meeting/form.py:116
+#: ./opengever/meeting/browser/meetings/protocol.py:169
+#: ./opengever/meeting/form.py:117
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
@@ -704,12 +726,12 @@ msgid "msg_successfully_deleted"
 msgstr "Das Objekt wurde erfolgreich gelöscht"
 
 #. Default: "Create a new document in dossier ${title}"
-#: ./opengever/meeting/browser/protocol.py:129
+#: ./opengever/meeting/browser/protocol.py:87
 msgid "new_document"
 msgstr "Ein neues Dokument im Dossier ${title} erstellen"
 
 #. Default: "Create a new document version for document ${title}"
-#: ./opengever/meeting/browser/protocol.py:123
+#: ./opengever/meeting/browser/protocol.py:81
 msgid "new_document_version"
 msgstr "Eine neue Dokumentversion des Dokuments ${title} erstellen"
 
@@ -719,8 +741,8 @@ msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:61
-#: ./opengever/meeting/model/proposal.py:96
+#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/proposal.py:95
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -760,33 +782,33 @@ msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"
 
 #. Default: "Protocol"
-#: ./opengever/meeting/protocol.py:45
+#: ./opengever/meeting/protocol.py:46
 msgid "protocol"
 msgstr "Protokoll"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:101
+#: ./opengever/meeting/protocol.py:113
 msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:104
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:110
+#: ./opengever/meeting/model/proposal.py:111
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/proposal.py:99
 msgid "scheduled"
 msgstr "Traktandiert"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:109
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:98
+#: ./opengever/meeting/model/proposal.py:97
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -796,7 +818,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:114
+#: ./opengever/meeting/model/proposal.py:113
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-30 15:13+0000\n"
+"POT-Creation-Date: 2015-10-12 10:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,12 +21,16 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:97
 msgid "Add Agenda Item"
 msgstr "Ajouter le point à l'ordre du jour"
 
+#: ./opengever/meeting/browser/meetings/meeting.py:62
+msgid "Add Dossier for Meeting"
+msgstr ""
+
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:61
 msgid "Add Meeting"
 msgstr "Ajouter la séance"
 
@@ -44,16 +48,16 @@ msgstr "Ajouter l'affiliation"
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:123
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:129
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:177
+#: ./opengever/meeting/browser/meetings/meeting.py:294
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:136
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:142
 msgid "Attachements"
 msgstr ""
 
@@ -66,9 +70,9 @@ msgid "Can't change membership, it overlaps an existing membership from ${date_f
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:159
-#: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/form.py:50
+#: ./opengever/meeting/browser/meetings/excerpt.py:153
+#: ./opengever/meeting/browser/meetings/protocol.py:175
+#: ./opengever/meeting/form.py:51
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -84,15 +88,15 @@ msgstr "Commission"
 msgid "Committee Container"
 msgstr "Conteneur avec commission"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:54
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:57
 msgid "Considerations"
 msgstr "Considérations"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:75
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:78
 msgid "Decision"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:65
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
 msgid "Discussion"
 msgstr "Discussion"
 
@@ -100,11 +104,11 @@ msgstr "Discussion"
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
 msgid "Download preview"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:72
 msgid "Edit"
 msgstr ""
 
@@ -116,12 +120,12 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:28
+#: ./opengever/meeting/committee.py:30
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:79
 msgid "Excerpts"
 msgstr ""
 
@@ -129,15 +133,15 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
 msgid "Generate"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
 msgid "Generate excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:152
 msgid "Generated proposal excerpt"
 msgstr ""
 
@@ -145,49 +149,63 @@ msgstr ""
 msgid "History"
 msgstr "Historique"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:46
+#: ./opengever/meeting/browser/meetings/excerpt.py:44
 msgid "Include considerations"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:70
+#: ./opengever/meeting/browser/meetings/excerpt.py:68
 msgid "Include copy for attention"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:58
+#: ./opengever/meeting/browser/meetings/excerpt.py:56
 msgid "Include decision"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:66
+#: ./opengever/meeting/browser/meetings/excerpt.py:64
 msgid "Include disclose to"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:54
+#: ./opengever/meeting/browser/meetings/excerpt.py:52
 msgid "Include discussion"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:38
+#: ./opengever/meeting/browser/meetings/excerpt.py:36
 msgid "Include initial position"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:42
+#: ./opengever/meeting/browser/meetings/excerpt.py:40
 msgid "Include legal basis"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:50
+#: ./opengever/meeting/browser/meetings/excerpt.py:48
 msgid "Include proposed action"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:62
+#: ./opengever/meeting/browser/meetings/excerpt.py:60
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:34
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:37
 msgid "Initial position"
 msgstr "Situation initiale"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:24
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:27
 msgid "Legal basis"
 msgstr "Base légale"
+
+#: ./opengever/meeting/committee.py:36
+msgid "Linked repository folder"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:61
+#: ./opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
+#: ./opengever/meeting/upgrades/profiles/4604/types/opengever.meeting.meetingdossier.xml
+msgid "Meeting Dossier"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/meeting.py:199
+msgid "Meeting on ${date}"
+msgstr ""
 
 #: ./opengever/meeting/browser/templates/member.pt:41
 msgid "Memberships"
@@ -197,11 +215,11 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:140
+#: ./opengever/meeting/browser/meetings/excerpt.py:134
 msgid "Please select at least one agenda item."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:87
+#: ./opengever/meeting/browser/meetings/excerpt.py:85
 msgid "Please select at least one field for the excerpt."
 msgstr ""
 
@@ -215,16 +233,16 @@ msgstr "Propriétés"
 msgid "Proposal"
 msgstr "Proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:44
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:47
 msgid "Proposed action"
 msgstr "Action proposée"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:61
-#: ./opengever/meeting/model/meeting.py:140
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+#: ./opengever/meeting/model/meeting.py:146
 msgid "Protocol"
 msgstr "Procès-verbal"
 
-#: ./opengever/meeting/model/meeting.py:143
+#: ./opengever/meeting/model/meeting.py:149
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -236,7 +254,7 @@ msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
-#: ./opengever/meeting/committee.py:22
+#: ./opengever/meeting/committee.py:24
 #: ./opengever/meeting/committeecontainer.py:13
 msgid "Protocol template"
 msgstr ""
@@ -247,8 +265,8 @@ msgid "Sablon Template"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:127
-#: ./opengever/meeting/browser/meetings/protocol.py:126
+#: ./opengever/meeting/browser/meetings/excerpt.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:164
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Enregistrer"
@@ -261,6 +279,10 @@ msgstr "Afficher plus"
 msgid "Submitted Proposal"
 msgstr "Proposition soumise"
 
+#: ./opengever/meeting/browser/meetings/meeting.py:153
+msgid "The meeting and its dossier were created successfully"
+msgstr ""
+
 #: ./opengever/meeting/browser/submitdocuments.py:179
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
@@ -270,27 +292,32 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:129
+#: ./opengever/meeting/browser/meetings/agendaitem.py:121
 msgid "agenda_item_order_updated"
 msgstr "Les points de l'ordre du jour ont été actualisés."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:122
 msgid "as free-text"
 msgstr "Comme point de l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:114
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
 msgid "as paragraph"
 msgstr "Comme paragraphe"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/documents/submit.py:94
-#: ./opengever/meeting/browser/protocol.py:80
-#: ./opengever/meeting/browser/submitdocuments.py:81
+#: ./opengever/meeting/browser/meetings/meeting.py:100
+#: ./opengever/meeting/browser/protocol.py:153
 msgid "button_cancel"
 msgstr "Annuler"
 
+#. Default: "Continue"
+#: ./opengever/meeting/browser/meetings/meeting.py:84
+msgid "button_continue"
+msgstr ""
+
 #. Default: "Generate"
-#: ./opengever/meeting/browser/protocol.py:63
+#: ./opengever/meeting/browser/protocol.py:127
 msgid "button_generate"
 msgstr "Générer"
 
@@ -305,12 +332,12 @@ msgid "button_submit_documents"
 msgstr "Soumettre les documents"
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:73
+#: ./opengever/meeting/model/meeting.py:74
 msgid "close"
 msgstr "Fermer"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/meeting.py:64
 msgid "closed"
 msgstr "Fermé"
 
@@ -320,7 +347,7 @@ msgid "column_comittee"
 msgstr "Commission"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:30
+#: ./opengever/meeting/tabs/meetinglisting.py:43
 msgid "column_date"
 msgstr "Date"
 
@@ -345,7 +372,7 @@ msgid "column_firstname"
 msgstr "Prénom"
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:34
+#: ./opengever/meeting/tabs/meetinglisting.py:47
 msgid "column_from"
 msgstr "De"
 
@@ -360,7 +387,7 @@ msgid "column_lastname"
 msgstr "Nom"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:27
+#: ./opengever/meeting/tabs/meetinglisting.py:40
 msgid "column_location"
 msgstr "Site"
 
@@ -386,92 +413,82 @@ msgstr "Etat"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:23
+#: ./opengever/meeting/tabs/meetinglisting.py:36
 #: ./opengever/meeting/tabs/proposallisting.py:33
 msgid "column_title"
 msgstr "Titre"
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:39
+#: ./opengever/meeting/tabs/meetinglisting.py:52
 msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:116
+#: ./opengever/meeting/model/proposal.py:115
 msgid "decide"
 msgstr "Décider"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:101
+#: ./opengever/meeting/model/proposal.py:100
 msgid "decided"
 msgstr "Décidé"
 
-#. Default: "Generate protocol"
-#: ./opengever/meeting/browser/protocol.py:50
-msgid "form_label_generate_protocol"
-msgstr "Créer le procès-verbal"
+#. Default: "Dossier"
+#: ./opengever/meeting/tabs/meetinglisting.py:57
+msgid "dossier"
+msgstr ""
 
 #. Default: "Update protocol"
-#: ./opengever/meeting/browser/protocol.py:156
+#: ./opengever/meeting/browser/protocol.py:114
 msgid "form_label_update_protocol"
 msgstr "Actualiser le procès-verbal"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/meeting.py:63
 msgid "held"
 msgstr "Tenu"
 
-#. Default: "Select the target dossier where the pre-protocol should be created."
-#: ./opengever/meeting/browser/protocol.py:37
-msgid "help_accept_select_dossier"
-msgstr "Choisissez le dossier dans lequel le procès-verbal doit être enregistré."
-
-#: ./opengever/meeting/proposal.py:98
+#: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:86
+#: ./opengever/meeting/proposal.py:96
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:92
+#: ./opengever/meeting/proposal.py:102
 msgid "help_proposed_action"
 msgstr ""
 
 #. Default: "Select the target dossier where the excerpts should be created."
-#: ./opengever/meeting/browser/meetings/excerpt.py:26
+#: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:74
+#: ./opengever/meeting/proposal.py:84
 msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:71
+#: ./opengever/meeting/model/meeting.py:72
 msgid "hold meeting"
 msgstr "Tenir séance"
 
-#. Default: "Target dossier"
-#: ./opengever/meeting/browser/protocol.py:35
-msgid "label_accept_select_dossier"
-msgstr "Dossier de destination"
-
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:34
+#: ./opengever/meeting/browser/meetings/meeting.py:42
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:34
+#: ./opengever/meeting/proposal.py:44
 msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/proposal.py:97
+#: ./opengever/meeting/proposal.py:107
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:105
-#: ./opengever/meeting/proposal.py:64
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:108
+#: ./opengever/meeting/proposal.py:74
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -493,20 +510,20 @@ msgid "label_date_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decision"
-#: ./opengever/meeting/proposal.py:175
+#: ./opengever/meeting/proposal.py:185
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:95
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:98
+#: ./opengever/meeting/proposal.py:69
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Documents"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:30
-#: ./opengever/meeting/proposal.py:122
+#: ./opengever/meeting/proposal.py:132
 msgid "label_documents"
 msgstr "Documents"
 
@@ -527,7 +544,7 @@ msgid "label_email"
 msgstr "Email"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:48
+#: ./opengever/meeting/browser/meetings/meeting.py:56
 msgid "label_end"
 msgstr "Fin"
 
@@ -543,7 +560,7 @@ msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/proposal.py:44
+#: ./opengever/meeting/proposal.py:54
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
@@ -559,12 +576,17 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/proposal.py:39
+#: ./opengever/meeting/proposal.py:49
 msgid "label_legal_basis"
 msgstr "Base légale"
 
+#. Default: "Contains automatically generated dossiers and documents for this committee."
+#: ./opengever/meeting/committee.py:37
+msgid "label_linked_repository_folder"
+msgstr ""
+
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:39
+#: ./opengever/meeting/browser/meetings/meeting.py:47
 msgid "label_location"
 msgstr "Site"
 
@@ -584,33 +606,33 @@ msgid "label_next_meeting"
 msgstr "Prochaine séance:"
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py:45
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:36
+#: ./opengever/meeting/browser/meetings/protocol.py:37
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:25
+#: ./opengever/meeting/browser/meetings/protocol.py:26
 msgid "label_presidency"
 msgstr "Présidence"
 
 #. Default: "Proposal"
-#: ./opengever/meeting/proposal.py:242
+#: ./opengever/meeting/proposal.py:252
 msgid "label_proposal"
 msgstr "Proposition"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/proposal.py:49
+#: ./opengever/meeting/proposal.py:59
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:85
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:88
+#: ./opengever/meeting/proposal.py:64
 msgid "label_publish_in"
 msgstr ""
 
@@ -631,24 +653,24 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:30
+#: ./opengever/meeting/browser/meetings/protocol.py:31
 msgid "label_secretary"
 msgstr "Secrétaire"
 
 #. Default: "Target dossier"
-#: ./opengever/meeting/browser/meetings/excerpt.py:24
+#: ./opengever/meeting/browser/meetings/excerpt.py:22
 msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/meetings/excerpt.py:33
-#: ./opengever/meeting/committee.py:38
-#: ./opengever/meeting/proposal.py:28
+#: ./opengever/meeting/browser/meetings/excerpt.py:31
+#: ./opengever/meeting/committee.py:49
+#: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr "Titre"
 
@@ -663,18 +685,18 @@ msgid "label_upcoming_meetings"
 msgstr "Prochaines séances"
 
 #. Default: "Choose how to update an existing protocol:"
-#: ./opengever/meeting/browser/protocol.py:138
+#: ./opengever/meeting/browser/protocol.py:96
 msgid "label_update_generated_protocol_choose_method"
 msgstr "Choix de la manière dont un procès-verbal existant soit actualisé:"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:178
+#: ./opengever/meeting/proposal.py:188
 msgid "label_workflow_state"
 msgstr "Etat"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
-#: ./opengever/meeting/form.py:116
+#: ./opengever/meeting/browser/meetings/protocol.py:169
+#: ./opengever/meeting/form.py:117
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
@@ -704,12 +726,12 @@ msgid "msg_successfully_deleted"
 msgstr ""
 
 #. Default: "Create a new document in dossier ${title}"
-#: ./opengever/meeting/browser/protocol.py:129
+#: ./opengever/meeting/browser/protocol.py:87
 msgid "new_document"
 msgstr "Créer un nouveau document dans le dossier ${title}"
 
 #. Default: "Create a new document version for document ${title}"
-#: ./opengever/meeting/browser/protocol.py:123
+#: ./opengever/meeting/browser/protocol.py:81
 msgid "new_document_version"
 msgstr "Créer une nouvelle version du document pour le document ${title}"
 
@@ -719,8 +741,8 @@ msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:61
-#: ./opengever/meeting/model/proposal.py:96
+#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/proposal.py:95
 msgid "pending"
 msgstr "En modification"
 
@@ -760,33 +782,33 @@ msgid "proposal_history_label_submitted"
 msgstr "Soumis par ${user}"
 
 #. Default: "Protocol"
-#: ./opengever/meeting/protocol.py:45
+#: ./opengever/meeting/protocol.py:46
 msgid "protocol"
 msgstr "Procès-verbal"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:101
+#: ./opengever/meeting/protocol.py:113
 msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:104
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:110
+#: ./opengever/meeting/model/proposal.py:111
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/proposal.py:99
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:109
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:98
+#: ./opengever/meeting/model/proposal.py:97
 msgid "submitted"
 msgstr "Soumis"
 
@@ -796,7 +818,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:114
+#: ./opengever/meeting/model/proposal.py:113
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-30 15:13+0000\n"
+"POT-Creation-Date: 2015-10-12 10:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,12 +21,15 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:97
 msgid "Add Agenda Item"
 msgstr ""
 
-#. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:62
+msgid "Add Dossier for Meeting"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/meeting.py:61
 msgid "Add Meeting"
 msgstr ""
 
@@ -44,16 +47,16 @@ msgstr ""
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:123
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:129
 msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:177
+#: ./opengever/meeting/browser/meetings/meeting.py:294
 msgid "An unexpected error has occurred"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:136
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:142
 msgid "Attachements"
 msgstr ""
 
@@ -66,9 +69,9 @@ msgid "Can't change membership, it overlaps an existing membership from ${date_f
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:159
-#: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/form.py:50
+#: ./opengever/meeting/browser/meetings/excerpt.py:153
+#: ./opengever/meeting/browser/meetings/protocol.py:175
+#: ./opengever/meeting/form.py:51
 msgid "Cancel"
 msgstr ""
 
@@ -84,15 +87,15 @@ msgstr ""
 msgid "Committee Container"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:54
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:57
 msgid "Considerations"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:75
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:78
 msgid "Decision"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:65
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
 msgid "Discussion"
 msgstr ""
 
@@ -100,11 +103,11 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
 msgid "Download preview"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:72
 msgid "Edit"
 msgstr ""
 
@@ -116,12 +119,12 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:28
+#: ./opengever/meeting/committee.py:30
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:79
 msgid "Excerpts"
 msgstr ""
 
@@ -129,15 +132,15 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
 msgid "Generate"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
 msgid "Generate excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:152
 msgid "Generated proposal excerpt"
 msgstr ""
 
@@ -145,48 +148,62 @@ msgstr ""
 msgid "History"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:46
+#: ./opengever/meeting/browser/meetings/excerpt.py:44
 msgid "Include considerations"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:70
+#: ./opengever/meeting/browser/meetings/excerpt.py:68
 msgid "Include copy for attention"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:58
+#: ./opengever/meeting/browser/meetings/excerpt.py:56
 msgid "Include decision"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:66
+#: ./opengever/meeting/browser/meetings/excerpt.py:64
 msgid "Include disclose to"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:54
+#: ./opengever/meeting/browser/meetings/excerpt.py:52
 msgid "Include discussion"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:38
+#: ./opengever/meeting/browser/meetings/excerpt.py:36
 msgid "Include initial position"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:42
+#: ./opengever/meeting/browser/meetings/excerpt.py:40
 msgid "Include legal basis"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:50
+#: ./opengever/meeting/browser/meetings/excerpt.py:48
 msgid "Include proposed action"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:62
+#: ./opengever/meeting/browser/meetings/excerpt.py:60
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:34
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:37
 msgid "Initial position"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:24
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:27
 msgid "Legal basis"
+msgstr ""
+
+#: ./opengever/meeting/committee.py:36
+msgid "Linked repository folder"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:61
+#: ./opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
+#: ./opengever/meeting/upgrades/profiles/4604/types/opengever.meeting.meetingdossier.xml
+msgid "Meeting Dossier"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/meeting.py:199
+msgid "Meeting on ${date}"
 msgstr ""
 
 #: ./opengever/meeting/browser/templates/member.pt:41
@@ -197,11 +214,11 @@ msgstr ""
 msgid "Metadata"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:140
+#: ./opengever/meeting/browser/meetings/excerpt.py:134
 msgid "Please select at least one agenda item."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:87
+#: ./opengever/meeting/browser/meetings/excerpt.py:85
 msgid "Please select at least one field for the excerpt."
 msgstr ""
 
@@ -215,16 +232,16 @@ msgstr ""
 msgid "Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:44
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:47
 msgid "Proposed action"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:61
-#: ./opengever/meeting/model/meeting.py:140
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+#: ./opengever/meeting/model/meeting.py:146
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:143
+#: ./opengever/meeting/model/meeting.py:149
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -236,7 +253,7 @@ msgstr ""
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:22
+#: ./opengever/meeting/committee.py:24
 #: ./opengever/meeting/committeecontainer.py:13
 msgid "Protocol template"
 msgstr ""
@@ -247,8 +264,8 @@ msgid "Sablon Template"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:127
-#: ./opengever/meeting/browser/meetings/protocol.py:126
+#: ./opengever/meeting/browser/meetings/excerpt.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:164
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr ""
@@ -261,6 +278,10 @@ msgstr ""
 msgid "Submitted Proposal"
 msgstr ""
 
+#: ./opengever/meeting/browser/meetings/meeting.py:153
+msgid "The meeting and its dossier were created successfully"
+msgstr ""
+
 #: ./opengever/meeting/browser/submitdocuments.py:179
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
@@ -270,27 +291,32 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:129
+#: ./opengever/meeting/browser/meetings/agendaitem.py:121
 msgid "agenda_item_order_updated"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:122
 msgid "as free-text"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:114
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
 msgid "as paragraph"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/documents/submit.py:94
-#: ./opengever/meeting/browser/protocol.py:80
-#: ./opengever/meeting/browser/submitdocuments.py:81
+#: ./opengever/meeting/browser/meetings/meeting.py:100
+#: ./opengever/meeting/browser/protocol.py:153
 msgid "button_cancel"
 msgstr ""
 
+#. Default: "Continue"
+#: ./opengever/meeting/browser/meetings/meeting.py:84
+msgid "button_continue"
+msgstr ""
+
 #. Default: "Generate"
-#: ./opengever/meeting/browser/protocol.py:63
+#: ./opengever/meeting/browser/protocol.py:127
 msgid "button_generate"
 msgstr ""
 
@@ -305,12 +331,12 @@ msgid "button_submit_documents"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:73
+#: ./opengever/meeting/model/meeting.py:74
 msgid "close"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/meeting.py:64
 msgid "closed"
 msgstr ""
 
@@ -320,7 +346,7 @@ msgid "column_comittee"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:30
+#: ./opengever/meeting/tabs/meetinglisting.py:43
 msgid "column_date"
 msgstr ""
 
@@ -345,7 +371,7 @@ msgid "column_firstname"
 msgstr ""
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:34
+#: ./opengever/meeting/tabs/meetinglisting.py:47
 msgid "column_from"
 msgstr ""
 
@@ -360,7 +386,7 @@ msgid "column_lastname"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:27
+#: ./opengever/meeting/tabs/meetinglisting.py:40
 msgid "column_location"
 msgstr ""
 
@@ -386,92 +412,82 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:23
+#: ./opengever/meeting/tabs/meetinglisting.py:36
 #: ./opengever/meeting/tabs/proposallisting.py:33
 msgid "column_title"
 msgstr ""
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:39
+#: ./opengever/meeting/tabs/meetinglisting.py:52
 msgid "column_to"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:116
+#: ./opengever/meeting/model/proposal.py:115
 msgid "decide"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:101
+#: ./opengever/meeting/model/proposal.py:100
 msgid "decided"
 msgstr ""
 
-#. Default: "Generate protocol"
-#: ./opengever/meeting/browser/protocol.py:50
-msgid "form_label_generate_protocol"
+#. Default: "Dossier"
+#: ./opengever/meeting/tabs/meetinglisting.py:57
+msgid "dossier"
 msgstr ""
 
 #. Default: "Update protocol"
-#: ./opengever/meeting/browser/protocol.py:156
+#: ./opengever/meeting/browser/protocol.py:114
 msgid "form_label_update_protocol"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/meeting.py:63
 msgid "held"
 msgstr ""
 
-#. Default: "Select the target dossier where the pre-protocol should be created."
-#: ./opengever/meeting/browser/protocol.py:37
-msgid "help_accept_select_dossier"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:98
+#: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:86
+#: ./opengever/meeting/proposal.py:96
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:92
+#: ./opengever/meeting/proposal.py:102
 msgid "help_proposed_action"
 msgstr ""
 
 #. Default: "Select the target dossier where the excerpts should be created."
-#: ./opengever/meeting/browser/meetings/excerpt.py:26
+#: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:74
+#: ./opengever/meeting/proposal.py:84
 msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:71
+#: ./opengever/meeting/model/meeting.py:72
 msgid "hold meeting"
 msgstr ""
 
-#. Default: "Target dossier"
-#: ./opengever/meeting/browser/protocol.py:35
-msgid "label_accept_select_dossier"
-msgstr ""
-
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:34
+#: ./opengever/meeting/browser/meetings/meeting.py:42
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:34
+#: ./opengever/meeting/proposal.py:44
 msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/proposal.py:97
+#: ./opengever/meeting/proposal.py:107
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:105
-#: ./opengever/meeting/proposal.py:64
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:108
+#: ./opengever/meeting/proposal.py:74
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -493,20 +509,20 @@ msgid "label_date_to"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/proposal.py:175
+#: ./opengever/meeting/proposal.py:185
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:95
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:98
+#: ./opengever/meeting/proposal.py:69
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Documents"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:30
-#: ./opengever/meeting/proposal.py:122
+#: ./opengever/meeting/proposal.py:132
 msgid "label_documents"
 msgstr ""
 
@@ -527,7 +543,7 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:48
+#: ./opengever/meeting/browser/meetings/meeting.py:56
 msgid "label_end"
 msgstr ""
 
@@ -543,7 +559,7 @@ msgid "label_firstname"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/proposal.py:44
+#: ./opengever/meeting/proposal.py:54
 msgid "label_initial_position"
 msgstr ""
 
@@ -559,12 +575,17 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/proposal.py:39
+#: ./opengever/meeting/proposal.py:49
 msgid "label_legal_basis"
 msgstr ""
 
+#. Default: "Contains automatically generated dossiers and documents for this committee."
+#: ./opengever/meeting/committee.py:37
+msgid "label_linked_repository_folder"
+msgstr ""
+
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:39
+#: ./opengever/meeting/browser/meetings/meeting.py:47
 msgid "label_location"
 msgstr ""
 
@@ -584,32 +605,32 @@ msgid "label_next_meeting"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py:45
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:36
+#: ./opengever/meeting/browser/meetings/protocol.py:37
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:25
+#: ./opengever/meeting/browser/meetings/protocol.py:26
 msgid "label_presidency"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:242
+#: ./opengever/meeting/proposal.py:252
 msgid "label_proposal"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/proposal.py:49
+#: ./opengever/meeting/proposal.py:59
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:85
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:88
+#: ./opengever/meeting/proposal.py:64
 msgid "label_publish_in"
 msgstr ""
 
@@ -630,24 +651,24 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:30
+#: ./opengever/meeting/browser/meetings/protocol.py:31
 msgid "label_secretary"
 msgstr ""
 
 #. Default: "Target dossier"
-#: ./opengever/meeting/browser/meetings/excerpt.py:24
+#: ./opengever/meeting/browser/meetings/excerpt.py:22
 msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/meetings/excerpt.py:33
-#: ./opengever/meeting/committee.py:38
-#: ./opengever/meeting/proposal.py:28
+#: ./opengever/meeting/browser/meetings/excerpt.py:31
+#: ./opengever/meeting/committee.py:49
+#: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr ""
 
@@ -662,18 +683,18 @@ msgid "label_upcoming_meetings"
 msgstr ""
 
 #. Default: "Choose how to update an existing protocol:"
-#: ./opengever/meeting/browser/protocol.py:138
+#: ./opengever/meeting/browser/protocol.py:96
 msgid "label_update_generated_protocol_choose_method"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:178
+#: ./opengever/meeting/proposal.py:188
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
-#: ./opengever/meeting/form.py:116
+#: ./opengever/meeting/browser/meetings/protocol.py:169
+#: ./opengever/meeting/form.py:117
 msgid "message_changes_saved"
 msgstr ""
 
@@ -703,12 +724,12 @@ msgid "msg_successfully_deleted"
 msgstr ""
 
 #. Default: "Create a new document in dossier ${title}"
-#: ./opengever/meeting/browser/protocol.py:129
+#: ./opengever/meeting/browser/protocol.py:87
 msgid "new_document"
 msgstr ""
 
 #. Default: "Create a new document version for document ${title}"
-#: ./opengever/meeting/browser/protocol.py:123
+#: ./opengever/meeting/browser/protocol.py:81
 msgid "new_document_version"
 msgstr ""
 
@@ -718,8 +739,8 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:61
-#: ./opengever/meeting/model/proposal.py:96
+#: ./opengever/meeting/model/meeting.py:62
+#: ./opengever/meeting/model/proposal.py:95
 msgid "pending"
 msgstr ""
 
@@ -759,33 +780,33 @@ msgid "proposal_history_label_submitted"
 msgstr ""
 
 #. Default: "Protocol"
-#: ./opengever/meeting/protocol.py:45
+#: ./opengever/meeting/protocol.py:46
 msgid "protocol"
 msgstr ""
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:101
+#: ./opengever/meeting/protocol.py:113
 msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:104
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:110
+#: ./opengever/meeting/model/proposal.py:111
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/proposal.py:99
 msgid "scheduled"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:109
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:98
+#: ./opengever/meeting/model/proposal.py:97
 msgid "submitted"
 msgstr ""
 
@@ -795,7 +816,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:114
+#: ./opengever/meeting/model/proposal.py:113
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/menu.py
+++ b/opengever/meeting/menu.py
@@ -1,6 +1,7 @@
 from five import grok
 from opengever.base.menu import FilteredPostFactoryMenu
 from opengever.meeting.committee import ICommittee
+from opengever.repository.interfaces import IRepositoryFolder
 from zope.interface import Interface
 
 
@@ -17,3 +18,12 @@ class CommitteePostFactoryMenu(FilteredPostFactoryMenu):
             return True
 
         return False
+
+
+class RepositoryFolderPostFactoryMenu(FilteredPostFactoryMenu):
+    grok.adapts(IRepositoryFolder, Interface)
+
+    def is_filtered(self, factory):
+        factory_id = factory.get('id')
+        if factory_id == u'opengever.meeting.meetingdossier':
+            return True

--- a/opengever/meeting/model/__init__.py
+++ b/opengever/meeting/model/__init__.py
@@ -7,6 +7,7 @@ from opengever.meeting.model.member import Member
 from opengever.meeting.model.membership import Membership
 from opengever.meeting.model.proposal import Proposal
 from opengever.meeting.model.submitteddocument import SubmittedDocument
+import opengever.meeting.model.query  # keep, initializes query classes!
 
 
 tables = [

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -279,6 +279,12 @@ class Meeting(Base):
 
         return '/'.join(elements)
 
+    def get_dossier_url(self):
+        return self.dossier_oguid.get_url()
+
+    def get_dossier(self):
+        return self.dossier_oguid.resolve_object()
+
     def get_edit_url(self, context):
         return self.get_url(view='edit')
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from opengever.base.model import Base
+from opengever.base.oguid import Oguid
 from opengever.base.utils import escape_html
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
@@ -7,6 +8,7 @@ from opengever.meeting.model import AgendaItem
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
+from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models.types import UnicodeCoercingText
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -17,6 +19,7 @@ from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy.orm import backref
+from sqlalchemy.orm import composite
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 from zope.component import getUtility
@@ -93,6 +96,10 @@ class Meeting(Base):
     participants = relationship('Member',
                                 secondary=meeting_participants,
                                 backref='meetings')
+
+    dossier_admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
+    dossier_int_id = Column(Integer, nullable=False)
+    dossier_oguid = composite(Oguid, dossier_admin_unit_id, dossier_int_id)
 
     agenda_items = relationship("AgendaItem", order_by='AgendaItem.sort_order',
                                 backref='meeting')

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4604</version>
+    <version>4605</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4603</version>
+    <version>4604</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/types.xml
+++ b/opengever/meeting/profiles/default/types.xml
@@ -4,4 +4,5 @@
     <object name="opengever.meeting.committee" meta_type="Dexterity FTI" />
     <object name="opengever.meeting.committeecontainer" meta_type="Dexterity FTI" />
     <object name="opengever.meeting.sablontemplate" meta_type="Dexterity FTI" />
+    <object name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI" />
 </object>

--- a/opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI"
+        i18n:domain="opengever.meeting" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Meeting Dossier</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="opengever.meeting.proposal" />
+        <element value="opengever.dossier.businesscasedossier" />
+        <element value="opengever.document.document" />
+        <element value="opengever.task.task" />
+        <element value="ftw.mail.mail"/>
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">opengever.meeting.interfaces.IMeetingDossier</property>
+
+    <!-- class used for content items -->
+    <property name="klass">opengever.meeting.dossier.MeetingDossier</property>
+
+    <!-- add permission -->
+    <property name="add_permission">opengever.dossier.AddBusinessCaseDossier</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+        <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+        <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+        <element value="opengever.dossier.behaviors.dossier.IDossier" />
+        <element value="opengever.dossier.behaviors.participation.IParticipationAware" />
+        <element value="opengever.base.behaviors.classification.IClassification" />
+        <element value="opengever.base.behaviors.lifecycle.ILifeCycle" />
+        <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
+        <element value="opengever.trash.trash.ITrashable" />
+        <element value="opengever.dossier.behaviors.dossiernamefromtitle.IDossierNameFromTitle" />
+        <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+        <element value="opengever.sharing.behaviors.IDossier" />
+        <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+        <element value="opengever.mail.behaviors.ISendableDocsContainer" />
+    </property>
+
+    <!-- View information -->
+    <property name="immediate_view">tabbed_view</property>
+    <property name="default_view">tabbed_view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+        <element value="tabbed_view" />
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(selected layout)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="@@view"/>
+
+    <!-- Actions -->
+    <action action_id="view"
+            visible="False"
+            title="View"
+            category="object"
+            url_expr="string:${object_url}"
+            condition_expr="">
+        <permission value="View"/>
+    </action>
+
+    <action action_id="edit"
+            visible="True"
+            title="Edit"
+            category="object"
+            url_expr="string:${object_url}/edit"
+            condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True">
+        <permission value="Modify portal content"/>
+    </action>
+
+    <action action_id="document_with_template"
+            visible="True"
+            title="document_with_template"
+            category="folder_factories"
+            url_expr="string:${object_url}/document_with_template"
+            icon_expr=""
+            condition_expr=""
+            i18n:domain="opengever.dossier">
+        <permission value="Add portal content"/>
+    </action>
+
+    <action action_id="add_participant"
+            visible="True"
+            title="Add Participant"
+            category="folder_factories"
+            url_expr="string:${object_url}/@@add-participation"
+            icon_expr=""
+            condition_expr=""
+            i18n:domain="opengever.dossier"
+            i18n:attributes="title">
+        <permission value="Add portal content"/>
+    </action>
+
+
+    <!-- Tabbedview tabs-->
+    <action i18n:domain="opengever.dossier" title="Overview" action_id="overview" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Subdossiers" action_id="subdossiers" category="tabbedview-tabs"
+            condition_expr="object/show_subdossier" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Documents" action_id="documents" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Tasks" action_id="tasks" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Proposals" action_id="proposals" category="tabbedview-tabs"
+            condition_expr="object/@@is_meeting_feature_enabled" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Participants" action_id="participants" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Trash" action_id="trash" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Journal" action_id="journal" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+
+    <action i18n:domain="opengever.dossier" title="Sharing" action_id="sharing" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#"
+            visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Give Filing Number" action_id="filing_nr" category="object_buttons"
+            condition_expr="python: object.portal_workflow.getInfoFor(object, 'review_state', None) == 'dossier-state-resolved' and getattr( object, 'filing_no', None) == None" url_expr="string:${object_url}/transition-archive" visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/opengever/meeting/profiles/default/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/meeting/profiles/default/types/opengever.repository.repositoryfolder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="opengever.repository.repositoryfolder">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="opengever.meeting.meetingdossier" />
+    </property>
+
+</object>

--- a/opengever/meeting/profiles/default/workflows.xml
+++ b/opengever/meeting/profiles/default/workflows.xml
@@ -22,6 +22,11 @@
     <type type_id="opengever.meeting.sablontemplate">
       <bound-workflow workflow_id="opengever_document_workflow"/>
     </type>
+        <type type_id="opengever.meeting.meetingdossier">
+      <bound-workflow workflow_id="opengever_dossier_workflow"/>
+    </type>
   </bindings>
 
 </object>
+
+

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -346,16 +346,17 @@ class Proposal(ProposalBase):
         committee_model = self.load_model().committee
         return committee_model.oguid.resolve_object()
 
-    def get_model_create_arguments(self, context):
+    def update_model_create_arguments(self, data, context):
         aq_wrapped_self = self.__of__(context)
 
         workflow_state = self.workflow.default_state.name
         reference_number = IReferenceNumber(
             context.get_main_dossier()).get_number()
 
-        return dict(workflow_state=workflow_state,
-                    physical_path=aq_wrapped_self.get_physical_path(),
-                    dossier_reference_number=reference_number)
+        data.update(dict(workflow_state=workflow_state,
+                         physical_path=aq_wrapped_self.get_physical_path(),
+                         dossier_reference_number=reference_number))
+        return data
 
     def get_edit_values(self, fieldnames):
         values = super(Proposal, self).get_edit_values(fieldnames)

--- a/opengever/meeting/sources.py
+++ b/opengever/meeting/sources.py
@@ -29,3 +29,15 @@ all_open_dossiers_source = RepositoryPathSourceBinder(
             'repositoryfolder-state-active'] + DOSSIER_STATES_OPEN,
     }
 )
+
+
+repository_folder_source = RepositoryPathSourceBinder(
+    object_provides='opengever.repository.repositoryfolder.IRepositoryFolderSchema',
+    review_state='repositoryfolder-state-active',
+    navigation_tree_query={
+        'object_provides': [
+            'opengever.repository.repositoryroot.IRepositoryRoot',
+            'opengever.repository.repositoryfolder.IRepositoryFolderSchema',
+        ]
+    }
+)

--- a/opengever/meeting/tabs/meetinglisting.py
+++ b/opengever/meeting/tabs/meetinglisting.py
@@ -1,6 +1,8 @@
 from five import grok
 from ftw.table.interfaces import ITableSource
 from ftw.table.interfaces import ITableSourceConfig
+from opengever.base.browser.helper import get_css_class
+from opengever.base.utils import escape_html
 from opengever.meeting import _
 from opengever.meeting.model import Meeting
 from opengever.tabbedview.browser.base import BaseListingTab
@@ -11,6 +13,17 @@ from zope.interface import Interface
 
 class IMeetingTableSourceConfig(ITableSourceConfig):
     """Marker interface for meeting table source configs."""
+
+
+def dossier_link(item, value):
+    dossier = item.get_dossier()
+    if not dossier:
+        return
+
+    url = dossier.absolute_url()
+    link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
+        url, escape_html(dossier.title), get_css_class(dossier))
+    return link
 
 
 class MeetingListingTab(BaseListingTab):
@@ -38,6 +51,11 @@ class MeetingListingTab(BaseListingTab):
         {'column': 'end_time',
          'column_title': _(u'column_to', default=u'To'),
          'transform': lambda item, value: item.get_end_time(),
+         'sortable': False},
+
+        {'column': 'dossier',
+         'column_title': _(u'dossier', default=u'Dossier'),
+         'transform': dossier_link,
          'sortable': False},
     )
 

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -23,13 +23,17 @@ class TestAgendaItem(FunctionalTestCase):
         super(TestAgendaItem, self).setUp()
         self.admin_unit.public_url = 'http://nohost/plone'
 
-        self.repo = create(Builder('repository_root'))
+        self.repository_root, self.repository_folder = create(
+            Builder('repository_tree'))
+        self.dossier = create(
+            Builder('dossier').within(self.repository_folder))
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee').within(container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model(),
                                       start=datetime(2013, 1, 1),
-                                      location='There',))
+                                      location='There',)
+                              .link_with(self.dossier))
 
     def setup_proposal(self):
         root, folder = create(Builder('repository_tree'))

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -27,13 +27,15 @@ class TestAgendaItem(FunctionalTestCase):
             Builder('repository_tree'))
         self.dossier = create(
             Builder('dossier').within(self.repository_folder))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee').within(container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model(),
                                       start=datetime(2013, 1, 1),
                                       location='There',)
-                              .link_with(self.dossier))
+                              .link_with(self.meeting_dossier))
 
     def setup_proposal(self):
         root, folder = create(Builder('repository_tree'))

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -14,8 +14,12 @@ class TestCloseMeeting(FunctionalTestCase):
     def setUp(self):
         super(TestCloseMeeting, self).setUp()
         self.repository_root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository')
+                                 .within(self.repository_root))
         self.dossier = create(Builder('dossier')
-                              .within(self.repository_root))
+                              .within(self.repository))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository))
 
         self.sablon_template = create(
             Builder('sablontemplate')
@@ -40,7 +44,7 @@ class TestCloseMeeting(FunctionalTestCase):
                                       start=datetime(2013, 1, 1),
                                       location='There')
                               .scheduled_proposals([self.proposal_a, self.proposal_b])
-                              .link_with(self.dossier))
+                              .link_with(self.meeting_dossier))
         self.meeting.execute_transition('pending-held')
 
         # set correct public url, used for generated meeting urls

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -39,7 +39,8 @@ class TestCloseMeeting(FunctionalTestCase):
                               .having(committee=self.committee.load_model(),
                                       start=datetime(2013, 1, 1),
                                       location='There')
-                              .scheduled_proposals([self.proposal_a, self.proposal_b]))
+                              .scheduled_proposals([self.proposal_a, self.proposal_b])
+                              .link_with(self.dossier))
         self.meeting.execute_transition('pending-held')
 
         # set correct public url, used for generated meeting urls

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -12,6 +12,10 @@ class TestCommittee(FunctionalTestCase):
 
     def setUp(self):
         super(TestCommittee, self).setUp()
+        self.repo_root = create(Builder('repository_root'))
+        self.repository_folder = create(Builder('repository')
+                                        .within(self.repo_root)
+                                        .titled('Repo'))
         self.container = create(Builder('committee_container'))
 
     def test_committee_can_be_added(self):
@@ -27,7 +31,9 @@ class TestCommittee(FunctionalTestCase):
         browser.login()
         browser.open(self.container, view='++add++opengever.meeting.committee')
 
-        browser.fill({'Title': u'A c\xf6mmittee'})
+        browser.fill(
+            {'Title': u'A c\xf6mmittee',
+             'Linked repository folder': self.repository_folder})
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Item created',
                       browser.css('.portalMessage.info dd').text)
@@ -44,12 +50,13 @@ class TestCommittee(FunctionalTestCase):
     def test_committee_can_be_edited_in_browser(self, browser):
         committee = create(Builder('committee')
                            .within(self.container)
-                           .titled(u'My Committee'))
+                           .titled(u'My Committee')
+                           .link_with(self.repository_folder))
 
         browser.login().visit(committee, view='edit')
         form = browser.css('#content-core form').first
-        self.assertEqual(u'My Committee', form.find_field('Title').value)
 
+        self.assertEqual(u'My Committee', form.find_field('Title').value)
         browser.fill({'Title': u'A c\xf6mmittee'})
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Changes saved',

--- a/opengever/meeting/tests/test_committee_tabs.py
+++ b/opengever/meeting/tests/test_committee_tabs.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -18,16 +17,24 @@ class TestCommitteeTabs(FunctionalTestCase):
                                 .titled(u'Kleiner Burgerrat'))
         self.committee_model = self.committee.load_model()
 
-        create(Builder('meeting')
-               .having(committee=self.committee_model,
-                       location='Bern',
-                       start=datetime(2015, 01, 01, 12, 00),
-                       end=datetime(2015, 01, 03, 18, 00)))
+        self.repository_root, self.repository_folder = create(
+            Builder('repository_tree'))
+        self.dossier = create(Builder('dossier')
+                              .titled(u'D\xf6ssier')
+                              .within(self.repository_folder))
 
         create(Builder('meeting')
                .having(committee=self.committee_model,
                        location='Bern',
-                       start=datetime(2015, 06, 13, 9, 30)))
+                       start=datetime(2015, 01, 01, 12, 00),
+                       end=datetime(2015, 01, 03, 18, 00))
+               .link_with(self.dossier))
+
+        create(Builder('meeting')
+               .having(committee=self.committee_model,
+                       location='Bern',
+                       start=datetime(2015, 06, 13, 9, 30))
+               .link_with(self.dossier))
 
     @browsing
     def test_meeting_listing(self, browser):
@@ -39,10 +46,12 @@ class TestCommitteeTabs(FunctionalTestCase):
              'Date': 'Jan 01, 2015',
              'Location': 'Bern',
              'From': '12:00 PM',
-             'To': '06:00 PM'},
+             'To': '06:00 PM',
+             'Dossier': u'D\xf6ssier'},
             {'Title': 'Bern, Jun 13, 2015',
              'Date': 'Jun 13, 2015',
              'Location': 'Bern',
              'From': '09:30 AM',
-             'To': ''}
+             'To': '',
+             'Dossier': u'D\xf6ssier'}
         ], table.dicts())

--- a/opengever/meeting/tests/test_committee_tabs.py
+++ b/opengever/meeting/tests/test_committee_tabs.py
@@ -19,22 +19,22 @@ class TestCommitteeTabs(FunctionalTestCase):
 
         self.repository_root, self.repository_folder = create(
             Builder('repository_tree'))
-        self.dossier = create(Builder('dossier')
-                              .titled(u'D\xf6ssier')
-                              .within(self.repository_folder))
+        self.meeting_dossier = create(Builder('meeting_dossier')
+                                      .titled(u'D\xf6ssier')
+                                      .within(self.repository_folder))
 
         create(Builder('meeting')
                .having(committee=self.committee_model,
                        location='Bern',
                        start=datetime(2015, 01, 01, 12, 00),
                        end=datetime(2015, 01, 03, 18, 00))
-               .link_with(self.dossier))
+               .link_with(self.meeting_dossier))
 
         create(Builder('meeting')
                .having(committee=self.committee_model,
                        location='Bern',
                        start=datetime(2015, 06, 13, 9, 30))
-               .link_with(self.dossier))
+               .link_with(self.meeting_dossier))
 
     @browsing
     def test_meeting_listing(self, browser):

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -21,6 +21,8 @@ class TestExcerpt(FunctionalTestCase):
             Builder('repository_tree'))
         self.dossier = create(
             Builder('dossier').within(self.repository_folder))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
 
         self.templates = create(Builder('templatedossier'))
         self.sablon_template = create(
@@ -50,7 +52,7 @@ class TestExcerpt(FunctionalTestCase):
                               .having(committee=self.committee_model,
                                       start=datetime(2014, 3, 4),
                                       location=u'B\xe4rn',)
-                              .link_with(self.dossier))
+                              .link_with(self.meeting_dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 
@@ -91,7 +93,7 @@ class TestExcerpt(FunctionalTestCase):
                          title_field.value)
 
         dossier_field = browser.find('form.widgets.dossier')
-        self.assertEqual('/'.join(self.dossier.getPhysicalPath()),
+        self.assertEqual('/'.join(self.meeting_dossier.getPhysicalPath()),
                          dossier_field.value)
 
     @browsing

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Meeting
@@ -26,11 +27,13 @@ class TestExcerpt(FunctionalTestCase):
             Builder('sablontemplate')
             .within(self.templates)
             .with_asset_file('sablon_template.docx'))
-        container = create(Builder('committee_container').having(
-            protocol_template=self.sablon_template,
-            excerpt_template=self.sablon_template))
+        container = create(
+            Builder('committee_container').having(
+                protocol_template=self.sablon_template,
+                excerpt_template=self.sablon_template))
 
-        self.committee = create(Builder('committee').within(container))
+        self.committee = create(Builder('committee').within(container).having(
+            repository_folder=self.repository_folder))
         self.proposal = create(Builder('proposal')
                                .within(self.dossier)
                                .having(title='Mach doch',
@@ -72,6 +75,7 @@ class TestExcerpt(FunctionalTestCase):
         browser.login().open(self.committee, view='edit')
         browser.fill({'Excerpt template': custom_template})
         browser.css('#form-buttons-save').first.click()
+        self.assertEqual([], error_messages())
 
         self.assertEqual(custom_template,
                          self.committee.get_excerpt_template())

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -120,6 +120,14 @@ class TestExcerpt(FunctionalTestCase):
         self.assertIsNotNone(browser.find('protocol-excerpt-barn-mar-04-2014'))
 
     @browsing
+    def test_manual_excerpt_form_redirects_to_meeting_on_abort(self, browser):
+        browser.login().open(self.meeting.get_url())
+        browser.find('Generate excerpt').click()
+
+        browser.find('form.buttons.cancel').click()
+        self.assertEqual(self.meeting.get_url(), browser.url)
+
+    @browsing
     def test_validator_excerpt_requires_at_least_one_field(self, browser):
         browser.login().open(self.meeting.get_url())
 

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -82,6 +82,19 @@ class TestExcerpt(FunctionalTestCase):
                          self.committee.get_excerpt_template())
 
     @browsing
+    def test_manual_excerpt_pre_fills_fields(self, browser):
+        browser.login().open(self.meeting.get_url())
+        browser.find('Generate excerpt').click()
+
+        title_field = browser.find('Title')
+        self.assertEqual(u'Protocol Excerpt-B\xe4rn, Mar 04, 2014',
+                         title_field.value)
+
+        dossier_field = browser.find('form.widgets.dossier')
+        self.assertEqual('/'.join(self.dossier.getPhysicalPath()),
+                         dossier_field.value)
+
+    @browsing
     def test_manual_excerpt_can_be_generated(self, browser):
         browser.login().open(self.meeting.get_url())
 

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -49,7 +49,8 @@ class TestExcerpt(FunctionalTestCase):
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee_model,
                                       start=datetime(2014, 3, 4),
-                                      location=u'B\xe4rn',))
+                                      location=u'B\xe4rn',)
+                              .link_with(self.dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -45,7 +45,8 @@ class TestMeetingLocking(FunctionalTestCase):
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee_model,
                                       start=datetime(2013, 1, 1),
-                                      location='There',))
+                                      location='There',)
+                              .link_with(self.dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -23,6 +23,8 @@ class TestMeetingLocking(FunctionalTestCase):
             Builder('repository_tree'))
         self.dossier = create(
             Builder('dossier').within(self.repository_folder))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
 
         self.templates = create(Builder('templatedossier'))
         self.sablon_template = create(
@@ -46,7 +48,7 @@ class TestMeetingLocking(FunctionalTestCase):
                               .having(committee=self.committee_model,
                                       start=datetime(2013, 1, 1),
                                       location='There',)
-                              .link_with(self.dossier))
+                              .link_with(self.meeting_dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -24,6 +24,8 @@ class TestMeeting(FunctionalTestCase):
                                         .within(self.repo))
         self.dossier = create(
             Builder('dossier').within(self.repository_folder))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee')
                                 .within(container)
@@ -94,7 +96,7 @@ class TestMeeting(FunctionalTestCase):
                          .having(committee=committee_model,
                                  start=datetime(2013, 1, 1),
                                  location='There',)
-                         .link_with(self.dossier))
+                         .link_with(self.meeting_dossier))
 
         browser.login()
         browser.open(meeting.get_url(view='edit'))

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -70,7 +70,7 @@ class TestMeeting(FunctionalTestCase):
             [u'The meeting and its dossier were created successfully'],
             info_messages())
         self.assertEqual(
-            'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting/1',
+            'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/view',
             browser.url)
 
         committee_model = self.committee.load_model()

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -80,6 +80,9 @@ class TestMeeting(FunctionalTestCase):
         self.assertEqual(datetime(2010, 1, 1, 10), meeting.start)
         self.assertEqual(datetime(2010, 1, 1, 11), meeting.end)
         self.assertEqual('Somewhere', meeting.location)
+        dossier = meeting.dossier_oguid.resolve_object()
+        self.assertIsNotNone(dossier)
+        self.assertEquals(u'Meeting on Jan 01, 2010', dossier.title)
 
     @browsing
     def test_edit_meeting(self, browser):

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -22,6 +22,8 @@ class TestMeeting(FunctionalTestCase):
         self.repo = create(Builder('repository_root'))
         self.repository_folder = create(Builder('repository')
                                         .within(self.repo))
+        self.dossier = create(
+            Builder('dossier').within(self.repository_folder))
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee')
                                 .within(container)
@@ -37,9 +39,10 @@ class TestMeeting(FunctionalTestCase):
             Meeting(start=datetime(2013, 10, 18)).get_title())
 
     def test_meeting_link(self):
-        meeting = Meeting(location=u'Bern',
-                          start=datetime(2013, 10, 18),
-                          committee=self.committee.load_model())
+        meeting = create(Builder('meeting').having(
+            location=u'Bern',
+            start=datetime(2013, 10, 18),
+            committee=self.committee.load_model()))
 
         link = PyQuery(meeting.get_link())[0]
 
@@ -90,7 +93,8 @@ class TestMeeting(FunctionalTestCase):
         meeting = create(Builder('meeting')
                          .having(committee=committee_model,
                                  start=datetime(2013, 1, 1),
-                                 location='There',))
+                                 location='There',)
+                         .link_with(self.dossier))
 
         browser.login()
         browser.open(meeting.get_url(view='edit'))

--- a/opengever/meeting/tests/test_meeting_dossier.py
+++ b/opengever/meeting/tests/test_meeting_dossier.py
@@ -1,0 +1,26 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.testing import FunctionalTestCase
+from plone import api
+
+
+class TestMeetingDossier(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestMeetingDossier, self).setUp()
+        self.repo = create(Builder('repository_root'))
+        self.repository_folder = create(Builder('repository')
+                                        .within(self.repo))
+
+    @browsing
+    def test_add_meeting_menu_not_visible(self, browser):
+        ttool = api.portal.get_tool('portal_types')
+        browser.login().open(self.repository_folder)
+        info = ttool.getTypeInfo('opengever.meeting.meetingdossier')
+        self.assertEqual('Meeting Dossier', info.title)
+
+        self.assertIsNone(browser.find(info.title))

--- a/opengever/meeting/tests/test_meeting_dossier.py
+++ b/opengever/meeting/tests/test_meeting_dossier.py
@@ -1,12 +1,13 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.contentmenu.menu import FactoriesMenu
 from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
-from opengever.testing import FunctionalTestCase
+from opengever.dossier.tests.test_dossier import TestDossier
 from plone import api
 
 
-class TestMeetingDossier(FunctionalTestCase):
+class TestMeetingDossier(TestDossier):
 
     layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
 
@@ -24,3 +25,34 @@ class TestMeetingDossier(FunctionalTestCase):
         self.assertEqual('Meeting Dossier', info.title)
 
         self.assertIsNone(browser.find(info.title))
+
+    def test_factory_menu_sorting(self):
+        menu = FactoriesMenu(self.dossier)
+        menu_items = menu.getMenuItems(self.dossier, self.dossier.REQUEST)
+
+        self.assertEquals(
+            [u'Document',
+             'document_with_template',
+             u'Task',
+             'Add task from template',
+             u'Subdossier',
+             u'Add Participant',
+             u'Proposal'],
+            [item.get('title') for item in menu_items])
+
+    def test_default_addable_types(self):
+        self.grant('Contributor')
+        self.assertItemsEqual(
+            ['opengever.document.document',
+             'ftw.mail.mail',
+             'opengever.dossier.businesscasedossier',
+             'opengever.meeting.proposal',
+             'opengever.task.task'],
+            [fti.id for fti in self.dossier.allowedContentTypes()])
+
+    def test_tabbedview_tabs(self):
+        expected_tabs = ['Overview', 'Subdossiers', 'Documents', 'Tasks',
+                         'Proposals', 'Participants', 'Trash', 'Journal',
+                         'Sharing', ]
+
+        self.assert_tabbedview_tabs_for_obj(expected_tabs, self.dossier)

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -22,6 +22,10 @@ class TestMeetingView(FunctionalTestCase):
         self.dossier = create(Builder('dossier')
                               .within(self.repository_root))
 
+        self.meeting_dossier = create(Builder('dossier')
+                                      .titled(u'Meeting Dossier')
+                                      .within(self.repository_root))
+
         self.attachement = create(Builder('document')
                                   .attach_file_containing(u"attachement",
                                                           u"attachement.docx")
@@ -84,23 +88,34 @@ class TestMeetingView(FunctionalTestCase):
         # restore session by refreshing instance
         self.generated_excerpt = GeneratedExcerpt.get(self.generated_excerpt.document_id)
 
-        self.meeting = create(Builder('meeting')
-                              .having(committee=self.committee.load_model(),
-                                      start=datetime(2013, 1, 1, 8, 30),
-                                      end=datetime(2013, 1, 1, 10, 30),
-                                      location='There',
-                                      presidency=self.hugo,
-                                      participants = [self.peter,
-                                                      self.hans,
-                                                      self.roland],
-                                      secretary=self.sile,
-                                      protocol_document=self.generated_protocol,
-                                      excerpt_documents=[self.generated_excerpt],)
-                              .scheduled_proposals([self.proposal_a, self.proposal_b]))
+        self.meeting = create(
+            Builder('meeting')
+            .having(committee=self.committee.load_model(),
+                    start=datetime(2013, 1, 1, 8, 30),
+                    end=datetime(2013, 1, 1, 10, 30),
+                    location='There',
+                    presidency=self.hugo,
+                    participants=[self.peter,
+                                  self.hans,
+                                  self.roland],
+                    secretary=self.sile,
+                    protocol_document=self.generated_protocol,
+                    excerpt_documents=[self.generated_excerpt],)
+            .scheduled_proposals([self.proposal_a, self.proposal_b])
+            .link_with(self.meeting_dossier))
 
         # set correct public url, used for generated meeting urls
         get_current_admin_unit().public_url = self.portal.absolute_url()
         transaction.commit()
+
+    @browsing
+    def test_meeting_dossier_is_linked_from_meeting_view(self, browser):
+        browser.login().open(self.meeting.get_url())
+
+        link_node = browser.css('fieldset.dossier a').first
+        self.assertEqual('Meeting Dossier', link_node.text)
+        self.assertEqual(self.meeting_dossier.absolute_url(),
+                         link_node.get('href'))
 
     @browsing
     def test_accessing_the_meeting_directly_shows_meeting_view(self, browser):

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -22,7 +22,7 @@ class TestMeetingView(FunctionalTestCase):
         self.dossier = create(Builder('dossier')
                               .within(self.repository_root))
 
-        self.meeting_dossier = create(Builder('dossier')
+        self.meeting_dossier = create(Builder('meeting_dossier')
                                       .titled(u'Meeting Dossier')
                                       .within(self.repository_root))
 

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -17,6 +17,8 @@ class TestProposalHistory(FunctionalTestCase):
         self.admin_unit.public_url = 'http://nohost/plone'
         self.repo, self.repo_folder = create(Builder('repository_tree'))
         self.dossier = create(Builder('dossier').within(self.repo_folder))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repo_folder))
 
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee').within(container))
@@ -24,7 +26,7 @@ class TestProposalHistory(FunctionalTestCase):
                               .having(committee=self.committee.load_model(),
                                       start=datetime(2013, 1, 1),
                                       location='There',)
-                              .link_with(self.dossier))
+                              .link_with(self.meeting_dossier))
 
         self.repo, self.repo_folder = create(Builder('repository_tree'))
         self.dossier = create(Builder('dossier').within(self.repo_folder))

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -15,13 +15,16 @@ class TestProposalHistory(FunctionalTestCase):
     def setUp(self):
         super(TestProposalHistory, self).setUp()
         self.admin_unit.public_url = 'http://nohost/plone'
+        self.repo, self.repo_folder = create(Builder('repository_tree'))
+        self.dossier = create(Builder('dossier').within(self.repo_folder))
 
         container = create(Builder('committee_container'))
         self.committee = create(Builder('committee').within(container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model(),
                                       start=datetime(2013, 1, 1),
-                                      location='There',))
+                                      location='There',)
+                              .link_with(self.dossier))
 
         self.repo, self.repo_folder = create(Builder('repository_tree'))
         self.dossier = create(Builder('dossier').within(self.repo_folder))

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.browser.protocol import METHOD_NEW_DOCUMENT
@@ -37,7 +38,10 @@ class TestProtocol(FunctionalTestCase):
             protocol_template=self.sablon_template,
             excerpt_template=self.sablon_template))
 
-        self.committee = create(Builder('committee').within(container))
+        self.committee = create(
+            Builder('committee')
+            .within(container)
+            .having(repository_folder=self.repository_folder))
         self.proposal = create(Builder('proposal')
                                .within(self.dossier)
                                .having(title='Mach doch',
@@ -85,6 +89,7 @@ class TestProtocol(FunctionalTestCase):
         browser.login().open(self.committee, view='edit')
         browser.fill({'Protocol template': custom_template})
         browser.css('#form-buttons-save').first.click()
+        self.assertEqual([], error_messages())
 
         self.assertEqual(custom_template,
                          self.committee.get_protocol_template())

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -28,6 +28,8 @@ class TestProtocol(FunctionalTestCase):
             Builder('repository_tree'))
         self.dossier = create(
             Builder('dossier').within(self.repository_folder))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
 
         self.templates = create(Builder('templatedossier'))
         self.sablon_template = create(
@@ -53,7 +55,7 @@ class TestProtocol(FunctionalTestCase):
                               .having(committee=self.committee_model,
                                       start=datetime(2013, 1, 1),
                                       location='There',)
-                              .link_with(self.dossier))
+                              .link_with(self.meeting_dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -52,7 +52,8 @@ class TestProtocol(FunctionalTestCase):
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee_model,
                                       start=datetime(2013, 1, 1),
-                                      location='There',))
+                                      location='There',)
+                              .link_with(self.dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -73,8 +73,6 @@ class TestProtocol(FunctionalTestCase):
     def setup_generated_protocol(self, browser):
         self.setup_protocol(browser)
         browser.css('a[href*="@@generate_protocol"]').first.click()
-        browser.fill({'Target dossier': self.dossier})
-        browser.find('Generate').click()
 
     def test_default_protocol_is_configured_on_commitee_container(self):
         self.assertEqual(self.sablon_template,
@@ -170,8 +168,6 @@ class TestProtocol(FunctionalTestCase):
     def test_protocol_can_be_generated(self, browser):
         self.setup_protocol(browser)
         browser.css('a[href*="@@generate_protocol"]').first.click()
-        browser.fill({'Target dossier': self.dossier})
-        browser.find('Generate').click()
 
         self.assertEquals(
             ['Protocol for meeting There, Jan 01, 2013 '
@@ -179,9 +175,8 @@ class TestProtocol(FunctionalTestCase):
             info_messages())
 
         meeting = Meeting.get(self.meeting.meeting_id)  # refresh meeting
-        document = browser.context
-        generated_document = GeneratedProtocol.query.by_document(
-            document).first()
+        self.assertIsNotNone(meeting.protocol_document)
+        generated_document = meeting.protocol_document
         self.assertIsNotNone(generated_document)
         self.assertEqual(0, generated_document.generated_version)
         self.assertEqual(meeting, generated_document.meeting)

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -325,4 +325,13 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4603 -> 4604 -->
+    <upgrade-step:importProfile
+        title="Add Meeting-Dossier content type."
+        source="4603"
+        destination="4604"
+        profile="opengever.meeting:default"
+        directory="profiles/4604"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -334,4 +334,14 @@
         directory="profiles/4604"
         />
 
+    <!-- 4604 -> 4605 -->
+    <genericsetup:upgradeStep
+        title="Link meeting and dossier"
+        description=""
+        source="4604"
+        destination="4605"
+        handler="opengever.meeting.upgrades.to4605.LinkMeetingToDossier"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4604/types.xml
+++ b/opengever/meeting/upgrades/profiles/4604/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types">
+    <object name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI" />
+</object>

--- a/opengever/meeting/upgrades/profiles/4604/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/meeting/upgrades/profiles/4604/types/opengever.meeting.meetingdossier.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI"
+        i18n:domain="opengever.meeting" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Meeting Dossier</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="opengever.meeting.proposal" />
+        <element value="opengever.dossier.businesscasedossier" />
+        <element value="opengever.document.document" />
+        <element value="opengever.task.task" />
+        <element value="ftw.mail.mail"/>
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">opengever.meeting.interfaces.IMeetingDossier</property>
+
+    <!-- class used for content items -->
+    <property name="klass">opengever.meeting.dossier.MeetingDossier</property>
+
+    <!-- add permission -->
+    <property name="add_permission">opengever.dossier.AddBusinessCaseDossier</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+        <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+        <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+        <element value="opengever.dossier.behaviors.dossier.IDossier" />
+        <element value="opengever.dossier.behaviors.participation.IParticipationAware" />
+        <element value="opengever.base.behaviors.classification.IClassification" />
+        <element value="opengever.base.behaviors.lifecycle.ILifeCycle" />
+        <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
+        <element value="opengever.trash.trash.ITrashable" />
+        <element value="opengever.dossier.behaviors.dossiernamefromtitle.IDossierNameFromTitle" />
+        <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+        <element value="opengever.sharing.behaviors.IDossier" />
+        <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+        <element value="opengever.mail.behaviors.ISendableDocsContainer" />
+    </property>
+
+    <!-- View information -->
+    <property name="immediate_view">tabbed_view</property>
+    <property name="default_view">tabbed_view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+        <element value="tabbed_view" />
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(selected layout)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="@@view"/>
+
+    <!-- Actions -->
+    <action action_id="view"
+            visible="False"
+            title="View"
+            category="object"
+            url_expr="string:${object_url}"
+            condition_expr="">
+        <permission value="View"/>
+    </action>
+
+    <action action_id="edit"
+            visible="True"
+            title="Edit"
+            category="object"
+            url_expr="string:${object_url}/edit"
+            condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True">
+        <permission value="Modify portal content"/>
+    </action>
+
+    <action action_id="document_with_template"
+            visible="True"
+            title="document_with_template"
+            category="folder_factories"
+            url_expr="string:${object_url}/document_with_template"
+            icon_expr=""
+            condition_expr=""
+            i18n:domain="opengever.dossier">
+        <permission value="Add portal content"/>
+    </action>
+
+    <action action_id="add_participant"
+            visible="True"
+            title="Add Participant"
+            category="folder_factories"
+            url_expr="string:${object_url}/@@add-participation"
+            icon_expr=""
+            condition_expr=""
+            i18n:domain="opengever.dossier"
+            i18n:attributes="title">
+        <permission value="Add portal content"/>
+    </action>
+
+
+    <!-- Tabbedview tabs-->
+    <action i18n:domain="opengever.dossier" title="Overview" action_id="overview" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Subdossiers" action_id="subdossiers" category="tabbedview-tabs"
+            condition_expr="object/show_subdossier" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Documents" action_id="documents" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Tasks" action_id="tasks" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Proposals" action_id="proposals" category="tabbedview-tabs"
+            condition_expr="object/@@is_meeting_feature_enabled" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Participants" action_id="participants" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Trash" action_id="trash" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Journal" action_id="journal" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#" visible="True">
+        <permission value="View"/>
+    </action>
+
+
+    <action i18n:domain="opengever.dossier" title="Sharing" action_id="sharing" category="tabbedview-tabs"
+            condition_expr="" url_expr="string:#"
+            visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action i18n:domain="opengever.dossier" title="Give Filing Number" action_id="filing_nr" category="object_buttons"
+            condition_expr="python: object.portal_workflow.getInfoFor(object, 'review_state', None) == 'dossier-state-resolved' and getattr( object, 'filing_no', None) == None" url_expr="string:${object_url}/transition-archive" visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/opengever/meeting/upgrades/profiles/4604/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/meeting/upgrades/profiles/4604/types/opengever.repository.repositoryfolder.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="opengever.repository.repositoryfolder">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="opengever.meeting.meetingdossier" />
+    </property>
+
+</object>

--- a/opengever/meeting/upgrades/profiles/4604/workflows.xml
+++ b/opengever/meeting/upgrades/profiles/4604/workflows.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <bindings>
+        <type type_id="opengever.meeting.meetingdossier">
+      <bound-workflow workflow_id="opengever_dossier_workflow"/>
+    </type>
+  </bindings>
+
+</object>
+
+

--- a/opengever/meeting/upgrades/to4605.py
+++ b/opengever/meeting/upgrades/to4605.py
@@ -1,0 +1,30 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class LinkMeetingToDossier(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4605
+
+    def migrate(self):
+        # This upgrade runs only when no content has been created.
+        # This assumption holds because this will be the first "productive"
+        # release of opengever.meeting.
+
+        meeting_table = table("meetings", column("id"))
+        meetings = self.connection.execute(meeting_table.select()).fetchall()
+        assert len(meetings) == 0, "runs only for empty meeting-tables"
+
+        self.add_dossier_columns()
+
+    def add_dossier_columns(self):
+        self.op.add_column('meetings',
+                           Column('dossier_admin_unit_id', String(30),
+                                  nullable=False))
+        self.op.add_column('meetings',
+                           Column('dossier_int_id', Integer, nullable=False))

--- a/opengever/task/browser/accept/newdossier.py
+++ b/opengever/task/browser/accept/newdossier.py
@@ -204,11 +204,17 @@ class SelectRepositoryfolderStepRedirector(grok.View):
 
 @grok.provider(IContextSourceBinder)
 def allowed_dossier_types_vocabulary(context):
+    """Return the dossier types that are visible in the task accept form."""
+
     dossier_behavior = 'opengever.dossier.behaviors.dossier.IDossier'
 
     terms = []
     for fti in context.allowedContentTypes():
         if dossier_behavior not in getattr(fti, 'behaviors', ()):
+            continue
+
+        # XXX refactor as soon as content types know their visible types
+        if fti.id == 'opengever.meeting.meetingdossier':
             continue
 
         title = MessageFactory(fti.i18n_domain)(fti.title)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -315,9 +315,19 @@ class CommitteeBuilder(DexterityBuilder):
 
     def __init__(self, session):
         super(CommitteeBuilder, self).__init__(session)
-        self.arguments = {'title': 'My Committee'}
+        self.arguments = {
+            'title': 'My Committee',
+        }
+
+    def link_with(self, repository_folder):
+        self.arguments['repository_folder'] = repository_folder
+        return self
 
     def after_create(self, obj):
+        self.arguments.pop('repository_folder', None)
+        self.arguments.pop('excerpt_template', None)
+        self.arguments.pop('protocol_template', None)
+
         obj.create_model(self.arguments, self.container)
         super(CommitteeBuilder, self).after_create(obj)
 

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -23,6 +23,12 @@ class DossierBuilder(DexterityBuilder):
 builder_registry.register('dossier', DossierBuilder)
 
 
+class MeetingDossierBuilder(DossierBuilder):
+    portal_type = 'opengever.meeting.meetingdossier'
+
+builder_registry.register('meeting_dossier', MeetingDossierBuilder)
+
+
 class TemplateDossierBuilder(DexterityBuilder):
     portal_type = 'opengever.dossier.templatedossier'
 

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -181,6 +181,8 @@ class MeetingBuilder(SqlObjectBuilder):
     def __init__(self, session):
         super(MeetingBuilder, self).__init__(session)
         self._scheduled_proposals = []
+        self.arguments['dossier_admin_unit_id'] = 'foo'
+        self.arguments['dossier_int_id'] = 1234
 
     def scheduled_proposals(self, proposals):
         for proposal in proposals:

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -5,6 +5,7 @@ from opengever.base.oguid import Oguid
 from opengever.globalindex.model.task import Task
 from opengever.locking.interfaces import ISQLLockable
 from opengever.locking.model import Lock
+from opengever.meeting.interfaces import IMeetingDossier
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Committee
 from opengever.meeting.model import Meeting
@@ -187,6 +188,7 @@ class MeetingBuilder(SqlObjectBuilder):
     def link_with(self, dossier):
         del self.arguments['dossier_admin_unit_id']
         del self.arguments['dossier_int_id']
+        assert IMeetingDossier.providedBy(dossier)
         self.arguments['dossier_oguid'] = Oguid.for_object(dossier)
         return self
 

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -184,6 +184,12 @@ class MeetingBuilder(SqlObjectBuilder):
         self.arguments['dossier_admin_unit_id'] = 'foo'
         self.arguments['dossier_int_id'] = 1234
 
+    def link_with(self, dossier):
+        del self.arguments['dossier_admin_unit_id']
+        del self.arguments['dossier_int_id']
+        self.arguments['dossier_oguid'] = Oguid.for_object(dossier)
+        return self
+
     def scheduled_proposals(self, proposals):
         for proposal in proposals:
             if IProposal.providedBy(proposal):

--- a/sources.cfg
+++ b/sources.cfg
@@ -8,6 +8,7 @@ development-packages =
   plonetheme.teamraum
   ftw.mail
   opengever.ogds.models
+  ftw.upgrade
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Styles are updated in https://github.com/4teamwork/plonetheme.teamraum/pull/361.

With this PR committees must always be linked to a corresponding repository folder. That folder then contains automatically generated dossiers for each meeting.

  - Add a new content-type, meeting-dossier.
  - Link dossier and meeting creation, automatically create a meeting-dossier when a meeting is created.
  - Automatically generate Protocols into the meeting's dossier.
  - Automatically suggest the dossier as dossier for manually generated excerpts.

Furthermore this PR contains a refactoring which adds a base-class for an `AddForm` that is wrapped in a wizard. The form for which i refactored has not made it into this PR, but the refactoring is still valuable.

It also contains a small fix for the currenlty broken master due to a new `ftw.testing` release.

Closes #1064.
Closes #1036.