### PR TITLE
Addded js workaroud to fix notification dropdown menu.

### DIFF
--- a/opengever/activity/browser/resources/notifications.js
+++ b/opengever/activity/browser/resources/notifications.js
@@ -77,7 +77,9 @@
       outlet: outlet,
       update: endpoints.readUrl
     });
-    $(".notificationsMenuHeader > a").on("click", function() {
+    $(".notificationsMenuHeader > a").on("click", function(event) {
+      event.preventDefault();
+      toggleMenuHandler.call(this, event);
       if($(this).parents(".notificationsMenu").hasClass("activated")) {
         outlet.empty();
         notifications.list(endpoints.listUrl);

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -7,7 +7,7 @@
                       data-list-url view/list_url"
       tal:define="num_unread view/num_unread">
 
-    <dt class="notificationsMenuHeader actionMenuHeader">
+    <dt class="notificationsMenuHeader">
 
       <a tal:attributes="href string:#"></a>
 


### PR DESCRIPTION
With the PR #1378 the order in the jsregistry gets modified, so that plone's dropdown.js is now called earlier than our notification.js. This means that the notification dropdown menu does not work (don't drop down when clicking on the bell image).

The real problem is that the `toggleMenuHandler` in plone's `dropdown.js` return false instead of just prevent the default link event.

So to resolve this issue, we removed the actionMenuHeader class from the notification viewlet template.

@lukasgraf @deiferni 

