### PR TITLE
Fixed issue in Tasks `by_container` query, with similar dossier-ids.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fixed issue in Tasks `by_container` query, with similar dossier-ids.
+  [phgross]
+
 - Notification viewlet: Fix javascript for sites with disabled activity feature.
   [phgross]
 

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -66,8 +66,8 @@ class TaskQuery(BaseQuery):
         path = '/'.join(url_tool.getRelativeContentPath(container))
         path = '{}/'.format(path)
 
-        return self.by_admin_unit(admin_unit)\
-                   .filter(Task.physical_path.like(path + '%'))
+        return self.by_admin_unit(admin_unit).filter(
+            Task.physical_path.startswith(path))
 
     def by_brain(self, brain):
         relative_content_path = '/'.join(brain.getPath().split('/')[2:])

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -64,6 +64,7 @@ class TaskQuery(BaseQuery):
     def by_container(self, container, admin_unit):
         url_tool = api.portal.get_tool(name='portal_url')
         path = '/'.join(url_tool.getRelativeContentPath(container))
+        path = '{}/'.format(path)
 
         return self.by_admin_unit(admin_unit)\
                    .filter(Task.physical_path.like(path + '%'))

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -4,6 +4,7 @@ from opengever.globalindex.model.task import Task
 from opengever.testing import FunctionalTestCase
 from opengever.testing import MEMORY_DB_LAYER
 from opengever.testing import obj2brain
+from plone import api
 from unittest2 import TestCase
 
 
@@ -169,6 +170,17 @@ class TestFunctionalTaskQueries(FunctionalTestCase):
 
         self.assertItemsEqual(
             [task1.get_sql_object(), subtask.get_sql_object()],
+            Task.query.by_container(self.dossier, self.admin_unit).all())
+
+    def test_by_container_handles_similar_paths_exactly(self):
+        task1 = create(Builder('task').within(self.dossier))
+
+        dossier_11 = create(Builder('dossier').titled(u'Dossier 11'))
+        dossier_11 = api.content.rename(obj=dossier_11, new_id='dossier-11')
+        task2 = create(Builder('task').within(dossier_11))
+
+        self.assertItemsEqual(
+            [task1.get_sql_object()],
             Task.query.by_container(self.dossier, self.admin_unit).all())
 
     def test_by_container_queries_adminunit_dependent(self):


### PR DESCRIPTION
If a two dossier exist inside the same repository folder, on with the id `dossier-22` and the other with the id `dossier-222`. The task from the Dossier-222 are wrongly listed in the task listing of Dossier-22.

This change will fix that issue.

@lukasgraf 

I would say it makes sense to backport this fix to the `4.5-stable` ... 