### PR TITLE
Update link to feedback forum in example content and policy template footers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Update link to feedback forum in example content and policy template footers.
+  [lgraf]
+
 - Update policy templates to include casauth plugin.
   [elioschmutz]
 

--- a/opengever/examplecontent/profiles/default/portlets.xml
+++ b/opengever/examplecontent/profiles/default/portlets.xml
@@ -15,7 +15,7 @@
               manager="ftw.footer.column3" type="plone.portlet.static.Static"
               visible="True">
     <property
-        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/dokumentation"&gt;Benutzerhandbuch&lt;/a&gt;&lt;br /&gt;&lt;a class="external-link" href="http://feedback.onegov.ch"&gt;Feedback Forum&lt;/a&gt;&lt;/p&gt;</property>
+        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/dokumentation"&gt;Benutzerhandbuch&lt;/a&gt;&lt;br /&gt;&lt;a class="external-link" href="https://feedback.onegovgever.ch"&gt;Feedback Forum&lt;/a&gt;&lt;/p&gt;</property>
     <property name="more_url"/>
     <property name="omit_border">False</property>
     <property name="header">Dokumentation</property>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/portlets.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/portlets.xml
@@ -15,7 +15,7 @@
               manager="ftw.footer.column3" type="plone.portlet.static.Static"
               visible="True">
     <property
-        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/dokumentation"&gt;Benutzerhandbuch&lt;/a&gt;&lt;br /&gt;&lt;a class="external-link" href="http://feedback.onegov.ch"&gt;Feedback Forum&lt;/a&gt;&lt;/p&gt;</property>
+        name="text">&lt;p&gt;&lt;a class="external-link" href="http://www.onegov.ch/gever/dokumentation"&gt;Benutzerhandbuch&lt;/a&gt;&lt;br /&gt;&lt;a class="external-link" href="https://feedback.onegovgever.ch/"&gt;Feedback Forum&lt;/a&gt;&lt;/p&gt;</property>
     <property name="more_url"/>
     <property name="omit_border">False</property>
     <property name="header">Dokumentation</property>


### PR DESCRIPTION
Old one points to http://feedback.onegov.ch, new one should point to https://feedback.onegovgever.ch/ instead. Fixes #1553