### PR TITLE
Allow rejecting proposals from a committee.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Allow rejecting proposals from a committee. It is possible to enter an optional comment.
+  [deiferni]
+
 - Add an option to decide a single agenda_item.
   [phgross]
 

--- a/opengever/base/security.py
+++ b/opengever/base/security.py
@@ -2,7 +2,9 @@ from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import setSecurityManager
 from AccessControl.SecurityManagement import SpecialUsers
+from AccessControl.User import UnrestrictedUser as BaseUnrestrictedUser
 from contextlib import contextmanager
+from plone import api
 from zope.globalrequest import getRequest
 
 
@@ -14,3 +16,41 @@ def changed_security(user=SpecialUsers.system):
     yield
 
     setSecurityManager(old_manager)
+
+
+class UnrestrictedUser(BaseUnrestrictedUser):
+    """Unrestricted user that still has an id.
+    """
+
+    def getId(self):
+        """Return the ID of the user.
+        """
+        return self.getUserName()
+
+
+@contextmanager
+def elevated_privileges():
+    """Temporarily elevate current user's privileges.
+
+    See http://docs.plone.org/develop/plone/security/permissions.html#bypassing-permission-checks
+    for more documentation on this code.
+
+    """
+    old_manager = getSecurityManager()
+    try:
+        # Clone the current user and assign a new role.
+        # Note that the username (getId()) is left in exception
+        # tracebacks in the error_log,
+        # so it is an important thing to store.
+        tmp_user = UnrestrictedUser(
+            api.user.get_current().getId(), '', ('manage', ), ''
+            )
+
+        # Wrap the user in the acquisition context of the portal
+        tmp_user = tmp_user.__of__(api.portal.get().acl_users)
+        newSecurityManager(getRequest(), tmp_user)
+
+        yield
+    finally:
+        # Restore the old security manager
+        setSecurityManager(old_manager)

--- a/opengever/base/tests/test_security.py
+++ b/opengever/base/tests/test_security.py
@@ -1,5 +1,6 @@
 from AccessControl.SecurityManagement import SpecialUsers
 from opengever.base.security import changed_security
+from opengever.base.security import elevated_privileges
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
@@ -17,4 +18,16 @@ class TestSecurity(FunctionalTestCase):
             self.assertEqual(
                 SpecialUsers.system.getUserName(),
                 api.user.get_current().getUserName())
+        self.assertEqual(self.test_user, api.user.get_current())
+
+    def test_elevated_privileges_sets_priviledged_user_and_restores_old(self):
+        self.assertEqual(self.test_user, api.user.get_current())
+        self.assertNotIn('manage', api.user.get_current().getRoles())
+
+        with elevated_privileges():
+            current_user = api.user.get_current()
+            self.assertEqual(self.test_user, current_user)
+            self.assertIn('manage', current_user.getRoles())
+
+        self.assertNotIn('manage', api.user.get_current().getRoles())
         self.assertEqual(self.test_user, api.user.get_current())

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -79,6 +79,9 @@
 
               <h3 tal:content="structure history_record/message" i18n:translate="">
               </h3>
+              <div tal:condition="history_record/text" class="text"
+                   tal:content="history_record/text">
+              </div>
             </div>
           </div>
           <div style="clear:both"><!-- --></div>

--- a/opengever/meeting/browser/proposaltransitions.py
+++ b/opengever/meeting/browser/proposaltransitions.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from five import grok
 from opengever.meeting import _
 from opengever.meeting.proposal import IProposal
+from plone import api
 from plone.protect.utils import addTokenToUrl
 from plone.z3cform import layout
 from z3c.form.field import Fields
@@ -65,18 +66,21 @@ class RejectProposalForm(Form):
 
         self.reject_proposal(data['comment'])
         committee = aq_parent(aq_inner(self.context))
+
+        api.portal.show_message(
+            _(u"The proposal has been rejected successfully"),
+            request=self.request)
         self.redirect(committee)
 
     def reject_proposal(self, comment):
-        proposal = self.context.load_model()
-        proposal.reject(comment)
+        self.context.reject(comment)
 
     @button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
     def cancel(self, action):
         return self.redirect(self.context)
 
     def redirect(self, content):
-        return self.request.RESPONSE.redirect(self.context.absolute_url())
+        return self.request.RESPONSE.redirect(content.absolute_url())
 
 
 class RejectProposalView(layout.FormWrapper, grok.View):

--- a/opengever/meeting/browser/proposaltransitions.py
+++ b/opengever/meeting/browser/proposaltransitions.py
@@ -1,7 +1,16 @@
+from Acqusition import aq_inner
+from Acqusition import aq_parent
 from five import grok
+from opengever.meeting import _
 from opengever.meeting.proposal import IProposal
 from plone.protect.utils import addTokenToUrl
+from plone.z3cform import layout
+from z3c.form.field import Fields
+from z3c.form.form import button
+from z3c.form.form import Form
 from zExceptions import NotFound
+from zope import schema
+from zope.interface import Interface
 
 
 class ProposalTransitionController(grok.View):
@@ -12,7 +21,7 @@ class ProposalTransitionController(grok.View):
     @classmethod
     def url_for(cls, context, transition):
         return addTokenToUrl("{}/@@{}?transition={}".format(
-                context.absolute_url(), cls.__view_name__, transition))
+            context.absolute_url(), cls.__view_name__, transition))
 
     def render(self):
         transition = self.request.get('transition')
