### PR TITLE
Fix an issue with setting-up translated content with transmogrifiers schemaupdater.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Include ftw.profilehook, when required.
   [deiferni]
 
+- Fix an issue with setting-up translated content with transmogrifiers schemaupdater.
+  [deiferni]
+
 
 4.6.0 (2015-12-11)
 ------------------

--- a/opengever/base/behaviors/translated_title.py
+++ b/opengever/base/behaviors/translated_title.py
@@ -95,34 +95,3 @@ class TranslatedTitle(object):
         if not isinstance(value, unicode):
             raise ValueError('title_fr must be unicode.')
         self.context.title_fr = value
-
-
-@indexer(ITranslatedTitleSupport)
-def translated_title_indexer(obj):
-    return obj.Title(language='de')
-
-
-@indexer(ITranslatedTitleSupport)
-def translated_sortable_title_indexer(obj):
-    ## mostly copied from Products.CMFPlone.CatalogTool.sortable_title
-    title = getattr(obj, 'Title', None)
-    if title is not None:
-        if safe_callable(title):
-            # CUSTOM
-            title = title(language='de')
-            # / CUSTOM
-
-        if isinstance(title, basestring):
-            # Ignore case, normalize accents, strip spaces
-            sortabletitle = mapUnicode(safe_unicode(title)).lower().strip()
-            # Replace numbers with zero filled numbers
-            sortabletitle = num_sort_regex.sub(zero_fill, sortabletitle)
-
-            # Truncate to prevent bloat, take bits from start and end
-            if len(sortabletitle) > MAX_SORTABLE_TITLE:
-                start = sortabletitle[:(MAX_SORTABLE_TITLE - 13)]
-                end = sortabletitle[-10:]
-                sortabletitle = start + '...' + end
-            return sortabletitle.encode('utf-8')
-
-    return ''

--- a/opengever/base/behaviors/translated_title.py
+++ b/opengever/base/behaviors/translated_title.py
@@ -78,6 +78,8 @@ class TranslatedTitle(object):
 
     @title_de.setter
     def title_de(self, value):
+        if value is None:
+            return
         if not isinstance(value, unicode):
             raise ValueError('title_de must be unicode.')
         self.context.title_de = value
@@ -88,6 +90,8 @@ class TranslatedTitle(object):
 
     @title_fr.setter
     def title_fr(self, value):
+        if value is None:
+            return
         if not isinstance(value, unicode):
             raise ValueError('title_fr must be unicode.')
         self.context.title_fr = value

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -288,3 +288,20 @@ class TestTranslatedTitleLanguageSupport(FunctionalTestCase):
             self.assertEquals(
                 u"Repository title in {}".format(lang),
                 getattr(brain, 'title_{}'.format(lang)))
+
+    def test_translated_attribute_can_be_set_to_none(self):
+        repository_root = create(Builder('repository_root')
+                                 .having(title_de=u"Ablage",
+                                         title_fr=u"syst\xe8me d'ordre"))
+        root_translation = ITranslatedTitle(repository_root)
+
+        repository_root.title_de = None
+        repository_root.title_fr = None
+
+        self.assertIsNone(root_translation.translated_title())
+        self.assertIsNone(root_translation.translated_title(language='de'))
+        self.assertIsNone(root_translation.translated_title(language='fr'))
+
+        self.assertEqual('', repository_root.Title())
+        self.assertEqual('', repository_root.Title(language='de'))
+        self.assertEqual('', repository_root.Title(language='fr'))


### PR DESCRIPTION
This PR allows `None` values to be set for translated attributes.

This happens when content is created during setup with transmogrifier. It
inserts default-values (`None` in this case) for some fields.

Closes #1471.