### PR TITLE
Exclude non visible fields from the scrollspy navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Exclude non visible fields from the scrollspy navigation.
+  [Kevin Bieri]
+
 - Introduce IDuringSetup marker interface to flag a request that
   happens during GEVER setup.
   [lgraf]

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -236,4 +236,4 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
         if field['needs_proposal']:
             return agenda_item.has_proposal
         else:
-            return True
+            return not agenda_item.is_paragraph

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -32,7 +32,8 @@
                       </a>
                       <ul class="nav">
                         <metal:block tal:repeat="field view/agenda_item_fields">
-                          <metal:block tal:define="field_name field/name">
+                          <metal:block tal:define="field_name field/name"
+                                       tal:condition="python: view.is_field_visible(field, protocol)">
                             <li>
                               <a tal:attributes="href string:#${name}-${field_name};
                                                  id string:${name}-${field_name}-anchor"
@@ -77,7 +78,8 @@
                     </span>
                   </h2>
                   <metal:block tal:repeat="field view/agenda_item_fields">
-                    <metal:block tal:define="field_name field/name;" tal:condition="python: view.is_field_visible(field, protocol)">
+                    <metal:block tal:define="field_name field/name;"
+                                 tal:condition="python: view.is_field_visible(field, protocol)">
                       <label tal:attributes="for string:${name}-${field_name};
                                              id string:${name}-${field_name}-label"
                              tal:content="field/label"></label>

--- a/opengever/meeting/browser/resources/Scrollspy.js
+++ b/opengever/meeting/browser/resources/Scrollspy.js
@@ -75,7 +75,10 @@
       var anchor;
       if (target.hasClass("expandable") && !target.hasClass("paragraph")) {
         anchor = this.extractAnchor(target.next().find("a").first());
-      } else {
+      } else if(target.hasClass("paragraph")) {
+        anchor = this.extractAnchor(target.parent().next().find("a").first().next().find("a").first());
+      }
+      else {
         anchor = this.extractAnchor(target);
       }
       beforeScrollCallback(target, anchor);

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -185,6 +185,21 @@ class TestProtocol(FunctionalTestCase):
         )
 
     @browsing
+    def test_does_not_render_any_field_for_paragraph(self, browser):
+        meeting = create(Builder('meeting')
+                         .having(committee=self.committee_model,
+                                 start=self.localized_datetime(2014, 1, 1, 10, 45),
+                                 location='Somewhere',
+                                 protocol_start_page_number=11)
+                         .link_with(self.meeting_dossier))
+        create(Builder('agenda_item').having(meeting=meeting, is_paragraph=True))
+
+        browser.login()
+        browser.open(meeting.get_url(view='protocol'))
+
+        self.assertEqual([], browser.css('.agenda_items .item label').text)
+
+    @browsing
     def test_protocol_fields_are_xss_safe(self, browser):
         browser.login()
         browser.open(self.meeting.get_url(view='protocol'))


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1548