### PR TITLE
Spalten in Antragsauflistungen überarbeitet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,14 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Adjust proposal tabbedview tab.
+
+  - Remove unused rows: 'initial_position' and 'proposed_action'
+  - Add referencenumber row
+  - Add meeting row: link to the related meeting if the proposal is scheduled
+
+  [elioschmutz]
+
 - Make a proposal's repository-folder title available as variable
   for sablon templates.
   [deiferni]

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-04 09:31+0000\n"
+"POT-Creation-Date: 2016-02-10 08:27+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,7 +291,7 @@ msgstr "Sablon Vorlage"
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:198
+#: ./opengever/meeting/browser/meetings/protocol.py:200
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Speichern"
@@ -426,7 +426,7 @@ msgid "closed"
 msgstr "geschlossen"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:50
+#: ./opengever/meeting/tabs/proposallisting.py:58
 msgid "column_comittee"
 msgstr "Gremium"
 
@@ -470,6 +470,11 @@ msgstr "Nachname"
 msgid "column_location"
 msgstr "Sitzungsort"
 
+#. Default: "Meeting"
+#: ./opengever/meeting/tabs/proposallisting.py:62
+msgid "column_meeting"
+msgstr "Sitzung"
+
 #. Default: "Member"
 #: ./opengever/meeting/tabs/membershiplisting.py:25
 msgid "column_member"
@@ -482,14 +487,14 @@ msgstr "Rolle"
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:46
+#: ./opengever/meeting/tabs/proposallisting.py:54
 msgid "column_state"
 msgstr "Status"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:42
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_title"
 msgstr "Titel"
 
@@ -597,7 +602,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:217
+#: ./opengever/meeting/browser/meetings/protocol.py:235
 msgid "label_close"
 msgstr "Schliessen"
 
@@ -609,13 +614,13 @@ msgid "label_committee"
 msgstr "Gremium"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/browser/meetings/protocol.py:128
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/browser/meetings/protocol.py:143
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
@@ -655,7 +660,7 @@ msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/browser/meetings/protocol.py:134
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr "Beschluss"
@@ -676,13 +681,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/browser/meetings/protocol.py:140
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
+#: ./opengever/meeting/browser/meetings/protocol.py:131
 msgid "label_discussion"
 msgstr "Diskussion"
 
@@ -719,7 +724,7 @@ msgstr "E-Mail"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:66
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_end"
 msgstr "Ende"
 
@@ -745,7 +750,7 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:122
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Ausgangslage"
@@ -762,7 +767,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py:119
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
@@ -779,7 +784,7 @@ msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in di
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:57
+#: ./opengever/meeting/browser/meetings/protocol.py:58
 msgid "label_location"
 msgstr "Sitzungsort"
 
@@ -819,38 +824,38 @@ msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:47
+#: ./opengever/meeting/browser/meetings/protocol.py:48
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:39
+#: ./opengever/meeting/browser/meetings/protocol.py:40
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:28
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/tabs/proposallisting.py:39
+#: ./opengever/meeting/tabs/proposallisting.py:47
 msgid "label_proposal_id"
 msgstr "Laufnummer"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/browser/meetings/protocol.py:125
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:51
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/browser/meetings/protocol.py:137
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
@@ -883,7 +888,7 @@ msgid "label_schedule"
 msgstr "Traktandieren"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py:34
 msgid "label_secretary"
 msgstr "Protokollführung"
 
@@ -894,7 +899,7 @@ msgstr "Zieldossier"
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/protocol.py:63
 msgid "label_start"
 msgstr "Start"
 
@@ -949,7 +954,7 @@ msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:232
+#: ./opengever/meeting/browser/meetings/protocol.py:257
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
@@ -965,7 +970,7 @@ msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:225
+#: ./opengever/meeting/browser/meetings/protocol.py:243
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-08 17:31+0000\n"
+"POT-Creation-Date: 2016-02-04 09:31+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,7 +291,7 @@ msgstr "Sablon Vorlage"
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:200
+#: ./opengever/meeting/browser/meetings/protocol.py:198
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Speichern"
@@ -426,7 +426,7 @@ msgid "closed"
 msgstr "geschlossen"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:47
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_comittee"
 msgstr "Gremium"
 
@@ -460,11 +460,6 @@ msgstr "Vorname"
 msgid "column_from"
 msgstr "Bis"
 
-#. Default: "Initial Position"
-#: ./opengever/meeting/tabs/proposallisting.py:51
-msgid "column_initial_position"
-msgstr "Ausgangslage"
-
 #. Default: "Lastname"
 #: ./opengever/meeting/tabs/memberlisting.py:30
 msgid "column_lastname"
@@ -480,11 +475,6 @@ msgstr "Sitzungsort"
 msgid "column_member"
 msgstr "Mitglied"
 
