### PR TITLE
Only show edit button when meeting is editable.

### DIFF
--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -82,7 +82,7 @@
           <div tal:attributes="class python: 'list-group metadata' if meeting.is_editable() else 'full-width list-group metadata'">
             <div class="list-group-item submit">
               <div class="button-group fluid">
-                <a class="button" tal:attributes="href view/url_protocol" i18n:translate="">Edit</a>
+                <a tal:condition="meeting/is_editable" class="button" tal:attributes="href view/url_protocol" i18n:translate="">Edit</a>
                 <metal:use use-macro="context/@@meeting-macros/workflow_actions" />
               </div>
             </div>


### PR DESCRIPTION
Also improve close meeting tests a bit by asserting that the info message is displayed..

Closes  #1461.