### PR TITLE
Add permissons for meetings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,15 @@ Changelog
     - Mark notifications as read when opening the dropdown.
 
   [phgross]
+- Add permissons for meetings.
+
+    - Add 'add Member' permission.
+    - Add permissions to Committee and CommitteeContainer workflows.
+    - Protect views with correct permissions instead of just View.
+    - Add configurable group to committees and set local roles on a committee for that group.
+    - Cleanup owner from rolemap.xml.
+
+  [deiferni]
 
 - Include missing items in protocol navigation.
   [deiferni]

--- a/opengever/activity/tests/test_watcher.py
+++ b/opengever/activity/tests/test_watcher.py
@@ -1,9 +1,9 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.activity.tests.base import ActivityTestCase
+from opengever.testing import FunctionalTestCase
 
 
-class TestWatcher(ActivityTestCase):
+class TestWatcher(FunctionalTestCase):
 
     def test_string_representation(self):
         watcher = create(Builder('watcher').having(actorid=u'h\xfcgo.boss'))

--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
@@ -11,19 +11,22 @@
                 "_id": "committee-1",
                 "_type": "opengever.meeting.committee",
                 "title": "Kommission für Rechtsfragen",
-                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/kommission-fuer-rechtsfragen"
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/kommission-fuer-rechtsfragen",
+                "group_id": "og_demo-ftw_users"
             },
             {
                 "_id": "committee-2",
                 "_type": "opengever.meeting.committee",
                 "title": "Rechnungsprüfungskommission",
-                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/rechnungspruefungskommission"
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/rechnungspruefungskommission",
+                "group_id": "og_demo-ftw_users"
             },
             {
                 "_id": "committee-3",
                 "_type": "opengever.meeting.committee",
                 "title": "Gemeindeversammlung",
-                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/gemeindeversammlung-gemeindeparlament-legislative/versammlungen-sitzungen"
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/gemeindeversammlung-gemeindeparlament-legislative/versammlungen-sitzungen",
+                "group_id": "og_demo-ftw_users"
             }
 
         ]

--- a/opengever/meeting/browser/committeecontainertabs.py
+++ b/opengever/meeting/browser/committeecontainertabs.py
@@ -5,6 +5,7 @@ from opengever.meeting.model import Meeting
 from opengever.meeting.service import meeting_service
 from opengever.meeting.tabs.memberlisting import MemberListingTab
 from opengever.tabbedview.browser.base import OpengeverTab
+from plone import api
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 
 
@@ -16,9 +17,15 @@ class Committees(grok.View, OpengeverTab):
 
     def committees(self):
         committees = []
-
         filter = self.get_filter_text()
