### PR TITLE
Prevent saving the protocol when it is locked by another user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Prevent saving the protocol when it is locked by another user.
+  [deiferni]
+
 - Rename "Kommission" to more generic "Gremium"
   [elioschmutz]
 
@@ -22,18 +25,20 @@ Changelog
   [elioschmutz]
 
 - Recycle reference numbers. When moving an object back to a previous
-  parent, the previous reference number is recycled. [jone]
+  parent, the previous reference number is recycled.
+  [jone]
 
-- Remove "reference_number" from catalog metadata. [jone]
-
-
-4.6.3 (2016-01-25)
-------------------
+- Remove "reference_number" from catalog metadata.
+  [jone]
 
 - Prevent that the protocol form can overwrite a newer version of the protocol.
   If concurrent modifications occur we don't offer conflict resolution as of yet but
   leave the submitted form open to allow the user to take manual action.
   [deiferni]
+
+
+4.6.3 (2016-01-25)
+------------------
 
 - Add migration for trix, convert fields from markdown to html.
   [deiferni]

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -210,7 +210,7 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
         super(EditProtocol, self).handleApply(self, action)
 
     def has_write_conflict(self):
-        return self.modified_timestamp() != self.submitted_modified_timestamp()
+        return self.server_timestamp != self.client_timestamp
 
     def is_locked_by_another_user(self):
         """Return False if the document is locked by the current user or is
@@ -277,12 +277,14 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
         else:
             return not agenda_item.is_paragraph
 
-    def modified_timestamp(self):
+    @property
+    def server_timestamp(self):
         """Return the modified timestamp as seconds since the epoch."""
 
         return timegm(as_utc(self.model.modified).timetuple())
 
-    def submitted_modified_timestamp(self):
+    @property
+    def client_timestamp(self):
         """Return the modified timestamp that has been submitted by the
         client.
 

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -9,6 +9,7 @@ from opengever.meeting.form import ModelEditForm
 from opengever.meeting.model import Meeting
 from opengever.meeting.sablon import Sablon
 from opengever.meeting.vocabulary import get_committee_member_vocabulary
+from opengever.ogds.base.actor import Actor
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.directives import form
@@ -152,6 +153,7 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
         """
         super(EditProtocol, self).__init__(context, request, context.model)
         self._has_write_conflict = False
+        self._is_locked_by_another_user = False
         self._has_successfully_saved = False
 
     def update(self):
@@ -201,11 +203,27 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
         if self.has_write_conflict():
             self._has_write_conflict = True
             return
+        if self.is_locked_by_another_user():
+            self._is_locked_by_another_user = True
+            return
 
         super(EditProtocol, self).handleApply(self, action)
 
     def has_write_conflict(self):
         return self.modified_timestamp() != self.submitted_modified_timestamp()
+
+    def is_locked_by_another_user(self):
+        """Return False if the document is locked by the current user or is
+        not locked at all, True otherwise.
+
+        """
+        lockable = ILockable(self.context)
+        return not lockable.can_safely_unlock()
+
+    def get_lock_creator_user_name(self):
+        lockable = ILockable(self.context)
+        creator = lockable.lock_info()[0]['creator']
+        return Actor.lookup(creator).get_label()
 
     def redirect_to_next_url(self):
         """
@@ -225,6 +243,13 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
             msg = _(u'message_write_conflict',
                     default='Your changes were not saved, the protocol has '
                             'been modified in the meantime.')
+            return JSONResponse(self.request).error(msg).dump()
+
+        elif self._is_locked_by_another_user:
+            msg = _(u'message_locked_by_another_user',
+                    default='Your changes were not saved, the protocol is '
+                            'locked by ${username}.',
+                    mapping={'username': self.get_lock_creator_user_name()})
             return JSONResponse(self.request).error(msg).dump()
 
         elif self._has_successfully_saved:

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -6,7 +6,7 @@
       <metal:use use-macro="context/@@ploneform-macros/titlelessform">
         <metal:block fill-slot="fields">
           <!-- for write conflict detection (optimistic locking) -->
-          <input type="hidden" name="modified" tal:attributes="value view/modified_timestamp" />
+          <input type="hidden" name="modified" tal:attributes="value view/server_timestamp" />
 
           <div class="protocol-navigation"
                tal:attributes="data-meeting meeting/meeting_id;

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-02 10:46+0000\n"
+"POT-Creation-Date: 2016-02-02 15:56+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,7 +291,7 @@ msgstr "Sablon Vorlage"
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:202
+#: ./opengever/meeting/browser/meetings/protocol.py:199
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Speichern"
@@ -607,7 +607,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:221
+#: ./opengever/meeting/browser/meetings/protocol.py:233
 msgid "label_close"
 msgstr "Schliessen"
 
