### PR TITLE
Add upgrade-step to update feedback link in footer (if necessary).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add upgrade-step to update feedback link in footer (if necessary).
+  [lgraf]
+
 - Prevent saving the protocol when it is locked by another user.
   [deiferni]
 

--- a/opengever/base/profiles/default/metadata.xml
+++ b/opengever/base/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4609</version>
+  <version>4610</version>
 </metadata>

--- a/opengever/base/upgrades/configure.zcml
+++ b/opengever/base/upgrades/configure.zcml
@@ -403,4 +403,13 @@
         profile="opengever.base:default"
         />
 
+    <!-- 4609 -> 4610 -->
+    <genericsetup:upgradeStep
+        title="Update feedback forum link in footer (if necessary)"
+        source="4609"
+        destination="4610"
+        handler="opengever.base.upgrades.to4610.UpdateFeedbackLinkInFooter"
+        profile="opengever.base:default"
+        />
+
 </configure>

--- a/opengever/base/upgrades/to4610.py
+++ b/opengever/base/upgrades/to4610.py
@@ -1,0 +1,55 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from zope.component import queryMultiAdapter
+from zope.component import queryUtility
+import logging
+import re
+
+
+MAX_COLUMNS = 4
+
+NEW_URL = u'https://feedback.onegovgever.ch'
+OLD_URL_RE = re.compile(u'http[s]?://feedback.onegov.ch', flags=re.IGNORECASE)
+
+log = logging.getLogger('ftw.upgrade')
+
+
+class UpdateFeedbackLinkInFooter(UpgradeStep):
+    """Updates any occurrences of the old URL for the feedback forum with
+    the new one in all ftw.footer portlets on the site root.
+    """
+
+    def __call__(self):
+        assignments = self._get_footer_portlet_assignments()
+        for assignment in assignments:
+            self._update_link_if_necessary(assignment)
+
+    def _update_link_if_necessary(self, assignment):
+        markup, name = assignment.text, assignment.__name__
+
+        if re.search(OLD_URL_RE, markup):
+            assignment.text = re.sub(OLD_URL_RE, NEW_URL, markup)
+            log.info("Updated feedback link for footer column %r" % name)
+
+    def _get_footer_portlet_assignments(self):
+        site = api.portal.get()
+        for col_num in range(1, MAX_COLUMNS + 1):
+            manager_name = 'ftw.footer.column%s' % col_num
+
+            assignments = self._get_all_portlet_assignments(
+                site, manager_name)
+
+            for assignment in assignments:
+                yield assignment
+
+    def _get_all_portlet_assignments(self, context, manager_name):
+            manager = queryUtility(
+                IPortletManager, context=context, name=manager_name,)
+
+            mapping = queryMultiAdapter(
+                (context, manager), IPortletAssignmentMapping, default={})
+
+            for name, assignment in mapping.items():
+                yield assignment


### PR DESCRIPTION
This is an upgrade step that basically applies the changes from #1554 to all deployments (if needed).

While the original change affects `opengever.examplecontent` and the policy template (in order not to set up new sites containing the wrong link), this upgrade step is in `opengever.base` and will be run for **all deployments**.

It's written in a way that should specifically fix the feedback forum URL if it occurs in an `ftw.footer` portlet, regardless of how that portlet was added.