### PR TITLE
Add subscriber that disallows access to views on the portal root for

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Disallow access to views on the portal root for anonymous except of login
+  form and password reset.
+  [buchi]
+
 - Make sure only the new responsible gets notified by mail, when a
   task gets reassigned.
   [phgross]

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -159,7 +159,7 @@ class TestSearchWithoutContent(FunctionalTestCase):
 
     @browsing
     def test_validate_searchstring_for_dossiers(self, browser):
-        browser.open(view='advanced_search')
+        browser.login().open(view='advanced_search')
         browser.fill({'form.widgets.searchableText': "dossier1",
                       'form.widgets.object_provides': ['opengever.dossier.behaviors.dossier.IDossierMarker'],
                       'form.widgets.start_1': "1/1/10",
@@ -189,7 +189,7 @@ class TestSearchWithoutContent(FunctionalTestCase):
 
     @browsing
     def test_validate_searchstring_for_documents(self, browser):
-        browser.open(view='advanced_search')
+        browser.login().open(view='advanced_search')
         browser.fill({'form.widgets.searchableText': "document1",
                       'form.widgets.object_provides': 'opengever.document.behaviors.IBaseDocument',
                       'form.widgets.receipt_date_1': "1/1/10",
@@ -217,7 +217,7 @@ class TestSearchWithoutContent(FunctionalTestCase):
 
     @browsing
     def test_validate_searchstring_for_tasks(self, browser):
-        browser.open(view='advanced_search')
+        browser.login().open(view='advanced_search')
         browser.fill({'form.widgets.searchableText': "task1",
                       'form.widgets.object_provides': 'opengever.task.task.ITask',
                       'form.widgets.deadline_1': "1/1/10",
@@ -237,5 +237,5 @@ class TestSearchWithoutContent(FunctionalTestCase):
 
     @browsing
     def test_disable_unload_protection(self, browser):
-        browser.open(view='advanced_search')
+        browser.login().open(view='advanced_search')
         self.assertNotIn('enableUnloadProtection', browser.contents)

--- a/opengever/base/tests/test_anonymous.py
+++ b/opengever/base/tests/test_anonymous.py
@@ -1,0 +1,23 @@
+from AccessControl import Unauthorized
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestAnonymousAccess(FunctionalTestCase):
+
+    @browsing
+    def test_anonymous_cannot_access_search(self, browser):
+        with self.assertRaises(Unauthorized):
+            browser.visit(self.portal, view='search')
+
+    @browsing
+    def test_anonymous_can_access_login_form(self, browser):
+        browser.visit(self.portal, view='login_form')
+        self.assertEquals(self.portal.absolute_url() + '/login_form',
+                          browser.url)
+
+    @browsing
+    def test_authenticated_can_access_search(self, browser):
+        browser.login().visit(self.portal, view='search')
+        self.assertEquals(self.portal.absolute_url() + '/@@search',
+                          browser.url)


### PR DESCRIPTION
anonymous.

Löst das Problem, dass diverse Views auf dem Portal Root anonym zugänglich sind und so keine Challenge für eine Authentisierung ausgelöst wird.

Konkretes Beispiel: `@@accept_choose_dossier?oguid=ska-arch:732703461` führt zu einen 404 wenn der Benutzer nicht angemeldet ist.

Bei anonymen Zugriff wird jetzt bei sämtlichen Views auf dem Portal Root ein Unauthorized geraised, ausser bei den explizit aufgeführten Ausnahmen. Diese beinhalten im Wesentlichen das Login Formular und die Password-Zurücksetzen-Funktion.

@phgross , @lukasgraf Bitte insbesondere prüfen, ob die Liste mit den erlaubten Views aus euer Sicht vollständig ist. Seht ihr andere Probleme, die sich mit diesem Ansatz ergeben könnten?

