### PR TITLE
Agendaitem table row width is not equal width original while dragging.

### DIFF
--- a/opengever/meeting/browser/resources/agendaitems.js
+++ b/opengever/meeting/browser/resources/agendaitems.js
@@ -91,13 +91,22 @@
       mask: { loadSpeed: 0 }
     }).data("overlay");
 
+    var sortableHelper = function(e, row) {
+      var helper = row.clone();
+      $.each(row.children(), function(idx, cell) {
+        helper.children().eq(idx).width($(cell).width());
+      });
+      return helper;
+    };
+
     var sortableSettings = {
       handle: ".sortable-handle",
       forcePlaceholderSize: true,
       placeholder: "placeholder",
       items: "tr",
       tolerance: "intersects",
-      update: self.updateSortOrder
+      update: self.updateSortOrder,
+      helper: sortableHelper
     };
 
     Controller.call(this, viewlet, $("#agendaitemsTemplate").html(), $("#agenda_items tbody"), options);


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1299

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/371

<img width="913" alt="bildschirmfoto 2015-11-09 um 17 12 32" src="https://cloud.githubusercontent.com/assets/1637820/11038823/425b3eba-8705-11e5-880d-3aebc63eea5d.png">