### PR TITLE
Link vom eingereichten Antrag zum Dossier

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add link from submitted proposal to dossier if it's in the same admin-unit.
+  [elioschmutz]
+
 - Setup upgrade-step directories for all default profiles. [jone]
 
 - Add link from proposal to meeting.

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-10 08:27+0000\n"
+"POT-Creation-Date: 2016-02-15 13:10+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgstr "Export-Einstellungen"
 msgid "Generate excerpts for all proposals"
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt"
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:66
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:64
 msgid "History"
 msgstr "Verlauf"
 
@@ -426,7 +426,7 @@ msgid "closed"
 msgstr "geschlossen"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:58
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_comittee"
 msgstr "Gremium"
 
@@ -471,7 +471,7 @@ msgid "column_location"
 msgstr "Sitzungsort"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/tabs/proposallisting.py:62
+#: ./opengever/meeting/tabs/proposallisting.py:54
 msgid "column_meeting"
 msgstr "Sitzung"
 
@@ -487,14 +487,14 @@ msgstr "Rolle"
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:54
+#: ./opengever/meeting/tabs/proposallisting.py:46
 msgid "column_state"
 msgstr "Status"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:50
+#: ./opengever/meeting/tabs/proposallisting.py:42
 msgid "column_title"
 msgstr "Titel"
 
@@ -505,7 +505,7 @@ msgstr "Von"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:35
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/proposal.py:132
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -516,7 +516,7 @@ msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:115
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -588,7 +588,7 @@ msgid "hold"
 msgstr "Sitzung durchführen"
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
 #: ./opengever/meeting/browser/submitdocuments.py:31
 #: ./opengever/meeting/proposal.py:142
 msgid "label_attachments"
@@ -615,13 +615,13 @@ msgstr "Gremium"
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:128
-#: ./opengever/meeting/proposal.py:108
+#: ./opengever/meeting/proposal.py:117
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/protocol.py:143
-#: ./opengever/meeting/proposal.py:75
+#: ./opengever/meeting/proposal.py:78
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
@@ -661,12 +661,12 @@ msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:134
-#: ./opengever/meeting/proposal.py:186
+#: ./opengever/meeting/proposal.py:198
 msgid "label_decision"
 msgstr "Beschluss"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:201
+#: ./opengever/meeting/proposal.py:213
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
@@ -682,14 +682,25 @@ msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py:140
-#: ./opengever/meeting/proposal.py:70
+#: ./opengever/meeting/proposal.py:73
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/proposal.py:293
 msgid "label_discussion"
 msgstr "Diskussion"
+
+#. Default: "Dossier"
+#: ./opengever/meeting/proposal.py:276
+msgid "label_dossier"
+msgstr "Dossier"
+
+#. Default: "Dossier not available"
+#: ./opengever/meeting/proposal.py:368
+msgid "label_dossier_not_available"
+msgstr "Dossier nicht verfügbar"
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
@@ -729,7 +740,7 @@ msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:47
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:45
 msgid "label_excerpt"
 msgstr "Protokollauszug"
 
@@ -751,7 +762,7 @@ msgstr "Gruppe"
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/protocol.py:122
-#: ./opengever/meeting/proposal.py:55
+#: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
@@ -768,7 +779,7 @@ msgstr "Nachname"
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/protocol.py:119
-#: ./opengever/meeting/proposal.py:50
+#: ./opengever/meeting/proposal.py:53
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
@@ -789,9 +800,14 @@ msgid "label_location"
 msgstr "Sitzungsort"
 
 #. Default: "Main Atrributes"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:13
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:12
 msgid "label_main_attributes"
 msgstr "Eigenschaften"
+
+#. Default: "Meeting"
+#: ./opengever/meeting/proposal.py:186
+msgid "label_meeting"
+msgstr "Sitzung"
 
 #. Default: "Member"
 #: ./opengever/meeting/browser/memberships.py:30
@@ -839,13 +855,13 @@ msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/tabs/proposallisting.py:47
+#: ./opengever/meeting/tabs/proposallisting.py:39
 msgid "label_proposal_id"
 msgstr "Laufnummer"
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/protocol.py:125
-#: ./opengever/meeting/proposal.py:60
+#: ./opengever/meeting/proposal.py:63
 msgid "label_proposed_action"
 msgstr "Antrag"
 
@@ -856,7 +872,7 @@ msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py:137
-#: ./opengever/meeting/proposal.py:65
+#: ./opengever/meeting/proposal.py:68
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
 
