### PR TITLE
Consistently name attachments of propoals.

### DIFF
--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -297,3 +297,8 @@ msgstr "Aktivieren"
 msgid "transition-add-document"
 msgstr "Dokument hinzugefügt"
 
+msgid "Submit additional documents"
+msgstr "Zusätzliche Anhänge einreichen"
+
+msgid "Submit additional document"
+msgstr "Zusätzlichen Anhang einreichen"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -297,3 +297,8 @@ msgstr "Activer"
 msgid "transition-add-document"
 msgstr ""
 
+msgid "Submit additional documents"
+msgstr ""
+
+msgid "Submit additional document"
+msgstr ""

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -305,3 +305,9 @@ msgstr ""
 
 msgid "Membership"
 msgstr ""
+
+msgid "Submit additional documents"
+msgstr ""
+
+msgid "Submit additional document"
+msgstr ""

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -105,7 +105,7 @@ msgstr "Als E-Mail versenden"
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4200/actions.xml
 msgid "Submit additional documents"
-msgstr "Dokumente nachreichen"
+msgstr "Zusätzliche Anhänge einreichen"
 
 #: ./opengever/document/browser/overview.py:165
 msgid "Submitted version: ${version}"

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -289,7 +289,7 @@ class TestOverviewMeetingFeatures(FunctionalTestCase):
 
         browser.login().open(self.document, view='tabbedview_view-overview')
         browser.find('Update document in proposal').click()