-#. Default: "Proposed action"
-#: ./opengever/meeting/tabs/proposallisting.py:55
-msgid "column_proposed_action"
-msgstr "Antrag"
-
 #. Default: "Role"
 #: ./opengever/meeting/tabs/membershiplisting.py:37
 msgid "column_role"
@@ -492,14 +482,14 @@ msgstr "Rolle"
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:43
+#: ./opengever/meeting/tabs/proposallisting.py:46
 msgid "column_state"
 msgstr "Status"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:39
+#: ./opengever/meeting/tabs/proposallisting.py:42
 msgid "column_title"
 msgstr "Titel"
 
@@ -607,7 +597,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:235
+#: ./opengever/meeting/browser/meetings/protocol.py:217
 msgid "label_close"
 msgstr "Schliessen"
 
@@ -619,14 +609,14 @@ msgid "label_committee"
 msgstr "Gremium"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
-#: ./opengever/meeting/proposal.py:117
+#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
-#: ./opengever/meeting/proposal.py:78
+#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
@@ -665,8 +655,8 @@ msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
-#: ./opengever/meeting/proposal.py:195
+#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr "Beschluss"
 
@@ -686,13 +676,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
-#: ./opengever/meeting/proposal.py:73
+#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 msgid "label_discussion"
 msgstr "Diskussion"
 
@@ -729,7 +719,7 @@ msgstr "E-Mail"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:67
+#: ./opengever/meeting/browser/meetings/protocol.py:66
 msgid "label_end"
 msgstr "Ende"
 
@@ -755,8 +745,8 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
-#: ./opengever/meeting/proposal.py:58
+#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
@@ -772,8 +762,8 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
-#: ./opengever/meeting/proposal.py:53
+#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
@@ -789,7 +779,7 @@ msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in di
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:58
+#: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
 msgstr "Sitzungsort"
 
@@ -829,34 +819,39 @@ msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:48
+#: ./opengever/meeting/browser/meetings/protocol.py:47
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:40
+#: ./opengever/meeting/browser/meetings/protocol.py:39
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/protocol.py:28
 msgid "label_presidency"
 msgstr "Vorsitz"
 
+#. Default: "Reference Number"
+#: ./opengever/meeting/tabs/proposallisting.py:39
+msgid "label_proposal_id"
+msgstr "Laufnummer"
+
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
-#: ./opengever/meeting/proposal.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py:51
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
-#: ./opengever/meeting/proposal.py:68
+#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
 
@@ -888,7 +883,7 @@ msgid "label_schedule"
 msgstr "Traktandieren"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:34
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_secretary"
 msgstr "Protokollführung"
 
@@ -899,7 +894,7 @@ msgstr "Zieldossier"
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_start"
 msgstr "Start"
 
@@ -954,7 +949,7 @@ msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:257
+#: ./opengever/meeting/browser/meetings/protocol.py:232
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
@@ -970,7 +965,7 @@ msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:243
+#: ./opengever/meeting/browser/meetings/protocol.py:225
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-08 17:31+0000\n"
+"POT-Creation-Date: 2016-02-04 09:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,7 +291,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:200
+#: ./opengever/meeting/browser/meetings/protocol.py:198
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Enregistrer"
@@ -426,7 +426,7 @@ msgid "closed"
 msgstr "Fermé"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:47
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_comittee"
 msgstr "Commission"
 
@@ -460,11 +460,6 @@ msgstr "Prénom"
 msgid "column_from"
 msgstr "De"
 
-#. Default: "Initial Position"
-#: ./opengever/meeting/tabs/proposallisting.py:51
-msgid "column_initial_position"
-msgstr "Position initiale"
-
 #. Default: "Lastname"
 #: ./opengever/meeting/tabs/memberlisting.py:30
 msgid "column_lastname"
@@ -480,11 +475,6 @@ msgstr "Site"
 msgid "column_member"
 msgstr ""
 
-#. Default: "Proposed action"
-#: ./opengever/meeting/tabs/proposallisting.py:55
-msgid "column_proposed_action"
-msgstr "Proposition"
-
 #. Default: "Role"
 #: ./opengever/meeting/tabs/membershiplisting.py:37
 msgid "column_role"
@@ -492,14 +482,14 @@ msgstr "Rôle"
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:43
+#: ./opengever/meeting/tabs/proposallisting.py:46
 msgid "column_state"
 msgstr "Etat"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:39
+#: ./opengever/meeting/tabs/proposallisting.py:42
 msgid "column_title"
 msgstr "Titre"
 
@@ -607,7 +597,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:235
+#: ./opengever/meeting/browser/meetings/protocol.py:217
 msgid "label_close"
 msgstr ""
 
@@ -619,14 +609,14 @@ msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
-#: ./opengever/meeting/proposal.py:117
+#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
-#: ./opengever/meeting/proposal.py:78
+#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -665,8 +655,8 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
-#: ./opengever/meeting/proposal.py:195
+#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
 
