### PR TITLE
Add confirm-dialog when closing meetings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add confirm-dialog when closing meetings.
+  [deiferni]
+
 - ResponseTransporter: fix de- and encoding of deadline changes.
   [phgross]
 

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -36,6 +36,20 @@
                     i18n:translate="label_cancel">Cancel</button>
           </div>
         </div>
+        <div class="overlay" id="confirm_close_meeting">
+          <div class="close">
+            <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
+          </div>
+          <h2 i18n:translate="">Close meeting</h2>
+          <p i18n:translate="label_close_meeting_confirm_text">Are you sure you want to close this meeting?</p>
+          <div class="button-group">
+            <button class="button confirm"
+                    i18n:translate="">Close meeting</button>
+            <button class="button decline"
+                    i18n:translate="label_cancel">Cancel</button>
+          </div>
+        </div>
+
         <div class="sidebar">
           <div class="list-group metadata">
             <div class="list-group-item submit">

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -40,11 +40,11 @@
           <div class="close">
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
-          <h2 i18n:translate="">Close meeting</h2>
+          <h2 i18n:translate="close_meeting">Close meeting</h2>
           <p i18n:translate="label_close_meeting_confirm_text">Are you sure you want to close this meeting?</p>
           <div class="button-group">
             <button class="button confirm"
-                    i18n:translate="">Close meeting</button>
+                    i18n:translate="close_meeting">Close meeting</button>
             <button class="button decline"
                     i18n:translate="label_cancel">Cancel</button>
           </div>

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -36,12 +36,22 @@
                     i18n:translate="label_cancel">Cancel</button>
           </div>
         </div>
+
         <div class="overlay" id="confirm_close_meeting">
           <div class="close">
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
           <h2 i18n:translate="close_meeting">Close meeting</h2>
-          <p i18n:translate="label_close_meeting_confirm_text">Are you sure you want to close this meeting?</p>
+          <p i18n:translate="">
+            Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:
+          </p>
+          <ul>
+            <li i18n:translate="">Close all proposals</li>
+            <li i18n:translate="">Generate excerpts for all proposals</li>
+          </ul>
+          <p i18n:translate="">
+            Are you sure you want to close this meeting?
+          </p>
           <div class="button-group">
             <button class="button confirm"
                     i18n:translate="close_meeting">Close meeting</button>

--- a/opengever/meeting/browser/resources/agendaitems.js
+++ b/opengever/meeting/browser/resources/agendaitems.js
@@ -237,8 +237,43 @@
 
   }
 
