### PR TITLE
Avoid duplicated slashes when generating the CAS portal URL.

### DIFF
--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -15,4 +15,4 @@ def is_cas_auth_enabled():
 
 def get_cas_portal_url():
     return CAS_SERVER_URL_FORMAT.format(
-        admin_unit_public_url=get_current_admin_unit().public_url)
+        admin_unit_public_url=get_current_admin_unit().public_url.rstrip('/'))

--- a/opengever/base/tests/test_casauth.py
+++ b/opengever/base/tests/test_casauth.py
@@ -1,0 +1,13 @@
+from opengever.base.casauth import get_cas_portal_url
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.testing import FunctionalTestCase
+
+
+class TestCASPortalUrl(FunctionalTestCase):
+
+    def test_is_adminunits_puplic_url_and_slash_portal(self):
+        self.assertEquals('http://example.com/portal', get_cas_portal_url())
+
+    def test_trailing_slashes_are_stripped(self):
+        get_current_admin_unit().public_url = 'http://example.com/'
+        self.assertEquals('http://example.com/portal', get_cas_portal_url())


### PR DESCRIPTION
Strip trailing slashes in admin_unit's public_url, when putting together the CAS portal URL.

@deiferni 