@@ -686,13 +676,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
-#: ./opengever/meeting/proposal.py:73
+#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 msgid "label_discussion"
 msgstr "Discussion"
 
@@ -729,7 +719,7 @@ msgstr "Email"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:67
+#: ./opengever/meeting/browser/meetings/protocol.py:66
 msgid "label_end"
 msgstr "Fin"
 
@@ -755,8 +745,8 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
-#: ./opengever/meeting/proposal.py:58
+#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
@@ -772,8 +762,8 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
-#: ./opengever/meeting/proposal.py:53
+#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Base légale"
 
@@ -789,7 +779,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:58
+#: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
 msgstr "Site"
 
@@ -829,34 +819,39 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:48
+#: ./opengever/meeting/browser/meetings/protocol.py:47
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:40
+#: ./opengever/meeting/browser/meetings/protocol.py:39
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/protocol.py:28
 msgid "label_presidency"
 msgstr "Présidence"
 
+#. Default: "Reference Number"
+#: ./opengever/meeting/tabs/proposallisting.py:39
+msgid "label_proposal_id"
+msgstr ""
+
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
-#: ./opengever/meeting/proposal.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py:51
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
-#: ./opengever/meeting/proposal.py:68
+#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
 
@@ -888,7 +883,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:34
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_secretary"
 msgstr "Secrétaire"
 
@@ -899,7 +894,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_start"
 msgstr "Début"
 
@@ -954,7 +949,7 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:257
+#: ./opengever/meeting/browser/meetings/protocol.py:232
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
@@ -970,7 +965,7 @@ msgid "message_record_created"
 msgstr "Enregistrement créé"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:243
+#: ./opengever/meeting/browser/meetings/protocol.py:225
 msgid "message_write_conflict"
 msgstr ""
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-04 09:31+0000\n"
+"POT-Creation-Date: 2016-02-10 08:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,7 +291,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:198
+#: ./opengever/meeting/browser/meetings/protocol.py:200
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Enregistrer"
@@ -426,7 +426,7 @@ msgid "closed"
 msgstr "Fermé"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:50
+#: ./opengever/meeting/tabs/proposallisting.py:58
 msgid "column_comittee"
 msgstr "Commission"
 
@@ -470,6 +470,11 @@ msgstr "Nom"
 msgid "column_location"
 msgstr "Site"
 
+#. Default: "Meeting"
+#: ./opengever/meeting/tabs/proposallisting.py:62
+msgid "column_meeting"
+msgstr "Séance"
+
 #. Default: "Member"
 #: ./opengever/meeting/tabs/membershiplisting.py:25
 msgid "column_member"
@@ -482,14 +487,14 @@ msgstr "Rôle"
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:46
+#: ./opengever/meeting/tabs/proposallisting.py:54
 msgid "column_state"
 msgstr "Etat"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:42
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_title"
 msgstr "Titre"
 
@@ -597,7 +602,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:217
+#: ./opengever/meeting/browser/meetings/protocol.py:235
 msgid "label_close"
 msgstr ""
 
@@ -609,13 +614,13 @@ msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/browser/meetings/protocol.py:128
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/browser/meetings/protocol.py:143
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
@@ -655,7 +660,7 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/browser/meetings/protocol.py:134
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
@@ -676,13 +681,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/browser/meetings/protocol.py:140
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
+#: ./opengever/meeting/browser/meetings/protocol.py:131
 msgid "label_discussion"
 msgstr "Discussion"
 
@@ -719,7 +724,7 @@ msgstr "Email"
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:66
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_end"
 msgstr "Fin"
 
@@ -745,7 +750,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:122
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr "Situation initiale"
@@ -762,7 +767,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py:119
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr "Base légale"
@@ -779,7 +784,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:57
+#: ./opengever/meeting/browser/meetings/protocol.py:58
 msgid "label_location"
 msgstr "Site"
 
@@ -819,38 +824,38 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:47
+#: ./opengever/meeting/browser/meetings/protocol.py:48
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:39
+#: ./opengever/meeting/browser/meetings/protocol.py:40
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:28
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_presidency"
 msgstr "Présidence"
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/tabs/proposallisting.py:39
+#: ./opengever/meeting/tabs/proposallisting.py:47
 msgid "label_proposal_id"
-msgstr ""
+msgstr "Numéro de référence"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/browser/meetings/protocol.py:125
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:51
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/browser/meetings/protocol.py:137
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
@@ -883,7 +888,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py:34
 msgid "label_secretary"
 msgstr "Secrétaire"
 
@@ -894,7 +899,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/protocol.py:63
 msgid "label_start"
 msgstr "Début"
 
@@ -949,7 +954,7 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:232
+#: ./opengever/meeting/browser/meetings/protocol.py:257
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
@@ -965,7 +970,7 @@ msgid "message_record_created"
 msgstr "Enregistrement créé"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:225
