### PR TITLE
Remove "reference_number" from catalog metadata.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove "reference_number" from catalog metadata. [jone]
 
 
 4.6.3 (2016-01-25)

--- a/opengever/dossier/profiles/default/metadata.xml
+++ b/opengever/dossier/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-    <version>4600</version>
+    <version>4601</version>
 </metadata>

--- a/opengever/dossier/upgrades/configure.zcml
+++ b/opengever/dossier/upgrades/configure.zcml
@@ -254,4 +254,13 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 4600 -> 4601 -->
+    <upgrade-step:importProfile
+        title="Remove 'reference_number' from catalog metadata."
+        profile="opengever.dossier:default"
+        source="4600"
+        destination="4601"
+        directory="profiles/4601"
+        />
+
 </configure>

--- a/opengever/dossier/upgrades/profiles/4601/catalog.xml
+++ b/opengever/dossier/upgrades/profiles/4601/catalog.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
 <object name="portal_catalog" meta_type="Dossier Catalog">
-    <column value="containing_subdossier"/>
-    <column value="containing_dossier"/>
+    <column value="reference_number" remove="True" />
 </object>


### PR DESCRIPTION
It seems that the "reference_number" metadata in the catalog is no longer in use.
It usually seems to be Missing.Value.
:scissors: :sunglasses: 

Closes #1570 