### PR TITLE
Protocolnavigation is not usable with too many entries.

### DIFF
--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -5,7 +5,99 @@
     <div id="opengever_meeting_protocol">
       <metal:use use-macro="context/@@ploneform-macros/titlelessform">
         <metal:block fill-slot="fields">
-          <div class="left">
+          <div class="protocol-navigation">
+            <div class="list-group">
+              <div class="list-group-item submit actions">
+                <div class="button-group fluid">
+                  <metal:use use-macro="context/@@ploneform-macros/actions" />
+                </div>
+              </div>
+              <div class="list-group-item navigation">
+                <ul class="nav">
+                  <li tal:repeat="protocol agenda_items"
+                      tal:attributes="class python: 'expandable ' + protocol.get_css_class()">
+                    <metal:block tal:define="name protocol/name">
+                      <a tal:attributes="href string:#${name};
+                                         id string:${name}-anchor;
+                                         class python: 'expandable ' + protocol.get_css_class()"
+                         tal:content="python: protocol.get_title(include_number=True)">
+                      </a>
+                      <metal:block tal:condition="not: protocol/is_paragraph">
+                        <ul class="nav">
+                          <metal:block tal:condition="protocol/has_proposal">
+                            <li>
+                              <a tal:attributes="href string:#${name}-legal_basis;
+                                                 id string:${name}-legal_basis-anchor"
+                                 i18n:translate="">
+                                     Legal basis
+                                  </a>
+                            </li>
+                            <li>
+                              <a tal:attributes="href string:#${name}-initial_position;
+                                                 id string:${name}-initial_position-anchor"
+                                 i18n:translate="label_initial_position">
+                                     Initial position
+                                  </a>
+                            </li>
+                            <li>
+                              <a tal:attributes="href string:#${name}-proposed_action;
+                                                 id string:${name}-proposed_action-anchor"
+                                 i18n:translate="label_proposed_action">
+                                     Proposed action
+                                  </a>
+                            </li>
+                            <li>
+                              <a tal:attributes="href string:#${name}-considerations;
+                                                 id string:${name}-considerations-anchor"
+                                 i18n:translate="label_considerations">
+                                     Considerations
+                                  </a>
+                            </li>
+                          </metal:block>
+                          <li>
+                            <a tal:attributes="href string:#${name}-discussion;
+                                               id string:${name}-discussion-anchor"
+                               i18n:translate="label_discussion">
+                                   Discussion
+                                </a>
+                          </li>
+                          <li>
+                            <a tal:attributes="href string:#${name}-decision;
+                                               id string:${name}-decision-anchor"
+                               i18n:translate="label_decision">
+                                   Decision
+                                </a>
+                          </li>
+                          <li>
+                            <a tal:attributes="href string:#${name}-publish_in;
+                                               id string:${name}-publish_in-anchor"
+                               i18n:translate="label_publish_in">
+                                   Publish in
+                                 </a>
+                          </li>
+                          <li>
+                            <a tal:attributes="href string:#${name}-disclose_to;
+                                               id string:${name}-disclose_to-anchor"
+                               i18n:translate="label_disclose_to">
+                                   Disclose to
+                                 </a>
+                          </li>
+                          <li>
+                            <a tal:attributes="href string:#${name}-copy_for_attention;
+                                               id string:${name}-copy_for_attention-anchor"
+                               i18n:translate="label_copy_for_attention">
+                                   Copy for attention
+                                 </a>
+                          </li>
+                        </ul>
+                      </metal:block>
+                    </metal:block>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="right">
             <div class="collapsible">
               <div class="collapsible-header">
                 <button class="button fa fa-plus"></button>
@@ -114,98 +206,6 @@
                 </metal:block>
               </metal:block>
               <metal:use use-macro="context/@@meeting-macros/disable_kss_inline_validation" />