+#: ./opengever/meeting/browser/meetings/protocol.py:243
 msgid "message_write_conflict"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-04 09:31+0000\n"
+"POT-Creation-Date: 2016-02-10 08:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -290,7 +290,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:198
+#: ./opengever/meeting/browser/meetings/protocol.py:200
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr ""
@@ -425,7 +425,7 @@ msgid "closed"
 msgstr ""
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:50
+#: ./opengever/meeting/tabs/proposallisting.py:58
 msgid "column_comittee"
 msgstr ""
 
@@ -469,6 +469,11 @@ msgstr ""
 msgid "column_location"
 msgstr ""
 
+#. Default: "Meeting"
+#: ./opengever/meeting/tabs/proposallisting.py:62
+msgid "column_meeting"
+msgstr ""
+
 #. Default: "Member"
 #: ./opengever/meeting/tabs/membershiplisting.py:25
 msgid "column_member"
@@ -481,14 +486,14 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:46
+#: ./opengever/meeting/tabs/proposallisting.py:54
 msgid "column_state"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:42
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_title"
 msgstr ""
 
@@ -596,7 +601,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:217
+#: ./opengever/meeting/browser/meetings/protocol.py:235
 msgid "label_close"
 msgstr ""
 
@@ -608,13 +613,13 @@ msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/browser/meetings/protocol.py:128
 #: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/browser/meetings/protocol.py:143
 #: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
@@ -654,7 +659,7 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/browser/meetings/protocol.py:134
 #: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
@@ -675,13 +680,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/browser/meetings/protocol.py:140
 #: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
+#: ./opengever/meeting/browser/meetings/protocol.py:131
 msgid "label_discussion"
 msgstr ""
 
@@ -718,7 +723,7 @@ msgstr ""
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:66
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_end"
 msgstr ""
 
@@ -744,7 +749,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/browser/meetings/protocol.py:122
 #: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr ""
@@ -761,7 +766,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py:119
 #: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr ""
@@ -778,7 +783,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:57
+#: ./opengever/meeting/browser/meetings/protocol.py:58
 msgid "label_location"
 msgstr ""
 
@@ -818,38 +823,38 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:47
+#: ./opengever/meeting/browser/meetings/protocol.py:48
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:39
+#: ./opengever/meeting/browser/meetings/protocol.py:40
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:28
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_presidency"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/tabs/proposallisting.py:39
+#: ./opengever/meeting/tabs/proposallisting.py:47
 msgid "label_proposal_id"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/browser/meetings/protocol.py:125
 #: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:51
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/browser/meetings/protocol.py:137
 #: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
@@ -882,7 +887,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py:34
 msgid "label_secretary"
 msgstr ""
 
@@ -893,7 +898,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/protocol.py:63
 msgid "label_start"
 msgstr ""
 
@@ -948,7 +953,7 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:232
+#: ./opengever/meeting/browser/meetings/protocol.py:257
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr ""
@@ -964,7 +969,7 @@ msgid "message_record_created"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:225
+#: ./opengever/meeting/browser/meetings/protocol.py:243
 msgid "message_write_conflict"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-08 17:31+0000\n"
+"POT-Creation-Date: 2016-02-04 09:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -290,7 +290,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:200
+#: ./opengever/meeting/browser/meetings/protocol.py:198
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr ""
@@ -425,7 +425,7 @@ msgid "closed"
 msgstr ""
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:47
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_comittee"
 msgstr ""
 
@@ -459,11 +459,6 @@ msgstr ""
 msgid "column_from"
 msgstr ""
 
-#. Default: "Initial Position"
-#: ./opengever/meeting/tabs/proposallisting.py:51
-msgid "column_initial_position"
-msgstr ""
-
 #. Default: "Lastname"
 #: ./opengever/meeting/tabs/memberlisting.py:30
 msgid "column_lastname"
@@ -479,11 +474,6 @@ msgstr ""
 msgid "column_member"
 msgstr ""
 
-#. Default: "Proposed action"
-#: ./opengever/meeting/tabs/proposallisting.py:55
-msgid "column_proposed_action"
-msgstr ""
-
 #. Default: "Role"
 #: ./opengever/meeting/tabs/membershiplisting.py:37
 msgid "column_role"
@@ -491,14 +481,14 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:43
+#: ./opengever/meeting/tabs/proposallisting.py:46
 msgid "column_state"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:39
+#: ./opengever/meeting/tabs/proposallisting.py:42
 msgid "column_title"
 msgstr ""
 
@@ -606,7 +596,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:235
+#: ./opengever/meeting/browser/meetings/protocol.py:217
 msgid "label_close"
 msgstr ""
 
