### PR TITLE
Use new SAAS customer path in ldap template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Update LDAP path in policy templates.
+  [deiferni]
+
 - meeting: Use trix as editor in proposals.
   [Kevin Bieri, deiferni]
 

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -32,7 +32,7 @@
 
 {{% if setup.maximum_repository_depth %}}
   <records interface="opengever.repository.interfaces.IRepositoryFolderRecords">
-    <value key="maximum_repository_depth">{{setup.maximum_repository_depth}}</value>
+    <value key="maximum_repository_depth">{{{setup.maximum_repository_depth}}}</value>
   </records>
 
 {{% endif %}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/ldap/ldap_plugin.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/ldap/ldap_plugin.xml.bob
@@ -25,7 +25,7 @@
                 <item value="cn"/>
             </property>
             <property id="users_base" type="str">
-                <item value="ou=Users,ou={{{deployment.ldap_ou}}},dc=4teamwork,dc=ch"/>
+                <item value="ou=Users,ou={{{deployment.ldap_ou}}},ou=OneGovGEVER,dc=4teamwork,dc=ch"/>
             </property>
             <property id="users_scope" type="int">
                 <item value="2"/>
@@ -37,7 +37,7 @@
                 <item value="0"/>
             </property>
             <property id="groups_base" type="str">
-                <item value="ou=Groups,ou={{{deployment.ldap_ou}}},dc=4teamwork,dc=ch"/>
+                <item value="ou=Groups,ou={{{deployment.ldap_ou}}},ou=OneGovGEVER,dc=4teamwork,dc=ch"/>
             </property>
             <property id="groups_scope" type="int">
                 <item value="2"/>


### PR DESCRIPTION
This PR catches up with recent changes in our LDAP structure and corrects the path used in LDAP templates.

It also fixes an error in a template where a variable was not substituted correctly.