### PR TITLE
Restructure headings of protocol view for styling reasons.

### DIFF
--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -19,8 +19,9 @@
                     <metal:block tal:define="name protocol/name">
                       <a tal:attributes="href string:#${name};
                                          id string:${name}-anchor;
-                                         class python: 'expandable ' + protocol.get_css_class()"
-                         tal:content="python: protocol.get_title(include_number=True)">
+                                         class python: 'expandable ' + protocol.get_css_class()">
+                        <span class="number" tal:content="python: protocol.number"></span>
+                        <span class="title" tal:content="python: protocol.get_title()"></span>
                       </a>
                       <metal:block tal:condition="not: protocol/is_paragraph">
                         <ul class="nav">
@@ -113,10 +114,15 @@
                 <metal:block tal:define="name protocol/name">
                   <h2 tal:attributes="id name;
                                           class python: 'protocol_title ' + protocol.get_css_class()">
-                        <span class="title"
-                              tal:content="python: protocol.get_title(include_number=True)"></span>
-                        <span class="dossier_reference_number"
-                              tal:content="protocol/get_dossier_reference_number"></span>
+                        <span class="heading">
+                          <span class="number"
+                                tal:content="python: protocol.number"></span>
+                          <span class="title">
+                            <span class="text" tal:content="python: protocol.get_title()"></span>
+                            <span class="dossier_reference_number"
+                                tal:content="protocol/get_dossier_reference_number"></span>
+                          </span>
+                        </span>
                       </h2>
                   <metal:block tal:condition="not: protocol/is_paragraph">
                     <metal:block tal:condition="protocol/has_proposal">

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -271,9 +271,13 @@ class TestProtocol(FunctionalTestCase):
         browser.css('a[href*="/protocol"]').first.click()
 
         navigation = browser.css('.navigation a.expandable')
-        headings = browser.css('.protocol_title .title')
+        headings = browser.css('.protocol_title .title .text')
+        numbers = browser.css('.protocol_title .number')
 
         self.assertEqual(map(lambda nav: nav.text, navigation),
                          ['1. Mach doch', '2. Mach ize'])
         self.assertEqual(map(lambda heading: heading.text, headings),
-                         ['1. Mach doch', '2. Mach ize'])
+                         ['Mach doch', 'Mach ize'])
+
+        self.assertEqual(map(lambda number: number.text, numbers),
+                         ['1.', '2.'])


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1342

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/383

![bildschirmfoto 2015-11-12 um 16 07 12](https://cloud.githubusercontent.com/assets/1637820/11121692/8e923b72-8957-11e5-8a23-41379bcc8a46.png)
