### PR TITLE
Validate that leaf repository folder is selected for committee.

### DIFF
--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-09 09:17+0000\n"
+"POT-Creation-Date: 2015-12-09 10:38+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -45,6 +45,10 @@ msgstr "In dieser Gruppe befinden sich keine Benutzer."
 #: ./opengever/base/browser/list_groupmembers.pt:3
 msgid "Users of group:"
 msgstr "Benutzer der Gruppe"
+
+#: ./opengever/base/validators.py:15
+msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
+msgstr "Sie können in der ausgewählten Ordnungsposition keine Dossiers erstellen. Die Ordnungsposition enthält entweder weitere Ordnungspositionen oder Sie besitzen nicht die erforderlichen Berechtigungen."
 
 #. Default ""
 #: opengever/repository/classification.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-09 09:17+0000\n"
+"POT-Creation-Date: 2015-12-09 10:38+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,10 @@ msgstr "Ce groupe n'a aucun utilisateur"
 #: ./opengever/base/browser/list_groupmembers.pt:3
 msgid "Users of group:"
 msgstr "Utilisateur du groupe"
+
+#: ./opengever/base/validators.py:15
+msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
+msgstr "Vous ne pouvez créer aucun dossier dans ce numéro de classement. Ce dernier en contient d'autres ou alors vous n'avez pas les droits suffisants pour effectuer cette tâche."
 
 #. Default ""
 #: opengever/repository/classification.py

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-09 09:17+0000\n"
+"POT-Creation-Date: 2015-12-09 10:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,6 +43,10 @@ msgstr ""
 
 #: ./opengever/base/browser/list_groupmembers.pt:3
 msgid "Users of group:"
+msgstr ""
+
+#: ./opengever/base/validators.py:15
+msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
 msgstr ""
 
 #. Default ""

--- a/opengever/base/validators.py
+++ b/opengever/base/validators.py
@@ -1,0 +1,29 @@
+from opengever.base import _
+from z3c.form.validator import SimpleFieldValidator
+from zope.interface import Invalid
+
+
+class BaseRepositoryfolderValidator(SimpleFieldValidator):
+    """This validator allows only repository folders that can contain a
+    dossier.
+
+    """
+    def validate(self, value):
+        super(BaseRepositoryfolderValidator, self).validate(value)
+
+        if not self._is_dossier_addable(value):
+            msg = _(u'You cannot add dossiers in the selected repository '
+                    u'folder. Either you do not have the privileges or the '
+                    u'repository folder contains another repository folder.')
+            raise Invalid(msg)
+
+    def _is_dossier_addable(self, repo_folder):
+        # The user should be able to create a dossier (of any type) in the
+        # selected repository folder.
+        dossier_behavior = 'opengever.dossier.behaviors.dossier.IDossier'
+
+        for fti in repo_folder.allowedContentTypes():
+            if dossier_behavior in getattr(fti, 'behaviors', ()):
+                return True
+
+        return False

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from five import grok
+from opengever.base.validators import BaseRepositoryfolderValidator
 from opengever.meeting import _
 from opengever.meeting.committeeroles import CommitteeRoles
 from opengever.meeting.container import ModelContainer
@@ -14,6 +15,7 @@ from opengever.meeting.wrapper import MeetingWrapper
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.directives import form
+from z3c.form.validator import WidgetValidatorDiscriminators
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
 from zope.interface import Interface
@@ -55,6 +57,15 @@ class ICommittee(form.Schema):
                     u'for this committee.'),
         source=repository_folder_source,
         required=True)
+
+
+class RepositoryfolderValidator(BaseRepositoryfolderValidator):
+    pass
+
+WidgetValidatorDiscriminators(
+    RepositoryfolderValidator,
+    field=ICommittee['repository_folder'])
+grok.global_adapter(RepositoryfolderValidator)
 
 
 class ICommitteeModel(Interface):

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -31,6 +31,30 @@ class TestCommittee(FunctionalTestCase):
         self.assertEqual(Oguid.for_object(committee), model.oguid)
 
     @browsing
+    def test_committee_repository_is_validated(self, browser):
+        parent_repo = create(Builder('repository')
+                             .within(self.repo_root))
+        leaf_repo = create(Builder('repository')
+                           .within(parent_repo))
+
+        self.grant('Administrator')
+        browser.login()
+        browser.open(self.container, view='++add++opengever.meeting.committee')
+
+        browser.fill(
+            {'Title': u'A c\xf6mmittee',
+             'Linked repository folder': parent_repo,
+             self.group_field_name: 'client1_users'})
+        browser.css('#form-buttons-save').first.click()
+
+        error = browser.css("#formfield-form-widgets-repository_folder div.error").first.text
+        self.assertEqual('You cannot add dossiers in the selected repository '
+                         'folder. Either you do not have the privileges or '
+                         'the repository folder contains another repository '
+                         'folder.',
+                         error)
+
+    @browsing
     def test_committee_can_be_created_in_browser(self, browser):
         self.grant('Administrator')
         browser.login()

--- a/opengever/task/browser/accept/newdossier.py
+++ b/opengever/task/browser/accept/newdossier.py
@@ -7,6 +7,7 @@ from five import grok
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.form import WizzardWrappedAddForm
 from opengever.base.source import RepositoryPathSourceBinder
+from opengever.base.validators import BaseRepositoryfolderValidator
 from opengever.globalindex.model.task import Task
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.task import _
@@ -97,27 +98,8 @@ class ISelectRepositoryfolderSchema(Schema):
                 }))
 
 
