### PR TITLE
Display versions tab for sablon templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Display versions tab for sablon templates.
+  [deiferni]
+
 - Translate "Standort" to "Sitzungsort" for Meetings.
   [elioschmutz]
 

--- a/opengever/meeting/profiles/default/metadata.xml
+++ b/opengever/meeting/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>4630</version>
+    <version>4631</version>
     <dependencies>
     </dependencies>
 </metadata>

--- a/opengever/meeting/profiles/default/types/opengever.meeting.sablontemplate.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.sablontemplate.xml
@@ -63,6 +63,7 @@
 
   <!-- Tab Actions -->
   <action title="overview" action_id="overview" category="tabbedview-tabs" condition_expr="" url_expr="string:#" visible="True"></action>
+  <action title="Versions" action_id="versions" category="tabbedview-tabs" condition_expr="" url_expr="string:#" visible="True"></action>
   <action title="journal" action_id="journal" category="tabbedview-tabs" condition_expr="" url_expr="string:#" visible="True"></action>
 
   <!-- disable some old actions -->

--- a/opengever/meeting/upgrades/configure.zcml
+++ b/opengever/meeting/upgrades/configure.zcml
@@ -622,4 +622,14 @@
         profile="opengever.meeting:default"
         />
 
+    <!-- 4630 -> 4631 -->
+    <genericsetup:upgradeStep
+        title="Show versions tab for sablon templates."
+        description=""
+        source="4630"
+        destination="4631"
+        handler="opengever.meeting.upgrades.to4631.ShowSablonTemplateVersionsTab"
+        profile="opengever.meeting:default"
+        />
+
 </configure>

--- a/opengever/meeting/upgrades/to4631.py
+++ b/opengever/meeting/upgrades/to4631.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ShowSablonTemplateVersionsTab(UpgradeStep):
+
+    def __call__(self):
+        self.actions_add_type_action(
+            'opengever.meeting.sablontemplate',
+            after='overview',
+            action_id='versions',
+            **{'title': 'Versions',
+               'action': 'string:#',
+               'category': 'tabbedview-tabs',
+               'condition': '',
+               'link_target': '',
+               'visible': True,
+               'permissions': tuple(),
+               })


### PR DESCRIPTION
![screen shot 2016-02-03 at 17 56 24](https://cloud.githubusercontent.com/assets/736583/12789923/2517305a-caa0-11e5-9971-19f3f6185377.png)

Closes #1508.