### PR TITLE
Don't generate decision numbers for paragraphs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.2 (unreleased)
 ------------------
 
+- Don't generate decision numbers for paragraphs.
+  [deiferni]
+
 - Fixed missing `responsible` parameters in synced responses when reassigning a multi AdminUnit task.
   [phgross]
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -148,6 +148,13 @@ class AgendaItem(Base):
     def get_state(self):
         return self.workflow.get_state(self.workflow_state)
 
+    def generate_decision_number(self, period):
+        if self.is_paragraph:
+            return
+
+        next_decision_number = period.get_next_decision_sequence_number()
+        self.decision_number = next_decision_number
+
     def remove(self):
         assert self.meeting.is_editable()
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -164,8 +164,7 @@ class Meeting(Base):
         period = Period.query.get_current_for_update(self.committee)
 
         for agenda_item in self.agenda_items:
-            next_decision_number = period.get_next_decision_sequence_number()
-            agenda_item.decision_number = next_decision_number
+            agenda_item.generate_decision_number(period)
 
     def update_protocol_document(self):
         """Update or create meeting's protocol."""

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -79,12 +79,16 @@ class TestUnitMeeting(TestCase):
         item_1 = create(Builder('agenda_item')
                         .having(meeting=self.meeting))
         item_2 = create(Builder('agenda_item')
+                        .having(meeting=self.meeting,
+                                is_paragraph=True))
+        item_3 = create(Builder('agenda_item')
                         .having(meeting=self.meeting))
 
         self.meeting.generate_decision_numbers()
 
         self.assertEqual(1, item_1.decision_number)
-        self.assertEqual(2, item_2.decision_number)
+        self.assertIsNone(item_2.decision_number)
+        self.assertEqual(2, item_3.decision_number)
         period = self.committee.periods[0]
         self.assertEqual(2, period.decision_sequence_number)
 


### PR DESCRIPTION
Paragraphs don't need decision numbers. They are not displayed anywhere but lead to gaps in the visible decision numbers for the other agenda items.

Fixes #1469.