### PR TITLE
Recycle reference numbers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Recycle reference numbers. When moving an object back to a previous
+  parent, the previous reference number is recycled. [jone]
+
 - Remove "reference_number" from catalog metadata. [jone]
 
 

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -71,10 +71,16 @@ class ReferenceNumberPrefixAdpater(grok.Adapter):
         """
 
         child_mapping = self.get_child_mapping(obj)
+        prefix_mapping = self.get_prefix_mapping(obj)
+        intid = obj and getUtility(IIntIds).getId(aq_base(obj))
 
         if not child_mapping.keys():
             # It's the first number ever issued
             return self.get_first_number(obj)
+        elif intid and intid in prefix_mapping:
+            # Moving back? The object already used to have a number
+            # here - lets recycle it!
+            return prefix_mapping[intid]
         else:
             prefixes_in_use = child_mapping.keys()
             # Sort the list of unicode strings *numerically*

--- a/opengever/base/tests/test_reference_prefix.py
+++ b/opengever/base/tests/test_reference_prefix.py
@@ -47,10 +47,11 @@ class TestReferencePrefixAdapter(FunctionalTestCase):
         self.assertEquals(u'42', self.adapter.set_number(item, u'42'))
         self.assertEquals(u'42', self.adapter.get_number(item))
 
-    def test_without_passing_a_number_set_number_generates_a_new_one(self):
+    def test_set_number_recycles_old_numbers(self):
         item = self.create_item()
-        self.assertEquals(u'2', self.adapter.set_number(item))
-        self.assertEquals(u'2', self.adapter.get_number(item))
+        self.assertEquals(u'1', self.adapter.get_number(item))
+        self.assertEquals(u'1', self.adapter.set_number(item))
+        self.assertEquals(u'1', self.adapter.get_number(item))
 
     def test_non_assigned_numbers_are_valid(self):
         self.create_numbered_item(u'3')


### PR DESCRIPTION
When moving an object back to a previous  parent, the previous reference number is recycled.

Solves these problems:

- When moving an object and selecting the current parent, which means that the object is not moved in fact, we now no longer change the reference number.

- When moving an object back to a container where it was before and already had a reference number, the reference number is now automatically recycled (unless explicitly set through the API).

Fixes #1521 