### PR TITLE
Add meeting-data debug view for sablon templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Add a view to fill sablon-templates with sample meeting-data.
+  [deiferni]
+
 - Add meeting number to period and meeting.
   Each meeting is assigned a meeting number when the meeting is closed. The meeting number is unique per period.
   [deiferni]

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -1,0 +1,72 @@
+from five import grok
+from opengever.meeting.command import MIME_DOCX
+from opengever.meeting.sablon import Sablon
+from opengever.meeting.sablontemplate import ISablonTemplate
+import json
+
+
+SAMPLE_MEETING_DATA = {
+    '_sablon': {'properties': {'start_page_number': 42}},
+    'agenda_items': [{
+        'description': u'Strafbefehl wegen Bauens ohne Bewilligung',
+        'dossier_reference_number': 'FD 2.6.8/1',
+        'markdown:considerations': u'Die Bauten sind eindeutig Baubewilligungspflichtig. Gem\xe4ss \xa7 59 des Baugesetzes bed\xfcrfen alle Bauten und ihre im Hinblick auf die Anliegen der Raumplanung, des Umweltschutzes oder der Baupolizei wesentliche Umgestaltung, Erweiterung oder Zweck\xe4nderung sowie die Beseitigung von Geb\xe4uden der Bewilligung durch den Gemeinderat. Das Bauen ohne Baubewilligung stellt eine strafbare Handlung nach \xa7 160 Baugesetz dar. Strafbar ist die vors\xe4tzliche oder fahrl\xe4ssige Widerhandlung, begangen durch Bauherren, Eigent\xfcmer, sonstige Berechtigte, Projektverfasser, Unternehmer und Bauleiter. Im vorliegenden Fall ist der Straftatbestand durch den Bauherrn und seinen Sohn erf\xfcllt. Aus Gr\xfcnden der Gleichbehandlung mit anderen F\xe4llen ist der Gemeinderat gezwungen, die \xdcbertretung angemessen zu bestrafen.',
+        'markdown:decision': u'Die Bauherren werden gest\xfctzt auf \xa7 160 und in Anwendung von \xa7 162 des Baugesetzes wegen Bauens ohne Baubewilligung gesamthaft bestraft. Der Betrag von je Fr. 1000.-- ist - sofern keine Einsprache erfolgt - innert 30 Tagen der Finanzverwaltung der Gemeinde zu bezahlen.',
+        'markdown:discussion': u'Der Gemeinderat setzt sich geschlossen f\xfcr eine Busse ein.',
+        'markdown:initial_position': u'Im Fru\u0308hjahr wurde festgestellt, dass Irgendwer neue Nebenbauten auf einer Liegenschaft erstellt hatte. Auf die mu\u0308ndliche Aufforderung des Ressortvorstehers des Gemeinderates hin reichte er in der Folge ein Baugesuch ein, welches nach Kontrolle durch die Bauverwaltung erga\u0308nzt wurde. Es zeigte sich, dass ein fr\xfcher erstellter Holzschopf durch ein Gartenhaus ersetzt und ein Unterstand fu\u0308r ein Campingfahrzeug an einen fr\xfcher errichteten Holz- und Gera\u0308teschuppen angebaut worden war. Die Baubewilligung konnte nun erteilt werden, wobei die Zustimmung des Departementes Bau, Verkehr und Umwelt eingeholt werden musste, da sich die Bauvorhaben ausserhalb des Baugebietes befinden. Aus dem schriftlich begru\u0308ndeten Nachweis der Notwendigkeit der ausserhalb Baugebiet liegenden Bauten durch den Bauherrn geht hervor, dass das auch als Werkstatt dienende Gartenhaus von seinem in der gleichen Liegenschaft lebenden Sohn erstellt wurde. Er nutzt diese Baute auch.',
+        'markdown:legal_basis': u'Gegen diesen Strafbefehl k\xf6nnen die Geb\xfcssten innert 20 Tagen seit Er\xf6ffnung beim Gemeinderat schriftlich Einsprache erheben. Die Einsprache hat ein Begehren und eine Begr\xfcndung zu enthalten. In diesem Falle wird eine Einspracheverhandlung vor dem Gemeinderat durchgef\xfchrt, in deren Folge der Gemeinderat einen Entscheid mit Beschwerdem\xf6glichkeit an das Bezirksgericht f\xe4llt.',
+        'markdown:proposed_action': u'Busse',
+        'markdown:copy_for_attention': u'Hanspeter',
+        'markdown:disclose_to': u'Jans\xf6rg',
+        'markdown:publish_in': u'Tagblatt',
+        'number': '1.',
+        'title': u'Strafbefehl wegen Bauens ohne Bewilligung',
+        'is_paragraph': False,
+        'decision_number': 1}, {
+        'description': u'R\xfccktritt Hans Muster',
+        'dossier_reference_number': None,
+        'markdown:considerations': None,
+        'markdown:decision': u'Der Gemeinderat hat den R\xfccktritt genehmigt. Die Neuwahl eines Ersatzmitglieds f\xfcr Hans Muster erfolgt bald. Die Wahlvorschl\xe4ge sind n\xe4chstens bei der Kanzlei einzureichen. Falls ein 2. Wahlgang notwendig werden sollte, wird dieser danach durchgef\xfchrt. Die detaillierten Angaben \xfcber den Eingang der Wahlvorschl\xe4ge usw. sind ab sofort auf der Gemeindehomepage publiziert.',
+        'markdown:discussion': u'Hans Muster tritt als Gemeinderat zur\xfcck.',
+        'markdown:initial_position': None,
+        'markdown:legal_basis': None,
+        'markdown:proposed_action': None,
+        'markdown:copy_for_attention': None,
+        'markdown:disclose_to': None,
+        'markdown:publish_in': None,
+        'number': '2.',
+        'title': u'R\xfccktritt Hans Muster',
+        'is_paragraph': False,
+        'decision_number': 2}],
+    'mandant': {'name': u'Client1'},
+    'meeting': {'date': u'Dec 13, 2011',
+                'end_time': u'11:45 AM',
+                'start_time': u'09:30 AM',
+                'number': 11},
+    'participants': {
+        'members': [{'fullname': u'Peter Meier',
+                    'role': u'F\xfcrst'},
+                   {'fullname': u'Franz M\xfcller',
+                    'role': None}],
+        'other': [u'Hans M\xfcller', u'Heidi Muster']},
+    'protocol': {'type': u'Protocol'}}
+
+
+class FillMeetingTemplate(grok.View):
+    """View to fill a template with sample data for a meeting."""
+
+    grok.name('fill_meeting_template')
+    grok.context(ISablonTemplate)
+    grok.require('cmf.ManagePortal')
+
+    def render(self):
+        sablon = Sablon(self.context)
+        sablon.process(json.dumps(SAMPLE_MEETING_DATA))
+        assert sablon.is_processed_successfully(), sablon.stderr
+
+        response = self.request.response
+        response.setHeader('X-Theme-Disabled', 'True')
+        response.setHeader('Content-Type', MIME_DOCX)
+        response.setHeader("Content-Disposition",
+                           'attachment; filename="{}"'.format('template.docx'))
+        return sablon.file_data

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -1,6 +1,7 @@
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.meeting.browser.sablontemplate import SAMPLE_MEETING_DATA
 from opengever.meeting.protocol import ProtocolData
 from opengever.testing import FunctionalTestCase
 
