### PR TITLE
Reassign: Make sure only the new responsible gets notified by mail.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Make sure only the new responsible gets notified by mail, when a
+  task gets reassigned.
+  [phgross]
+
 - Move plone-group creation in OrgUnitBuilder to opengever.core.
   [deiferni]
 

--- a/opengever/activity/model/subscription.py
+++ b/opengever/activity/model/subscription.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship
 
 TASK_ISSUER_ROLE = 'task_issuer'
 TASK_RESPONSIBLE_ROLE = 'task_responsible'
+TASK_OLD_RESPONSIBLE_ROLE = 'task_old_responsible'
 WATCHER_ROLE = 'regular_watcher'
 
 

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -1,4 +1,5 @@
 from opengever.activity import notification_center
+from opengever.activity.model.subscription import TASK_OLD_RESPONSIBLE_ROLE
 from opengever.base.model import get_locale
 from opengever.ogds.base.actor import Actor
 from opengever.task import _
@@ -207,15 +208,22 @@ class TaskReassignActivity(TaskTransitionActivity):
 
     def before_recording(self):
         """Adds new responsible to watchers list.
+        And change roles for old responsible from TASK_RESPONSIBLE
+        to OLD_RESPONSIBLE.
         """
-        self.center.add_task_responsible(
-            self.context, self.context.responsible)
+        change = self.response.get_change('responsible')
+        self.center.add_task_responsible(self.context, self.context.responsible)
+
+        self.center.remove_task_responsible(self.context, change.get('before'))
+        self.center.add_watcher_to_resource(
+            self.context, change.get('before'), TASK_OLD_RESPONSIBLE_ROLE)
 
     def after_recording(self):
         """Remove old responsible from watchers list.
         """
         change = self.response.get_change('responsible')
-        self.center.remove_task_responsible(self.context, change.get('before'))
+        self.center.remove_watcher_from_resource(
+            self.context, change.get('before'), TASK_OLD_RESPONSIBLE_ROLE)
 
     def _is_ignored_transition(self):
         return False


### PR DESCRIPTION
Make sure only the new responsible gets notified by mail, when a task gets reassigned.
To make sure that the old responsible is notified via batch icon, but not via mail, we change the role to `old_responsible` before record the activity, after notification creation, we remove the watcher definitely.

Theoretical it would also be possible to change the configuration, in a way that the old responsible gets also be notified by mail.

@lukasgraf please have a look.

Needs-Backport: `4.5-stable`