@@ -619,13 +619,13 @@ msgid "label_committee"
 msgstr "Gremium"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/browser/meetings/protocol.py:128
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/browser/meetings/protocol.py:143
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
@@ -665,7 +665,7 @@ msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/browser/meetings/protocol.py:134
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr "Beschluss"
@@ -686,13 +686,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/browser/meetings/protocol.py:140
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
+#: ./opengever/meeting/browser/meetings/protocol.py:131
 msgid "label_discussion"
 msgstr "Diskussion"
 
@@ -729,7 +729,7 @@ msgstr "E-Mail"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:66
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_end"
 msgstr "Ende"
 
@@ -755,7 +755,7 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:122
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Ausgangslage"
@@ -772,7 +772,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py:119
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
@@ -789,7 +789,7 @@ msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in di
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:57
+#: ./opengever/meeting/browser/meetings/protocol.py:58
 msgid "label_location"
 msgstr "Sitzungsort"
 
@@ -829,33 +829,33 @@ msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:47
+#: ./opengever/meeting/browser/meetings/protocol.py:48
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:39
+#: ./opengever/meeting/browser/meetings/protocol.py:40
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:28
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/browser/meetings/protocol.py:125
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:51
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/browser/meetings/protocol.py:137
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
@@ -888,7 +888,7 @@ msgid "label_schedule"
 msgstr "Traktandieren"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py:34
 msgid "label_secretary"
 msgstr "Protokollführung"
 
@@ -899,7 +899,7 @@ msgstr "Zieldossier"
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/protocol.py:63
 msgid "label_start"
 msgstr "Start"
 
@@ -949,10 +949,15 @@ msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:193
+#: ./opengever/meeting/browser/meetings/protocol.py:255
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
+
+#. Default: "Your changes were not saved, the protocol is locked by ${username}."
+#: ./opengever/meeting/browser/meetings/protocol.py:247
+msgid "message_locked_by_another_user"
+msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde von ${username} gesperrt."
 
 #. Default: "Record created"
 #: ./opengever/meeting/form.py:50
@@ -960,7 +965,7 @@ msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:229
+#: ./opengever/meeting/browser/meetings/protocol.py:241
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
@@ -1063,11 +1068,6 @@ msgstr "Protokoll"
 #: ./opengever/meeting/protocol.py:131
 msgid "protocol_excerpt"
 msgstr "Protokollauszug"
-
-#. Default: "Protocol successfully changed."
-#: ./opengever/meeting/browser/meetings/protocol.py:236
-msgid "protocol_successfully_changed"
-msgstr "Protokoll erfolgreich gespeichert."
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-02 10:46+0000\n"
+"POT-Creation-Date: 2016-02-02 15:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,7 +291,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:202
+#: ./opengever/meeting/browser/meetings/protocol.py:199
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Enregistrer"
@@ -607,7 +607,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:221
+#: ./opengever/meeting/browser/meetings/protocol.py:233
 msgid "label_close"
 msgstr ""
 
@@ -619,13 +619,13 @@ msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/browser/meetings/protocol.py:128
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/browser/meetings/protocol.py:143
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
@@ -665,7 +665,7 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/browser/meetings/protocol.py:134
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
@@ -686,13 +686,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/browser/meetings/protocol.py:140
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
+#: ./opengever/meeting/browser/meetings/protocol.py:131
 msgid "label_discussion"
 msgstr "Discussion"
 
@@ -729,7 +729,7 @@ msgstr "Email"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:66
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_end"
 msgstr "Fin"
 
@@ -755,7 +755,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:122
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Situation initiale"
@@ -772,7 +772,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py:119
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Base légale"
@@ -789,7 +789,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:57
+#: ./opengever/meeting/browser/meetings/protocol.py:58
 msgid "label_location"
 msgstr "Site"
 
@@ -829,33 +829,33 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:47
+#: ./opengever/meeting/browser/meetings/protocol.py:48
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:39
+#: ./opengever/meeting/browser/meetings/protocol.py:40
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:28
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_presidency"
 msgstr "Présidence"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/browser/meetings/protocol.py:125
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:51
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/browser/meetings/protocol.py:137
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
@@ -888,7 +888,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py:34
 msgid "label_secretary"
 msgstr "Secrétaire"
 
