### PR TITLE
Refactor sequence number generation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Refactor sequence number generation in order to reduce conflicts
+  in content creation requests and to ensure uniqueness.
+  [jone]
+
 - Update link to feedback forum in example content and policy template footers.
   [lgraf]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Introduce IDuringSetup marker interface to flag a request that
+  happens during GEVER setup.
+  [lgraf]
+
 - Refactor sequence number generation in order to reduce conflicts
   in content creation requests and to ensure uniqueness.
   [jone]

--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4608</version>
+  <version>4609</version>
 </metadata>

--- a/opengever/base/sequence.py
+++ b/opengever/base/sequence.py
@@ -1,16 +1,20 @@
 from five import grok
+from opengever.base.interfaces import ISequenceNumber
+from opengever.base.interfaces import ISequenceNumberGenerator
 from opengever.base.protect import unprotected_write
 from persistent.dict import PersistentDict
 from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFCore.interfaces import ISiteRoot
-from Products.Transience.Transience import Increaser
+from ZODB.DemoStorage import DemoStorage
+from ZODB.POSException import ConflictError
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility, getAdapter
+import logging
+import transaction
 
-from opengever.base.interfaces import ISequenceNumber
-from opengever.base.interfaces import ISequenceNumberGenerator
 
 SEQUENCE_NUMBER_ANNOTATION_KEY = 'ISequenceNumber.sequence_number'
+LOG = logging.getLogger('opengever.base.sequence')
 
 
 class SequenceNumber(grok.GlobalUtility):
@@ -36,9 +40,6 @@ class SequenceNumber(grok.GlobalUtility):
 class DefaultSequenceNumberGenerator(grok.Adapter):
     """ Provides a default sequence number generator.
     The portal_type of the object is used as *unique-key*
-    For choosing the number the
-    Products.Transience.Transience.Increaser should be used. See:
-    http://pyyou.wordpress.com/2009/12/09/how-to-add-a-counter-without-conflict-error-in-zope/
     """
 
     grok.provides(ISequenceNumberGenerator)
@@ -52,15 +53,79 @@ class DefaultSequenceNumberGenerator(grok.Adapter):
         return u'DefaultSequenceNumberGenerator.%s' % self.context.portal_type
 
     def get_next(self, key):
+        return SequenceNumberIncrementer()(key)
+
+
+class SequenceNumberIncrementer(object):
+    """The sequence number increment creates and returns the next
+    sequence number for a given key when called.
+
+    It does this in a separate connection to the ZODB.
+    When the integer value is returned, the incrementation is
+    already committed and the value will be unique and not raise
+    any conflict when committing the main transaction of the
+    requesting code.
+
+    This behavior is important in order to eliminate conflicts of
+    content-creation request and to provide safe, unique sequence
+    numbers.
+    When the requesting transaction is aborted or repeated, the
+    sequence number which was requested in this transaction will
+    not be used, which results in gaps in the sequence numbering
+    system. These gaps are expected and accepted.
+    """
+
+    maximum_retries = 10
+
+    def __call__(self, sequence_number_key):
         portal = getUtility(ISiteRoot)
+        if isinstance(portal._p_jar.db().storage, DemoStorage):
+            # We use DemoStorage (probably in tests), which
+            # do not allow concurrent DB connections,
+            # thus we don't spawn a new database connection.
+            return self._increment_number(portal, sequence_number_key)
+
+        return self._separate_zodb_connection(
+            self._increment_number,
+            sequence_number_key)
+
+    def _increment_number(self, portal, key):
         ann = unprotected_write(IAnnotations(portal))
-        if SEQUENCE_NUMBER_ANNOTATION_KEY not in ann.keys():
-            ann[SEQUENCE_NUMBER_ANNOTATION_KEY] = unprotected_write(PersistentDict())
+        if SEQUENCE_NUMBER_ANNOTATION_KEY not in ann:
+            ann[SEQUENCE_NUMBER_ANNOTATION_KEY] = unprotected_write(
+                PersistentDict())
+
         mapping = unprotected_write(ann.get(SEQUENCE_NUMBER_ANNOTATION_KEY))
         if key not in mapping:
