### PR TITLE
Remove leftover related_items catalog metadata.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Remove leftover related_items catalog metadata.
+  [deiferni]
+
 - Notification center: Register actor as watcher instead of every single user.
   [phgross]
 

--- a/opengever/document/profiles/default/metadata.xml
+++ b/opengever/document/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4302</version>
+    <version>4600</version>
     <dependencies>
         <dependency>profile-plone.app.versioningbehavior:default</dependency>
     </dependencies>

--- a/opengever/document/upgrades/configure.zcml
+++ b/opengever/document/upgrades/configure.zcml
@@ -204,4 +204,14 @@
         profile="opengever.document:default"
         />
 
+    <!-- 4302 -> 4600 -->
+    <genericsetup:upgradeStep
+        title="Remove related_items catalog metadata."
+        description=""
+        source="4302"
+        destination="4600"
+        handler="opengever.document.upgrades.to4600.RemoveRelatedItemsMetadata"
+        profile="opengever.document:default"
+        />
+
 </configure>

--- a/opengever/document/upgrades/to4600.py
+++ b/opengever/document/upgrades/to4600.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class RemoveRelatedItemsMetadata(UpgradeStep):
+    """Remove leftover related_items catalog metadata.
+
+    Index and column in catalog.xml has already been removed in an upgrade to
+    2602 - but not the actual metadata column in the catalog.
+
+    """
+    def __call__(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        if 'related_items' in catalog.schema():
+            catalog.delColumn('related_items')


### PR DESCRIPTION
Index and column in catalog.xml has already been removed in an upgrade to
2602 - but not the actual metadata column in the catalog.


*For most customers this update is not critical and can be done eventually, in critical cases an update will be executed manually.*