### PR TITLE
Refactor blocking portlet inheritance, for easier inclusion in policies.

### DIFF
--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -6,6 +6,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder import session
 from opengever.base.model import create_session
+from opengever.setup.hooks import block_context_portlets
 from opengever.testing import builders  # keep!
 from plone import api
 from plone.portlets.constants import CONTEXT_CATEGORY
@@ -182,14 +183,7 @@ class MeetingExampleContentCreator(object):
 
 
 def block_portlets_for_meetings(site):
-    content = site.restrictedTraverse('sitzungen')
-    manager = getUtility(
-        IPortletManager, name=u'plone.leftcolumn', context=content)
-
-    # Block inherited context portlets on content
-    assignable = getMultiAdapter(
-        (content, manager), ILocalPortletAssignmentManager)
-    assignable.setBlacklistStatus(CONTEXT_CATEGORY, True)
+    block_context_portlets(site, 'sitzungen')
 
 
 def municipality_content_profile_installed(site):

--- a/opengever/setup/hooks.py
+++ b/opengever/setup/hooks.py
@@ -53,7 +53,8 @@ def assign_roles(context, admin_groups):
 
 
 def assign_default_navigation_portlet(context, content_id):
-    # Add a new navigation portlet to content
+    """Add a new navigation portlet to content."""
+
     content = context.restrictedTraverse(content_id)
     manager = getUtility(
         IPortletManager, name=u'plone.leftcolumn', context=content)
@@ -66,6 +67,17 @@ def assign_default_navigation_portlet(context, content_id):
             includeTop=False,
             topLevel=1,
             bottomLevel=0)
+
+    # Block inherited context portlets on content
+    assignable = getMultiAdapter(
+        (content, manager), ILocalPortletAssignmentManager)
+    assignable.setBlacklistStatus(CONTEXT_CATEGORY, True)
+
+
+def block_context_portlets(site, content_id):
+    content = site.restrictedTraverse(content_id)
+    manager = getUtility(
+        IPortletManager, name=u'plone.leftcolumn', context=content)
 
     # Block inherited context portlets on content
     assignable = getMultiAdapter(


### PR DESCRIPTION
I'd like to include this in policies, similar to `assign_default_navigation_portlet`.