### PR TITLE
Translate "Standort" to "Sitzungsort" for Meetings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Translate "Standort" to "Sitzungsort" for Meetings.
+  [elioschmutz]
+
 - Change translation for label_publish_in
   [elioschmutz]
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -473,7 +473,7 @@ msgstr "Nachname"
 #. Default: "Location"
 #: ./opengever/meeting/tabs/meetinglisting.py:54
 msgid "column_location"
-msgstr "Standort"
+msgstr "Sitzungsort"
 
 #. Default: "Member"
 #: ./opengever/meeting/tabs/membershiplisting.py:25
@@ -791,7 +791,7 @@ msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in di
 #: ./opengever/meeting/browser/meetings/meeting.py:42
 #: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
-msgstr "Standort"
+msgstr "Sitzungsort"
 
 #. Default: "Main Atrributes"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:13


### PR DESCRIPTION
Folgende Übersetzungen wurden angepasst:

<img width="493" alt="bildschirmfoto 2016-02-03 um 11 47 46" src="https://cloud.githubusercontent.com/assets/557005/12780128/5124a3fa-ca6c-11e5-9b2a-48ab62d2437b.png">

<img width="350" alt="bildschirmfoto 2016-02-03 um 11 47 37" src="https://cloud.githubusercontent.com/assets/557005/12780129/514c35dc-ca6c-11e5-8237-478abead46f0.png">

closes #1537 