### PR TITLE
Extend protocol json data with the committee name.

### DIFF
--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -43,6 +43,7 @@ SAMPLE_MEETING_DATA = {
                 'end_time': u'11:45 AM',
                 'start_time': u'09:30 AM',
                 'number': 11},
+    'committee': {'name': 'Gemeinderat'},
     'participants': {
         'members': [{'fullname': u'Peter Meier',
                     'role': u'F\xfcrst'},

--- a/opengever/meeting/protocol.py
+++ b/opengever/meeting/protocol.py
@@ -34,6 +34,7 @@ class ProtocolData(object):
         self.add_protocol_type()
         self.add_participants()
         self.add_meeting()
+        self.add_commitee()
         self.add_agenda_items()
 
     def add_settings(self):
@@ -94,6 +95,11 @@ class ProtocolData(object):
             'start_time': self.meeting.get_start_time(),
             'end_time': self.meeting.get_end_time(),
             'number': self.meeting.meeting_number,
+        }
+
+    def add_commitee(self):
+        self.data['committee'] = {
+            'name': self.meeting.committee.title,
         }
 
     def add_agenda_items(self):

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -23,7 +23,8 @@ class TestProtocolJsonData(FunctionalTestCase):
                     copy_for_attention=u'Hanspeter',
                     disclose_to=u'Jans\xf6rg',
                     publish_in=u'Tagblatt'))
-        self.committee = create(Builder('committee_model'))
+        self.committee = create(Builder('committee_model')
+                                .having(title=u'Gemeinderat'))
         self.member_peter = create(Builder('member'))
         self.member_franz = create(Builder('member')
                                    .having(firstname=u'Franz',


### PR DESCRIPTION
Adjustments on the template aren't necessary, because the committee.name is already used in the template.

Fixes #1422

@deiferni 
