### PR TITLE
Extend meeting metadata with date.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Meetingview rework:
 
     - Implement clientside processing for meeting view (Controller Pattern).
+    - Display date in metadata section.
 
   [Kevin Bieri, phgross, deiferni]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Meetingview rework:
+
+    - Implement clientside processing for meeting view (Controller Pattern).
+
+  [Kevin Bieri, phgross, deiferni]
+
 - Eliminate duplicate notification, about a task acceptance, when creating a successor.
   [phgross]
 

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -52,6 +52,9 @@
                 <dt id="meeting_location"></dt>
                 <dd tal:content="meeting/location"></dd>
 
+                <dt id="meeting_date"></dt>
+                <dd tal:content="meeting/get_date"></dd>
+
                 <dt id="meeting_time"></dt>
                 <dd>
                   <span tal:replace="python: meeting.get_start_time()"></span>


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1314

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/370

<img width="355" alt="bildschirmfoto 2015-11-09 um 16 39 12" src="https://cloud.githubusercontent.com/assets/1637820/11037885/801cfc66-8700-11e5-93ac-ed8abc8b0abd.png">