### PR TITLE
Moving caret to end does not work.

### DIFF
--- a/opengever/meeting/browser/resources/Scrollspy.js
+++ b/opengever/meeting/browser/resources/Scrollspy.js
@@ -64,8 +64,9 @@
 
     this.focus = function(target) {
       target.focus();
-      if (typeof target.stargetectionStart === "number") {
-        target.stargetectionStart = target.stargetectionEnd = target.value.length;
+      target = target[0];
+      if (typeof target.selectionStart === "number") {
+        target.selectionStart = target.selectionEnd = target.value.length;
       } else if (target.createTextRange) {
         var range = target.createTextRange();
         range.collapse(false);

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -113,7 +113,6 @@
       if(target.hasClass("expandable")) {
         scrollspy.expand(target);
       }
-      moveCaretToEnd(toElement[0]);
     });
 
     var protocolController = new ProtocolController();


### PR DESCRIPTION
Because of https://github.com/4teamwork/opengever.core/pull/1449 the `moveToCaret` function was not moved correctly to `Srollspy.js`.