### PR TITLE
Two buttons and one input for adding paragraphs and text is not useful.

### DIFF
--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -177,16 +177,22 @@
             </div>
             <div class="collapsible-content">
               <div class="input-group">
-                <label i18n:translate="" for="title">Freitext:</label>
-                <input id="title" type="text" />
+                <label i18n:translate="" for="schedule-text">Text:</label>
+                <input id="schedule-text" type="text" />
                 <div class="button-group">
                   <input type="submit"
-                         value="as free-text"
+                         value="label_schedule"
                          i18n:attributes="value"
                          tal:attributes="data-url view/url_schedule_text"
                          class="schedule-text allowMultiSubmit" />
+                </div>
+              </div>
+              <div class="input-group">
+                <label i18n:translate="" for="schedule-paragraph">Paragraph:</label>
+                <input id="schedule-paragraph" type="text" />
+                <div class="button-group">
                   <input type="submit"
-                         value="as paragraph"
+                         value="label_schedule"
                          i18n:attributes="value"
                          tal:attributes="data-url view/url_schedule_paragraph"
                          class="schedule-paragraph allowMultiSubmit" />

--- a/opengever/meeting/browser/resources/agendaitems.js
+++ b/opengever/meeting/browser/resources/agendaitems.js
@@ -184,7 +184,6 @@
     var viewlet = $("#opengever_meeting_meeting");
     Controller.call(this, $("#proposalsTemplate").html(), $("#unscheduled_porposals"), options);
     var self = this;
-    var title = $("#title");
 
     this.fetch = function() { return $.get(viewlet.data().listUnscheduledProposalsUrl); };
 
