### PR TITLE
Register actor as watcher instead of every single user

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Notification center: Register actor as watcher instead of every single user.
+  [phgross]
+
 - Introduce wrapper objects for members and memberships to eliminate
   traversal hacks.
   [deiferni]

--- a/opengever/activity/browser/resolve.py
+++ b/opengever/activity/browser/resolve.py
@@ -32,7 +32,7 @@ class ResolveNotificationView(ResolveOGUIDView):
         """Check if the current user is allowed to view the notification."""
 
         current_user = api.user.get_current()
-        return self.notification.watcher.user_id == current_user.getId()
+        return self.notification.userid == current_user.getId()
 
     def mark_as_read(self):
         self.notification.is_read = True

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -8,7 +8,6 @@ from opengever.activity.model.subscription import TASK_RESPONSIBLE_ROLE
 from opengever.activity.model.subscription import WATCHER_ROLE
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
-from opengever.ogds.base.actor import Actor
 from plone import api
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.sql.expression import asc
@@ -56,13 +55,13 @@ class NotificationCenter(object):
         resource = Resource.query.get_by_oguid(oguid)
         return resource
 
-    def add_watcher(self, user_id):
-        watcher = Watcher(user_id=user_id)
+    def add_watcher(self, actorid):
+        watcher = Watcher(actorid=actorid)
         self.session.add(watcher)
         return watcher
 
-    def fetch_watcher(self, user_id):
-        return Watcher.query.get_by_userid(user_id)
+    def fetch_watcher(self, actorid):
+        return Watcher.query.get_by_actorid(actorid)
 
     def add_watcher_to_resource(self, oguid, userid, role=WATCHER_ROLE):
         resource = self.fetch_resource(oguid)
@@ -240,10 +239,10 @@ class DisabledNotificationCenter(NotificationCenter):
     def fetch_resource(self, oguid):
         return None
 
-    def add_watcher(self, user_id):
+    def add_watcher(self, actorid):
         pass
 
-    def fetch_watcher(self, user_id):
+    def fetch_watcher(self, actorid):
         return None
 
     def add_watcher_to_resource(self, obj, userid, role):

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -144,10 +144,11 @@ class NotificationCenter(object):
                                      sort_reverse=False, offset=0, limit=None):
 
         order = desc if sort_reverse else asc
-        query = Notification.query.join(Notification.activity)
+        query = Notification.query
         if userid:
             query = query.by_user(userid)
 
+        query = query.join(Notification.activity)
         query = query.order_by(order(sort_on))
         query = query.offset(offset).limit(limit)
         return query.options(contains_eager(Notification.activity)).all()
@@ -167,11 +168,9 @@ class PloneNotificationCenter(NotificationCenter):
         return item
 
     def add_watcher_to_resource(self, obj, actorid, role):
-        actor = Actor.lookup(actorid)
         oguid = self._get_oguid_for(obj)
-        for representative in actor.representatives():
-            super(PloneNotificationCenter, self).add_watcher_to_resource(
-                oguid, representative.userid, role)
+        return super(PloneNotificationCenter, self).add_watcher_to_resource(
+            oguid, actorid, role)
 
     def remove_watcher_from_resource(self, obj, userid, role):
         oguid = self._get_oguid_for(obj)

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -48,8 +48,8 @@ class NotificationDispatcher(object):
             return []
 
         not_dispatched = []
-        notifications = activity.get_notifications_for_watcher_roles(
-            self.get_roles_to_dispatch(activity.kind))
+        roles = self.get_roles_to_dispatch(activity.kind)
+        notifications = activity.get_notifications_for_watcher_roles(roles)
 
         for notification in notifications:
             try:
@@ -99,7 +99,7 @@ class PloneNotificationMailer(NotificationDispatcher):
         actor = ogds_service().fetch_user(notification.activity.actor_id)
         msg['From'] = make_addr_header(actor.fullname(), actor.email, 'utf-8')
 
-        recipient = ogds_service().fetch_user(notification.watcher.user_id)
+        recipient = ogds_service().fetch_user(notification.userid)
         msg['To'] = recipient.email
         msg['Subject'] = self.get_subject(notification)
 

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -55,12 +55,19 @@ class Activity(Base, Translatable):
         """
 
         notifications = []
-        for watcher in self.resource.watchers:
-            if not self.is_current_user(watcher):
+        for userid in self.get_users_for_watchers():
+            if not self.is_current_user(userid):
                 notifications.append(
-                    Notification(watcher=watcher, activity=self))
+                    Notification(userid=userid, activity=self))
 
         return notifications
+
+    def get_users_for_watchers(self):
+        users = []
+        for watcher in self.resource.watchers:
+            users += watcher.get_user_ids()
+
+        return set(users)
 
     def get_notifications_for_watcher_roles(self, roles):
         """Returns a list of activities notifications, but only those