@@ -32,4 +41,50 @@ class ProposalTransitionController(grok.View):
         response = self.request.RESPONSE
         if response.status != 302:  # only redirect if not already redirecting
             return response.redirect(self.context.absolute_url())
+
+
+class IRejectProposalSchema(Interface):
+
+    comment = schema.Text(
+        title=_(u'label_reject_proposal_comment', default=u'Comment'),
+        description=_(u'help_reject_proposal_comment',
+                      default=u'Describe why the proposal is rejected'),
+        required=False)
+
+
+class RejectProposalForm(Form):
+    fields = Fields(IRejectProposalSchema)
+    ignoreContext = True
+    label = _(u'heading_reject_proposal_form', u'Reject proposal')
+
+    @button.buttonAndHandler(_(u'reject', default=u'Reject'))
+    def reject_handler(self, action):
+        data, errors = self.extractData()
+        if len(errors) > 0:
+            return
+
+        self.reject_proposal(data['comment'])
+        committee = aq_parent(aq_inner(self.context))
+        self.redirect(committee)
+
+    def reject_proposal(self, comment):
+        proposal = self.context.load_model()
+        proposal.reject(comment)
+
+    @button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def cancel(self, action):
+        return self.redirect(self.context)
+
+    def redirect(self, content):
         return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+
+class RejectProposalView(layout.FormWrapper, grok.View):
+    grok.context(IProposal)
+    grok.name('reject_proposal')
+    grok.require('cmf.ModifyPortalContent')
+    form = RejectProposalForm
+
+    def __init__(self, context, request):
+        layout.FormWrapper.__init__(self, context, request)
+        grok.View.__init__(self, context, request)

--- a/opengever/meeting/browser/proposaltransitions.py
+++ b/opengever/meeting/browser/proposaltransitions.py
@@ -1,5 +1,5 @@
-from Acqusition import aq_inner
-from Acqusition import aq_parent
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from five import grok
 from opengever.meeting import _
 from opengever.meeting.proposal import IProposal

--- a/opengever/meeting/browser/proposaltransitions.py
+++ b/opengever/meeting/browser/proposaltransitions.py
@@ -29,4 +29,7 @@ class ProposalTransitionController(grok.View):
         return self.context.execute_transition(transition_name)
 
     def redirect_to_proposal(self):
+        response = self.request.RESPONSE
+        if response.status != 302:  # only redirect if not already redirecting
+            return response.redirect(self.context.absolute_url())
         return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/meeting/browser/proposaltransitions.py
+++ b/opengever/meeting/browser/proposaltransitions.py
@@ -46,9 +46,9 @@ class ProposalTransitionController(grok.View):
 
 class IRejectProposalSchema(Interface):
 
