### PR TITLE
No longer show wrapper objects in pathbar.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- No longer show wrapper objects in pathbar.
+  [deiferni]
+
 - Merge changes made on `minimal` repository configuration to the `municipality` one.
   [phgross]
 

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -1,4 +1,3 @@
-from opengever.meeting.interfaces import IMeetingWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
 from plone.app.layout.viewlets import common
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -17,9 +16,6 @@ class PathBar(common.PathBarViewlet):
             self.append_model_breadcrumbs()
 
     def append_model_breadcrumbs(self):
-        if IMeetingWrapper.providedBy(self.context):
-            model = self.context.model
-
         model = self.view.model
         model_breadcrumbs = model.get_breadcrumbs(self.view.context)
         self.breadcrumbs = self.breadcrumbs + (model_breadcrumbs,)

--- a/opengever/meeting/meeting_wrapper.py
+++ b/opengever/meeting/meeting_wrapper.py
@@ -2,13 +2,14 @@ from Acquisition import Implicit
 from OFS.Traversable import Traversable
 from opengever.locking.interfaces import ISQLLockable
 from opengever.meeting.interfaces import IMeetingWrapper
+from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
 from zope.interface import implements
 import ExtensionClass
 
 
 class MeetingWrapper(ExtensionClass.Base, Implicit, Traversable):
 
-    implements(IMeetingWrapper, ISQLLockable)
+    implements(IMeetingWrapper, ISQLLockable, IHideFromBreadcrumbs)
 
     def __init__(self, model):
         self.model = model

--- a/opengever/meeting/tests/test_pathbar.py
+++ b/opengever/meeting/tests/test_pathbar.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestPathBar(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPathBar, self).setUp()
+        self.admin_unit.public_url = 'http://nohost/plone'
+
+        self.root = create(Builder('repository_root').titled(u'Repository'))
+        self.repo = create(Builder('repository')
+                           .within(self.root)
+                           .titled(u'Testposition'))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repo)
+                              .titled(u'Dossier 1'))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repo))
+
+    @browsing
+    def test_regression_committee_is_not_duplicated_in_pathbar(self, browser):
+        container = create(Builder('committee_container'))
+        committee = create(Builder('committee').within(container))
+        meeting = create(Builder('meeting')
+                         .having(committee=committee.load_model(),
+                                 start=datetime(2010, 1, 1))
+                         .link_with(self.meeting_dossier))
+
+        browser.login().open(meeting.get_url())
+        self.assertEqual(
+            ['Client1', 'opengever-meeting-committeecontainer',
+             'My Committee', 'Jan 01, 2010'],
+            browser.css('#portal-breadcrumbs a').text)


### PR DESCRIPTION
In https://github.com/4teamwork/opengever.core/pull/1174 wrapper objects were introduced. Currently they are also displayed in the pathbar (the wrappers acquisition-parent, to be precise). This PR adds a marker interface to hide the wrapper object.

Closes #1240.