-class RepositoryfolderValidator(SimpleFieldValidator):
-
-    def validate(self, value):
-
-        super(RepositoryfolderValidator, self).validate(value)
-
-        # The user should be able to create a dossier (of any type) in the
-        # selected repository folder.
-        dossier_behavior = 'opengever.dossier.behaviors.dossier.IDossier'
-        dossier_addable = False
-
-        for fti in value.allowedContentTypes():
-            if dossier_behavior in getattr(fti, 'behaviors', ()):
-                dossier_addable = True
-                break
-
-        if not dossier_addable:
-            msg = _(u'You cannot add dossiers in the selected repository '
-                    u'folder. Either you do not have the privileges or the '
-                    u'repository folder contains another repository folder.')
-            raise Invalid(msg)
+class RepositoryfolderValidator(BaseRepositoryfolderValidator):
+    pass
 
 WidgetValidatorDiscriminators(
     RepositoryfolderValidator,

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-07-01 14:17+0000\n"
+"POT-Creation-Date: 2015-12-09 10:39+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -76,12 +76,12 @@ msgstr "Aufgabe"
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr "Die Dokumente wurde an den Auftraggeber geliefert und die Aufgaben wurden abgeschlossen."
 
-#: ./opengever/task/browser/accept/inbox.py:31
+#: ./opengever/task/browser/accept/inbox.py:33
 msgid "The forwarding has been stored in the local inbox"
 msgstr "Die Weiterleitung wurde im lokalen Eingangskorb gespeichert."
 
 #: ./opengever/task/browser/accept/existingdossier.py:119
-#: ./opengever/task/browser/accept/newdossier.py:373
+#: ./opengever/task/browser/accept/newdossier.py:319
 msgid "The forwarding has been stored in the local inbox and the succesor task has been created"
 msgstr "Die Weiterleitung wurde im lokalen Eingangskorb abgelegt und die Kopierte Aufgabe erstellt."
 
@@ -89,11 +89,11 @@ msgstr "Die Weiterleitung wurde im lokalen Eingangskorb abgelegt und die Kopiert
 msgid "The forwarding is now assigned to the dossier"
 msgstr "Die Weiterleitung wurde nun dem Dossier zugewiesen."
 
-#: ./opengever/task/browser/accept/newdossier.py:358
+#: ./opengever/task/browser/accept/newdossier.py:304
 msgid "The forwarding is now assigned to the new dossier"
 msgstr "Die Weiterleitung wurde nun dem neuen Dossier zugewiesen."
 
-#: ./opengever/task/browser/accept/newdossier.py:388
+#: ./opengever/task/browser/accept/newdossier.py:334
 msgid "The new dossier has been created and the task has been copied to the new dossier."
 msgstr "Das neue Dossier wurde erstellt und die akzeptierte Aufgabe wurde in das neue Dossier kopiert."
 
@@ -120,10 +120,6 @@ msgstr "Sie sind nicht dem Auftragnehmer-Mandanten (${client}) zugewiesen. Sie k
 #: ./opengever/task/browser/close.py:187
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr "Sie haben nicht genügend Berechtigungen um Dokumente im ausgewählten Dossier hinzuzfügen. Möglicherweise ist das Dossier bereits abgeschlossen."
-
-#: ./opengever/task/browser/accept/newdossier.py:116
-msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
-msgstr "Sie können in der ausgewählten Ordnungsposition keine Dossiers erstellen. Die Ordnungsposition enthält entweder weitere Ordnungspositionen oder Sie besitzen nicht die erforderlichen Berechtigungen."
 
 #: ./opengever/task/browser/accept/existingdossier.py:71
 msgid "You cannot add tasks in the selected dossier. Either the dossier is closed or you do not have the privileges."
@@ -172,20 +168,20 @@ msgstr "Zuweisen"
 #. Default: "Cancel"
 #: ./opengever/task/browser/accept/existingdossier.py:134
 #: ./opengever/task/browser/accept/main.py:208
-#: ./opengever/task/browser/accept/newdossier.py:155
+#: ./opengever/task/browser/accept/newdossier.py:138
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
 #: ./opengever/task/browser/accept/main.py:144
-#: ./opengever/task/browser/accept/newdossier.py:132
+#: ./opengever/task/browser/accept/newdossier.py:115
 #: ./opengever/task/browser/assign_dossier.py:73
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Save"
 #: ./opengever/task/browser/accept/existingdossier.py:93
-#: ./opengever/task/browser/accept/newdossier.py:330
+#: ./opengever/task/browser/accept/newdossier.py:276
 #: ./opengever/task/browser/close.py:201
 msgid "button_save"
 msgstr "Speichern"
@@ -230,12 +226,12 @@ msgid "existing_dossier"
 msgstr "bestehendes Dossier"
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:70
+#: ./opengever/task/task.py:68
 msgid "fieldset_additional"
 msgstr "Erweitert"
 
 #. Default: "Common"
-#: ./opengever/task/task.py:55
+#: ./opengever/task/task.py:53
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -250,12 +246,12 @@ msgid "help_accept_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem Sie die Aufgabe bearbeiten wollen."
 
 #. Default: "Select the type for the new dossier."
-#: ./opengever/task/browser/accept/newdossier.py:224
+#: ./opengever/task/browser/accept/newdossier.py:213
 msgid "help_accept_select_dossier_type"
 msgstr "Wählen Sie den Typ des neuen Dossiers aus."
 
 #. Default: "Select the repository folder within the dossier should be created."
-#: ./opengever/task/browser/accept/newdossier.py:82
+#: ./opengever/task/browser/accept/newdossier.py:84
 msgid "help_accept_select_repositoryfolder"
 msgstr "Wählen Sie die Ordnungsposition aus, in welchem das neue Dossier erstellt werden soll."
 
@@ -291,42 +287,42 @@ msgid "help_complete_task_response"
 msgstr "Der hier eingegebene Text erscheint in der Antwort, die die Aufgabe abschliesst."
 
 #: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:133
+#: ./opengever/task/task.py:132
 msgid "help_date_of_completion"
 msgstr "Das Datum an dem die Aufgabe beendet wurde"
 
 #. Default: "Deadline"
 #: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:126
+#: ./opengever/task/task.py:125
 msgid "help_deadline"
 msgstr "Tragen Sie ein Datum ein, bis wann die Aufgabe erledigt werden muss"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:191
+#: ./opengever/task/task.py:190
 msgid "help_effectiveCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:185
+#: ./opengever/task/task.py:184
 msgid "help_effectiveDuration"
 msgstr "Dauer in h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:179
+#: ./opengever/task/task.py:178
 msgid "help_expectedCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:173
+#: ./opengever/task/task.py:172
 msgid "help_expectedDuration"
 msgstr "Dauer in h"
 
-#: ./opengever/task/task.py:167
+#: ./opengever/task/task.py:166
 msgid "help_expectedStartOfWork"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:91
+#: ./opengever/task/task.py:90
 msgid "help_issuer"
 msgstr ""
 
@@ -334,7 +330,7 @@ msgstr ""
 msgid "help_new_deadline"
 msgstr ""
 
-#: ./opengever/task/task.py:198
+#: ./opengever/task/task.py:197
 msgid "help_predecessor"
 msgstr ""
 
@@ -344,31 +340,31 @@ msgstr ""
 msgid "help_response"
 msgstr ""
 
-#: ./opengever/task/task.py:118
+#: ./opengever/task/task.py:117
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person aus, die dem oben gewählten Mandanten angehört."
 
 #: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:110
+#: ./opengever/task/task.py:109
 msgid "help_responsible_client"
 msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer."
 
 #: ./opengever/task/browser/assign.py:46
-#: ./opengever/task/task.py:404
+#: ./opengever/task/form.py:41
 msgid "help_responsible_single_client_setup"
 msgstr "Wählen Sie die verantwortliche Person aus"
 
-#: ./opengever/task/task.py:99
+#: ./opengever/task/task.py:98
 msgid "help_task_type"
 msgstr "Wählen Sie den Auftragstyp"
 
 #: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:141
+#: ./opengever/task/task.py:140
 msgid "help_text"
 msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein"
 
 #: ./opengever/task/browser/delegate/metadata.py:23
-#: ./opengever/task/task.py:84
+#: ./opengever/task/task.py:82
 msgid "help_title"
 msgstr "Der Name der Aufgabe"
 
@@ -397,12 +393,12 @@ msgid "label_accept_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Dossier type"
-#: ./opengever/task/browser/accept/newdossier.py:223
+#: ./opengever/task/browser/accept/newdossier.py:212
 msgid "label_accept_select_dossier_type"
 msgstr "Dossier Typ"
 
 #. Default: "Repository folder"
-#: ./opengever/task/browser/accept/newdossier.py:80
+#: ./opengever/task/browser/accept/newdossier.py:82
 msgid "label_accept_select_repositoryfolder"
 msgstr "Ordnungsposition"
 
@@ -447,16 +443,16 @@ msgid "label_created"
 msgstr "erstellt am"
 
 #. Default: "Date of completion"
-#: ./opengever/task/browser/overview.py:103
+#: ./opengever/task/browser/overview.py:102
 #: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:132
+#: ./opengever/task/task.py:131
 msgid "label_date_of_completion"
 msgstr "Erledigungsdatum"
 
 #. Default: "Deadline"
-#: ./opengever/task/activities.py:105
+#: ./opengever/task/activities.py:134
 #: ./opengever/task/browser/delegate/metadata.py:33
-#: ./opengever/task/browser/overview.py:87
+#: ./opengever/task/browser/overview.py:86
 msgid "label_deadline"
 msgstr "Zu erledigen bis"
 
@@ -466,7 +462,7 @@ msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Dossier title"
-#: ./opengever/task/activities.py:110
+#: ./opengever/task/activities.py:138
 msgid "label_dossier_title"
 msgstr "Dossiertitel"
 
@@ -476,12 +472,12 @@ msgid "label_edit_response_not_allowed"
 msgstr "Sie sind nicht berechtigt diese Antwort zu löschen"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:189
 msgid "label_effectiveCost"
 msgstr "Effektive Kosten (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:183
 msgid "label_effectiveDuration"
 msgstr "Effektive Dauer (h)"
 
@@ -491,24 +487,24 @@ msgid "label_enter_response"
 msgstr "Bitte tragen sie ihre Antwort unten ein"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:177
 msgid "label_expectedCost"
 msgstr "Geschätzte Kosten (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:172
+#: ./opengever/task/task.py:171
 msgid "label_expectedDuration"
 msgstr "Geschätzte Dauer (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:166
+#: ./opengever/task/task.py:165
 msgid "label_expectedStartOfWork"
 msgstr "Beginn der Arbeit"
 
 #. Default: "Issuer"
 #: ./opengever/task/browser/delegate/metadata.py:27
-#: ./opengever/task/browser/overview.py:92
-#: ./opengever/task/task.py:90
+#: ./opengever/task/browser/overview.py:91
+#: ./opengever/task/task.py:89
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -528,12 +524,12 @@ msgid "label_new_deadline"
 msgstr "Neue Frist"
 
 #. Default: "Dossiertitle"
-#: ./opengever/task/browser/overview.py:70
+#: ./opengever/task/browser/overview.py:69
 msgid "label_parent_dossier_title"
 msgstr "Dossiertitel"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:197
+#: ./opengever/task/task.py:196
 msgid "label_predecessor"
 msgstr "Vorgänger"
 
@@ -545,13 +541,13 @@ msgstr "Ursprüngliche Aufgabe"
 #. Default: "Related Items"
 #: ./opengever/task/browser/complete.py:215
 #: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:146
+#: ./opengever/task/task.py:145
 msgid "label_related_items"
 msgstr "Verweise"
 
 #. Default: "Responsible Client"
 #: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:108
+#: ./opengever/task/task.py:107
 msgid "label_resonsible_client"
 msgstr "Mandant des Auftragnehmers"
 
@@ -564,7 +560,7 @@ msgstr "Antworttext"
 
 #. Default: "Responsible"
 #: ./opengever/task/browser/assign.py:45
-#: ./opengever/task/browser/overview.py:98
+#: ./opengever/task/browser/overview.py:97
 #: ./opengever/task/statesyncer.py:134
 msgid "label_responsible"
 msgstr "Auftragnehmer"
@@ -590,33 +586,33 @@ msgid "label_successor_task"
 msgstr "Kopierte Aufgabe"
 
 #. Default: "New task added by ${user}"
-#: ./opengever/task/activities.py:84
+#: ./opengever/task/activities.py:108
 msgid "label_task_added"
 msgstr "Neue Aufgabe hinzugefügt durch ${user}"
 
 #. Default: "Task title"
-#: ./opengever/task/activities.py:103
-#: ./opengever/task/browser/overview.py:66
+#: ./opengever/task/activities.py:133
+#: ./opengever/task/browser/overview.py:65
 msgid "label_task_title"
 msgstr "Aufgabentitel"
 
 #. Default: "Task Type"
-#: ./opengever/task/activities.py:107
-#: ./opengever/task/browser/overview.py:78
-#: ./opengever/task/task.py:98
+#: ./opengever/task/activities.py:136
+#: ./opengever/task/browser/overview.py:77
+#: ./opengever/task/task.py:97
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Text"
-#: ./opengever/task/activities.py:112
+#: ./opengever/task/activities.py:140
 #: ./opengever/task/browser/delegate/metadata.py:38
-#: ./opengever/task/browser/overview.py:74
+#: ./opengever/task/browser/overview.py:73
 msgid "label_text"
 msgstr "Beschreibung"
 
 #. Default: "Title"
 #: ./opengever/task/browser/delegate/metadata.py:22
-#: ./opengever/task/task.py:83
+#: ./opengever/task/task.py:81
 msgid "label_title"
 msgstr "Titel"
 
@@ -628,7 +624,7 @@ msgid "label_transition"
 msgstr "Aktion"
 
 #. Default: "State"
-#: ./opengever/task/browser/overview.py:82
+#: ./opengever/task/browser/overview.py:81
 msgid "label_workflow_state"
 msgstr "Status"
 
@@ -673,24 +669,24 @@ msgstr "Speichern"
 #. Default: "Step 1"
 #: ./opengever/task/browser/accept/existingdossier.py:87
 #: ./opengever/task/browser/accept/main.py:37
-#: ./opengever/task/browser/accept/newdossier.py:53
+#: ./opengever/task/browser/accept/newdossier.py:55
 msgid "step_1"
 msgstr "Schritt 1"
 
 #. Default: "Step 2"
 #: ./opengever/task/browser/accept/existingdossier.py:90
-#: ./opengever/task/browser/accept/newdossier.py:56
+#: ./opengever/task/browser/accept/newdossier.py:58
 #: ./opengever/task/browser/close.py:52
 msgid "step_2"
 msgstr "Schritt 2"
 
 #. Default: "Step 3"
-#: ./opengever/task/browser/accept/newdossier.py:59
+#: ./opengever/task/browser/accept/newdossier.py:61
 msgid "step_3"
 msgstr "Schritt 3"
 
 #. Default: "Step 4"
-#: ./opengever/task/browser/accept/newdossier.py:62
+#: ./opengever/task/browser/accept/newdossier.py:64
 msgid "step_4"
 msgstr "Schritt 4"
 
@@ -745,42 +741,42 @@ msgid "title_modify_deadline"
 msgstr "Frist ändern"
 
 #. Default: "Document ${doc} added by ${user}"
-#: ./opengever/task/response_description.py:313
+#: ./opengever/task/response_description.py:311
 msgid "transition_add_document"
 msgstr "Dokument ${doc} hinzugefügt durch ${user}"
 
 #. Default: "Subtask ${task} added by ${user}"
-#: ./opengever/task/response_description.py:293
+#: ./opengever/task/response_description.py:291
 msgid "transition_add_subtask"
 msgstr "Unteraufgabe ${task} hinzugefügt durch ${user}"
 
 #. Default: "Task accepted"
-#: ./opengever/task/response_description.py:148
+#: ./opengever/task/response_description.py:146
 msgid "transition_label_accept"
 msgstr "Aufgabe akzeptiert"
 
 #. Default: "Document added to Task"
-#: ./opengever/task/response_description.py:319
+#: ./opengever/task/response_description.py:317
 msgid "transition_label_add_document"
 msgstr "Dokument zur Aufgabe hinzugefügt"
 
 #. Default: "Subtask added to task"
-#: ./opengever/task/response_description.py:299
+#: ./opengever/task/response_description.py:297
 msgid "transition_label_add_subtask"
 msgstr "Unteraufgabe zur Aufgabe hinzugefügt"
 
 #. Default: "Forwarding assigned to Dossier"
-#: ./opengever/task/response_description.py:276
+#: ./opengever/task/response_description.py:274
 msgid "transition_label_assign_to_dossier"
 msgstr "Weiterleitung zu einem Dossier hinzugefügt"
 
 #. Default: "Task cancelled"
-#: ./opengever/task/response_description.py:132
+#: ./opengever/task/response_description.py:130
 msgid "transition_label_cancelled"
 msgstr "Aufgabe storniert"
 
 #. Default: "Task closed"
-#: ./opengever/task/response_description.py:118
+#: ./opengever/task/response_description.py:116
 msgid "transition_label_close"
 msgstr "Aufgabe abgeschlossen"
 
@@ -790,122 +786,123 @@ msgid "transition_label_created"
 msgstr "Erstellt durch ${user}"
 
 #. Default: "Task added"
-#: ./opengever/task/response_description.py:51
+#: ./opengever/task/activities.py:103
+#: ./opengever/task/response_description.py:49
 msgid "transition_label_default"
 msgstr "Aufgabe hinzugefügt"
 
 #. Default: "Task deadline modified"
-#: ./opengever/task/response_description.py:226
+#: ./opengever/task/response_description.py:224
 msgid "transition_label_modify_deadline"
 msgstr "Aufgabenfrist verändert"
 
 #. Default: "Task reactivated"
-#: ./opengever/task/response_description.py:70
+#: ./opengever/task/response_description.py:68
 msgid "transition_label_reactivate"
 msgstr "Aufgabe reaktiviert"
 
 #. Default: "Task reassigned"
-#: ./opengever/task/response_description.py:201
+#: ./opengever/task/response_description.py:199
 msgid "transition_label_reassign"
 msgstr "Aufgabe neu zugewiesen"
 
 #. Default: "Forwarding refused"
-#: ./opengever/task/response_description.py:256
+#: ./opengever/task/response_description.py:254
 msgid "transition_label_refuse"
 msgstr "Weiterleitung abgelehnt"
 
 #. Default: "Task rejected"
-#: ./opengever/task/response_description.py:84
+#: ./opengever/task/response_description.py:82
 msgid "transition_label_reject"
 msgstr "Aufgabe abgelehnt"
 
 #. Default: "Task reopened"
-#: ./opengever/task/response_description.py:163
+#: ./opengever/task/response_description.py:161
 msgid "transition_label_reopen"
 msgstr "Aufgaben wieder eröffnet"
 
 #. Default: "Task resolved"
-#: ./opengever/task/response_description.py:100
+#: ./opengever/task/response_description.py:98
 msgid "transition_label_resolve"
 msgstr "Aufgabe erledigt"
 
 #. Default: "Task revised"
-#: ./opengever/task/response_description.py:178
+#: ./opengever/task/response_description.py:176
 msgid "transition_label_revise"
 msgstr "Überarbeitung der Aufgabe angefordert"
 
 #. Default: "Accepted by ${user}"
-#: ./opengever/task/response_description.py:144
+#: ./opengever/task/response_description.py:142
 msgid "transition_msg_accept"
 msgstr "Akzeptiert durch ${user}"
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
-#: ./opengever/task/response_description.py:270
+#: ./opengever/task/response_description.py:268
 msgid "transition_msg_assign_to_dossier"
 msgstr "Einem Dossier zugewiesen durch ${user} Nachfolgeaufgabe=${successor}"
 
 #. Default: "Cancelled by ${user}"
-#: ./opengever/task/response_description.py:128
+#: ./opengever/task/response_description.py:126
 msgid "transition_msg_cancel"
 msgstr "Storniert durch ${user}"
 
 #. Default: "Closed by ${user}"
-#: ./opengever/task/response_description.py:114
+#: ./opengever/task/response_description.py:112
 msgid "transition_msg_close"
 msgstr "Abgeschlossen durch ${user}"
 
 #. Default: "Response added"
-#: ./opengever/task/response_description.py:46
+#: ./opengever/task/response_description.py:44
 msgid "transition_msg_default"
 msgstr "Antwort hinzugefügt"
 
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
-#: ./opengever/task/response_description.py:218
+#: ./opengever/task/response_description.py:216
 msgid "transition_msg_modify_deadline"
 msgstr "Frist geändert von ${deadline_old} zu ${deadline_new} durch ${user}"
 
 #. Default: "Reactivate by ${user}"
-#: ./opengever/task/response_description.py:66
+#: ./opengever/task/response_description.py:64
 msgid "transition_msg_reactivate"
 msgstr "Reaktiviert durch ${user}"
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
-#: ./opengever/task/response_description.py:193
+#: ./opengever/task/response_description.py:191
 msgid "transition_msg_reassign"
 msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new} durch ${user}"
 
 #. Default: "Refused by ${user}"