-    comment = schema.Text(
-        title=_(u'label_reject_proposal_comment', default=u'Comment'),
-        description=_(u'help_reject_proposal_comment',
+    text = schema.Text(
+        title=_(u'label_reject_proposal_text', default=u'Comment'),
+        description=_(u'help_reject_proposal_text',
                       default=u'Describe why the proposal is rejected'),
         required=False)
 
@@ -64,7 +64,7 @@ class RejectProposalForm(Form):
         if len(errors) > 0:
             return
 
-        self.reject_proposal(data['comment'])
+        self.reject_proposal(data['text'])
         committee = aq_parent(aq_inner(self.context))
 
         api.portal.show_message(
@@ -72,8 +72,8 @@ class RejectProposalForm(Form):
             request=self.request)
         self.redirect(committee)
 
-    def reject_proposal(self, comment):
-        self.context.reject(comment)
+    def reject_proposal(self, text):
+        self.context.reject(text)
 
     @button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
     def cancel(self, action):

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-03 12:57+0000\n"
+"POT-Creation-Date: 2015-12-07 12:39+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:325
+#: ./opengever/meeting/command.py:309
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
@@ -57,7 +57,7 @@ msgstr "Neue Periode hinzufügen"
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:358
+#: ./opengever/meeting/command.py:342
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
@@ -114,7 +114,7 @@ msgstr "Ordner mit Kommissionen"
 msgid "Delete"
 msgstr "Löschen"
 
-#: ./opengever/meeting/command.py:288
+#: ./opengever/meeting/command.py:272
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
@@ -312,6 +312,10 @@ msgstr "Freitext:"
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
+#: ./opengever/meeting/browser/proposaltransitions.py:71
+msgid "The proposal has been rejected successfully"
+msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
+
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:246
 msgid "Title"
 msgstr "Titel"
@@ -328,7 +332,7 @@ msgstr "Das Protokoll wird erstellt oder aktualisiert"
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
-#: ./opengever/meeting/command.py:241
+#: ./opengever/meeting/command.py:225
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
@@ -384,11 +388,6 @@ msgstr "Periode abschliessen"
 #: ./opengever/meeting/browser/meetings/meeting.py:150
 msgid "button_continue"
 msgstr "Weiter"
-
-#. Default: "Generate"
-#: ./opengever/meeting/browser/protocol.py:127
-msgid "button_generate"
-msgstr "Erstellen"
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
@@ -497,7 +496,7 @@ msgstr "Von"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:34
-#: ./opengever/meeting/model/proposal.py:119
+#: ./opengever/meeting/model/proposal.py:128
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -508,7 +507,7 @@ msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:29
-#: ./opengever/meeting/model/proposal.py:104
+#: ./opengever/meeting/model/proposal.py:111
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -526,11 +525,6 @@ msgstr "Dossier"
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
-#. Default: "Update protocol"
-#: ./opengever/meeting/browser/protocol.py:114
-msgid "form_label_update_protocol"
-msgstr "Protokoll aktualisieren"
-
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
@@ -543,29 +537,39 @@ msgstr "Protokoll als Worddokument generieren"
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
+#. Default: "Reject proposal"
+#: ./opengever/meeting/browser/proposaltransitions.py:59
+msgid "heading_reject_proposal_form"
+msgstr "Antrag zurückweisen"
+
 #. Default: "Held"
 #: ./opengever/meeting/model/meeting.py:71
 msgid "held"
 msgstr "Durchgeführt"
 
-#: ./opengever/meeting/proposal.py:108
+#: ./opengever/meeting/proposal.py:109
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:96
+#: ./opengever/meeting/proposal.py:97
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:102
+#: ./opengever/meeting/proposal.py:103
 msgid "help_proposed_action"
 msgstr ""
+
+#. Default: "Describe why the proposal is rejected"
+#: ./opengever/meeting/browser/proposaltransitions.py:51
+msgid "help_reject_proposal_text"
+msgstr "Beschreiben Sie warum der Antrag zurückgewiesen wird"
 
 #. Default: "Select the target dossier where the excerpts should be created."
 #: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt werden soll."
 
-#: ./opengever/meeting/proposal.py:84
+#: ./opengever/meeting/proposal.py:85
 msgid "help_title"
 msgstr ""
 
@@ -577,7 +581,7 @@ msgstr "Sitzung durchführen"
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:31
-#: ./opengever/meeting/proposal.py:132
+#: ./opengever/meeting/proposal.py:133
 msgid "label_attachments"
 msgstr "Anhänge"
 
@@ -591,19 +595,19 @@ msgstr "Abbrechen"
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:37
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:44
+#: ./opengever/meeting/proposal.py:45
 msgid "label_committee"
 msgstr "Kommission"
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:53
-#: ./opengever/meeting/proposal.py:107
+#: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:89
-#: ./opengever/meeting/proposal.py:74
+#: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
@@ -643,12 +647,12 @@ msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
-#: ./opengever/meeting/proposal.py:185
+#: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr "Beschluss"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:191
+#: ./opengever/meeting/proposal.py:192
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
@@ -659,7 +663,7 @@ msgstr "Traktandum löschen"
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:82
-#: ./opengever/meeting/proposal.py:69
+#: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
@@ -728,7 +732,7 @@ msgstr "Gruppe"
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:39
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
@@ -745,7 +749,7 @@ msgstr "Nachname"
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:132
-#: ./opengever/meeting/proposal.py:49
+#: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
@@ -807,7 +811,7 @@ msgstr "Vorsitz"
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:46
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Antrag"
 
@@ -818,9 +822,14 @@ msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:75
-#: ./opengever/meeting/proposal.py:64
+#: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr "Veröffentlichung im"
+
+#. Default: "Comment"
+#: ./opengever/meeting/browser/proposaltransitions.py:50
+msgid "label_reject_proposal_text"
+msgstr "Kommentar"
 
 #. Default: "Remove"
 #: ./opengever/meeting/browser/templates/member.pt:66
@@ -867,6 +876,11 @@ msgstr "Start"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "Transition ${transition} executed"
+#: ./opengever/meeting/browser/meetings/transitions.py:25
+msgid "label_transition_executed"
+msgstr "Statusänderung ${transition} ausgeführt"
+
 #. Default: "Are you sure you want to delete this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:32
 msgid "label_unschedule_agenda_item_confirm_text"
@@ -882,13 +896,8 @@ msgstr "Nicht traktandierte Anträge"
 msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
-#. Default: "Choose how to update an existing protocol:"
-#: ./opengever/meeting/browser/protocol.py:96
-msgid "label_update_generated_protocol_choose_method"
-msgstr "Wählen Sie wie ein bestehendes Protokoll aktualisiert werden soll:"
-
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:188
+#: ./opengever/meeting/proposal.py:189
 msgid "label_workflow_state"
 msgstr "Status"
 
@@ -936,16 +945,6 @@ msgstr "Antrag erfolgreich eingereicht."
 msgid "msg_successfully_deleted"
 msgstr "Das Objekt wurde erfolgreich gelöscht"
 
-#. Default: "Create a new document in dossier ${title}"
-#: ./opengever/meeting/browser/protocol.py:87
-msgid "new_document"
-msgstr "Ein neues Dokument im Dossier ${title} erstellen"
-
-#. Default: "Create a new document version for document ${title}"
-#: ./opengever/meeting/browser/protocol.py:81
-msgid "new_document_version"
-msgstr "Eine neue Dokumentversion des Dokuments ${title} erstellen"
-
 #. Default: "New unschedulded proposals:"
 #: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:14
 msgid "new_unscheduled_proposals"
@@ -963,7 +962,7 @@ msgstr "Teilnehmende"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:28
 #: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/proposal.py:99
+#: ./opengever/meeting/model/proposal.py:106
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -972,37 +971,42 @@ msgid "presidency"
 msgstr "Vorsitz"
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:61
+#: ./opengever/meeting/model/proposalhistory.py:63
 msgid "proposal_history_label_created"
 msgstr "Erstellt durch ${user}"
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:141
+#: ./opengever/meeting/model/proposalhistory.py:155
 msgid "proposal_history_label_decided"
 msgstr "Antrag beschlossen durch ${user}"
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:113
+#: ./opengever/meeting/model/proposalhistory.py:127
 msgid "proposal_history_label_document_submitted"
 msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:127
+#: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_document_updated"
 msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
 
+#. Default: "Rejected by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:87
+msgid "proposal_history_label_rejected"
+msgstr "Zurückgewiesen von ${user}"
+
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:100
+#: ./opengever/meeting/model/proposalhistory.py:114
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Von der Traktandenliste der Sitzung ${meeting} entfernt durch ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:86
+#: ./opengever/meeting/model/proposalhistory.py:100
 msgid "proposal_history_label_scheduled"
 msgstr "Geplant für die Sitzung ${meeting} durch ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:73
+#: ./opengever/meeting/model/proposalhistory.py:75
 msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"
 
@@ -1021,13 +1025,19 @@ msgstr "Protokollauszug"
 msgid "protocol_successfully_changed"
 msgstr "Protokoll erfolgreich gespeichert."
 
+#. Default: "Reject"
+#: ./opengever/meeting/browser/proposaltransitions.py:61
+#: ./opengever/meeting/model/proposal.py:122
+msgid "reject"
+msgstr "Zurückweisen"
+
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/proposal.py:124
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:103
+#: ./opengever/meeting/model/proposal.py:110
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1040,12 +1050,12 @@ msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:120
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:101
+#: ./opengever/meeting/model/proposal.py:108
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1064,6 +1074,7 @@ msgid "time"
 msgstr "Zeit"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:117
+#: ./opengever/meeting/model/proposal.py:126
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
+

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-03 12:57+0000\n"
+"POT-Creation-Date: 2015-12-07 12:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:325
+#: ./opengever/meeting/command.py:309
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:358
+#: ./opengever/meeting/command.py:342
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
@@ -114,7 +114,7 @@ msgstr "Conteneur avec commission"
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/meeting/command.py:288
+#: ./opengever/meeting/command.py:272
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
@@ -312,6 +312,10 @@ msgstr ""
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
+#: ./opengever/meeting/browser/proposaltransitions.py:71
+msgid "The proposal has been rejected successfully"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:246
 msgid "Title"
 msgstr ""
@@ -328,7 +332,7 @@ msgstr ""
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
 
-#: ./opengever/meeting/command.py:241
+#: ./opengever/meeting/command.py:225
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
@@ -384,11 +388,6 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/meeting.py:150
 msgid "button_continue"
 msgstr ""
-
-#. Default: "Generate"
-#: ./opengever/meeting/browser/protocol.py:127
-msgid "button_generate"
-msgstr "Générer"
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
@@ -497,7 +496,7 @@ msgstr "Jusqu'à"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:34
-#: ./opengever/meeting/model/proposal.py:119
+#: ./opengever/meeting/model/proposal.py:128
 msgid "decide"
 msgstr "Décider"
 
@@ -508,7 +507,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:29
-#: ./opengever/meeting/model/proposal.py:104
+#: ./opengever/meeting/model/proposal.py:111
 msgid "decided"
 msgstr "Décidé"
 
@@ -526,11 +525,6 @@ msgstr ""
 msgid "download protocol"
 msgstr ""
 
-#. Default: "Update protocol"
-#: ./opengever/meeting/browser/protocol.py:114
-msgid "form_label_update_protocol"
-msgstr "Actualiser le procès-verbal"
-
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
 msgid "generate new excerpt"
 msgstr ""
@@ -543,21 +537,31 @@ msgstr ""
 msgid "generate new version as word document"
 msgstr ""
 
+#. Default: "Reject proposal"
+#: ./opengever/meeting/browser/proposaltransitions.py:59
+msgid "heading_reject_proposal_form"
+msgstr ""
+
 #. Default: "Held"
 #: ./opengever/meeting/model/meeting.py:71
 msgid "held"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:108
+#: ./opengever/meeting/proposal.py:109
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:96
+#: ./opengever/meeting/proposal.py:97
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:102
+#: ./opengever/meeting/proposal.py:103
 msgid "help_proposed_action"
+msgstr ""
+
+#. Default: "Describe why the proposal is rejected"
+#: ./opengever/meeting/browser/proposaltransitions.py:51
+msgid "help_reject_proposal_text"
 msgstr ""
 
 #. Default: "Select the target dossier where the excerpts should be created."
@@ -565,7 +569,7 @@ msgstr ""
 msgid "help_select_dossier"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:84
+#: ./opengever/meeting/proposal.py:85
 msgid "help_title"
 msgstr ""
 
@@ -577,7 +581,7 @@ msgstr ""
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:31
-#: ./opengever/meeting/proposal.py:132
+#: ./opengever/meeting/proposal.py:133
 msgid "label_attachments"
 msgstr ""
 
@@ -591,19 +595,19 @@ msgstr ""
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:37
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:44
+#: ./opengever/meeting/proposal.py:45
 msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:53
-#: ./opengever/meeting/proposal.py:107
+#: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:89
-#: ./opengever/meeting/proposal.py:74
+#: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -643,12 +647,12 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
-#: ./opengever/meeting/proposal.py:185
+#: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:191
+#: ./opengever/meeting/proposal.py:192
 msgid "label_decision_number"
 msgstr ""
 
@@ -659,7 +663,7 @@ msgstr ""
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:82
-#: ./opengever/meeting/proposal.py:69
+#: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
@@ -728,7 +732,7 @@ msgstr ""
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:39
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
@@ -745,7 +749,7 @@ msgstr "Nom"
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:132
-#: ./opengever/meeting/proposal.py:49
+#: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Base légale"
 
@@ -807,7 +811,7 @@ msgstr "Présidence"
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:46
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Proposition"
 
@@ -818,8 +822,13 @@ msgstr ""
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:75
-#: ./opengever/meeting/proposal.py:64
+#: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
+msgstr ""
+
+#. Default: "Comment"
+#: ./opengever/meeting/browser/proposaltransitions.py:50
+msgid "label_reject_proposal_text"
 msgstr ""
 
 #. Default: "Remove"
@@ -867,6 +876,11 @@ msgstr "Début"
 msgid "label_title"
 msgstr "Titre"
 
+#. Default: "Transition ${transition} executed"
+#: ./opengever/meeting/browser/meetings/transitions.py:25
+msgid "label_transition_executed"
+msgstr ""
+
 #. Default: "Are you sure you want to delete this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:32
 msgid "label_unschedule_agenda_item_confirm_text"
@@ -882,13 +896,8 @@ msgstr "Propositions imprévues"
 msgid "label_upcoming_meetings"
 msgstr "Prochaines séances"
 
-#. Default: "Choose how to update an existing protocol:"
-#: ./opengever/meeting/browser/protocol.py:96
-msgid "label_update_generated_protocol_choose_method"
-msgstr "Choix de la manière dont un procès-verbal existant soit actualisé:"
-
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:188
+#: ./opengever/meeting/proposal.py:189
 msgid "label_workflow_state"
 msgstr "Etat"
 
@@ -936,16 +945,6 @@ msgstr ""
 msgid "msg_successfully_deleted"
 msgstr ""
 
-#. Default: "Create a new document in dossier ${title}"
-#: ./opengever/meeting/browser/protocol.py:87
-msgid "new_document"
-msgstr "Créer un nouveau document dans le dossier ${title}"
-
-#. Default: "Create a new document version for document ${title}"
-#: ./opengever/meeting/browser/protocol.py:81
-msgid "new_document_version"
-msgstr "Créer une nouvelle version du document pour le document ${title}"
-
 #. Default: "New unschedulded proposals:"
 #: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:14
 msgid "new_unscheduled_proposals"
@@ -963,7 +962,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:28
 #: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/proposal.py:99
+#: ./opengever/meeting/model/proposal.py:106
 msgid "pending"
 msgstr "En modification"
 
@@ -972,37 +971,42 @@ msgid "presidency"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:61
+#: ./opengever/meeting/model/proposalhistory.py:63
 msgid "proposal_history_label_created"
 msgstr "Créé par ${user}"
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:141
+#: ./opengever/meeting/model/proposalhistory.py:155
 msgid "proposal_history_label_decided"
 msgstr ""
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:113
+#: ./opengever/meeting/model/proposalhistory.py:127
 msgid "proposal_history_label_document_submitted"
 msgstr "Document ${title} soumis en version ${version} par ${user}"
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:127
+#: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_document_updated"
 msgstr "Document soumis ${title} actualisé en version ${version} par ${user}"
 
+#. Default: "Rejected by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:87
+msgid "proposal_history_label_rejected"
+msgstr ""
+
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:100
+#: ./opengever/meeting/model/proposalhistory.py:114
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Enlevé de l'ordre du jour de la séance ${meeting} par ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:86
+#: ./opengever/meeting/model/proposalhistory.py:100
 msgid "proposal_history_label_scheduled"
 msgstr "Prévu pour la séance ${meeting} par ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:73
+#: ./opengever/meeting/model/proposalhistory.py:75
 msgid "proposal_history_label_submitted"
 msgstr "Soumis par ${user}"
 
@@ -1021,13 +1025,19 @@ msgstr ""
 msgid "protocol_successfully_changed"
 msgstr ""
 
+#. Default: "Reject"
+#: ./opengever/meeting/browser/proposaltransitions.py:61
+#: ./opengever/meeting/model/proposal.py:122
+msgid "reject"
+msgstr ""
+
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/proposal.py:124
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:103
+#: ./opengever/meeting/model/proposal.py:110
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1040,12 +1050,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:120
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:101
+#: ./opengever/meeting/model/proposal.py:108
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1064,7 +1074,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:117
+#: ./opengever/meeting/model/proposal.py:126
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-03 12:57+0000\n"
+"POT-Creation-Date: 2015-12-07 12:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:325
+#: ./opengever/meeting/command.py:309
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
@@ -56,7 +56,7 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:358
+#: ./opengever/meeting/command.py:342
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/meeting/command.py:288
+#: ./opengever/meeting/command.py:272
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
@@ -311,6 +311,10 @@ msgstr ""
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
+#: ./opengever/meeting/browser/proposaltransitions.py:71
+msgid "The proposal has been rejected successfully"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:246
 msgid "Title"
 msgstr ""
@@ -327,7 +331,7 @@ msgstr ""
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
-#: ./opengever/meeting/command.py:241
+#: ./opengever/meeting/command.py:225
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
@@ -382,11 +386,6 @@ msgstr ""
 #: ./opengever/meeting/browser/committeeforms.py:57
 #: ./opengever/meeting/browser/meetings/meeting.py:150
 msgid "button_continue"
-msgstr ""
-
-#. Default: "Generate"
-#: ./opengever/meeting/browser/protocol.py:127
-msgid "button_generate"
 msgstr ""
 
 #. Default: "Submit Attachments"
@@ -496,7 +495,7 @@ msgstr ""
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:34
-#: ./opengever/meeting/model/proposal.py:119
+#: ./opengever/meeting/model/proposal.py:128
 msgid "decide"
 msgstr ""
 
@@ -507,7 +506,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:29
-#: ./opengever/meeting/model/proposal.py:104
+#: ./opengever/meeting/model/proposal.py:111
 msgid "decided"
 msgstr ""
 
@@ -525,11 +524,6 @@ msgstr ""
 msgid "download protocol"
 msgstr ""
 
-#. Default: "Update protocol"
-#: ./opengever/meeting/browser/protocol.py:114
-msgid "form_label_update_protocol"
-msgstr ""
-
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:181
 msgid "generate new excerpt"
 msgstr ""
@@ -542,21 +536,31 @@ msgstr ""
 msgid "generate new version as word document"
 msgstr ""
 
+#. Default: "Reject proposal"
+#: ./opengever/meeting/browser/proposaltransitions.py:59
+msgid "heading_reject_proposal_form"
+msgstr ""
+
 #. Default: "Held"
 #: ./opengever/meeting/model/meeting.py:71
 msgid "held"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:108
+#: ./opengever/meeting/proposal.py:109
 msgid "help_considerations"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:96
+#: ./opengever/meeting/proposal.py:97
 msgid "help_initial_position"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:102
+#: ./opengever/meeting/proposal.py:103
 msgid "help_proposed_action"
+msgstr ""
+
+#. Default: "Describe why the proposal is rejected"
+#: ./opengever/meeting/browser/proposaltransitions.py:51
+msgid "help_reject_proposal_text"
 msgstr ""
 
 #. Default: "Select the target dossier where the excerpts should be created."
@@ -564,7 +568,7 @@ msgstr ""
 msgid "help_select_dossier"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:84
+#: ./opengever/meeting/proposal.py:85
 msgid "help_title"
 msgstr ""
 
@@ -576,7 +580,7 @@ msgstr ""
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
 #: ./opengever/meeting/browser/submitdocuments.py:31
-#: ./opengever/meeting/proposal.py:132
+#: ./opengever/meeting/proposal.py:133
 msgid "label_attachments"
 msgstr ""
 
@@ -590,19 +594,19 @@ msgstr ""
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:37
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:44
+#: ./opengever/meeting/proposal.py:45
 msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:53
-#: ./opengever/meeting/proposal.py:107
+#: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:89
-#: ./opengever/meeting/proposal.py:74
+#: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -642,12 +646,12 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:68
-#: ./opengever/meeting/proposal.py:185
+#: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:191
+#: ./opengever/meeting/proposal.py:192
 msgid "label_decision_number"
 msgstr ""
 
@@ -658,7 +662,7 @@ msgstr ""
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:82
-#: ./opengever/meeting/proposal.py:69
+#: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
@@ -727,7 +731,7 @@ msgstr ""
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:39
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr ""
 
@@ -744,7 +748,7 @@ msgstr ""
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:132
-#: ./opengever/meeting/proposal.py:49
+#: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr ""
 
@@ -806,7 +810,7 @@ msgstr ""
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:46
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr ""
 
@@ -817,8 +821,13 @@ msgstr ""
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt:75
-#: ./opengever/meeting/proposal.py:64
+#: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
+msgstr ""
+
+#. Default: "Comment"
+#: ./opengever/meeting/browser/proposaltransitions.py:50
+msgid "label_reject_proposal_text"
 msgstr ""
 
 #. Default: "Remove"
@@ -866,6 +875,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "Transition ${transition} executed"
+#: ./opengever/meeting/browser/meetings/transitions.py:25
+msgid "label_transition_executed"
+msgstr ""
+
 #. Default: "Are you sure you want to delete this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:32
 msgid "label_unschedule_agenda_item_confirm_text"
@@ -881,13 +895,8 @@ msgstr ""
 msgid "label_upcoming_meetings"
 msgstr ""
 
-#. Default: "Choose how to update an existing protocol:"
-#: ./opengever/meeting/browser/protocol.py:96
-msgid "label_update_generated_protocol_choose_method"
-msgstr ""
-
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:188
+#: ./opengever/meeting/proposal.py:189
 msgid "label_workflow_state"
 msgstr ""
 
@@ -935,16 +944,6 @@ msgstr ""
 msgid "msg_successfully_deleted"
 msgstr ""
 
-#. Default: "Create a new document in dossier ${title}"
-#: ./opengever/meeting/browser/protocol.py:87
-msgid "new_document"
-msgstr ""
-
-#. Default: "Create a new document version for document ${title}"
-#: ./opengever/meeting/browser/protocol.py:81
-msgid "new_document_version"
-msgstr ""
-
 #. Default: "New unschedulded proposals:"
 #: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:14
 msgid "new_unscheduled_proposals"
@@ -962,7 +961,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:28
 #: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/proposal.py:99
+#: ./opengever/meeting/model/proposal.py:106
 msgid "pending"
 msgstr ""
 
@@ -971,37 +970,42 @@ msgid "presidency"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:61
+#: ./opengever/meeting/model/proposalhistory.py:63
 msgid "proposal_history_label_created"
 msgstr ""
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:141
+#: ./opengever/meeting/model/proposalhistory.py:155
 msgid "proposal_history_label_decided"
 msgstr ""
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:113
+#: ./opengever/meeting/model/proposalhistory.py:127
 msgid "proposal_history_label_document_submitted"
 msgstr ""
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:127
+#: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
+#. Default: "Rejected by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:87
+msgid "proposal_history_label_rejected"
+msgstr ""
+
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:100
+#: ./opengever/meeting/model/proposalhistory.py:114
 msgid "proposal_history_label_remove_scheduled"
 msgstr ""
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:86
+#: ./opengever/meeting/model/proposalhistory.py:100
 msgid "proposal_history_label_scheduled"
 msgstr ""
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/model/proposalhistory.py:73
+#: ./opengever/meeting/model/proposalhistory.py:75
 msgid "proposal_history_label_submitted"
 msgstr ""
 
@@ -1020,13 +1024,19 @@ msgstr ""
 msgid "protocol_successfully_changed"
 msgstr ""
 
+#. Default: "Reject"
+#: ./opengever/meeting/browser/proposaltransitions.py:61
+#: ./opengever/meeting/model/proposal.py:122
+msgid "reject"
+msgstr ""
+
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/proposal.py:124
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:103
+#: ./opengever/meeting/model/proposal.py:110
 msgid "scheduled"
 msgstr ""
 
@@ -1039,12 +1049,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:120
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:101
+#: ./opengever/meeting/model/proposal.py:108
 msgid "submitted"
 msgstr ""
 
@@ -1063,7 +1073,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:117
+#: ./opengever/meeting/model/proposal.py:126
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -243,6 +243,16 @@ class Proposal(Base):
     def reject(self, comment):
         assert self.workflow.can_execute_transition(self, 'submitted-pending')
 
+        self.submitted_physical_path = None
+        self.submitted_oguid = None
+
+        # kill references to submitted documents (i.e. copies), they will be
+        # deleted.
+        query = proposalhistory.DocumentSubmitted.query.filter_by(
+            proposal=self)
+        for record in query.all():
+            record.submitted_document = None
+
         # set workflow state directly for once, the transition is used to
         # redirect to a form.
         self.workflow_state = self.STATE_PENDING.name

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -41,6 +41,13 @@ class Submit(Transition):
         api.portal.show_message(msg, request=getRequest(), type='info')
 
 
+class Reject(Transition):
+
+    def execute(self, obj, model):
+        url = "{}/reject".format(obj.absolute_url())
+        return getRequest().RESPONSE.redirect(url)
+
+
 class Proposal(Base):
     """Sql representation of a proposal."""
 
@@ -111,6 +118,8 @@ class Proposal(Base):
         ], [
         Submit('pending', 'submitted',
                title=_('submit', default='Submit')),
+        Reject('submitted', 'pending',
+               title=_('reject', default='Reject')),
         Transition('submitted', 'scheduled',
                    title=_('schedule', default='Schedule')),
         Transition('scheduled', 'submitted',

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -44,7 +44,7 @@ class Submit(Transition):
 class Reject(Transition):
 
     def execute(self, obj, model):
-        url = "{}/reject".format(obj.absolute_url())
+        url = "{}/reject_proposal".format(obj.absolute_url())
         return getRequest().RESPONSE.redirect(url)
 
 
@@ -239,6 +239,13 @@ class Proposal(Base):
         session = create_session()
         meeting.agenda_items.append(AgendaItem(proposal=self))
         session.add(proposalhistory.Scheduled(proposal=self, meeting=meeting))
+
+    def reject(self, comment):
+        assert self.workflow.can_execute_transition(self, 'submitted-pending')
+
+        # set workflow state directly for once, the transition is used to
+        # redirect to a form.
+        self.workflow_state = self.STATE_PENDING.name
 
     def remove_scheduled(self, meeting):
         self.execute_transition('scheduled-submitted')

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -246,6 +246,8 @@ class Proposal(Base):
         # set workflow state directly for once, the transition is used to
         # redirect to a form.
         self.workflow_state = self.STATE_PENDING.name
+        session = create_session()
+        session.add(proposalhistory.Rejected(proposal=self, comment=comment))
 
     def remove_scheduled(self, meeting):
         self.execute_transition('scheduled-submitted')

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -240,7 +240,7 @@ class Proposal(Base):
         meeting.agenda_items.append(AgendaItem(proposal=self))
         session.add(proposalhistory.Scheduled(proposal=self, meeting=meeting))
 
-    def reject(self, comment):
+    def reject(self, text):
         assert self.workflow.can_execute_transition(self, 'submitted-pending')
 
         self.submitted_physical_path = None
@@ -258,7 +258,7 @@ class Proposal(Base):
         # redirect to a form.
         self.workflow_state = self.STATE_PENDING.name
         session = create_session()
-        session.add(proposalhistory.Rejected(proposal=self, comment=comment))
+        session.add(proposalhistory.Rejected(proposal=self, text=text))
 
     def remove_scheduled(self, meeting):
         self.execute_transition('scheduled-submitted')

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -244,7 +244,8 @@ class Proposal(Base):
         assert self.workflow.can_execute_transition(self, 'submitted-pending')
 
         self.submitted_physical_path = None
-        self.submitted_oguid = None
+        self.submitted_admin_unit_id = None
+        self.submitted_int_id = None
 
         # kill references to submitted documents (i.e. copies), they will be
         # deleted.

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -4,6 +4,7 @@ from opengever.base.model import UTCDateTime
 from opengever.meeting import _
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.models import USER_ID_LENGTH
+from opengever.ogds.models.types import UnicodeCoercingText
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -30,6 +31,7 @@ class ProposalHistory(Base):
     proposal = relationship('Proposal')
     created = Column(UTCDateTime(timezone=True), default=utcnow_tz_aware, nullable=False)
     userid = Column(String(USER_ID_LENGTH), default=get_current_user_id, nullable=False)
+    text = Column(UnicodeCoercingText)
 
     # intended to be used only by DocumentSubmitted/DocumentUpdated
     submitted_document_id = Column(Integer, ForeignKey('submitteddocuments.id'))
@@ -72,6 +74,18 @@ class Submitted(ProposalHistory):
     def message(self):
         return _(u'proposal_history_label_submitted',
                  u'Submitted by ${user}',
+                 mapping={'user': self.get_actor_link()})
+
+
+class Rejected(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'rejected'}
+
+    css_class = 'rejected'
+
+    def message(self):
+        return _(u'proposal_history_label_rejected',
+                 u'Rejected by ${user}',
                  mapping={'user': self.get_actor_link()})
 
 

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4624</version>
+    <version>4625</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -306,6 +306,12 @@ class SubmittedProposal(ProposalBase):
     def is_submit_additional_documents_allowed(self):
         return False
 
+    def reject(self, comment):
+        proposal = self.load_model()
+        proposal.reject(comment)
+
+        api.content.delete(self)
+
 
 class Proposal(ProposalBase):
     """Act as proxy for the proposal stored in the database.

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -234,7 +234,8 @@ class SubmittedProposal(ProposalBase):
     model_class = ProposalModel
 
     implements(content_schema)
-    workflow = ProposalModel.workflow.with_visible_transitions([])
+    workflow = ProposalModel.workflow.with_visible_transitions(
+        ['submitted-pending'])
 
     def is_editable(self):
         """A proposal in a meeting/committee is editable when submitted but not

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -1,6 +1,7 @@
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
+from opengever.base.security import elevated_privileges
 from opengever.base.source import DossierPathSourceBinder
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
@@ -310,7 +311,8 @@ class SubmittedProposal(ProposalBase):
         proposal = self.load_model()
         proposal.reject(comment)
 
-        api.content.delete(self)
+        with elevated_privileges():
+            api.content.delete(self)
 
 
 class Proposal(ProposalBase):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -307,9 +307,9 @@ class SubmittedProposal(ProposalBase):
     def is_submit_additional_documents_allowed(self):
         return False
 
-    def reject(self, comment):
+    def reject(self, text):
         proposal = self.load_model()
-        proposal.reject(comment)
+        proposal.reject(text)
 
         with elevated_privileges():
             api.content.delete(self)

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -72,6 +72,26 @@ class TestProposalHistory(FunctionalTestCase):
             self.get_history_entries_text(browser)[:2])
 
     @browsing
+    def test_rejecting_proposals_creates_history_entries(self, browser):
+        browser.login()
+        self.open_overview(browser)
+
+        # submit proposal
+        browser.css('#pending-submitted').first.click()
+        proposal = browser.context
+
+        # reject submitted proposal
+        submitted_proposal = proposal.load_model().resolve_sumitted_proposal()
+        browser.open(submitted_proposal, view='tabbedview_view-overview')
+        browser.find('Reject').click()
+        browser.fill({'Comment': u'Bitte \xfcberarbeiten'}).submit()
+
+        self.open_overview(browser)
+        self.assertSequenceEqual(
+            u'Rejected by Test User (test_user_1_)',
+            self.get_history_entries_text(browser)[0])
+
+    @browsing
     def test_submitting_additional_document_creates_history_entry(self, browser):
         self.submit_proposal()
         document = create(Builder('document')

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -555,4 +555,14 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4624 -> 4625 -->
+    <genericsetup:upgradeStep
+        title="Add comment to proposalhistory."
+        description=""
+        source="4624"
+        destination="4625"
+        handler="opengever.meeting.upgrades.to4625.AddCommentColumnToProposalHistory"
+        profile="opengever.meeting:default"
+    />
+
 </configure>

--- a/opengever/meeting/upgrades/to4625.py
+++ b/opengever/meeting/upgrades/to4625.py
@@ -1,0 +1,17 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import Text
+
+
+class AddCommentColumnToProposalHistory(SchemaMigration):
+
+    profileid = 'opengever.meeting'
+    upgradeid = 4625
+
+    def migrate(self):
+        self.add_text_to_history()
+
+    def add_text_to_history(self):
+        self.op.add_column(
+            'proposalhistory',
+            Column('text', Text))


### PR DESCRIPTION
This PR adds a workflow transition to reject a proposal and revert it to pending state. It is possible to enter an optional comment indicating why the proposal was rejected.

This PR also contains an improved way to elevate a current user's privileges, it is now possible to retain the username and avoid `specialusers.system`.

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/399.

Closes #1371.