### PR TITLE
Simplify meeting workflow, drop state held.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Simplify meeting workflow, drop state `held`.
+  [deiferni]
+
 - Make sure reassign a task over the edit form creates a response and record an activity.
   [phgross]
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 14:04+0000\n"
+"POT-Creation-Date: 2015-11-11 14:54+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -214,11 +214,11 @@ msgid "Proposals:"
 msgstr "Anträge"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:106
-#: ./opengever/meeting/model/meeting.py:148
+#: ./opengever/meeting/model/meeting.py:144
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:151
+#: ./opengever/meeting/model/meeting.py:147
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
@@ -330,13 +330,13 @@ msgstr "Erstellen"
 msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
-#. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:74
+#. Default: "Close meeting"
+#: ./opengever/meeting/model/meeting.py:70
 msgid "close"
-msgstr "Schliessen"
+msgstr "Abschliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:64
+#: ./opengever/meeting/model/meeting.py:63
 msgid "closed"
 msgstr "geschlossen"
 
@@ -463,11 +463,6 @@ msgstr "Protokoll als Worddokument generieren"
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
-#. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:63
-msgid "held"
-msgstr "Durchgeführt"
-
 #: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
 msgstr ""
@@ -488,11 +483,6 @@ msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt wer
 #: ./opengever/meeting/proposal.py:84
 msgid "help_title"
 msgstr ""
-
-#. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:72
-msgid "hold meeting"
-msgstr "Sitzung durchführen"
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 14:04+0000\n"
+"POT-Creation-Date: 2015-11-11 14:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -214,11 +214,11 @@ msgid "Proposals:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:106
-#: ./opengever/meeting/model/meeting.py:148
+#: ./opengever/meeting/model/meeting.py:144
 msgid "Protocol"
 msgstr "Procès-verbal"
 
-#: ./opengever/meeting/model/meeting.py:151
+#: ./opengever/meeting/model/meeting.py:147
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -330,13 +330,13 @@ msgstr "Générer"
 msgid "button_submit_attachments"
 msgstr ""
 
-#. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:74
+#. Default: "Close meeting"
+#: ./opengever/meeting/model/meeting.py:70
 msgid "close"
 msgstr "Fermer"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:64
+#: ./opengever/meeting/model/meeting.py:63
 msgid "closed"
 msgstr "Fermé"
 
@@ -463,11 +463,6 @@ msgstr ""
 msgid "generate new version as word document"
 msgstr ""
 
-#. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:63
-msgid "held"
-msgstr "Tenu"
-
 #: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
 msgstr ""
@@ -488,11 +483,6 @@ msgstr ""
 #: ./opengever/meeting/proposal.py:84
 msgid "help_title"
 msgstr ""
-
-#. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:72
-msgid "hold meeting"
-msgstr "Tenir séance"
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 14:04+0000\n"
+"POT-Creation-Date: 2015-11-11 14:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -213,11 +213,11 @@ msgid "Proposals:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:106
-#: ./opengever/meeting/model/meeting.py:148
+#: ./opengever/meeting/model/meeting.py:144
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:151
+#: ./opengever/meeting/model/meeting.py:147
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -329,13 +329,13 @@ msgstr ""
 msgid "button_submit_attachments"
 msgstr ""
 
-#. Default: "Close"
-#: ./opengever/meeting/model/meeting.py:74
+#. Default: "Close meeting"
+#: ./opengever/meeting/model/meeting.py:70
 msgid "close"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:64
+#: ./opengever/meeting/model/meeting.py:63
 msgid "closed"
 msgstr ""
 
@@ -462,11 +462,6 @@ msgstr ""
 msgid "generate new version as word document"
 msgstr ""
 
-#. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:63
-msgid "held"
-msgstr ""
-
 #: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
 msgstr ""
@@ -486,11 +481,6 @@ msgstr ""
 
 #: ./opengever/meeting/proposal.py:84
 msgid "help_title"
-msgstr ""
-
-#. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:72
-msgid "hold meeting"
 msgstr ""
 
 #. Default: "Attachments"

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -41,7 +41,7 @@ meeting_excerpts = Table(
 )
 
 
-class HeldCloseTransition(Transition):
+class PendingClosedTransition(Transition):
 
     def execute(self, obj, model):
         assert self.can_execute(model)
@@ -60,18 +60,14 @@ class Meeting(Base):
 
     STATE_PENDING = State('pending', is_default=True,
                           title=_('pending', default='Pending'))
-    STATE_HELD = State('held', title=_('held', default='Held'))
     STATE_CLOSED = State('closed', title=_('closed', default='Closed'))
 
     workflow = Workflow([
         STATE_PENDING,
-        STATE_HELD,
         STATE_CLOSED,
         ], [
-        Transition('pending', 'held',
-                   title=_('hold meeting', default='Hold meeting')),
-        HeldCloseTransition('held', 'closed',
-                            title=_('close', default='Close')),
+        PendingClosedTransition('pending', 'closed',
+                                title=_('close', default='Close meeting')),
         ])
 
     __tablename__ = 'meetings'
@@ -125,7 +121,7 @@ class Meeting(Base):
         return 'contenttype-opengever-meeting-meeting'
 
     def is_editable(self):
-        return self.get_state() in (self.STATE_PENDING, self.STATE_HELD)
+        return self.get_state() == self.STATE_PENDING
 
     def has_protocol_document(self):
         return self.protocol_document is not None

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4615</version>
+    <version>4616</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -42,7 +42,6 @@ class TestCloseMeeting(FunctionalTestCase):
                               .having(committee=self.committee.load_model())
                               .scheduled_proposals([self.proposal_a, self.proposal_b])
                               .link_with(self.meeting_dossier))
