### PR TITLE
Add last modified column to meeting.

### DIFF
--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -184,8 +184,12 @@ class Meeting(Base):
         return values
 
     def update_model(self, data):
+        """Manually set the modified timestamp when updating meetings."""
+
         for key, value in data.items():
             setattr(self, key, value)
+
+        self.modified = utcnow_tz_aware()
 
     def get_title(self):
         if self.location:

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import Base
 from opengever.base.model import UTCDateTime
 from opengever.base.oguid import Oguid
@@ -81,6 +82,8 @@ class Meeting(Base):
     end = Column('end_datetime', UTCDateTime(timezone=True))
     workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False,
                             default=workflow.default_state.name)
+    modified = Column(UTCDateTime(timezone=True), nullable=False,
+                      default=utcnow_tz_aware)
 
     presidency = relationship(
         'Member', primaryjoin="Member.member_id==Meeting.presidency_id")

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4619</version>
+    <version>4620</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -84,3 +84,4 @@ class TestMeeting(FunctionalTestCase):
         dossier = meeting.dossier_oguid.resolve_object()
         self.assertIsNotNone(dossier)
         self.assertEquals(u'Meeting on Jan 01, 2010', dossier.title)
+        self.assertIsNotNone(meeting.modified)

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -149,6 +149,8 @@ class TestProtocol(FunctionalTestCase):
     def test_protocol_can_be_edited(self, browser):
         browser.login()
         browser.open(self.meeting.get_url(view='protocol'))
+        self.assertIsNotNone(self.meeting.modified)
+        prev_modified = self.meeting.modified
 
         browser.fill({'Legal basis': 'Yes we can',
                       'Initial position': 'Still the same',
@@ -162,6 +164,9 @@ class TestProtocol(FunctionalTestCase):
                       'Protocol start-page': '10'}).submit()
 
         self.assertEquals(['Changes saved'], info_messages())
+
+        meeting = Meeting.query.get(self.meeting.meeting_id)
+        self.assertGreater(meeting.modified, prev_modified)
 
         proposal = Proposal.query.get(self.proposal_model.proposal_id)
         self.assertEqual('Yes we can', proposal.legal_basis)
@@ -189,6 +194,7 @@ class TestProtocol(FunctionalTestCase):
         create(Builder('membership').having(
             member=hans,
             committee=self.committee_model).as_active())
+        prev_modified = self.meeting.modified
 
         browser.login()
         browser.open(self.meeting.get_url(view='protocol'))
@@ -199,6 +205,9 @@ class TestProtocol(FunctionalTestCase):
                       'Other Participants': 'Klara'}).submit()
 
         self.assertEquals(['Changes saved'], info_messages())
+
+        meeting = Meeting.query.get(self.meeting.meeting_id)
+        self.assertGreater(meeting.modified, prev_modified)
 
         # refresh intances
         meeting = Meeting.query.get(self.meeting.meeting_id)

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -506,4 +506,14 @@
         directory="profiles/4619"
         />
 
+    <!-- 4619 -> 4620 -->
+    <genericsetup:upgradeStep
+        title="Add modified timestamp to meeting."
+        description=""
+        source="4619"
+        destination="4620"
+        handler="opengever.meeting.upgrades.to4620.AddModifiedTimestampToMeeting"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4620.py
+++ b/opengever/meeting/upgrades/to4620.py
@@ -1,0 +1,38 @@
+from opengever.base.date_time import utcnow_tz_aware
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class AddModifiedTimestampToMeeting(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4620
+
+    def migrate(self):
+        self.add_modified_column()
+        self.insert_default_modified()
+        self.make_modified_non_nullable()
+
+    def add_modified_column(self):
+        self.op.add_column(
+            'meetings', Column('modified', DateTime(timezone=True),
+                               nullable=True))
+
+    def insert_default_modified(self):
+        """Insert time of migration as last modified timestamp."""
+
+        meeting_table = table(
+            'meetings',
+            column('id'),
+            column('modified'),
+        )
+
+        self.execute(meeting_table.update().values(modified=utcnow_tz_aware()))
+
+    def make_modified_non_nullable(self):
+        self.op.alter_column('meetings', 'modified',
+                             existing_type=DateTime(timezone=True),
+                             nullable=False)


### PR DESCRIPTION
Required by #1359.

*The column cannot be updated with onupdate since changes usually occur elsewehere, i.e. in an agenda item.*