### PR TITLE
Antragsansicht überarbeitet: Zweispaltiges Layout in einspaltiges Layout geändert.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Adjust proposaloverview view.
+  Moves the document listing into the attributes-table, to gain more
+  space for the table.
+  [elioschmutz]
+
 - Adjust proposal tabbedview tab.
 
   - Remove unused rows: 'initial_position' and 'proposed_action'

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -5,10 +5,9 @@
 
   <tal:i18n i18n:domain="opengever.meeting"
             tal:define="documents view/documents;
-                        excerpt view/excerpt;
-                        css_width python:99/2;">
+                        excerpt view/excerpt;">
 
-    <div tal:attributes="class string:boxGroup; style string:width:${css_width}%">
+    <div tal:attributes="class string:boxGroup">
       <div id="main_attributesBox" class="box">
         <h2 i18n:translate="label_main_attributes">Main Atrributes</h2>
           <table class="vertical listing">
@@ -23,26 +22,25 @@
                   tal:attributes="class item/css_class|nothing"
                   tal:content="structure item/value" />
             </tr>
+            <tr tal:condition="documents">
+              <th i18n:translate="label_attachments">Attachments</th>
+              <td>
+                <ul>
+                  <li tal:repeat="item documents">
+                    <a href="" tal:attributes="href item/absolute_url;
+                    title python: getattr(item, 'document_date', None) and item.document_date.strftime('%d.%m.%Y') or '';
+                    class python:view.get_css_class(item)">
+                      <span class="document" tal:condition="item/absolute_url" tal:content="item/Title" />
+                    </a>
+                  </li>
+                </ul>
+              </td>
+            </tr>
           </table>
       </div>
     </div>
 
-    <div id="documentsBox" class="box">
-      <tal:condition tal:condition="documents">
-        <h2 i18n:translate="label_attachments">Attachments</h2>
-        <ul>
-          <li tal:repeat="item documents">
-            <a href="" tal:attributes="href item/absolute_url;
-                                       title python: getattr(item, 'document_date', None) and item.document_date.strftime('%d.%m.%Y') or '';
-                                       class python:view.get_css_class(item)">
-              <span class="document" tal:condition="item/absolute_url" tal:content="item/Title" />
-            </a>
-          </li>
-        </ul>
-      </tal:condition>
-    </div>
-
-    <div id="excerptBox" class="box">
+     <div id="excerptBox" class="box">
       <tal:condition tal:condition="excerpt">
         <h2 i18n:translate="label_excerpt">Excerpt</h2>
         <ul>


### PR DESCRIPTION
Das zweispaltige Layout brauch zu viel Platz für Dokumente und stellt zu wenig Platz für die Tabelle dar.
Es wird nicht erwartet, dass die Benutzer viele Dokumente hochladen.

Deshalb werden die Dokumente neu in der Tabelle angezeigt und das Layout auf ein einspaltiges Layout reduziert.

Die Tabelle hat nun bei bedarf die ganze Seitenbreite zur Verfügung.


Before:
----------
![bildschirmfoto 2016-02-04 um 15 52 19](https://cloud.githubusercontent.com/assets/557005/12818986/693f95f6-cb59-11e5-909d-140680c70fd9.png)

After:
-------
![bildschirmfoto 2016-02-04 um 15 51 40](https://cloud.githubusercontent.com/assets/557005/12818991/6c496894-cb59-11e5-9e4e-09d39841a2d5.png)

closes #1542 