-        for committee in Committee.query.by_searchable_text(text_filters=filter).all():
+        query = Committee.query.by_searchable_text(text_filters=filter)
+        for committee in query.all():
+            content_obj = committee.resolve_committee()
+            if not content_obj:
+                continue
+            if not api.user.has_permission('View', obj=content_obj):
+                continue
+
             committees.append(
                 {'title': committee.title,
                  'url': committee.get_url(),

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -22,7 +22,7 @@
       for="opengever.meeting.committeecontainer.ICommitteeContainer"
       name="add-member"
       class=".members.AddMember"
-      permission="zope2.View"
+      permission="opengever.meeting.AddMember"
     />
 
   <browser:page

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -15,7 +15,7 @@
       for="opengever.meeting.committee.ICommittee"
       name="add-membership"
       class=".memberships.AddMembership"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
     />
 
   <browser:page
@@ -82,21 +82,21 @@
       for="opengever.meeting.interfaces.IMemberWrapper"
       name="edit"
       class=".members.EditMember"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMembershipWrapper"
       name="edit"
       class=".memberships.EditMembership"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMembershipWrapper"
       name="remove"
       class=".memberships.RemoveMembership"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
 </configure>

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -7,7 +7,7 @@
       for="opengever.meeting.committee.ICommittee"
       name="add-meeting"
       class=".meeting.AddMeetingWizardStepView"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
     />
 
   <browser:page
@@ -21,21 +21,21 @@
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="edit"
       class=".meeting.EditMeeting"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="meetingtransitioncontroller"
       class=".transitions.MeetingTransitionController"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="protocol"
       class=".protocol.EditProtocol"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
@@ -56,35 +56,35 @@
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="generate_excerpt"
       class=".excerpt.GenerateExcerpt"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="schedule_proposal"
       class=".agendaitem.ScheduleSubmittedProposal"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="schedule_text"
       class=".agendaitem.ScheduleText"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="update_agenda_item_order"
       class=".agendaitem.UpdateAgendaItemOrder"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="delete_agenda_item"
       class=".agendaitem.DeleteAgendaItem"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <browser:page

--- a/opengever/meeting/browser/protocol.py
+++ b/opengever/meeting/browser/protocol.py
@@ -161,7 +161,7 @@ class ChooseProtocolUpdateMethod(Form):
 class UpdateProtocol(FormWrapper, grok.View):
     grok.context(IDocumentSchema)
     grok.name('update_protocol')
-    grok.require('zope2.View')
+    grok.require('cmf.ModifyPortalContent')
 
     form = ChooseProtocolUpdateMethod
 

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from five import grok
 from opengever.meeting import _
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.model import Committee as CommitteeModel
@@ -9,11 +10,24 @@ from opengever.meeting.service import meeting_service
 from opengever.meeting.sources import repository_folder_source
 from opengever.meeting.sources import sablon_template_source
 from opengever.meeting.wrapper import MeetingWrapper
+from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.directives import form
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
 from zope.interface import Interface
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+@grok.provider(IContextSourceBinder)
+def get_group_vocabulary(context):
+    service = ogds_service()
+    groups = []
+    for group in service.all_groups():
+        groups.append(SimpleVocabulary.createTerm(
+            group.groupid, group.groupid, group.title))
+    return SimpleVocabulary(groups)
 
 
 class ICommittee(form.Schema):
@@ -50,6 +64,12 @@ class ICommitteeModel(Interface):
         required=True,
         max_length=256,
         )
+
+    group_id = schema.Choice(
+        title=_('label_group', default="Group"),
+        source=get_group_vocabulary,
+        required=True,
+    )
 
 
 _marker = object()

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -68,6 +68,10 @@ class ICommitteeModel(Interface):
 
     group_id = schema.Choice(
         title=_('label_group', default="Group"),
+        description=_(
+            u'description_group',
+            default=u'Automatically configure permissions on the committee '
+                    u'for this group.'),
         source=get_group_vocabulary,
         required=True,
     )

--- a/opengever/meeting/committeeroles.py
+++ b/opengever/meeting/committeeroles.py
@@ -1,0 +1,50 @@
+class CommitteeRoles(object):
+    """Sets roles for committees based on an ogds group.
+
+    The roles that are managed currently are 'Reader', 'Contributor' and
+    'Editor'. These roles will be added for the group that can be selected in
+    the add/edit forms.
+
+    Caution: this may conflict with roles that are set manually.
+    """
+
+    # XXX: Replace with proper CommitteeMember role
+    roles = ('Reader', 'Contributor', 'Editor')
+
+    def __init__(self, group_id, previous_group_id=None):
+        self.group_id = group_id
+        self.previous_group_id = previous_group_id
+
+    def _add_local_roles(self, context, principal, roles):
+        """Adds managed roles to context."""
+
+        current_roles = dict(context.get_local_roles()).get(principal, ())
+        new_roles = list(set(list(current_roles) + list(roles)))
+        context.manage_setLocalRoles(principal, new_roles)
+
+    def _drop_local_roles(self, context, principal, roles):
+        """Removes managed roles from context."""
+
+        current_roles = dict(context.get_local_roles()).get(principal, ())
+        new_roles = list(set([role for role in current_roles
+                              if role not in self.roles]))
+        if new_roles:
+            context.manage_setLocalRoles(principal, new_roles)
+        else:
+            context.manage_delLocalRoles([principal])
+
+    def initialize(self, committee):
+        """Initialize local roles for a committee."""
+
+        committee.__ac_local_roles_block__ = True
+        self.update(committee)
+
+    def update(self, committee):
+        """Update local roles for a committee."""
+
+        if self.previous_group_id:
+            self._drop_local_roles(committee, self.previous_group_id,
+                                   self.roles)
+        self._add_local_roles(committee, self.group_id, self.roles)
+
+        committee.reindexObjectSecurity()

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -5,6 +5,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     >
 
+    <include file="permissions.zcml" />
     <include package=".behaviors" />
     <include package=".browser" />
     <include package=".upgrades" />
@@ -23,25 +24,5 @@
         directory="profiles/default"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
-
-    <permission
-          id="opengever.meeting.AddProposal"
-          title="opengever.meeting: Add Proposal"
-          />
-
-    <permission
-          id="opengever.meeting.AddCommittee"
-          title="opengever.meeting: Add Committee"
-          />
-
-    <permission
-          id="opengever.meeting.AddSablonTemplate"
-          title="opengever.meeting: Add Sablon Template"
-          />
-
-    <permission
-          id="opengever.meeting.AddMember"
-          title="opengever.meeting: Add Member"
-          />
 
 </configure>

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -39,4 +39,9 @@
           title="opengever.meeting: Add Sablon Template"
           />
 
+    <permission
+          id="opengever.meeting.AddMember"
+          title="opengever.meeting: Add Member"
+          />
+
 </configure>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-10-22 13:51+0000\n"
+"POT-Creation-Date: 2015-10-27 14:09+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -422,6 +422,11 @@ msgstr "Beschliessen"
 #: ./opengever/meeting/model/proposal.py:100
 msgid "decided"
 msgstr "Beschlossen"
+
+#. Default: "Automatically configure permissions on the committee for this group."
+#: ./opengever/meeting/committee.py:71
+msgid "description_group"
+msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Kommittee vergeben."
 
 #. Default: "Dossier"
 #: ./opengever/meeting/tabs/meetinglisting.py:57

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-10-22 13:11+0000\n"
+"POT-Creation-Date: 2015-10-22 13:51+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -104,7 +104,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:30
+#: ./opengever/meeting/committee.py:45
 #: ./opengever/meeting/committeecontainer.py:21
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
@@ -173,7 +173,7 @@ msgstr "Veröffentlichung im einfügen"
 msgid "Legal basis"
 msgstr "Rechtsgrundlage"
 
-#: ./opengever/meeting/committee.py:36
+#: ./opengever/meeting/committee.py:51
 msgid "Linked repository folder"
 msgstr "Ablageposition"
 
@@ -234,7 +234,7 @@ msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:24
+#: ./opengever/meeting/committee.py:39
 #: ./opengever/meeting/committeecontainer.py:15
 msgid "Protocol template"
 msgstr "Vorlage Protokoll"
@@ -560,6 +560,11 @@ msgstr "Protokollauszug"
 msgid "label_firstname"
 msgstr "Vorname"
 
+#. Default: "Group"
+#: ./opengever/meeting/committee.py:70
+msgid "label_group"
+msgstr "Gruppe"
+
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:41
 #: ./opengever/meeting/proposal.py:54
@@ -584,7 +589,7 @@ msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:37
+#: ./opengever/meeting/committee.py:52
 msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
@@ -677,7 +682,7 @@ msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/committee.py:49
+#: ./opengever/meeting/committee.py:64
 #: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr "Titel"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
+<<<<<<< HEAD
 "POT-Creation-Date: 2015-10-22 13:11+0000\n"
+=======
+"POT-Creation-Date: 2015-10-22 13:51+0000\n"
+>>>>>>> Update translations.
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -104,7 +108,11 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
+<<<<<<< HEAD
 #: ./opengever/meeting/committee.py:30
+=======
+#: ./opengever/meeting/committee.py:45
+>>>>>>> Update translations.
 #: ./opengever/meeting/committeecontainer.py:21
 msgid "Excerpt template"
 msgstr ""
@@ -173,7 +181,7 @@ msgstr ""
 msgid "Legal basis"
 msgstr "Base légale"
 
-#: ./opengever/meeting/committee.py:36
+#: ./opengever/meeting/committee.py:51
 msgid "Linked repository folder"
 msgstr ""
 
@@ -234,7 +242,11 @@ msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
+<<<<<<< HEAD
 #: ./opengever/meeting/committee.py:24
+=======
+#: ./opengever/meeting/committee.py:39
+>>>>>>> Update translations.
 #: ./opengever/meeting/committeecontainer.py:15
 msgid "Protocol template"
 msgstr ""
@@ -560,6 +572,11 @@ msgstr ""
 msgid "label_firstname"
 msgstr "Prénom"
 
+#. Default: "Group"
+#: ./opengever/meeting/committee.py:70
+msgid "label_group"
+msgstr ""
+
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:41
 #: ./opengever/meeting/proposal.py:54
@@ -584,7 +601,7 @@ msgid "label_legal_basis"
 msgstr "Base légale"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:37
+#: ./opengever/meeting/committee.py:52
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -677,7 +694,7 @@ msgstr "Début"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/committee.py:49
+#: ./opengever/meeting/committee.py:64
 #: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr "Titre"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,11 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-<<<<<<< HEAD
-"POT-Creation-Date: 2015-10-22 13:11+0000\n"
-=======
-"POT-Creation-Date: 2015-10-22 13:51+0000\n"
->>>>>>> Update translations.
+"POT-Creation-Date: 2015-10-27 14:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,11 +104,7 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-<<<<<<< HEAD
-#: ./opengever/meeting/committee.py:30
-=======
 #: ./opengever/meeting/committee.py:45
->>>>>>> Update translations.
 #: ./opengever/meeting/committeecontainer.py:21
 msgid "Excerpt template"
 msgstr ""
@@ -242,11 +234,7 @@ msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
-<<<<<<< HEAD
-#: ./opengever/meeting/committee.py:24
-=======
 #: ./opengever/meeting/committee.py:39
->>>>>>> Update translations.
 #: ./opengever/meeting/committeecontainer.py:15
 msgid "Protocol template"
 msgstr ""
@@ -434,6 +422,11 @@ msgstr "Décider"
 #: ./opengever/meeting/model/proposal.py:100
 msgid "decided"
 msgstr "Décidé"
+
+#. Default: "Automatically configure permissions on the committee for this group."
+#: ./opengever/meeting/committee.py:71
+msgid "description_group"
+msgstr ""
 
 #. Default: "Dossier"
 #: ./opengever/meeting/tabs/meetinglisting.py:57

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,11 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
+<<<<<<< HEAD
 "POT-Creation-Date: 2015-10-22 13:11+0000\n"
+=======
+"POT-Creation-Date: 2015-10-22 13:51+0000\n"
+>>>>>>> Update translations.
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -172,7 +176,7 @@ msgstr ""
 msgid "Legal basis"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:36
+#: ./opengever/meeting/committee.py:51
 msgid "Linked repository folder"
 msgstr ""
 
@@ -559,6 +563,11 @@ msgstr ""
 msgid "label_firstname"
 msgstr ""
 
+#. Default: "Group"
+#: ./opengever/meeting/committee.py:70
+msgid "label_group"
+msgstr ""
+
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:41
 #: ./opengever/meeting/proposal.py:54
@@ -583,7 +592,7 @@ msgid "label_legal_basis"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:37
+#: ./opengever/meeting/committee.py:52
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -675,7 +684,7 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/committee.py:49
+#: ./opengever/meeting/committee.py:64
 #: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr ""

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,11 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-<<<<<<< HEAD
-"POT-Creation-Date: 2015-10-22 13:11+0000\n"
-=======
-"POT-Creation-Date: 2015-10-22 13:51+0000\n"
->>>>>>> Update translations.
+"POT-Creation-Date: 2015-10-27 14:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -424,6 +420,11 @@ msgstr ""
 #. Default: "Decided"
 #: ./opengever/meeting/model/proposal.py:100
 msgid "decided"
+msgstr ""
+
+#. Default: "Automatically configure permissions on the committee for this group."
+#: ./opengever/meeting/committee.py:71
+msgid "description_group"
 msgstr ""
 
 #. Default: "Dossier"

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -2,6 +2,7 @@ from opengever.base.model import Base
 from opengever.base.oguid import Oguid
 from opengever.base.utils import escape_html
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import UNIT_ID_LENGTH
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -18,6 +19,9 @@ class Committee(Base):
 
     committee_id = Column("id", Integer, Sequence("committee_id_seq"),
                           primary_key=True)
+
+    group_id = Column(String(GROUP_ID_LENGTH),
+                      nullable=False)
 
     admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)