-#: ./opengever/task/response_description.py:252
+#: ./opengever/task/response_description.py:250
 msgid "transition_msg_refuse"
 msgstr "Abgelehnt durch ${user}"
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/task/response_description.py:80
+#: ./opengever/task/response_description.py:78
 msgid "transition_msg_reject"
 msgstr "Abgelehnt durch ${user}"
 
 #. Default: "Reopened by ${user}"
-#: ./opengever/task/response_description.py:159
+#: ./opengever/task/response_description.py:157
 msgid "transition_msg_reopen"
 msgstr "Wieder eröffnet durch ${user}"
 
 #. Default: "Resolved by ${user}"
-#: ./opengever/task/response_description.py:96
+#: ./opengever/task/response_description.py:94
 msgid "transition_msg_resolve"
 msgstr "Erledigt durch ${user}"
 
 #. Default: "Revised by ${user}"
-#: ./opengever/task/response_description.py:174
+#: ./opengever/task/response_description.py:172
 msgid "transition_msg_revise"
 msgstr "Überarbeitung angefordert durch ${user}"
 
 #. Default: "Document copied from forwarding (forwarding accepted)"
-#: ./opengever/task/browser/accept/utils.py:94
+#: ./opengever/task/browser/accept/utils.py:90
 msgid "version_message_accept_forwarding"
 msgstr "Dokument von Weiterleitung kopiert (Weiterleitung akzeptiert)"
 
 #. Default: "Document copied from task (task accepted)"
