### PR TITLE
Reduce conflict errors by using uuid4 in CMFEditions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change CMFEdition IDs to uuid4 instead of auto-increment.
+  This reduces conflict errors.
+  [jone]
 
 
 4.6.2 (2015-12-22)

--- a/opengever/base/monkeypatch.py
+++ b/opengever/base/monkeypatch.py
@@ -414,3 +414,34 @@ utils.URL_MATCH = re.compile(r'''(url\s*\(\s*['"]?)(?!data:)([^'")]+)(['"]?\s*\)
 
 
 LOGGER.info('Monkey patched Products.ResourceRegistries.utils.URL_MATCH regexp')
+
+
+# --------
+# Patch for Products.CMFEditions.historyidhandlertool
+#           .HistoryIdHandlerTool.register
+#
+# The default "register" method uses the Products.CMFUid IUniqueIdGenerator
+# utility for generating the history ID. This utility uses the auto-increment
+# strategy, which generates a lot of conflicts.
+#
+# In order to reduce the conflicts when generating the history id,
+# we switch to the uuid4 implementation, generating a random number instead
+# and thus not writing to the same place.
+
+from Products.CMFEditions.historyidhandlertool import HistoryIdHandlerTool
+from uuid import uuid4
+
+
+def HistoryIdHandlerTool_register(self, obj):
+    uid = self.queryUid(obj, default=None)
+    if uid is None:
+        # generate a new unique id and set it
+        uid = uuid4().int
+        self._setUid(obj, uid)
+
+    return uid
+
+
+HistoryIdHandlerTool.register = HistoryIdHandlerTool_register
+LOGGER.info('Monkey patched Products.CMFEditions.historyidhandlertool'
+            '.HistoryIdHandlerTool.register')


### PR DESCRIPTION
Patch for Products.CMFEditions.historyidhandlertool.HistoryIdHandlerTool.register

The default "register" method uses the Products.CMFUid IUniqueIdGenerator utility for generating the history ID. This utility uses the auto-increment strategy, which generates a lot of conflicts.

In order to reduce the conflicts when generating the history id, we switch to the uuid4 implementation, generating a random number instead and thus not writing to the same place

--

The problem is when multiple users upload documents at the same time. The format of the used ID is not really relevant. Therefore no migration of existing objects is required; the old objects just use a smaller integer as ID.