--- a/opengever/meeting/permissions.zcml
+++ b/opengever/meeting/permissions.zcml
@@ -1,0 +1,25 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.meeting">
+
+    <permission
+          id="opengever.meeting.AddProposal"
+          title="opengever.meeting: Add Proposal"
+          />
+
+    <permission
+          id="opengever.meeting.AddCommittee"
+          title="opengever.meeting: Add Committee"
+          />
+
+    <permission
+          id="opengever.meeting.AddSablonTemplate"
+          title="opengever.meeting: Add Sablon Template"
+          />
+
+    <permission
+          id="opengever.meeting.AddMember"
+          title="opengever.meeting: Add Member"
+          />
+
+</configure>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4608</version>
+    <version>4609</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4607</version>
+    <version>4608</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4605</version>
+    <version>4607</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/types/opengever.meeting.committeecontainer.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.committeecontainer.xml
@@ -50,7 +50,7 @@
           url_expr="string:${object_url}/add-member"
           icon_expr=""
           condition_expr="">
-      <permission value="Add portal content"/>
+      <permission value="opengever.meeting: Add Member"/>
   </action>
 
   <!-- Actions -->

--- a/opengever/meeting/profiles/default/workflows/opengever_committeecontainer_workflow/definition.xml
+++ b/opengever/meeting/profiles/default/workflows/opengever_committeecontainer_workflow/definition.xml
@@ -1,6 +1,49 @@
 <?xml version="1.0"?>
 <dc-workflow workflow_id="opengever_committeecontainer_workflow" title="Committee Container Workflow" description="" state_variable="review_state" initial_state="committeecontainer-state-active" manager_bypass="False">
