### PR TITLE
Prevent protocol overwrites.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.3 (unreleased)
 ------------------
 
+- Prevent that the protocol form can overwrite a newer version of the protocol.
+  If concurrent modifications occur we don't offer conflict resolution as of yet but
+  leave the submitted form open to allow the user to take manual action.
+  [deiferni]
+
 - Add migration for trix, convert fields from markdown to html.
   [deiferni]
 

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -188,10 +188,6 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
 
         for agenda_item in self.get_agenda_items():
             agenda_item.update(self.request)
-
-        api.portal.show_message(
-            _(u'message_changes_saved', default='Changes saved'),
-            self.request)
         self._has_successfully_saved = True
 
         self.unlock()
@@ -232,9 +228,10 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
             return JSONResponse(self.request).error(msg).dump()
 
         elif self._has_successfully_saved:
-            return JSONResponse(self.request).redirect(self.nextURL()).info(
-                _('protocol_successfully_changed',
-                  default=u"Protocol successfully changed.")).dump()
+            api.portal.show_message(
+                _(u'message_changes_saved', default='Changes saved'),
+                self.request)
+            return JSONResponse(self.request).redirect(self.nextURL()).dump()
 
         return self.template()
 

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -5,6 +5,9 @@
     <div id="opengever_meeting_protocol">
       <metal:use use-macro="context/@@ploneform-macros/titlelessform">
         <metal:block fill-slot="fields">
+          <!-- for write conflict detection (optimistic locking) -->
+          <input type="hidden" name="modified" tal:attributes="value view/modified_timestamp" />
+
           <div class="protocol-navigation"
                tal:attributes="data-meeting meeting/meeting_id;
                                data-modified meeting/modified">

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -52,8 +52,13 @@
       payload.push({ name: "form.buttons.save", value: saveButton.val() });
       return $.post(target.attr("action"), payload)
               .done(function(data) {
-              meetingStorage.deleteCurrentMeeting();
-              window.location = data.redirectUrl;
+                if (data.redirectUrl !== undefined) {
+                  meetingStorage.deleteCurrentMeeting();
+                  window.location = data.redirectUrl;
+                } else {
+                  // we stay on the same site. allow re-submit.
+                  $("#form-buttons-save").removeClass("submitting");
+                }
              });
     };
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-20 09:24+0000\n"
+"POT-Creation-Date: 2016-02-02 10:46+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,7 +118,7 @@ msgstr "Löschen"
 msgid "Delete proposal"
 msgstr "Traktandum löschen"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:15
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:18
 msgid "Discard"
 msgstr "Verwerfen"
 
@@ -216,7 +216,7 @@ msgstr "Sitzungsnummer"
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:55
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:59
 msgid "Meetinginformation"
 msgstr "Sitzungsangaben"
 
@@ -291,7 +291,7 @@ msgstr "Sablon Vorlage"
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:198
+#: ./opengever/meeting/browser/meetings/protocol.py:202
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Speichern"
@@ -431,7 +431,7 @@ msgid "column_comittee"
 msgstr "Kommission"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:43
+#: ./opengever/meeting/tabs/meetinglisting.py:57
 msgid "column_date"
 msgstr "Datum"
 
@@ -456,7 +456,7 @@ msgid "column_firstname"
 msgstr "Vorname"
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:47
+#: ./opengever/meeting/tabs/meetinglisting.py:61
 msgid "column_from"
 msgstr "Bis"
 
@@ -471,7 +471,7 @@ msgid "column_lastname"
 msgstr "Nachname"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:40
+#: ./opengever/meeting/tabs/meetinglisting.py:54
 msgid "column_location"
 msgstr "Standort"
 
@@ -491,19 +491,20 @@ msgid "column_role"
 msgstr "Rolle"
 
 #. Default: "State"
+#: ./opengever/meeting/tabs/meetinglisting.py:50
 #: ./opengever/meeting/tabs/proposallisting.py:43
 msgid "column_state"
 msgstr "Status"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:36
