### PR TITLE
Closing a meeting throws error on javascript.

### DIFF
--- a/opengever/meeting/browser/resources/agendaitems.js
+++ b/opengever/meeting/browser/resources/agendaitems.js
@@ -257,8 +257,8 @@
       mask: { loadSpeed: 0 }
     }).data("overlay");
 
-    this.openModal = function(e) {
-      self.currentItem = $(e.currentTarget);
+    this.openModal = function(target) {
+      self.currentItem = target;
       dialog.load();
     };
 


### PR DESCRIPTION
Because of https://github.com/4teamwork/opengever.core/pull/1369 the
controller no longer has the event as the first argument. So use the
target object from the callback to get the href from the modal.