+ <permission>View</permission>
+ <permission>List folder contents</permission>
+ <permission>Access contents information</permission>
+ <permission>Add portal content</permission>
+ <permission>Sharing page: Delegate roles</permission>
+ <permission>Modify portal content</permission>
+ <permission>opengever.meeting: Add Committee</permission>
+ <permission>opengever.meeting: Add Member</permission>
  <state state_id="committeecontainer-state-active" title="committeecontainer-state-active">
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+   <permission-role>Reader</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Contributor</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="List folder contents" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Sharing page: Delegate roles" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+   <permission-role>Reader</permission-role>
+  </permission-map>
+  <permission-map name="opengever.meeting: Add Committee" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="opengever.meeting: Add Member" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
  </state>
  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
   <description>Previous transition</description>

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -12,6 +12,8 @@ class TestCommittee(FunctionalTestCase):
 
     def setUp(self):
         super(TestCommittee, self).setUp()
+        self.grant('Administrator')
+
         self.repo_root = create(Builder('repository_root'))
         self.repository_folder = create(Builder('repository')
                                         .within(self.repo_root)

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -35,7 +35,8 @@ class TestCommittee(FunctionalTestCase):
 
         browser.fill(
             {'Title': u'A c\xf6mmittee',
-             'Linked repository folder': self.repository_folder})
+             'Linked repository folder': self.repository_folder,
+             'Group': 'client1_users'})
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Item created',
                       browser.css('.portalMessage.info dd').text)

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -43,6 +43,10 @@ class TestCommittee(FunctionalTestCase):
 
         committee = browser.context
         self.assertEqual('committee-1', committee.getId())