-#: ./opengever/task/browser/accept/utils.py:259
+#: ./opengever/task/browser/accept/utils.py:249
 msgid "version_message_accept_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe akzeptiert)"
 
@@ -919,3 +916,4 @@ msgstr "Dokument von Aufgabe kopiert (Aufgabe abgeschlossen)"
 #: ./opengever/task/browser/complete.py:291
 msgid "version_message_resolved_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe erledigt)"
+

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-01 14:17+0000\n"
+"POT-Creation-Date: 2015-12-09 10:39+0000\n"
 "PO-Revision-Date: 2015-02-17 18:42+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -76,12 +76,12 @@ msgstr "Tâche"
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr "Les documents sont transmis au mandataire et les tâches sont fermées."
 
-#: ./opengever/task/browser/accept/inbox.py:31
+#: ./opengever/task/browser/accept/inbox.py:33
 msgid "The forwarding has been stored in the local inbox"
 msgstr "L'acheminement est sauvegardé dans la boîte de réception locale."
 
 #: ./opengever/task/browser/accept/existingdossier.py:119
-#: ./opengever/task/browser/accept/newdossier.py:373
+#: ./opengever/task/browser/accept/newdossier.py:319
 msgid "The forwarding has been stored in the local inbox and the succesor task has been created"
 msgstr "L'acheminement est déposé dans la boîte de réception locale et une copie de la tâche est créée."
 
@@ -89,11 +89,11 @@ msgstr "L'acheminement est déposé dans la boîte de réception locale et une c
 msgid "The forwarding is now assigned to the dossier"
 msgstr "L'acheminement a été attribué au dossier."
 
-#: ./opengever/task/browser/accept/newdossier.py:358
+#: ./opengever/task/browser/accept/newdossier.py:304
 msgid "The forwarding is now assigned to the new dossier"
 msgstr "L'acheminement a été attribué à un noveau dossier."
 
-#: ./opengever/task/browser/accept/newdossier.py:388
+#: ./opengever/task/browser/accept/newdossier.py:334
 msgid "The new dossier has been created and the task has been copied to the new dossier."
 msgstr "Le nouveau dossier a été créé. La tâche acceptée a été copiée dans le nouveau dossier."
 
@@ -120,10 +120,6 @@ msgstr "Vous n'avez pas été désigné comme client. Vous ne pouvez traiter la 
 #: ./opengever/task/browser/close.py:187
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr "Vos droits ne sont pas suffisants pour ajouter des documents dans le dossier choisi. Le dossier est probablement déjà fermé."
-
-#: ./opengever/task/browser/accept/newdossier.py:116
-msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
-msgstr "Vous ne pouvez créer aucun dossier dans ce numéro de classement. Ce dernier en contient d'autres ou alors vous n'avez pas les droits suffisants pour effectuer cette tâche."
 
 #: ./opengever/task/browser/accept/existingdossier.py:71
 msgid "You cannot add tasks in the selected dossier. Either the dossier is closed or you do not have the privileges."
@@ -172,20 +168,20 @@ msgstr "Attribuer"
 #. Default: "Cancel"
 #: ./opengever/task/browser/accept/existingdossier.py:134
 #: ./opengever/task/browser/accept/main.py:208
-#: ./opengever/task/browser/accept/newdossier.py:155
+#: ./opengever/task/browser/accept/newdossier.py:138
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Continue"
 #: ./opengever/task/browser/accept/main.py:144
-#: ./opengever/task/browser/accept/newdossier.py:132
+#: ./opengever/task/browser/accept/newdossier.py:115
 #: ./opengever/task/browser/assign_dossier.py:73
 msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Save"
 #: ./opengever/task/browser/accept/existingdossier.py:93
-#: ./opengever/task/browser/accept/newdossier.py:330
+#: ./opengever/task/browser/accept/newdossier.py:276
 #: ./opengever/task/browser/close.py:201
 msgid "button_save"
 msgstr "Sauvegarder"
@@ -230,12 +226,12 @@ msgid "existing_dossier"
 msgstr "Dossier existant"
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:70
+#: ./opengever/task/task.py:68
 msgid "fieldset_additional"
 msgstr "Avancé"
 
 #. Default: "Common"
-#: ./opengever/task/task.py:55
+#: ./opengever/task/task.py:53
 msgid "fieldset_common"
 msgstr "En général"
 
@@ -250,12 +246,12 @@ msgid "help_accept_select_dossier"
 msgstr "Choix du dossier dans lequel vous voulez modifier la tâche."
 
 #. Default: "Select the type for the new dossier."
-#: ./opengever/task/browser/accept/newdossier.py:224
+#: ./opengever/task/browser/accept/newdossier.py:213
 msgid "help_accept_select_dossier_type"
 msgstr "Choix du type du nouveau dossier"
 
 #. Default: "Select the repository folder within the dossier should be created."
-#: ./opengever/task/browser/accept/newdossier.py:82
+#: ./opengever/task/browser/accept/newdossier.py:84
 msgid "help_accept_select_repositoryfolder"
 msgstr "Choix du numéro de classement où le dossier doit être créé"
 
@@ -291,41 +287,41 @@ msgid "help_complete_task_response"
 msgstr "Le texte saisi ici apparaît dans la réponse qui clôture cette tâche."
 
 #: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:133
+#: ./opengever/task/task.py:132
 msgid "help_date_of_completion"
 msgstr "Date d'achèvement de la tâche"
 
 #: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:126
+#: ./opengever/task/task.py:125
 msgid "help_deadline"
 msgstr "Saisissez la date d'achèvement de la tâche"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:191
+#: ./opengever/task/task.py:190
 msgid "help_effectiveCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:185
+#: ./opengever/task/task.py:184
 msgid "help_effectiveDuration"
 msgstr "Durée effective en h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:179
