### PR TITLE
Add periods to committees

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,14 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add periods to committees. A period represents a timespan similar to a fiscal year.
+
+    - Display the current period on committee overview.
+    - Add a wizard to close the current and create its successor.
+    - Add a wizard that creates an initial period upon committee creation.
+
+  [deiferni]
+
 - No longer allow adding content to proposals.
   Add excerpt to proposal's dossier instead.
   [deiferni]

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -38,6 +38,9 @@ msgstr "Auschecken"
 msgid "Checkout and edit"
 msgstr "Auschecken / Bearbeiten"
 
+msgid "Close current period"
+msgstr "Aktuelle Periode abschliessen"
+
 msgid "Create successor task"
 msgstr "Folgeaufgabe erstellen"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -38,6 +38,9 @@ msgstr "Checkout"
 msgid "Checkout and edit"
 msgstr "Checkout et modifier"
 
+msgid "Close current period"
+msgstr ""
+
 msgid "Create successor task"
 msgstr "Créer tâche suivante"
 

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -311,3 +311,6 @@ msgstr ""
 
 msgid "Submit additional document"
 msgstr ""
+
+msgid "Close current period"
+msgstr ""

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -59,6 +59,9 @@ class MeetingExampleContentCreator(object):
         self.committee_law = self.site['sitzungen']['committee-1']
         self.committee_law_model = self.committee_law.load_model()
 
+        self.committee_accounting = self.site['sitzungen']['committee-2']
+        self.committee_accounting_model = self.committee_accounting.load_model()
+
         self.committee_assembly = self.site['sitzungen']['committee-3']
         self.committee_assembly_model = self.committee_assembly.load_model()
 
@@ -88,9 +91,15 @@ class MeetingExampleContentCreator(object):
         session.current_session.session = self.db_session
 
     def create_content(self):
+        self.create_periods()
         self.create_members_and_memberships()
         self.create_meetings()
         self.create_proposals()