-            mapping[key] = Increaser(0)
-        # increase
-        inc = mapping[key]
-        unprotected_write(inc).set(inc() + 1)
-        mapping[key] = inc
-        return inc()
+            mapping[key] = 0
+
+        mapping[key] += 1
+        return mapping[key]
+
+    def _separate_zodb_connection(self, callback, *args, **kwargs):
+        main_connection_portal = getUtility(ISiteRoot)
+        manager = transaction.TransactionManager()
+        connection = main_connection_portal._p_jar.db().open(
+            transaction_manager=manager)
+        try:
+
+            for _r in range(self.maximum_retries):
+                manager.begin()
+                portal = connection[main_connection_portal._p_oid]
+                result = callback(portal, *args, **kwargs)
+
+                try:
+                    manager.commit()
+                except ConflictError:
+                    LOG.info('SequenceNumberIncrementer'
+                             ' ConflictError; retrying')
+                    manager.abort()
+                else:
+                    return result
+
+            # Maximum retries exceeded, raise conflict to main
+            # transaction / actual request.
+            raise
+
+        finally:
+            connection.close()

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -393,4 +393,14 @@
         directory="profiles/4608"
         />
 
+    <!-- 4608 -> 4609 -->
+    <genericsetup:upgradeStep
+        title="Migrate sequence number increasers"
+        description=""
+        source="4608"
+        destination="4609"
+        handler="opengever.base.upgrades.to4609.MigrateSequenceNumberIncreasers"
+        profile="opengever.base:default"
+        />
+
 </configure>

--- a/opengever/base/upgrades/to4609.py
+++ b/opengever/base/upgrades/to4609.py
@@ -1,0 +1,19 @@
+from ftw.upgrade import UpgradeStep
+from Products.Transience.Transience import Increaser
+from zope.annotation.interfaces import IAnnotations
+
+
+SEQUENCE_NUMBER_ANNOTATION_KEY = 'ISequenceNumber.sequence_number'
+
+
+class MigrateSequenceNumberIncreasers(UpgradeStep):
+
+    def __call__(self):
+        annotations = IAnnotations(self.portal)
+        if SEQUENCE_NUMBER_ANNOTATION_KEY not in annotations:
+            return
+
+        mapping = annotations[SEQUENCE_NUMBER_ANNOTATION_KEY]
+        for key in mapping:
+            if isinstance(mapping[key], Increaser):
+                mapping[key] = mapping[key]()

--- a/opengever/setup/browser/admin.py
+++ b/opengever/setup/browser/admin.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from opengever.base.model import create_session
 from opengever.setup.deploy import GeverDeployment
 from opengever.setup.interfaces import IDeploymentConfigurationRegistry
+from opengever.setup.interfaces import IDuringSetup
 from opengever.setup.interfaces import ILDAPConfigurationRegistry
 from plone.protect.interfaces import IDisableCSRFProtection
 from Products.CMFPlone.browser.admin import AddPloneSite
@@ -120,6 +121,7 @@ class CreateDeployment(BrowserView):
 
     def __call__(self):
         alsoProvides(self.request, IDisableCSRFProtection)
+        alsoProvides(self.request, IDuringSetup)
 
         self.form = self.request.form
         self.db_session = create_session()

--- a/opengever/setup/interfaces.py
+++ b/opengever/setup/interfaces.py
@@ -1,6 +1,12 @@
 from zope.interface import Interface
 
 
+class IDuringSetup(Interface):
+    """Marker interface to tag a request to indicate that we're currently
+    setting up a GEVER deployment (which may require some special handling).
+    """
+
+
 class IDeploymentConfigurationRegistry(Interface):
     """A deployment configuration registry is a utility which knows all the
     registered configurations.


### PR DESCRIPTION
:construction: DON'T MERGE YET - SEE DISCUSSION :construction: 

Refactor sequence number generation in order to reduce conflicts
in content creation requests and to ensure uniqueness.

The old Increaser approach hat various flaws, such as it did not make
sure that the number is unique and it did not really help regarding
conflicts.

The new approach moves the incrementation of the sequence number to a
separate transaction which is commited before the number is returned and
thus uniqueness is assured.
By handling the conflict errors while generating the number we reduce
conflict errors in the main content creation transaction.

The Increaser-objects needs to be migrated to normal integers so that
conflicts arise and we can handle them by retrying.

Up to 10 retries are made before the conflict error is raised to the
main transaction, resulting in a retry of the complete request and
delegating further error handling to Zope so that we have a standard
error handling fallback.