### PR TITLE
Fixes activity upgradestep 4505 for MySQL.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Fixes activity upgradestep for mysql. Drop foreign key first before droping
+  the column when using mysql as OGDS backend.
+  [phgross]
+
 - Add meeting number to period and meeting.
   Each meeting is assigned a meeting number when the meeting is closed. The meeting number is unique per period.
   [deiferni]

--- a/opengever/activity/upgrades/to4505.py
+++ b/opengever/activity/upgrades/to4505.py
@@ -50,6 +50,10 @@ class ReplaceNotificationsWatcherRelation(SchemaMigration):
             )
 
     def remove_watcherid_column(self):
+        if self.is_mysql:
+            fk_name = self.get_foreign_key_name('notifications', 'watcher_id')
+            self.op.drop_constraint(fk_name, 'notifications', type_='foreignkey')
+
         self.op.drop_column('notifications', 'watcher_id')
 
     def make_userid_column_required(self):


### PR DESCRIPTION
On deployments with a MySQL OGDS backend the `ReplaceNotificationsWatcherRelation` Upgradestep has raised the following MySQL error:
```
  Module opengever.core.upgrade, line 100, in drop_column
  Module alembic.operations, line 650, in drop_column
  Module alembic.ddl.impl, line 179, in drop_column
  Module alembic.ddl.impl, line 122, in _exec
  Module sqlalchemy.engine.base, line 914, in execute
  Module sqlalchemy.sql.ddl, line 68, in _execute_on_connection
  Module sqlalchemy.engine.base, line 968, in _execute_ddl
  Module sqlalchemy.engine.base, line 1146, in _execute_context
  Module sqlalchemy.engine.base, line 1341, in _handle_dbapi_exception
  Module sqlalchemy.util.compat, line 199, in raise_from_cause
  Module sqlalchemy.engine.base, line 1139, in _execute_context
  Module sqlalchemy.engine.default, line 450, in do_execute
  Module MySQLdb.cursors, line 205, in execute
  Module MySQLdb.connections, line 36, in defaulterrorhandler
OperationalError: (_mysql_exceptions.OperationalError) (1553, "Cannot drop index 'watcher_id': needed in a foreign key constraint") [SQL: u'ALTER TABLE notifications DROP COLUMN watcher_id']
```

So the ugpradestep drops now the foreign key first, before dropping the column when using mysql as OGDS backend. Because MySQL has problem, to drop a column when an foreign_key constraint is registered for this column.

I've made the fix MySQL specific, because I won't touch the partly deployed implementation for Oracle and PostgreSQL.

Needs-backport: `4.5-stable`

@lukasgraf please review ...