-        self.meeting.execute_transition('pending-held')
 
         # set correct public url, used for generated meeting urls
         get_current_admin_unit().public_url = self.portal.absolute_url()
@@ -51,7 +50,7 @@ class TestCloseMeeting(FunctionalTestCase):
     @browsing
     def test_generate_excerpt_and_add_it_to_submittedproposal(self, browser):
         browser.login().open(self.meeting.get_url())
-        browser.css('#held-closed').first.click()
+        browser.css('#pending-closed').first.click()
 
         submitted_proposal = self.proposal_a.load_model().resolve_sumitted_proposal()
         excerpt = submitted_proposal.listFolderContents()[0]
@@ -66,7 +65,7 @@ class TestCloseMeeting(FunctionalTestCase):
     @browsing
     def test_excerpt_is_copied_to_proposal(self, browser):
         browser.login().open(self.meeting.get_url())
-        browser.css('#held-closed').first.click()
+        browser.css('#pending-closed').first.click()
 
         excerpt = self.proposal_a.listFolderContents()[0]
         self.assertEquals('Protocol Excerpt-barn-dec-13-2011',
@@ -80,7 +79,7 @@ class TestCloseMeeting(FunctionalTestCase):
     @browsing
     def test_proposalhistory_is_added(self, browser):
         browser.login().open(self.meeting.get_url())
-        browser.css('#held-closed').first.click()
+        browser.css('#pending-closed').first.click()
 
         browser.open(self.proposal_a, view=u'tabbedview_view-overview')
         entry = browser.css('.answer').first
@@ -92,7 +91,7 @@ class TestCloseMeeting(FunctionalTestCase):
     @browsing
     def test_excerpt_is_displayed_in_proposal_view(self, browser):
         browser.login().open(self.meeting.get_url())
-        browser.css('#held-closed').first.click()
+        browser.css('#pending-closed').first.click()
 
         generated_document = self.proposal_a.load_model().excerpt_document
         excerpt = generated_document.oguid.resolve_object()
@@ -105,14 +104,14 @@ class TestCloseMeeting(FunctionalTestCase):
     @browsing
     def test_states_are_updated(self, browser):
         browser.login().open(self.meeting.get_url())
-        browser.css('#held-closed').first.click()
+        browser.css('#pending-closed').first.click()
         self.assertEquals('closed', Meeting.query.first().get_state().name)
         self.assertEquals('decided', self.proposal_a.get_state().name)
 
     @browsing
     def test_redirects_to_meeting_and_show_statusmessage(self, browser):
         browser.login().open(self.meeting.get_url())
-        browser.css('#held-closed').first.click()
+        browser.css('#pending-closed').first.click()
 
         self.assertEquals(
             [u'The meeting B\xe4rn, Dec 13, 2011 has been successfully closed, '

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -50,7 +50,6 @@ class TestExcerpt(FunctionalTestCase):
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee_model)
                               .link_with(self.meeting_dossier))
-        self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 
         self.agenda_item = create(

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -47,7 +47,6 @@ class TestMeetingLocking(FunctionalTestCase):
                               .having(committee=self.committee_model,
                                       location='Somewhere')
                               .link_with(self.meeting_dossier))
-        self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 
         self.agenda_item = create(

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -60,7 +60,6 @@ class TestProtocol(FunctionalTestCase):
                                       location='There',
                                       protocol_start_page_number=42)
                               .link_with(self.meeting_dossier))
-        self.meeting.execute_transition('pending-held')
         self.proposal_model = self.proposal.load_model()
 
         self.agenda_item = create(
@@ -119,7 +118,7 @@ class TestProtocol(FunctionalTestCase):
     @browsing
     def test_protocol_document_is_unlocked_when_meeting_is_closed(self, browser):
         self.setup_generated_protocol(browser)
-        browser.find('Close').click()
+        browser.find('Close meeting').click()
 
         browser.find('Protocol-there-jan-01-2013').click()
         document = browser.context

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -27,8 +27,6 @@ class TestUnitMeeting(TestCase):
 
     def test_is_editable(self):
         self.assertTrue(self.meeting.is_editable())
-        self.meeting.workflow_state = 'held'
-        self.assertTrue(self.meeting.is_editable())
         self.meeting.workflow_state = 'closed'
         self.assertFalse(self.meeting.is_editable())
 

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -468,4 +468,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4615 -> 4616 -->
+    <genericsetup:upgradeStep
+        title="Drop meeting state held"
+        description=""
+        source="4615"
+        destination="4616"
+        handler="opengever.meeting.upgrades.to4616.DropMeetingStateHeld"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4616.py
+++ b/opengever/meeting/upgrades/to4616.py
@@ -1,0 +1,28 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class DropMeetingStateHeld(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4616
+
+    def migrate(self):
+        self.migrate_held_state()
+
+    def migrate_held_state(self):
+        """The state held lost its relevance and is equivalent to pending.
+
+        The migrations thus resets all meetings in the state held to the state
+        pending.
+
+        """
+        meeting_table = table("meetings",
+                              column("id"),
+                              column("workflow_state"))
+
+        self.execute(
+            meeting_table.update()
+                         .values(workflow_state='pending')
+                         .where(meeting_table.c.workflow_state == 'held'))


### PR DESCRIPTION
The state `held` lost its relevance and is now equivalent to `pending`.

Closes #900