### PR TITLE
Activate add-permissions for Contributor in committeecontainer workflow.

### DIFF
--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4614</version>
+    <version>4615</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -449,4 +449,23 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4614 -> 4615 -->
+    <genericsetup:upgradeStep
+        title="Activate add-permissions for Contributor in committeecontainer workflow."
+        description=""
+        source="4614"
+        destination="4615"
+        handler="opengever.meeting.upgrades.to4615.UpdateCommitteeContainerWorkflow"
+        profile="opengever.meeting:default"
+        />
+
+    <genericsetup:registerProfile
+        name="4615"
+        title="opengever.meeting: upgrade profile 4615"
+        description=""
+        directory="profiles/4615"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4615/workflows/opengever_committeecontainer_workflow/definition.xml
+++ b/opengever/meeting/upgrades/profiles/4615/workflows/opengever_committeecontainer_workflow/definition.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <dc-workflow workflow_id="opengever_committeecontainer_workflow" title="Committee Container Workflow" description="" state_variable="review_state" initial_state="committeecontainer-state-active" manager_bypass="False">
- <permission>View</permission>
- <permission>List folder contents</permission>
  <permission>Access contents information</permission>
  <permission>Add portal content</permission>
- <permission>Sharing page: Delegate roles</permission>
+ <permission>List folder contents</permission>
  <permission>Modify portal content</permission>
+ <permission>Sharing page: Delegate roles</permission>
+ <permission>View</permission>
  <permission>opengever.meeting: Add Committee</permission>
  <permission>opengever.meeting: Add Member</permission>
  <state state_id="committeecontainer-state-active" title="committeecontainer-state-active">

--- a/opengever/meeting/upgrades/to4615.py
+++ b/opengever/meeting/upgrades/to4615.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateCommitteeContainerWorkflow(UpgradeStep):
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-opengever.meeting.upgrades:4615')
+
+        self.update_workflow_security(
+            ['opengever_committeecontainer_workflow'],
+            reindex_security=False)


### PR DESCRIPTION
Closes #1293.

*Changelog entry not necessary, it is already covered by other unreleased entries.*

*reviewer note: contains an intentional upgrade-step gap, so that https://github.com/4teamwork/opengever.core/pull/1286 can be merged first*