+#: ./opengever/meeting/tabs/meetinglisting.py:46
 #: ./opengever/meeting/tabs/proposallisting.py:39
 msgid "column_title"
 msgstr "Titel"
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:52
+#: ./opengever/meeting/tabs/meetinglisting.py:66
 msgid "column_to"
 msgstr "Von"
 
@@ -530,7 +531,7 @@ msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf der Kommission vergeben."
 
 #. Default: "Dossier"
-#: ./opengever/meeting/tabs/meetinglisting.py:57
+#: ./opengever/meeting/tabs/meetinglisting.py:71
 msgid "dossier"
 msgstr "Dossier"
 
@@ -606,7 +607,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:210
+#: ./opengever/meeting/browser/meetings/protocol.py:221
 msgid "label_close"
 msgstr "Schliessen"
 
@@ -618,13 +619,13 @@ msgid "label_committee"
 msgstr "Kommission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:127
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:142
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
@@ -664,7 +665,7 @@ msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:133
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr "Beschluss"
@@ -685,13 +686,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:139
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 msgid "label_discussion"
 msgstr "Diskussion"
 
@@ -728,7 +729,7 @@ msgstr "E-Mail"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:64
+#: ./opengever/meeting/browser/meetings/protocol.py:66
 msgid "label_end"
 msgstr "Ende"
 
@@ -754,7 +755,7 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
+#: ./opengever/meeting/browser/meetings/protocol.py:121
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Ausgangslage"
@@ -771,7 +772,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:116
+#: ./opengever/meeting/browser/meetings/protocol.py:118
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
@@ -788,7 +789,7 @@ msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in di
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:55
+#: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
 msgstr "Standort"
 
@@ -828,33 +829,33 @@ msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:45
+#: ./opengever/meeting/browser/meetings/protocol.py:47
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:37
+#: ./opengever/meeting/browser/meetings/protocol.py:39
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:26
+#: ./opengever/meeting/browser/meetings/protocol.py:28
 msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
+#: ./opengever/meeting/browser/meetings/protocol.py:124
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:49
+#: ./opengever/meeting/browser/meetings/protocol.py:51
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:136
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr "Veröffentlichung im"
@@ -887,7 +888,7 @@ msgid "label_schedule"
 msgstr "Traktandieren"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:31
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_secretary"
 msgstr "Protokollführung"
 
@@ -898,7 +899,7 @@ msgstr "Zieldossier"
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:60
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_start"
 msgstr "Start"
 
@@ -915,7 +916,7 @@ msgid "label_transition_executed"
 msgstr "Statusänderung ${transition} ausgeführt"
 
 #. Default: "You have unsaved changes"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:19
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
 msgid "label_unsaved_changes"
 msgstr "Sie haben nicht gespeicherte lokale Änderungen"
 
@@ -948,7 +949,7 @@ msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:190
+#: ./opengever/meeting/browser/meetings/protocol.py:193
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
@@ -957,6 +958,11 @@ msgstr "Änderungen gespeichert"
 #: ./opengever/meeting/form.py:50
 msgid "message_record_created"
 msgstr "Eintrag erzeugt"
+
+#. Default: "Your changes were not saved, the protocol has been modified in the meantime."
+#: ./opengever/meeting/browser/meetings/protocol.py:229
+msgid "message_write_conflict"
+msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:80
@@ -1059,7 +1065,7 @@ msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Protocol successfully changed."
-#: ./opengever/meeting/browser/meetings/protocol.py:219
+#: ./opengever/meeting/browser/meetings/protocol.py:236
 msgid "protocol_successfully_changed"
 msgstr "Protokoll erfolgreich gespeichert."
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-20 09:24+0000\n"
+"POT-Creation-Date: 2016-02-02 10:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,7 +118,7 @@ msgstr ""
 msgid "Delete proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:15
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:18
 msgid "Discard"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:55
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:59
 msgid "Meetinginformation"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:198
