### PR TITLE
Fix an encoding issue while editing memberships.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.2 (unreleased)
 ------------------
 
+- Fix an encoding issue while editing memberships.
+  [deiferni]
+
 - Show diffrent buttons for deleting or unscheduling agenda items
   [Kevin Bieri]
 

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -45,7 +45,7 @@ SAMPLE_MEETING_DATA = {
                 'number': 11},
     'committee': {'name': 'Gemeinderat'},
     'participants': {
-        'members': [{'fullname': u'Peter Meier',
+        'members': [{'fullname': u'Peter M\xfcller',
                     'role': u'F\xfcrst'},
                    {'fullname': u'Franz M\xfcller',
                     'role': None}],

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -40,7 +40,7 @@ class TestCommitteeOverview(FunctionalTestCase):
 
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
-        self.assertEquals(['Peter Meier', u'Hans M\xfcller'],
+        self.assertEquals([u'Peter M\xfcller', u'Hans M\xfcller'],
                           browser.css('#current_membersBox li:not(.moreLink)').text)
 
     @browsing

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -63,8 +63,8 @@ class TestMemberListing(FunctionalTestCase):
             'http://nohost/plone/opengever-meeting-committeecontainer/member-1',
             link.get('href'))
         self.assertEqual('contenttype-opengever-meeting-member', link.get('class'))
-        self.assertEqual('Peter Meier', link.get('title'))
-        self.assertEqual('Peter Meier', link.text)
+        self.assertEqual(u'Peter M\xfcller', link.get('title'))
+        self.assertEqual(u'Peter M\xfcller', link.text)
 
 
 class TestMemberView(FunctionalTestCase):
@@ -98,7 +98,7 @@ class TestMemberView(FunctionalTestCase):
         browser.login().open(self.member.get_url(self.container))
 
         self.assertEqual(
-            [['Lastname', 'Meier'],
+            [['Lastname', u'M\xfcller'],
              ['Firstname', 'Peter'],
              ['E-Mail', 'p.meier@example.com']],
             browser.css('table#properties').first.lists())

--- a/opengever/meeting/tests/test_pathbar.py
+++ b/opengever/meeting/tests/test_pathbar.py
@@ -43,7 +43,9 @@ class TestPathBar(FunctionalTestCase):
 
         browser.login().open(member.get_url(container))
         self.assertEqual(
-            ['Client1', 'opengever-meeting-committeecontainer', 'Peter Meier'],
+            [u'Client1',
+             u'opengever-meeting-committeecontainer',
+             u'Peter M\xfcller'],
             browser.css('#portal-breadcrumbs a').text)
 
     @browsing
@@ -61,6 +63,8 @@ class TestPathBar(FunctionalTestCase):
         wrapped_member = MemberWrapper.wrap(container, member)
         browser.login().open(membership.get_url(wrapped_member))
         self.assertEqual(
-            ['Client1', 'opengever-meeting-committeecontainer', 'Peter Meier',
-             'Peter Meier, Jan 01, 2014 - Jan 01, 2015'],
+            [u'Client1',
+             u'opengever-meeting-committeecontainer',
+             u'Peter M\xfcller',
+             u'Peter M\xfcller, Jan 01, 2014 - Jan 01, 2015'],
             browser.css('#portal-breadcrumbs a').text)

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -72,6 +72,6 @@ class TestProtocolJsonData(FunctionalTestCase):
         create_session().delete(self.membership_peter)
 
         self.assertEquals(
-            {'members': [{'fullname': u'Peter Meier', 'role': None},
+            {'members': [{'fullname': u'Peter M\xfcller', 'role': None},
                          {'fullname': u'Franz M\xfcller', 'role': None}]},
             ProtocolData(self.meeting).add_members())

--- a/opengever/meeting/wrapper.py
+++ b/opengever/meeting/wrapper.py
@@ -89,9 +89,9 @@ class MembershipWrapper(BaseWrapper):
         return self.model.get_url(self.parent)
 
     def get_title(self):
-        return '{}, {} - {}'.format(self.model.title(),
-                                    self.model.format_date_from(),
-                                    self.model.format_date_to())
+        return u'{}, {} - {}'.format(self.model.title(),
+                                     self.model.format_date_from(),
+                                     self.model.format_date_to())
 
     def get_breadcrumbs(self):
         my_breadcrumbs = super(MembershipWrapper, self).get_breadcrumbs()

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -165,8 +165,8 @@ class MemberBuilder(SqlObjectBuilder):
 
     def __init__(self, session):
         super(MemberBuilder, self).__init__(session)
-        self.arguments['firstname'] = 'Peter'
-        self.arguments['lastname'] = 'Meier'
+        self.arguments['firstname'] = u'Peter'
+        self.arguments['lastname'] = u'M\xfcller'
 
 builder_registry.register('member', MemberBuilder)
 


### PR DESCRIPTION
Also introduce umlauts to the default member fixture created by the builder to avoid such errors in the future.

Fixes #1488.