+  function MeetingController() {
+
+    Controller.call(this);
+
+    var self = this;
+
+    var dialog = $( "#confirm_close_meeting" ).overlay({
+      speed: 0,
+      closeSpeed: 0,
+      mask: { loadSpeed: 0 }
+    }).data("overlay");
+
+    this.openModal = function(e) {
+      self.currentItem = $(e.currentTarget);
+      dialog.load();
+    };
+
+    this.closeMeeting = function() {
+      this.closeModal();
+      window.location.href = self.currentItem.attr("href");
+    };
+
+    this.closeModal = function() { dialog.close(); };
+
+    this.events = {
+      "click##pending-closed": this.openModal,
+      "click##confirm_close_meeting .confirm!$": this.closeMeeting,
+      "click##confirm_close_meeting .decline!": this.closeModal
+    };
+
+    this.init();
+
+  }
+
   $(function() {
     var collapsibleController = new CollapsibleController();
+    var meetingController = new MeetingController();
     if($("#opengever_meeting_meeting").length) {
 
       var agendaItemController = new AgendaItemController();

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 14:54+0000\n"
+"POT-Creation-Date: 2015-11-11 17:10+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -48,7 +48,7 @@ msgstr "Mitgliedschaft hinzufügen"
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:152
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:176
 msgid "Agenda Items"
 msgstr "Traktanden"
 
@@ -56,6 +56,10 @@ msgstr "Traktanden"
 #: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:52
+msgid "Are you sure you want to close this meeting?"
+msgstr "Wollen sie diese Sitzung wirklich abschliessen?"
 
 #: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
@@ -68,6 +72,10 @@ msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
 msgid "Choose Agenda Items"
 msgstr "Traktanden auswählen"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+msgid "Close all proposals"
+msgstr "Alle Anträge werden abgeschlossen"
 
 #: ./opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
 msgid "Committee"
@@ -85,11 +93,11 @@ msgstr "Löschen"
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
 msgid "Documents"
 msgstr "Dokumente"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:43
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -106,7 +114,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:130
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:154
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -114,9 +122,13 @@ msgstr "Protokollauszüge"
 msgid "Export settings"
 msgstr "Export-Einstellungen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:156
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
 msgid "Freitext:"
 msgstr "Freitext:"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
+msgid "Generate excerpts for all proposals"
+msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt"
 
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:66
 msgid "History"
@@ -183,11 +195,15 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:207
 msgid "Number"
 msgstr "Nummer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
+msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:205
 msgid "Order"
 msgstr "Sortierung"
 
@@ -209,11 +225,11 @@ msgstr "Eigenschaften"
 msgid "Proposal"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:171
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:195
 msgid "Proposals:"
 msgstr "Anträge"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:130
 #: ./opengever/meeting/model/meeting.py:144
 msgid "Protocol"
 msgstr "Protokoll"
@@ -263,7 +279,7 @@ msgstr "Eingereichter Antrag"
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:184
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:208
 msgid "Title"
 msgstr "Titel"
 
@@ -299,11 +315,11 @@ msgstr "Der Titel eines Traktandums darf nicht leer sein."
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:159
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
 msgid "as free-text"
 msgstr "Als Traktandum"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:188
 msgid "as paragraph"
 msgstr "Als Abschnitt"
 
@@ -331,8 +347,9 @@ msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
 #. Default: "Close meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:44
 #: ./opengever/meeting/model/meeting.py:70
-msgid "close"
+msgid "close_meeting"
 msgstr "Abschliessen"
 
 #. Default: "Closed"
@@ -442,7 +459,7 @@ msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Kommittee ve
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:122
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
@@ -451,15 +468,15 @@ msgstr "Protokoll herunterladen"
 msgid "form_label_update_protocol"
 msgstr "Protokoll aktualisieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:155
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:107
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:131
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:113
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:137
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
@@ -774,11 +791,11 @@ msgstr "Wählen Sie wie ein bestehendes Protokoll aktualisiert werden soll:"
 msgid "label_workflow_state"
 msgstr "Status"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:54
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
 msgid "location"
 msgstr "Ort"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:95
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:119
 msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
@@ -833,7 +850,7 @@ msgstr "Neu eingereichte Anträge"
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:109
 msgid "participants"
 msgstr "Teilnehmende"
 
@@ -843,7 +860,7 @@ msgstr "Teilnehmende"
 msgid "pending"
 msgstr "In Bearbeitung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:71
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:95
 msgid "presidency"
 msgstr "Vorsitz"
 
@@ -902,11 +919,11 @@ msgstr "traktandieren"
 msgid "scheduled"
 msgstr "Traktandiert"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:102
 msgid "secretary"
 msgstr "Protokollführer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
 msgid "status"
 msgstr "Status"
 
@@ -930,7 +947,7 @@ msgstr "${amount} Treffer"
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:62
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:86
 msgid "time"
 msgstr "Zeit"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 14:54+0000\n"
+"POT-Creation-Date: 2015-11-11 17:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
 msgid "Actions"
 msgstr ""
 
@@ -48,7 +48,7 @@ msgstr "Ajouter l'affiliation"
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:152
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:176
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
@@ -56,6 +56,10 @@ msgstr "Points de l'ordre du jour"
 #: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:52
+msgid "Are you sure you want to close this meeting?"
+msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
@@ -67,6 +71,10 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
 msgid "Choose Agenda Items"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+msgid "Close all proposals"
 msgstr ""
 
 #: ./opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
@@ -85,11 +93,11 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
 msgid "Documents"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:43
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
 msgid "Edit"
 msgstr ""
 
@@ -106,7 +114,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:130
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:154
 msgid "Excerpts"
 msgstr ""
 
@@ -114,8 +122,12 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:156
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
 msgid "Freitext:"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
+msgid "Generate excerpts for all proposals"
 msgstr ""
 
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:66
@@ -183,11 +195,15 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:207
 msgid "Number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:205
 msgid "Order"
 msgstr ""
 
@@ -209,11 +225,11 @@ msgstr "Propriétés"
 msgid "Proposal"
 msgstr "Proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:171
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:195
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:130
 #: ./opengever/meeting/model/meeting.py:144
 msgid "Protocol"
 msgstr "Procès-verbal"
@@ -263,7 +279,7 @@ msgstr "Proposition soumise"
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:184
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:208
 msgid "Title"
 msgstr ""
 
@@ -299,11 +315,11 @@ msgstr ""
 msgid "agenda_item_updated"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:159
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
 msgid "as free-text"
 msgstr "Comme point de l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:188
 msgid "as paragraph"
 msgstr "Comme paragraphe"
 
@@ -331,9 +347,10 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Close meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:44
 #: ./opengever/meeting/model/meeting.py:70
-msgid "close"
-msgstr "Fermer"
+msgid "close_meeting"
+msgstr ""
 
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:63
@@ -442,7 +459,7 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:122
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
 msgid "download protocol"
 msgstr ""
 
@@ -451,15 +468,15 @@ msgstr ""
 msgid "form_label_update_protocol"
 msgstr "Actualiser le procès-verbal"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:155
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:107
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:131
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:113
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:137
 msgid "generate new version as word document"
 msgstr ""
 
@@ -774,11 +791,11 @@ msgstr "Choix de la manière dont un procès-verbal existant soit actualisé:"
 msgid "label_workflow_state"
 msgstr "Etat"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:54
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
 msgid "location"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:95
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:119
 msgid "meetingdossier"
 msgstr ""
 
@@ -833,7 +850,7 @@ msgstr "Nouvelles propositions soumises"
 msgid "paragraph_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:109
 msgid "participants"
 msgstr ""
 
@@ -843,7 +860,7 @@ msgstr ""
 msgid "pending"
 msgstr "En modification"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:71
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:95
 msgid "presidency"
 msgstr ""
 
@@ -902,11 +919,11 @@ msgstr "Mettre à l`ordre du jour"
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:102
 msgid "secretary"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
 msgid "status"
 msgstr ""
 
@@ -930,7 +947,7 @@ msgstr "${amount} résultats"
 msgid "text_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:62
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:86
 msgid "time"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-11 14:54+0000\n"
+"POT-Creation-Date: 2015-11-11 17:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
 msgid "Actions"
 msgstr ""
 
@@ -47,13 +47,17 @@ msgstr ""
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:152
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:176
 msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
 #: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "An unexpected error has occurred"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:52
+msgid "Are you sure you want to close this meeting?"
 msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
@@ -66,6 +70,10 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
 msgid "Choose Agenda Items"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+msgid "Close all proposals"
 msgstr ""
 
 #: ./opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
@@ -84,11 +92,11 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
 msgid "Documents"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:43
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
 msgid "Edit"
 msgstr ""
 
@@ -105,7 +113,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:130
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:154
 msgid "Excerpts"
 msgstr ""
 
@@ -113,8 +121,12 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:156
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
 msgid "Freitext:"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
+msgid "Generate excerpts for all proposals"
 msgstr ""
 
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:66
@@ -182,11 +194,15 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:207
 msgid "Number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:205
 msgid "Order"
 msgstr ""
 
@@ -208,11 +224,11 @@ msgstr ""
 msgid "Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:171
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:195
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:130
 #: ./opengever/meeting/model/meeting.py:144
 msgid "Protocol"
 msgstr ""
@@ -262,7 +278,7 @@ msgstr ""
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:184
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:208
 msgid "Title"
 msgstr ""
 
@@ -298,11 +314,11 @@ msgstr ""
 msgid "agenda_item_updated"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:159
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:183
 msgid "as free-text"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:188
 msgid "as paragraph"
 msgstr ""
 
@@ -330,8 +346,9 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Close meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:44
 #: ./opengever/meeting/model/meeting.py:70
-msgid "close"
+msgid "close_meeting"
 msgstr ""
 
 #. Default: "Closed"
@@ -441,7 +458,7 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:122
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
 msgid "download protocol"
 msgstr ""
 
@@ -450,15 +467,15 @@ msgstr ""
 msgid "form_label_update_protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:155
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:107
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:131
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:113
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:137
 msgid "generate new version as word document"
 msgstr ""
 
@@ -772,11 +789,11 @@ msgstr ""
 msgid "label_workflow_state"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:54
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
 msgid "location"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:95
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:119
 msgid "meetingdossier"
 msgstr ""
 
@@ -831,7 +848,7 @@ msgstr ""
 msgid "paragraph_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:109
 msgid "participants"
 msgstr ""
 
@@ -841,7 +858,7 @@ msgstr ""
 msgid "pending"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:71
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:95
 msgid "presidency"
 msgstr ""
 
@@ -900,11 +917,11 @@ msgstr ""
 msgid "scheduled"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:78
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:102
 msgid "secretary"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:73
 msgid "status"
 msgstr ""
 
@@ -928,7 +945,7 @@ msgstr ""
 msgid "text_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:62
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:86
 msgid "time"
 msgstr ""
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -67,7 +67,7 @@ class Meeting(Base):
         STATE_CLOSED,
         ], [
         PendingClosedTransition('pending', 'closed',
-                                title=_('close', default='Close meeting')),
+                                title=_('close_meeting', default='Close meeting')),
         ])
 
     __tablename__ = 'meetings'


### PR DESCRIPTION
Add a js-modal dialog that requires confirmation before a meeting is closed.

![screen shot 2015-11-11 at 18 18 39](https://cloud.githubusercontent.com/assets/736583/11097671/dfd9d40c-88a0-11e5-8bd7-036b896e3e65.png)

Closes #1316.