### PR TITLE
Revert "Change merge strategy(union) for the changelog."

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-docs/HISTORY.txt merge=union


### PR DESCRIPTION
This reverts commit 28762239692c74cf3b30fdfe0cecbe6e1843e288.

In our experience this merge-strategy did not prove itself in production. It cannot always
reliably resolve conflicts without causing invalid files with missing whitespace or dropping
contributors.