### PR TITLE
Include ftw.profilehook, when required.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Include ftw.profilehook, when required.
+  [deiferni]
 
 
 4.6.0 (2015-12-11)

--- a/opengever/activity/configure.zcml
+++ b/opengever/activity/configure.zcml
@@ -6,6 +6,8 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.activity">
 
+  <include package="ftw.profilehook" />
+
   <grok:grok package="." />
 
   <include package=".browser" />

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -18,6 +18,7 @@
   <include package="plone.directives.form" />
   <include package="plone.directives.form" file="meta.zcml" />
   <include package="plone.formwidget.namedfile" />
+  <include package="ftw.profilehook" />
 
   <include package=".behaviors" />
   <include package=".browser" />

--- a/opengever/contact/configure.zcml
+++ b/opengever/contact/configure.zcml
@@ -8,6 +8,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.contact">
 
+  <include package="ftw.profilehook" />
+
   <include file="permissions.zcml" />
 
   <grok:grok package="." />

--- a/opengever/document/profiles.zcml
+++ b/opengever/document/profiles.zcml
@@ -4,6 +4,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.document">
 
+  <include package="ftw.profilehook" />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.document"

--- a/opengever/dossier/profiles.zcml
+++ b/opengever/dossier/profiles.zcml
@@ -3,6 +3,8 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:profilehook="http://namespaces.zope.org/profilehook">
 
+  <include package="ftw.profilehook" />
+
   <!-- default profile -->
   <genericsetup:registerProfile
       name="default"

--- a/opengever/examplecontent/configure.zcml
+++ b/opengever/examplecontent/configure.zcml
@@ -7,6 +7,8 @@
     xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
     i18n_domain="opengever.examplecontent">
 
+  <include package="ftw.profilehook" />
+
   <include package=".upgrades" />
 
   <opengever:registerDeployment

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -8,6 +8,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.inbox">
 
+  <include package="ftw.profilehook" />
+
   <grok:grok package="." />
 
   <i18n:registerTranslations directory="locales" />

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -9,6 +9,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.mail">
 
+  <include package="ftw.profilehook" />
+
   <grok:grok package="." />
 
   <include package=".browser" />

--- a/opengever/ogds/base/configure.zcml
+++ b/opengever/ogds/base/configure.zcml
@@ -8,6 +8,8 @@
     i18n_domain="opengever.ogds.base"
     package="opengever.ogds.base">
 
+  <include package="ftw.profilehook" />
+
   <include package=".browser" />
   <include package=".viewlets" />
   <include package=".upgrades" />

--- a/opengever/setup/profiles.zcml
+++ b/opengever/setup/profiles.zcml
@@ -4,6 +4,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.setup">
 
+  <include package="ftw.profilehook" />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.setup: default"

--- a/opengever/tabbedview/configure.zcml
+++ b/opengever/tabbedview/configure.zcml
@@ -10,6 +10,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.tabbedview">
 
+  <include package="ftw.profilehook" />
+
   <include package=".browser" />
   <include package=".upgrades" />
 

--- a/opengever/task/profiles.zcml
+++ b/opengever/task/profiles.zcml
@@ -4,6 +4,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.task">
 
+  <include package="ftw.profilehook" />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.task"

--- a/opengever/trash/profiles.zcml
+++ b/opengever/trash/profiles.zcml
@@ -4,6 +4,8 @@
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     i18n_domain="opengever.trash">
 
+  <include package="ftw.profilehook" />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.trash"


### PR DESCRIPTION
As documented in https://github.com/4teamwork/ftw.profilehook#usage we should always include ftw.profilehook in our zcml files.

This helps fixing an issue with failing opengever.maintenance tests.