### PR TITLE
Translate portal_repository comments.

### DIFF
--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -1,23 +1,26 @@
 from AccessControl import Unauthorized
 from AccessControl.SecurityManagement import getSecurityManager
-from OFS.interfaces import IObjectClonedEvent
-from Products.CMFCore.interfaces import ISiteRoot
-from Products.PluggableAuthService.interfaces.events import IUserLoggedOutEvent
-from ZPublisher.interfaces import IPubAfterTraversal
 from five import grok
+from OFS.interfaces import IObjectClonedEvent
 from opengever.base import _
 from plone.app.lockingbehavior.behaviors import ILocking
 from plone.app.relationfield.event import extract_relations
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.interfaces import IEditBegunEvent
 from plone.protect.interfaces import IDisableCSRFProtection
+from Products.CMFCore.interfaces import ISiteRoot
+from Products.PluggableAuthService.interfaces.events import IUserLoggedOutEvent
 from z3c.relationfield.event import _setRelation
 from zope.annotation import IAnnotations
 from zope.component.hooks import getSite
-from zope.interface import Interface
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 from zope.interface import alsoProvides
+from zope.interface import Interface
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectCreatedEvent
+from ZPublisher.interfaces import IPubAfterTraversal
+
 
 ALLOWED_VIEWS = set([
     'customlogo',
@@ -51,8 +54,9 @@ def create_initial_version(obj, event):
     history = pr.getHistory(obj)
 
     if history is not None and not len(history) > 0:
-        comment = _(u'label_initial_version_copied',
-                    default="Initial version (document copied)")
+        comment = translate(_(u'label_initial_version_copied',
+                            default="Initial version (document copied)"),
+                            context=getRequest())
         # Create an initial version
         pr._recursiveSave(obj, {}, pr._prepareSysMetadata(comment),
             autoapply=pr.autoapply)

--- a/opengever/document/checkout/handlers.py
+++ b/opengever/document/checkout/handlers.py
@@ -6,6 +6,8 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFEditions.interfaces.IArchivist import ArchivistUnregisteredError
 from Products.CMFEditions.interfaces.IModifier import FileTooLargeToVersionError
 from Products.CMFPlone.utils import base_hasattr
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 
 
@@ -42,6 +44,7 @@ def create_initial_version(context):
     else:
         change_note = _(u'initial_document_version_change_note',
                         default=u'Initial version')
+    change_note = translate(change_note, context=getRequest())
 
     changed = False
     if not base_hasattr(context, 'version_id'):

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -19,6 +19,7 @@ from z3c.relationfield.schema import RelationList
 from zExceptions import Unauthorized
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
+from zope.i18n import translate
 from zope.schema import TextLine
 import json
 
@@ -178,8 +179,10 @@ class ReceiveObject(grok.View):
         portal_path = '/'.join(api.portal.get().getPhysicalPath())
         intids = getUtility(IIntIds)
         repository = api.portal.get_tool('portal_repository')
-        comment = _(u"Updated with a newer docment version from proposal's "
-                    "dossier.")
+        comment = translate(
+            _(u"Updated with a newer docment version from proposal's "
+                "dossier."),
+            context=self.request)
         repository.save(obj=self.context, comment=comment)
 
         data = {

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -19,6 +19,8 @@ from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.locking.interfaces import ILockable
 from zope.component import getUtility
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 import json
 
 
@@ -235,9 +237,10 @@ class UpdateGeneratedDocumentCommand(object):
         document.file.data = self.generate_file_data()
 
         repository = api.portal.get_tool('portal_repository')
-        comment = _(u'Updated with a newer generated version from meeting '
-                    '${title}.',
-                    mapping=dict(title=self.meeting.get_title()))
+        comment = translate(
+            _(u'Updated with a newer generated version from meeting ${title}.',
+              mapping=dict(title=self.meeting.get_title())),
+            context=getRequest())
         repository.save(obj=document, comment=comment)
 
         new_version = document.get_current_version()


### PR DESCRIPTION
This PR fixes an issue with untranslated `portal_repository` comments. This issue affects all comments not only some meeting comments as stated in #1375.

When storing translated `Messages` in the `portal_repository` they are not translated automatically but need to be translated manually with `translate`.

Closes #1375.