@@ -618,14 +608,14 @@ msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
-#: ./opengever/meeting/proposal.py:117
+#: ./opengever/meeting/browser/meetings/protocol.py:127
+#: ./opengever/meeting/proposal.py:108
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
-#: ./opengever/meeting/proposal.py:78
+#: ./opengever/meeting/browser/meetings/protocol.py:142
+#: ./opengever/meeting/proposal.py:75
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -664,8 +654,8 @@ msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
-#: ./opengever/meeting/proposal.py:195
+#: ./opengever/meeting/browser/meetings/protocol.py:133
+#: ./opengever/meeting/proposal.py:186
 msgid "label_decision"
 msgstr ""
 
@@ -685,13 +675,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
-#: ./opengever/meeting/proposal.py:73
+#: ./opengever/meeting/browser/meetings/protocol.py:139
+#: ./opengever/meeting/proposal.py:70
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 msgid "label_discussion"
 msgstr ""
 
@@ -728,7 +718,7 @@ msgstr ""
 
 #. Default: "End"
 #: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:67
+#: ./opengever/meeting/browser/meetings/protocol.py:66
 msgid "label_end"
 msgstr ""
 
@@ -754,8 +744,8 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
-#: ./opengever/meeting/proposal.py:58
+#: ./opengever/meeting/browser/meetings/protocol.py:121
+#: ./opengever/meeting/proposal.py:55
 msgid "label_initial_position"
 msgstr ""
 
@@ -771,8 +761,8 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
-#: ./opengever/meeting/proposal.py:53
+#: ./opengever/meeting/browser/meetings/protocol.py:118
+#: ./opengever/meeting/proposal.py:50
 msgid "label_legal_basis"
 msgstr ""
 
@@ -788,7 +778,7 @@ msgstr ""
 
 #. Default: "Location"
 #: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:58
+#: ./opengever/meeting/browser/meetings/protocol.py:57
 msgid "label_location"
 msgstr ""
 
@@ -828,34 +818,39 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:48
+#: ./opengever/meeting/browser/meetings/protocol.py:47
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:40
+#: ./opengever/meeting/browser/meetings/protocol.py:39
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/protocol.py:28
 msgid "label_presidency"
 msgstr ""
 
+#. Default: "Reference Number"
+#: ./opengever/meeting/tabs/proposallisting.py:39
+msgid "label_proposal_id"
+msgstr ""
+
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
-#: ./opengever/meeting/proposal.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:124
+#: ./opengever/meeting/proposal.py:60
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py:51
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
-#: ./opengever/meeting/proposal.py:68
+#: ./opengever/meeting/browser/meetings/protocol.py:136
+#: ./opengever/meeting/proposal.py:65
 msgid "label_publish_in"
 msgstr ""
 
@@ -887,7 +882,7 @@ msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:34
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_secretary"
 msgstr ""
 
@@ -898,7 +893,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_start"
 msgstr ""
 
@@ -953,7 +948,7 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:257
+#: ./opengever/meeting/browser/meetings/protocol.py:232
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr ""
@@ -969,7 +964,7 @@ msgid "message_record_created"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:243
+#: ./opengever/meeting/browser/meetings/protocol.py:225
 msgid "message_write_conflict"
 msgstr ""
 

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -57,7 +57,4 @@ class ProposalTableSource(SqlTableSource):
     grok.implements(ITableSource)
     grok.adapts(ProposalListingTab, Interface)
 
-    searchable_columns = [Proposal.proposal_id,
-                          Proposal.title,
-                          Proposal.initial_position,
-                          Proposal.proposed_action]
+    searchable_columns = [Proposal.title, ]

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -58,7 +58,7 @@ class ProposalListingTab(BaseListingTab):
              'column_title': _(u'column_comittee', default=u'Comittee'),
              'transform': lambda item, value: item.committee.title},
 
-            {'column': 'genertated_meeting_link',
+            {'column': 'generated_meeting_link',
              'column_title': _(u'column_meeting', default=u'Meeting'),
              'transform': meeting_link},
 

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -35,6 +35,9 @@ class ProposalListingTab(BaseListingTab):
     @property
     def columns(self):
         return (
+            {'column': 'proposal_id',
+             'column_title': _(u'label_proposal_id', default=u'Reference Number')},
+
             {'column': 'title',
              'column_title': _(u'column_title', default=u'Title'),
              'transform': proposal_link},
@@ -46,6 +49,7 @@ class ProposalListingTab(BaseListingTab):
             {'column': 'committee_id',
              'column_title': _(u'column_comittee', default=u'Comittee'),
              'transform': lambda item, value: item.committee.title},
+
         )
 
 
@@ -53,6 +57,7 @@ class ProposalTableSource(SqlTableSource):
     grok.implements(ITableSource)
     grok.adapts(ProposalListingTab, Interface)
 
-    searchable_columns = [Proposal.title,
+    searchable_columns = [Proposal.proposal_id,
+                          Proposal.title,
                           Proposal.initial_position,
                           Proposal.proposed_action]

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -46,14 +46,6 @@ class ProposalListingTab(BaseListingTab):
             {'column': 'committee_id',
              'column_title': _(u'column_comittee', default=u'Comittee'),
              'transform': lambda item, value: item.committee.title},
-
-            {'column': 'initial_position',
-             'column_title': _(u'column_initial_position',
-                               default=u'Initial Position')},
-
-            {'column': 'proposed_action',
-             'column_title': _(u'column_proposed_action',
-                               default=u'Proposed action')},
         )
 
 

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -23,6 +23,14 @@ def translated_state(item, value):
     )
 
 
