### PR TITLE
Lock protocol documents while a meeting is not closed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Lock protocol documents while a meeting is not closed.
+  [deiferni]
+
 - Adjust footer links (Release-Informationen, Quellcode).
   [phgross]
 

--- a/opengever/locking/lock.py
+++ b/opengever/locking/lock.py
@@ -1,0 +1,6 @@
+from plone.locking.interfaces import LockType
+from plone.locking.interfaces import MAX_TIMEOUT
+
+
+SYS_LOCK = LockType(u'sys.lock', stealable=True, user_unlockable=True,
+                    timeout=MAX_TIMEOUT)

--- a/opengever/meeting/browser/protocol.py
+++ b/opengever/meeting/browser/protocol.py
@@ -56,7 +56,8 @@ class GenerateProtocol(grok.View):
         meeting = self.get_meeting()
 
         command = CreateGeneratedDocumentCommand(
-            self.context, meeting, self.operations)
+            self.context, meeting, self.operations,
+            lock_document_after_creation=True)
         command.execute()
         command.show_message()
 


### PR DESCRIPTION
This PR lock protocol documents while a meeting is not closed to avoid that users get confused when editing the protocol document and the protocol through the web in parallel.

It takes a rather minimalistic approach with `plone.locking`. This has the advantage that we don't have to take further action on the document side (info message, disable actions like external editor, ...).
*The info message might need some customizing in the future though, i.e. show why the document is locked.*

Closes #1061.