@@ -936,7 +952,7 @@ msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:198
+#: ./opengever/meeting/proposal.py:210
 msgid "label_workflow_state"
 msgstr "Status"
 
@@ -990,7 +1006,7 @@ msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:39
+#: ./opengever/meeting/model/proposal.py:41
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
 
@@ -1016,7 +1032,7 @@ msgstr "Teilnehmende"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
 #: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:108
+#: ./opengever/meeting/model/proposal.py:110
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -1076,17 +1092,17 @@ msgstr "Protokollauszug"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:126
 msgid "reject"
 msgstr "Zurückweisen"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:126
+#: ./opengever/meeting/model/proposal.py:128
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/model/proposal.py:114
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1099,12 +1115,12 @@ msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:122
+#: ./opengever/meeting/model/proposal.py:124
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:112
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1123,7 +1139,7 @@ msgid "time"
 msgstr "Zeit"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:128
+#: ./opengever/meeting/model/proposal.py:130
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-10 08:27+0000\n"
+"POT-Creation-Date: 2016-02-15 13:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:66
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:64
 msgid "History"
 msgstr "Historique"
 
@@ -426,7 +426,7 @@ msgid "closed"
 msgstr "Fermé"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:58
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_comittee"
 msgstr "Commission"
 
@@ -471,7 +471,7 @@ msgid "column_location"
 msgstr "Site"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/tabs/proposallisting.py:62
+#: ./opengever/meeting/tabs/proposallisting.py:54
 msgid "column_meeting"
 msgstr "Séance"
 
@@ -487,14 +487,14 @@ msgstr "Rôle"
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:54
+#: ./opengever/meeting/tabs/proposallisting.py:46
 msgid "column_state"
 msgstr "Etat"
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:50
+#: ./opengever/meeting/tabs/proposallisting.py:42
 msgid "column_title"
 msgstr "Titre"
 
@@ -505,7 +505,7 @@ msgstr "Jusqu'à"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:35
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/proposal.py:132
 msgid "decide"
 msgstr "Décider"
 
@@ -516,7 +516,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:115
 msgid "decided"
 msgstr "Décidé"
 
@@ -588,7 +588,7 @@ msgid "hold"
 msgstr ""
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
 #: ./opengever/meeting/browser/submitdocuments.py:31
 #: ./opengever/meeting/proposal.py:142
 msgid "label_attachments"
@@ -615,13 +615,13 @@ msgstr "Commission"
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:128
-#: ./opengever/meeting/proposal.py:108
+#: ./opengever/meeting/proposal.py:117
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/protocol.py:143
-#: ./opengever/meeting/proposal.py:75
+#: ./opengever/meeting/proposal.py:78
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -661,12 +661,12 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:134
-#: ./opengever/meeting/proposal.py:186
+#: ./opengever/meeting/proposal.py:198
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:201
+#: ./opengever/meeting/proposal.py:213
 msgid "label_decision_number"
 msgstr ""
 
@@ -682,14 +682,25 @@ msgstr ""
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py:140
-#: ./opengever/meeting/proposal.py:70
+#: ./opengever/meeting/proposal.py:73
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/proposal.py:293
 msgid "label_discussion"
 msgstr "Discussion"
+
+#. Default: "Dossier"
+#: ./opengever/meeting/proposal.py:276
+msgid "label_dossier"
+msgstr "Dossier"
+
+#. Default: "Dossier not available"
+#: ./opengever/meeting/proposal.py:368
+msgid "label_dossier_not_available"
+msgstr "Dossier indisponible"
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
@@ -729,7 +740,7 @@ msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:47
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:45
 msgid "label_excerpt"
 msgstr ""
 
@@ -751,7 +762,7 @@ msgstr ""
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/protocol.py:122
-#: ./opengever/meeting/proposal.py:55
+#: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
@@ -768,7 +779,7 @@ msgstr "Nom"
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/protocol.py:119
-#: ./opengever/meeting/proposal.py:50
+#: ./opengever/meeting/proposal.py:53
 msgid "label_legal_basis"
 msgstr "Base légale"
 
@@ -789,9 +800,14 @@ msgid "label_location"
 msgstr "Site"
 
 #. Default: "Main Atrributes"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:13
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:12
 msgid "label_main_attributes"
 msgstr "Propriétés"
+
+#. Default: "Meeting"
+#: ./opengever/meeting/proposal.py:186
+msgid "label_meeting"
+msgstr "Séance"
 
 #. Default: "Member"
 #: ./opengever/meeting/browser/memberships.py:30
