### PR TITLE
Make sure that decision numbers are available when rendering excerpts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.2 (unreleased)
 ------------------
 
+- Make sure that decision numbers are available when rendering excerpts.
+  [deiferni]
+
 - Don't generate decision numbers for paragraphs.
   [deiferni]
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -237,10 +237,10 @@ class AgendaItem(Base):
         if self.get_state() == self.STATE_DECIDED:
             return
 
+        self.meeting.hold()
+
         if self.has_proposal:
             self.proposal.generate_excerpt(self)
             self.proposal.decide()
-
-        self.meeting.hold()
 
         self.workflow.execute_transition(None, self, 'pending-decided')


### PR DESCRIPTION
The problem currently only surfaces in the generated excerpt word documents. I did not see a way to add  tests for those :disappointed:. 

Fixes #1468.