+def meeting_link(item, value):
+    agenda_item = item.agenda_item
+    if not agenda_item:
+        return u''
+
+    return agenda_item.meeting.get_link()
+
+
 class IProposalTableSourceConfig(ITableSourceConfig):
     """Marker interface for proposal table source configs."""
 
@@ -49,6 +57,10 @@ class ProposalListingTab(BaseListingTab):
             {'column': 'committee_id',
              'column_title': _(u'column_comittee', default=u'Comittee'),
              'transform': lambda item, value: item.committee.title},
+
+            {'column': 'genertated_meeting_link',
+             'column_title': _(u'column_meeting', default=u'Meeting'),
+             'transform': meeting_link},
 
         )
 

--- a/opengever/meeting/tabs/submittedproposallisting.py
+++ b/opengever/meeting/tabs/submittedproposallisting.py
@@ -42,6 +42,4 @@ class SubmittedProposalTableSource(SqlTableSource):
     grok.implements(ITableSource)
     grok.adapts(SubmittedProposalListingTab, Interface)
 
-    searchable_columns = [Proposal.title,
-                          Proposal.initial_position,
-                          Proposal.proposed_action]
+    searchable_columns = [Proposal.title, ]

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -7,7 +7,6 @@ from opengever.meeting.model.agendaitem import AgendaItem
 from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
 from plone.protect import createToken
-from plone.protect import createToken
 from z3c.relationfield.relation import RelationValue
 from zExceptions import NotFound
 from zExceptions import Unauthorized

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -31,8 +31,7 @@ class TestDossierProposalListing(ProposalListingTests):
         # TODO: state should be translated
         self.assertEquals(
             [{'State': 'Pending',
-              'Proposed action': u'My proposed acti\xf6n',
-              'Initial Position': u'My p\xf6sition is',
+              'Reference Number': '1',
               'Comittee': 'My committee',
               'Title': 'My Proposal'}],
             table.dicts())
@@ -66,8 +65,7 @@ class TestSubmittedProposals(ProposalListingTests):
         # TODO: state should be translated
         self.assertEquals(
             [{'State': 'Submitted',
-              'Proposed action': u'My proposed acti\xf6n',
-              'Initial Position': u'My p\xf6sition is',
+              'Reference Number': '1',
               'Comittee': 'My committee',
               'Title': 'My Proposal'}],
             table.dicts())

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -8,11 +8,16 @@ class ProposalListingTests(FunctionalTestCase):
 
     def setUp(self):
         super(ProposalListingTests, self).setUp()
-        self.repo, self.repo_folder = create(Builder('repository_tree'))
+        self.repository_root, self.repository_folder = create(
+            Builder('repository_tree'))
         self.dossier = create(Builder('dossier')
-                              .titled(u'Dossier A')
-                              .within(self.repo_folder))
-        self.committee = create(Builder('committee').titled('My committee'))
+                              .within(self.repository_folder)
+                              .titled(u'Dossier A'))
+        self.committee_container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee')
+                                .within(self.committee_container)
+                                .titled('My committee'))
+
         self.proposal = create(Builder('proposal')
                                .within(self.dossier)
                                .titled(u'My Proposal')
@@ -33,7 +38,8 @@ class TestDossierProposalListing(ProposalListingTests):
             [{'State': 'Pending',
               'Reference Number': '1',
               'Comittee': 'My committee',
-              'Title': 'My Proposal'}],
+              'Title': 'My Proposal',
+              'Meeting': ''}],
             table.dicts())
 
     @browsing
@@ -44,8 +50,33 @@ class TestDossierProposalListing(ProposalListingTests):
         link = table.rows[1].css('a').first
 
         self.assertEquals('My Proposal', link.text)