+        self.assertTrue(committee.__ac_local_roles_block__)
+        self.assertEqual(
+            ('Contributor', 'Editor', 'Reader'),
+            dict(committee.get_local_roles()).get('client1_users'))
 
         model = committee.load_model()
         self.assertIsNotNone(model)
@@ -56,17 +60,29 @@ class TestCommittee(FunctionalTestCase):
                            .titled(u'My Committee')
                            .link_with(self.repository_folder))
 
+        self.assertEqual(
+            ('Contributor', 'Editor', 'Reader'),
+            dict(committee.get_local_roles()).get('client1_users'))
+
         browser.login().visit(committee, view='edit')
         form = browser.css('#content-core form').first
 
         self.assertEqual(u'My Committee', form.find_field('Title').value)
-        browser.fill({'Title': u'A c\xf6mmittee'})
+
+        browser.fill({'Title': u'A c\xf6mmittee',
+                      'Group': u'client1_inbox_users'})
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Changes saved',
                       browser.css('.portalMessage.info dd').text)
 
         committee = browser.context
         self.assertEqual('committee-1', committee.getId())
+        local_roles = dict(committee.get_local_roles())
+        self.assertNotIn('client1_users', local_roles,
+                         local_roles.get('client1_users'))
+        self.assertEqual(
+            ('Contributor', 'Editor', 'Reader'),
+            local_roles.get('client1_inbox_users'))
 
         model = committee.load_model()
         self.assertIsNotNone(model)

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -34,6 +34,30 @@ class TestCommitteesTab(FunctionalTestCase):
             browser.css('#committees_view .committee_box h2').text)
 
     @browsing
+    def test_can_only_see_committees_for_corresponding_group(self, browser):
+        user = create(Builder('user')
+                      .with_userid('hugo.boss'))
+        create(Builder('group')
+               .with_groupid('kom_wirtschaft')
+               .with_members(user))
+        # make committee-container accessible
+        self.container.manage_setLocalRoles('kom_wirtschaft', ['Reader'])
+
+        create(Builder('committee')
+               .within(self.container)
+               .having(group_id='kom_wirtschaft')
+               .titled(u'Wirtschafts Kommission'))
+        create(Builder('committee')
+               .within(self.container)
+               .titled(u'Gew\xe4sser Kommission'))
+
+        browser.login('hugo.boss').open(self.container,
+                                        view='tabbedview_view-committees')
+        self.assertEquals(
+            [u'Wirtschafts Kommission'],
+            browser.css('#committees_view .committee_box h2').text)
+
+    @browsing
     def test_tabbedview_text_filter(self, browser):
         create(Builder('committee')
                .within(self.container)

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -1,0 +1,29 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.meeting.committeeroles import CommitteeRoles
+from opengever.testing import FunctionalTestCase
+
+
+class TestCommitteeTabs(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCommitteeTabs, self).setUp()
+
+        self.container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee')
+                                .within(self.container))
+
+    def test_committee_roles_initialized(self):
+        self.assertEqual(
+            ('Contributor', 'Editor', 'Reader'),
+            dict(self.committee.get_local_roles())['client1_users'])
+
+    def test_update_roles_removes_old_role(self):
+        CommitteeRoles('foo', previous_group_id='client1_users').update(
+            self.committee)
+
+        local_roles = dict(self.committee.get_local_roles())
+        self.assertNotIn('client1_users', local_roles)
+        self.assertEqual(
+            ('Contributor', 'Editor', 'Reader'),
+            local_roles['foo'])

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -70,6 +70,7 @@ class TestExcerpt(FunctionalTestCase):
 
     @browsing
     def test_excerpt_template_can_be_configured_per_commitee(self, browser):
