### PR TITLE
Allow accessing the ftw.zopemaster view `zauth` as anonymous.

### DIFF
--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -29,6 +29,7 @@ ALLOWED_VIEWS = set([
     'pwreset_finish',
     'pwreset_form',
     'require_login',
+    'zauth',
 ])
 
 


### PR DESCRIPTION
With the change made in #1278 the `zauth` view was no longer accessible on the site Root for an anonymous. Therefore I've added the `zauth` view to the `ALLOWED_VIEWS `.

@buchi or @lukasgraf please have a look.

Need-Backport: `4.5-stable`