### PR TITLE
Refactor meeting-permissions, add own role for commitee-group-members.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,17 @@ Changelog
 
   [lgraf]
 
+- Refactor meeting-permissions, add own role for commitee-group-members.
+  [deiferni]
+
+- Disallow access to views on the portal root for anonymous except of login
+  form and password reset.
+  [buchi]
+
+- Make sure only the new responsible gets notified by mail, when a
+  task gets reassigned.
+  [phgross]
+
 - Move plone-group creation in OrgUnitBuilder to opengever.core.
   [deiferni]
 

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -5,6 +5,7 @@ from opengever.meeting.form import ModelProxyAddForm
 from opengever.meeting.form import ModelProxyEditForm
 from plone.directives import dexterity
 from z3c.form import field
+from z3c.form.interfaces import HIDDEN_MODE
 
 
 class AddForm(ModelProxyAddForm, dexterity.AddForm):
@@ -19,3 +20,9 @@ class EditForm(ModelProxyEditForm, dexterity.EditForm):
     grok.context(ICommittee)
     fields = field.Fields(Committee.model_schema, ignoreContext=True)
     content_type = Committee
+
+    def updateWidgets(self):
+        if not self.context.is_group_editable():
+            self.fields['group_id'].mode = HIDDEN_MODE
+
+        super(EditForm, self).updateWidgets()

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -146,6 +146,10 @@ class Committee(ModelContainer):
 
         return True
 
+    def is_group_editable(self):
+        return api.user.has_permission(
+            'Modify portal content', obj=self.get_committee_container())
+
     def get_upcoming_meetings(self):
         committee_model = self.load_model()
         return Meeting.query.all_upcoming_meetings(committee_model)

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -79,6 +79,7 @@ class ICommitteeModel(Interface):
 
 _marker = object()
 
+
 class Committee(ModelContainer):
     """Plone Proxy for a Committe."""
 
@@ -121,14 +122,12 @@ class Committee(ModelContainer):
 
     def _after_model_created(self, model_instance):
         super(Committee, self)._after_model_created(model_instance)
-        CommitteeRoles(model_instance.group_id).initialize(self)
+        CommitteeRoles(self).initialize(model_instance.group_id)
 
     def update_model(self, data):
         model = self.load_model()
-        if 'group_id' in data and data['group_id'] != model.group_id:
-            CommitteeRoles(data['group_id'],
-                           previous_group_id=model.group_id).update(self)
-
+        CommitteeRoles(self).update(
+            data.get('group_id'), previous_principal=model.group_id)
         return super(Committee, self).update_model(data)
 
     def get_physical_path(self):

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4610</version>
+    <version>4611</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/rolemap.xml
+++ b/opengever/meeting/profiles/default/rolemap.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <rolemap>
+
+  <roles>
+    <role name="CommitteeGroupMember" />
+  </roles>
+
   <permissions>
 
     <permission name="opengever.meeting: Add Proposal" acquire="True">

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import FormFieldNotFound
 from opengever.base.oguid import Oguid
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.testing import FunctionalTestCase
@@ -10,10 +11,10 @@ class TestCommittee(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
 
+    group_field_name = 'Group'
+
     def setUp(self):
         super(TestCommittee, self).setUp()
-        self.grant('Administrator')
-
         self.repo_root = create(Builder('repository_root'))
         self.repository_folder = create(Builder('repository')
                                         .within(self.repo_root)
@@ -30,22 +31,22 @@ class TestCommittee(FunctionalTestCase):
 
     @browsing
     def test_committee_can_be_created_in_browser(self, browser):
+        self.grant('Administrator')
         browser.login()
         browser.open(self.container, view='++add++opengever.meeting.committee')
 
         browser.fill(
             {'Title': u'A c\xf6mmittee',
              'Linked repository folder': self.repository_folder,
-             'Group': 'client1_users'})
+             self.group_field_name: 'client1_users'})
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Item created',
                       browser.css('.portalMessage.info dd').text)
 
         committee = browser.context
         self.assertEqual('committee-1', committee.getId())
-        self.assertTrue(committee.__ac_local_roles_block__)
         self.assertEqual(
-            ('Contributor', 'Editor', 'Reader'),
+            ('CommitteeGroupMember',),
             dict(committee.get_local_roles()).get('client1_users'))
 
         model = committee.load_model()
@@ -61,7 +62,7 @@ class TestCommittee(FunctionalTestCase):
                            .link_with(self.repository_folder))
 
         self.assertEqual(
-            ('Contributor', 'Editor', 'Reader'),
+            ('CommitteeGroupMember',),
             dict(committee.get_local_roles()).get('client1_users'))
 
         browser.login().visit(committee, view='edit')
@@ -70,7 +71,7 @@ class TestCommittee(FunctionalTestCase):
         self.assertEqual(u'My Committee', form.find_field('Title').value)
 
         browser.fill({'Title': u'A c\xf6mmittee',
-                      'Group': u'client1_inbox_users'})
+                      self.group_field_name: u'client1_inbox_users'})
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Changes saved',
                       browser.css('.portalMessage.info dd').text)
@@ -81,9 +82,24 @@ class TestCommittee(FunctionalTestCase):
         self.assertNotIn('client1_users', local_roles,
                          local_roles.get('client1_users'))
         self.assertEqual(
-            ('Contributor', 'Editor', 'Reader'),
+            ('CommitteeGroupMember',),
             local_roles.get('client1_inbox_users'))
 
         model = committee.load_model()
         self.assertIsNotNone(model)
         self.assertEqual(u'A c\xf6mmittee', model.title)
