### PR TITLE
Saving protocol does not work.

### DIFF
--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -50,11 +50,6 @@
       });
     };
 
-    this.saveProtocol = function(target) {
-      var action = target.attr("action");
-      return $.post(action, target.serialize());
-    };
-
     this.events = {
       "submit##form": this.saveProtocol
     };


### PR DESCRIPTION
Fix for https://github.com/4teamwork/opengever.core/pull/1378

Probably because of a rebase issue the saveProtocol method is defined
twice.