### PR TITLE
Display state column in meeting overview tab of committee.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Display an additional column for the meeting state in the meeting overview.
+  [Kevin Bieri]
+
 - Displays hint that no documents have been generated yet.
   [Kevin Bieri]
 

--- a/opengever/meeting/tabs/meetinglisting.py
+++ b/opengever/meeting/tabs/meetinglisting.py
@@ -7,12 +7,21 @@ from opengever.meeting import _
 from opengever.meeting.model import Meeting
 from opengever.tabbedview.browser.base import BaseListingTab
 from opengever.tabbedview.browser.sqltablelisting import SqlTableSource
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
 
 
 class IMeetingTableSourceConfig(ITableSourceConfig):
     """Marker interface for meeting table source configs."""
+
+
+def translated_state(item, value):
+    wrapper = '<span class="{0}">{1}</span>'
+    return wrapper.format(
+        item.get_state().title,
+        translate(item.get_state().title, context=getRequest()))
 
 
 def dossier_link(item, value):
@@ -35,6 +44,10 @@ class MeetingListingTab(BaseListingTab):
         {'column': 'committee_id',
          'column_title': _(u'column_title', default=u'Title'),
          'transform': lambda item, value: item.get_link()},
+
+        {'column': 'workflow_state',
+         'column_title': _(u'column_state', default=u'State'),
+         'transform': translated_state},
 
         {'column': 'location',
          'column_title': _(u'column_location', default=u'Location')},

--- a/opengever/meeting/tests/test_committee_tabs.py
+++ b/opengever/meeting/tests/test_committee_tabs.py
@@ -38,12 +38,14 @@ class TestCommitteeTabs(FunctionalTestCase):
 
         self.assertEquals([
             {'Title': u'B\xe4rn, Dec 13, 2011',
+             'State': u'Pending',
              'Date': 'Dec 13, 2011',
              'Location': u'B\xe4rn',
              'From': '09:30 AM',
              'To': '11:45 AM',
              'Dossier': u'D\xf6ssier'},
             {'Title': u'B\xe4rn, Dec 13, 2011',
+             'State': u'Pending',
              'Date': 'Dec 13, 2011',
              'Location': u'B\xe4rn',
              'From': '09:30 AM',


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1456

As requested in https://github.com/4teamwork/opengever.core/issues/1456
display an additional column for the meeting state similar to the
proposals overview.

![bildschirmfoto 2016-01-12 um 10 58 25](https://cloud.githubusercontent.com/assets/1637820/12260681/4b7e0e42-b91d-11e5-9c42-68ed6e5670d5.png)