+#: ./opengever/meeting/browser/meetings/protocol.py:202
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Enregistrer"
@@ -431,7 +431,7 @@ msgid "column_comittee"
 msgstr "Commission"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:43
+#: ./opengever/meeting/tabs/meetinglisting.py:57
 msgid "column_date"
 msgstr "Date"
 
@@ -456,7 +456,7 @@ msgid "column_firstname"
 msgstr "Prénom"
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:47
+#: ./opengever/meeting/tabs/meetinglisting.py:61
 msgid "column_from"
 msgstr "De"
 
@@ -471,7 +471,7 @@ msgid "column_lastname"
 msgstr "Nom"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:40
+#: ./opengever/meeting/tabs/meetinglisting.py:54
 msgid "column_location"
 msgstr "Site"
 
@@ -491,19 +491,20 @@ msgid "column_role"
 msgstr "Rôle"
 
 #. Default: "State"
+#: ./opengever/meeting/tabs/meetinglisting.py:50
 #: ./opengever/meeting/tabs/proposallisting.py:43
 msgid "column_state"
 msgstr "Etat"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:36
+#: ./opengever/meeting/tabs/meetinglisting.py:46
 #: ./opengever/meeting/tabs/proposallisting.py:39
 msgid "column_title"
 msgstr "Titre"
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:52
+#: ./opengever/meeting/tabs/meetinglisting.py:66
 msgid "column_to"
 msgstr "Jusqu'à"
 
@@ -530,7 +531,7 @@ msgid "description_group"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/tabs/meetinglisting.py:57
+#: ./opengever/meeting/tabs/meetinglisting.py:71
 msgid "dossier"
 msgstr ""
 
@@ -606,7 +607,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:210
+#: ./opengever/meeting/browser/meetings/protocol.py:221
 msgid "label_close"
 msgstr ""
 
@@ -618,13 +619,13 @@ msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:127
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:142
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
@@ -664,7 +665,7 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:133
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
@@ -685,13 +686,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:139
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 msgid "label_discussion"
 msgstr "Discussion"
 
@@ -728,7 +729,7 @@ msgstr "Email"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:64
+#: ./opengever/meeting/browser/meetings/protocol.py:66
 msgid "label_end"
 msgstr "Fin"
 
@@ -754,7 +755,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
+#: ./opengever/meeting/browser/meetings/protocol.py:121
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Situation initiale"
@@ -771,7 +772,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:116
+#: ./opengever/meeting/browser/meetings/protocol.py:118
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Base légale"
@@ -788,7 +789,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:55
+#: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
 msgstr "Site"
 
@@ -828,33 +829,33 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:45
+#: ./opengever/meeting/browser/meetings/protocol.py:47
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:37
+#: ./opengever/meeting/browser/meetings/protocol.py:39
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:26
+#: ./opengever/meeting/browser/meetings/protocol.py:28
 msgid "label_presidency"
 msgstr "Présidence"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
+#: ./opengever/meeting/browser/meetings/protocol.py:124
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:49
+#: ./opengever/meeting/browser/meetings/protocol.py:51
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:136
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
@@ -887,7 +888,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:31
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_secretary"
 msgstr "Secrétaire"
 
@@ -898,7 +899,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:60
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_start"
 msgstr "Début"
 
@@ -915,7 +916,7 @@ msgid "label_transition_executed"
 msgstr ""
 
 #. Default: "You have unsaved changes"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:19
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
 msgid "label_unsaved_changes"
 msgstr ""
 
@@ -948,7 +949,7 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:190
+#: ./opengever/meeting/browser/meetings/protocol.py:193
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
@@ -957,6 +958,11 @@ msgstr "Modifications sauvegardées"
 #: ./opengever/meeting/form.py:50
 msgid "message_record_created"
 msgstr "Enregistrement créé"