@@ -68,8 +75,8 @@ class Activity(Base, Translatable):
         """
         return Notification.query.by_subscription_roles(roles, self).all()
 
-    def is_current_user(self, watcher):
-        return watcher.user_id == self.actor_id
+    def is_current_user(self, user_id):
+        return user_id == self.actor_id
 
 
 class ActivityTranslation(translation_base(Activity)):

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -1,12 +1,14 @@
 from opengever.activity.model.resource import Resource
 from opengever.activity.model.subscription import Subscription
 from opengever.base.model import Base
+from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import and_
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
+from sqlalchemy import String
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 
@@ -14,7 +16,7 @@ from sqlalchemy.schema import Sequence
 class NotificationQuery(BaseQuery):
 
     def by_user(self, userid):
-        return self.join(Notification.watcher).filter_by(user_id=userid)
+        return self.filter_by(userid=userid)
 
     def by_subscription_roles(self, roles, activity):
         query = self.filter_by(activity=activity).join(Notification.activity)
@@ -35,9 +37,7 @@ class Notification(Base):
     notification_id = Column('id', Integer, Sequence('notifications_id_seq'),
                              primary_key=True)
 
-    watcher_id = Column(Integer, ForeignKey('watchers.id'))
-    watcher = relationship("Watcher", backref="notifications")
-
+    userid = Column(String(USER_ID_LENGTH), nullable=False)
     activity_id = Column(Integer, ForeignKey('activities.id'))
     activity = relationship("Activity", backref="notifications")
 

--- a/opengever/activity/model/resource.py
+++ b/opengever/activity/model/resource.py
@@ -39,10 +39,10 @@ class Resource(Base):
     def __repr__(self):
         return '<Resource {}:{}>'.format(self.admin_unit_id, self.int_id)
 
-    def add_watcher(self, user_id, role):
-        watcher = Watcher.query.get_by_userid(user_id)
+    def add_watcher(self, actorid, role):
+        watcher = Watcher.query.get_by_actorid(actorid)
         if not watcher:
-            watcher = Watcher(user_id=user_id)
+            watcher = Watcher(actorid=actorid)
             create_session().add(watcher)
 
         subscription = Subscription.query.fetch(self, watcher, role)

--- a/opengever/activity/model/subscription.py
+++ b/opengever/activity/model/subscription.py
@@ -21,6 +21,10 @@ class SubscriptionQuery(BaseQuery):
     def get_by_watcher_resource(self, resource, watcher):
         return self.filter_by(resource=resource, watcher=watcher).first()
 
+    def by_resource_and_role(self, resource, roles):
+        return self.filter_by(resource=resource).filter(
+            Subscription.role.in_(roles))
+
 
 class Subscription(Base):
     query_cls = SubscriptionQuery

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -11,8 +11,8 @@ from sqlalchemy.schema import Sequence
 
 class WatcherQuery(BaseQuery):
 
-    def get_by_userid(self, user_id):
-        return self.filter_by(user_id=user_id).first()
+    def get_by_actorid(self, actorid):
+        return self.filter_by(actorid=actorid).first()
 
 
 class Watcher(Base):
@@ -24,12 +24,12 @@ class Watcher(Base):
 
     watcher_id = Column('id', Integer, Sequence('watchers_id_seq'),
                         primary_key=True)
-    user_id = Column(String(USER_ID_LENGTH), nullable=False, unique=True)
+    actorid = Column(String(USER_ID_LENGTH), nullable=False, unique=True)
 
     resources = association_proxy('subscriptions', 'resource')
 
     def __repr__(self):
-        return '<Watcher {}>'.format(repr(self.user_id))
+        return '<Watcher {}>'.format(repr(self.actorid))
 
     def get_user_ids(self):
         """Returns a list of userids which represents the given watcher:
@@ -39,10 +39,10 @@ class Watcher(Base):
         """
         # XXX Use opengever.ogds.models.actor instead of own actor differentiation.
         ogds_service = OGDSService(self.session)
-        if self.user_id.startswith('inbox:'):
-            org_unit_id = self.user_id.split(':', 1)[1]
+        if self.actorid.startswith('inbox:'):
+            org_unit_id = self.actorid.split(':', 1)[1]
             org_unit = ogds_service.fetch_org_unit(org_unit_id)
             return [user.userid for user in org_unit.inbox_group.users]
 
         else:
-            return [self.user_id]
+            return [self.actorid]

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
+from opengever.ogds.models.service import OGDSService
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -29,3 +30,19 @@ class Watcher(Base):
 
     def __repr__(self):
         return '<Watcher {}>'.format(repr(self.user_id))
+
+    def get_user_ids(self):
+        """Returns a list of userids which represents the given watcher:
+
+        Means for a single user, a list with the user_id and for a inbox watcher,
+        a list of the userids of all inbox_group users.
+        """
+        # XXX Use opengever.ogds.models.actor instead of own actor differentiation.
+        ogds_service = OGDSService(self.session)
+        if self.user_id.startswith('inbox:'):
+            org_unit_id = self.user_id.split(':', 1)[1]
+            org_unit = ogds_service.fetch_org_unit(org_unit_id)
+            return [user.userid for user in org_unit.inbox_group.users]
+
+        else:
+            return [self.user_id]

--- a/opengever/activity/profiles/default/metadata.xml
+++ b/opengever/activity/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4504</version>
+  <version>4505</version>
 </metadata>

--- a/opengever/activity/profiles/default/metadata.xml
+++ b/opengever/activity/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4505</version>
+  <version>4506</version>
 </metadata>

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -22,7 +22,7 @@ class TestMyNotifications(FunctionalTestCase):
 
         self.center = NotificationCenter()
         self.test_user = create(Builder('watcher')
-                                .having(user_id=TEST_USER_ID))
+                                .having(actorid=TEST_USER_ID))
 
         self.resource_a = create(Builder('resource')
                                  .oguid('fd:123')

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -32,7 +32,7 @@ class TestEmailNotification(FunctionalTestCase):
                        lastname='Michel',
                        email='franz.michel@example.org'))
 
-        create(Builder('watcher').having(user_id='hugo.boss'))
+        create(Builder('watcher').having(actorid='hugo.boss'))
 
         self.dossier = create(Builder('dossier').titled(u'Dossier A'))
 

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -19,11 +19,11 @@ class TestEmailNotification(FunctionalTestCase):
         Mailing(self.portal).set_up()
 
         self.hugo = create(Builder('ogds_user')
-               .assign_to_org_units([self.org_unit])
-               .having(userid='hugo.boss',
-                       firstname='Hugo',
-                       lastname='Boss',
-                       email='hugo.boss@example.org'))
+                           .assign_to_org_units([self.org_unit])
+                           .having(userid='hugo.boss',
+                                   firstname='Hugo',
+                                   lastname='Boss',
+                                   email='hugo.boss@example.org'))
 
         self.franz = create(Builder('ogds_user')
                .assign_to_org_units([self.org_unit])

--- a/opengever/activity/tests/test_model.py
+++ b/opengever/activity/tests/test_model.py
@@ -12,19 +12,18 @@ import transaction
 class TestNotification(ActivityTestCase):
 
     def test_string_representation(self):
-        watcher = create(Builder('watcher').having(user_id=u'h\xfcgo.boss'))
         resource = create(Builder('resource').oguid('fd:123'))
         activity = create(Builder('activity').having(
             title=u'Bitte \xc4nderungen nachvollziehen', resource=resource))
         notification = create(Builder('notification')
-                              .having(activity=activity, watcher=watcher))
+                              .having(activity=activity, userid=u'h\xfcgo.boss'))
 
         self.assertEqual(
-            "<Notification 1 for <Watcher u'h\\xfcgo.boss'> on <Resource fd:123> >",
+            "<Notification 1 for u'h\\xfcgo.boss' on <Resource fd:123> >",
             str(notification))
 
         self.assertEqual(
-            "<Notification 1 for <Watcher u'h\\xfcgo.boss'> on <Resource fd:123> >",
+            "<Notification 1 for u'h\\xfcgo.boss' on <Resource fd:123> >",
             repr(notification))
 
     def test_by_subscription_role_query(self):
@@ -46,9 +45,9 @@ class TestNotification(ActivityTestCase):
                                               role=WATCHER_ROLE))
 
         notification_1 = create(Builder('notification')
-                                .having(activity=activity, watcher=hugo))
+                                .having(activity=activity, userid=u'h\xfcgo'))
         notification_2 = create(Builder('notification')
-                                .having(activity=activity, watcher=peter))
+                                .having(activity=activity, userid=u'peter'))
 
         notifications = Notification.query.by_subscription_roles(
             [TASK_ISSUER_ROLE], activity).all()
@@ -61,15 +60,6 @@ class TestNotification(ActivityTestCase):
         notifications = Notification.query.by_subscription_roles(
             [TASK_RESPONSIBLE_ROLE], activity).all()
         self.assertEqual([], notifications)
-
-
-class TestWatcher(ActivityTestCase):
-
-    def test_string_representation(self):
-        watcher = create(Builder('watcher').having(user_id=u'h\xfcgo.boss'))
-
-        self.assertEqual("<Watcher u'h\\xfcgo.boss'>", str(watcher))
-        self.assertEqual("<Watcher u'h\\xfcgo.boss'>", repr(watcher))
 
 
 class TestResource(ActivityTestCase):

--- a/opengever/activity/tests/test_model.py
+++ b/opengever/activity/tests/test_model.py
@@ -31,8 +31,8 @@ class TestNotification(ActivityTestCase):
         activity = create(Builder('activity').having(
             title=u'Bitte \xc4nderungen nachvollziehen', resource=resource))
 
-        hugo = create(Builder('watcher').having(user_id=u'h\xfcgo'))
-        peter = create(Builder('watcher').having(user_id=u'peter'))
+        hugo = create(Builder('watcher').having(actorid=u'h\xfcgo'))
+        peter = create(Builder('watcher').having(actorid=u'peter'))
 
         create(Builder('subscription').having(resource=resource,
                                               watcher=peter,
@@ -90,7 +90,7 @@ class TestSubscription(ActivityTestCase):
 
     def test_string_representation(self):
         resource = create(Builder('resource').oguid('fd:123'))
-        watcher = create(Builder('watcher').having(user_id=u'h\xfcgo.boss'))
+        watcher = create(Builder('watcher').having(actorid=u'h\xfcgo.boss'))
         subscription = create(Builder('subscription')
                               .having(resource=resource,
                                       watcher=watcher,
@@ -105,7 +105,7 @@ class TestSubscription(ActivityTestCase):
 
     def test_primary_key_definition(self):
         resource = create(Builder('resource').oguid('fd:123'))
-        watcher = create(Builder('watcher').having(user_id=u'h\xfcgo.boss'))
+        watcher = create(Builder('watcher').having(actorid=u'h\xfcgo.boss'))
         create(Builder('subscription')
                .having(resource=resource, watcher=watcher, role=WATCHER_ROLE))
 

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -22,8 +22,8 @@ class TestResourceHandling(ActivityTestCase):
         self.center = NotificationCenter()
 
     def test_add_watcher_to_a_resource(self):
-        hugo = create(Builder('watcher').having(user_id='hugo'))
-        peter = create(Builder('watcher').having(user_id='peter'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
+        peter = create(Builder('watcher').having(actorid='peter'))
         res = create(Builder('resource').oguid('fd:1234'))
 
         res.add_watcher('hugo', TASK_ISSUER_ROLE)
@@ -58,9 +58,9 @@ class TestWatcherHandling(ActivityTestCase):
         super(TestWatcherHandling, self).setUp()
         self.center = NotificationCenter()
 
-    def test_fetch_returns_watcher_by_means_of_user_id(self):
-        hugo = create(Builder('watcher').having(user_id='hugo'))
-        peter = create(Builder('watcher').having(user_id='peter'))
+    def test_fetch_returns_watcher_by_means_of_actor_id(self):
+        hugo = create(Builder('watcher').having(actorid='hugo'))
+        peter = create(Builder('watcher').having(actorid='peter'))
 
         self.assertEquals(hugo, self.center.fetch_watcher('hugo'))
         self.assertEquals(peter, self.center.fetch_watcher('peter'))
@@ -72,7 +72,7 @@ class TestWatcherHandling(ActivityTestCase):
         self.center.add_watcher('peter')
 
         self.assertEquals(1, len(Watcher.query.all()))
-        self.assertEquals('peter', Watcher.query.first().user_id)
+        self.assertEquals('peter', Watcher.query.first().actorid)
 
     def test_add_watcher_twice_raise_integrity_error(self):
         self.center.add_watcher('peter')
@@ -83,7 +83,7 @@ class TestWatcherHandling(ActivityTestCase):
         transaction.abort()
 
     def test_add_watcher_to_resource(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
+        peter = create(Builder('watcher').having(actorid='peter'))
         resource = create(Builder('resource').oguid('fd:123'))
 
         self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
@@ -91,7 +91,7 @@ class TestWatcherHandling(ActivityTestCase):
         self.assertEquals([peter], list(resource.watchers))
 
     def test_adding_watcher_twice_to_resource_is_ignored(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
+        peter = create(Builder('watcher').having(actorid='peter'))
         resource = create(Builder('resource').oguid('fd:123'))
 
         self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
@@ -100,7 +100,7 @@ class TestWatcherHandling(ActivityTestCase):
         self.assertEquals([peter], list(resource.watchers))
 
     def test_add_watcher_to_resource_creates_resource_when_not_exitst(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
+        peter = create(Builder('watcher').having(actorid='peter'))
 
         self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
 
@@ -113,12 +113,12 @@ class TestWatcherHandling(ActivityTestCase):
         self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
 
         watcher = list(resource.watchers)[0]
-        self.assertEquals('peter', watcher.user_id)
+        self.assertEquals('peter', watcher.actorid)
 
     def test_get_watchers_returns_a_list_of_resource_watchers(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
-        hugo = create(Builder('watcher').having(user_id='hugo'))
-        fritz = create(Builder('watcher').having(user_id='fritz'))
+        peter = create(Builder('watcher').having(actorid='peter'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
+        fritz = create(Builder('watcher').having(actorid='fritz'))
 
         resource_1 = create(Builder('resource')
                             .oguid('fd:123').watchers([hugo, fritz]))
@@ -140,7 +140,7 @@ class TestWatcherHandling(ActivityTestCase):
 
     def test_remove_watcher_from_resource_will_remove_subscription_if_no_roles_left(self):
         resource = create(Builder('resource').oguid('fd:123'))
-        watcher = create(Builder('watcher').having(user_id=u'peter'))
+        watcher = create(Builder('watcher').having(actorid=u'peter'))
         create(Builder('subscription')
                .having(resource=resource, watcher=watcher, role=WATCHER_ROLE))
 
@@ -150,14 +150,14 @@ class TestWatcherHandling(ActivityTestCase):
         self.assertEquals([], resource.watchers)
 
     def test_remove_watcher_from_resource_will_be_ignored_when_resource_not_exists(self):
-        create(Builder('watcher').having(user_id='peter'))
+        create(Builder('watcher').having(actorid='peter'))
 
         self.center.remove_watcher_from_resource(
             Oguid('fd', '123'), 'peter', WATCHER_ROLE)
 
     def test_remove_watcher_from_resource(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
-        hugo = create(Builder('watcher').having(user_id='hugo'))
+        peter = create(Builder('watcher').having(actorid='peter'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
         resource = create(Builder('resource')
                           .oguid('fd:123')
                           .watchers([hugo, peter]))
@@ -190,8 +190,8 @@ class TestAddActivity(ActivityTestCase):
         self.assertEquals(123, resource.int_id)
 
     def test_creates_notifications_for_each_resource_watcher(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
-        hugo = create(Builder('watcher').having(user_id='hugo'))
+        peter = create(Builder('watcher').having(actorid='peter'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
 
         resource_a = create(Builder('resource').oguid('fd:123')
                             .watchers([hugo, peter]))
@@ -216,8 +216,8 @@ class TestAddActivity(ActivityTestCase):
         self.assertFalse(notification.is_read)
 
     def test_does_not_create_an_notification_for_the_actor(self):
-        peter = create(Builder('watcher').having(user_id='peter'))
-        hugo = create(Builder('watcher').having(user_id='hugo'))
+        peter = create(Builder('watcher').having(actorid='peter'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
 
         create(Builder('resource').oguid('fd:123').watchers([hugo, peter]))
 
@@ -242,9 +242,9 @@ class TestNotificationHandling(ActivityTestCase):
         self.center = NotificationCenter()
 
         self.peter = create(Builder('ogds_user').id('peter'))
-        self.peter = create(Builder('watcher').having(user_id='peter'))
+        self.peter = create(Builder('watcher').having(actorid='peter'))
         self.hugo = create(Builder('ogds_user').id('hugo'))
-        self.hugo = create(Builder('watcher').having(user_id='hugo'))
+        self.hugo = create(Builder('watcher').having(actorid='hugo'))
 
         self.resource_a = create(Builder('resource')
                                  .oguid('fd:123')
@@ -311,7 +311,7 @@ class TestNotificationHandling(ActivityTestCase):
         self.assertEquals(2, len(peters_notifications))
 
     def test_get_users_notifications_retuns_empty_list_when_no_notifications_for_this_user_exists(self):
-        create(Builder('watcher').having(user_id='franz'))
+        create(Builder('watcher').having(actorid='franz'))
 
         self.assertEquals([],
                           self.center.get_users_notifications('franz'))
@@ -391,8 +391,8 @@ class TestDispatchers(ActivityTestCase):
         self.dispatcher = FakeMailDispatcher()
         self.center = NotificationCenter([self.dispatcher])
 
-        hugo = create(Builder('watcher').having(user_id='hugo'))
-        peter = create(Builder('watcher').having(user_id='peter'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
+        peter = create(Builder('watcher').having(actorid='peter'))
         resource = create(Builder('resource').oguid('fd:123'))
         create(Builder('subscription')
                .having(resource=resource, watcher=hugo, role=WATCHER_ROLE))

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -48,11 +48,14 @@ class TestNotificationViewlet(FunctionalTestCase):
     @browsing
     def test_header_contains_number_of_unread_messages(self, browser):
         create(Builder('notification')
-               .having(activity=self.activity_a, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_a))
         create(Builder('notification')
-               .having(activity=self.activity_b, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_b))
         create(Builder('notification')
-               .having(activity=self.activity_c, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_c))
 
         browser.login().open()
         self.assertEquals(
@@ -74,12 +77,15 @@ class TestNotificationViewlet(FunctionalTestCase):
     @browsing
     def test_lists_only_unread_notifications(self, browser):
         create(Builder('notification')
-               .having(activity=self.activity_a, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_a))
         create(Builder('notification')
                .as_read()
-               .having(activity=self.activity_b, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_b))
         create(Builder('notification')
-               .having(activity=self.activity_c, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_c))
 
         browser.login().open()
 
@@ -90,11 +96,14 @@ class TestNotificationViewlet(FunctionalTestCase):
     @browsing
     def test_lists_notification_chronologic_newest_at_the_top(self, browser):
         create(Builder('notification')
-               .having(activity=self.activity_a, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_a))
         create(Builder('notification')
-               .having(activity=self.activity_b, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_b))
         create(Builder('notification')
-               .having(activity=self.activity_c, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_c))
 
         browser.login().open()
 
@@ -105,7 +114,8 @@ class TestNotificationViewlet(FunctionalTestCase):
     @browsing
     def test_notifications_are_linked_to_resolve_notification_view(self, browser):
         create(Builder('notification')
-               .having(activity=self.activity_c, watcher=self.test_watcher))
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_c))
 
         browser.login().open()
         link = browser.css('dl.notificationsMenu .item-content a').first

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -25,8 +25,8 @@ class TestNotificationViewlet(FunctionalTestCase):
     def setUp(self):
         super(TestNotificationViewlet, self).setUp()
         self.test_watcher = create(Builder('watcher')
-                                   .having(user_id=TEST_USER_ID))
-        self.hugo = create(Builder('watcher').having(user_id='hugo'))
+                                   .having(actorid=TEST_USER_ID))
+        self.hugo = create(Builder('watcher').having(actorid='hugo'))
 
         self.resource_a = create(Builder('resource')
                                  .oguid('fd:123')

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -42,7 +42,7 @@ class TestPloneNotificationCenter(FunctionalTestCase):
         self.dossier = create(Builder('dossier').titled(u'Dossier A'))
 
     @browsing
-    def test_add_watcher_adds_every_actor_representatives(self, member):
+    def test_add_watcher_adds_subscription_for_each_actor(self, member):
         browser.login().open(self.dossier, view='++add++opengever.task.task')
         browser.fill({'Title': 'Test Task',
                       'Responsible': 'inbox:client1',
@@ -55,10 +55,8 @@ class TestPloneNotificationCenter(FunctionalTestCase):
         subscriptions = resource.subscriptions
 
         self.assertItemsEqual(
-            [(u'franz.michel', u'task_responsible'),
-             (u'hugo.boss', u'task_responsible'),
-             (u'test_user_1_', u'task_issuer'),
-             (u'test_user_1_', u'task_responsible')],
+            [(u'inbox:client1', u'task_responsible'),
+             (u'test_user_1_', u'task_issuer')],
             [(sub.watcher.user_id, sub.role) for sub in subscriptions])
 
 

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -57,7 +57,7 @@ class TestPloneNotificationCenter(FunctionalTestCase):
         self.assertItemsEqual(
             [(u'inbox:client1', u'task_responsible'),
              (u'test_user_1_', u'task_issuer')],
-            [(sub.watcher.user_id, sub.role) for sub in subscriptions])
+            [(sub.watcher.actorid, sub.role) for sub in subscriptions])
 
 
 class TestNotifactionCenterErrorHandling(FunctionalTestCase):

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -13,7 +13,9 @@ from zExceptions import Unauthorized
 class TestResolveNotificationView(FunctionalTestCase):
 
     def test_resolve_notification_url(self):
-        notification = create(Builder('notification').id('123'))
+        notification = create(Builder('notification')
+                              .id('123')
+                              .having(userid='peter'))
         url = resolve_notification_url(notification)
         self.assertEquals(
             'http://example.com/@@resolve_notification?notification_id=123',
@@ -31,15 +33,14 @@ class TestResolveNotificationView(FunctionalTestCase):
                                  data={'notification_id': '123'})
 
     @browsing
-    def test_raises_unauthorized_when_notification_watcher_is_not_the_current_user(self, browser):
+    def test_raises_unauthorized_when_notification_is_not_for_the_current_user(self, browser):
         task = create(Builder('task'))
         oguid = Oguid.for_object(task)
 
-        watcher = create(Builder('watcher').having(user_id='hugo.boss'))
         resource = create(Builder('resource').oguid(oguid.id))
         activity = create(Builder('activity').having(resource=resource))
         notification = create(Builder('notification')
-                              .having(activity=activity, watcher=watcher))
+                              .having(activity=activity, userid='hugo.boss'))
 
         with self.assertRaises(Unauthorized):
             browser.login().open(
@@ -51,11 +52,10 @@ class TestResolveNotificationView(FunctionalTestCase):
         task = create(Builder('task'))
         oguid = Oguid.for_object(task)
 
-        watcher = create(Builder('watcher').having(user_id=TEST_USER_ID))
         resource = create(Builder('resource').oguid(oguid.id))
         activity = create(Builder('activity').having(resource=resource))
         notification = create(Builder('notification')
-                              .having(activity=activity, watcher=watcher))
+                              .having(activity=activity, userid=TEST_USER_ID))
 
         browser.login().open(self.portal, view='resolve_notification',
                              data={'notification_id': notification.notification_id})
@@ -70,11 +70,10 @@ class TestResolveNotificationView(FunctionalTestCase):
         task = create(Builder('task'))
         oguid = Oguid.for_object(task)
 
-        watcher = create(Builder('watcher').having(user_id=TEST_USER_ID))
         resource = create(Builder('resource').oguid(oguid.id))
         activity = create(Builder('activity').having(resource=resource))
         notification = create(Builder('notification')
-                              .having(activity=activity, watcher=watcher))
+                              .having(activity=activity, userid=TEST_USER_ID))
 
         browser.login().open(self.portal, view='resolve_notification',
                              data={'notification_id': notification.notification_id})
@@ -88,11 +87,10 @@ class TestResolveNotificationView(FunctionalTestCase):
                .having(public_url='http://example.com/additional')
                .id('additional'))
 
-        watcher = create(Builder('watcher').having(user_id=TEST_USER_ID))
         resource = create(Builder('resource').oguid('additional:123'))
         activity = create(Builder('activity').having(resource=resource))
         notification = create(Builder('notification')
-                              .having(activity=activity, watcher=watcher))
+                              .having(activity=activity, userid=TEST_USER_ID))
 
         # Calling the resolve_notification view for a foreign object should
         # raise an NotFound exception,  because the view redirects to the

--- a/opengever/activity/tests/test_views.py
+++ b/opengever/activity/tests/test_views.py
@@ -17,7 +17,7 @@ class TestNotificationView(FunctionalTestCase):
 
         self.center = NotificationCenter()
         self.test_user = create(Builder('watcher')
-                                .having(user_id=TEST_USER_ID))
+                                .having(actorid=TEST_USER_ID))
 
         self.resource_a = create(Builder('resource')
                                  .oguid('fd:123')

--- a/opengever/activity/tests/test_watcher.py
+++ b/opengever/activity/tests/test_watcher.py
@@ -6,7 +6,7 @@ from opengever.activity.tests.base import ActivityTestCase
 class TestWatcher(ActivityTestCase):
 
     def test_string_representation(self):
-        watcher = create(Builder('watcher').having(user_id=u'h\xfcgo.boss'))
+        watcher = create(Builder('watcher').having(actorid=u'h\xfcgo.boss'))
 
         self.assertEqual("<Watcher u'h\\xfcgo.boss'>", str(watcher))
         self.assertEqual("<Watcher u'h\\xfcgo.boss'>", repr(watcher))
@@ -28,6 +28,6 @@ class TestWatcher(ActivityTestCase):
                .assign_users([hugo, peter])
                .assign_users([james], to_inbox=False))
 
-        watcher = create(Builder('watcher').having(user_id=u'inbox:fd'))
+        watcher = create(Builder('watcher').having(actorid=u'inbox:fd'))
         self.assertEqual(['hugo.boss', 'peter.michel'],
                          watcher.get_user_ids())

--- a/opengever/activity/tests/test_watcher.py
+++ b/opengever/activity/tests/test_watcher.py
@@ -1,0 +1,33 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.activity.tests.base import ActivityTestCase
+
+
+class TestWatcher(ActivityTestCase):
+
+    def test_string_representation(self):
+        watcher = create(Builder('watcher').having(user_id=u'h\xfcgo.boss'))
+
+        self.assertEqual("<Watcher u'h\\xfcgo.boss'>", str(watcher))
+        self.assertEqual("<Watcher u'h\\xfcgo.boss'>", repr(watcher))
+
+    def test_get_user_ids_returns_userid_for_user_watcher(self):
+        create(Builder('ogds_user').id(u'hugo.boss'))
+        watcher = create(Builder('watcher').having(actorid=u'hugo.boss'))
+        self.assertEqual(['hugo.boss'], watcher.get_user_ids())
+
+    def test_get_user_ids_returns_userids_of_inbox_group_users_for_inbox_watcher(self):
+        hugo = create(Builder('ogds_user').id(u'hugo.boss'))
+        peter = create(Builder('ogds_user').id(u'peter.michel'))
+        james = create(Builder('ogds_user').id(u'james.bond'))
+
+        create(Builder('admin_unit').id('fd'))
+        create(Builder('org_unit')
+               .id('fd')
+               .having(admin_unit_id='fd')
+               .assign_users([hugo, peter])
+               .assign_users([james], to_inbox=False))
+
+        watcher = create(Builder('watcher').having(user_id=u'inbox:fd'))
+        self.assertEqual(['hugo.boss', 'peter.michel'],
+                         watcher.get_user_ids())

--- a/opengever/activity/upgrades/configure.zcml
+++ b/opengever/activity/upgrades/configure.zcml
@@ -137,4 +137,14 @@
         profile="opengever.activity:default"
         />
 
+    <!-- 4505 -> 4506 -->
+    <genericsetup:upgradeStep
+        title="Rename Watcher's user_id column to actorid"
+        description=""
+        source="4505"
+        destination="4506"
+        handler="opengever.activity.upgrades.to4506.RenameUserIdColumn"
+        profile="opengever.activity:default"
+        />
+
 </configure>

--- a/opengever/activity/upgrades/configure.zcml
+++ b/opengever/activity/upgrades/configure.zcml
@@ -127,4 +127,14 @@
         profile="opengever.activity:default"
         />
 
+    <!-- 4504 -> 4505 -->
+    <genericsetup:upgradeStep
+        title="Replace watcher relation on Notification table with a userid column"
+        description=""
+        source="4504"
+        destination="4505"
+        handler="opengever.activity.upgrades.to4505.ReplaceNotificationsWatcherRelation"
+        profile="opengever.activity:default"
+        />
+
 </configure>

--- a/opengever/activity/upgrades/to4505.py
+++ b/opengever/activity/upgrades/to4505.py
@@ -1,0 +1,71 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+USER_ID_LENGTH = 255
+
+
+class ReplaceNotificationsWatcherRelation(SchemaMigration):
+
+    profileid = 'opengever.activity'
+    upgradeid = 4505
+
+    def migrate(self):
+        self.add_userid_column()
+        self.migrate_data()
+        self.remove_watcherid_column()
+        self.make_userid_column_required()
+
+        self.notifications_table = table(
+            "notifications",
+            column("id"),
+            column("activity_id"),
+            column("watcher_id"),
+        )
+
+    def add_userid_column(self):
+        self.op.add_column('notifications', Column('userid', String(USER_ID_LENGTH)))
+
+    def migrate_data(self):
+        watcher_id_mapping = self.get_watcherid_userid_mapping()
+        notifications_table = table(
+            "notifications",
+            column("id"),
+            column("activity_id"),
+            column("watcher_id"),
+            column("userid")
+        )
+
+        notifications = self.connection.execute(
+            notifications_table.select()).fetchall()
+        for notification in notifications:
+            userid = watcher_id_mapping[notification.watcher_id]
+            self.execute(
+                notifications_table.update()
+                .values(userid=userid)
+                .where(notifications_table.columns.id == notification.id)
+            )
+
+    def remove_watcherid_column(self):
+        self.op.drop_column('notifications', 'watcher_id')
+
+    def make_userid_column_required(self):
+        self.op.alter_column('notifications', 'userid', nullable=False,
+                             existing_type=String(USER_ID_LENGTH))
+
+    def get_watcherid_userid_mapping(self):
+        mapping = {}
+        watchers_table = table(
+            "watchers",
+            column("id"),
+            column("user_id")
+        )
+
+        watchers = self.connection.execute(watchers_table.select()).fetchall()
+        for watcher in watchers:
+            mapping[watcher.id] = watcher.user_id
+
+        return mapping

--- a/opengever/activity/upgrades/to4506.py
+++ b/opengever/activity/upgrades/to4506.py
@@ -1,0 +1,16 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+USER_ID_LENGTH = 255
+
+
+class RenameUserIdColumn(SchemaMigration):
+    profileid = 'opengever.activity'
+    upgradeid = 4506
+
+    def migrate(self):
+        self.op.alter_column('watchers', 'user_id',
+                             new_column_name='actorid',
+                             existing_nullable=False,
+                             existing_type=String(USER_ID_LENGTH))

--- a/opengever/inbox/tests/test_activities.py
+++ b/opengever/inbox/tests/test_activities.py
@@ -63,12 +63,9 @@ class TestForwardingActivites(FunctionalTestCase):
                                             dossier, "Ok!")
 
         resource = notification_center().fetch_resource(task)
-        # The responsible of the task is the `inbox:client1`,
-        # but the PloneNotificationCenter adds every actor representative.
         self.assertItemsEqual(
             [(u'hugo.boss', u'task_responsible'),
-             (u'peter.mueller', u'task_issuer'),
-             (u'test_user_1_', u'task_issuer')],
+             (u'inbox:client1', u'task_issuer')],
             [(subscription.watcher.user_id, subscription.role)
              for subscription in resource.subscriptions])
 
@@ -96,8 +93,7 @@ class TestForwardingActivites(FunctionalTestCase):
 
         self.assertItemsEqual(
             [(u'test_user_1_', u'task_responsible'),
-             (u'test_user_1_', u'task_issuer'),
-             (u'peter.mueller', u'task_issuer')],
+             (u'inbox:client1', u'task_issuer')],
             [(subscription.watcher.user_id, subscription.role)
              for subscription in successor_resource.subscriptions])
 
@@ -189,7 +185,7 @@ class TestForwardingReassignActivity(FunctionalTestCase):
         reassign_activity = activities[-1]
         self.assertItemsEqual(
             [u'jon.meier', u'peter.mueller', u'hugo.boss'],
-            [notes.watcher.user_id for notes in reassign_activity.notifications])
+            [notes.userid for notes in reassign_activity.notifications])
 
     @browsing
     def test_removes_old_responsible_from_watchers_list(self, browser):

--- a/opengever/inbox/tests/test_activities.py
+++ b/opengever/inbox/tests/test_activities.py
@@ -66,7 +66,7 @@ class TestForwardingActivites(FunctionalTestCase):
         self.assertItemsEqual(
             [(u'hugo.boss', u'task_responsible'),
              (u'inbox:client1', u'task_issuer')],
-            [(subscription.watcher.user_id, subscription.role)
+            [(subscription.watcher.actorid, subscription.role)
              for subscription in resource.subscriptions])
 
     @browsing
@@ -88,13 +88,13 @@ class TestForwardingActivites(FunctionalTestCase):
 
         self.assertItemsEqual(
             [(u'hugo.boss', u'task_issuer')],
-            [(subscription.watcher.user_id, subscription.role)
+            [(subscription.watcher.actorid, subscription.role)
              for subscription in forwarding_resource.subscriptions])
 
         self.assertItemsEqual(
             [(u'test_user_1_', u'task_responsible'),
              (u'inbox:client1', u'task_issuer')],
-            [(subscription.watcher.user_id, subscription.role)
+            [(subscription.watcher.actorid, subscription.role)
              for subscription in successor_resource.subscriptions])
 
     @browsing
@@ -116,10 +116,10 @@ class TestForwardingActivites(FunctionalTestCase):
         task_resource = self.center.fetch_resource(task)
         self.assertItemsEqual(
             ['hugo.boss'],
-            [watcher.user_id for watcher in forwarding_resource.watchers])
+            [watcher.actorid for watcher in forwarding_resource.watchers])
         self.assertItemsEqual(
             [TEST_USER_ID],
-            [watcher.user_id for watcher in task_resource.watchers])
+            [watcher.actorid for watcher in task_resource.watchers])
 
 
 class TestForwardingReassignActivity(FunctionalTestCase):
@@ -195,4 +195,4 @@ class TestForwardingReassignActivity(FunctionalTestCase):
         resource = notification_center().fetch_resource(forwarding)
         self.assertItemsEqual(
             ['peter.mueller', u'hugo.boss'],
-            [watcher.user_id for watcher in resource.watchers])
+            [watcher.actorid for watcher in resource.watchers])

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -274,7 +274,7 @@ class TestTaskReassignActivity(FunctionalTestCase):
         reassign_activity = activities[-1]
         self.assertItemsEqual(
             [u'james.meier', u'peter.meier', u'hugo.boss'],
-            [notes.watcher.user_id for notes in reassign_activity.notifications])
+            [notes.userid for notes in reassign_activity.notifications])
 
     @browsing
     def test_removes_old_responsible_from_watchers_list(self, browser):

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -69,7 +69,7 @@ class TestTaskActivites(FunctionalTestCase):
         self.assertItemsEqual(
             [(u'hugo.boss', TASK_RESPONSIBLE_ROLE),
              (u'test_user_1_', TASK_ISSUER_ROLE)],
-            [(subscription.watcher.user_id, subscription.role)
+            [(subscription.watcher.actorid, subscription.role)
              for subscription in subscriptions])
 
     @browsing
@@ -287,7 +287,7 @@ class TestTaskReassignActivity(FunctionalTestCase):
         self.assertItemsEqual(
             [(u'hugo.boss', TASK_RESPONSIBLE_ROLE),
              (u'peter.meier', TASK_ISSUER_ROLE)],
-            [(sub.watcher.user_id, sub.role) for sub in subscriptions])
+            [(sub.watcher.actorid, sub.role) for sub in subscriptions])
 
 
 class TestSuccesssorHandling(FunctionalTestCase):
@@ -336,10 +336,10 @@ class TestSuccesssorHandling(FunctionalTestCase):
         self.assertItemsEqual(
             [(u'james.meier', u'task_issuer'),
              (u'hugo.boss', u'regular_watcher')],
-            [(subscription.watcher.user_id, subscription.role)
+            [(subscription.watcher.actorid, subscription.role)
              for subscription in predecessor_resource.subscriptions])
 
         self.assertItemsEqual(
             [(u'peter.meier', u'task_responsible')],
-            [(subscription.watcher.user_id, subscription.role)
+            [(subscription.watcher.actorid, subscription.role)
              for subscription in successor_resource.subscriptions])

--- a/opengever/testing/builders/activity.py
+++ b/opengever/testing/builders/activity.py
@@ -75,6 +75,10 @@ class NotificationBuilder(SqlObjectBuilder):
     mapped_class = Notification
     id_argument_name = 'notification_id'
 
+    def watcher(self, watcher):
+        self.arguments['userid'] = watcher.user_id
+        return self
+
     def as_read(self):
         self.arguments['is_read'] = True
         return self

--- a/opengever/testing/builders/activity.py
+++ b/opengever/testing/builders/activity.py
@@ -33,7 +33,7 @@ class ResourceBuilder(SqlObjectBuilder):
 
     def after_create(self, obj):
         for watcher in self._watchers:
-            obj.add_watcher(watcher.user_id, WATCHER_ROLE)
+            obj.add_watcher(watcher.actorid, WATCHER_ROLE)
         return obj
 
 
@@ -76,7 +76,7 @@ class NotificationBuilder(SqlObjectBuilder):
     id_argument_name = 'notification_id'
 
     def watcher(self, watcher):
-        self.arguments['userid'] = watcher.user_id
+        self.arguments['userid'] = watcher.actorid
         return self
 
     def as_read(self):


### PR DESCRIPTION
With the current implementation, the notification center has registered every single user of a inbox_group, when a task was assigned or issued by a inbox. This lead to following problems:
 - A user has been notified twice in some cases.
 - A user, which is no longer be part of the inbox_group, is still notified about this task, even if the user has no permissions.
 ...

Therefore we replaced the direct  relation between `Notification` and `Watcher` and create a Watcher for each actor instead. This means that now Watchers with the actor_id `inbox:fd` exist. 

With the described changes, the notification_center must have the ability to fetch all representatives for an actor. 
Right now the watcher model, has therefore a separate get_representatives method, which differs between users and inbox actors. This is only a temporarily solution, because the notification improvements should be available in the 4.4 release (backport). This method should use the Actor functionality, but right now it's part of the opengever.core instead of opengever.ogds.models. I'll improve that with a separate PR, which has not be backported to the 4.4 release.

@lukasgraf or @deiferni please review