### PR TITLE
Don't use current date when editing meeting participants.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.2 (unreleased)
 ------------------
 
+- Don't use current date when editing meeting participants but the meeting's date.
+  [deiferni]
+
 - Fix an encoding issue while editing memberships.
   [deiferni]
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -11,6 +11,7 @@ from opengever.meeting.command import ProtocolOperations
 from opengever.meeting.command import UpdateGeneratedDocumentCommand
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Period
+from opengever.meeting.model.membership import Membership
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
@@ -138,7 +139,7 @@ class Meeting(Base):
 
         """
         self.participants = [membership.member for membership in
-                             self.committee.get_active_memberships()]
+                             Membership.query.for_meeting(self)]
 
     def __repr__(self):
         return '<Meeting at "{}">'.format(self.start)

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -63,6 +63,20 @@ Committee.query_cls = CommitteeQuery
 
 class MembershipQuery(BaseQuery):
 
+    def for_meeting(self, meeting):
+        """Return all memberships that are active when the meeting takes place.
+        """
+
+        start_date = meeting.start.date()
+        end_date = start_date
+        if meeting.end:
+            end_date = meeting.end.date()
+
+        query = self.filter(
+            and_(Membership.date_from <= start_date,
+                 Membership.date_to >= end_date))
+        return query.filter_by(committee=meeting.committee)
+
     def only_active(self):
         return self.filter(
             and_(Membership.date_from <= date.today(),
@@ -82,6 +96,8 @@ class MembershipQuery(BaseQuery):
         return query.first()
 
     def fetch_for_meeting(self, meeting, member):
+        """Fetch the membership for a member at the time of a meeting."""
+
         end = meeting.end if meeting.end else meeting.start
         return self.fetch_overlapping(
             meeting.start, end, member, meeting.committee)

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -43,8 +43,7 @@ class TestMeeting(FunctionalTestCase):
                             .having(firstname=u'Peter', lastname=u'M\xfcller'))
         self.membership = create(Builder('membership')
                                  .having(committee=self.committee_model,
-                                         member=self.peter)
-                                 .as_active())
+                                         member=self.peter))
 
     def test_meeting_title(self):
         self.assertEqual(

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -212,10 +212,10 @@ class TestProtocol(FunctionalTestCase):
             firstname=u'Hans', lastname=u'M\xfcller'))
         create(Builder('membership').having(
             member=peter,
-            committee=self.committee_model).as_active())
+            committee=self.committee_model))
         create(Builder('membership').having(
             member=hans,
-            committee=self.committee_model).as_active())
+            committee=self.committee_model))
         prev_modified = self.meeting.modified
 
         browser.login()

--- a/opengever/meeting/tests/test_unit_membership_query.py
+++ b/opengever/meeting/tests/test_unit_membership_query.py
@@ -57,6 +57,18 @@ class TestUnitMembershipQuery(TestCase):
         active = self.setup_membership(yesterday, tomorrow)
         self.assertEqual([active], Membership.query.only_active().all())
 
+    def test_by_meeting(self):
+        prev = self.setup_membership(date(2004, 1, 20), date(2010, 1, 19))
+        active = self.setup_membership(date(2010, 1, 20), date(2013, 7, 21))
+        post = self.setup_membership(date(2013, 7, 22), date(2016, 1, 1))
+
+        meeting = create(Builder('meeting').having(
+                         committee=self.committee,
+                         start=localized_datetime(2010, 1, 29),
+                         end=None))
+
+        self.assertEqual([active], Membership.query.for_meeting(meeting).all())
+
     def test_fetch_overlapping(self):
         membership = self.setup_membership(date(2012, 5, 1), date(2012, 7, 10))
         self.assertEqual(membership, Membership.query.fetch_overlapping(

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -1,5 +1,6 @@
 from five import grok
 from opengever.meeting.model import Member
+from opengever.meeting.model import Membership
 from opengever.meeting.service import meeting_service
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import IVocabularyFactory
@@ -37,9 +38,9 @@ class MemberVocabulary(grok.GlobalUtility):
 
 @grok.provider(IContextSourceBinder)
 def get_committee_member_vocabulary(meetingwrapper):
-    committee = meetingwrapper.model.committee.resolve_committee()
+    meeting = meetingwrapper.model
     members = []
-    for membership in committee.get_active_memberships():
+    for membership in Membership.query.for_meeting(meeting):
         member = membership.member
         members.append(
             SimpleVocabulary.createTerm(member,


### PR DESCRIPTION
Use the meeting's date to find active memberships at the time when the
meeting takes place to edit the meetings participants instead of the current
date.

Fixes #1482.