### PR TITLE
No longer allow adding content to proposals.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- No longer allow adding content to proposals.
+  Add excerpt to proposal's dossier instead.
+  [deiferni]
+
 - Make sure protocol exists and is updated when closing a meeting.
   [deiferni]
 

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -2,7 +2,6 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.base.browser.helper import get_css_class
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.meeting.proposal import IProposal
 from opengever.task.task import ITask
 from plone import api
 
@@ -33,8 +32,6 @@ class BaseDocumentMixin(object):
         if IDossierMarker.providedBy(parent):
             return parent
         if ITask.providedBy(parent):
-            return parent.get_containing_dossier()
-        if IProposal.providedBy(parent):
             return parent.get_containing_dossier()
 
         return None

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -231,13 +231,6 @@ class TestDocument(FunctionalTestCase):
 
         self.assertEqual(dossier, document.get_parent_dossier())
 
-    def test_get_parent_dossier_returns_proposals_dossier(self):
-        dossier = create(Builder('dossier'))
-        proposal = create(Builder('proposal').within(dossier))
-        document = create(Builder('document').within(proposal))
-
-        self.assertEqual(dossier, document.get_parent_dossier())
-
 
 class TestDocumentDefaultValues(FunctionalTestCase):
 

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -445,10 +445,11 @@ class DecideProposalsCommand(object):
         proposal.execute_transition('scheduled-decided')
 
     def copy_document(self, proposal):
+        dossier = proposal.resolve_proposal().get_containing_dossier()
         response = OgCopyCommand(
             proposal.resolve_submitted_excerpt_document(),
             proposal.admin_unit_id,
-            proposal.physical_path).execute()
+            '/'.join(dossier.getPhysicalPath())).execute()
         return response['intid']
 
 

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4616</version>
+    <version>4617</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/types/opengever.meeting.proposal.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.proposal.xml
@@ -9,8 +9,6 @@
   <property name="allow_discussion">False</property>
   <property name="global_allow">True</property>
   <property name="allowed_content_types">
-      <element value="opengever.document.document"/>
-      <element value="ftw.mail.mail"/>
   </property>
 
   <!-- schema interface -->

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -296,7 +296,9 @@ class SubmittedProposal(ProposalBase):
             sort_on='modified',
             sort_order='reverse')
 
-        return [document.getObject() for document in documents]
+        excerpt = self.get_excerpt()
+        all_docs = [document.getObject() for document in documents]
+        return [doc for doc in all_docs if doc != excerpt]
 
     def get_excerpt(self):
         return self.load_model().resolve_submitted_excerpt_document()

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -2,7 +2,6 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.source import DossierPathSourceBinder
-from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
@@ -330,9 +329,6 @@ class Proposal(ProposalBase):
 
         """
         return self.load_model().is_editable_in_dossier()
-
-    def get_containing_dossier(self):
-        return get_containing_dossier(self)
 
     def get_documents(self):
         documents = [relation.to_object for relation in self.relatedItems]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -2,6 +2,7 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.source import DossierPathSourceBinder
+from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
@@ -341,6 +342,9 @@ class Proposal(ProposalBase):
     def get_committee(self):
         committee_model = self.load_model().committee
         return committee_model.oguid.resolve_object()
+
+    def get_containing_dossier(self):
+        return get_containing_dossier(self)
 
     def update_model_create_arguments(self, data, context):
         aq_wrapped_self = self.__of__(context)

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -64,11 +64,11 @@ class TestCloseMeeting(FunctionalTestCase):
         self.assertEquals(excerpt, generated_document.oguid.resolve_object())
 
     @browsing
-    def test_excerpt_is_copied_to_proposal(self, browser):
+    def test_excerpt_is_copied_to_proposals_dossier(self, browser):
         browser.login().open(self.meeting.get_url())
         browser.css('#pending-closed').first.click()
 
-        excerpt = self.proposal_a.listFolderContents()[0]
+        excerpt = self.dossier.listFolderContents()[-2]
         self.assertEquals('Protocol Excerpt-barn-dec-13-2011',
                           excerpt.Title())
         self.assertEquals(u'protocol-excerpt-barn-dec-13-2011.docx',

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -478,4 +478,13 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4616 -> 4617 -->
+    <upgrade-step:importProfile
+        title="No longer allow to add content to proposals."
+        source="4616"
+        destination="4617"
+        profile="opengever.meeting:default"
+        directory="profiles/4617"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4617/types/opengever.meeting.proposal.xml
+++ b/opengever/meeting/upgrades/profiles/4617/types/opengever.meeting.proposal.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.proposal"
+        i18n:domain="opengever.meeting"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <property name="allowed_content_types">
+  </property>
+
+</object>


### PR DESCRIPTION
The excerpt related to a proposal will be stored in the proposal's dossier instead the proposal. It is already displayed on the proposal overview over a reference that is maintained from `Proposal.excerpt_document`.

Closes #1233.