@@ -839,13 +855,13 @@ msgid "label_presidency"
 msgstr "Présidence"
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/tabs/proposallisting.py:47
+#: ./opengever/meeting/tabs/proposallisting.py:39
 msgid "label_proposal_id"
 msgstr "Numéro de référence"
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/protocol.py:125
-#: ./opengever/meeting/proposal.py:60
+#: ./opengever/meeting/proposal.py:63
 msgid "label_proposed_action"
 msgstr "Proposition"
 
@@ -856,7 +872,7 @@ msgstr ""
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py:137
-#: ./opengever/meeting/proposal.py:65
+#: ./opengever/meeting/proposal.py:68
 msgid "label_publish_in"
 msgstr ""
 
@@ -936,7 +952,7 @@ msgid "label_upcoming_meetings"
 msgstr "Prochaines séances"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:198
+#: ./opengever/meeting/proposal.py:210
 msgid "label_workflow_state"
 msgstr "Etat"
 
@@ -990,7 +1006,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:39
+#: ./opengever/meeting/model/proposal.py:41
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1016,7 +1032,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
 #: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:108
+#: ./opengever/meeting/model/proposal.py:110
 msgid "pending"
 msgstr "En modification"
 
@@ -1076,17 +1092,17 @@ msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:126
 msgid "reject"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:126
+#: ./opengever/meeting/model/proposal.py:128
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/model/proposal.py:114
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1099,12 +1115,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:122
+#: ./opengever/meeting/model/proposal.py:124
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:112
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1123,7 +1139,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:128
+#: ./opengever/meeting/model/proposal.py:130
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-10 08:27+0000\n"
+"POT-Creation-Date: 2016-02-15 13:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -158,7 +158,7 @@ msgstr ""
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:66
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:64
 msgid "History"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgid "closed"
 msgstr ""
 
 #. Default: "Comittee"
-#: ./opengever/meeting/tabs/proposallisting.py:58
+#: ./opengever/meeting/tabs/proposallisting.py:50
 msgid "column_comittee"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgid "column_location"
 msgstr ""
 
 #. Default: "Meeting"
-#: ./opengever/meeting/tabs/proposallisting.py:62
+#: ./opengever/meeting/tabs/proposallisting.py:54
 msgid "column_meeting"
 msgstr ""
 
@@ -486,14 +486,14 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/meeting/tabs/meetinglisting.py:50
-#: ./opengever/meeting/tabs/proposallisting.py:54
+#: ./opengever/meeting/tabs/proposallisting.py:46
 msgid "column_state"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/proposallisting.py:50
+#: ./opengever/meeting/tabs/proposallisting.py:42
 msgid "column_title"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgstr ""
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:35
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/proposal.py:132
 msgid "decide"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:113
+#: ./opengever/meeting/model/proposal.py:115
 msgid "decided"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgid "hold"
 msgstr ""
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:32
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
 #: ./opengever/meeting/browser/submitdocuments.py:31
 #: ./opengever/meeting/proposal.py:142
 msgid "label_attachments"
@@ -614,13 +614,13 @@ msgstr ""
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:128
-#: ./opengever/meeting/proposal.py:108
+#: ./opengever/meeting/proposal.py:117
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/protocol.py:143
-#: ./opengever/meeting/proposal.py:75
+#: ./opengever/meeting/proposal.py:78
 msgid "label_copy_for_attention"
 msgstr ""
 
@@ -660,12 +660,12 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:134
-#: ./opengever/meeting/proposal.py:186
+#: ./opengever/meeting/proposal.py:198
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:201
+#: ./opengever/meeting/proposal.py:213
 msgid "label_decision_number"
 msgstr ""
 
@@ -681,13 +681,24 @@ msgstr ""
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py:140
-#: ./opengever/meeting/proposal.py:70
+#: ./opengever/meeting/proposal.py:73
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/proposal.py:293
 msgid "label_discussion"
+msgstr ""
+
+#. Default: "Dossier"
+#: ./opengever/meeting/proposal.py:276
+msgid "label_dossier"
+msgstr ""
+
+#. Default: "Dossier not available"
+#: ./opengever/meeting/proposal.py:368
+msgid "label_dossier_not_available"
 msgstr ""
 
 #. Default: "Edit"
@@ -728,7 +739,7 @@ msgid "label_end"
 msgstr ""
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:47
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:45
 msgid "label_excerpt"
 msgstr ""
 
@@ -750,7 +761,7 @@ msgstr ""
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/protocol.py:122
-#: ./opengever/meeting/proposal.py:55
+#: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr ""
 