-        browser.find('Submit Document').click()
+        browser.find('Submit Attachments').click()
 
         self.assertEqual(
             [u'A new submitted version of document Testdokum\xe4nt has been created'],

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -78,7 +78,8 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
         disable_edit_bar()
         return super(SubmitAdditionalDocument, self).__call__()
 
-    @buttonAndHandler(_(u'button_submit_document', default=u'Submit Document'))
+    @buttonAndHandler(_(u'button_submit_attachments',
+                        default=u'Submit Attachments'))
     def submit_documents(self, action):
         data, errors = self.extractData()
         if errors:

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -77,7 +77,7 @@ def get_committee_oguid():
 
 class AddMeetingWizardStep(BaseWizardStepForm, Form):
     step_name = 'add-meeting'
-    label = _('Add Meeting', default=u'Add Meeting')
+    label = _('Add Meeting')
     steps = ADD_MEETING_STEPS
 
     fields = Fields(IMeetingModel)

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -157,7 +157,7 @@
                            tal:attributes="data-id agenda_item/agenda_item_id"></a>
                         <tal:cond tal:condition="agenda_item/has_proposal">
                           <div class="attachements">
-                            <h2 i18n:translate="">Attachements</h2>
+                            <h2 i18n:translate="label_attachments">Attachments</h2>
                             <ul>
                               <li tal:repeat="document agenda_item/proposal/resolve_submitted_documents">
                                 <a tal:content="document/Title" tal:attributes="href document/absolute_url; class python: view.get_css_class(document)"></a>

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -29,7 +29,7 @@
 
     <div id="documentsBox" class="box">
       <tal:condition tal:condition="documents">
-        <h2 i18n:translate="label_documents">Documents</h2>
+        <h2 i18n:translate="label_attachments">Attachments</h2>
         <ul>
           <li tal:repeat="item documents">
             <a href="" tal:attributes="href item/absolute_url;

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -27,7 +27,7 @@ class ISubmitAdditionalDocuments(form.Schema):
     """Meeting model schema interface."""
 
     additionalDocuments = RelationList(
-        title=_(u'label_documents', default=u'Documents'),
+        title=_(u'label_attachments', default=u'Attachments'),
         default=[],
         missing_value=[],
         value_type=RelationChoice(
@@ -65,7 +65,8 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
         return is_meeting_feature_enabled() and \
             self.context.is_submit_additional_documents_allowed()
 
-    @buttonAndHandler(_(u'button_submit_documents', default=u'Submit Documents'))
+    @buttonAndHandler(_(u'button_submit_attachments',
+                        default=u'Submit Attachments'))
     def submit_documents(self, action):
         data, errors = self.extractData()
         if errors:
@@ -105,7 +106,8 @@ class SubmitDocumentsByPaths(AutoExtensibleForm, Form):
     def available(self):
         return is_meeting_feature_enabled()
 
-    @buttonAndHandler(_(u'button_submit_documents', default=u'Submit Documents'))
+    @buttonAndHandler(_(u'button_submit_attachments',
+                        default=u'Submit Attachments'))
     def submit_documents(self, action):
         data, errors = self.extractData()
         if errors:

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-10-27 14:09+0000\n"
+"POT-Creation-Date: 2015-10-28 09:48+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,10 +56,6 @@ msgstr "Traktanden"
 #: ./opengever/meeting/browser/meetings/meeting.py:299
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:160
-msgid "Attachements"
-msgstr "Anhänge"
 
 #: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
@@ -263,7 +259,7 @@ msgstr "Eingereichter Antrag"
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/submitdocuments.py:179
+#: ./opengever/meeting/browser/submitdocuments.py:181
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
@@ -295,7 +291,7 @@ msgid "as paragraph"
 msgstr "Als Abschnitt"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/documents/submit.py:94
+#: ./opengever/meeting/browser/documents/submit.py:95
 #: ./opengever/meeting/browser/meetings/meeting.py:101
 #: ./opengever/meeting/browser/protocol.py:152
 msgid "button_cancel"
@@ -311,15 +307,11 @@ msgstr "Weiter"
 msgid "button_generate"
 msgstr "Erstellen"
 
-#. Default: "Submit Document"
+#. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-msgid "button_submit_document"
-msgstr "Dokument einreichen"
-
-#. Default: "Submit Documents"
 #: ./opengever/meeting/browser/submitdocuments.py:68
-msgid "button_submit_documents"
-msgstr "Dokumente einreichen"
+msgid "button_submit_attachments"
+msgstr "Anhänge einreichen"
 
 #. Default: "Close"
 #: ./opengever/meeting/model/meeting.py:74
@@ -469,6 +461,13 @@ msgstr ""
 msgid "hold meeting"
 msgstr "Sitzung durchführen"
 
+#. Default: "Attachments"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:160
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
+#: ./opengever/meeting/browser/submitdocuments.py:30
+msgid "label_attachments"
+msgstr "Anhänge"
+
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:149
 msgid "label_cancel_edit_box"
 msgstr "Abbrechen"
@@ -525,13 +524,6 @@ msgstr "Zu eröffnen an"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:72
 msgid "label_discussion"
 msgstr "Diskussion"
-
-#. Default: "Documents"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
-#: ./opengever/meeting/browser/submitdocuments.py:30
-#: ./opengever/meeting/proposal.py:132
-msgid "label_documents"
-msgstr "Dokumente"
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-10-27 14:09+0000\n"
+"POT-Creation-Date: 2015-10-28 09:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,10 +56,6 @@ msgstr "Points de l'ordre du jour"
 #: ./opengever/meeting/browser/meetings/meeting.py:299
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:160
-msgid "Attachements"
-msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
@@ -263,7 +259,7 @@ msgstr "Proposition soumise"
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:179
+#: ./opengever/meeting/browser/submitdocuments.py:181
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
 
@@ -295,7 +291,7 @@ msgid "as paragraph"
 msgstr "Comme paragraphe"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/documents/submit.py:94
+#: ./opengever/meeting/browser/documents/submit.py:95
 #: ./opengever/meeting/browser/meetings/meeting.py:101
 #: ./opengever/meeting/browser/protocol.py:152
 msgid "button_cancel"
@@ -311,15 +307,11 @@ msgstr ""
 msgid "button_generate"
 msgstr "Générer"
 
-#. Default: "Submit Document"
+#. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-msgid "button_submit_document"
-msgstr "Soumettre le document"
-
-#. Default: "Submit Documents"
 #: ./opengever/meeting/browser/submitdocuments.py:68
-msgid "button_submit_documents"
-msgstr "Soumettre les documents"
+msgid "button_submit_attachments"
+msgstr ""
 
 #. Default: "Close"
 #: ./opengever/meeting/model/meeting.py:74
@@ -469,6 +461,13 @@ msgstr ""
 msgid "hold meeting"
 msgstr "Tenir séance"
 
+#. Default: "Attachments"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:160
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
+#: ./opengever/meeting/browser/submitdocuments.py:30
+msgid "label_attachments"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:149
 msgid "label_cancel_edit_box"
 msgstr ""
@@ -525,13 +524,6 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:72
 msgid "label_discussion"
 msgstr "Discussion"
-
-#. Default: "Documents"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
-#: ./opengever/meeting/browser/submitdocuments.py:30
-#: ./opengever/meeting/proposal.py:132
-msgid "label_documents"
-msgstr "Documents"
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-10-27 14:09+0000\n"
+"POT-Creation-Date: 2015-10-28 09:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,10 +56,6 @@ msgstr ""
 msgid "An unexpected error has occurred"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:160
-msgid "Attachements"
-msgstr ""
-
 #: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr ""
@@ -103,7 +99,7 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:30
+#: ./opengever/meeting/committee.py:45
 #: ./opengever/meeting/committeecontainer.py:21
 msgid "Excerpt template"
 msgstr ""
@@ -233,7 +229,7 @@ msgstr ""
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:24
+#: ./opengever/meeting/committee.py:39
 #: ./opengever/meeting/committeecontainer.py:15
 msgid "Protocol template"
 msgstr ""
@@ -262,7 +258,7 @@ msgstr ""
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:179
+#: ./opengever/meeting/browser/submitdocuments.py:181
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
@@ -294,7 +290,7 @@ msgid "as paragraph"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/documents/submit.py:94
+#: ./opengever/meeting/browser/documents/submit.py:95
 #: ./opengever/meeting/browser/meetings/meeting.py:101
 #: ./opengever/meeting/browser/protocol.py:152
 msgid "button_cancel"
@@ -310,14 +306,10 @@ msgstr ""
 msgid "button_generate"
 msgstr ""
 
-#. Default: "Submit Document"
+#. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-msgid "button_submit_document"
-msgstr ""
-
-#. Default: "Submit Documents"
 #: ./opengever/meeting/browser/submitdocuments.py:68
-msgid "button_submit_documents"
+msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Close"
@@ -468,6 +460,13 @@ msgstr ""
 msgid "hold meeting"
 msgstr ""
 
+#. Default: "Attachments"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:160
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
+#: ./opengever/meeting/browser/submitdocuments.py:30
+msgid "label_attachments"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:149
 msgid "label_cancel_edit_box"
 msgstr ""
@@ -523,13 +522,6 @@ msgstr ""
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:72
 msgid "label_discussion"
-msgstr ""
-
-#. Default: "Documents"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
-#: ./opengever/meeting/browser/submitdocuments.py:30
-#: ./opengever/meeting/proposal.py:132
-msgid "label_documents"
 msgstr ""
 
 #. Default: "Edit"

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -129,7 +129,7 @@ class IProposal(form.Schema):
     """Proposal Proxy Object Schema Interface"""
 
     relatedItems = RelationList(
-        title=_(u'label_documents', default=u'Documents'),
+        title=_(u'label_attachments', default=u'Attachments'),
         default=[],
         missing_value=[],
         value_type=RelationChoice(

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -83,8 +83,8 @@ class TestProposalHistory(FunctionalTestCase):
 
         browser.login().visit(self.proposal)
         browser.find('Submit additional documents').click()
-        browser.fill({'Documents': document})
-        browser.find('Submit Documents').click()
+        browser.fill({'Attachments': document})
+        browser.find('Submit Attachments').click()
 
         self.open_overview(browser)
         self.assertEqual(
@@ -100,8 +100,8 @@ class TestProposalHistory(FunctionalTestCase):
 
         browser.login().visit(self.proposal)
         browser.find('Submit additional documents').click()
-        browser.fill({'Documents': self.document})
-        browser.find('Submit Documents').click()
+        browser.fill({'Attachments': self.document})
+        browser.find('Submit Attachments').click()
 
         self.open_overview(browser)
         self.assertEqual(

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -104,7 +104,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         browser.login().visit(self.document)
         browser.find('Submit additional document').click()
         browser.fill({'Proposal': proposal})
-        browser.find('Submit Document').click()
+        browser.find('Submit Attachments').click()
 
         self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
@@ -117,8 +117,8 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         browser.login().visit(proposal)
         browser.find('Submit additional documents').click()
-        browser.fill({'Documents': self.document})
-        browser.find('Submit Documents').click()
+        browser.fill({'Attachments': self.document})
+        browser.find('Submit Attachments').click()
 
         self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
@@ -137,8 +137,8 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         browser.login().visit(proposal)
         browser.find('Submit additional documents').click()
-        browser.fill({'Documents': self.document})
-        browser.find('Submit Documents').click()
+        browser.fill({'Attachments': self.document})
+        browser.find('Submit Attachments').click()
 
         self.assertSubmittedDocumentCreated(
             proposal, self.document, submitted_version=2)


### PR DESCRIPTION
This just updates the translations but leaves actions and views untouched (that's why some translation ids could not be changed yet). They should be renamed later™ though, see #1276.

Closes #1076