@@ -13,12 +14,15 @@ class TestProtocolJsonData(FunctionalTestCase):
         super(TestProtocolJsonData, self).setUp()
         self.proposal = create(
             Builder('proposal_model')
-            .having(title=u'Proposal',
-                    initial_position=u'Initial',
-                    legal_basis=u'Legal!',
-                    proposed_action=u'Yep',
+            .having(title=u'Strafbefehl wegen Bauens ohne Bewilligung',
+                    initial_position=u'Im Fru\u0308hjahr wurde festgestellt, dass Irgendwer neue Nebenbauten auf einer Liegenschaft erstellt hatte. Auf die mu\u0308ndliche Aufforderung des Ressortvorstehers des Gemeinderates hin reichte er in der Folge ein Baugesuch ein, welches nach Kontrolle durch die Bauverwaltung erga\u0308nzt wurde. Es zeigte sich, dass ein fr\xfcher erstellter Holzschopf durch ein Gartenhaus ersetzt und ein Unterstand fu\u0308r ein Campingfahrzeug an einen fr\xfcher errichteten Holz- und Gera\u0308teschuppen angebaut worden war. Die Baubewilligung konnte nun erteilt werden, wobei die Zustimmung des Departementes Bau, Verkehr und Umwelt eingeholt werden musste, da sich die Bauvorhaben ausserhalb des Baugebietes befinden. Aus dem schriftlich begru\u0308ndeten Nachweis der Notwendigkeit der ausserhalb Baugebiet liegenden Bauten durch den Bauherrn geht hervor, dass das auch als Werkstatt dienende Gartenhaus von seinem in der gleichen Liegenschaft lebenden Sohn erstellt wurde. Er nutzt diese Baute auch.',
+                    legal_basis=u'Gegen diesen Strafbefehl k\xf6nnen die Geb\xfcssten innert 20 Tagen seit Er\xf6ffnung beim Gemeinderat schriftlich Einsprache erheben. Die Einsprache hat ein Begehren und eine Begr\xfcndung zu enthalten. In diesem Falle wird eine Einspracheverhandlung vor dem Gemeinderat durchgef\xfchrt, in deren Folge der Gemeinderat einen Entscheid mit Beschwerdem\xf6glichkeit an das Bezirksgericht f\xe4llt.',
+                    proposed_action=u'Busse',
                     dossier_reference_number='FD 2.6.8/1',
-                    considerations=u'We should think about it'))
+                    considerations=u'Die Bauten sind eindeutig Baubewilligungspflichtig. Gem\xe4ss \xa7 59 des Baugesetzes bed\xfcrfen alle Bauten und ihre im Hinblick auf die Anliegen der Raumplanung, des Umweltschutzes oder der Baupolizei wesentliche Umgestaltung, Erweiterung oder Zweck\xe4nderung sowie die Beseitigung von Geb\xe4uden der Bewilligung durch den Gemeinderat. Das Bauen ohne Baubewilligung stellt eine strafbare Handlung nach \xa7 160 Baugesetz dar. Strafbar ist die vors\xe4tzliche oder fahrl\xe4ssige Widerhandlung, begangen durch Bauherren, Eigent\xfcmer, sonstige Berechtigte, Projektverfasser, Unternehmer und Bauleiter. Im vorliegenden Fall ist der Straftatbestand durch den Bauherrn und seinen Sohn erf\xfcllt. Aus Gr\xfcnden der Gleichbehandlung mit anderen F\xe4llen ist der Gemeinderat gezwungen, die \xdcbertretung angemessen zu bestrafen.',
+                    copy_for_attention=u'Hanspeter',
+                    disclose_to=u'Jans\xf6rg',
+                    publish_in=u'Tagblatt'))
         self.committee = create(Builder('committee_model'))
         self.member_peter = create(Builder('member'))
         self.member_franz = create(Builder('member')
@@ -47,63 +51,17 @@ class TestProtocolJsonData(FunctionalTestCase):
             Builder('agenda_item').having(
                 proposal=self.proposal,
                 meeting=self.meeting,
-                discussion=u'Hmm',
-                decision=u'Do it',
+                decision=u'Die Bauherren werden gest\xfctzt auf \xa7 160 und in Anwendung von \xa7 162 des Baugesetzes wegen Bauens ohne Baubewilligung gesamthaft bestraft. Der Betrag von je Fr. 1000.-- ist - sofern keine Einsprache erfolgt - innert 30 Tagen der Finanzverwaltung der Gemeinde zu bezahlen.',
+                discussion=u'Der Gemeinderat setzt sich geschlossen f\xfcr eine Busse ein.',
                 decision_number=1))
         self.agend_item_text = create(
             Builder('agenda_item').having(
-                title=u'Free Text',
+                title=u'R\xfccktritt Hans Muster',
                 meeting=self.meeting,
-                discussion=u'Blah',
-                decision=u'Done',
+                discussion=u'Hans Muster tritt als Gemeinderat zur\xfcck.',
+                decision=u'Der Gemeinderat hat den R\xfccktritt genehmigt. Die Neuwahl eines Ersatzmitglieds f\xfcr Hans Muster erfolgt bald. Die Wahlvorschl\xe4ge sind n\xe4chstens bei der Kanzlei einzureichen. Falls ein 2. Wahlgang notwendig werden sollte, wird dieser danach durchgef\xfchrt. Die detaillierten Angaben \xfcber den Eingang der Wahlvorschl\xe4ge usw. sind ab sofort auf der Gemeindehomepage publiziert.',
                 decision_number=2))
 
     def test_protocol_json(self):
         data = ProtocolData(self.meeting).data