+#: ./opengever/task/task.py:178
 msgid "help_expectedCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:173
+#: ./opengever/task/task.py:172
 msgid "help_expectedDuration"
 msgstr "Durée effective en h"
 
-#: ./opengever/task/task.py:167
+#: ./opengever/task/task.py:166
 msgid "help_expectedStartOfWork"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:91
+#: ./opengever/task/task.py:90
 msgid "help_issuer"
 msgstr ""
 
@@ -333,7 +329,7 @@ msgstr ""
 msgid "help_new_deadline"
 msgstr ""
 
-#: ./opengever/task/task.py:198
+#: ./opengever/task/task.py:197
 msgid "help_predecessor"
 msgstr ""
 
@@ -343,31 +339,31 @@ msgstr ""
 msgid "help_response"
 msgstr ""
 
-#: ./opengever/task/task.py:118
+#: ./opengever/task/task.py:117
 msgid "help_responsible"
 msgstr "Choix de la personne responsable, membre du client mentionné ci-dessus"
 
 #: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:110
+#: ./opengever/task/task.py:109
 msgid "help_responsible_client"
 msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire"
 
 #: ./opengever/task/browser/assign.py:46
-#: ./opengever/task/task.py:404
+#: ./opengever/task/form.py:41
 msgid "help_responsible_single_client_setup"
 msgstr "Choix de la personne responsable"
 
-#: ./opengever/task/task.py:99
+#: ./opengever/task/task.py:98
 msgid "help_task_type"
 msgstr "Choix du type de mandat"
 
 #: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:141
+#: ./opengever/task/task.py:140
 msgid "help_text"
 msgstr "Saisissez une instruction de travail détaillée ou un commentaire"
 
 #: ./opengever/task/browser/delegate/metadata.py:23
-#: ./opengever/task/task.py:84
+#: ./opengever/task/task.py:82
 msgid "help_title"
 msgstr "Nom de la tâche"
 
@@ -396,12 +392,12 @@ msgid "label_accept_select_dossier"
 msgstr "Dossier de destination"
 
 #. Default: "Dossier type"
-#: ./opengever/task/browser/accept/newdossier.py:223
+#: ./opengever/task/browser/accept/newdossier.py:212
 msgid "label_accept_select_dossier_type"
 msgstr "Type de dossier"
 
 #. Default: "Repository folder"
-#: ./opengever/task/browser/accept/newdossier.py:80
+#: ./opengever/task/browser/accept/newdossier.py:82
 msgid "label_accept_select_repositoryfolder"
 msgstr "Numéro de classement"
 
@@ -446,16 +442,16 @@ msgid "label_created"
 msgstr "Créé le"
 
 #. Default: "Date of completion"
-#: ./opengever/task/browser/overview.py:103
+#: ./opengever/task/browser/overview.py:102
 #: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:132
+#: ./opengever/task/task.py:131
 msgid "label_date_of_completion"
 msgstr "Date de réalisation"
 
 #. Default: "Deadline"
-#: ./opengever/task/activities.py:105
+#: ./opengever/task/activities.py:134
 #: ./opengever/task/browser/delegate/metadata.py:33
-#: ./opengever/task/browser/overview.py:87
+#: ./opengever/task/browser/overview.py:86
 msgid "label_deadline"
 msgstr "A réaliser jusqu'au"
 
@@ -465,7 +461,7 @@ msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Dossier title"
-#: ./opengever/task/activities.py:110
+#: ./opengever/task/activities.py:138
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
 
@@ -475,12 +471,12 @@ msgid "label_edit_response_not_allowed"
 msgstr "Vous n'avez pas les droits pour effacer cette réponse"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:189
 msgid "label_effectiveCost"
 msgstr "Coûts effectifs (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:183
 msgid "label_effectiveDuration"
 msgstr "Durée effective (h)"
 
@@ -490,24 +486,24 @@ msgid "label_enter_response"
 msgstr "Saisissez votre réponse ci-dessous"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:177
 msgid "label_expectedCost"
 msgstr "Coûts estimés (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:172
+#: ./opengever/task/task.py:171
 msgid "label_expectedDuration"
 msgstr "Durée estimées (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:166
+#: ./opengever/task/task.py:165
 msgid "label_expectedStartOfWork"
 msgstr "Début du travail"
 
 #. Default: "Issuer"
 #: ./opengever/task/browser/delegate/metadata.py:27
-#: ./opengever/task/browser/overview.py:92
-#: ./opengever/task/task.py:90
+#: ./opengever/task/browser/overview.py:91
+#: ./opengever/task/task.py:89
 msgid "label_issuer"
 msgstr "Mandant"
 
@@ -527,12 +523,12 @@ msgid "label_new_deadline"
 msgstr "Nouveau délai"
 
 #. Default: "Dossiertitle"
-#: ./opengever/task/browser/overview.py:70
+#: ./opengever/task/browser/overview.py:69
 msgid "label_parent_dossier_title"
 msgstr "Titre de la dossier"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:197
+#: ./opengever/task/task.py:196
 msgid "label_predecessor"
 msgstr "Prédécesseur"
 
@@ -544,13 +540,13 @@ msgstr "Tâche initiale"
 #. Default: "Related Items"
 #: ./opengever/task/browser/complete.py:215
 #: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:146
+#: ./opengever/task/task.py:145
 msgid "label_related_items"
 msgstr "Renvois"
 
 #. Default: "Responsible Client"
 #: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:108
+#: ./opengever/task/task.py:107
 msgid "label_resonsible_client"
 msgstr "Mandataire du client"
 
@@ -563,7 +559,7 @@ msgstr "Response"
 
 #. Default: "Responsible"
 #: ./opengever/task/browser/assign.py:45
-#: ./opengever/task/browser/overview.py:98
+#: ./opengever/task/browser/overview.py:97
 #: ./opengever/task/statesyncer.py:134
 msgid "label_responsible"
 msgstr "Mandataire"
@@ -589,33 +585,33 @@ msgid "label_successor_task"
 msgstr "Tâche copiée"
 
 #. Default: "New task added by ${user}"
-#: ./opengever/task/activities.py:84
+#: ./opengever/task/activities.py:108
 msgid "label_task_added"
 msgstr "Nouvelle tâche ajoutée par ${user}"
 
 #. Default: "Task title"
-#: ./opengever/task/activities.py:103
-#: ./opengever/task/browser/overview.py:66
+#: ./opengever/task/activities.py:133
+#: ./opengever/task/browser/overview.py:65
 msgid "label_task_title"
 msgstr "Titre de la tâche"
 
 #. Default: "Task Type"
-#: ./opengever/task/activities.py:107
-#: ./opengever/task/browser/overview.py:78
-#: ./opengever/task/task.py:98
+#: ./opengever/task/activities.py:136
+#: ./opengever/task/browser/overview.py:77
+#: ./opengever/task/task.py:97
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Text"
-#: ./opengever/task/activities.py:112
+#: ./opengever/task/activities.py:140
 #: ./opengever/task/browser/delegate/metadata.py:38
-#: ./opengever/task/browser/overview.py:74
+#: ./opengever/task/browser/overview.py:73
 msgid "label_text"
 msgstr "Description"
 
 #. Default: "Title"
 #: ./opengever/task/browser/delegate/metadata.py:22
-#: ./opengever/task/task.py:83
+#: ./opengever/task/task.py:81
 msgid "label_title"
 msgstr "Titre"
 
@@ -627,7 +623,7 @@ msgid "label_transition"
 msgstr "Action"
 
 #. Default: "State"
-#: ./opengever/task/browser/overview.py:82
+#: ./opengever/task/browser/overview.py:81
 msgid "label_workflow_state"
 msgstr "Etat"
 
@@ -672,24 +668,24 @@ msgstr "Enregistrer"
 #. Default: "Step 1"
 #: ./opengever/task/browser/accept/existingdossier.py:87
 #: ./opengever/task/browser/accept/main.py:37
-#: ./opengever/task/browser/accept/newdossier.py:53
+#: ./opengever/task/browser/accept/newdossier.py:55
 msgid "step_1"
 msgstr "Premier étape"
 
 #. Default: "Step 2"
 #: ./opengever/task/browser/accept/existingdossier.py:90
-#: ./opengever/task/browser/accept/newdossier.py:56
+#: ./opengever/task/browser/accept/newdossier.py:58
 #: ./opengever/task/browser/close.py:52
 msgid "step_2"
 msgstr "Deuxième étape"
 
 #. Default: "Step 3"
