### PR TITLE
Fix an issue where proposals could not be rejected.

### DIFF
--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -249,7 +249,7 @@ class Proposal(Base):
 
         # kill references to submitted documents (i.e. copies), they will be
         # deleted.
-        query = proposalhistory.DocumentSubmitted.query.filter_by(
+        query = proposalhistory.ProposalHistory.query.filter_by(
             proposal=self)
         for record in query.all():
             record.submitted_document = None


### PR DESCRIPTION
The problem was caused by not removing all references to submitted_document from the proposal history entries. The submitted documents are deleted when rejecting the proposal because the `SubmittedProposal` proxy object is removed upon reject.

Fixes #1433.