+
+#. Default: "Your changes were not saved, the protocol has been modified in the meantime."
+#: ./opengever/meeting/browser/meetings/protocol.py:229
+msgid "message_write_conflict"
+msgstr ""
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:80
@@ -1059,7 +1065,7 @@ msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Protocol successfully changed."
-#: ./opengever/meeting/browser/meetings/protocol.py:219
+#: ./opengever/meeting/browser/meetings/protocol.py:236
 msgid "protocol_successfully_changed"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-20 09:24+0000\n"
+"POT-Creation-Date: 2016-02-02 10:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,7 +117,7 @@ msgstr ""
 msgid "Delete proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:15
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:18
 msgid "Discard"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:55
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:59
 msgid "Meetinginformation"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:198
+#: ./opengever/meeting/browser/meetings/protocol.py:202
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr ""
@@ -430,7 +430,7 @@ msgid "column_comittee"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:43
+#: ./opengever/meeting/tabs/meetinglisting.py:57
 msgid "column_date"
 msgstr ""
 
@@ -455,7 +455,7 @@ msgid "column_firstname"
 msgstr ""
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:47
+#: ./opengever/meeting/tabs/meetinglisting.py:61
 msgid "column_from"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgid "column_lastname"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:40
+#: ./opengever/meeting/tabs/meetinglisting.py:54
 msgid "column_location"
 msgstr ""
 
@@ -490,19 +490,20 @@ msgid "column_role"
 msgstr ""
 
 #. Default: "State"
+#: ./opengever/meeting/tabs/meetinglisting.py:50
 #: ./opengever/meeting/tabs/proposallisting.py:43
 msgid "column_state"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:36
+#: ./opengever/meeting/tabs/meetinglisting.py:46
 #: ./opengever/meeting/tabs/proposallisting.py:39
 msgid "column_title"
 msgstr ""
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:52
+#: ./opengever/meeting/tabs/meetinglisting.py:66
 msgid "column_to"
 msgstr ""
 
@@ -529,7 +530,7 @@ msgid "description_group"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/tabs/meetinglisting.py:57
+#: ./opengever/meeting/tabs/meetinglisting.py:71
 msgid "dossier"
 msgstr ""
 
@@ -605,7 +606,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:210
+#: ./opengever/meeting/browser/meetings/protocol.py:221
 msgid "label_close"
 msgstr ""
 
@@ -617,13 +618,13 @@ msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:127
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:142
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
@@ -663,7 +664,7 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:133
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
@@ -684,13 +685,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:139
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 msgid "label_discussion"
 msgstr ""
 
@@ -727,7 +728,7 @@ msgstr ""
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:64
+#: ./opengever/meeting/browser/meetings/protocol.py:66
 msgid "label_end"
 msgstr ""
 
@@ -753,7 +754,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
+#: ./opengever/meeting/browser/meetings/protocol.py:121
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr ""
@@ -770,7 +771,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:116
+#: ./opengever/meeting/browser/meetings/protocol.py:118
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr ""
@@ -787,7 +788,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:55
+#: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
 msgstr ""
 
@@ -827,33 +828,33 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:45
+#: ./opengever/meeting/browser/meetings/protocol.py:47
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:37
+#: ./opengever/meeting/browser/meetings/protocol.py:39
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:26
+#: ./opengever/meeting/browser/meetings/protocol.py:28
 msgid "label_presidency"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
+#: ./opengever/meeting/browser/meetings/protocol.py:124
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:49
+#: ./opengever/meeting/browser/meetings/protocol.py:51
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:136
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
@@ -886,7 +887,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:31
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_secretary"
 msgstr ""
 
@@ -897,7 +898,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:60
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_start"
 msgstr ""
 
@@ -914,7 +915,7 @@ msgid "label_transition_executed"
 msgstr ""
 
 #. Default: "You have unsaved changes"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:19
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
 msgid "label_unsaved_changes"
 msgstr ""
 
@@ -947,7 +948,7 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:190
+#: ./opengever/meeting/browser/meetings/protocol.py:193
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr ""
@@ -955,6 +956,11 @@ msgstr ""
 #. Default: "Record created"
 #: ./opengever/meeting/form.py:50
 msgid "message_record_created"
