### PR TITLE
Set all active members of a committee as meeting participants by default.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.0 (unreleased)
 ------------------
 
+- Set all active members of a committee as meeting participants by default.
+  [deiferni]
+
 - Allow rejecting proposals from a committee. It is possible to enter an optional comment.
   [deiferni]
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -244,6 +244,7 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
                 data = dm.get_data(get_dm_key())
                 data['dossier_oguid'] = Oguid.for_object(dossier)
                 meeting = Meeting(**data)
+                meeting.initialize_participants()
                 session = create_session()
                 session.add(meeting)
                 session.flush()  # required to create an autoincremented id

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -146,8 +146,7 @@ class Committee(ModelContainer):
         return '/'.join(url_tool.getRelativeContentPath(self))
 
     def get_active_memberships(self):
-        return Membership.query.filter_by(
-            committee=self.load_model()).only_active()
+        return self.load_model().get_active_memberships()
 
     def get_memberships(self):
         return self.load_model().memberships

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.base.oguid import Oguid
 from opengever.base.utils import escape_html
+from opengever.meeting.model.membership import Membership
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import UNIT_ID_LENGTH
@@ -59,3 +60,7 @@ class Committee(Base):
 
     def get_excerpt_template(self):
         return self.resolve_committee().get_excerpt_template()
+
+    def get_active_memberships(self):
+        return Membership.query.filter_by(
+            committee=self).only_active()

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -129,6 +129,17 @@ class Meeting(Base):
     excerpt_documents = relationship('GeneratedExcerpt',
                                      secondary=meeting_excerpts,)
 
+    def __init__(self, *args, **kwargs):
+        super(Meeting, self).__init__(*args, **kwargs)
+
+    def initialize_participants(self):
+        """Set all active members of our committee as participants of
+        this meeting.
+
+        """
+        self.participants = [membership.member for membership in
+                             self.committee.get_active_memberships()]
+
     def __repr__(self):
         return '<Meeting at "{}">'.format(self.start)
 

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -1,10 +1,13 @@
+from datetime import date
 from datetime import datetime
+from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Meeting
+from opengever.meeting.model import Member
 from opengever.testing import FunctionalTestCase
 from pyquery import PyQuery
 
@@ -36,6 +39,12 @@ class TestMeeting(FunctionalTestCase):
                                 .within(self.container)
                                 .link_with(self.repository_folder))
         self.committee_model = self.committee.load_model()
+        self.peter = create(Builder('member')
+                            .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        self.membership = create(Builder('membership')
+                                 .having(committee=self.committee_model,
+                                         member=self.peter)
+                                 .as_active())
 
     def test_meeting_title(self):
         self.assertEqual(
@@ -89,6 +98,8 @@ class TestMeeting(FunctionalTestCase):
         self.assertEqual(self.localized_datetime(2010, 1, 1, 10), meeting.start)
         self.assertEqual(self.localized_datetime(2010, 1, 1, 11), meeting.end)
         self.assertEqual('Somewhere', meeting.location)
+        self.assertEqual([Member.get(self.peter.member_id)],
+                         meeting.participants)
         dossier = meeting.dossier_oguid.resolve_object()
         self.assertIsNotNone(dossier)
         self.assertEquals(u'Meeting on Jan 01, 2010', dossier.title)


### PR DESCRIPTION
This is done for convenience, usually most of the active members of a meeting do participate.

Closes #1424.