### PR TITLE
Fix save link in meetings protocol view.

### DIFF
--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -53,7 +53,7 @@
     this.discardProtocol = function() { meetingStorage.deleteCurrentMeeting(); };
 
     this.events = {
-      "click##form-buttons-save$": this.saveProtocol,
+      "click##form-buttons-save": this.saveProtocol,
       "click##form-buttons-cancel$": this.discardProtocol
     };
 


### PR DESCRIPTION
Prevent the default event, when clicking on the save link in the protocol view.
Because the save method is redirecting manually back to the meeting view, after saving the changes via AJAX requests, we prevent the default link event. Fixes #1420.

@deiferni 
