### PR TITLE
Adjust french translation 'En modification' to eCH-0039-standard 'En cours de traitement'

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Adjust french translation 'En modification' to eCH-0039-standard 'En cours de traitement'
+  [elioschmutz]
+
 - Adjust proposaloverview view.
   Moves the document listing into the attributes-table, to gain more
   space for the table.

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -66,7 +66,7 @@ msgid "Document state changed to document-state-working_copy"
 msgstr "Etat du document modifié : copie de travail"
 
 msgid "Dossier state changed to dossier-state-active"
-msgstr "Etat du dossier modifié : En modification"
+msgstr "Etat du dossier modifié : En cours de traitement"
 
 msgid "Dossier state changed to dossier-state-archived"
 msgstr "Etat du dossier modifié : Archivé"
@@ -148,7 +148,7 @@ msgid "document_with_template"
 msgstr "Document à partir du modèle"
 
 msgid "dossier-state-active"
-msgstr "En modification"
+msgstr "En cours de traitement"
 
 msgid "dossier-state-archived"
 msgstr "Archivé"


### PR DESCRIPTION
Die französische Übersetzung für "In bearbeitung" (En modifiaction) im Dossier-Tab stimmt nicht mit dem eCH-0039 Standard überein.

Dieser PR übersetzt die französische Übersetzung gem. eCH-0039 Standard.

![bildschirmfoto 2016-02-10 um 10 30 08](https://cloud.githubusercontent.com/assets/557005/12943656/fbfbf73a-cfe2-11e5-91a9-d6b6b22cccc2.png)

closes #1513 