+msgstr ""
+
+#. Default: "Your changes were not saved, the protocol has been modified in the meantime."
+#: ./opengever/meeting/browser/meetings/protocol.py:229
+msgid "message_write_conflict"
 msgstr ""
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
@@ -1058,7 +1064,7 @@ msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Protocol successfully changed."
-#: ./opengever/meeting/browser/meetings/protocol.py:219
+#: ./opengever/meeting/browser/meetings/protocol.py:236
 msgid "protocol_successfully_changed"
 msgstr ""
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -85,9 +85,6 @@ class TestProtocol(FunctionalTestCase):
         self.assertEqual(self.sablon_template,
                          self.committee.get_protocol_template())
 
-    def json_messages(self, browser):
-        return browser.json.get('messages', None)
-
     @browsing
     def test_protocol_template_can_be_configured_per_commitee(self, browser):
         self.grant("Administrator")
@@ -228,17 +225,11 @@ class TestProtocol(FunctionalTestCase):
                       'Disclose to': 'Nobody',
                       'Copy for attention': 'Hanspeter',
                       'Protocol start-page': '10'}).submit()
-
-        self.json_messages(browser)
-
-        self.assertEquals(
-            [{
-                u'messageTitle': u'Information',
-                u'message': u'Protocol successfully changed.',
-                u'messageClass': u'info'
-            }],
-            self.json_messages(browser)
-        )
+        self.assertEqual({
+            u'redirectUrl': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/view'},
+            browser.json)
+        browser.open(self.meeting.get_url(view='view'))
+        self.assertEqual(['Changes saved'], info_messages())
 
         meeting = Meeting.query.get(self.meeting.meeting_id)
         self.assertGreater(meeting.modified, prev_modified)
@@ -282,14 +273,11 @@ class TestProtocol(FunctionalTestCase):
                       'Participants': str(peter.member_id),
                       'Other Participants': 'Klara'}).submit()
 
-        self.assertEquals(
-            [{
-                u'messageTitle': u'Information',
-                u'message': u'Protocol successfully changed.',
-                u'messageClass': u'info'
-            }],
-            self.json_messages(browser)
-        )
+        self.assertEqual({
+            u'redirectUrl': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/view'},
+            browser.json)
+        browser.open(self.meeting.get_url(view='view'))
+        self.assertEqual(['Changes saved'], info_messages())
 
         meeting = Meeting.query.get(self.meeting.meeting_id)
         self.assertGreater(meeting.modified, prev_modified)

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -305,6 +305,21 @@ class TestProtocol(FunctionalTestCase):
         self.assertEqual(u'Klara', meeting.other_participants)
 
     @browsing
+    def test_protocol_conflicts_are_detected(self, browser):
+        browser.login()
+        browser.open(self.meeting.get_url(view='protocol'))
+
+        browser.fill({"modified": '1'}).submit()
+        self.assertEqual({
+            u'messages': [{
+                u'messageTitle': u'Error',
+                u'message': u'Your changes were not saved, the protocol has been modified in the meantime.',
+                u'messageClass': u'error'}
+            ]},
+            browser.json
+        )
+
+    @browsing
     def test_protocol_can_be_downloaded(self, browser):
         self.setup_protocol(browser)
         browser.css('.generate-protocol').first.click()


### PR DESCRIPTION
Prevent that the protocol form can overwrite a newer version of the protocol.

If concurrent modifications occur we don't offer conflict resolution as of yet but leave the submitted form open to allow the user to take manual action.

Closes #1563.

*This problem should only occur in rare cases when users leave tabs open that contain unsaved changes or modify the same content in several tabs at the same time.*

![screen shot 2016-02-02 at 11 47 30](https://cloud.githubusercontent.com/assets/736583/12747794/706f0a5a-c9a6-11e5-9048-5b9a9d94fec7.png)
