### PR TITLE
Link von Antrag nach Meeting hinzugefügt

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add link from proposal to meeting.
+  [elioschmutz]
+
 - Add attributes for proposal view.
 
   - publish_in

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -305,3 +305,10 @@ class Proposal(Base):
             self.admin_unit_id,
             '/'.join(dossier.getPhysicalPath())).execute()
         return response['intid']
+
+    def get_meeting_link(self):
+        agenda_item = self.agenda_item
+        if not agenda_item:
+            return u''
+
+        return agenda_item.meeting.get_link()

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -183,6 +183,9 @@ class ProposalBase(ModelContainer):
             {'label': _('label_committee', default=u'Committee'),
              'value': model.committee.get_link()},
 
+            {'label': _('label_meeting', default=u'Meeting'),
+             'value': model.get_meeting_link()},
+
             {'label': _('label_legal_basis', default=u'Legal basis'),
              'value': model.legal_basis},
 
@@ -269,7 +272,7 @@ class SubmittedProposal(ProposalBase):
 
         # Insert considerations after proposed_action
         data.insert(
-            5, {
+            6, {
                 'label': _('label_considerations', default=u"Considerations"),
                 'value': model.considerations,
             }
@@ -278,7 +281,7 @@ class SubmittedProposal(ProposalBase):
         # Insert discussion after considerations
         agenda = model.agenda_item
         data.insert(
-            6, {
+            7, {
                 'label': _('label_discussion', default=u"Discussion"),
                 'value': agenda and agenda.discussion or ''
             }

--- a/opengever/meeting/tabs/proposallisting.py
+++ b/opengever/meeting/tabs/proposallisting.py
@@ -23,14 +23,6 @@ def translated_state(item, value):
     )
 
 
-def meeting_link(item, value):
-    agenda_item = item.agenda_item
-    if not agenda_item:
-        return u''
-
-    return agenda_item.meeting.get_link()
-
-
 class IProposalTableSourceConfig(ITableSourceConfig):
     """Marker interface for proposal table source configs."""
 
@@ -60,7 +52,7 @@ class ProposalListingTab(BaseListingTab):
 
             {'column': 'generated_meeting_link',
              'column_title': _(u'column_meeting', default=u'Meeting'),
-             'transform': meeting_link},
+             'transform': lambda item, value: item.get_meeting_link()},
 
         )
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -508,6 +508,7 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(
             [u'label_title',
              u'label_committee',
+             u'label_meeting',
              u'label_legal_basis',
              u'label_initial_position',
              u'label_proposed_action',
@@ -535,6 +536,7 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(
             [u'label_title',
              u'label_committee',
+             u'label_meeting',
              u'label_legal_basis',
              u'label_initial_position',
              u'label_proposed_action',
@@ -548,6 +550,24 @@ class TestProposal(FunctionalTestCase):
              u'label_decision_number'],
             [attribute.get('label') for attribute in attributes],
             )
+
+    def test_get_meeting_link_returns_empty_string_if_not_scheduled(self):
+        proposal = create(Builder('proposal_model'))
+
+        self.assertEqual('', proposal.get_meeting_link())
+
+    def test_get_meeting_link_returns_link_if_scheduled(self):
+        admin_unit = create(Builder('admin_unit'))
+        proposal = create(Builder('proposal_model'))
+        committee = create(Builder('committee_model')
+                           .having(admin_unit_id=admin_unit.unit_id))
+        meeting = create(Builder('meeting').having(committee=committee))
+        create(Builder('agenda_item').having(meeting=meeting, proposal=proposal))
+
+        self.assertEqual(
+            proposal.get_meeting_link(),
+            meeting.get_link(),
+            "The method should return the meeting link.")
 
     def assertSubmittedDocumentCreated(self, proposal, document, submitted_document):
         submitted_document_model = SubmittedDocument.query.get_by_source(


### PR DESCRIPTION
In den Antrags-Eigenschaften wird nun ein Link zum jeweiligen Meeting angezeigt: 

<img width="380" alt="bildschirmfoto 2016-02-10 um 17 24 26" src="https://cloud.githubusercontent.com/assets/557005/12953583/5f8d2ffc-d01b-11e5-80e4-1072d3afa7d2.png">

closes #1568 