+        self.grant("Administrator")
         custom_template = create(
             Builder('sablontemplate')
             .within(self.templates)

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -101,7 +101,9 @@ class TestMeetingLocking(FunctionalTestCase):
 
     @browsing
     def test_protocol_raise_redirect_back_to_meeting_view_when_protocol_is_locked(self, browser):
-        user = create(Builder('user').named('Hugo', 'Boss'))
+        user = create(Builder('user')
+                      .named('Hugo', 'Boss')
+                      .in_groups('client1_users'))
         browser.login(username='hugo.boss').open(self.meeting.get_url('protocol'))
 
         with self.assertRaises(Redirect) as cm:
@@ -113,7 +115,9 @@ class TestMeetingLocking(FunctionalTestCase):
 
     @browsing
     def test_meeting_view_shows_information_when_is_locked(self, browser):
-        user = create(Builder('user').named('Hugo', 'Boss'))
+        user = create(Builder('user')
+                      .named('Hugo', 'Boss')
+                      .in_groups('client1_users'))
         browser.login(username='hugo.boss').open(self.meeting.get_url('protocol'))
 
         browser.login().open(self.meeting.get_url())

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -22,6 +22,7 @@ class TestMemberListing(FunctionalTestCase):
 
     @browsing
     def test_members_can_be_added_in_browser(self, browser):
+        self.grant("Administrator")
         browser.login().open(self.container, view='add-member')
         browser.fill({'Firstname': u'Hanspeter',
                       'Lastname': u'Hansj\xf6rg',

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -180,6 +180,7 @@ class TestProposal(FunctionalTestCase):
 
     @browsing
     def test_edit_view_availability_for_submitted_proposal(self, browser):
+        self.grant("Administrator")
         committee = create(Builder('committee'))
         proposal = create(Builder('proposal')
                           .within(self.dossier)
@@ -191,7 +192,7 @@ class TestProposal(FunctionalTestCase):
         submitted_proposal = api.portal.get().restrictedTraverse(
             proposal.load_model().submitted_physical_path.encode('utf-8'))
         browser.login().open(submitted_proposal)
-        self.assertEqual(['Contents', 'Edit', 'Sharing'],
+        self.assertEqual(['Edit', 'Sharing'],
                          browser.css('#content-views li').text)
 
         proposal_model = submitted_proposal.load_model()
@@ -200,7 +201,7 @@ class TestProposal(FunctionalTestCase):
 
         # cannot edit decided SubmittedProposal
         browser.open(submitted_proposal)
-        self.assertEqual(['Contents', 'Sharing'],
+        self.assertEqual(['Sharing'],
                          browser.css('#content-views li').text)
         with self.assertRaises(Unauthorized):
             browser.open(submitted_proposal, view='edit')

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -82,6 +82,7 @@ class TestProtocol(FunctionalTestCase):
 
     @browsing
     def test_protocol_template_can_be_configured_per_commitee(self, browser):
+        self.grant("Administrator")
         custom_template = create(
             Builder('sablontemplate')
             .within(self.templates)

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -344,4 +344,12 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4605 -> 4606 -->
+    <upgrade-step:importProfile
+        title="Add 'add Member' permission, cleanup owner from rolemap."
+        source="4605"
+        destination="4606"
+        profile="opengever.meeting:default"
+        directory="profiles/4606"
+        />
 </configure>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -352,4 +352,24 @@
         profile="opengever.meeting:default"
         directory="profiles/4606"
         />
+
+    <!-- 4606 -> 4607 -->
+    <genericsetup:upgradeStep
+        title="Let meeting workflows manage some permissions."
+        description=""
+        source="4606"
+        destination="4607"
+        handler="opengever.meeting.upgrades.to4607.AddPermissionsToWorkflows"
+        profile="opengever.meeting:default"
+        />
+
+    <genericsetup:registerProfile
+        name="4607"
+        title="opengever.meeting: upgrade profile 4607"
+        description=""
+        directory="profiles/4607"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -382,4 +382,13 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4608 -> 4609 -->
+    <upgrade-step:importProfile
+        title="Use Add Member permission to protect add-member action."
+        source="4608"
+        destination="4609"
+        profile="opengever.meeting:default"
+        directory="profiles/4609"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -372,4 +372,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4607 -> 4608 -->
+    <genericsetup:upgradeStep
+        title="Add group-id to committee"
+        description=""
+        source="4607"
+        destination="4608"
+        handler="opengever.meeting.upgrades.to4608.AddGroupIdColumn"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4606/rolemap.xml
+++ b/opengever/meeting/upgrades/profiles/4606/rolemap.xml
@@ -20,10 +20,5 @@
       <role name="Administrator"/>
     </permission>
 
-    <permission name="opengever.meeting: Add Sablon Template" acquire="True">
-      <role name="Manager"/>
-      <role name="Administrator"/>
-    </permission>
-
   </permissions>
 </rolemap>

--- a/opengever/meeting/upgrades/profiles/4607/workflows/opengever_committee_workflow/definition.xml
+++ b/opengever/meeting/upgrades/profiles/4607/workflows/opengever_committee_workflow/definition.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <dc-workflow workflow_id="opengever_committee_workflow" title="Committee Workflow" description="" state_variable="review_state" initial_state="committee-state-active" manager_bypass="False">
- <permission>View</permission>
  <permission>Access contents information</permission>
  <permission>Add portal content</permission>
  <permission>List folder contents</permission>
  <permission>Modify portal content</permission>
  <permission>Sharing page: Delegate roles</permission>
+ <permission>View</permission>
  <state state_id="committee-state-active" title="committee-state-active">
   <permission-map name="Access contents information" acquired="False">
    <permission-role>Administrator</permission-role>
@@ -38,7 +38,7 @@
  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
   <description>Previous transition</description>
   <default>
-
+   
    <expression>transition/getId|nothing</expression>
   </default>
   <guard>
@@ -47,7 +47,7 @@
  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
   <description>The ID of the user who performed the previous transition</description>
   <default>
-
+   
    <expression>user/getUserName</expression>
   </default>
   <guard>
@@ -56,7 +56,7 @@
  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
   <description>Comment about the last transition</description>
   <default>
-
+   
    <expression>python:state_change.kwargs.get('comment', '')</expression>
   </default>
   <guard>
@@ -65,7 +65,7 @@
  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
   <description>Provides access to workflow history</description>
   <default>
-
+   
    <expression>state_change/getHistory</expression>
   </default>
   <guard>
@@ -76,7 +76,7 @@
  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
   <description>When the previous transition was performed</description>
   <default>
-
+   
    <expression>state_change/getDateTime</expression>
   </default>
   <guard>

--- a/opengever/meeting/upgrades/profiles/4607/workflows/opengever_committeecontainer_workflow/definition.xml
+++ b/opengever/meeting/upgrades/profiles/4607/workflows/opengever_committeecontainer_workflow/definition.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0"?>
-<dc-workflow workflow_id="opengever_committee_workflow" title="Committee Workflow" description="" state_variable="review_state" initial_state="committee-state-active" manager_bypass="False">
- <permission>View</permission>
+<dc-workflow workflow_id="opengever_committeecontainer_workflow" title="Committee Container Workflow" description="" state_variable="review_state" initial_state="committeecontainer-state-active" manager_bypass="False">
  <permission>Access contents information</permission>
  <permission>Add portal content</permission>
  <permission>List folder contents</permission>
  <permission>Modify portal content</permission>
  <permission>Sharing page: Delegate roles</permission>
- <state state_id="committee-state-active" title="committee-state-active">
+ <permission>View</permission>
+ <permission>opengever.meeting: Add Committee</permission>
+ <permission>opengever.meeting: Add Member</permission>
+ <state state_id="committeecontainer-state-active" title="committeecontainer-state-active">
   <permission-map name="Access contents information" acquired="False">
    <permission-role>Administrator</permission-role>
    <permission-role>Manager</permission-role>
@@ -34,11 +36,19 @@
    <permission-role>Manager</permission-role>
    <permission-role>Reader</permission-role>
   </permission-map>
+  <permission-map name="opengever.meeting: Add Committee" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="opengever.meeting: Add Member" acquired="False">
+   <permission-role>Administrator</permission-role>
+   <permission-role>Manager</permission-role>
+  </permission-map>
  </state>
  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
   <description>Previous transition</description>
   <default>
-
+   
    <expression>transition/getId|nothing</expression>
   </default>
   <guard>
@@ -47,7 +57,7 @@
  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
   <description>The ID of the user who performed the previous transition</description>
   <default>
-
+   
    <expression>user/getUserName</expression>
   </default>
   <guard>
@@ -56,7 +66,7 @@
  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
   <description>Comment about the last transition</description>
   <default>
-
+   
    <expression>python:state_change.kwargs.get('comment', '')</expression>
   </default>
   <guard>
@@ -65,7 +75,7 @@
  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
   <description>Provides access to workflow history</description>
   <default>
-
+   
    <expression>state_change/getHistory</expression>
   </default>
   <guard>
@@ -76,7 +86,7 @@
  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
   <description>When the previous transition was performed</description>
   <default>
-
+   
    <expression>state_change/getDateTime</expression>
   </default>
   <guard>

--- a/opengever/meeting/upgrades/profiles/4609/types/opengever.meeting.committeecontainer.xml
+++ b/opengever/meeting/upgrades/profiles/4609/types/opengever.meeting.committeecontainer.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.committeecontainer"
+        i18n:domain="opengever.meeting"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <action action_id="add-member"
+          visible="True"
+          title="Member"
+          category="folder_factories"
+          url_expr="string:${object_url}/add-member"
+          icon_expr=""
+          condition_expr="">
+      <permission value="opengever.meeting: Add Member"/>
+  </action>
+
+</object>

--- a/opengever/meeting/upgrades/to4607.py
+++ b/opengever/meeting/upgrades/to4607.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPermissionsToWorkflows(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-opengever.meeting.upgrades:4607')
+
+        self.update_workflow_security(
+            ['opengever_committeecontainer_workflow',
+             'opengever_committee_workflow'],
+            reindex_security=True)

--- a/opengever/meeting/upgrades/to4608.py
+++ b/opengever/meeting/upgrades/to4608.py
@@ -1,0 +1,42 @@
+from opengever.core.upgrade import SchemaMigration
+from opengever.ogds.base.utils import get_current_org_unit
+from sqlalchemy import Column
+from sqlalchemy import String
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class AddGroupIdColumn(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4608
+
+    def migrate(self):
+        self.add_group_id_column()
+        self.insert_org_units_group_id()
+        self.make_group_id_non_nullable()
+
+    def add_group_id_column(self):
+        self.op.add_column(
+            'committees',
+            Column('group_id', String(255), nullable=True))
+
+    def insert_org_units_group_id(self):
+        """Insert the current org-unit's group_id for all committees.
+
+        Bye default we use the users group. This choice is somewhat arbitrary,
+        but id does not really matter since meeting is not in production when
+        this upgrade is executed.
+
+        """
+        proposal_table = table("committees",
+                               column("id"),
+                               column("group_id"))
+        group_id = get_current_org_unit().users_group.groupid
+
+        self.execute(
+            proposal_table.update().values(group_id=group_id))
+
+    def make_group_id_non_nullable(self):
+        self.op.alter_column('committees', 'group_id',
+                             existing_type=String(255), nullable=False)

--- a/opengever/setup/tests/profiles/templates/opengever_content/committees.json
+++ b/opengever/setup/tests/profiles/templates/opengever_content/committees.json
@@ -7,7 +7,8 @@
             {
                 "_id": "committee-1",
                 "_type": "opengever.meeting.committee",
-                "title": "Testkommission"
+                "title": "Testkommission",
+                "group_id": "client1_users"
             }
         ]
     }

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -321,9 +321,7 @@ class CommitteeBuilder(DexterityBuilder):
 
     def __init__(self, session):
         super(CommitteeBuilder, self).__init__(session)
-        self.arguments = {
-            'title': 'My Committee',
-        }
+        self.arguments = {'title': 'My Committee', 'group_id': 'client1_users'}
 
     def link_with(self, repository_folder):
         self.arguments['repository_folder'] = repository_folder

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -136,6 +136,7 @@ class CommitteeBuilder(SqlObjectBuilder):
         self.arguments['admin_unit_id'] = 'foo'
         self.arguments['int_id'] = 1234
         self.arguments['physical_path'] = '/foo'
+        self.arguments['group_id'] = 'client1_users'
 
 builder_registry.register('committee_model', CommitteeBuilder)
 

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -103,8 +103,9 @@ class FunctionalTestCase(TestCase):
         props = registry.forInterface(ITemplateDossierProperties)
         props.create_doc_properties = enabled
 
-    def grant(self, *roles):
-        setRoles(self.portal, TEST_USER_ID, list(roles))
+    def grant(self, *roles, **kwargs):
+        user_id = kwargs.get('user_id', TEST_USER_ID)
+        setRoles(self.portal, user_id, list(roles))
         transaction.commit()
 
     def login(self, user_id=TEST_USER_NAME):

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,6 +9,7 @@ development-packages =
   ftw.mail
   opengever.ogds.models
   ftw.upgrade
+  ftw.builder
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
This PR adds permissons for meetings:

- Add 'add Member' permission.
- Add permissions to Committee and CommitteeContainer workflows.
- Protect views with correct permissions instead of just View.
- Add configurable group to committees and set local roles on a committee for that group.
- Cleanup owner from rolemap.xml.


Requires https://github.com/4teamwork/opengever.ogds.models/pull/35.