-            </div>
-          </div>
-          <div class="protocol-navigation">
-            <div class="list-group">
-              <div class="list-group-item submit actions">
-                <div class="button-group fluid">
-                  <metal:use use-macro="context/@@ploneform-macros/actions" />
-                </div>
-              </div>
-              <div class="list-group-item navigation">
-                <ul id="scrollspy" class="nav">
-                  <li tal:repeat="protocol agenda_items"
-                      tal:attributes="class python: 'expandable ' + protocol.get_css_class()">
-                    <metal:block tal:define="name protocol/name">
-                      <a tal:attributes="href string:#${name};
-                                         id string:${name}-anchor;
-                                         class python: 'expandable ' + protocol.get_css_class()"
-                         tal:content="python: protocol.get_title(include_number=True)">
-                      </a>
-                      <metal:block tal:condition="not: protocol/is_paragraph">
-                        <ul class="nav">
-                          <metal:block tal:condition="protocol/has_proposal">
-                            <li>
-                              <a tal:attributes="href string:#${name}-legal_basis;
-                                                 id string:${name}-legal_basis-anchor"
-                                 i18n:translate="">
-                                     Legal basis
-                                  </a>
-                            </li>
-                            <li>
-                              <a tal:attributes="href string:#${name}-initial_position;
-                                                 id string:${name}-initial_position-anchor"
-                                 i18n:translate="label_initial_position">
-                                     Initial position
-                                  </a>
-                            </li>
-                            <li>
-                              <a tal:attributes="href string:#${name}-proposed_action;
-                                                 id string:${name}-proposed_action-anchor"
-                                 i18n:translate="label_proposed_action">
-                                     Proposed action
-                                  </a>
-                            </li>
-                            <li>
-                              <a tal:attributes="href string:#${name}-considerations;
-                                                 id string:${name}-considerations-anchor"
-                                 i18n:translate="label_considerations">
-                                     Considerations
-                                  </a>
-                            </li>
-                          </metal:block>
-                          <li>
-                            <a tal:attributes="href string:#${name}-discussion;
-                                               id string:${name}-discussion-anchor"
-                               i18n:translate="label_discussion">
-                                   Discussion
-                                </a>
-                          </li>
-                          <li>
-                            <a tal:attributes="href string:#${name}-decision;
-                                               id string:${name}-decision-anchor"
-                               i18n:translate="label_decision">
-                                   Decision
-                                </a>
-                          </li>
-                          <li>
-                            <a tal:attributes="href string:#${name}-publish_in;
-                                               id string:${name}-publish_in-anchor"
-                               i18n:translate="label_publish_in">
-                                   Publish in
-                                 </a>
-                          </li>
-                          <li>
-                            <a tal:attributes="href string:#${name}-disclose_to;
-                                               id string:${name}-disclose_to-anchor"
-                               i18n:translate="label_disclose_to">
-                                   Disclose to
-                                 </a>
-                          </li>
-                          <li>
-                            <a tal:attributes="href string:#${name}-copy_for_attention;
-                                               id string:${name}-copy_for_attention-anchor"
-                               i18n:translate="label_copy_for_attention">
-                                   Copy for attention
-                                 </a>
-                          </li>
-                        </ul>
-                      </metal:block>
-                    </metal:block>
-                  </li>
-                </ul>
-              </div>
             </div>
           </div>
         </metal:block>

