### PR TITLE
Transform trix input to safe_html to prevent XSS vulerability.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Transform trix input to safe_html to prevent XSS vulerability.
+  Implemented for protocol page and trix widgets.
+  [deiferni]
+
 - Introduce request method on controller to pass a validator for ajax requests.
   Only show notify messages when the response does not contain a redirect statement.
   [Kevin Bieri]

--- a/opengever/base/tests/test_widget.py
+++ b/opengever/base/tests/test_widget.py
@@ -18,3 +18,14 @@ class TestWidget(FunctionalTestCase):
         browser.fill({u'trix_field': u'<div>P\xe4ter</div>'}).submit()
         self.assertEquals({u'trix_field': u'<div>P\xe4ter</div>'},
                           browser.json)
+
+    @browsing
+    def test_trix_field_is_xss_safe(self, browser):
+        browser.login().visit(view='test-z3cform-widget')
+
+        browser.fill({
+            u'trix_field':
+            u'<div onclick="alert(\'foo\');">P\xe4ter<script>alert("foo");</script></div>'
+        }).submit()
+        self.assertEquals({u'trix_field': u'<div>P\xe4ter</div>'},
+                          browser.json)

--- a/opengever/base/widgets.py
+++ b/opengever/base/widgets.py
@@ -1,16 +1,20 @@
 from five import grok
 from plone.z3cform.textlines.textlines import TextLinesFieldWidget
+from z3c.form.converter import BaseDataConverter
+from zope.schema.interfaces import IField
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import IFormLayer
 from z3c.form.interfaces import ITextAreaWidget
 from z3c.form.widget import FieldWidget
 from z3c.form.widget import Widget
 from zope.component import adapter
+from zope.component import adapts
 from zope.interface import implementer
 from zope.interface import implementsOnly
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 from zope.schema.interfaces import ISequence
 from zope.schema.interfaces import ITextLine
+from plone import api
 
 
 @grok.implementer(IFieldWidget)
@@ -36,3 +40,17 @@ def TrixFieldWidget(field, request):
     """IFieldWidget factory for TrixWidget."""
 
     return FieldWidget(field, TrixWidget(request))
+
+
+class TrixDataConverter(BaseDataConverter):
+    """Convert trix input to safe html."""
+
+    adapts(IField, ITrixWidget)
+
+    def __init__(self, field, widget):
+        super(TrixDataConverter, self).__init__(field, widget)
+        self.transformer = api.portal.get_tool('portal_transforms')
+
+    def toFieldValue(self, value):
+        safe_html = self.transformer.convert('safe_html', value).getData()
+        return super(TrixDataConverter, self).toFieldValue(safe_html)

--- a/opengever/base/widgets.zcml
+++ b/opengever/base/widgets.zcml
@@ -3,6 +3,7 @@
     xmlns:z3c="http://namespaces.zope.org/z3c">
 
   <adapter factory=".widgets.TrixFieldWidget" />
+  <adapter factory=".widgets.TrixDataConverter" />
 
   <class class=".widgets.TrixFieldWidget">
       <require

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -185,6 +185,18 @@ class TestProtocol(FunctionalTestCase):
         )
 
     @browsing
+    def test_protocol_fields_are_xss_safe(self, browser):
+        browser.login()
+        browser.open(self.meeting.get_url(view='protocol'))
+        browser.fill({
+            'Legal basis':
+            '<div onload="alert(\'qux\');">Hans<script>alert("qux");</script></div>'
+        }).submit()
+
+        proposal = Proposal.query.get(self.proposal_model.proposal_id)
+        self.assertEqual('<div>Hans</div>', proposal.legal_basis)
+
+    @browsing
     def test_protocol_can_be_edited(self, browser):
         browser.login()
         browser.open(self.meeting.get_url(view='protocol'))


### PR DESCRIPTION
This PR prevents vulerability to XSS by transforming trix input to safe_html using a plone transform on:

- The protocol page (where input fields are rendered manually)
- For the trix widget using a `DataConverter`

Closes #1529.