### PR TITLE
Notification dropdown fixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Notification viewlet: Fix javascript for sites with disabled activity feature.
+  [phgross]
+
 - Rework notification viewlet:
 
     - Reimplement viewlet functionality clientside

--- a/opengever/activity/browser/resources/notifications.js
+++ b/opengever/activity/browser/resources/notifications.js
@@ -85,7 +85,10 @@
     });
   };
 
-  $(initNotifications);
-
+  $(function(){
+    if($('#portal-notifications-selector-menu').length){
+      initNotifications();
+    }
+  });
 
 }(window, jQuery, window.Handlebars));

--- a/opengever/base/profiles/default/jsregistry.xml
+++ b/opengever/base/profiles/default/jsregistry.xml
@@ -25,4 +25,8 @@
                 enabled="True" id="++resource++opengever.base/MessageFactory.js" inline="False"
                 />
 
+    <javascript cacheable="True" compression="safe" cookable="True" enabled="on"
+                expression="" id="++resource++opengever.base/handlebars.min.js"
+                inline="False"/>
+
 </object>

--- a/opengever/base/profiles/default/jsregistry.xml
+++ b/opengever/base/profiles/default/jsregistry.xml
@@ -25,7 +25,7 @@
                 enabled="True" id="++resource++opengever.base/MessageFactory.js" inline="False"
                 />
 
-    <javascript cacheable="True" compression="safe" cookable="True" enabled="on"
+    <javascript cacheable="True" compression="none" cookable="True" enabled="on"
                 expression="" id="++resource++opengever.base/handlebars.min.js"
                 inline="False"/>
 

--- a/opengever/base/upgrades/profiles/4504/jsregistry.xml
+++ b/opengever/base/upgrades/profiles/4504/jsregistry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <object name="portal_javascripts" meta_type="JavaScripts Registry" autogroup="False">
 
-  <javascript cacheable="True" compression="safe" cookable="True" enabled="on"
+  <javascript cacheable="True" compression="none" cookable="True" enabled="on"
               expression="" id="++resource++opengever.base/handlebars.min.js"
               inline="False"/>
 


### PR DESCRIPTION
When deploying on the DEV system I found some issues on the reworked notification dropdown.
 - Fix javascript for sites with disabled activity feature.
 - Added missing javascript registration in the default profile of `opengever.base`
   The PR #1268 only adds the handlebar.js to the upgrade profile. So newly created GEVER sites will fail with javascript errors.
 - Fixed compression type for the handlebars.js, we already use the minified javascript, so no compression is needed anymore.

@lukasgraf 

Needs-backport: `4.5-stable`