### PR TITLE
Neue Attribute für die Antrags-Ansicht hinzugefügt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,19 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add attributes for proposal view.
+
+  - publish_in
+  - disclose_to
+  - copy_for_attention
+
+  Add additional attributes for submitted proposal view:
+
+  - considerations
+  - discussion
+
+  [elioschmutz]
+
 - Add link from proposal to committee.
   [elioschmutz]
 

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -266,12 +266,24 @@ class SubmittedProposal(ProposalBase):
     def get_overview_attributes(self):
         data = super(SubmittedProposal, self).get_overview_attributes()
         model = self.load_model()
-        data.extend([
-            {
+
+        # Insert considerations after proposed_action
+        data.insert(
+            5, {
                 'label': _('label_considerations', default=u"Considerations"),
                 'value': model.considerations,
             }
-        ])
+        )
+
+        # Insert discussion after considerations
+        agenda = model.agenda_item
+        data.insert(
+            6, {
+                'label': _('label_discussion', default=u"Discussion"),
+                'value': agenda and agenda.discussion or ''
+            }
+        )
+
         return data
 
     @classmethod

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -195,6 +195,15 @@ class ProposalBase(ModelContainer):
             {'label': _('label_decision', default=u'Decision'),
              'value': model.get_decision()},
 
+            {'label': _('label_publish_in', default=u'Publish in'),
+             'value': model.publish_in},
+
+            {'label': _('label_disclose_to', default=u'Disclose to'),
+             'value': model.disclose_to},
+
+            {'label': _('label_copy_for_attention', default=u'Copy for attention'),
+             'value': model.copy_for_attention},
+
             {'label': _('label_workflow_state', default=u'State'),
              'value': self.get_state().title},
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -496,6 +496,59 @@ class TestProposal(FunctionalTestCase):
 
         self.assertEqual(1, submitted_document.get_current_version())
 
+    def test_attributes_sort_order_for_proposal(self):
+        committee = create(Builder('committee').titled('My committee'))
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model())
+                          .as_submitted())
+
+        attributes = proposal.get_overview_attributes()
+        self.assertEqual(
+            [u'label_title',
+             u'label_committee',
+             u'label_legal_basis',
+             u'label_initial_position',
+             u'label_proposed_action',
+             u'label_decision',
+             u'label_publish_in',
+             u'label_disclose_to',
+             u'label_copy_for_attention',
+             u'label_workflow_state',
+             u'label_decision_number'],
+            [attribute.get('label') for attribute in attributes],
+            )
+
+    def test_attributes_sort_order_for_submitted_proposal(self):
+        committee = create(Builder('committee').titled('My committee'))
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model())
+                          .as_submitted())
+
+        submitted_proposal = api.portal.get().restrictedTraverse(
+            proposal.load_model().submitted_physical_path.encode('utf-8'))
+
+        attributes = submitted_proposal.get_overview_attributes()
+        self.assertEqual(
+            [u'label_title',
+             u'label_committee',
+             u'label_legal_basis',
+             u'label_initial_position',
+             u'label_proposed_action',
+             u'label_considerations',
+             u'label_discussion',
+             u'label_decision',
+             u'label_publish_in',
+             u'label_disclose_to',
+             u'label_copy_for_attention',
+             u'label_workflow_state',
+             u'label_decision_number'],
+            [attribute.get('label') for attribute in attributes],
+            )
+
     def assertSubmittedDocumentCreated(self, proposal, document, submitted_document):
         submitted_document_model = SubmittedDocument.query.get_by_source(
             proposal, document)


### PR DESCRIPTION
Die Antragsansicht hat neue Attribute erhalten:

Folgende Attribute wurden für Anträge und gesendete Anträge hinzugefügt:

- Veröffentlichung in
- Zu eröffnen an
- Kopie z.K.

Folgende Attribute wurden nur für gesendete Anträge hinzugefügt:

- Erwägung
- Diskussion

closes #1582 