### PR TITLE
Refactor meeting/protocol editing, drop duplicate forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,8 @@ Changelog
     - Display date in metadata section.
 
   [Kevin Bieri, phgross, deiferni]
+- Refactor meeting/protocol editing, drop duplicate forms.
+  [deiferni]
 
 - Eliminate duplicate notification, about a task acceptance, when creating a successor.
   [phgross]

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -12,7 +12,7 @@ class PathBar(common.PathBarViewlet):
     def update(self):
         super(PathBar, self).update()
 
-        if hasattr(self.view, 'is_model_view') and self.view.is_model_view:
+        if getattr(self.view, 'has_model_breadcrumbs', False):
             self.append_model_breadcrumbs()
 
     def append_model_breadcrumbs(self):

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -19,13 +19,6 @@
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
-      name="edit"
-      class=".meeting.EditMeeting"
-      permission="cmf.ModifyPortalContent"
-      />
-
-  <browser:page
-      for="opengever.meeting.interfaces.IMeetingWrapper"
       name="meetingtransitioncontroller"
       class=".transitions.MeetingTransitionController"
       permission="cmf.ModifyPortalContent"

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -87,8 +87,7 @@ class IGenerateExcerpt(form.Schema):
 
 class GenerateExcerpt(AutoExtensibleForm, EditForm):
 
-    is_model_view = True
-    is_model_edit_view = False
+    has_model_breadcrumbs = True
     ignoreContext = True
     schema = IGenerateExcerpt
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -11,7 +11,6 @@ from opengever.meeting.browser.meetings.transitions import MeetingTransitionCont
 from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.browser.protocol import UpdateProtocol
 from opengever.meeting.committee import ICommittee
-from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Meeting
 from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
@@ -20,7 +19,6 @@ from plone.directives import form
 from plone.z3cform.layout import FormWrapper
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from z3c.form import field
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.form import Form
@@ -265,31 +263,9 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
         return super(AddMeetingDossierView, self).__call__()
 
 
-class EditMeeting(ModelEditForm):
-
-    fields = field.Fields(IMeetingModel)
-
-    def __init__(self, context, request):
-        super(EditMeeting, self).__init__(context, request, context.model)
-
-    def updateWidgets(self):
-        super(EditMeeting, self).updateWidgets()
-        self.inject_initial_data()
-
-        committee_id = self.context.load_model().committee_id
-        self.widgets['committee'].mode = HIDDEN_MODE
-        self.widgets['committee'].value = (str(committee_id), )
-
-    def nextURL(self):
-        return self.model.get_url()
-
-
 class MeetingView(BrowserView):
 
     template = ViewPageTemplateFile('templates/meeting.pt')
-
-    is_model_view = True
-    is_model_edit_view = False
 
     def __init__(self, context, request):
         super(MeetingView, self).__init__(context, request)

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -265,6 +265,8 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
 
 class MeetingView(BrowserView):
 
+    has_model_breadcrumbs = True
+
     template = ViewPageTemplateFile('templates/meeting.pt')
 
     def __init__(self, context, request):

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -104,8 +104,7 @@ class DownloadProtocolJson(DownloadGeneratedProtocol):
 
 class EditProtocol(AutoExtensibleForm, ModelEditForm):
 
-    is_model_view = True
-    is_model_edit_view = False
+    has_model_breadcrumbs = True
     ignoreContext = True
     schema = IMeetingMetadata
     content_type = Meeting

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -1,9 +1,9 @@
+from opengever.base.schema import UTCDatetime
 from opengever.meeting import _
 from opengever.meeting.command import MIME_DOCX
 from opengever.meeting.command import ProtocolOperations
-from opengever.meeting.form import ModelProxyEditForm
+from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Meeting
-from opengever.meeting.model import Member
 from opengever.meeting.sablon import Sablon
 from opengever.meeting.vocabulary import get_committee_member_vocabulary
 from plone import api
@@ -14,13 +14,12 @@ from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
-from z3c.form.form import EditForm
 from zExceptions import Redirect
 from zope import schema
 
 
-class IParticipants(form.Schema):
-    """Schema interface for participants of a meeting."""
+class IMeetingMetadata(form.Schema):
+    """Schema interface for meeting metadata."""
 
     presidency = schema.Choice(
         title=_('label_presidency', default=u'Presidency'),
@@ -49,7 +48,20 @@ class IParticipants(form.Schema):
         title=_(u"label_protocol_start_page_number",
                 default=u"Protocol start-page"),
         required=False
-        )
+    )
+
+    location = schema.TextLine(
+        title=_(u"label_location", default=u"Location"),
+        max_length=256,
+        required=False)
+
+    start = UTCDatetime(
+        title=_('label_start', default=u"Start"),
+        required=True)
+
+    end = UTCDatetime(
+        title=_('label_end', default=u"End"),
+        required=False)
 
 
 class DownloadGeneratedProtocol(BrowserView):
@@ -90,15 +102,18 @@ class DownloadProtocolJson(DownloadGeneratedProtocol):
         return self.get_protocol_json(pretty=True)
 
 
