### PR TITLE
Separates beschliessen eines AgendaItems 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add an option to decide a single agenda_item.
+  [phgross]
+
 - Add a view to fill sablon-templates with sample meeting-data.
   [deiferni]
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -110,8 +110,10 @@ class AgendaItemsView(BrowserView):
                 view='agenda_items/{}/delete'.format(item.agenda_item_id))
             data['edit_link'] = meeting.get_url(
                 view='agenda_items/{}/edit'.format(item.agenda_item_id))
-            data['decide_link'] = meeting.get_url(
-                view='agenda_items/{}/decide'.format(item.agenda_item_id))
+            if item.is_decide_possible():
+                data['decide_link'] = meeting.get_url(
+                    view='agenda_items/{}/decide'.format(item.agenda_item_id))
+
             agenda_items.append(data)
 
         return JSONResponse(self.request).data(items=agenda_items).dump()

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -174,7 +174,8 @@ class AgendaItemsView(BrowserView):
               default=u'Agenda Item Successfully deleted')).dump()
 
     def decide(self):
-        """Decide the current agendaitem and decide the meeting.
+        """Decide the current agendaitem and move the meeting in the
+        held state.
         """
         meeting_state = self.meeting.get_state()
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -99,6 +99,7 @@ AGENDAITEMS_TEMPLATE = '''
         <div class="button-group">
           <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>
           <a href="{{delete_link}}" title="%(label_delete_action)s" class="button delete-agenda-item"></a>
+          <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
         </div>
       </td>
       {{/if}}
@@ -324,10 +325,14 @@ class MeetingView(BrowserView):
         label_edit_save = translate(_('label_edit_save', default='Save'), context=self.request)
         label_edit_action = translate(_('label_edit_action', default='edit title'), context=self.request)
         label_delete_action = translate(_('label_delete_action', default='delete this agenda item'), context=self.request)
+        label_decide_action = translate(
+            _('label_decide_action', default='Decide this agenda item'),
+            context=self.request)
         return AGENDAITEMS_TEMPLATE  % {'label_edit_cancel': label_edit_cancel,
                                         'label_edit_save': label_edit_save,
                                         'label_edit_action': label_edit_action,
-                                        'label_delete_action': label_delete_action}
+                                        'label_delete_action': label_delete_action,
+                                        'label_decide_action': label_decide_action}
 
     def render_handlebars_proposals_template(self):
         label_schedule = translate(_('label_schedule', default='Schedule'), context=self.request)

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -61,7 +61,7 @@ AGENDAITEMS_TEMPLATE = '''
 <script id="agendaitemsTemplate" type="text/x-handlebars-template">
   {{#each agendaitems}}
     <tr class="{{css_class}}" data-uid={{id}}>
-      {{#if ../editable}}<td class="sortable-handle"></td>{{/if}}
+      {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
       <td class="number">{{number}}</td>
       <td class="title">
         <span>{{{link}}}</span>
@@ -97,8 +97,10 @@ AGENDAITEMS_TEMPLATE = '''
       {{#if ../editable}}
       <td class="actions">
         <div class="button-group">
-          <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>
-          <a href="{{delete_link}}" title="%(label_delete_action)s" class="button delete-agenda-item"></a>
+          {{#if ../agendalist_editable}}
+              <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>
+              <a href="{{delete_link}}" title="%(label_delete_action)s" class="button delete-agenda-item"></a>
+          {{/if}}
           <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
         </div>
       </td>
@@ -342,6 +344,9 @@ class MeetingView(BrowserView):
 
     def json_is_editable(self):
         return json.dumps(self.model.is_editable());
+
+    def json_is_agendalist_editable(self):
+        return json.dumps(self.model.is_agendalist_editable());
 
     @property
     def url_update_agenda_item_order(self):

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -101,7 +101,9 @@ AGENDAITEMS_TEMPLATE = '''
               <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>
               <a href="{{delete_link}}" title="%(label_delete_action)s" class="button delete-agenda-item"></a>
           {{/if}}
-          <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
+          {{#if decide_link}}
+            <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
+          {{/if}}
         </div>
       </td>
       {{/if}}

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -62,6 +62,22 @@
           </div>
         </div>
 
+        <div class="overlay" id="confirm_hold_meeting">
+          <h2 i18n:translate="hold_meeting">Hold meeting</h2>
+          <p i18n:translate="msg_hold_meeting_dialog">
+            When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable.
+          </p>
+          <p i18n:translate="">
+            Are you sure you want to decide this agendaitem?
+          </p>
+          <div class="button-group">
+            <button class="button confirm"
+                    i18n:translate="label_decide">Decide</button>
+            <button class="button decline"
+                    i18n:translate="label_cancel">Cancel</button>
+          </div>
+        </div>
+
         <div class="sidebar">
           <div tal:attributes="class python: 'list-group metadata' if meeting.is_editable() else 'full-width list-group metadata'">
             <div class="list-group-item submit">

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -63,7 +63,7 @@
         </div>
 
         <div class="overlay" id="confirm_hold_meeting">
-          <h2 i18n:translate="hold_meeting">Hold meeting</h2>
+          <h2 i18n:translate="decide_agendaitem">Decide Agendaitem</h2>
           <p i18n:translate="msg_hold_meeting_dialog">
             When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable.
           </p>
@@ -207,8 +207,8 @@
                 <input id="schedule-text" type="text" />
                 <div class="button-group">
                   <input type="submit"
-                         value="label_schedule"
-                         i18n:attributes="value"
+                         value="Schedule"
+                         i18n:attributes="value label_schedule"
                          tal:attributes="data-url view/url_schedule_text"
                          class="schedule-text allowMultiSubmit" />
                 </div>
@@ -218,8 +218,8 @@
                 <input id="schedule-paragraph" type="text" />
                 <div class="button-group">
                   <input type="submit"
-                         value="label_schedule"
-                         i18n:attributes="value"
+                         value="Schedule"
+                         i18n:attributes="value label_schedule"
                          tal:attributes="data-url view/url_schedule_paragraph"
                          class="schedule-paragraph allowMultiSubmit" />
                 </div>

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -21,7 +21,8 @@
            tal:attributes="data-update-agenda-item-order-url view/url_update_agenda_item_order;
                            data-list-agenda-items-url view/url_list_agenda_items;
                            data-list-unscheduled-proposals-url view/url_list_unscheduled_proposals;
-                           data-editable view/json_is_editable">
+                           data-editable view/json_is_editable;
+                           data-agendalist_editable view/json_is_agendalist_editable">
 
         <div class="overlay" id="confirm_unschedule">
           <div class="close">
@@ -179,7 +180,7 @@
         </div>
         <div class="content">
           <div class="collapsible"
-               tal:condition="meeting/is_editable">
+               tal:condition="meeting/is_agendalist_editable">
             <div class="collapsible-header">
               <button class="button fa fa-plus"></button>
               <span class="label" i18n:translate="">Agenda Items</span>
@@ -224,7 +225,7 @@
             <thead>
               <tr>
                 <th i18n:translate=""
-                    tal:condition="meeting/is_editable">Order</th>
+                    tal:condition="meeting/is_agendalist_editable">Order</th>
                 <th i18n:translate="">Number</th>
                 <th i18n:translate="">Title</th>
                 <th i18n:translate="">Documents</th>

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -132,6 +132,10 @@
       target.addClass('loading');
       return $.post(target.attr("href")).always(function(){
         target.removeClass('loading');
+      }).done(function(data){
+        if (data.redirectUrl){
+          window.location = data.redirectUrl;
+        }
       });
     };
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -28,6 +28,7 @@
 
     this.events = {
       "click##pending-closed": this.openModal,
+      "click##held-closed": this.openModal,
       "click##confirm_close_meeting .confirm!$": this.closeMeeting,
       "click##confirm_close_meeting .decline!": this.closeModal
     };

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -69,8 +69,13 @@
 
     this.fetch = function() { return $.get(viewlet.data().listAgendaItemsUrl); };
 
-    this.render = function(data) { self.outlet.html(self.template({ agendaitems: data.items,
-                                                                    editable: viewlet.data().editable })); };
+    this.render = function(data) {
+      self.outlet.html(self.template({
+        agendaitems: data.items,
+        editable: viewlet.data().editable,
+        agendalist_editable: viewlet.data().agendalist_editable
+      }));
+    };
 
     this.openModal = function(target) {
       this.currentItem = target;

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -123,9 +123,17 @@
 
     this.toggleAttachements = function(target) { target.parents("tr").toggleClass("expanded"); };
 
+    this.decide = function(target) {
+      target.addClass('loading');
+      return $.post(target.attr("href")).always(function(){
+        target.removeClass('loading');
+      });
+    };
+
     this.events = {
       "click#.delete-agenda-item": this.openModal,
       "click#.edit-agenda-item": this.showEditbox,
+      "click#.decide-agenda-item!": this.decide,
       "sortupdate##agenda_items tbody!$": this.updateSortOrder,
       "click#.toggle-attachements": this.toggleAttachements,
       "click##confirm_unschedule .confirm!$": this.unschedule,

--- a/opengever/meeting/browser/templates/macros.pt
+++ b/opengever/meeting/browser/templates/macros.pt
@@ -19,7 +19,7 @@
       <div tal:condition="view/transitions" class="actionButtons">
         <ul class="regular_buttons">
             <tal:block repeat="transition view/transitions">
-              <li>
+              <li tal:condition="transition/visible">
                 <a tal:attributes="href python: view.transition_url(transition);
                                    title transition/title;
                                    id transition/name;

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-27 09:50+0000\n"
+"POT-Creation-Date: 2015-12-03 12:57+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:248
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -61,18 +61,22 @@ msgstr "Periode hinzufügen"
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:202
 msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py:375
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:53
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:54
 msgid "Are you sure you want to close this meeting?"
 msgstr "Wollen sie diese Sitzung wirklich abschliessen?"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:70
+msgid "Are you sure you want to decide this agendaitem?"
+msgstr "Sind Sie sicher das Sie dieses Traktandum beschliessen möchten?"
 
 #: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
@@ -86,7 +90,7 @@ msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende
 msgid "Choose Agenda Items"
 msgstr "Traktanden auswählen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
 msgid "Close all proposals"
 msgstr "Alle Anträge werden abgeschlossen"
 
@@ -106,7 +110,7 @@ msgstr "Kommission"
 msgid "Committee Container"
 msgstr "Ordner mit Kommissionen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:33
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:34
 msgid "Delete"
 msgstr "Löschen"
 
@@ -114,11 +118,11 @@ msgstr "Löschen"
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:230
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Documents"
 msgstr "Dokumente"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -135,7 +139,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -143,7 +147,7 @@ msgstr "Protokollauszüge"
 msgid "Export settings"
 msgstr "Export-Einstellungen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:51
 msgid "Generate excerpts for all proposals"
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt"
 
@@ -200,11 +204,11 @@ msgstr "Ablageposition"
 msgid "Meeting Dossier"
 msgstr "Sitzungsdossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:128
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:145
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:259
+#: ./opengever/meeting/browser/meetings/meeting.py:264
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
@@ -216,19 +220,19 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:228
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "Number"
 msgstr "Nummer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:46
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:226
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:243
 msgid "Order"
 msgstr "Sortierung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:200
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
 msgid "Paragraph:"
 msgstr "Abschnitt:"
 
@@ -250,16 +254,16 @@ msgstr "Eigenschaften"
 msgid "Proposal"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:227
 msgid "Proposals:"
 msgstr "Anträge"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:139
-#: ./opengever/meeting/model/meeting.py:173
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:156
+#: ./opengever/meeting/model/meeting.py:233
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:176
+#: ./opengever/meeting/model/meeting.py:236
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
@@ -300,23 +304,23 @@ msgstr "Mehr anzeigen"
 msgid "Submitted Proposal"
 msgstr "Eingereichter Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:189
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:206
 msgid "Text:"
 msgstr "Freitext:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:214
+#: ./opengever/meeting/browser/meetings/meeting.py:219
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:229
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:246
 msgid "Title"
 msgstr "Titel"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:30
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:31
 msgid "Unschedule proposal"
 msgstr "Traktandum löschen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:51
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:52
 msgid "Update or create the protocol"
 msgstr "Das Protokoll wird erstellt oder aktualisiert"
 
@@ -333,30 +337,40 @@ msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 msgid "active"
 msgstr "Aktiv"
 
+#. Default: "Agenda Item decided."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:197
+msgid "agenda_item_decided"
+msgstr "Traktandum wurde beschlossen."
+
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:164
+#: ./opengever/meeting/browser/meetings/agendaitem.py:173
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:123
+#: ./opengever/meeting/browser/meetings/agendaitem.py:132
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
+#. Default: "Agenda Item decided and excerpt generated."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:194
+msgid "agenda_item_proposal_decided"
+msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
+
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:140
+#: ./opengever/meeting/browser/meetings/agendaitem.py:149
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:145
+#: ./opengever/meeting/browser/meetings/agendaitem.py:154
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:161
+#: ./opengever/meeting/browser/meetings/meeting.py:166
 msgid "button_cancel"
 msgstr "Abbrechen"
 
@@ -367,7 +381,7 @@ msgstr "Periode abschliessen"
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:145
+#: ./opengever/meeting/browser/meetings/meeting.py:150
 msgid "button_continue"
 msgstr "Weiter"
 
@@ -383,8 +397,8 @@ msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
 #. Default: "Close meeting"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:44
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+#: ./opengever/meeting/model/meeting.py:78
 msgid "close_meeting"
 msgstr "Abschliessen"
 
@@ -394,7 +408,7 @@ msgid "close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:65
+#: ./opengever/meeting/model/meeting.py:72
 #: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr "geschlossen"
@@ -482,12 +496,19 @@ msgid "column_to"
 msgstr "Von"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/proposal.py:119
 msgid "decide"
 msgstr "Beschliessen"
 
+#. Default: "Decide Agendaitem"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:66
+msgid "decide_agendaitem"
+msgstr "Traktandum beschliessen"
+
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/agendaitem.py:29
+#: ./opengever/meeting/model/proposal.py:104
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -501,7 +522,7 @@ msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Kommittee ve
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:155
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:172
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
@@ -510,17 +531,22 @@ msgstr "Protokoll herunterladen"
 msgid "form_label_update_protocol"
 msgstr "Protokoll aktualisieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:157
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:163
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
+
+#. Default: "Held"
+#: ./opengever/meeting/model/meeting.py:71
+msgid "held"
+msgstr "Durchgeführt"
 
 #: ./opengever/meeting/proposal.py:108
 msgid "help_considerations"
@@ -543,6 +569,11 @@ msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt wer
 msgid "help_title"
 msgstr ""
 
+#. Default: "Hold meeting"
+#: ./opengever/meeting/model/meeting.py:80
+msgid "hold"
+msgstr "Sitzung durchführen"
+
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:31
@@ -553,7 +584,7 @@ msgstr "Anhänge"
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/meetings/excerpt.py:152
 #: ./opengever/meeting/browser/meetings/protocol.py:179
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:35
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
 msgstr "Abbrechen"
 
@@ -600,6 +631,16 @@ msgstr "Von"
 msgid "label_date_to"
 msgstr "Bis"
 
+#. Default: "Decide"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
+msgid "label_decide"
+msgstr "Beschliessen"
+
+#. Default: "Decide this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:333
+msgid "label_decide_action"
+msgstr "Dieses Traktandum beschliessen"
+
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
 #: ./opengever/meeting/proposal.py:185
@@ -612,7 +653,7 @@ msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:326
+#: ./opengever/meeting/browser/meetings/meeting.py:331
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -633,12 +674,12 @@ msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:325
+#: ./opengever/meeting/browser/meetings/meeting.py:330
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:323
+#: ./opengever/meeting/browser/meetings/meeting.py:328
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
@@ -648,7 +689,7 @@ msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:324
+#: ./opengever/meeting/browser/meetings/meeting.py:329
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -670,7 +711,7 @@ msgid "label_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:212
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:229
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -745,7 +786,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:343
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -798,8 +839,8 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:333
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:192
+#: ./opengever/meeting/browser/meetings/meeting.py:342
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -827,7 +868,7 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Are you sure you want to delete this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:31
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:32
 msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
@@ -851,11 +892,11 @@ msgstr "Wählen Sie wie ein bestehendes Protokoll aktualisiert werden soll:"
 msgid "label_workflow_state"
 msgstr "Status"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:79
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:96
 msgid "location"
 msgstr "Ort"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:137
 msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
@@ -870,8 +911,13 @@ msgstr "Änderungen gespeichert"
 msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
+#. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+msgid "msg_hold_meeting_dialog"
+msgstr "Beim Abschluss dieses Traktandums wird die Sitzung in den Status `Durchgeführt`  versetzt. Anschliessend kann die Traktandenliste nicht mehr bearbeitet werden."
+
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/command.py:500
+#: ./opengever/meeting/model/meeting.py:58
 msgid "msg_meeting_successfully_closed"
 msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollauszüge wurden generiert und an die Urprungsdossiers zurückgespielt."
 
@@ -881,7 +927,7 @@ msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:35
+#: ./opengever/meeting/model/proposal.py:39
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
 
@@ -906,21 +952,22 @@ msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:179
+#: ./opengever/meeting/browser/meetings/agendaitem.py:217
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:127
 msgid "participants"
 msgstr "Teilnehmende"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:64
-#: ./opengever/meeting/model/proposal.py:95
+#: ./opengever/meeting/model/agendaitem.py:28
+#: ./opengever/meeting/model/meeting.py:70
+#: ./opengever/meeting/model/proposal.py:99
 msgid "pending"
 msgstr "In Bearbeitung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:96
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:113
 msgid "presidency"
 msgstr "Vorsitz"
 
@@ -975,30 +1022,30 @@ msgid "protocol_successfully_changed"
 msgstr "Protokoll erfolgreich gespeichert."
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:111
+#: ./opengever/meeting/model/proposal.py:115
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:99
+#: ./opengever/meeting/model/proposal.py:103
 msgid "scheduled"
 msgstr "Traktandiert"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:103
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
 msgid "secretary"
 msgstr "Protokollführer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
 msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:109
+#: ./opengever/meeting/model/proposal.py:113
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:97
+#: ./opengever/meeting/model/proposal.py:101
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1008,16 +1055,15 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:193
+#: ./opengever/meeting/browser/meetings/agendaitem.py:231
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:87
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:104
 msgid "time"
 msgstr "Zeit"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:117
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
-

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-27 09:50+0000\n"
+"POT-Creation-Date: 2015-12-03 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:248
 msgid "Actions"
 msgstr ""
 
@@ -61,17 +61,21 @@ msgstr ""
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:202
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py:375
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:53
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:54
 msgid "Are you sure you want to close this meeting?"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:70
+msgid "Are you sure you want to decide this agendaitem?"
 msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
@@ -86,7 +90,7 @@ msgstr ""
 msgid "Choose Agenda Items"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
 msgid "Close all proposals"
 msgstr ""
 
@@ -106,7 +110,7 @@ msgstr "Commission"
 msgid "Committee Container"
 msgstr "Conteneur avec commission"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:33
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:34
 msgid "Delete"
 msgstr ""
 
@@ -114,11 +118,11 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:230
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Documents"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
 msgid "Edit"
 msgstr ""
 
@@ -135,7 +139,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
 msgid "Excerpts"
 msgstr ""
 
@@ -143,7 +147,7 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:51
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
@@ -200,11 +204,11 @@ msgstr ""
 msgid "Meeting Dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:128
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:145
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:259
+#: ./opengever/meeting/browser/meetings/meeting.py:264
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -216,19 +220,19 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:228
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "Number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:46
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:226
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:243
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:200
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
 msgid "Paragraph:"
 msgstr ""
 
@@ -250,16 +254,16 @@ msgstr "Propriétés"
 msgid "Proposal"
 msgstr "Proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:227
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:139
-#: ./opengever/meeting/model/meeting.py:173
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:156
+#: ./opengever/meeting/model/meeting.py:233
 msgid "Protocol"
 msgstr "Procès-verbal"
 
-#: ./opengever/meeting/model/meeting.py:176
+#: ./opengever/meeting/model/meeting.py:236
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -300,23 +304,23 @@ msgstr "Afficher plus"
 msgid "Submitted Proposal"
 msgstr "Proposition soumise"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:189
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:206
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:214
+#: ./opengever/meeting/browser/meetings/meeting.py:219
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:229
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:246
 msgid "Title"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:30
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:31
 msgid "Unschedule proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:51
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:52
 msgid "Update or create the protocol"
 msgstr ""
 
@@ -333,30 +337,40 @@ msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 msgid "active"
 msgstr ""
 
+#. Default: "Agenda Item decided."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:197
+msgid "agenda_item_decided"
+msgstr ""
+
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:164
+#: ./opengever/meeting/browser/meetings/agendaitem.py:173
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:123
+#: ./opengever/meeting/browser/meetings/agendaitem.py:132
 msgid "agenda_item_order_updated"
 msgstr "Les points de l'ordre du jour ont été actualisés."
 
+#. Default: "Agenda Item decided and excerpt generated."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:194
+msgid "agenda_item_proposal_decided"
+msgstr ""
+
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:140
+#: ./opengever/meeting/browser/meetings/agendaitem.py:149
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:145
+#: ./opengever/meeting/browser/meetings/agendaitem.py:154
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:161
+#: ./opengever/meeting/browser/meetings/meeting.py:166
 msgid "button_cancel"
 msgstr "Annuler"
 
@@ -367,7 +381,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:145
+#: ./opengever/meeting/browser/meetings/meeting.py:150
 msgid "button_continue"
 msgstr ""
 
@@ -383,8 +397,8 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Close meeting"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:44
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+#: ./opengever/meeting/model/meeting.py:78
 msgid "close_meeting"
 msgstr ""
 
@@ -394,7 +408,7 @@ msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:65
+#: ./opengever/meeting/model/meeting.py:72
 #: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr "Fermé"
@@ -482,12 +496,19 @@ msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/proposal.py:119
 msgid "decide"
 msgstr "Décider"
 
+#. Default: "Decide Agendaitem"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:66
+msgid "decide_agendaitem"
+msgstr ""
+
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/agendaitem.py:29
+#: ./opengever/meeting/model/proposal.py:104
 msgid "decided"
 msgstr "Décidé"
 
@@ -501,7 +522,7 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:155
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:172
 msgid "download protocol"
 msgstr ""
 
@@ -510,16 +531,21 @@ msgstr ""
 msgid "form_label_update_protocol"
 msgstr "Actualiser le procès-verbal"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:157
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:163
 msgid "generate new version as word document"
+msgstr ""
+
+#. Default: "Held"
+#: ./opengever/meeting/model/meeting.py:71
+msgid "held"
 msgstr ""
 
 #: ./opengever/meeting/proposal.py:108
@@ -543,6 +569,11 @@ msgstr ""
 msgid "help_title"
 msgstr ""
 
+#. Default: "Hold meeting"
+#: ./opengever/meeting/model/meeting.py:80
+msgid "hold"
+msgstr ""
+
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:31
@@ -553,7 +584,7 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/meetings/excerpt.py:152
 #: ./opengever/meeting/browser/meetings/protocol.py:179
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:35
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
 msgstr ""
 
@@ -600,6 +631,16 @@ msgstr "De"
 msgid "label_date_to"
 msgstr "Jusqu'à"
 
+#. Default: "Decide"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
+msgid "label_decide"
+msgstr ""
+
+#. Default: "Decide this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:333
+msgid "label_decide_action"
+msgstr ""
+
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
 #: ./opengever/meeting/proposal.py:185
@@ -612,7 +653,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:326
+#: ./opengever/meeting/browser/meetings/meeting.py:331
 msgid "label_delete_action"
 msgstr ""
 
@@ -633,12 +674,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:325
+#: ./opengever/meeting/browser/meetings/meeting.py:330
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:323
+#: ./opengever/meeting/browser/meetings/meeting.py:328
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -648,7 +689,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:324
+#: ./opengever/meeting/browser/meetings/meeting.py:329
 msgid "label_edit_save"
 msgstr ""
 
@@ -670,7 +711,7 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:212
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:229
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -745,7 +786,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:343
 msgid "label_no_proposals"
 msgstr ""
 
@@ -798,8 +839,8 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:333
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:192
+#: ./opengever/meeting/browser/meetings/meeting.py:342
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
 msgid "label_schedule"
 msgstr ""
 
@@ -827,7 +868,7 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Are you sure you want to delete this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:31
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:32
 msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
@@ -851,11 +892,11 @@ msgstr "Choix de la manière dont un procès-verbal existant soit actualisé:"
 msgid "label_workflow_state"
 msgstr "Etat"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:79
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:96
 msgid "location"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:137
 msgid "meetingdossier"
 msgstr ""
 
@@ -870,8 +911,13 @@ msgstr "Modifications sauvegardées"
 msgid "message_record_created"
 msgstr "Enregistrement créé"
 
+#. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+msgid "msg_hold_meeting_dialog"
+msgstr ""
+
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/command.py:500
+#: ./opengever/meeting/model/meeting.py:58
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 
@@ -881,7 +927,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:35
+#: ./opengever/meeting/model/proposal.py:39
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -906,21 +952,22 @@ msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:179
+#: ./opengever/meeting/browser/meetings/agendaitem.py:217
 msgid "paragraph_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:127
 msgid "participants"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:64
-#: ./opengever/meeting/model/proposal.py:95
+#: ./opengever/meeting/model/agendaitem.py:28
+#: ./opengever/meeting/model/meeting.py:70
+#: ./opengever/meeting/model/proposal.py:99
 msgid "pending"
 msgstr "En modification"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:96
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:113
 msgid "presidency"
 msgstr ""
 
@@ -975,30 +1022,30 @@ msgid "protocol_successfully_changed"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:111
+#: ./opengever/meeting/model/proposal.py:115
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:99
+#: ./opengever/meeting/model/proposal.py:103
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:103
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
 msgid "secretary"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
 msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:109
+#: ./opengever/meeting/model/proposal.py:113
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:97
+#: ./opengever/meeting/model/proposal.py:101
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1008,16 +1055,16 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:193
+#: ./opengever/meeting/browser/meetings/agendaitem.py:231
 msgid "text_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:87
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:104
 msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:117
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-27 09:50+0000\n"
+"POT-Creation-Date: 2015-12-03 12:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:248
 msgid "Actions"
 msgstr ""
 
@@ -60,17 +60,21 @@ msgstr ""
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:202
 msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py:375
 msgid "An unexpected error has occurred"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:53
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:54
 msgid "Are you sure you want to close this meeting?"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:70
+msgid "Are you sure you want to decide this agendaitem?"
 msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
@@ -85,7 +89,7 @@ msgstr ""
 msgid "Choose Agenda Items"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
 msgid "Close all proposals"
 msgstr ""
 
@@ -105,7 +109,7 @@ msgstr ""
 msgid "Committee Container"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:33
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:34
 msgid "Delete"
 msgstr ""
 
@@ -113,11 +117,11 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:230
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Documents"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:85
 msgid "Edit"
 msgstr ""
 
@@ -134,7 +138,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:180
 msgid "Excerpts"
 msgstr ""
 
@@ -142,7 +146,7 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:50
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:51
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
@@ -199,11 +203,11 @@ msgstr ""
 msgid "Meeting Dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:128
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:145
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:259
+#: ./opengever/meeting/browser/meetings/meeting.py:264
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -215,19 +219,19 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:228
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "Number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:46
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:226
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:243
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:200
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
 msgid "Paragraph:"
 msgstr ""
 
@@ -249,16 +253,16 @@ msgstr ""
 msgid "Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:210
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:227
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:139
-#: ./opengever/meeting/model/meeting.py:173
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:156
+#: ./opengever/meeting/model/meeting.py:233
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:176
+#: ./opengever/meeting/model/meeting.py:236
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -299,23 +303,23 @@ msgstr ""
 msgid "Submitted Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:189
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:206
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:214
+#: ./opengever/meeting/browser/meetings/meeting.py:219
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:229
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:246
 msgid "Title"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:30
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:31
 msgid "Unschedule proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:51
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:52
 msgid "Update or create the protocol"
 msgstr ""
 
@@ -332,30 +336,40 @@ msgstr ""
 msgid "active"
 msgstr ""
 
+#. Default: "Agenda Item decided."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:197
+msgid "agenda_item_decided"
+msgstr ""
+
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:164
+#: ./opengever/meeting/browser/meetings/agendaitem.py:173
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:123
+#: ./opengever/meeting/browser/meetings/agendaitem.py:132
 msgid "agenda_item_order_updated"
 msgstr ""
 
+#. Default: "Agenda Item decided and excerpt generated."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:194
+msgid "agenda_item_proposal_decided"
+msgstr ""
+
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:140
+#: ./opengever/meeting/browser/meetings/agendaitem.py:149
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:145
+#: ./opengever/meeting/browser/meetings/agendaitem.py:154
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:161
+#: ./opengever/meeting/browser/meetings/meeting.py:166
 msgid "button_cancel"
 msgstr ""
 
@@ -366,7 +380,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:145
+#: ./opengever/meeting/browser/meetings/meeting.py:150
 msgid "button_continue"
 msgstr ""
 
@@ -382,8 +396,8 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Close meeting"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:44
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:45
+#: ./opengever/meeting/model/meeting.py:78
 msgid "close_meeting"
 msgstr ""
 
@@ -393,7 +407,7 @@ msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:65
+#: ./opengever/meeting/model/meeting.py:72
 #: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr ""
@@ -481,12 +495,19 @@ msgid "column_to"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/proposal.py:119
 msgid "decide"
 msgstr ""
 
+#. Default: "Decide Agendaitem"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:66
+msgid "decide_agendaitem"
+msgstr ""
+
 #. Default: "Decided"
-#: ./opengever/meeting/model/proposal.py:100
+#: ./opengever/meeting/model/agendaitem.py:29
+#: ./opengever/meeting/model/proposal.py:104
 msgid "decided"
 msgstr ""
 
@@ -500,7 +521,7 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:155
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:172
 msgid "download protocol"
 msgstr ""
 
@@ -509,16 +530,21 @@ msgstr ""
 msgid "form_label_update_protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:157
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:146
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:163
 msgid "generate new version as word document"
+msgstr ""
+
+#. Default: "Held"
+#: ./opengever/meeting/model/meeting.py:71
+msgid "held"
 msgstr ""
 
 #: ./opengever/meeting/proposal.py:108
@@ -542,6 +568,11 @@ msgstr ""
 msgid "help_title"
 msgstr ""
 
+#. Default: "Hold meeting"
+#: ./opengever/meeting/model/meeting.py:80
+msgid "hold"
+msgstr ""
+
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:31
@@ -552,7 +583,7 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/meetings/excerpt.py:152
 #: ./opengever/meeting/browser/meetings/protocol.py:179
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:35
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
 msgstr ""
 
@@ -599,6 +630,16 @@ msgstr ""
 msgid "label_date_to"
 msgstr ""
 
+#. Default: "Decide"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
+msgid "label_decide"
+msgstr ""
+
+#. Default: "Decide this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:333
+msgid "label_decide_action"
+msgstr ""
+
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
 #: ./opengever/meeting/proposal.py:185
@@ -611,7 +652,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:326
+#: ./opengever/meeting/browser/meetings/meeting.py:331
 msgid "label_delete_action"
 msgstr ""
 
@@ -632,12 +673,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:325
+#: ./opengever/meeting/browser/meetings/meeting.py:330
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:323
+#: ./opengever/meeting/browser/meetings/meeting.py:328
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -647,7 +688,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:324
+#: ./opengever/meeting/browser/meetings/meeting.py:329
 msgid "label_edit_save"
 msgstr ""
 
@@ -669,7 +710,7 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:212
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:229
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -744,7 +785,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:343
 msgid "label_no_proposals"
 msgstr ""
 
@@ -796,8 +837,9 @@ msgstr ""
 msgid "label_sablon_template_file"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:333
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:192
+#. Default: "Schedule"
+#: ./opengever/meeting/browser/meetings/meeting.py:342
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:209
 msgid "label_schedule"
 msgstr ""
 
@@ -825,7 +867,7 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Are you sure you want to delete this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:31
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:32
 msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
@@ -849,11 +891,11 @@ msgstr ""
 msgid "label_workflow_state"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:79
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:96
 msgid "location"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:137
 msgid "meetingdossier"
 msgstr ""
 
@@ -868,8 +910,13 @@ msgstr ""
 msgid "message_record_created"
 msgstr ""
 
+#. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:67
+msgid "msg_hold_meeting_dialog"
+msgstr ""
+
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/command.py:500
+#: ./opengever/meeting/model/meeting.py:58
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 
@@ -879,7 +926,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:35
+#: ./opengever/meeting/model/proposal.py:39
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -904,21 +951,22 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:179
+#: ./opengever/meeting/browser/meetings/agendaitem.py:217
 msgid "paragraph_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:127
 msgid "participants"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/meeting.py:64
-#: ./opengever/meeting/model/proposal.py:95
+#: ./opengever/meeting/model/agendaitem.py:28
+#: ./opengever/meeting/model/meeting.py:70
+#: ./opengever/meeting/model/proposal.py:99
 msgid "pending"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:96
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:113
 msgid "presidency"
 msgstr ""
 
@@ -973,30 +1021,30 @@ msgid "protocol_successfully_changed"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:111
+#: ./opengever/meeting/model/proposal.py:115
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:99
+#: ./opengever/meeting/model/proposal.py:103
 msgid "scheduled"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:103
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:120
 msgid "secretary"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:74
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:91
 msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:109
+#: ./opengever/meeting/model/proposal.py:113
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:97
+#: ./opengever/meeting/model/proposal.py:101
 msgid "submitted"
 msgstr ""
 
@@ -1006,16 +1054,16 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:193
+#: ./opengever/meeting/browser/meetings/agendaitem.py:231
 msgid "text_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:87
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:104
 msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:117
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -227,6 +227,9 @@ class AgendaItem(Base):
         return False
 
     def decide(self):
+        if self.get_state() == self.STATE_DECIDED:
+            return
+
         if self.has_proposal:
             self.proposal.generate_excerpt(self)
             self.proposal.decide()

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -229,6 +229,6 @@ class AgendaItem(Base):
             self.proposal.generate_excerpt(self)
             self.proposal.decide()
 
-        self.meeting.decide()
+        self.meeting.hold()
 
         self.workflow.execute_transition(None, self, 'pending-decided')

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -222,7 +222,9 @@ class AgendaItem(Base):
         return self.has_proposal and self.proposal.has_submitted_excerpt_document()
 
     def is_decide_possible(self):
-        return self.get_state() == self.STATE_PENDING
+        if not self.is_paragraph:
+            return self.get_state() == self.STATE_PENDING
+        return False
 
     def decide(self):
         if self.has_proposal:

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -223,3 +223,4 @@ class AgendaItem(Base):
             self.proposal.generate_excerpt(self)
             self.proposal.decide()
 
+        self.workflow.execute_transition(None, self, 'pending-decided')

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -145,6 +145,9 @@ class AgendaItem(Base):
             css_classes.append("expandable")
         return " ".join(css_classes)
 
+    def get_state(self):
+        return self.workflow.get_state(self.workflow_state)
+
     def remove(self):
         assert self.meeting.is_editable()
 
@@ -217,6 +220,9 @@ class AgendaItem(Base):
 
     def has_submitted_excerpt_document(self):
         return self.has_proposal and self.proposal.has_submitted_excerpt_document()
+
+    def is_decide_possible(self):
+        return self.get_state() == self.STATE_PENDING
 
     def decide(self):
         if self.has_proposal:

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -223,4 +223,6 @@ class AgendaItem(Base):
             self.proposal.generate_excerpt(self)
             self.proposal.decide()
 
+        self.meeting.decide()
+
         self.workflow.execute_transition(None, self, 'pending-decided')

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -1,5 +1,10 @@
 from opengever.base.model import Base
 from opengever.base.model import create_session
+from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
+from opengever.meeting import _
+from opengever.meeting.workflow import State
+from opengever.meeting.workflow import Transition
+from opengever.meeting.workflow import Workflow
 from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -15,10 +20,24 @@ class AgendaItem(Base):
     """An item must either have a reference to a proposal or a title.
 
     """
+
     __tablename__ = 'agendaitems'
+
+    # workflow definition
+    STATE_PENDING = State('pending', is_default=True,
+                          title=_('pending', default='Pending'))
+    STATE_DECIDED = State('decided', title=_('decided', default='Decided'))
+
+    workflow = Workflow(
+        [STATE_PENDING, STATE_DECIDED],
+        [Transition('pending', 'decided',
+                    title=_('decide', default='Decide'))]
+    )
 
     agenda_item_id = Column("id", Integer, Sequence("agendaitems_id_seq"),
                             primary_key=True)
+    workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False,
+                            default=workflow.default_state.name)
     proposal_id = Column(Integer, ForeignKey('proposals.id'))
     proposal = relationship("Proposal", uselist=False,
                             backref=backref('agenda_item', uselist=False))

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -170,6 +170,9 @@ class Meeting(Base):
         self.protocol_document.unlock_document()
 
     def decide(self):
+        if self.workflow_state == 'decided':
+            return
+
         for agenda_item in self.agenda_items:
             agenda_item.decide()
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -207,6 +207,9 @@ class Meeting(Base):
         return 'contenttype-opengever-meeting-meeting'
 
     def is_editable(self):
+        return self.get_state() in [self.STATE_PENDING, self.STATE_DECIDED]
+
+    def is_agendalist_editable(self):
         return self.get_state() == self.STATE_PENDING
 
     def has_protocol_document(self):

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4623</version>
+    <version>4624</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -147,13 +147,13 @@ class TestAgendaItemDecide(TestAgendaItem):
         self.container.excerpt_template = RelationValue(
             getUtility(IIntIds).getId(sablon_template))
 
-    def test_meeting_is_decided_when_deciding_an_agendaitem(self):
+    def test_meeting_is_held_when_deciding_an_agendaitem(self):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
 
         item.decide()
 
-        self.assertEquals('decided', self.meeting.workflow_state)
+        self.assertEquals('held', self.meeting.workflow_state)
 
     @browsing
     def test_decide_agenda_item(self, browser):

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -146,6 +146,14 @@ class TestAgendaItemDecide(TestAgendaItem):
         self.container.excerpt_template = RelationValue(
             getUtility(IIntIds).getId(sablon_template))
 
+    def test_meeting_is_decided_when_deciding_an_agendaitem(self):
+        item = create(Builder('agenda_item').having(
+            title=u'foo', meeting=self.meeting))
+
+        item.decide()
+
+        self.assertEquals('decided', self.meeting.workflow_state)
+
     @browsing
     def test_decide_agenda_item(self, browser):
         item = create(Builder('agenda_item').having(

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -155,6 +155,13 @@ class TestAgendaItemDecide(TestAgendaItem):
 
         self.assertEquals('held', self.meeting.workflow_state)
 
+    def test_decide_an_decided_agenda_item_is_ignored(self):
+        item = create(Builder('agenda_item').having(
+            title=u'foo', meeting=self.meeting))
+        item.decide()
+
+        item.decide()
+
     @browsing
     def test_decide_agenda_item(self, browser):
         item = create(Builder('agenda_item').having(

--- a/opengever/meeting/tests/test_decide.py
+++ b/opengever/meeting/tests/test_decide.py
@@ -1,0 +1,67 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.meeting.model import AgendaItem
+from opengever.meeting.model import Meeting
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.testing import FunctionalTestCase
+import transaction
+
+
+class TestDecideMeeting(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDecideMeeting, self).setUp()
+        self.repository_root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository')
+                                 .within(self.repository_root))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repository))
+        self.meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository))
+
+        self.sablon_template = create(
+            Builder('sablontemplate')
+            .with_asset_file('excerpt_template.docx'))
+        container = create(Builder('committee_container').having(
+            excerpt_template=self.sablon_template,
+            protocol_template=self.sablon_template))
+        self.committee = create(Builder('committee').within(container))
+
+        self.proposal_a = create(Builder('proposal')
+                                 .titled(u'Proposal A')
+                                 .within(self.dossier)
+                                 .as_submitted()
+                                 .having(committee=self.committee.load_model()))
+        self.proposal_b = create(Builder('proposal')
+                                 .titled(u'Proposal B')
+                                 .within(self.dossier)
+                                 .as_submitted()
+                                 .having(committee=self.committee.load_model()))
+
+        self.meeting = create(Builder('meeting')
+                              .having(committee=self.committee.load_model())
+                              .scheduled_proposals([self.proposal_a, self.proposal_b])
+                              .link_with(self.meeting_dossier))
+
+        # set correct public url, used for generated meeting urls
+        get_current_admin_unit().public_url = self.portal.absolute_url()
+        transaction.commit()
+
+    def test_change_workflow_state(self):
+        meeting = Meeting.query.first()
+        meeting.decide()
+
+        self.assertEquals('decided', meeting.workflow_state)
+
+    def test_generates_meeting_number(self):
+        meeting = Meeting.query.first()
+        meeting.decide()
+
+        self.assertEquals(1, meeting.meeting_number)
+
+    def test_generate_decision_numbers(self):
+        Meeting.query.first().decide()
+
+        item_a, item_b = AgendaItem.query.all()
+        self.assertEquals(1, item_a.decision_number)
+        self.assertEquals(2, item_b.decision_number)

--- a/opengever/meeting/tests/test_decide.py
+++ b/opengever/meeting/tests/test_decide.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Meeting
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -65,3 +66,10 @@ class TestDecideMeeting(FunctionalTestCase):
         item_a, item_b = AgendaItem.query.all()
         self.assertEquals(1, item_a.decision_number)
         self.assertEquals(2, item_b.decision_number)
+
+    @browsing
+    def test_decide_transition_is_not_visible(self, browser):
+        browser.login().open(self.meeting.get_url())
+
+        self.assertEquals(
+            ['Close meeting'], browser.css('.actionButtons a').text)

--- a/opengever/meeting/tests/test_hold.py
+++ b/opengever/meeting/tests/test_hold.py
@@ -8,10 +8,10 @@ from opengever.testing import FunctionalTestCase
 import transaction
 
 
-class TestDecideMeeting(FunctionalTestCase):
+class TestHoldMeeting(FunctionalTestCase):
 
     def setUp(self):
-        super(TestDecideMeeting, self).setUp()
+        super(TestHoldMeeting, self).setUp()
         self.repository_root = create(Builder('repository_root'))
         self.repository = create(Builder('repository')
                                  .within(self.repository_root))
@@ -50,25 +50,25 @@ class TestDecideMeeting(FunctionalTestCase):
 
     def test_change_workflow_state(self):
         meeting = Meeting.query.first()
-        meeting.decide()
+        meeting.hold()
 
-        self.assertEquals('decided', meeting.workflow_state)
+        self.assertEquals('held', meeting.workflow_state)
 
     def test_generates_meeting_number(self):
         meeting = Meeting.query.first()
-        meeting.decide()
+        meeting.hold()
 
         self.assertEquals(1, meeting.meeting_number)
 
     def test_generate_decision_numbers(self):
-        Meeting.query.first().decide()
+        Meeting.query.first().hold()
 
         item_a, item_b = AgendaItem.query.all()
         self.assertEquals(1, item_a.decision_number)
         self.assertEquals(2, item_b.decision_number)
 
     @browsing
-    def test_decide_transition_is_not_visible(self, browser):
+    def test_hold_transition_is_not_visible(self, browser):
         browser.login().open(self.meeting.get_url())
 
         self.assertEquals(

--- a/opengever/meeting/tests/test_unit_agenda_item.py
+++ b/opengever/meeting/tests/test_unit_agenda_item.py
@@ -87,6 +87,12 @@ class TestUnitAgendaItem(TestCase):
         self.assertFalse(
             self.simple_agenda_item.is_decide_possible())
 
+    def test_decide_is_not_possible_for_paragraphs(self):
+        item = create(Builder('agenda_item')
+                      .having(is_paragraph=True, meeting=self.meeting))
+
+        self.assertFalse(item.is_decide_possible())
+
     def test_get_state(self):
         item = self.simple_agenda_item
         self.assertEquals(item.STATE_PENDING, item.get_state())

--- a/opengever/meeting/tests/test_unit_agenda_item.py
+++ b/opengever/meeting/tests/test_unit_agenda_item.py
@@ -78,3 +78,18 @@ class TestUnitAgendaItem(TestCase):
                           'has_proposal': True,
                           'link': u'<a href="http://example.com/public/meetings/proposal-1" title="Pr\xf6posal">Pr\xf6posal</a>'},
                          self.proposal_agenda_item.serialize())
+
+    def test_decide_is_only_possible_if_agenda_item_is_pending(self):
+        self.assertTrue(
+            self.simple_agenda_item.is_decide_possible())
+
+        self.simple_agenda_item.workflow_state = 'decided'
+        self.assertFalse(
+            self.simple_agenda_item.is_decide_possible())
+
+    def test_get_state(self):
+        item = self.simple_agenda_item
+        self.assertEquals(item.STATE_PENDING, item.get_state())
+
+        item.workflow_state = 'decided'
+        self.assertEquals(item.STATE_DECIDED, item.get_state())

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -27,8 +27,21 @@ class TestUnitMeeting(TestCase):
 
     def test_is_editable(self):
         self.assertTrue(self.meeting.is_editable())
+
+        self.meeting.workflow_state = 'decided'
+        self.assertTrue(self.meeting.is_editable())
+
         self.meeting.workflow_state = 'closed'
         self.assertFalse(self.meeting.is_editable())
+
+    def test_is_agendalist_editable(self):
+        self.assertTrue(self.meeting.is_agendalist_editable())
+
+        self.meeting.workflow_state = 'decided'
+        self.assertFalse(self.meeting.is_agendalist_editable())
+
+        self.meeting.workflow_state = 'closed'
+        self.assertFalse(self.meeting.is_agendalist_editable())
 
     def test_has_protocol_document(self):
         self.assertFalse(self.meeting.has_protocol_document())

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -28,7 +28,7 @@ class TestUnitMeeting(TestCase):
     def test_is_editable(self):
         self.assertTrue(self.meeting.is_editable())
 
-        self.meeting.workflow_state = 'decided'
+        self.meeting.workflow_state = 'held'
         self.assertTrue(self.meeting.is_editable())
 
         self.meeting.workflow_state = 'closed'
@@ -37,7 +37,7 @@ class TestUnitMeeting(TestCase):
     def test_is_agendalist_editable(self):
         self.assertTrue(self.meeting.is_agendalist_editable())
 
-        self.meeting.workflow_state = 'decided'
+        self.meeting.workflow_state = 'held'
         self.assertFalse(self.meeting.is_agendalist_editable())
 
         self.meeting.workflow_state = 'closed'

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -545,4 +545,14 @@
         directory="profiles/4623"
     />
 
+    <!-- 4623 -> 4624 -->
+    <genericsetup:upgradeStep
+        title="Add workflow state to AgendaItem."
+        description=""
+        source="4623"
+        destination="4624"
+        handler="opengever.meeting.upgrades.to4624.AddWorkflowStateToAgendaItem"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4624.py
+++ b/opengever/meeting/upgrades/to4624.py
@@ -1,0 +1,51 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+# copied from opengever.globalindex.model.WORKFLOW_STATE_LENGTH
+WORKFLOW_STATE_LENGTH = 255
+
+
+class AddWorkflowStateToAgendaItem(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4624
+
+    def migrate(self):
+        self.add_workflow_state_column()
+        self.insert_workflow_state_data()
+        self.make_workflow_state()
+
+    def add_workflow_state_column(self):
+        self.op.add_column('agendaitems',
+                           Column('workflow_state',
+                                  String(WORKFLOW_STATE_LENGTH),
+                                  nullable=True))
+
+    def insert_workflow_state_data(self):
+        agenda_items_table = table(
+            'agendaitems',
+            column('id'), column('workflow_state'), column('meeting_id'))
+        self.execute(
+            agenda_items_table.update().values(workflow_state='pending'))
+
+        meeting_table = table('meetings',
+                              column('id'), column('workflow_state'))
+
+        for meeting in self.execute(
+                meeting_table
+                .select()
+                .where(meeting_table.c.workflow_state == 'closed')):
+
+            self.execute(agenda_items_table
+                         .update()
+                         .where(agenda_items_table.c.meeting_id == meeting.id)
+                         .values(workflow_state='decided'))
+
+    def make_workflow_state(self):
+        self.op.alter_column('agendaitems', 'workflow_state',
+                             existing_type=String(WORKFLOW_STATE_LENGTH),
+                             nullable=False)

--- a/opengever/meeting/workflow.py
+++ b/opengever/meeting/workflow.py
@@ -33,10 +33,11 @@ class State(object):
 
 class Transition(object):
 
-    def __init__(self, state_from, state_to, title=None):
+    def __init__(self, state_from, state_to, title=None, visible=True):
         self.state_from = state_from
         self.state_to = state_to
         self.title = title or self.name
+        self.visible = visible
 
     @property
     def name(self):


### PR DESCRIPTION
Wie in #1356 bereits beschrieben, müssen AgendaItems einzeln abgeschlossen werden können.
Dieser PR fügt diese Funktionalität hinzu.

Dazugehöriger PR: https://github.com/4teamwork/plonetheme.teamraum/pull/397

![bildschirmfoto 2015-12-01 um 14 09 33](https://cloud.githubusercontent.com/assets/485755/11524958/b196bd28-98cf-11e5-98a1-b029506de1bc.png)
![bildschirmfoto 2015-12-01 um 14 13 04](https://cloud.githubusercontent.com/assets/485755/11524956/b18c51d0-98cf-11e5-943c-9b25f1b8f5a0.png)
![bildschirmfoto 2015-12-01 um 14 10 00](https://cloud.githubusercontent.com/assets/485755/11524957/b1907710-98cf-11e5-9159-99e70de648b3.png)

Wird ein Traktandum beschlossen, so wird automatisch auch die Sitzung in den Status `beschlossen` versetzt. Im Status `beschlossen` kann zwar das Protokoll noch bearbeitet werden, die Traktandenliste ist aber fix (löschen, verschieben ist nicht mehr möglich) da die Sitzungs- und Beschlussnummern bereits vergeben sind.

Noch nicht Teil des PR sind folgende Wünsche/Anpassungen:
 - Aktualisieren eines Entscheids/Protokollauszug
 - Die Funktionalität für den Status `Communicated`

Stylings in separatem PR in `plonetheme.teamraum` umgesetzt.

@deiferni 