### PR TITLE
Don't create savepoints in 46xx upgrade steps

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Don't create savepoints in 46xx upgrade steps - MySQL implicitly commits
+  savepoints as soon as a DDL statement is emitted (similar to Oracle).
+  That means we can't reliably use savepoints in upgrade paths that contain
+  upgrades involving DDL.
+  [lgraf]
+
 - Remove modified_seconds index and refactor tree portlet to use default
   modified index.
   [jone]

--- a/opengever/contact/upgrades/to4600.py
+++ b/opengever/contact/upgrades/to4600.py
@@ -16,7 +16,7 @@ class ActivateTranslatedTitle(UpgradeStep):
 
         query = {'portal_type': self.portal_types}
         msg = 'Migrate title of contactfolders'
-        for contactfolder in self.objects(query, msg, savepoints=500):
+        for contactfolder in self.objects(query, msg):
             self.migrate_titles(contactfolder)
 
         self.remove_base_behavior()

--- a/opengever/contact/upgrades/to4601.py
+++ b/opengever/contact/upgrades/to4601.py
@@ -13,6 +13,6 @@ class ChangeContactFolderClass(UpgradeStep):
     def migrate_contactfolder_class(self):
         query = {'portal_type': 'opengever.contact.contactfolder'}
         msg = 'Migrate contactfolder class'
-        for contactfolder in self.objects(query, msg, savepoints=500):
+        for contactfolder in self.objects(query, msg):
             self.migrate_class(contactfolder, ContactFolder)
             notify(ObjectModifiedEvent(contactfolder))

--- a/opengever/dossier/upgrades/to4600.py
+++ b/opengever/dossier/upgrades/to4600.py
@@ -14,7 +14,7 @@ class ActivateTranslatedTitle(UpgradeStep):
 
         query = {'portal_type': 'opengever.dossier.templatedossier'}
         msg = 'Migrate title of templatedossiers'
-        for templatedossier in self.objects(query, msg, savepoints=500):
+        for templatedossier in self.objects(query, msg):
             self.migrate_titles(templatedossier)
 
         self.remove_base_behavior()

--- a/opengever/inbox/upgrades/to4600.py
+++ b/opengever/inbox/upgrades/to4600.py
@@ -16,7 +16,7 @@ class ActivateTranslatedTitle(UpgradeStep):
 
         query = {'portal_type': self.portal_types}
         msg = 'Migrate title of inboxes and inboxcontainers'
-        for inbox in self.objects(query, msg, savepoints=500):
+        for inbox in self.objects(query, msg):
             self.migrate_titles(inbox)
 
         self.remove_base_behavior()

--- a/opengever/meeting/upgrades/to4627.py
+++ b/opengever/meeting/upgrades/to4627.py
@@ -11,7 +11,7 @@ class ActivateTranslatedTitle(UpgradeStep):
 
         query = {'portal_type': 'opengever.meeting.committeecontainer'}
         msg = 'Migrate committeecontainer titles'
-        for container in self.objects(query, msg, savepoints=500):
+        for container in self.objects(query, msg):
             self.migrate_titles(container)
 
         self.remove_base_behaviors()

--- a/opengever/repository/upgrades/to4601.py
+++ b/opengever/repository/upgrades/to4601.py
@@ -14,7 +14,7 @@ class TranslatedTitleForRepositoryRoots(UpgradeStep):
 
         query = {'portal_type': 'opengever.repository.repositoryroot'}
         msg = 'Migrate repositoryroot title'
-        for repository in self.objects(query, msg, savepoints=500):
+        for repository in self.objects(query, msg):
             self.migrate_repositoryroot_titles(repository)
 
         self.remove_basic_behavior()

--- a/opengever/repository/upgrades/to4602.py
+++ b/opengever/repository/upgrades/to4602.py
@@ -12,7 +12,7 @@ class TranslatedTitleForRepositoryFolders(UpgradeStep):
 
         query = {'portal_type': 'opengever.repository.repositoryfolder'}
         msg = 'Migrate repositoryfolder title'
-        for repository in self.objects(query, msg, savepoints=500):
+        for repository in self.objects(query, msg):
             self.migrate_repositoryfolder_titles(repository)
 
     def migrate_repositoryfolder_titles(self, repositoryfolder):


### PR DESCRIPTION
MySQL implicitly commits savepoints as soon as a DDL statement is emitted (similar to Oracle).

That means we can't reliably use savepoints in upgrade paths that contain upgrades involving DDL.

@deiferni 