+
+    @browsing
+    def test_committee_group_is_not_editable_for_users_with_missing_permission(self, browser):
+        user = create(Builder('user')
+                      .named('Hugo', 'Boss')
+                      .in_groups('client1_users'))
+        committee = create(Builder('committee')
+                           .within(self.container)
+                           .titled(u'My Committee')
+                           .having(group_id='client1_users')
+                           .link_with(self.repository_folder))
+
+        browser.login(username='hugo.boss').visit(committee, view='edit')
+        with self.assertRaises(FormFieldNotFound):
+            browser.fill({self.group_field_name: 'client1_users'})

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -56,6 +56,7 @@ class TestCommittee(FunctionalTestCase):
 
     @browsing
     def test_committee_can_be_edited_in_browser(self, browser):
+        self.grant('Administrator')
         committee = create(Builder('committee')
                            .within(self.container)
                            .titled(u'My Committee')

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -15,15 +15,27 @@ class TestCommitteeTabs(FunctionalTestCase):
 
     def test_committee_roles_initialized(self):
         self.assertEqual(
-            ('Contributor', 'Editor', 'Reader'),
+            ('CommitteeGroupMember',),
             dict(self.committee.get_local_roles())['client1_users'])
 
     def test_update_roles_removes_old_role(self):
-        CommitteeRoles('foo', previous_group_id='client1_users').update(
-            self.committee)
+        CommitteeRoles(self.committee).update(
+            'foo', previous_principal='client1_users')
 
         local_roles = dict(self.committee.get_local_roles())
         self.assertNotIn('client1_users', local_roles)
-        self.assertEqual(
-            ('Contributor', 'Editor', 'Reader'),
+        self.assertEqual(('CommitteeGroupMember',), local_roles['foo'])
+
+    def test_update_roles_preserves_unmanaged_roles(self):
+        self.committee.manage_addLocalRoles('foo', ['Contributor', 'Reader'])
+        self.committee.manage_addLocalRoles('client1_users', ['Contributor'])
+
+        CommitteeRoles(self.committee).update(
+            'foo', previous_principal='client1_users')
+        local_roles = dict(self.committee.get_local_roles())
+        self.assertItemsEqual(
+            ['CommitteeGroupMember', 'Contributor', 'Reader'],
             local_roles['foo'])
+        self.assertItemsEqual(
+            ['Contributor'],
+            local_roles['client1_users'])

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -401,4 +401,22 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4610 -> 4611 -->
+    <genericsetup:upgradeStep
+        title="Add role for committee group members."
+        description=""
+        source="4610"
+        destination="4611"
+        handler="opengever.meeting.upgrades.to4611.UpdateWorkflowWithCustomRole"
+        profile="opengever.meeting:default"
+        />
+
+    <genericsetup:registerProfile
+        name="4611"
+        title="opengever.meeting: upgrade profile 4611"
+        description=""
+        directory="profiles/4611"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
 </configure>

--- a/opengever/meeting/upgrades/profiles/4611/rolemap.xml
+++ b/opengever/meeting/upgrades/profiles/4611/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rolemap>
+
+  <roles>
+    <role name="CommitteeGroupMember" />
+  </roles>
+
+  <permissions>
+  </permissions>
+
+</rolemap>

--- a/opengever/meeting/upgrades/profiles/4611/workflows/opengever_committee_workflow/definition.xml
+++ b/opengever/meeting/upgrades/profiles/4611/workflows/opengever_committee_workflow/definition.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <dc-workflow workflow_id="opengever_committee_workflow" title="Committee Workflow" description="" state_variable="review_state" initial_state="committee-state-active" manager_bypass="False">
- <permission>View</permission>
  <permission>Access contents information</permission>
  <permission>Add portal content</permission>
  <permission>List folder contents</permission>
  <permission>Modify portal content</permission>
  <permission>Sharing page: Delegate roles</permission>
+ <permission>View</permission>
  <state state_id="committee-state-active" title="committee-state-active">
   <permission-map name="Access contents information" acquired="False">
    <permission-role>Administrator</permission-role>
-   <permission-role>Manager</permission-role>
    <permission-role>CommitteeGroupMember</permission-role>
+   <permission-role>Manager</permission-role>
   </permission-map>
   <permission-map name="Add portal content" acquired="False">
    <permission-role>Administrator</permission-role>
@@ -31,8 +31,8 @@
   </permission-map>
   <permission-map name="View" acquired="False">
    <permission-role>Administrator</permission-role>
-   <permission-role>Manager</permission-role>
    <permission-role>CommitteeGroupMember</permission-role>
+   <permission-role>Manager</permission-role>
   </permission-map>
  </state>
  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">

--- a/opengever/meeting/upgrades/to4611.py
+++ b/opengever/meeting/upgrades/to4611.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateWorkflowWithCustomRole(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-opengever.meeting.upgrades:4611')
+
+        self.update_workflow_security(
+            ['opengever_committee_workflow'],
+            reindex_security=True)


### PR DESCRIPTION
This PR refactors meeting-permissions and adds an own role for commitee-group-members. This replaces the previous behavior where existing roles `Reader`, `Editor` and `Contributor` were managed.

Closes #950.

*When upgrading from current master (with https://github.com/4teamwork/opengever.core/pull/1263) to this PR the permissions for your dev-committees with non-zopemaster users will be broken. This is a development issue only and not addressed in this PR.*