### PR TITLE
Revert review_state check when accepting or assigning a tasks/forwarding

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Revert review_state checks when accepting or assigning a task/forwarding.
+  [phgross]
+
 - Fixed issue in Tasks `by_container` query, with similar dossier-ids.
   [phgross]
 

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -11,8 +11,6 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import _
 from opengever.task.adapters import IResponseContainer
-from opengever.task.exceptions import CannotAcceptTaskException
-from opengever.task.exceptions import CannotAssignForwardingException
 from opengever.task.exceptions import TaskRemoteRequestError
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import ITaskDocumentsTransporter
@@ -65,8 +63,6 @@ def accept_forwarding_with_successor(
 
     # the predessecor (the forwarding on the remote client)
     predecessor = Task.query.by_oguid(predecessor_oguid)
-    if not predecessor.is_open():
-        raise CannotAcceptTaskException('Forwarding has already been accepted')
 
     # transport the remote forwarding to the inbox or actual yearfolder
     transporter = Transporter()
@@ -183,9 +179,6 @@ def assign_forwarding_to_dossier(
         context, forwarding_oguid, dossier, response_text):
 
     forwarding = Task.query.by_oguid(forwarding_oguid)
-    if not forwarding.is_open():
-        raise CannotAssignForwardingException(
-            'Forwarding has already been accepted')
 
     forwarding_obj = context.unrestrictedTraverse(
         forwarding.physical_path.encode('utf-8'))
@@ -237,8 +230,6 @@ def assign_forwarding_to_dossier(
 
 def accept_task_with_successor(dossier, predecessor_oguid, response_text):
     predecessor = Task.query.by_oguid(predecessor_oguid)
-    if not predecessor.is_open():
-        raise CannotAcceptTaskException('Task has already been accepted')
 
     # Transport the original task (predecessor) to this dossier. The new
     # response and task change is not yet done and will be done later. This

--- a/opengever/task/exceptions.py
+++ b/opengever/task/exceptions.py
@@ -2,13 +2,5 @@ class TaskException(Exception):
     """Base exception class for custom task exceptions."""
 
 
-class CannotAcceptTaskException(TaskException):
-    pass
-
-
-class CannotAssignForwardingException(TaskException):
-    pass
-
-
 class TaskRemoteRequestError(TaskException):
     pass

--- a/opengever/task/tests/test_accept.py
+++ b/opengever/task/tests/test_accept.py
@@ -1,3 +1,4 @@
+from Products.CMFCore.utils import getToolByName
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -8,15 +9,11 @@ from opengever.globalindex.model.task import Task
 from opengever.ogds.base import utils
 from opengever.task.adapters import IResponseContainer
 from opengever.task.browser.accept.utils import accept_forwarding_with_successor
-from opengever.task.browser.accept.utils import accept_task_with_successor
-from opengever.task.exceptions import CannotAcceptTaskException
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.tests.data import DOCUMENT_EXTRACTION, FORWARDING_EXTRACTION
-from opengever.testing import FunctionalTestCase
 from opengever.testing import OPENGEVER_INTEGRATION_TESTING
-from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from Products.CMFCore.utils import getToolByName
+from plone.app.testing import setRoles
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 import unittest2
@@ -31,30 +28,6 @@ class FakeResponse(object):
 
     def read(self):
         return self.result
-
-
-class TestAcceptTask(FunctionalTestCase):
-
-    def test_cannot_accept_task_twice(self):
-        dossier = create(Builder('dossier').titled(u'Dosssier A'))
-        predecessor = create(Builder('task')
-                             .in_state('task-state-in-progress')
-                             .within(dossier))
-
-        with self.assertRaises(CannotAcceptTaskException):
-            accept_task_with_successor(
-                dossier, predecessor.oguid.id, 'msg')
-
-    def test_cannot_accept_forwarding_twice(self):
-        inbox = create(Builder('inbox').titled(u'Inbox'))
-        forwarding = create(Builder('forwarding')
-                            .within(inbox)
-                            .in_state('forwarding-state-closed '))
-
-        with self.assertRaises(CannotAcceptTaskException):
-            accept_forwarding_with_successor(
-                inbox, forwarding.oguid.id, 'msg')
-
 
 class TestTaskAccepting(MockTestCase):
 

--- a/opengever/task/tests/test_assign_to_dossier.py
+++ b/opengever/task/tests/test_assign_to_dossier.py
@@ -3,8 +3,6 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.task.browser.accept.utils import assign_forwarding_to_dossier
-from opengever.task.exceptions import CannotAssignForwardingException
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 
@@ -34,17 +32,6 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         self.repo_folder = create(Builder('repository')
                                   .titled('Repo A')
                                   .within(self.repo_root))
-
-    def test_cannot_assign_forwarding_twice(self):
-        dossier = create(Builder('dossier').titled(u'Dosssier A'))
-        inbox = create(Builder('inbox').titled(u'Inbox'))
-        forwarding = create(Builder('forwarding')
-                            .within(inbox)
-                            .in_state('forwarding-state-closed '))
-
-        with self.assertRaises(CannotAssignForwardingException):
-            assign_forwarding_to_dossier(
-                inbox, forwarding.oguid.id, dossier, 'msg')
 
     @browsing
     def test_assign_to_new_dossier(self, browser):


### PR DESCRIPTION
Because this checks, introduced by #1006, breaks the ConflictError handling for multi adminunit requests and functionalities. See #1251 for more information.

@deiferni @lukasgraf 