@@ -899,7 +899,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/protocol.py:63
 msgid "label_start"
 msgstr "Début"
 
@@ -949,10 +949,15 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:193
+#: ./opengever/meeting/browser/meetings/protocol.py:255
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
+
+#. Default: "Your changes were not saved, the protocol is locked by ${username}."
+#: ./opengever/meeting/browser/meetings/protocol.py:247
+msgid "message_locked_by_another_user"
+msgstr ""
 
 #. Default: "Record created"
 #: ./opengever/meeting/form.py:50
@@ -960,7 +965,7 @@ msgid "message_record_created"
 msgstr "Enregistrement créé"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:229
+#: ./opengever/meeting/browser/meetings/protocol.py:241
 msgid "message_write_conflict"
 msgstr ""
 
@@ -1062,11 +1067,6 @@ msgstr "Procès-verbal"
 #. Default: "Protocol-Excerpt"
 #: ./opengever/meeting/protocol.py:131
 msgid "protocol_excerpt"
-msgstr ""
-
-#. Default: "Protocol successfully changed."
-#: ./opengever/meeting/browser/meetings/protocol.py:236
-msgid "protocol_successfully_changed"
 msgstr ""
 
 #. Default: "Reject"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-02 10:46+0000\n"
+"POT-Creation-Date: 2016-02-02 15:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -290,7 +290,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:202
+#: ./opengever/meeting/browser/meetings/protocol.py:199
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr ""
@@ -606,7 +606,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:221
+#: ./opengever/meeting/browser/meetings/protocol.py:233
 msgid "label_close"
 msgstr ""
 
@@ -618,13 +618,13 @@ msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/browser/meetings/protocol.py:128
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/browser/meetings/protocol.py:143
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
@@ -664,7 +664,7 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/browser/meetings/protocol.py:134
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
@@ -685,13 +685,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/browser/meetings/protocol.py:140
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
+#: ./opengever/meeting/browser/meetings/protocol.py:131
 msgid "label_discussion"
 msgstr ""
 
@@ -728,7 +728,7 @@ msgstr ""
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:66
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_end"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:122
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr ""
@@ -771,7 +771,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py:119
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr ""
@@ -788,7 +788,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:57
+#: ./opengever/meeting/browser/meetings/protocol.py:58
 msgid "label_location"
 msgstr ""
 
@@ -828,33 +828,33 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:47
+#: ./opengever/meeting/browser/meetings/protocol.py:48
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:39
+#: ./opengever/meeting/browser/meetings/protocol.py:40
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:28
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_presidency"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/browser/meetings/protocol.py:125
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:51
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/browser/meetings/protocol.py:137
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
@@ -887,7 +887,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py:34
 msgid "label_secretary"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/protocol.py:63
 msgid "label_start"
 msgstr ""
 
@@ -948,9 +948,14 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:193
+#: ./opengever/meeting/browser/meetings/protocol.py:255
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
+msgstr ""
+
+#. Default: "Your changes were not saved, the protocol is locked by ${username}."
+#: ./opengever/meeting/browser/meetings/protocol.py:247
+msgid "message_locked_by_another_user"
 msgstr ""
 
 #. Default: "Record created"
@@ -959,7 +964,7 @@ msgid "message_record_created"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:229
+#: ./opengever/meeting/browser/meetings/protocol.py:241
 msgid "message_write_conflict"
 msgstr ""
 
@@ -1061,11 +1066,6 @@ msgstr ""
 #. Default: "Protocol-Excerpt"
 #: ./opengever/meeting/protocol.py:131
 msgid "protocol_excerpt"
-msgstr ""
-
-#. Default: "Protocol successfully changed."
-#: ./opengever/meeting/browser/meetings/protocol.py:236
-msgid "protocol_successfully_changed"
 msgstr ""
 
 #. Default: "Reject"


### PR DESCRIPTION
Fixes #1564.

Remain on the form after a the error occurred, when the other user unlocks the protocol without modifications, it can be saved again by the current user.

![screen shot 2016-02-02 at 16 58 53](https://cloud.githubusercontent.com/assets/736583/12757481/8298e52a-c9d8-11e5-96f7-f574e0c6be35.png)

Also, cleanup changelog.
