### PR TITLE
Make sure reassign a task over the edit form, creates a response and record an activity.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Make sure reassign a task over the edit form creates a response and record an activity.
+  [phgross]
+
 - Fix member edit link and refactor generating breadcrumbs for models.
   [deiferni]
 

--- a/opengever/task/form.py
+++ b/opengever/task/form.py
@@ -1,0 +1,62 @@
+from five import grok
+from opengever.ogds.base.utils import ogds_service
+from opengever.task import _
+from opengever.task.activities import TaskAddedActivity
+from opengever.task.task import ITask
+from plone.directives import dexterity
+from z3c.form.interfaces import HIDDEN_MODE
+from zope.component import getMultiAdapter
+
+
+REASSIGN_TRANSITION = 'task-transition-reassign'
+
+
+# XXX
+# setting the default value of a RelationField does not work as expected
+# or we don't know how to set it.
+# thus we use an add form hack by injecting the values into the request.
+
+class AddForm(dexterity.AddForm):
+    grok.name('opengever.task.task')
+
+    def update(self):
+        # put default value for relatedItems into request
+        paths = self.request.get('paths', [])
+        if paths:
+            self.request.set('form.widgets.relatedItems', paths)
+        # put default value for issuer into request
+        portal_state = getMultiAdapter((self.context, self.request),
+                                       name=u"plone_portal_state")
+        member = portal_state.member()
+        if not self.request.get('form.widgets.issuer', None):
+            self.request.set('form.widgets.issuer', [member.getId()])
+        super(AddForm, self).update()
+
+        # omit the responsible_client field and adjust the field description
+        # of the responsible field if there is only one orgunit configured.
+        if not ogds_service().has_multiple_org_units():
+            self.groups[0].widgets['responsible_client'].mode = HIDDEN_MODE
+            self.groups[0].widgets['responsible'].field.description = _(
+                u"help_responsible_single_client_setup", default=u"")
+
+    def createAndAdd(self, data):
+        task = super(AddForm, self).createAndAdd(data=data)
+        activity = TaskAddedActivity(task, self.request, self.context)
+        activity.record()
+        return task
+
+
+class EditForm(dexterity.EditForm):
+    """Standard EditForm, just require the Edit Task permission"""
+    grok.context(ITask)
+    grok.require('opengever.task.EditTask')
+
+    def update(self):
+        super(EditForm, self).update()
+
+        # omit the responsible_client field and adjust the field description
+        # of the responsible field if there is only one client configured.
+        if not ogds_service().has_multiple_org_units():
+            self.groups[0].widgets['responsible_client'].mode = HIDDEN_MODE
+            self.groups[0].widgets['responsible'].field.description = _(
+                u"help_responsible_single_client_setup", default=u"")

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -1,0 +1,66 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.activity.model import Activity
+from opengever.activity.model import Subscription
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+
+
+class TestTaskEditForm(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
+
+    def setUp(self):
+        super(TestTaskEditForm, self).setUp()
+        create(Builder('ogds_user')
+               .id('peter.meier')
+               .assign_to_org_units([self.org_unit])
+               .having(firstname=u'Peter', lastname=u'Meier'))
+        create(Builder('ogds_user')
+               .id('james.meier')
+               .assign_to_org_units([self.org_unit])
+               .having(firstname=u'James', lastname=u'Meier'))
+
+        self.dossier = create(Builder('dossier').titled(u'Dossier'))
+
+    @browsing
+    def test_edit_responsible_adds_reassign_response(self, browser):
+        task = create(Builder('task')
+                      .within(self.dossier)
+                      .having(title=u'Test task',
+                              task_type='comment',
+                              responsible='peter.meier'))
+
+        browser.login().open(task, view='edit')
+        browser.fill({'Responsible': 'james.meier'})
+        browser.find('Save').click()
+
+        browser.open(task, view='tabbedview_view-overview')
+        answer = browser.css('.answer')[0]
+        self.assertEquals('answer reassign', answer.get('class'))
+        self.assertEquals(
+            [u'Reassigned from Meier Peter (peter.meier)'
+             ' to Meier James (james.meier) by Test User (test_user_1_)'],
+            answer.css('h3').text)
+
+    @browsing
+    def test_edit_responsible_records_activity(self, browser):
+        browser.login().open(self.dossier, view='++add++opengever.task.task')
+        browser.fill({'Title': u'Abkl\xe4rung Fall Meier',
+                      'Responsible': u'peter.meier',
+                      'Task Type': 'comment',
+                      'Text': 'Lorem ipsum'})
+        browser.find('Save').click()
+
+        browser.open(browser.context.get('task-1'), view='edit')
+        browser.fill({'Responsible': 'james.meier'})
+        browser.find('Save').click()
+
+        activity = Activity.query.order_by(Activity.created.desc()).first()
+        self.assertEquals(u'task-transition-reassign', activity.kind)
+        self.assertEquals(
+            [(TEST_USER_ID, u'task_issuer'),
+             (u'james.meier', u'task_responsible')],
+            [(sub.watcher.actorid, sub.role) for sub in Subscription.query.all()])


### PR DESCRIPTION
In some situation it's also possible to reassign a task, by changing the responsible in the edit form.  So this way of reassigning a task should also create a response and record an activity. 

@deiferni @lukasgraf 

Backport: `4.5-stable`

 