### PR TITLE
Drop foreign key constraint before dropping column.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Fix opengever.meeting upgrade to 4600 for MySQL. Delete a foreign key before
+  its corresponding column is removed.
+  [deiferni]
+
 - Don't create savepoints in 46xx upgrade steps - MySQL implicitly commits
   savepoints as soon as a DDL statement is emitted (similar to Oracle).
   That means we can't reliably use savepoints in upgrade paths that contain

--- a/opengever/meeting/upgrades/to4600.py
+++ b/opengever/meeting/upgrades/to4600.py
@@ -10,4 +10,7 @@ class DropPreProtocol(SchemaMigration):
         self.drop_pre_protocol_column_from_meeting()
 
     def drop_pre_protocol_column_from_meeting(self):
+        fk_name = self.get_foreign_key_name(
+            'meetings', 'pre_protocol_document_id')
+        self.op.drop_constraint(fk_name, 'meetings', type_='foreignkey')
         self.op.drop_column('meetings', 'pre_protocol_document_id')


### PR DESCRIPTION
This fixes the migration when run with MySQL.

Tested and working with MySQL, PostreSQL and Oracle.

Fixes #1514.