-#: ./opengever/task/browser/accept/newdossier.py:59
+#: ./opengever/task/browser/accept/newdossier.py:61
 msgid "step_3"
 msgstr "Troisième étape"
 
 #. Default: "Step 4"
-#: ./opengever/task/browser/accept/newdossier.py:62
+#: ./opengever/task/browser/accept/newdossier.py:64
 msgid "step_4"
 msgstr "Quatrième étape"
 
@@ -744,42 +740,42 @@ msgid "title_modify_deadline"
 msgstr "Changer le délai"
 
 #. Default: "Document ${doc} added by ${user}"
-#: ./opengever/task/response_description.py:313
+#: ./opengever/task/response_description.py:311
 msgid "transition_add_document"
 msgstr "Document ${doc} ajouté par ${user}"
 
 #. Default: "Subtask ${task} added by ${user}"
-#: ./opengever/task/response_description.py:293
+#: ./opengever/task/response_description.py:291
 msgid "transition_add_subtask"
 msgstr "Sous-tâche ${task} ajoutée par ${user}"
 
 #. Default: "Task accepted"
-#: ./opengever/task/response_description.py:148
+#: ./opengever/task/response_description.py:146
 msgid "transition_label_accept"
 msgstr ""
 
 #. Default: "Document added to Task"
-#: ./opengever/task/response_description.py:319
+#: ./opengever/task/response_description.py:317
 msgid "transition_label_add_document"
 msgstr ""
 
 #. Default: "Subtask added to task"
-#: ./opengever/task/response_description.py:299
+#: ./opengever/task/response_description.py:297
 msgid "transition_label_add_subtask"
 msgstr ""
 
 #. Default: "Forwarding assigned to Dossier"
-#: ./opengever/task/response_description.py:276
+#: ./opengever/task/response_description.py:274
 msgid "transition_label_assign_to_dossier"
 msgstr ""
 
 #. Default: "Task cancelled"
-#: ./opengever/task/response_description.py:132
+#: ./opengever/task/response_description.py:130
 msgid "transition_label_cancelled"
 msgstr ""
 
 #. Default: "Task closed"
-#: ./opengever/task/response_description.py:118
+#: ./opengever/task/response_description.py:116
 msgid "transition_label_close"
 msgstr ""
 
@@ -789,122 +785,123 @@ msgid "transition_label_created"
 msgstr ""
 
 #. Default: "Task added"
-#: ./opengever/task/response_description.py:51
+#: ./opengever/task/activities.py:103
+#: ./opengever/task/response_description.py:49
 msgid "transition_label_default"
 msgstr ""
 
 #. Default: "Task deadline modified"
-#: ./opengever/task/response_description.py:226
+#: ./opengever/task/response_description.py:224
 msgid "transition_label_modify_deadline"
 msgstr ""
 
 #. Default: "Task reactivated"
-#: ./opengever/task/response_description.py:70
+#: ./opengever/task/response_description.py:68
 msgid "transition_label_reactivate"
 msgstr ""
 
 #. Default: "Task reassigned"
-#: ./opengever/task/response_description.py:201
+#: ./opengever/task/response_description.py:199
 msgid "transition_label_reassign"
 msgstr ""
 
 #. Default: "Forwarding refused"
-#: ./opengever/task/response_description.py:256
+#: ./opengever/task/response_description.py:254
 msgid "transition_label_refuse"
 msgstr ""
 
 #. Default: "Task rejected"
-#: ./opengever/task/response_description.py:84
+#: ./opengever/task/response_description.py:82
 msgid "transition_label_reject"
 msgstr ""
 
 #. Default: "Task reopened"
-#: ./opengever/task/response_description.py:163
+#: ./opengever/task/response_description.py:161
 msgid "transition_label_reopen"
 msgstr ""
 
 #. Default: "Task resolved"
-#: ./opengever/task/response_description.py:100
+#: ./opengever/task/response_description.py:98
 msgid "transition_label_resolve"
 msgstr ""
 
 #. Default: "Task revised"
-#: ./opengever/task/response_description.py:178
+#: ./opengever/task/response_description.py:176
 msgid "transition_label_revise"
 msgstr ""
 
 #. Default: "Accepted by ${user}"
-#: ./opengever/task/response_description.py:144
+#: ./opengever/task/response_description.py:142
 msgid "transition_msg_accept"
 msgstr "Accépté par ${user}"
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
-#: ./opengever/task/response_description.py:270
+#: ./opengever/task/response_description.py:268
 msgid "transition_msg_assign_to_dossier"
 msgstr "Attribué à un dossier par ${user} Tâche suivante=${successor}"
 
 #. Default: "Cancelled by ${user}"
-#: ./opengever/task/response_description.py:128
+#: ./opengever/task/response_description.py:126
 msgid "transition_msg_cancel"
 msgstr "Annulé par ${user}"
 
 #. Default: "Closed by ${user}"
-#: ./opengever/task/response_description.py:114
+#: ./opengever/task/response_description.py:112
 msgid "transition_msg_close"
 msgstr "Fermé par ${user}"
 
 #. Default: "Response added"
-#: ./opengever/task/response_description.py:46
+#: ./opengever/task/response_description.py:44
 msgid "transition_msg_default"
 msgstr "Réponse ajouté"
 
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
-#: ./opengever/task/response_description.py:218
+#: ./opengever/task/response_description.py:216
 msgid "transition_msg_modify_deadline"
 msgstr "Délai modifié de ${deadline_old} à ${deadline_new} par ${user}"
 
 #. Default: "Reactivate by ${user}"
-#: ./opengever/task/response_description.py:66
+#: ./opengever/task/response_description.py:64
 msgid "transition_msg_reactivate"
 msgstr "Réactivé par ${user}"
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
-#: ./opengever/task/response_description.py:193
+#: ./opengever/task/response_description.py:191
 msgid "transition_msg_reassign"
 msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new} par ${user}"
 
 #. Default: "Refused by ${user}"
-#: ./opengever/task/response_description.py:252
+#: ./opengever/task/response_description.py:250
 msgid "transition_msg_refuse"
 msgstr "Refusé par ${user}"
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/task/response_description.py:80
+#: ./opengever/task/response_description.py:78
 msgid "transition_msg_reject"
 msgstr "Refusé par ${user}"
 
 #. Default: "Reopened by ${user}"
-#: ./opengever/task/response_description.py:159
+#: ./opengever/task/response_description.py:157
 msgid "transition_msg_reopen"
 msgstr "Réouvert par ${user}"
 
 #. Default: "Resolved by ${user}"
-#: ./opengever/task/response_description.py:96
+#: ./opengever/task/response_description.py:94
 msgid "transition_msg_resolve"
 msgstr "Accompli par ${user}"
 
 #. Default: "Revised by ${user}"
-#: ./opengever/task/response_description.py:174
+#: ./opengever/task/response_description.py:172
 msgid "transition_msg_revise"
 msgstr "Révision demandée par ${user}"
 
 #. Default: "Document copied from forwarding (forwarding accepted)"
-#: ./opengever/task/browser/accept/utils.py:94
+#: ./opengever/task/browser/accept/utils.py:90
 msgid "version_message_accept_forwarding"
 msgstr "Document copié de l'acheminement (Acheminement accepté)"
 
 #. Default: "Document copied from task (task accepted)"
-#: ./opengever/task/browser/accept/utils.py:259
+#: ./opengever/task/browser/accept/utils.py:249
 msgid "version_message_accept_task"
 msgstr "Document copié de la tâche (Tâche accepté)"
 

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-07-01 14:17+0000\n"
+"POT-Creation-Date: 2015-12-09 10:39+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -77,12 +77,12 @@ msgstr ""
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr ""
 
-#: ./opengever/task/browser/accept/inbox.py:31
+#: ./opengever/task/browser/accept/inbox.py:33
 msgid "The forwarding has been stored in the local inbox"
 msgstr ""
 
 #: ./opengever/task/browser/accept/existingdossier.py:119
-#: ./opengever/task/browser/accept/newdossier.py:373
+#: ./opengever/task/browser/accept/newdossier.py:319
 msgid "The forwarding has been stored in the local inbox and the succesor task has been created"
 msgstr ""
 
@@ -90,11 +90,11 @@ msgstr ""
 msgid "The forwarding is now assigned to the dossier"
 msgstr ""
 
-#: ./opengever/task/browser/accept/newdossier.py:358
+#: ./opengever/task/browser/accept/newdossier.py:304
 msgid "The forwarding is now assigned to the new dossier"
 msgstr ""
 
-#: ./opengever/task/browser/accept/newdossier.py:388
+#: ./opengever/task/browser/accept/newdossier.py:334
 msgid "The new dossier has been created and the task has been copied to the new dossier."
 msgstr ""
 