-        self.assertEquals('http://example.com/opengever-repository-repositoryroot/opengever-repository-repositoryfolder/dossier-1/proposal-1',
-                          link.get('href'))
+
+        self.assertEquals(
+            'http://example.com/opengever-repository-repositoryroot/'
+            'opengever-repository-repositoryfolder/dossier-1/proposal-1',
+            link.get('href'))
+
+    @browsing
+    def test_proposals_are_linked_to_meeting_if_scheduled(self, browser):
+        meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
+
+        create(Builder('submitted_proposal').submitting(self.proposal))
+        create(Builder('meeting')
+               .having(committee=self.committee)
+               .link_with(meeting_dossier)
+               .scheduled_proposals([self.proposal, ]))
+
+        browser.login().open(self.dossier, view='tabbedview_view-proposals')
+        table = browser.css('table.listing').first
+
+        self.assertEquals(
+            [{'State': 'Scheduled',
+              'Reference Number': '1',
+              'Comittee': 'My committee',
+              'Title': 'My Proposal',
+              'Meeting': u'B\xe4rn, Dec 13, 2011'}],
+            table.dicts())
 
 
 class TestSubmittedProposals(ProposalListingTests):
@@ -67,7 +98,8 @@ class TestSubmittedProposals(ProposalListingTests):
             [{'State': 'Submitted',
               'Reference Number': '1',
               'Comittee': 'My committee',
-              'Title': 'My Proposal'}],
+              'Title': 'My Proposal',
+              'Meeting': ''}],
             table.dicts())
 
     @browsing
@@ -80,5 +112,28 @@ class TestSubmittedProposals(ProposalListingTests):
 
         self.assertEquals('My Proposal', link.text)
         self.assertEquals(
-            'http://example.com/committee-1/submitted-proposal-1',
+            'http://example.com/opengever-meeting-committeecontainer/'
+            'committee-1/submitted-proposal-1',
             link.get('href'))
+
+    @browsing
+    def test_submitted_proposals_are_linked_to_meeting_if_scheduled(self, browser):
+        meeting_dossier = create(
+            Builder('meeting_dossier').within(self.repository_folder))
+
+        create(Builder('meeting')
+               .having(committee=self.committee)
+               .link_with(meeting_dossier)
+               .scheduled_proposals([self.submitted_proposal, ]))
+
+        browser.login().open(self.committee,
+                             view='tabbedview_view-submittedproposals')
+        table = browser.css('table.listing').first
+
+        self.assertEquals(
+            [{'State': 'Scheduled',
+              'Reference Number': '1',
+              'Comittee': 'My committee',
+              'Title': 'My Proposal',
+              'Meeting': u'B\xe4rn, Dec 13, 2011'}],
+            table.dicts())

--- a/opengever/tabbedview/profiles/default/metadata.xml
+++ b/opengever/tabbedview/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>4300</version>
+    <version>4600</version>
     <dependencies>
         <dependency>profile-ftw.tabbedview:extjs</dependency>
         <dependency>profile-ftw.tabbedview:quickupload</dependency>

--- a/opengever/tabbedview/upgrades/configure.zcml
+++ b/opengever/tabbedview/upgrades/configure.zcml
@@ -75,4 +75,15 @@
         directory="profiles/4300"
         />
 
+    <!-- 4300 -> 4600 -->
+    <genericsetup:upgradeStep
+        title="Moves the new proposal_id-column for proposallisting
+               tabbedview tab to the first position"
+        description=""
+        source="4300"
+        destination="4600"
+        handler="opengever.tabbedview.upgrades.to4600.SortSubmittedProposallistingTabbbedviewTabs"
+        profile="opengever.tabbedview:default"
+        />
+
 </configure>

--- a/opengever/tabbedview/upgrades/configure.zcml
+++ b/opengever/tabbedview/upgrades/configure.zcml
@@ -77,12 +77,11 @@
 
     <!-- 4300 -> 4600 -->
     <genericsetup:upgradeStep
-        title="Moves the new proposal_id-column for proposallisting
-               tabbedview tab to the first position"
+        title="Reset proposallisting tabbbedview tabs for new rows"
         description=""
         source="4300"
         destination="4600"
-        handler="opengever.tabbedview.upgrades.to4600.SortSubmittedProposallistingTabbbedviewTabs"
+        handler="opengever.tabbedview.upgrades.to4600.ResetProposallistingTabbbedviewTabsForNewRows"
         profile="opengever.tabbedview:default"
         />
 

--- a/opengever/tabbedview/upgrades/to4600.py
+++ b/opengever/tabbedview/upgrades/to4600.py
@@ -1,0 +1,40 @@
+from ftw.dictstorage.sql import DictStorageModel
+from opengever.base.model import create_session
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import or_
+import json
+
+
+CONFIG_KEY_MEETING = 'ftw.tabbedview-opengever.meeting.committee-tabbedview_view-submittedproposals-'
+CONFIG_KEY_DOSSIER = 'ftw.tabbedview-openever.dossier-tabbedview_view-proposals-'
+
+
+class SortSubmittedProposallistingTabbbedviewTabs(SchemaMigration):
+    """ Moves the new proposal_id-column to the first position
+    """
+    profileid = 'opengever.tabbedview'
+    upgradeid = 4600
+
+    def migrate(self):
+        session = create_session()
+        query = session.query(DictStorageModel)
+        query = query.filter(or_(
+            DictStorageModel.key.like('{}%'.format(CONFIG_KEY_MEETING)),
+            DictStorageModel.key.like('{}%'.format(CONFIG_KEY_DOSSIER))
+            ))
+
+        for record in query:
+            data = self.change_sortable(record.value)
+            record.value = json.dumps(data)
+
+    def change_sortable(self, value):
+        data = json.loads(value.encode('utf-8'))
+        columns = data.get('columns')
+
+        for index, column in enumerate(columns):
+            if column.get('id') in ['proposal_id']:
+                columns.insert(0, columns.pop(index))
+                break
+
+        data['columns'] = columns
+        return data