-        self.assertEqual(
-            {'_sablon': {'properties': {'start_page_number': 42}},
-             'agenda_items': [
-                {'description': u'Proposal',
-                 'dossier_reference_number': 'FD 2.6.8/1',
-                 'markdown:considerations': u'We should think about it',
-                 'markdown:decision': u'Do it',
-                 'markdown:discussion': u'Hmm',
-                 'markdown:initial_position': u'Initial',
-                 'markdown:legal_basis': u'Legal!',
-                 'markdown:proposed_action': u'Yep',
-                 'markdown:copy_for_attention': None,
-                 'markdown:disclose_to': None,
-                 'markdown:publish_in': None,
-                 'number': '1.',
-                 'title': u'Proposal',
-                 'is_paragraph': False,
-                 'decision_number': 1},
-                {'description': u'Free Text',
-                 'dossier_reference_number': None,
-                 'markdown:considerations': None,
-                 'markdown:decision': u'Done',
-                 'markdown:discussion': u'Blah',
-                 'markdown:initial_position': None,
-                 'markdown:legal_basis': None,
-                 'markdown:proposed_action': None,
-                 'markdown:copy_for_attention': None,
-                 'markdown:disclose_to': None,
-                 'markdown:publish_in': None,
-                 'number': '2.',
-                 'title': u'Free Text',
-                 'is_paragraph': False,
-                 'decision_number': 2}],
-             'mandant': {'name': u'Client1'},
-             'meeting': {'date': u'Dec 13, 2011',
-                         'end_time': u'11:45 AM',
-                         'start_time': u'09:30 AM',
-                         'number': 11},
-             'participants': {
-                'members': [{'fullname': u'Peter Meier',
-                             'role': u'F\xfcrst'},
-                            {'fullname': u'Franz M\xfcller',
-                             'role': None}],
-                'other': [u'Hans M\xfcller', u'Heidi Muster']},
-             'protocol': {'type': u'Protocol'}},
-            data
-        )
+        self.assertDictEqual(SAMPLE_MEETING_DATA, data)

--- a/opengever/meeting/tests/test_sablon_template.py
+++ b/opengever/meeting/tests/test_sablon_template.py
@@ -1,0 +1,27 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.command import MIME_DOCX
+from opengever.testing import FunctionalTestCase
+
+
+class TestSablonTemplateView(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestSablonTemplateView, self).setUp()
+        self.templates = create(Builder('templatedossier'))
+        self.sablon_template = create(
+            Builder('sablontemplate')
+            .within(self.templates)
+            .with_asset_file('sablon_template.docx'))
+
+    @browsing
+    def test_sablon_template_debug_view_returns_rendered_template(self, browser):
+        self.grant('Manager')
+        browser.login().open(self.sablon_template, view='fill_meeting_template')
+
+        self.assertEqual(browser.headers['content-type'], MIME_DOCX)
+        self.assertIsNotNone(browser.contents)


### PR DESCRIPTION
This view aims to simplify modifying templates by providing a method to debug them without the need to setup additional content.

Closes #1385.