@@ -193,22 +192,30 @@
     this.schedule = function(e) { return $.post($(e.target).attr("href")); };
 
     this.addParagraph = function() {
-      return $.post($(".schedule-paragraph").data().url, { title: title.val() }).done(function() {
-        title.val("");
+      var input = $("#schedule-paragraph");
+      return $.post($(".schedule-paragraph").data().url, { title: input.val() }).done(function() {
+        input.val("");
         self.updateConnected();
       });
     };
 
     this.addText = function() {
-      return $.post($(".schedule-text").first().data().url, { title: title.val() }).done(function() {
-        title.val("");
+      var input = $("#schedule-text");
+      return $.post($(".schedule-text").first().data().url, { title: input.val() }).done(function() {
+        input.val("");
         self.updateConnected();
       });
     };
 
-    this.trackEnter = function(e) {
+    this.trackText = function(e) {
       if(e.which === $.ui.keyCode.ENTER) {
         this.addText();
+      }
+    };
+
+    this.trackParagraph = function(e) {
+      if(e.which === $.ui.keyCode.ENTER) {
+        this.addParagraph();
       }
     };
 
@@ -216,7 +223,8 @@
       "click#.schedule-proposal!": this.schedule,
       "click#.schedule-paragraph": this.addParagraph,
       "click#.schedule-text": this.addText,
-      "keyup##title": this.trackEnter
+      "keyup##schedule-text": this.trackText,
+      "keyup##schedule-paragraph": this.trackParagraph
     };
 
     this.init();

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 17:10+0000\n"
+"POT-Creation-Date: 2015-11-12 11:26+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:216
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -93,7 +93,7 @@ msgstr "Löschen"
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -121,10 +121,6 @@ msgstr "Protokollauszüge"
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:19
 msgid "Export settings"
 msgstr "Export-Einstellungen"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
-msgid "Freitext:"
-msgstr "Freitext:"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
 msgid "Generate excerpts for all proposals"
@@ -170,7 +166,7 @@ msgstr "Antrag einfügen"
 msgid "Include publish in"
 msgstr "Veröffentlichung im einfügen"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:140
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:29
 msgid "Legal basis"
 msgstr "Rechtsgrundlage"
 
@@ -187,7 +183,7 @@ msgstr "Sitzungsdossier"
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:12
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:104
 msgid "Meetinginformation"
 msgstr "Sitzungsangaben"
 
@@ -195,7 +191,7 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:207
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:213
 msgid "Number"
 msgstr "Nummer"
 
@@ -203,9 +199,13 @@ msgstr "Nummer"
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:205
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:211
 msgid "Order"
 msgstr "Sortierung"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:191
+msgid "Paragraph:"
+msgstr "Abschnitt:"
 
 #: ./opengever/meeting/browser/meetings/excerpt.py:133
 msgid "Please select at least one agenda item."
@@ -225,7 +225,7 @@ msgstr "Eigenschaften"
 msgid "Proposal"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:195
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:201
 msgid "Proposals:"
 msgstr "Anträge"
 
@@ -275,11 +275,15 @@ msgstr "Mehr anzeigen"
 msgid "Submitted Proposal"
 msgstr "Eingereichter Antrag"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
+msgid "Text:"
+msgstr "Freitext:"
+
 #: ./opengever/meeting/browser/meetings/meeting.py:214
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:214
 msgid "Title"
 msgstr "Titel"
 
@@ -314,14 +318,6 @@ msgstr "Der Titel eines Traktandums darf nicht leer sein."
 #: ./opengever/meeting/browser/meetings/agendaitem.py:145
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
-msgid "as free-text"
-msgstr "Als Traktandum"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:188
-msgid "as paragraph"
-msgstr "Als Abschnitt"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/documents/submit.py:95
@@ -523,13 +519,13 @@ msgid "label_committee"
 msgstr "Kommission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:58
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:50
 #: ./opengever/meeting/proposal.py:107
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:104
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:86
 #: ./opengever/meeting/proposal.py:74
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
@@ -552,7 +548,7 @@ msgid "label_date_to"
 msgstr "Bis"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:77
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:65
 #: ./opengever/meeting/proposal.py:185
 msgid "label_decision"
 msgstr "Beschluss"
@@ -563,13 +559,13 @@ msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:95
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:79
 #: ./opengever/meeting/proposal.py:69
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:58
 msgid "label_discussion"
 msgstr "Diskussion"
 
@@ -627,7 +623,7 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:40
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:36
 #: ./opengever/meeting/proposal.py:54
 msgid "label_initial_position"
 msgstr "Ausgangslage"
@@ -644,7 +640,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:31
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:123
 #: ./opengever/meeting/proposal.py:49
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
@@ -706,7 +702,7 @@ msgid "label_proposal"
 msgstr "Antrag"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:49
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:43
 #: ./opengever/meeting/proposal.py:59
 msgid "label_proposed_action"
 msgstr "Antrag"
@@ -717,7 +713,7 @@ msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:86
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:72
 #: ./opengever/meeting/proposal.py:64
 msgid "label_publish_in"
 msgstr "Veröffentlichung im"
@@ -740,6 +736,7 @@ msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/meeting.py:333
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
 msgid "label_schedule"
 msgstr "Traktandieren"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 17:10+0000\n"
+"POT-Creation-Date: 2015-11-12 11:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:216
 msgid "Actions"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
 msgid "Documents"
 msgstr ""
 
@@ -120,10 +120,6 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:19
 msgid "Export settings"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
-msgid "Freitext:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
@@ -170,7 +166,7 @@ msgstr ""
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:140
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:29
 msgid "Legal basis"
 msgstr "Base légale"
 
@@ -187,7 +183,7 @@ msgstr ""
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:12
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:104
 msgid "Meetinginformation"
 msgstr ""
 
@@ -195,7 +191,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:207
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:213
 msgid "Number"
 msgstr ""
 
@@ -203,8 +199,12 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:205
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:211
 msgid "Order"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:191
+msgid "Paragraph:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/excerpt.py:133
@@ -225,7 +225,7 @@ msgstr "Propriétés"
 msgid "Proposal"
 msgstr "Proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:195
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:201
 msgid "Proposals:"
 msgstr ""
 
@@ -275,11 +275,15 @@ msgstr "Afficher plus"
 msgid "Submitted Proposal"
 msgstr "Proposition soumise"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
+msgid "Text:"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/meeting.py:214
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:214
 msgid "Title"
 msgstr ""
 
@@ -314,14 +318,6 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/agendaitem.py:145
 msgid "agenda_item_updated"
 msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
-msgid "as free-text"
-msgstr "Comme point de l'ordre du jour"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:188
-msgid "as paragraph"
-msgstr "Comme paragraphe"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/documents/submit.py:95
@@ -523,13 +519,13 @@ msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:58
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:50
 #: ./opengever/meeting/proposal.py:107
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:104
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:86
 #: ./opengever/meeting/proposal.py:74
 msgid "label_copy_for_attention"
 msgstr ""
@@ -552,7 +548,7 @@ msgid "label_date_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:77
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:65
 #: ./opengever/meeting/proposal.py:185
 msgid "label_decision"
 msgstr ""
@@ -563,13 +559,13 @@ msgid "label_delete_action"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:95
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:79
 #: ./opengever/meeting/proposal.py:69
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:58
 msgid "label_discussion"
 msgstr "Discussion"
 
@@ -627,7 +623,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:40
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:36
 #: ./opengever/meeting/proposal.py:54
 msgid "label_initial_position"
 msgstr "Situation initiale"
@@ -644,7 +640,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:31
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:123
 #: ./opengever/meeting/proposal.py:49
 msgid "label_legal_basis"
 msgstr "Base légale"
@@ -706,7 +702,7 @@ msgid "label_proposal"
 msgstr "Proposition"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:49
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:43
 #: ./opengever/meeting/proposal.py:59
 msgid "label_proposed_action"
 msgstr "Proposition"
@@ -717,7 +713,7 @@ msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:86
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:72
 #: ./opengever/meeting/proposal.py:64
 msgid "label_publish_in"
 msgstr ""
@@ -740,6 +736,7 @@ msgstr ""
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/meeting.py:333
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
 msgid "label_schedule"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 17:10+0000\n"
+"POT-Creation-Date: 2015-11-12 11:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:216
 msgid "Actions"
 msgstr ""
 
@@ -92,7 +92,7 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
 msgid "Documents"
 msgstr ""
 
@@ -119,10 +119,6 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:19
 msgid "Export settings"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
-msgid "Freitext:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
@@ -169,7 +165,7 @@ msgstr ""
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:140
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:29
 msgid "Legal basis"
 msgstr ""
 
@@ -186,7 +182,7 @@ msgstr ""
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:12
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:104
 msgid "Meetinginformation"
 msgstr ""
 
@@ -194,7 +190,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:207
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:213
 msgid "Number"
 msgstr ""
 
@@ -202,8 +198,12 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:205
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:211
 msgid "Order"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:191
+msgid "Paragraph:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/excerpt.py:133
@@ -224,7 +224,7 @@ msgstr ""
 msgid "Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:195
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:201
 msgid "Proposals:"
 msgstr ""
 
@@ -274,11 +274,15 @@ msgstr ""
 msgid "Submitted Proposal"
 msgstr ""
 
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
+msgid "Text:"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/meeting.py:214
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:214
 msgid "Title"
 msgstr ""
 
@@ -312,14 +316,6 @@ msgstr ""
 #. Default: "Agenda Item updated."
 #: ./opengever/meeting/browser/meetings/agendaitem.py:145
 msgid "agenda_item_updated"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
-msgid "as free-text"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:188
-msgid "as paragraph"
 msgstr ""
 
 #. Default: "Cancel"
@@ -522,13 +518,13 @@ msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:58
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:50
 #: ./opengever/meeting/proposal.py:107
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:104
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:86
 #: ./opengever/meeting/proposal.py:74
 msgid "label_copy_for_attention"
 msgstr ""
@@ -551,7 +547,7 @@ msgid "label_date_to"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:77
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:65
 #: ./opengever/meeting/proposal.py:185
 msgid "label_decision"
 msgstr ""
@@ -562,13 +558,13 @@ msgid "label_delete_action"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:95
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:79
 #: ./opengever/meeting/proposal.py:69
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:58
 msgid "label_discussion"
 msgstr ""
 
@@ -626,7 +622,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:40
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:36
 #: ./opengever/meeting/proposal.py:54
 msgid "label_initial_position"
 msgstr ""
@@ -643,7 +639,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:31
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:123
 #: ./opengever/meeting/proposal.py:49
 msgid "label_legal_basis"
 msgstr ""
@@ -704,7 +700,7 @@ msgid "label_proposal"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:49
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:43
 #: ./opengever/meeting/proposal.py:59
 msgid "label_proposed_action"
 msgstr ""
@@ -715,7 +711,7 @@ msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:86
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:72
 #: ./opengever/meeting/proposal.py:64
 msgid "label_publish_in"
 msgstr ""
@@ -736,8 +732,8 @@ msgstr ""
 msgid "label_sablon_template_file"
 msgstr ""
 
-#. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/meeting.py:333
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
 msgid "label_schedule"
 msgstr ""
 


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1306

Split paragraphs and text in two seperate input fields.

![bildschirmfoto 2015-11-12 um 11 15 56](https://cloud.githubusercontent.com/assets/1637820/11115882/c95828d0-892e-11e5-9fa2-98aa8c533fe4.png)

