### PR TITLE
Save protocol only when clicking on save button.

### DIFF
--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -50,8 +50,11 @@
       });
     };
 
+    this.discardProtocol = function() { meetingStorage.deleteCurrentMeeting(); };
+
     this.events = {
       "click##form-buttons-save$": this.saveProtocol,
+      "click##form-buttons-cancel$": this.discardProtocol
     };
 
     this.init();

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -36,7 +36,7 @@
     }
 
     this.saveProtocol = function(target) {
-      var payload = target.serializeArray();
+      var payload = target.parents("form").serializeArray();
       payload.push({ name: "form.buttons.save", value: $("#form-buttons-save").val() });
       var action = target.attr("action");
       return $.ajax({
@@ -51,7 +51,7 @@
     };
 
     this.events = {
-      "submit##form": this.saveProtocol
+      "click##form-buttons-save$": this.saveProtocol,
     };
 
     this.init();


### PR DESCRIPTION
- Protocol gets saved when clicking cancel.
- Set event handler to save button instead of form.
- Discard localstorage saved protocol when hitting cancel.