### PR TITLE
Remove publishTraverse hacks in favour of wrapper objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Introduce wrapper objects for members and memberships to eliminate
+  traversal hacks.
+  [deiferni]
+
 - No longer show wrapper objects in pathbar.
   [deiferni]
 

--- a/opengever/base/viewlets/contentviews.py
+++ b/opengever/base/viewlets/contentviews.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from plone.app.layout.viewlets.common import ContentViewsViewlet
 
 
@@ -25,6 +27,10 @@ class ModelContentViewsViewlet(ContentViewsViewlet):
         model = self.view.model
         if not model.is_editable():
             return tuple()
+
+        context = self.view.context
+        if hasattr(context, 'is_wrapper'):
+            context = aq_parent(aq_inner(context))
 
         return ({
             'category': 'object',

--- a/opengever/base/viewlets/contentviews.py
+++ b/opengever/base/viewlets/contentviews.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from plone.app.layout.viewlets.common import ContentViewsViewlet
 
 
@@ -27,10 +25,6 @@ class ModelContentViewsViewlet(ContentViewsViewlet):
         model = self.view.model
         if not model.is_editable():
             return tuple()
-
-        context = self.view.context
-        if hasattr(context, 'is_wrapper'):
-            context = aq_parent(aq_inner(context))
 
         return ({
             'category': 'object',

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from opengever.ogds.base.utils import get_current_admin_unit
 from plone.app.layout.viewlets import common
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -19,9 +17,6 @@ class PathBar(common.PathBarViewlet):
 
     def append_model_breadcrumbs(self):
         model = self.view.model
-        context = self.view.context
-        if hasattr(context, 'is_wrapper'):
-            context = aq_parent(aq_inner(context))
 
         model_breadcrumbs = model.get_breadcrumbs(self.view.context)
         self.breadcrumbs = self.breadcrumbs + (model_breadcrumbs,)

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from opengever.ogds.base.utils import get_current_admin_unit
 from plone.app.layout.viewlets import common
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -17,5 +19,9 @@ class PathBar(common.PathBarViewlet):
 
     def append_model_breadcrumbs(self):
         model = self.view.model
+        context = self.view.context
+        if hasattr(context, 'is_wrapper'):
+            context = aq_parent(aq_inner(context))
+
         model_breadcrumbs = model.get_breadcrumbs(self.view.context)
         self.breadcrumbs = self.breadcrumbs + (model_breadcrumbs,)

--- a/opengever/locking/tests/test_lockable.py
+++ b/opengever/locking/tests/test_lockable.py
@@ -6,7 +6,7 @@ from ftw.testing import freeze
 from opengever.base.model import create_session
 from opengever.locking.model import Lock
 from opengever.locking.model.locks import utcnow_tz_aware
-from opengever.meeting.meeting_wrapper import MeetingWrapper
+from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from plone.locking.interfaces import ILockable
@@ -19,12 +19,13 @@ class TestSQLLockable(FunctionalTestCase):
     def setUp(self):
         super(TestSQLLockable, self).setUp()
         self.session = create_session()
-        self.committee = create(Builder('committee_model'))
+        self.container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee').within(self.container))
         self.meeting = create(Builder('meeting').having(
-            committee=self.committee,
+            committee=self.committee.load_model(),
             start=datetime(2010, 1, 1)))
 
-        self.wrapper = MeetingWrapper(self.meeting)
+        self.wrapper = MeetingWrapper.wrap(self.committee, self.meeting)
 
     def test_lock_use_model_class_name_as_object_type(self):
         lockable = ILockable(self.wrapper)

--- a/opengever/meeting/browser/committeetabs.py
+++ b/opengever/meeting/browser/committeetabs.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from five import grok
 from opengever.meeting.committee import ICommittee
 from opengever.meeting.tabs.meetinglisting import MeetingListingTab
@@ -38,3 +40,6 @@ class Memberships(MembershipListingTab):
 
     enabled_actions = []
     major_actions = []
+
+    def get_member_link(self, item, value):
+        return item.member.get_link(aq_parent(aq_inner(self.context)))

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -85,4 +85,18 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IMembershipWrapper"
+      name="edit"
+      class=".memberships.EditMembership"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="opengever.meeting.interfaces.IMembershipWrapper"
+      name="remove"
+      class=".memberships.RemoveMembership"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -71,4 +71,18 @@
       allowed_interface="plone.app.layout.globals.interfaces.ILayoutPolicy"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IMemberWrapper"
+      name="view"
+      class=".members.MemberView"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="opengever.meeting.interfaces.IMemberWrapper"
+      name="edit"
+      class=".members.EditMember"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/meeting/browser/memberships.py
+++ b/opengever/meeting/browser/memberships.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from ftw.datepicker.widget import DatePickerFieldWidget
 from opengever.meeting import _
 from opengever.meeting.browser.members import MemberView
@@ -12,10 +10,7 @@ from z3c.form import field
 from z3c.form.interfaces import ActionExecutionError
 from z3c.form.interfaces import INPUT_MODE
 from zope import schema
-from zope.interface import implements
 from zope.interface import Invalid
-from zope.publisher.interfaces import IPublishTraverse
-from zope.publisher.interfaces.browser import IBrowserView
 
 
 class IMembershipModel(form.Schema):
@@ -104,7 +99,6 @@ class EditMembership(ModelEditForm):
 
 
 class RemoveMembership(RemoveModelView):
-    implements(IBrowserView, IPublishTraverse)
 
     def __init__(self, context, request):
         super(RemoveMembership, self).__init__(context, request, context.model)

--- a/opengever/meeting/browser/memberships.py
+++ b/opengever/meeting/browser/memberships.py
@@ -1,4 +1,5 @@
-from five import grok
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from ftw.datepicker.widget import DatePickerFieldWidget
 from opengever.meeting import _
 from opengever.meeting.browser.members import MemberView
@@ -7,14 +8,11 @@ from opengever.meeting.form import ModelAddForm
 from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Membership
 from plone.directives import form
-from Products.Five.browser import BrowserView
 from z3c.form import field
 from z3c.form.interfaces import ActionExecutionError
 from z3c.form.interfaces import INPUT_MODE
-from zExceptions import NotFound
 from zope import schema
 from zope.interface import implements
-from zope.interface import Interface
 from zope.interface import Invalid
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces.browser import IBrowserView
@@ -83,6 +81,9 @@ class EditMembership(ModelEditForm):
     fields['date_to'].widgetFactory[INPUT_MODE] = DatePickerFieldWidget
     fields['date_from'].widgetFactory[INPUT_MODE] = DatePickerFieldWidget
 
+    def __init__(self, context, request):
+        super(EditMembership, self).__init__(context, request, context.model)
+
     def validate(self, data):
         overlapping = Membership.query.fetch_overlapping(
             data.get('date_from'), data.get('date_to'),
@@ -98,11 +99,15 @@ class EditMembership(ModelEditForm):
             raise(ActionExecutionError(Invalid(msg)))
 
     def nextURL(self):
-        return MemberView.url_for(self.context, self.model.member)
+        return MemberView.url_for(self.context.parent.parent,
+                                  self.model.member)
 
 
 class RemoveMembership(RemoveModelView):
     implements(IBrowserView, IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(RemoveMembership, self).__init__(context, request, context.model)
 
     @property
     def success_message(self):
@@ -110,62 +115,5 @@ class RemoveMembership(RemoveModelView):
                  default=u'The membership was deleted successfully')
 
     def nextURL(self):
-        return MemberView.url_for(self.context, self.model.member)
-
-
-class MembershipTraverser(grok.View):
-
-    implements(IPublishTraverse)
-    grok.context(Interface)
-    grok.name('membership')
-
-    @classmethod
-    def url_for(cls, context):
-        return "{}/{}".format(
-            context.absolute_url(), cls.__view_name__)
-
-    def render(self):
-        """This view is never rendered directly.
-        This method ist still needed to make grok checks happy, every grokked
-        view must have an associated template or 'render' method.
-        """
-        pass
-
-    def publishTraverse(self, request, name):
-        try:
-            membership_id = int(name)
-        except ValueError:
-            raise NotFound
-
-        membership = Membership.query.get(membership_id)
-        if membership is None:
-            raise NotFound
-
-        return MembershipView(self.context, self.request, membership)
-
-
-class MembershipView(BrowserView):
-    implements(IBrowserView, IPublishTraverse)
-
-    is_model_view = True
-    is_model_edit_view = False
-
-    mapped_actions = {
-        'edit': EditMembership,
-        'remove': RemoveMembership,
-    }
-
-    @classmethod
-    def url_for(cls, context, membership):
-        return "{}/membership/{}".format(
-            context.absolute_url(), membership.membership_id)
-
-    def __init__(self, context, request, membership):
-        super(MembershipView, self).__init__(context, request)
-        self.model = membership
-
-    def publishTraverse(self, request, name):
-        if name in self.mapped_actions:
-            view_class = self.mapped_actions.get(name)
-            return view_class(self.context, self.request, self.model)
-        raise NotFound
+        return MemberView.url_for(self.context.parent.parent,
+                                  self.model.member)

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -2,13 +2,13 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.meeting import _
 from opengever.meeting.container import ModelContainer
-from opengever.meeting.meeting_wrapper import MeetingWrapper
 from opengever.meeting.model import Committee as CommitteeModel
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Membership
 from opengever.meeting.service import meeting_service
 from opengever.meeting.sources import repository_folder_source
 from opengever.meeting.sources import sablon_template_source
+from opengever.meeting.wrapper import MeetingWrapper
 from plone import api
 from plone.directives import form
 from z3c.relationfield.schema import RelationChoice
@@ -74,8 +74,7 @@ class Committee(ModelContainer):
             meeting_id = int(id_.split('-')[-1])
             meeting = Meeting.query.get(meeting_id)
             if meeting:
-                wrapper = MeetingWrapper(meeting)
-                return wrapper.__of__(self)
+                return MeetingWrapper.wrap(self, meeting)
 
         if default is _marker:
             raise KeyError(id_)

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,5 +1,7 @@
 from opengever.meeting import _
+from opengever.meeting.model import Member
 from opengever.meeting.sources import sablon_template_source
+from opengever.meeting.wrapper import MemberWrapper
 from plone.dexterity.content import Container
 from plone.directives import form
 from z3c.relationfield.schema import RelationChoice
@@ -22,8 +24,30 @@ class ICommitteeContainer(form.Schema):
     )
 
 
+_marker = object()
+
+
 class CommitteeContainer(Container):
     """Committee Container class, a container for all committees."""
+
+    def _getOb(self, id_, default=_marker):
+        """We extend `_getOb` in order to change the context for member
+        objects to `MemeberWrapper`. That allows us to register the
+        members view as regular Browser view without any traversal hacks."""
+
+        obj = super(CommitteeContainer, self)._getOb(id_, default)
+        if obj is not default:
+            return obj
+
+        if id_.startswith('member'):
+            member_id = int(id_.split('-')[-1])
+            member = Member.query.get(member_id)
+            if member:
+                return MemberWrapper.wrap(self, member)
+
+        if default is _marker:
+            raise KeyError(id_)
+        return default
 
     def get_protocol_template(self):
         return self.protocol_template.to_object

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -19,5 +19,9 @@ class IMemberWrapper(Interface):
     """Marker interface for member object wrappers."""
 
 
+class IMembershipWrapper(Interface):
+    """Marker interface for membership object wrappers."""
+
+
 class IMeetingDossier(form.Schema):
     """Marker interface for MeetingDossier"""

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -15,5 +15,9 @@ class IMeetingWrapper(Interface):
     """Marker interface for meeting object wrappers."""
 
 
+class IMemberWrapper(Interface):
+    """Marker interface for member object wrappers."""
+
+
 class IMeetingDossier(form.Schema):
     """Marker interface for MeetingDossier"""

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -45,13 +45,14 @@ class Member(Base):
         return self.get_link(context, title=self.lastname)
 
     def get_url(self, context):
-        return "{}/member/{}".format(context.absolute_url(), self.member_id)
+        return "{}/member-{}".format(context.absolute_url(), self.member_id)
 
     def get_edit_url(self, context):
         return '/'.join((self.get_url(context), 'edit'))
 
     def get_breadcrumbs(self, context):
-        return {'absolute_url': self.get_url(context), 'Title': self.fullname}
+        return {'absolute_url': self.get_url(context),
+                'Title': self.fullname}
 
     def get_edit_values(self, fieldnames):
         values = {}

--- a/opengever/meeting/model/membership.py
+++ b/opengever/meeting/model/membership.py
@@ -78,7 +78,7 @@ class Membership(Base):
             setattr(self, key, value)
 
     def get_url(self, context):
-        return "{}/membership/{}".format(context.absolute_url(),
+        return "{}/membership-{}".format(context.absolute_url(),
                                          self.membership_id)
 
     def get_edit_url(self, context):

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -7,9 +7,9 @@ from opengever.meeting.browser.meetings.agendaitem import DeleteAgendaItem
 from opengever.meeting.browser.meetings.agendaitem import ScheduleSubmittedProposal
 from opengever.meeting.browser.meetings.agendaitem import ScheduleText
 from opengever.meeting.browser.meetings.agendaitem import UpdateAgendaItemOrder
-from opengever.meeting.meeting_wrapper import MeetingWrapper
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Proposal
+from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
 from zExceptions import Unauthorized
 import transaction
@@ -153,7 +153,8 @@ class TestAgendaItem(FunctionalTestCase):
         self.assertEqual(1, item1.sort_order)
         self.assertEqual(2, item2.sort_order)
 
-        view = UpdateAgendaItemOrder(MeetingWrapper(self.meeting), self.request)
+        view = UpdateAgendaItemOrder(
+            MeetingWrapper.wrap(self.committee, self.meeting), self.request)
         view.update_sortorder({"sortOrder": [2, 1]})
 
         self.assertEqual(2, item1.sort_order)

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -49,7 +49,7 @@ class TestCommitteeOverview(FunctionalTestCase):
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
         self.assertEquals(
-            'http://nohost/plone/committee-1/member/1',
+            'http://nohost/plone/committee-1/member-1',
             browser.css('#current_membersBox li a').first.get('href'))
 
     @browsing

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -4,7 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
-from opengever.meeting.meeting_wrapper import MeetingWrapper
+from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from plone.locking.interfaces import ILockable
@@ -62,7 +62,8 @@ class TestMeetingLocking(FunctionalTestCase):
         browser.login().open(self.meeting.get_url('protocol'))
 
         browser.open(self.meeting.get_url('plone_lock_info/lock_info'))
-        lock_infos = ILockable(MeetingWrapper(self.meeting)).lock_info()
+        lock_infos = ILockable(
+            MeetingWrapper.wrap(self.committee, self.meeting)).lock_info()
 
         self.assertEquals(1, len(lock_infos))
         lock = lock_infos[0]
@@ -77,22 +78,26 @@ class TestMeetingLocking(FunctionalTestCase):
     @browsing
     def test_saving_protocol_unlock_meeting(self, browser):
         browser.login().open(self.meeting.get_url('protocol'))
-        lock_infos = ILockable(MeetingWrapper(self.meeting)).lock_info()
+        lock_infos = ILockable(
+            MeetingWrapper.wrap(self.committee, self.meeting)).lock_info()
         self.assertEquals(1, len(lock_infos))
 
         browser.find('Save').click()
         self.assertEquals(
-            [], ILockable(MeetingWrapper(self.meeting)).lock_info())
+            [], ILockable(
+                MeetingWrapper.wrap(self.committee, self.meeting)).lock_info())
 
     @browsing
     def test_cancelling_protocol_unlock_meeting(self, browser):
         browser.login().open(self.meeting.get_url('protocol'))
-        lock_infos = ILockable(MeetingWrapper(self.meeting)).lock_info()
+        lock_infos = ILockable(
+            MeetingWrapper.wrap(self.committee, self.meeting)).lock_info()
         self.assertEquals(1, len(lock_infos))
 
         browser.find('Cancel').click()
         self.assertEquals(
-            [], ILockable(MeetingWrapper(self.meeting)).lock_info())
+            [], ILockable(
+                MeetingWrapper.wrap(self.committee, self.meeting)).lock_info())
 
     @browsing
     def test_protocol_raise_redirect_back_to_meeting_view_when_protocol_is_locked(self, browser):

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -6,6 +6,7 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.browser.members import MemberView
 from opengever.meeting.model import Member
+from opengever.meeting.wrapper import MemberWrapper
 from opengever.testing import FunctionalTestCase
 from pyquery import PyQuery
 
@@ -74,6 +75,7 @@ class TestMemberView(FunctionalTestCase):
         self.container = create(Builder('committee_container'))
         self.member = create(Builder('member')
                              .having(email='p.meier@example.com'))
+        self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
         self.committee = create(Builder('committee').within(self.container))
 
         self.membership_1 = create(Builder('membership')
@@ -141,7 +143,7 @@ class TestMemberView(FunctionalTestCase):
         browser.login().open(self.member.get_url(self.container))
 
         link = browser.css('a.edit_membership').first
-        self.assertEqual(self.membership_2.get_edit_url(self.container),
+        self.assertEqual(self.membership_2.get_edit_url(self.member_wrapper),
                          link.get('href'))
 
     @browsing
@@ -149,7 +151,7 @@ class TestMemberView(FunctionalTestCase):
         browser.login().open(self.member.get_url(self.container))
 
         link = browser.css('a.remove_membership').first
-        self.assertEqual(self.membership_2.get_remove_url(self.container),
+        self.assertEqual(self.membership_2.get_remove_url(self.member_wrapper),
                          link.get('href'))
 
     @browsing

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -58,7 +58,7 @@ class TestMemberListing(FunctionalTestCase):
         link = PyQuery(link)[0]
 
         self.assertEqual(
-            'http://nohost/plone/opengever-meeting-committeecontainer/member/1',
+            'http://nohost/plone/opengever-meeting-committeecontainer/member-1',
             link.get('href'))
         self.assertEqual('contenttype-opengever-meeting-member', link.get('class'))
         self.assertEqual('Peter Meier', link.get('title'))

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Member
 from opengever.meeting.model import Membership
+from opengever.meeting.wrapper import MemberWrapper
 from opengever.testing import FunctionalTestCase
 
 
@@ -20,6 +21,7 @@ class TestMemberships(FunctionalTestCase):
         self.container = create(Builder('committee_container'))
         self.committee = create(Builder('committee').within(self.container))
         self.member = create(Builder('member'))
+        self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
 
     @browsing
     def test_membership_can_be_added(self, browser):
@@ -71,7 +73,7 @@ class TestMemberships(FunctionalTestCase):
                                     date_from=date(2003, 01, 01),
                                     date_to=date(2007, 12, 31)))
 
-        browser.login().open(membership.get_edit_url(self.committee))
+        browser.login().open(membership.get_edit_url(self.member_wrapper))
         browser.fill({'Role': u'tempor\xe4re Leitung',
                       'Start date': 'December 31, 2003'}).submit()
 
@@ -93,7 +95,7 @@ class TestMemberships(FunctionalTestCase):
                                     date_from=date(2008, 01, 01),
                                     date_to=date(2014, 01, 01)))
 
-        browser.login().open(membership.get_edit_url(self.committee))
+        browser.login().open(membership.get_edit_url(self.member_wrapper))
         browser.fill({'Start date': 'December 31, 2005'}).submit()
 
         self.assertEqual(['There were some errors.'], error_messages())

--- a/opengever/meeting/wrapper.py
+++ b/opengever/meeting/wrapper.py
@@ -2,17 +2,26 @@ from Acquisition import Implicit
 from OFS.Traversable import Traversable
 from opengever.locking.interfaces import ISQLLockable
 from opengever.meeting.interfaces import IMeetingWrapper
+from opengever.meeting.interfaces import IMemberWrapper
 from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
 from zope.interface import implements
 import ExtensionClass
 
 
-class MeetingWrapper(ExtensionClass.Base, Implicit, Traversable):
+class BaseWrapper(ExtensionClass.Base, Implicit, Traversable):
 
-    implements(IMeetingWrapper, ISQLLockable, IHideFromBreadcrumbs)
+    implements(IHideFromBreadcrumbs)
 
-    def __init__(self, model):
+    is_wrapper = True
+
+    def __init__(self, context, model):
+        self.parent = context
         self.model = model
+
+    @classmethod
+    def wrap(cls, context, model):
+        wrapper = cls(context, model)
+        return wrapper.__of__(context)
 
     def absolute_url(self):
         return self.model.get_url(view=None)
@@ -32,3 +41,16 @@ class MeetingWrapper(ExtensionClass.Base, Implicit, Traversable):
         if stack == []:
             stack.append('view')
             REQUEST._hacked_path = 1
+
+
+class MeetingWrapper(BaseWrapper):
+
+    implements(IMeetingWrapper, ISQLLockable)
+
+
+class MemberWrapper(BaseWrapper):
+
+    implements(IMemberWrapper)
+
+    def absolute_url(self):
+        return self.model.get_url(self.parent)

--- a/opengever/meeting/wrapper.py
+++ b/opengever/meeting/wrapper.py
@@ -14,7 +14,6 @@ class BaseWrapper(ExtensionClass.Base, Implicit, Traversable):
 
     implements(IHideFromBreadcrumbs)
 
-    is_wrapper = True
     default_view = 'view'
 
     def __init__(self, context, model):


### PR DESCRIPTION
This PR removes `publishTraverse` hacks to lookup objects for `Member` and `Membership`. Instead a wrapper-object as first defined for `Meeting` is used.

Closes #1255.

*This PR introduces some temporary changes necessary while refactoring (green tests), i'd suggest to have a look ad the full diff only to avoid confusion*