+
+    def create_periods(self):
+        create(Builder('period').having(committee=self.committee_law_model))
+        create(Builder('period').having(committee=self.committee_accounting_model))
+        create(Builder('period').having(committee=self.committee_assembly_model))
 
     def create_members_and_memberships(self):
         peter = create(Builder('member')

--- a/opengever/meeting/browser/committee.py
+++ b/opengever/meeting/browser/committee.py
@@ -1,6 +1,7 @@
 from five import grok
 from opengever.meeting import _
 from opengever.meeting.committee import ICommittee
+from opengever.meeting.model import Period
 from opengever.tabbedview.browser.base import OpengeverTab
 
 
@@ -16,7 +17,11 @@ class CommitteeOverview(grok.View, OpengeverTab):
 
     def boxes(self):
         items = [
-            [{'id': 'upcoming_meetings',
+            [{'id': 'period',
+              'label': _('label_current_period', default=u'Current Period'),
+              'content': [self.period()],
+              'href': ''},
+             {'id': 'upcoming_meetings',
               'label': _('label_upcoming_meetings', default=u'Upcoming meetings'),
               'content': self.upcoming_meetings(),
               'href': 'meetings'}],
@@ -47,3 +52,7 @@ class CommitteeOverview(grok.View, OpengeverTab):
         memberships = self.context.get_active_memberships().all()
         members = [membership.member for membership in memberships]
         return [member.get_link(self.context) for member in members]
+
+    def period(self):
+        period = Period.query.get_current(self.context.load_model())
+        return period.get_title()

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -1,18 +1,157 @@
+from datetime import date
 from five import grok
+from opengever.base.browser.wizard import BaseWizardStepForm
+from opengever.base.browser.wizard.interfaces import IWizardDataStorage
+from opengever.base.form import WizzardWrappedAddForm
+from opengever.base.model import create_session
+from opengever.base.oguid import Oguid
+from opengever.meeting import _
+from opengever.meeting.browser.periods import IPeriodModel
 from opengever.meeting.committee import Committee
 from opengever.meeting.committee import ICommittee
+from opengever.meeting.committeecontainer import ICommitteeContainer
+from opengever.meeting.form import ModelAddForm
 from opengever.meeting.form import ModelProxyAddForm
 from opengever.meeting.form import ModelProxyEditForm
+from opengever.meeting.model import Period
+from plone import api
+from plone.dexterity.browser.add import DefaultAddForm
+from plone.dexterity.i18n import MessageFactory as pd_mf
 from plone.directives import dexterity
+from plone.z3cform.layout import FormWrapper
 from z3c.form import field
+from z3c.form.button import buttonAndHandler
+from z3c.form.field import Fields
+from z3c.form.form import Form
 from z3c.form.interfaces import HIDDEN_MODE
+from z3c.form.interfaces import IDataConverter
+from zope.component import getUtility
 
 
-class AddForm(ModelProxyAddForm, dexterity.AddForm):
+ADD_COMMITTEE_STEPS = (
+    ('add-committee', _(u'Add committee')),
+    ('add-period', _(u'Add period'))
+)
 
+
+def get_dm_key(context):
+    container_oguid = Oguid.for_object(context)
+    return 'create_committee:{}'.format(container_oguid)
+
+
+class AddForm(BaseWizardStepForm, dexterity.AddForm):
+    """Form to create a committee.
+
+    Is registered as default add form for committees. Does not create the
+    committee when submitted but store its data in IIWizardStorage. Then
+    redirects to the second step to add an initial period.
+
+    """
     grok.name('opengever.meeting.committee')
-    content_type = Committee
     fields = field.Fields(Committee.model_schema)
+    label = _('Add committee')
+
+    step_name = 'add-meeting-dossier'
+    steps = ADD_COMMITTEE_STEPS
+
+    @buttonAndHandler(_(u'button_continue', default=u'Continue'), name='save')
+    def handle_continue(self, action):
+        data, errors = self.extractData()
+        if errors:
+            return
+
+        dm = getUtility(IWizardDataStorage)
+        dm.update(get_dm_key(self.context), data)
+
+        return self.request.RESPONSE.redirect(
+            "{}/add-initial-period".format(self.context.absolute_url()))
+
+    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+
+class AddInitialPeriodStep(BaseWizardStepForm, ModelProxyAddForm, DefaultAddForm):
+    """Form to add an initial period during committee creation.
+
+    Second part of a two-step wizard. Loads data from IIWizardStorage to
+    also create the committee from the first step after successful submission.
+
+
+    This form extends from dexterity's DefaultAddForm to create the plone
+    content-type easily.
+
+    Does not extend from dexterity.AddForm to avoid auto-registering this
+    form as add-form for committees, this would conflict with the form
+    from the first step. Instead configure portal_type manually.
+
+    """
+    step_name = 'add-period'
+    label = _('Add period')
+    steps = ADD_COMMITTEE_STEPS
+
+    portal_type = 'opengever.meeting.committee'
+    content_type = Committee
+    schema = IPeriodModel
+    fields = Fields(IPeriodModel)
+
+    @property
+    def additionalSchemata(self):
+        return []
+
+    def updateWidgets(self):
+        super(AddInitialPeriodStep, self).updateWidgets()
+        self.inject_default_values()
+
+    def inject_default_values(self):
+        today = date.today()
+        title = self.widgets['title']
+        date_from = self.widgets['date_from']
+        date_to = self.widgets['date_to']
+
+        if not title.value:
+            title.value = unicode(today.year)
+        if not date_from.value:
+            date_from.value = IDataConverter(date_from).toWidgetValue(
+                date(today.year, 1, 1))
+        if not date_to.value:
+            date_to.value = IDataConverter(date_to).toWidgetValue(
+                date(today.year, 12, 31))
+
+    def createAndAdd(self, data):
+        """Remember data for period and inject committee data from previous
+        form.
+
+        """
+        dm = getUtility(IWizardDataStorage)
+        committee_data = dm.get_data(get_dm_key(self.context))
+        committee = super(AddInitialPeriodStep, self).createAndAdd(
+            committee_data)
+
+        self.create_period(committee, data)
+
+        dm.drop_data(get_dm_key(self.context))
+        return committee
+
+    def create_period(self, committee, data):
+        session = create_session()
+        data.update({'committee': committee.load_model()})
+        period = Period(**data)
+        session.add(period)
+        session.flush()  # required to immediately create an autoincremented id
+
+
+class AddInitialPeriodStepView(FormWrapper, grok.View):
+    """View to render the form to close a period."""
+
+    grok.context(ICommitteeContainer)
+    grok.name('add-initial-period')
+    grok.require('cmf.ModifyPortalContent')
+    form = AddInitialPeriodStep
+
+    def __init__(self, *args, **kwargs):
+         FormWrapper.__init__(self, *args, **kwargs)
+         grok.View.__init__(self, *args, **kwargs)
 
 
 class EditForm(ModelProxyEditForm, dexterity.EditForm):

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -1,0 +1,187 @@
+from datetime import date
+from five import grok
+from opengever.base.browser.wizard import BaseWizardStepForm
+from opengever.base.browser.wizard.interfaces import IWizardDataStorage
+from opengever.meeting import _
+from opengever.meeting import is_meeting_feature_enabled
+from opengever.meeting.committee import ICommittee
+from opengever.meeting.form import ModelAddForm
+from opengever.meeting.form import ModelEditForm
+from opengever.meeting.model import Period
+from plone.directives import form
+from plone.z3cform.layout import FormWrapper
+from z3c.form.button import buttonAndHandler
+from z3c.form.field import Fields
+from z3c.form.interfaces import IDataConverter
+from zope import schema
+from zope.component import getUtility
+
+
+class IPeriodModel(form.Schema):
+
+    title = schema.TextLine(
+        title=_(u"label_title", default=u"Title"),
+        max_length=256,
+        required=True)
+
+    date_from = schema.Date(
+        description=_('label_date_from', default='Start'),
+        required=False,
+    )
+
+    date_to = schema.Date(
+        description=_('label_date_to', default='End'),
+        required=False,
+    )
+
+
+CLOSE_PERIOD_STEPS = (
+    ('close-period', _(u'Close period')),
+    ('add-period', _(u'Add new period'))
+)
+
+
+def get_dm_key(committee):
+    """Return the key used to store data in the wizard-storage."""
+
+    return 'close_period:{}'.format(committee.committee_id)
+
+
+class CloseCurrentPeriodStep(BaseWizardStepForm, ModelEditForm):
+    """Form to close the current period.
+
+    First part of a two-step wizard. Stores its data in IIWizardStorage when
+    submitted.
+
+    """
+    step_name = 'close-period'
+    label = _('Close period')
+    step_title = _('Close currently active period')
+    steps = CLOSE_PERIOD_STEPS
+
+    fields = Fields(IPeriodModel)
+
+    def __init__(self, context, request):
+        self.committee = context.load_model()
+        model = Period.query.get_current(self.committee)
+        super(CloseCurrentPeriodStep, self).__init__(
+            context, request, model)
+
+    def get_edit_values(self, keys):
+        return self.model.get_edit_values(keys)
+
+    def partition_data(self, data):
+        obj_data, model_data = {}, data
+        return obj_data, model_data
+
+    def update_model(self, model_data):
+        self.model.update_model(model_data)
+
+    @buttonAndHandler(_(u'button_close_period',
+                        default=u'Close period'), name='save')
+    def handle_continue(self, action):
+        data, errors = self.extractData()
+        if errors:
+            return
+
+        dm = getUtility(IWizardDataStorage)
+        dm.update(get_dm_key(self.committee), data)
+
+        return self.request.RESPONSE.redirect(
+            '{}/add-period'.format(self.context.absolute_url()))
+
+    @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+    def nextURL(self):
+        return self._created_object.get_url()
+
+
+class CloseCurrentPeriodStepView(FormWrapper, grok.View):
+    """View to render the form to close a period."""
+
+    grok.context(ICommittee)
+    grok.name('close-period')
+    grok.require('cmf.ModifyPortalContent')
+    form = CloseCurrentPeriodStep
+
+    def __init__(self, *args, **kwargs):
+         FormWrapper.__init__(self, *args, **kwargs)
+         grok.View.__init__(self, *args, **kwargs)
+
+    def available(self):
+        return is_meeting_feature_enabled()
+
+
+class AddNewPeriodStep(BaseWizardStepForm, ModelAddForm):
+    """Form to add a new period to an existing committee.
+
+    Second part of a two-step wizard. Loads data from IIWizardStorage to
+    update the period to close when submitted.
+
+    """
+    step_name = 'add-period'
+    label = _('Add period')
+    step_title = _('Add new period')
+    steps = CLOSE_PERIOD_STEPS
+
+    schema = IPeriodModel
+
+    model_class = Period
+
+    def __init__(self, context, request):
+        self.committee = context.load_model()
+        self.period_to_close = Period.query.get_current(self.committee)
+        super(AddNewPeriodStep, self).__init__(context, request)
+
+    def updateWidgets(self):
+        super(AddNewPeriodStep, self).updateWidgets()
+        self.inject_default_values()
+
+    def inject_default_values(self):
+        today = date.today()
+        title = self.widgets['title']
+        date_from = self.widgets['date_from']
+        date_to = self.widgets['date_to']
+
+        if not title.value:
+            title.value = unicode(today.year)
+        if not date_from.value:
+            date_from.value = IDataConverter(date_from).toWidgetValue(
+                date(today.year, 1, 1))
+        if not date_to.value:
+            date_to.value = IDataConverter(date_to).toWidgetValue(
+                date(today.year, 12, 31))
+
+    def create(self, data):
+        self.close_previous_period()
+
+        period = super(AddNewPeriodStep, self).create(data)
+        period.committee = self.committee
+        return period
+
+    def close_previous_period(self):
+        dm = getUtility(IWizardDataStorage)
+        data = dm.get_data(get_dm_key(self.committee))
+
+        self.period_to_close.update_model(data)
+        self.period_to_close.execute_transition('active-closed')
+
+        dm.drop_data(get_dm_key(self.committee))
+
+
+class AddNewPeriodStepView(FormWrapper, grok.View):
+    """View to render the form to create a new period."""
+
+    grok.context(ICommittee)
+    grok.name('add-period')
+    grok.require('cmf.AddPortalContent')
+    form = AddNewPeriodStep
+
+    def __init__(self, *args, **kwargs):
+         FormWrapper.__init__(self, *args, **kwargs)
+         grok.View.__init__(self, *args, **kwargs)
+
+    def available(self):
+        return is_meeting_feature_enabled()

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -25,12 +25,12 @@ class IPeriodModel(form.Schema):
         required=True)
 
     date_from = schema.Date(
-        description=_('label_date_from', default='Start'),
+        description=_('label_date_from', default='Start date'),
         required=False,
     )
 
     date_to = schema.Date(
-        description=_('label_date_to', default='End'),
+        description=_('label_date_to', default='End date'),
         required=False,
     )
 

--- a/opengever/meeting/container.py
+++ b/opengever/meeting/container.py
@@ -50,6 +50,7 @@ class ModelContainer(Container):
         self.update_model_create_arguments(data, context)
         model_instance = self.model_class(oguid=oguid, **data)
         session.add(model_instance)
+        session.flush()  # required to create an autoincremented id
         self._after_model_created(model_instance)
 
         notify(ObjectModifiedEvent(aq_wrapped_self))

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -43,6 +43,9 @@ class ModelAddForm(AutoExtensibleForm, AddForm):
     def handleAdd(self, action):
         # self as first argument is required by the decorator
         super(ModelAddForm, self).handleAdd(self, action)
+        if not self._finishedAdd:
+            return
+
         api.portal.show_message(
             _(u'message_record_created', default='Record created'),
             api.portal.get().REQUEST)

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-16 12:50+0000\n"
+"POT-Creation-Date: 2015-11-19 08:34+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,19 @@ msgstr "Mitglied hinzufügen"
 msgid "Add Membership"
 msgstr "Mitgliedschaft hinzufügen"
 
+#: ./opengever/meeting/browser/committeeforms.py:32
+msgid "Add committee"
+msgstr "Kommittee hinzufügen"
+
+#: ./opengever/meeting/browser/periods.py:40
+msgid "Add new period"
+msgstr "Neue Periode hinzufügen"
+
+#: ./opengever/meeting/browser/committeeforms.py:33
+#: ./opengever/meeting/browser/periods.py:125
+msgid "Add period"
+msgstr "Periode hinzufügen"
+
 #: ./opengever/meeting/command.py:355
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
@@ -76,6 +89,14 @@ msgstr "Traktanden auswählen"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
 msgid "Close all proposals"
 msgstr "Alle Anträge werden abgeschlossen"
+
+#: ./opengever/meeting/browser/periods.py:59
+msgid "Close currently active period"
+msgstr "Aktuelle Periode abschliessen"
+
+#: ./opengever/meeting/browser/periods.py:39
+msgid "Close period"
+msgstr "Periode abschliessen"
 
 #: ./opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
 msgid "Committee"
@@ -303,6 +324,11 @@ msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier übe
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
+#. Default: "Active"
+#: ./opengever/meeting/model/period.py:20
+msgid "active"
+msgstr "Aktiv"
+
 #. Default: "Agenda Item Successfully deleted"
 #: ./opengever/meeting/browser/meetings/agendaitem.py:164
 msgid "agenda_item_deleted"
@@ -324,13 +350,19 @@ msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
+#: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
 #: ./opengever/meeting/browser/meetings/meeting.py:161
-#: ./opengever/meeting/browser/protocol.py:153
 msgid "button_cancel"
 msgstr "Abbrechen"
 
+#. Default: "Close period"
+#: ./opengever/meeting/browser/periods.py:80
+msgid "button_close_period"
+msgstr "Periode abschliessen"
+
 #. Default: "Continue"
+#: ./opengever/meeting/browser/committeeforms.py:57
 #: ./opengever/meeting/browser/meetings/meeting.py:145
 msgid "button_continue"
 msgstr "Weiter"
@@ -352,8 +384,14 @@ msgstr "Anhänge einreichen"
 msgid "close_meeting"
 msgstr "Abschliessen"
 
+#. Default: "Close period"
+#: ./opengever/meeting/model/period.py:28
+msgid "close_period"
+msgstr "Periode abschliessen"
+
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr "geschlossen"
 
@@ -535,18 +573,25 @@ msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:31
+#: ./opengever/meeting/browser/committee.py:36
 msgid "label_current_members"
 msgstr "Aktuelle Mitglieder"
 
+#. Default: "Current Period"
+#: ./opengever/meeting/browser/committee.py:21
+msgid "label_current_period"
+msgstr "Aktuelle Periode"
+
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:21
+#: ./opengever/meeting/browser/periods.py:28
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "Von"
 
 #. Default: "End date"
 #: ./opengever/meeting/browser/memberships.py:26
+#: ./opengever/meeting/browser/periods.py:33
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Bis"
@@ -767,8 +812,8 @@ msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
+#: ./opengever/meeting/browser/periods.py:23
 #: ./opengever/meeting/committee.py:64
-#: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr "Titel"
 
@@ -778,12 +823,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:25
+#: ./opengever/meeting/browser/committee.py:30
 msgid "label_unscheduled_proposals"
 msgstr "Nicht traktandierte Anträge"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:20
+#: ./opengever/meeting/browser/committee.py:25
 msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
@@ -807,17 +852,17 @@ msgstr "Sitzungsdossier"
 
 #. Default: "Changes saved"
 #: ./opengever/meeting/browser/meetings/protocol.py:153
-#: ./opengever/meeting/form.py:119
+#: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
 #. Default: "Record created"
-#: ./opengever/meeting/form.py:47
+#: ./opengever/meeting/form.py:50
 msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/command.py:490
+#: ./opengever/meeting/command.py:492
 msgid "msg_meeting_successfully_closed"
 msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollauszüge wurden generiert und an die Urprungsdossiers zurückgespielt."
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-16 12:50+0000\n"
+"POT-Creation-Date: 2015-11-19 08:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,19 @@ msgstr "Ajouter le membre"
 msgid "Add Membership"
 msgstr "Ajouter l'affiliation"
 
+#: ./opengever/meeting/browser/committeeforms.py:32
+msgid "Add committee"
+msgstr ""
+
+#: ./opengever/meeting/browser/periods.py:40
+msgid "Add new period"
+msgstr ""
+
+#: ./opengever/meeting/browser/committeeforms.py:33
+#: ./opengever/meeting/browser/periods.py:125
+msgid "Add period"
+msgstr ""
+
 #: ./opengever/meeting/command.py:355
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
@@ -75,6 +88,14 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
 msgid "Close all proposals"
+msgstr ""
+
+#: ./opengever/meeting/browser/periods.py:59
+msgid "Close currently active period"
+msgstr ""
+
+#: ./opengever/meeting/browser/periods.py:39
+msgid "Close period"
 msgstr ""
 
 #: ./opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
@@ -303,6 +324,11 @@ msgstr "Le document a été écrasé par une version plus récente du dossier pr
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
+#. Default: "Active"
+#: ./opengever/meeting/model/period.py:20
+msgid "active"
+msgstr ""
+
 #. Default: "Agenda Item Successfully deleted"
 #: ./opengever/meeting/browser/meetings/agendaitem.py:164
 msgid "agenda_item_deleted"
@@ -324,13 +350,19 @@ msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
+#: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
 #: ./opengever/meeting/browser/meetings/meeting.py:161
-#: ./opengever/meeting/browser/protocol.py:153
 msgid "button_cancel"
 msgstr "Annuler"
 
+#. Default: "Close period"
+#: ./opengever/meeting/browser/periods.py:80
+msgid "button_close_period"
+msgstr ""
+
 #. Default: "Continue"
+#: ./opengever/meeting/browser/committeeforms.py:57
 #: ./opengever/meeting/browser/meetings/meeting.py:145
 msgid "button_continue"
 msgstr ""
@@ -352,8 +384,14 @@ msgstr ""
 msgid "close_meeting"
 msgstr ""
 
+#. Default: "Close period"
+#: ./opengever/meeting/model/period.py:28
+msgid "close_period"
+msgstr ""
+
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr "Fermé"
 
@@ -535,18 +573,25 @@ msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:31
+#: ./opengever/meeting/browser/committee.py:36
 msgid "label_current_members"
 msgstr "Membres actuels"
 
+#. Default: "Current Period"
+#: ./opengever/meeting/browser/committee.py:21
+msgid "label_current_period"
+msgstr ""
+
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:21
+#: ./opengever/meeting/browser/periods.py:28
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "De"
 
 #. Default: "End date"
 #: ./opengever/meeting/browser/memberships.py:26
+#: ./opengever/meeting/browser/periods.py:33
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Jusqu'à"
@@ -767,8 +812,8 @@ msgstr "Début"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
+#: ./opengever/meeting/browser/periods.py:23
 #: ./opengever/meeting/committee.py:64
-#: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr "Titre"
 
@@ -778,12 +823,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:25
+#: ./opengever/meeting/browser/committee.py:30
 msgid "label_unscheduled_proposals"
 msgstr "Propositions imprévues"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:20
+#: ./opengever/meeting/browser/committee.py:25
 msgid "label_upcoming_meetings"
 msgstr "Prochaines séances"
 
@@ -807,17 +852,17 @@ msgstr ""
 
 #. Default: "Changes saved"
 #: ./opengever/meeting/browser/meetings/protocol.py:153
-#: ./opengever/meeting/form.py:119
+#: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
 #. Default: "Record created"
-#: ./opengever/meeting/form.py:47
+#: ./opengever/meeting/form.py:50
 msgid "message_record_created"
 msgstr "Enregistrement créé"
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/command.py:490
+#: ./opengever/meeting/command.py:492
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-16 12:50+0000\n"
+"POT-Creation-Date: 2015-11-19 08:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,6 +43,19 @@ msgstr ""
 msgid "Add Membership"
 msgstr ""
 
+#: ./opengever/meeting/browser/committeeforms.py:32
+msgid "Add committee"
+msgstr ""
+
+#: ./opengever/meeting/browser/periods.py:40
+msgid "Add new period"
+msgstr ""
+
+#: ./opengever/meeting/browser/committeeforms.py:33
+#: ./opengever/meeting/browser/periods.py:125
+msgid "Add period"
+msgstr ""
+
 #: ./opengever/meeting/command.py:355
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
@@ -74,6 +87,14 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
 msgid "Close all proposals"
+msgstr ""
+
+#: ./opengever/meeting/browser/periods.py:59
+msgid "Close currently active period"
+msgstr ""
+
+#: ./opengever/meeting/browser/periods.py:39
+msgid "Close period"
 msgstr ""
 
 #: ./opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
@@ -302,6 +323,11 @@ msgstr ""
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
+#. Default: "Active"
+#: ./opengever/meeting/model/period.py:20
+msgid "active"
+msgstr ""
+
 #. Default: "Agenda Item Successfully deleted"
 #: ./opengever/meeting/browser/meetings/agendaitem.py:164
 msgid "agenda_item_deleted"
@@ -323,13 +349,19 @@ msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
+#: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
 #: ./opengever/meeting/browser/meetings/meeting.py:161
-#: ./opengever/meeting/browser/protocol.py:153
 msgid "button_cancel"
 msgstr ""
 
+#. Default: "Close period"
+#: ./opengever/meeting/browser/periods.py:80
+msgid "button_close_period"
+msgstr ""
+
 #. Default: "Continue"
+#: ./opengever/meeting/browser/committeeforms.py:57
 #: ./opengever/meeting/browser/meetings/meeting.py:145
 msgid "button_continue"
 msgstr ""
@@ -351,8 +383,14 @@ msgstr ""
 msgid "close_meeting"
 msgstr ""
 
+#. Default: "Close period"
+#: ./opengever/meeting/model/period.py:28
+msgid "close_period"
+msgstr ""
+
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr ""
 
@@ -534,18 +572,25 @@ msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:31
+#: ./opengever/meeting/browser/committee.py:36
 msgid "label_current_members"
+msgstr ""
+
+#. Default: "Current Period"
+#: ./opengever/meeting/browser/committee.py:21
+msgid "label_current_period"
 msgstr ""
 
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:21
+#: ./opengever/meeting/browser/periods.py:28
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr ""
 
 #. Default: "End date"
 #: ./opengever/meeting/browser/memberships.py:26
+#: ./opengever/meeting/browser/periods.py:33
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr ""
@@ -764,8 +809,8 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
+#: ./opengever/meeting/browser/periods.py:23
 #: ./opengever/meeting/committee.py:64
-#: ./opengever/meeting/proposal.py:37
 msgid "label_title"
 msgstr ""
 
@@ -775,12 +820,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:25
+#: ./opengever/meeting/browser/committee.py:30
 msgid "label_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:20
+#: ./opengever/meeting/browser/committee.py:25
 msgid "label_upcoming_meetings"
 msgstr ""
 
@@ -804,17 +849,17 @@ msgstr ""
 
 #. Default: "Changes saved"
 #: ./opengever/meeting/browser/meetings/protocol.py:153
-#: ./opengever/meeting/form.py:119
+#: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr ""
 
 #. Default: "Record created"
-#: ./opengever/meeting/form.py:47
+#: ./opengever/meeting/form.py:50
 msgid "message_record_created"
 msgstr ""
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/command.py:490
+#: ./opengever/meeting/command.py:492
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 

--- a/opengever/meeting/model/__init__.py
+++ b/opengever/meeting/model/__init__.py
@@ -7,6 +7,7 @@ from opengever.meeting.model.member import Member
 from opengever.meeting.model.membership import Membership
 from opengever.meeting.model.proposal import Proposal
 from opengever.meeting.model.submitteddocument import SubmittedDocument
+from opengever.meeting.model.period import Period
 import opengever.meeting.model.query  # keep, initializes query classes!
 
 
@@ -19,6 +20,7 @@ tables = [
     'meetings',
     'members',
     'memberships',
+    'periods',
     'proposalhistory',
     'proposals',
     'submitteddocuments',

--- a/opengever/meeting/model/period.py
+++ b/opengever/meeting/model/period.py
@@ -4,6 +4,7 @@ from opengever.meeting import _
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
+from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Date
 from sqlalchemy import ForeignKey
@@ -42,6 +43,26 @@ class Period(Base):
 
     def __repr__(self):
         return '<Period {}>'.format(repr(self.title))
+
+    def get_title(self):
+        if self.date_from or self.date_to:
+            return u'{} ({} - {})'.format(
+                self.title, self.get_date_from(), self.get_date_to())
+        return self.title
+
+    def get_date_from(self):
+        """Return a localized date."""
+
+        if self.date_from:
+            return api.portal.get_localized_time(datetime=self.date_from)
+        return ''
+
+    def get_date_to(self):
+        """Return a localized date."""
+
+        if self.date_to:
+            return api.portal.get_localized_time(datetime=self.date_to)
+        return ''
 
     def execute_transition(self, name):
         self.workflow.execute_transition(self, self, name)

--- a/opengever/meeting/model/period.py
+++ b/opengever/meeting/model/period.py
@@ -1,0 +1,50 @@
+from opengever.base.model import Base
+from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
+from opengever.meeting import _
+from opengever.meeting.workflow import State
+from opengever.meeting.workflow import Transition
+from opengever.meeting.workflow import Workflow
+from sqlalchemy import Column
+from sqlalchemy import Date
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
+
+
+class Period(Base):
+
+    STATE_ACTIVE = State('active', is_default=True,
+                         title=_('active', default='Active'))
+    STATE_CLOSED = State('closed', title=_('closed', default='Closed'))
+
+    workflow = Workflow([
+        STATE_ACTIVE,
+        STATE_CLOSED,
+        ], [
+        Transition('active', 'closed',
+                   title=_('close_period', default='Close period')),
+        ])
+
+    __tablename__ = 'periods'
+
+    period_id = Column('id', Integer, Sequence('period_id_seq'),
+                       primary_key=True)
+    committee_id = Column('committee_id', Integer, ForeignKey('committees.id'),
+                          nullable=False)
+    committee = relationship('Committee', backref='periods')
+    workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False,
+                            default=workflow.default_state.name)
+    title = Column(String(256), nullable=False)
+    date_from = Column(Date)
+    date_to = Column(Date)
+
+    def __repr__(self):
+        return '<Period {}>'.format(repr(self.title))
+
+    def execute_transition(self, name):
+        self.workflow.execute_transition(self, self, name)
+
+    def can_execute_transition(self, name):
+        return self.workflow.can_execute_transition(self, name)

--- a/opengever/meeting/model/period.py
+++ b/opengever/meeting/model/period.py
@@ -48,3 +48,16 @@ class Period(Base):
 
     def can_execute_transition(self, name):
         return self.workflow.can_execute_transition(self, name)
+
+    def get_edit_values(self, fieldnames):
+        values = {}
+        for fieldname in fieldnames:
+            value = getattr(self, fieldname, None)
+            if value:
+                values[fieldname] = value
+
+        return values
+
+    def update_model(self, data):
+        for key, value in data.items():
+            setattr(self, key, value)

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -5,6 +5,7 @@ from opengever.meeting.model.committee import Committee
 from opengever.meeting.model.generateddocument import GeneratedDocument
 from opengever.meeting.model.meeting import Meeting
 from opengever.meeting.model.membership import Membership
+from opengever.meeting.model.period import Period
 from opengever.meeting.model.proposal import Proposal
 from opengever.meeting.model.submitteddocument import SubmittedDocument
 from opengever.ogds.models.query import BaseQuery
@@ -172,3 +173,17 @@ class GeneratedDocumentQuery(BaseQuery):
 
 
 GeneratedDocument.query_cls = GeneratedDocumentQuery
+
+
+class PeriodQuery(BaseQuery):
+
+    def active(self):
+        return self.filter_by(workflow_state=Period.STATE_ACTIVE.name)
+
+    def by_committee(self, committee):
+        return self.filter_by(committee=committee)
+
+    def get_current(self, committee):
+        return self.active().by_committee(committee).one()
+
+Period.query_cls = PeriodQuery

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4617</version>
+    <version>4618</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4618</version>
+    <version>4619</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.committee.xml
@@ -111,4 +111,15 @@
           url_expr="string:#"
           visible="True">
   </action>
+
+  <action
+        action_id="close-period"
+        visible="True"
+        title="Close current period"
+        url_expr="string:${object_url}/@@close-period"
+        condition_expr="object/@@close-period/available"
+        category="object_buttons">
+    <permission value="Modify portal content"/>
+  </action>
+
 </object>

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -40,6 +41,11 @@ class TestCommittee(FunctionalTestCase):
              'Linked repository folder': self.repository_folder,
              self.group_field_name: 'client1_users'})
         browser.css('#form-buttons-save').first.click()
+
+        browser.fill({'Title': u'Initial',
+                      'Start date': 'January 1, 2012',
+                      'End date': 'December 31, 2012'}).submit()
+
         self.assertIn('Item created',
                       browser.css('.portalMessage.info dd').text)
 
@@ -53,6 +59,13 @@ class TestCommittee(FunctionalTestCase):
         self.assertIsNotNone(model)
         self.assertEqual(Oguid.for_object(committee), model.oguid)
         self.assertEqual(u'A c\xf6mmittee', model.title)
+
+        self.assertEqual(1, len(model.periods))
+        period = model.periods[0]
+        self.assertEqual('active', period.workflow_state)
+        self.assertEqual(u'Initial', period.title)
+        self.assertEqual(date(2012, 1, 1), period.date_from)
+        self.assertEqual(date(2012, 12, 31), period.date_to)
 
     @browsing
     def test_committee_can_be_edited_in_browser(self, browser):

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -14,6 +14,13 @@ class TestCommitteeOverview(FunctionalTestCase):
         self.committee_model = self.committee.load_model()
 
     @browsing
+    def test_shows_current_period_box(self, browser):
+        browser.login().open(self.committee, view='tabbedview_view-overview')
+
+        self.assertEqual(unicode(date.today().year),
+                         browser.css('#periodBox li').first.text)
+
+    @browsing
     def test_membership_box_shows_only_active_members(self, browser):
         peter = create(Builder('member'))
         hans = create(Builder('member')

--- a/opengever/meeting/tests/test_period.py
+++ b/opengever/meeting/tests/test_period.py
@@ -1,0 +1,51 @@
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.testing import FunctionalTestCase
+
+
+class TestPeriod(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestPeriod, self).setUp()
+        self.repo_root = create(Builder('repository_root'))
+        self.repository_folder = create(Builder('repository')
+                                        .within(self.repo_root)
+                                        .titled('Repo'))
+        self.container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee').within(self.container))
+        self.committee_model = self.committee.load_model()
+
+    @browsing
+    def test_close_and_create_new_period(self, browser):
+        browser.login()
+        browser.open(self.committee)
+        browser.find('Close current period').click()
+
+        browser.fill({'Title': u'Old',
+                      'Start date': 'January 1, 2012',
+                      'End date': 'December 31, 2012'}).submit()
+        browser.fill({'Title': u'New',
+                      'Start date': 'January 1, 2013',
+                      'End date': 'December 31, 2013'}).submit()
+
+        self.assertEqual(["Record created"], info_messages())
+
+        committee_model = browser.context.load_model()  # refresh model
+        self.assertEqual(2, len(committee_model.periods))
+        old_period = committee_model.periods[0]
+        new_period = committee_model.periods[1]
+
+        self.assertEqual('closed', old_period.workflow_state)
+        self.assertEqual(u'Old', old_period.title)
+        self.assertEqual(date(2012, 1, 1), old_period.date_from)
+        self.assertEqual(date(2012, 12, 31), old_period.date_to)
+        self.assertEqual('active', new_period.workflow_state)
+        self.assertEqual(u'New', new_period.title)
+        self.assertEqual(date(2013, 1, 1), new_period.date_from)
+        self.assertEqual(date(2013, 12, 31), new_period.date_to)

--- a/opengever/meeting/tests/test_period.py
+++ b/opengever/meeting/tests/test_period.py
@@ -49,3 +49,27 @@ class TestPeriod(FunctionalTestCase):
         self.assertEqual(u'New', new_period.title)
         self.assertEqual(date(2013, 1, 1), new_period.date_from)
         self.assertEqual(date(2013, 12, 31), new_period.date_to)
+
+    def test_period_title_without_date(self):
+        period = create(Builder('period').having(
+            title=u'Foo', committee=self.committee_model))
+        self.assertEqual(u'Foo', period.get_title())
+
+    def test_period_title_with_start_date(self):
+        period = create(Builder('period').having(
+            title=u'Foo', date_from=date(2010, 1, 1),
+            committee=self.committee_model))
+        self.assertEqual('Foo (Jan 01, 2010 - )', period.get_title())
+
+    def test_period_title_with_end_date(self):
+        period = create(Builder('period').having(
+            title=u'Foo', date_to=date(2010, 12, 31),
+            committee=self.committee_model))
+        self.assertEqual('Foo ( - Dec 31, 2010)', period.get_title())
+
+    def test_period_title_with_start_and_end_date(self):
+        period = create(Builder('period').having(
+            title=u'Foo', date_from=date(2010, 1, 1),
+            date_to=date(2010, 12, 31), committee=self.committee_model))
+        self.assertEqual('Foo (Jan 01, 2010 - Dec 31, 2010)',
+                         period.get_title())

--- a/opengever/meeting/tests/test_period_query.py
+++ b/opengever/meeting/tests/test_period_query.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.meeting.model import Period
+from opengever.testing import MEMORY_DB_LAYER
+from unittest2 import TestCase
+
+
+class TestPeriodQuery(TestCase):
+
+    layer = MEMORY_DB_LAYER
+
+    def setUp(self):
+        super(TestPeriodQuery, self).setUp()
+
+        self.committee = create(Builder('committee_model'))
+        self.period = create(Builder('period').having(committee=self.committee))
+
+    def test_active_returns_only_active(self):
+        create(Builder('period').having(workflow_state='closed',
+                                        committee=self.committee))
+
+        self.assertEqual([self.period], Period.query.active().all())
+
+    def test_by_committee_returns_periods_for_committee_in_all_states(self):
+        committee_2 = create(Builder('committee_model').having(int_id=123))
+        create(Builder('period').having(committee=committee_2))
+
+        period = create(Builder('period').having(workflow_state='closed',
+                                                 committee=self.committee))
+
+        self.assertEqual([self.period, period],
+                         Period.query.by_committee(self.committee).all())
+
+    def test_get_current(self):
+        create(Builder('period').having(workflow_state='closed',
+                                        committee=self.committee))
+
+        self.assertEqual(self.period, Period.query.get_current(self.committee))

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -487,4 +487,14 @@
         directory="profiles/4617"
         />
 
+    <!-- 4617 -> 4618 -->
+    <genericsetup:upgradeStep
+        title="Add periods table."
+        description=""
+        source="4617"
+        destination="4618"
+        handler="opengever.meeting.upgrades.to4618.AddPeriods"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -497,4 +497,13 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4618 -> 4619 -->
+    <upgrade-step:importProfile
+        title="Add close period action to committee."
+        profile="opengever.meeting:default"
+        source="4618"
+        destination="4619"
+        directory="profiles/4619"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/profiles/4619/types/opengever.meeting.committee.xml
+++ b/opengever/meeting/upgrades/profiles/4619/types/opengever.meeting.committee.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.committee"
+        i18n:domain="opengever.meeting"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <action
+        action_id="close-period"
+        visible="True"
+        title="Close current period"
+        url_expr="string:${object_url}/@@close-period"
+        condition_expr="object/@@close-period/available"
+        category="object_buttons">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>

--- a/opengever/meeting/upgrades/to4618.py
+++ b/opengever/meeting/upgrades/to4618.py
@@ -1,0 +1,48 @@
+from datetime import date
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import Date
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class AddPeriods(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4618
+
+    def migrate(self):
+        self.create_periods_table()
+        self.create_default_periods_for_committees()
+
+    def create_periods_table(self):
+        self.periods_table = self.op.create_table(
+            'periods',
+            Column('id', Integer, primary_key=True),
+            Column('committee_id', Integer,
+                   ForeignKey('committees.id'), nullable=False),
+            Column("workflow_state", String(255), nullable=False,
+                   default='active'),
+            Column('title', String(256), nullable=False),
+            Column('date_from', Date),
+            Column('date_to', Date),
+        )
+
+    def create_default_periods_for_committees(self):
+        self.committees_table = table("committees", column("id"))
+        self.date = date.today()
+        self.end_of_year = date(self.date.year, 12, 31)
+
+        for committee in self.connection.execute(
+                self.committees_table.select()).fetchall():
+            self.create_initial_period(committee)
+
+    def create_initial_period(self, committee):
+        self.execute(self.periods_table.insert().values(
+            committee_id=committee.id,
+            title=self.date.strftime('%Y').decode(),
+            date_from=self.date,
+            date_to=self.end_of_year))

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -1,9 +1,11 @@
+from datetime import date
 from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.document import Document
 from opengever.globalindex.handlers.task import sync_task
 from opengever.mail.mail import OGMail
+from opengever.meeting.model import Period
 from opengever.meeting.proposal import Proposal
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.testing import assets
@@ -333,7 +335,20 @@ class CommitteeBuilder(DexterityBuilder):
         self.arguments.pop('protocol_template', None)
 
         obj.create_model(self.arguments, self.container)
+        self.create_default_period(obj)
+
         super(CommitteeBuilder, self).after_create(obj)
+
+    def create_default_period(self, obj):
+        committee_model = obj.load_model()
+        today = date.today()
+        db_session = self.session.session
+
+        db_session.add(Period(committee=committee_model,
+                              title=unicode(today.year)))
+
+        if self.session.auto_commit:
+            db_session.flush()
 
 builder_registry.register('committee', CommitteeBuilder)
 

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -13,6 +13,7 @@ from opengever.meeting.model import Committee
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Member
 from opengever.meeting.model import Membership
+from opengever.meeting.model import Period
 from opengever.meeting.model import Proposal as ProposalModel
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.model.generateddocument import GeneratedProtocol
@@ -278,3 +279,15 @@ class LockBuilder(SqlObjectBuilder):
         return self
 
 builder_registry.register('lock', LockBuilder)
+
+
+class PeriodBuilder(SqlObjectBuilder):
+
+    mapped_class = Period
+    id_argument_name = 'period_id'
+
+    def __init__(self, session):
+        super(PeriodBuilder, self).__init__(session)
+        self.arguments['title'] = unicode(date.today().year)
+
+builder_registry.register('period', PeriodBuilder)


### PR DESCRIPTION
A period represents a timespan similar to a fiscal year.

  - Display the current period on committee overview.
  - Add a wizard to close the current and create its successor.
  - Add a wizard that creates an initial period upon committee creation.

Addresses the first part of #1065.

![screen shot 2015-11-18 at 17 53 30](https://cloud.githubusercontent.com/assets/736583/11247682/70112652-8e1d-11e5-8841-5c590333e730.png)

![untitled](https://cloud.githubusercontent.com/assets/736583/11247815/0859c2e8-8e1e-11e5-8a53-57aadadfe21d.gif)

