### PR TITLE
Removed wrong and outdated handlebars.js registration from the activity jsregistry.

### DIFF
--- a/opengever/activity/profiles/default/jsregistry.xml
+++ b/opengever/activity/profiles/default/jsregistry.xml
@@ -2,12 +2,8 @@
 <object name="portal_javascripts" meta_type="JavaScripts Registry" autogroup="False">
 
   <javascript cacheable="True" compression="safe" cookable="True" enabled="on"
-              expression="" id="++resource++opengever.activity.resources/handlebars.min.js"
-              inline="False"/>
-
-  <javascript cacheable="True" compression="safe" cookable="True" enabled="on"
               expression="" id="++resource++opengever.activity.resources/notifications.js"
-              insert-after="++resource++opengever.activity.resources/handlebars.min.js"
+              insert-after="++resource++opengever.base/handlebars.min.js"
               inline="False"/>
 
 </object>


### PR DESCRIPTION
The handlebars was moved to opengever.base, but I've not cleanely removed the javascript registration entry from the activity jsregistry.xml.

Backport: `4.5-stable`


@lukasgraf 