@@ -767,7 +778,7 @@ msgstr ""
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/protocol.py:119
-#: ./opengever/meeting/proposal.py:50
+#: ./opengever/meeting/proposal.py:53
 msgid "label_legal_basis"
 msgstr ""
 
@@ -788,8 +799,13 @@ msgid "label_location"
 msgstr ""
 
 #. Default: "Main Atrributes"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:13
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:12
 msgid "label_main_attributes"
+msgstr ""
+
+#. Default: "Meeting"
+#: ./opengever/meeting/proposal.py:186
+msgid "label_meeting"
 msgstr ""
 
 #. Default: "Member"
@@ -838,13 +854,13 @@ msgid "label_presidency"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/tabs/proposallisting.py:47
+#: ./opengever/meeting/tabs/proposallisting.py:39
 msgid "label_proposal_id"
 msgstr ""
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/protocol.py:125
-#: ./opengever/meeting/proposal.py:60
+#: ./opengever/meeting/proposal.py:63
 msgid "label_proposed_action"
 msgstr ""
 
@@ -855,7 +871,7 @@ msgstr ""
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py:137
-#: ./opengever/meeting/proposal.py:65
+#: ./opengever/meeting/proposal.py:68
 msgid "label_publish_in"
 msgstr ""
 
@@ -935,7 +951,7 @@ msgid "label_upcoming_meetings"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:198
+#: ./opengever/meeting/proposal.py:210
 msgid "label_workflow_state"
 msgstr ""
 
@@ -989,7 +1005,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:39
+#: ./opengever/meeting/model/proposal.py:41
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1015,7 +1031,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
 #: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:108
+#: ./opengever/meeting/model/proposal.py:110
 msgid "pending"
 msgstr ""
 
@@ -1075,17 +1091,17 @@ msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:126
 msgid "reject"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:126
+#: ./opengever/meeting/model/proposal.py:128
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/model/proposal.py:114
 msgid "scheduled"
 msgstr ""
 
@@ -1098,12 +1114,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:122
+#: ./opengever/meeting/model/proposal.py:124
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:112
 msgid "submitted"
 msgstr ""
 
@@ -1122,7 +1138,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:128
+#: ./opengever/meeting/model/proposal.py:130
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -270,9 +270,17 @@ class SubmittedProposal(ProposalBase):
         data = super(SubmittedProposal, self).get_overview_attributes()
         model = self.load_model()
 
+        # Insert dossier link if dossier exists after committee
+        data.insert(
+            2, {
+                'label': _('label_dossier', default=u"Dossier"),
+                'value': self.get_dossier_link(),
+            }
+        )
+
         # Insert considerations after proposed_action
         data.insert(
-            6, {
+            7, {
                 'label': _('label_considerations', default=u"Considerations"),
                 'value': model.considerations,
             }
@@ -281,7 +289,7 @@ class SubmittedProposal(ProposalBase):
         # Insert discussion after considerations
         agenda = model.agenda_item
         data.insert(
-            7, {
+            8, {
                 'label': _('label_discussion', default=u"Discussion"),
                 'value': agenda and agenda.discussion or ''
             }
@@ -346,6 +354,23 @@ class SubmittedProposal(ProposalBase):
 
         with elevated_privileges():
             api.content.delete(self)
+
+    def get_containing_dossier(self):
+        model = self.load_model()
+        proposal = model.resolve_proposal()
+        if not proposal:
+            return None
+        return get_containing_dossier(proposal)
+
+    def get_dossier_link(self):
+        dossier = self.get_containing_dossier()
+        if not dossier:
+            return _('label_dossier_not_available',
+                     default=u"Dossier not available")
+
+        return u'<a href="{0}" title="{1}">{1}</a>'.format(
+            '/'.join(dossier.getPhysicalPath()),
+            dossier.title)
 
 
 class Proposal(ProposalBase):


### PR DESCRIPTION
Link vom eingereichten Antrag zum Dossier hinzugefügt.

Dieser Link funktioniert nur, wenn sich der Antrag und das Dossier auf der gleichen AdminUnit befinden.

Sollten sich die AdminUnit unterscheiden, wird anstatt der Link ein statischer Text angezeigt mit "Dossier nicht verfügbar".

<img width="398" alt="bildschirmfoto 2016-02-11 um 11 30 23" src="https://cloud.githubusercontent.com/assets/557005/12974312/353df108-d0b3-11e5-9e57-2a57245e2257.png">

closes #1355 