--- a/opengever/tabbedview/upgrades/to4600.py
+++ b/opengever/tabbedview/upgrades/to4600.py
@@ -2,15 +2,14 @@ from ftw.dictstorage.sql import DictStorageModel
 from opengever.base.model import create_session
 from opengever.core.upgrade import SchemaMigration
 from sqlalchemy import or_
-import json
 
 
 CONFIG_KEY_MEETING = 'ftw.tabbedview-opengever.meeting.committee-tabbedview_view-submittedproposals-'
 CONFIG_KEY_DOSSIER = 'ftw.tabbedview-openever.dossier-tabbedview_view-proposals-'
 
 
-class SortSubmittedProposallistingTabbbedviewTabs(SchemaMigration):
-    """ Moves the new proposal_id-column to the first position
+class ResetProposallistingTabbbedviewTabsForNewRows(SchemaMigration):
+    """Reset proposallisting tabbbedview tabs for new rows
     """
     profileid = 'opengever.tabbedview'
     upgradeid = 4600
@@ -23,18 +22,4 @@ class SortSubmittedProposallistingTabbbedviewTabs(SchemaMigration):
             DictStorageModel.key.like('{}%'.format(CONFIG_KEY_DOSSIER))
             ))
 
-        for record in query:
-            data = self.change_sortable(record.value)
-            record.value = json.dumps(data)
-
-    def change_sortable(self, value):
-        data = json.loads(value.encode('utf-8'))
-        columns = data.get('columns')
-
-        for index, column in enumerate(columns):
-            if column.get('id') in ['proposal_id']:
-                columns.insert(0, columns.pop(index))
-                break
-
-        data['columns'] = columns
-        return data
+        query.delete(synchronize_session='fetch')

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -7,6 +7,7 @@ from opengever.base.oguid import Oguid
 from opengever.globalindex.model.task import Task
 from opengever.locking.interfaces import ISQLLockable
 from opengever.locking.model import Lock
+from opengever.meeting.committee import ICommittee
 from opengever.meeting.interfaces import IMeetingDossier
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Committee
@@ -31,7 +32,6 @@ from plone import api
 from plone.locking.interfaces import ILockable
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
-
 
 class PloneAdminUnitBuilder(AdminUnitBuilder):
     """Add plone specific functionality to opengever.ogds.models
@@ -207,6 +207,14 @@ class MeetingBuilder(SqlObjectBuilder):
         self.arguments['start'] = localized_datetime(2011, 12, 13, 9, 30)
         self.arguments['end'] = localized_datetime(2011, 12, 13, 11, 45)
         self.arguments['location'] = u'B\xe4rn'
+
+    def before_create(self):
+        committee = self.arguments.get('committee')
+        if not committee:
+            return
+
+        if ICommittee.providedBy(committee):
+            self.arguments['committee'] = committee.load_model()
 
     def link_with(self, dossier):
         del self.arguments['dossier_admin_unit_id']


### PR DESCRIPTION
Die Spalten `Ausgangslage` und `Antrag` können Markup Text enthalten.

Eine Tabelle mit Markup kann nicht schön dargestellt werden. Zudem sind es zu viele Infos für den Benuzer.

- Deshalb wurden die o.g. Spalten aus den Auflistungen entfernt.

Zwei neue Spalten kamen dazu:

- Die `Laufnummer` ist hilfreich für das wiederfinden eines Antrags und wird deshalb neu in den Auflistungen dargestellt.


- Die `Sitzung` beinhaltet ein Link zur Sitzung in welcher der Antrag traktandiert wurde. Dieser Link ist sehr hilfreich zum schnellen auffinden der jeweiligen Sitzung.

Before:
----------
 
![bildschirmfoto 2016-02-04 um 14 25 02](https://cloud.githubusercontent.com/assets/557005/12818515/8d704db4-cb57-11e5-9ca3-51beb41f1ade.png)

After:
--------

![bildschirmfoto 2016-02-04 um 15 51 02](https://cloud.githubusercontent.com/assets/557005/12818528/96b24440-cb57-11e5-9fe3-e16bb802a251.png)


see #1542 