### PR TITLE
Adjust footer links (Release-Informationen, Quellcode).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Adjust footer links (Release-Informationen, Quellcode).
+  [phgross]
+
 - Include plone4.csrffixes in order to get back on the "Plone Way" to use
   automatic CSRF protection with Plone 4. This allows use to drop some of
   our custom handling of certain cases:

--- a/opengever/examplecontent/profiles/default/portlets.xml
+++ b/opengever/examplecontent/profiles/default/portlets.xml
@@ -27,9 +27,9 @@
               visible="True">
     <property
         name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/die-wichtigsten-module-von-onegov-gever"&gt;Funktionen&lt;/a&gt;&lt;/p&gt;
-    &lt;p&gt;&lt;a class="external-link" href="https://github.com/4teamwork/opengever.core"&gt;Quellcode&lt;/a&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;a class="external-link" href="https://github.com/OneGov/onegov.gever"&gt;Quellcode&lt;/a&gt;&lt;/p&gt;
     &lt;p&gt;&lt;a class="external-link" href="https://jenkins.4teamwork.ch"&gt;Software Tests&lt;/a&gt;&lt;/p&gt;
-    &lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/aktuell/onegov-gever-release-3.0"&gt;Release 3.0&lt;/a&gt;&lt;/p&gt;</property>
+    &lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/aktuell"&gt;Release-Informationen&lt;/a&gt;&lt;/p&gt;</property>
     <property name="more_url"/>
     <property name="omit_border">False</property>
     <property name="header">Über OneGov GEVER</property>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/portlets.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/portlets.xml
@@ -27,9 +27,9 @@
               visible="True">
     <property
         name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/die-wichtigsten-module-von-onegov-gever"&gt;Funktionen&lt;/a&gt;&lt;/p&gt;
-    &lt;p&gt;&lt;a class="external-link" href="https://github.com/4teamwork/opengever.core"&gt;Quellcode&lt;/a&gt;&lt;/p&gt;
+    &lt;p&gt;&lt;a class="external-link" href="https://github.com/OneGov/onegov.gever"&gt;Quellcode&lt;/a&gt;&lt;/p&gt;
     &lt;p&gt;&lt;a class="external-link" href="https://jenkins.4teamwork.ch"&gt;Software Tests&lt;/a&gt;&lt;/p&gt;
-    &lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/aktuell/onegov-gever-release-3.0"&gt;Release 3.0&lt;/a&gt;&lt;/p&gt;</property>
+    &lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/aktuell"&gt;Release-Informationen&lt;/a&gt;&lt;/p&gt;</property>
     <property name="more_url"/>
     <property name="omit_border">False</property>
     <property name="header">Über OneGov GEVER</property>


### PR DESCRIPTION
Fixed #1290.

An upgradestep is not necessary, because all productive deployments has their own footer configuration in the policy.

@deiferni 