### PR TITLE
 Extend whitelist for anonymous access on siteroot.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Extend whitelist for anonymous access on siteroot.
+  [lgraf, phgross]
+
 - Add confirm-dialog when closing meetings.
   [deiferni]
 

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -20,15 +20,24 @@ from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 
 ALLOWED_VIEWS = set([
+    'customlogo',
+    'favicon',
+    'list-open-dossiers-json',
     'logged_out',
     'login',
+    'login_failed',
     'login_form',
+    'logout',
+    'mail-inbound',
     'mail_password',
     'mail_password_form',
+    'mnt-warmup',
     'passwordreset',
     'pwreset_finish',
     'pwreset_form',
     'require_login',
+    'update_sync_stamp',
+    'watcher-feed',
     'zauth',
 ])
 


### PR DESCRIPTION
Whitelists the `mail-inbound` view which needs to be accessed anonymously by the `mta2plone.py` script.

Needs backport to `4.5-stable`

@phgross 