### PR TITLE
Disable unload protection for protocol.

### DIFF
--- a/opengever/advancedsearch/advanced_search.py
+++ b/opengever/advancedsearch/advanced_search.py
@@ -276,18 +276,10 @@ class AdvancedSearchForm(directives_form.Form):
 
     ignoreContext = True
 
+    enable_unload_protection = False
+
     def field_mapping(self):
         return FIELD_MAPPING
-
-    def render(self):
-        """Overwritting the render method to disable the UnloadProtection.
-        Becuase overwrite and copy the whole template makes no sense.
-        Unfortunately it's not configurable in the plone.app.z3c form itself.
-        """
-
-        html = super(AdvancedSearchForm, self).render()
-        html = html.replace('enableUnloadProtection', '')
-        return html
 
     def get_fields(self):
         if getattr(self, '_fields', None) is not None:

--- a/opengever/base/browser/templates/macros.pt
+++ b/opengever/base/browser/templates/macros.pt
@@ -58,6 +58,8 @@
                                   form_tabbing python:(has_groups and enable_form_tabbing) and 'enableFormTabbing' or '';
                                   show_default_label python:has_groups and default_fieldset_label and len(view.widgets);
                                   enable_refreshable_locks context/@@ploneform-macros/enable_refreshable_locks;
+                                  enable_unload_protection view/enable_unload_protection|python:True;
+                                  unload_protection python: 'enableUnloadProtection' if enable_unload_protection else '';
                                   lock_class python: enable_refreshable_locks and 'enableUnlockProtection' or '';
                                   kss_class python: 'kssattr-formname-{}'.format(request.getURL().split('/')[-1])
                                   "
@@ -65,7 +67,7 @@
                                       enctype view/enctype;
                                       id view/id;
                                       method view/method|string:'post';
-                                      class python:' '.join(['rowlike', 'enableUnloadProtection', kss_class, form_tabbing, lock_class])"
+                                      class python:' '.join(['rowlike', unload_protection, kss_class, form_tabbing, lock_class])"
                       >
 
                     <metal:block define-slot="formtop" />

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -109,6 +109,7 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
     ignoreContext = True
     schema = IMeetingMetadata
     content_type = Meeting
+    enable_unload_protection = False
 
     template = ViewPageTemplateFile('templates/protocol.pt')
 


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1454

Implement enable_unload_protection configurable for each form. Will be fixed in plone.app.z3cform@0.7.6 -> https://pypi.python.org/pypi/plone.app.z3cform#id12
Disable unload_protection for protocol.
Disable unload protection for advanced search instead of overriding render method.