--- a/opengever/meeting/browser/resources/Scrollspy.js
+++ b/opengever/meeting/browser/resources/Scrollspy.js
@@ -1,100 +1,101 @@
-(function($){
+(function(global, $) {
 
   "use strict";
 
   function Scrollspy(_options) {
 
-    var options = $.extend({
-      selector: "#scrollspy",
-      selectParent: false
+    this.options = $.extend({
+      selector: "",
+      offset: 0
     }, _options || {});
 
     var scrollCallback = function() {};
-    var selectCallback = function() {};
 
-    function init() {
-      $(options.selector + " a").click(function(event) {
+    var beforeScrollCallback = function() {};
+
+    var root = $(":root");
+
+    var self = this;
+
+    this.element = $(this.options.selector);
+
+    this.init = function() {
+      $("a", this.element).click(function(event) {
         event.preventDefault();
         var target = $(event.target);
-        if(target.hasClass("paragraph")) {
-          scrollTo(target.parent().next().find("> a"));
-        } else {
-          scrollTo(event.target);
-        }
+        self.applyAnchor(target);
       });
-    }
-
-    function scrollTo(target) {
-      var target = $(target)
-      var toElement = $(target.attr("href"));
-      var offset = 0;
-      if(!target.hasClass("expandable")) {
-        offset = options.offset;
-      }
-      $('html, body').scrollTop(toElement.offset().top - (offset) + 1);
-      scrollCallback(target, toElement);
-    }
-
-    function select(target) {
-      target = $(target);
-      $(options.selector + " .selected").not(target).removeClass("selected");
-      target.addClass("selected");
-      if(options.selectParent) {
-        var parent = target.closest("ul").prev("a.expandable");
-        $(options.selector + " .selected").not(target).not(parent).removeClass("selected");
-        parent.addClass("selected")
-      }
-      selectCallback(target);
-    }
-
-    function expand(target) {
-      $(options.selector + " .expandable").not(target).removeClass("expanded");
-      $(target).addClass("expanded");
-    }
-
-    function reset() {
-      $(options.selector + " .expandable").removeClass("expanded");
-      $(options.selector + " .selected").removeClass("selected");
-    }
-
-    init();
-
-    var app = {
-
-      scrollTo: function(target) {
-        scrollTo(target);
-      },
-
-      select: function(target) {
-        select(target);
-      },
-
-      onScroll: function(callback) {
-        scrollCallback = callback;
-      },
-
-      onSelect: function(callback) {
-        selectCallback = callback;
-      },
-
-      expand: function(target) {
-        expand(target);
-      },
-
-      offset: function(offset) {
-        options.offset = offset;
-      },
-
-      reset: function() {
-        reset();
-      }
-
+      this.element.on("mouseover", function() {
+        var range = self.element.children("ul").height() - self.element.height();
+        self.trapScroll(range);
+      });
+      this.element.on("mouseleave", function() { self.releaseScroll(); });
     };
 
-    return app;
+    this.trapScroll = function(range) {
+      $(window).on("wheel", function(event) {
+        var deltaY = event.originalEvent.deltaY;
+        var offset = self.element.scrollTop();
+        if ((deltaY > 0 && offset >= range) || (deltaY < 0 && offset <= 0)) {
+          event.preventDefault();
+        }
+      });
+    };
 
+    this.releaseScroll = function() { $(window).off("wheel"); };
+
+    this.align = function() {
+      var selected = $(".selected", this.element);
+      var offset = 0;
+      if(selected.length) {
+        offset = selected.offset().top - this.element.offset().top + this.element.scrollTop() - 100;
+      }
+      $(this.element).stop().animate({ scrollTop: offset + "px" }, 400);
+    };
+
+    this.expand = function(target) {
+      if(target.hasClass("expandable")) {
+        $(".expandable", this.element).not(target).removeClass("expanded");
+        target.addClass("expanded");
+      }
+    };
+
+    this.scrollTo = function(offset) {
+      offset = offset - this.options.offset;
+      root.animate({ scrollTop: offset + "px" }, 300);
+    };
+
+    this.applyAnchor = function(target) {
+      var anchor;
+      if(target.hasClass("paragraph")) {
+        anchor = $(target.next().attr("href"));
+      } else if (target.hasClass("expandable")) {
+        anchor = $(target.next().find("a").first().attr("href"));
+      } else {
+        anchor = $(target.attr("href"));
+      }
+      beforeScrollCallback(target, anchor);
+      this.scrollTo(anchor.offset().top);
+      scrollCallback(target, anchor);
+    };
+
+    this.select = function(target) {
+      var selected = $(".selected", this.element).not(target);
+      selected.removeClass("selected");
+      target.addClass("selected");
+      var parent = target.closest("ul").prev(".expandable");
+      selected.not(parent).removeClass("selected");
+      parent.addClass("selected");
+      this.align();
+    };
+
+    this.onBeforeScroll = function(callback) { beforeScrollCallback = callback; };
+
+    this.onScroll = function(callback) { scrollCallback = callback; };
+
+    this.init();
   }
 
-  window.Scrollspy = Scrollspy;
+  global.Scrollspy = Scrollspy;
 
-}(jQuery));
+}(window, jQuery));

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -1,66 +1,68 @@
-$(document).ready(function() {
-  var scrollSpy = $("#scrollspy");
+(function(global) {
 
-  $("#opengever_meeting_protocol textarea").autosize();
+  "use strict";
 
-  var scrollspy = new Scrollspy({ selectParent: true });
+  $(function() {
 
-  var navigation = $(".protocol-navigation");
+    $("#opengever_meeting_protocol textarea").autosize();
 
-  var headings = new StickyHeading({ selector: "#opengever_meeting_protocol .protocol_title" });
-  var labels = new StickyHeading({ selector: "#opengever_meeting_protocol .agenda_items label", fix: false, dependsOn: headings});
-  var collapsible = StickyHeading({ selector: "#opengever_meeting_protocol .collapsible", clone: false});
+    var scrollspy = new global.Scrollspy({ selector: ".navigation" });
 
-  var currentOffset;
+    var navigation = $(".protocol-navigation");
 
-  collapsible.onSticky(function() {
-    navigation.addClass("sticky");
-  });
+    var headings = new global.StickyHeading({ selector: "#opengever_meeting_protocol .protocol_title" });
+    var labels = new global.StickyHeading({ selector: "#opengever_meeting_protocol .agenda_items label", fix: false, dependsOn: headings});
+    var collapsible = new global.StickyHeading({ selector: "#opengever_meeting_protocol .collapsible", clone: false});
 
-  headings.onNoSticky(function() {
-    navigation.removeClass("sticky");
-    $(".metadata .fields").css("position", "static");
-  });
-
-  headings.onSticky(function(heading) {
-    navigation.addClass("sticky");
-    currentOffset = heading.clone.outerHeight();
-    $(".metadata .fields").css("position", "fixed");
-    scrollspy.expand($("#" + heading.node.attr("id") + "-anchor"));
-    scrollspy.select($("#" + heading.node.attr("id") + "-anchor"));
-  });
-
-  headings.onCollision(function() {
-    navigation.addClass("sticky");
-    $(".metadata .fields").css("position", "fixed");
-  });
-
-  labels.onSticky(function(label) {
-    scrollspy.select($("#" + label.node.attr("for") + "-anchor"));
-  });
-  labels.onCollision(function(fadingIn, fadingOut) {
-    //Manual offset from sticky hading to label
-    scrollspy.offset(currentOffset + 20);
-    scrollspy.select($("#" + fadingOut.node.attr("for") + "-anchor"));
-  });
-
-  scrollspy.onScroll(function(target, toElement) {
-    if(target.hasClass("expandable")) {
-      scrollspy.expand(target);
+    function moveCaretToEnd(el) {
+      if (typeof el.selectionStart === "number") {
+          el.selectionStart = el.selectionEnd = el.value.length;
+      } else if (el.createTextRange) {
+          var range = el.createTextRange();
+          range.collapse(false);
+      }
+      el.focus();
     }
-    moveCaretToEnd(toElement[0])
-    //Trigger Scrolltop event with 3 pixel more for triggering the first item to be selected
-    $(window).scrollTop($(window).scrollTop() + 3)
+
+    scrollspy.onBeforeScroll(function(target) {
+      if(target.hasClass("expandable")) {
+        scrollspy.options.offset = target.outerHeight() + 60;
+      }
+    });
+
+    collapsible.onSticky(function() { navigation.addClass("sticky"); });
+
+    headings.onNoSticky(function() {
+      navigation.removeClass("sticky");
+      $(".metadata .fields").css("position", "static");
+    });
+
+    headings.onSticky(function(heading) {
+      navigation.addClass("sticky");
+      $(".metadata .fields").css("position", "fixed");
+      scrollspy.expand($("#" + heading.node.attr("id") + "-anchor"));
+      scrollspy.select($("#" + heading.node.attr("id") + "-anchor"));
+    });
+
+    headings.onCollision(function() {
+      navigation.addClass("sticky");
+      $(".metadata .fields").css("position", "fixed");
+    });
+
+    labels.onSticky(function(label) {
+      scrollspy.select($("#" + label.node.attr("for") + "-anchor"));
+    });
+    labels.onCollision(function(fadingIn, fadingOut) {
+      scrollspy.select($("#" + fadingOut.node.attr("for") + "-anchor"));
+    });
+
+    scrollspy.onScroll(function(target, toElement) {
+      if(target.hasClass("expandable")) {
+        scrollspy.expand(target);
+      }
+      moveCaretToEnd(toElement[0]);
+    });
+
   });
 
-  function moveCaretToEnd(el) {
-    if (typeof el.selectionStart == "number") {
-        el.selectionStart = el.selectionEnd = el.value.length;
-    } else if (el.createTextRange) {
-        var range = el.createTextRange();
-        range.collapse(false);
-    }
-    el.focus();
-  }
-
-});
+}(window));

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -271,7 +271,7 @@ class TestProtocol(FunctionalTestCase):
         browser.open(self.meeting.get_url())
         browser.css('a[href*="/protocol"]').first.click()
 
-        navigation = browser.css('#scrollspy a.expandable')
+        navigation = browser.css('.navigation a.expandable')
         headings = browser.css('.protocol_title .title')
 
         self.assertEqual(map(lambda nav: nav.text, navigation),


### PR DESCRIPTION
Fixes #1317 

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/374

When the protocol navigation is longer than the viewport it's unable to
see the entries below the end of the browser window. So make the
navigation scrolling automatically.

![autoscrolling_navigation](https://cloud.githubusercontent.com/assets/1637820/11093289/ae7a6992-8889-11e5-80ef-dbe1efdb1279.gif)
