### PR TITLE
Fixed missing `responsible` parameters in synced responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.2 (unreleased)
 ------------------
 
+- Fixed missing `responsible` parameters in synced responses when reassigning a multi AdminUnit task.
+  [phgross]
+
 - Cluster URL: Add heuristic to determine the correct cluster base URL
   for both single- and multi-admin-unit setups.
   [lgraf]

--- a/opengever/task/statesyncer.py
+++ b/opengever/task/statesyncer.py
@@ -97,10 +97,12 @@ class SyncTaskWorkflowStateReceiveView(grok.View):
     # grok.layer(IInternalOpengeverRequestLayer)
     # grok.require('zope2.Public')
 
-    def render(self):
-
+    def check_internal_request(self):
         if not IInternalOpengeverRequestLayer.providedBy(self.request):
             raise Forbidden()
+
+    def render(self):
+        self.check_internal_request()
 
         transition = self.request.get('transition')
         text = self.request.get('text')

--- a/opengever/task/statesyncer.py
+++ b/opengever/task/statesyncer.py
@@ -132,7 +132,7 @@ class SyncTaskWorkflowStateReceiveView(grok.View):
         if responsible and responsible is not 'None':
             # special handling for reassign
             response.add_change(
-                'reponsible',
+                'responsible',
                 _(u"label_responsible", default=u"Responsible"),
                 ITask(self.context).responsible,
                 responsible)


### PR DESCRIPTION
When reassigning a multi AdminUnit task, the response on the foreign side, was not completly synchronised. The responsible attribute in the response changes was wrong. This PR fixes this problem.

Before:
![kopierte_aufgabe_1024](https://cloud.githubusercontent.com/assets/485755/11844617/0fcf220e-a410-11e5-9136-5183f0d50df4.jpg)

After:
![bildschirmfoto 2015-12-16 um 16 08 14](https://cloud.githubusercontent.com/assets/485755/11844619/136be370-a410-11e5-806e-5574c42c597a.png)

@lukasgraf or @deiferni 