@@ -120,10 +120,6 @@ msgstr ""
 
 #: ./opengever/task/browser/close.py:187
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
-msgstr ""
-
-#: ./opengever/task/browser/accept/newdossier.py:116
-msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
 msgstr ""
 
 #: ./opengever/task/browser/accept/existingdossier.py:71
@@ -173,20 +169,20 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/task/browser/accept/existingdossier.py:134
 #: ./opengever/task/browser/accept/main.py:208
-#: ./opengever/task/browser/accept/newdossier.py:155
+#: ./opengever/task/browser/accept/newdossier.py:138
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/task/browser/accept/main.py:144
-#: ./opengever/task/browser/accept/newdossier.py:132
+#: ./opengever/task/browser/accept/newdossier.py:115
 #: ./opengever/task/browser/assign_dossier.py:73
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Save"
 #: ./opengever/task/browser/accept/existingdossier.py:93
-#: ./opengever/task/browser/accept/newdossier.py:330
+#: ./opengever/task/browser/accept/newdossier.py:276
 #: ./opengever/task/browser/close.py:201
 msgid "button_save"
 msgstr ""
@@ -231,12 +227,12 @@ msgid "existing_dossier"
 msgstr ""
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:70
+#: ./opengever/task/task.py:68
 msgid "fieldset_additional"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/task/task.py:55
+#: ./opengever/task/task.py:53
 msgid "fieldset_common"
 msgstr ""
 
@@ -251,12 +247,12 @@ msgid "help_accept_select_dossier"
 msgstr ""
 
 #. Default: "Select the type for the new dossier."
-#: ./opengever/task/browser/accept/newdossier.py:224
+#: ./opengever/task/browser/accept/newdossier.py:213
 msgid "help_accept_select_dossier_type"
 msgstr ""
 
 #. Default: "Select the repository folder within the dossier should be created."
-#: ./opengever/task/browser/accept/newdossier.py:82
+#: ./opengever/task/browser/accept/newdossier.py:84
 msgid "help_accept_select_repositoryfolder"
 msgstr ""
 
@@ -292,41 +288,41 @@ msgid "help_complete_task_response"
 msgstr ""
 
 #: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:133
+#: ./opengever/task/task.py:132
 msgid "help_date_of_completion"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:126
+#: ./opengever/task/task.py:125
 msgid "help_deadline"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:191
+#: ./opengever/task/task.py:190
 msgid "help_effectiveCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:185
+#: ./opengever/task/task.py:184
 msgid "help_effectiveDuration"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:179
+#: ./opengever/task/task.py:178
 msgid "help_expectedCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:173
+#: ./opengever/task/task.py:172
 msgid "help_expectedDuration"
 msgstr ""
 
-#: ./opengever/task/task.py:167
+#: ./opengever/task/task.py:166
 msgid "help_expectedStartOfWork"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:91
+#: ./opengever/task/task.py:90
 msgid "help_issuer"
 msgstr ""
 
@@ -334,7 +330,7 @@ msgstr ""
 msgid "help_new_deadline"
 msgstr ""
 
-#: ./opengever/task/task.py:198
+#: ./opengever/task/task.py:197
 msgid "help_predecessor"
 msgstr ""
 
@@ -344,31 +340,31 @@ msgstr ""
 msgid "help_response"
 msgstr ""
 
-#: ./opengever/task/task.py:118
+#: ./opengever/task/task.py:117
 msgid "help_responsible"
 msgstr ""
 
 #: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:110
+#: ./opengever/task/task.py:109
 msgid "help_responsible_client"
 msgstr ""
 
 #: ./opengever/task/browser/assign.py:46
-#: ./opengever/task/task.py:404
+#: ./opengever/task/form.py:41
 msgid "help_responsible_single_client_setup"
 msgstr ""
 
-#: ./opengever/task/task.py:99
+#: ./opengever/task/task.py:98
 msgid "help_task_type"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:141
+#: ./opengever/task/task.py:140
 msgid "help_text"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:23
-#: ./opengever/task/task.py:84
+#: ./opengever/task/task.py:82
 msgid "help_title"
 msgstr ""
 
@@ -397,12 +393,12 @@ msgid "label_accept_select_dossier"
 msgstr ""
 
 #. Default: "Dossier type"
-#: ./opengever/task/browser/accept/newdossier.py:223
+#: ./opengever/task/browser/accept/newdossier.py:212
 msgid "label_accept_select_dossier_type"
 msgstr ""
 
 #. Default: "Repository folder"
-#: ./opengever/task/browser/accept/newdossier.py:80
+#: ./opengever/task/browser/accept/newdossier.py:82
 msgid "label_accept_select_repositoryfolder"
 msgstr ""
 
@@ -447,16 +443,16 @@ msgid "label_created"
 msgstr ""
 
 #. Default: "Date of completion"
-#: ./opengever/task/browser/overview.py:103
+#: ./opengever/task/browser/overview.py:102
 #: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:132
+#: ./opengever/task/task.py:131
 msgid "label_date_of_completion"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/task/activities.py:105
+#: ./opengever/task/activities.py:134
 #: ./opengever/task/browser/delegate/metadata.py:33
-#: ./opengever/task/browser/overview.py:87
+#: ./opengever/task/browser/overview.py:86
 msgid "label_deadline"
 msgstr ""
 
@@ -466,7 +462,7 @@ msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossier title"
-#: ./opengever/task/activities.py:110
+#: ./opengever/task/activities.py:138
 msgid "label_dossier_title"
 msgstr ""
 
@@ -476,12 +472,12 @@ msgid "label_edit_response_not_allowed"
 msgstr ""
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:189
 msgid "label_effectiveCost"
 msgstr ""
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:183
 msgid "label_effectiveDuration"
 msgstr ""
 
@@ -491,24 +487,24 @@ msgid "label_enter_response"
 msgstr ""
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:177
 msgid "label_expectedCost"
 msgstr ""
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:172
+#: ./opengever/task/task.py:171
 msgid "label_expectedDuration"
 msgstr ""
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:166
+#: ./opengever/task/task.py:165
 msgid "label_expectedStartOfWork"
 msgstr ""
 
 #. Default: "Issuer"
 #: ./opengever/task/browser/delegate/metadata.py:27
-#: ./opengever/task/browser/overview.py:92
-#: ./opengever/task/task.py:90
+#: ./opengever/task/browser/overview.py:91
+#: ./opengever/task/task.py:89
 msgid "label_issuer"
 msgstr ""
 
@@ -527,12 +523,12 @@ msgstr ""
 msgid "label_new_deadline"
 msgstr ""
 
-#: ./opengever/task/browser/overview.py:70
+#: ./opengever/task/browser/overview.py:69
 msgid "label_parent_dossier_title"
 msgstr ""
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:197
+#: ./opengever/task/task.py:196
 msgid "label_predecessor"
 msgstr ""
 
@@ -544,13 +540,13 @@ msgstr ""
 #. Default: "Related Items"
 #: ./opengever/task/browser/complete.py:215
 #: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:146
+#: ./opengever/task/task.py:145
 msgid "label_related_items"
 msgstr ""
 
 #. Default: "Responsible Client"
 #: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:108
+#: ./opengever/task/task.py:107
 msgid "label_resonsible_client"
 msgstr ""
 
@@ -563,7 +559,7 @@ msgstr ""
 
 #. Default: "Responsible"
 #: ./opengever/task/browser/assign.py:45
-#: ./opengever/task/browser/overview.py:98
+#: ./opengever/task/browser/overview.py:97
 #: ./opengever/task/statesyncer.py:134
 msgid "label_responsible"
 msgstr ""
@@ -589,33 +585,33 @@ msgid "label_successor_task"
 msgstr ""
 
 #. Default: "New task added by ${user}"
-#: ./opengever/task/activities.py:84
+#: ./opengever/task/activities.py:108
 msgid "label_task_added"
 msgstr ""
 
 #. Default: "Task title"
-#: ./opengever/task/activities.py:103
-#: ./opengever/task/browser/overview.py:66
+#: ./opengever/task/activities.py:133
+#: ./opengever/task/browser/overview.py:65
 msgid "label_task_title"
 msgstr ""
 
 #. Default: "Task Type"
-#: ./opengever/task/activities.py:107
-#: ./opengever/task/browser/overview.py:78
-#: ./opengever/task/task.py:98
+#: ./opengever/task/activities.py:136
+#: ./opengever/task/browser/overview.py:77
+#: ./opengever/task/task.py:97
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Text"
-#: ./opengever/task/activities.py:112
+#: ./opengever/task/activities.py:140
 #: ./opengever/task/browser/delegate/metadata.py:38