-class EditProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
+class EditProtocol(AutoExtensibleForm, ModelEditForm):
 
     is_model_view = True
     is_model_edit_view = False
     ignoreContext = True
-    schema = IParticipants
+    schema = IMeetingMetadata
     content_type = Meeting
 
     template = ViewPageTemplateFile('templates/protocol.pt')
+
+    def __init__(self, context, request):
+        super(EditProtocol, self).__init__(context, request, context.model)
 
     def update(self):
         super(EditProtocol, self).update()
@@ -109,10 +124,6 @@ class EditProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
             raise Redirect(self.context.absolute_url())
 
         self.lock()
-
-    def __init__(self, context, request):
-        super(EditProtocol, self).__init__(context, request)
-        self.model = context.model
 
     def is_available_for_current_user(self):
         """Check whether the current meeting can be safely unlocked.
@@ -134,7 +145,8 @@ class EditProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
             lockable.unlock()
 
     def applyChanges(self, data):
-        ModelProxyEditForm.applyChanges(self, data)
+        ModelEditForm.applyChanges(self, data)
+
         for agenda_item in self.get_agenda_items():
             agenda_item.update(self.request)
 
@@ -143,49 +155,21 @@ class EditProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
             self.request)
 
         self.unlock()
-        self.redirect_to_meeting()
         # pretend to always change the underlying data
         return True
 
-    def partition_data(self, data):
-        participation_data = {}
-        for key in self.schema.names():
-            if key in data:
-                participation_data[key] = data.pop(key)
-        return {}, participation_data
-
-    def _convert_value(self, value):
-        if isinstance(value, Member):
-            value = str(value.member_id)
-        elif isinstance(value, list):
-            value = [self._convert_value(item) for item in value]
-        return value
-
-    def get_edit_values(self, keys):
-        values = {}
-        for fieldname in keys:
-            value = getattr(self.model, fieldname, None)
-            if value is None:
-                continue
-            values[fieldname] = self._convert_value(value)
-        return values
-
-    def update_model(self, model_data):
-        self.model.update_model(model_data)
-
-    # this renames the button but otherwise preserves super's behaviour
     @button.buttonAndHandler(_('Save', default=u'Save'), name='save')
     def handleApply(self, action):
-        # self as first argument is required by to the decorator
+        # needs duplication, otherwise button does not appear
         super(EditProtocol, self).handleApply(self, action)
 
-    @button.buttonAndHandler(_('label_cancel', default=u'Cancel'), name='cancel')
-    def handleCancel(self, action):
+    @button.buttonAndHandler(_('Cancel', default=u'Cancel'), name='cancel')
+    def cancel(self, action):
         self.unlock()
-        return self.redirect_to_meeting()
+        # self as first argument is required by to the decorator
+        super(EditProtocol, self).cancel(self, action)
 
     def render(self):
-        ModelProxyEditForm.render(self)
         return self.template()
 
     def get_agenda_items(self, include_paragraphs=False):
@@ -196,5 +180,5 @@ class EditProtocol(AutoExtensibleForm, ModelProxyEditForm, EditForm):
             else:
                 yield agenda_item
 
-    def redirect_to_meeting(self):
-        return self.request.RESPONSE.redirect(self.model.get_url())
+    def nextURL(self):
+        return self.model.get_url()

--- a/opengever/meeting/browser/members.py
+++ b/opengever/meeting/browser/members.py
@@ -65,6 +65,7 @@ class MemberView(BrowserView):
     template = ViewPageTemplateFile('templates/member.pt')
     implements(IBrowserView, IPublishTraverse)
 
+    has_model_breadcrumbs = True
     is_model_view = True
     is_model_edit_view = False
 

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -94,6 +94,9 @@ class ModelEditForm(EditForm):
     def updateWidgets(self):
         super(ModelEditForm, self).updateWidgets()
         self.inject_initial_data()
+        # inject_initial_data will change widget values, they might need
+        # another update
+        self.widgets.update()
 
     def applyChanges(self, data):
         self.model.update_model(data)

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -64,6 +64,7 @@ class ModelEditForm(EditForm):
     """
 
     ignoreContext = True
+    has_model_breadcrumbs = True
     is_model_view = True
     is_model_edit_view = True
 

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -44,7 +44,8 @@ class TestMeetingLocking(FunctionalTestCase):
 
         self.committee_model = self.committee.load_model()
         self.meeting = create(Builder('meeting')
-                              .having(committee=self.committee_model)
+                              .having(committee=self.committee_model,
+                                      location='Somewhere')
                               .link_with(self.meeting_dossier))
         self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -56,7 +56,7 @@ class TestProtocol(FunctionalTestCase):
         self.committee_model = self.committee.load_model()
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee_model,
-                                      start=self.localized_datetime(2013, 1, 1),
+                                      start=self.localized_datetime(2013, 1, 1, 10, 45),
                                       location='There',
                                       protocol_start_page_number=42)
                               .link_with(self.meeting_dossier))


### PR DESCRIPTION
This PR
- drops meeting edit form, and merges it with protocol-editing
- refactors the protocol edit form and changes super classes to make more sense for our use-case (we edit a model, there is no proxy object)

Closes #1300.

Styling will be fixed with #1312.