### PR TITLE
Add fallback for members without any committee membership when generating ProtocolData.

### DIFF
--- a/opengever/meeting/protocol.py
+++ b/opengever/meeting/protocol.py
@@ -65,8 +65,8 @@ class ProtocolData(object):
                 self.meeting, participant)
             members.append({
                 "fullname": participant.fullname,
-                "role": membership.role
-                })
+                "role": membership.role if membership else None
+            })
 
         participants = {
             'members': members

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -1,6 +1,7 @@
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.model import create_session
 from opengever.meeting.browser.sablontemplate import SAMPLE_MEETING_DATA
 from opengever.meeting.protocol import ProtocolData
 from opengever.testing import FunctionalTestCase
@@ -65,3 +66,11 @@ class TestProtocolJsonData(FunctionalTestCase):
     def test_protocol_json(self):
         data = ProtocolData(self.meeting).data
         self.assertDictEqual(SAMPLE_MEETING_DATA, data)
+
+    def test_add_members_handles_participants_are_no_longer_committee_memberships(self):
+        create_session().delete(self.membership_peter)
+
+        self.assertEquals(
+            {'members': [{'fullname': u'Peter Meier', 'role': None},
+                         {'fullname': u'Franz M\xfcller', 'role': None}]},
+            ProtocolData(self.meeting).add_members())


### PR DESCRIPTION
Right now its possible to remove a membership, but the meeting stores a list of members not of memberships, therefore it needs a fallback when no membership is found.

Fixes #1425