-#: ./opengever/task/browser/overview.py:74
+#: ./opengever/task/browser/overview.py:73
 msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/task/browser/delegate/metadata.py:22
-#: ./opengever/task/task.py:83
+#: ./opengever/task/task.py:81
 msgid "label_title"
 msgstr ""
 
@@ -626,7 +622,7 @@ msgstr ""
 msgid "label_transition"
 msgstr ""
 
-#: ./opengever/task/browser/overview.py:82
+#: ./opengever/task/browser/overview.py:81
 msgid "label_workflow_state"
 msgstr ""
 
@@ -671,24 +667,24 @@ msgstr ""
 #. Default: "Step 1"
 #: ./opengever/task/browser/accept/existingdossier.py:87
 #: ./opengever/task/browser/accept/main.py:37
-#: ./opengever/task/browser/accept/newdossier.py:53
+#: ./opengever/task/browser/accept/newdossier.py:55
 msgid "step_1"
 msgstr ""
 
 #. Default: "Step 2"
 #: ./opengever/task/browser/accept/existingdossier.py:90
-#: ./opengever/task/browser/accept/newdossier.py:56
+#: ./opengever/task/browser/accept/newdossier.py:58
 #: ./opengever/task/browser/close.py:52
 msgid "step_2"
 msgstr ""
 
 #. Default: "Step 3"
-#: ./opengever/task/browser/accept/newdossier.py:59
+#: ./opengever/task/browser/accept/newdossier.py:61
 msgid "step_3"
 msgstr ""
 
 #. Default: "Step 4"
-#: ./opengever/task/browser/accept/newdossier.py:62
+#: ./opengever/task/browser/accept/newdossier.py:64
 msgid "step_4"
 msgstr ""
 
@@ -743,42 +739,42 @@ msgid "title_modify_deadline"
 msgstr ""
 
 #. Default: "Document ${doc} added by ${user}"
-#: ./opengever/task/response_description.py:313
+#: ./opengever/task/response_description.py:311
 msgid "transition_add_document"
 msgstr ""
 
 #. Default: "Subtask ${task} added by ${user}"
-#: ./opengever/task/response_description.py:293
+#: ./opengever/task/response_description.py:291
 msgid "transition_add_subtask"
 msgstr ""
 
 #. Default: "Task accepted"
-#: ./opengever/task/response_description.py:148
+#: ./opengever/task/response_description.py:146
 msgid "transition_label_accept"
 msgstr ""
 
 #. Default: "Document added to Task"
-#: ./opengever/task/response_description.py:319
+#: ./opengever/task/response_description.py:317
 msgid "transition_label_add_document"
 msgstr ""
 
 #. Default: "Subtask added to task"
-#: ./opengever/task/response_description.py:299
+#: ./opengever/task/response_description.py:297
 msgid "transition_label_add_subtask"
 msgstr ""
 
 #. Default: "Forwarding assigned to Dossier"
-#: ./opengever/task/response_description.py:276
+#: ./opengever/task/response_description.py:274
 msgid "transition_label_assign_to_dossier"
 msgstr ""
 
 #. Default: "Task cancelled"
-#: ./opengever/task/response_description.py:132
+#: ./opengever/task/response_description.py:130
 msgid "transition_label_cancelled"
 msgstr ""
 
 #. Default: "Task closed"
-#: ./opengever/task/response_description.py:118
+#: ./opengever/task/response_description.py:116
 msgid "transition_label_close"
 msgstr ""
 
@@ -788,122 +784,123 @@ msgid "transition_label_created"
 msgstr ""
 
 #. Default: "Task added"
-#: ./opengever/task/response_description.py:51
+#: ./opengever/task/activities.py:103
+#: ./opengever/task/response_description.py:49
 msgid "transition_label_default"
 msgstr ""
 
 #. Default: "Task deadline modified"
-#: ./opengever/task/response_description.py:226
+#: ./opengever/task/response_description.py:224
 msgid "transition_label_modify_deadline"
 msgstr ""
 
 #. Default: "Task reactivated"
-#: ./opengever/task/response_description.py:70
+#: ./opengever/task/response_description.py:68
 msgid "transition_label_reactivate"
 msgstr ""
 
 #. Default: "Task reassigned"
-#: ./opengever/task/response_description.py:201
+#: ./opengever/task/response_description.py:199
 msgid "transition_label_reassign"
 msgstr ""
 
 #. Default: "Forwarding refused"
-#: ./opengever/task/response_description.py:256
+#: ./opengever/task/response_description.py:254
 msgid "transition_label_refuse"
 msgstr ""
 
 #. Default: "Task rejected"
-#: ./opengever/task/response_description.py:84
+#: ./opengever/task/response_description.py:82
 msgid "transition_label_reject"
 msgstr ""
 
 #. Default: "Task reopened"
-#: ./opengever/task/response_description.py:163
+#: ./opengever/task/response_description.py:161
 msgid "transition_label_reopen"
 msgstr ""
 
 #. Default: "Task resolved"
-#: ./opengever/task/response_description.py:100
+#: ./opengever/task/response_description.py:98
 msgid "transition_label_resolve"
 msgstr ""
 
 #. Default: "Task revised"
-#: ./opengever/task/response_description.py:178
+#: ./opengever/task/response_description.py:176
 msgid "transition_label_revise"
 msgstr ""
 
 #. Default: "Accepted by ${user}"
-#: ./opengever/task/response_description.py:144
+#: ./opengever/task/response_description.py:142
 msgid "transition_msg_accept"
 msgstr ""
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
-#: ./opengever/task/response_description.py:270
+#: ./opengever/task/response_description.py:268
 msgid "transition_msg_assign_to_dossier"
 msgstr ""
 
 #. Default: "Cancelled by ${user}"
-#: ./opengever/task/response_description.py:128
+#: ./opengever/task/response_description.py:126
 msgid "transition_msg_cancel"
 msgstr ""
 
 #. Default: "Closed by ${user}"
-#: ./opengever/task/response_description.py:114
+#: ./opengever/task/response_description.py:112
 msgid "transition_msg_close"
 msgstr ""
 
 #. Default: "Response added"
-#: ./opengever/task/response_description.py:46
+#: ./opengever/task/response_description.py:44
 msgid "transition_msg_default"
 msgstr ""
 
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
-#: ./opengever/task/response_description.py:218
+#: ./opengever/task/response_description.py:216
 msgid "transition_msg_modify_deadline"
 msgstr ""
 
 #. Default: "Reactivate by ${user}"
-#: ./opengever/task/response_description.py:66
+#: ./opengever/task/response_description.py:64
 msgid "transition_msg_reactivate"
 msgstr ""
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
-#: ./opengever/task/response_description.py:193
+#: ./opengever/task/response_description.py:191
 msgid "transition_msg_reassign"
 msgstr ""
 
 #. Default: "Refused by ${user}"
-#: ./opengever/task/response_description.py:252
+#: ./opengever/task/response_description.py:250
 msgid "transition_msg_refuse"
 msgstr ""
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/task/response_description.py:80
+#: ./opengever/task/response_description.py:78
 msgid "transition_msg_reject"
 msgstr ""
 
 #. Default: "Reopened by ${user}"
-#: ./opengever/task/response_description.py:159
+#: ./opengever/task/response_description.py:157
 msgid "transition_msg_reopen"
 msgstr ""
 
 #. Default: "Resolved by ${user}"
-#: ./opengever/task/response_description.py:96
+#: ./opengever/task/response_description.py:94
 msgid "transition_msg_resolve"
 msgstr ""
 
 #. Default: "Revised by ${user}"
-#: ./opengever/task/response_description.py:174
+#: ./opengever/task/response_description.py:172
 msgid "transition_msg_revise"
 msgstr ""
 
 #. Default: "Document copied from forwarding (forwarding accepted)"
-#: ./opengever/task/browser/accept/utils.py:94
+#: ./opengever/task/browser/accept/utils.py:90
 msgid "version_message_accept_forwarding"
 msgstr ""
 
 #. Default: "Document copied from task (task accepted)"
-#: ./opengever/task/browser/accept/utils.py:259
+#: ./opengever/task/browser/accept/utils.py:249
 msgid "version_message_accept_task"
 msgstr ""
 


### PR DESCRIPTION
When linking committees to a repository folder it is essential that a leaf
repository folder is selected. Otherwise it cannot contain dossiers for the
committee's meeting.

Fixes #1415.