### PR TITLE
Ändert den Titel des Protokollauszugs

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add skip_defaults_fields for CreateGeneratedDocumentCommand.
+  Fix the issue, where the object-title was always the document-title.
+  [elioschmutz]
+
 - Add link from submitted proposal to dossier if it's in the same admin-unit.
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Change title and filename for generated excerpts.
+  Old title format: Protocolexcerpt-[meetingtitle, meetingdate]
+  New title format: [excerpttitle] - [meetingtitle, meetingdate].
+  [elioschmutz]
+
 - Add skip_defaults_fields for CreateGeneratedDocumentCommand.
   Fix the issue, where the object-title was always the document-title.
   [elioschmutz]

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -148,6 +148,8 @@ class ManualExcerptOperations(ExcerptOperations):
 
 class CreateGeneratedDocumentCommand(CreateDocumentCommand):
 
+    skip_defaults_fields = ['title', ]
+
     def __init__(self, target_dossier, meeting, document_operations,
                  lock_document_after_creation=False):
         """Data will be initialized lazily since it is only available after the

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -275,7 +275,7 @@ class Proposal(Base):
 
     def generate_excerpt(self, agenda_item):
         proposal_obj = self.resolve_sumitted_proposal()
-        operations = ExcerptOperations([agenda_item])
+        operations = ExcerptOperations(agenda_item)
         CreateGeneratedDocumentCommand(
             proposal_obj, agenda_item.meeting, operations).execute()
 

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -55,9 +55,9 @@ class TestCloseMeeting(FunctionalTestCase):
 
         submitted_proposal = self.proposal_a.load_model().resolve_sumitted_proposal()
         excerpt = submitted_proposal.listFolderContents()[0]
-        self.assertEquals('Protocol Excerpt-B\xc3\xa4rn, Dec 13, 2011',
+        self.assertEquals('Proposal A - B\xc3\xa4rn, Dec 13, 2011',
                           excerpt.Title())
-        self.assertEquals(u'protocol-excerpt-barn-dec-13-2011.docx',
+        self.assertEquals(u'proposal-a-barn-dec-13-2011.docx',
                           excerpt.file.filename)
 
         generated_document = self.proposal_a.load_model().submitted_excerpt_document
@@ -69,9 +69,9 @@ class TestCloseMeeting(FunctionalTestCase):
         browser.css('#pending-closed').first.click()
 
         excerpt = self.dossier.listFolderContents()[-2]
-        self.assertEquals('Protocol Excerpt-B\xc3\xa4rn, Dec 13, 2011',
+        self.assertEquals('Proposal A - B\xc3\xa4rn, Dec 13, 2011',
                           excerpt.Title())
-        self.assertEquals(u'protocol-excerpt-barn-dec-13-2011.docx',
+        self.assertEquals(u'proposal-a-barn-dec-13-2011.docx',
                           excerpt.file.filename)
 
         generated_document = self.proposal_a.load_model().excerpt_document
@@ -100,7 +100,7 @@ class TestCloseMeeting(FunctionalTestCase):
         browser.open(self.proposal_a, view=u'tabbedview_view-overview')
         link = browser.css('#excerptBox a').first
         self.assertEquals(excerpt.absolute_url(), link.get('href'))
-        self.assertEquals(u'Protocol Excerpt-B\xe4rn, Dec 13, 2011', link.text)
+        self.assertEquals(u'Proposal A - B\xe4rn, Dec 13, 2011', link.text)
 
     @browsing
     def test_states_are_updated(self, browser):

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -55,7 +55,7 @@ class TestCloseMeeting(FunctionalTestCase):
 
         submitted_proposal = self.proposal_a.load_model().resolve_sumitted_proposal()
         excerpt = submitted_proposal.listFolderContents()[0]
-        self.assertEquals('Protocol Excerpt-barn-dec-13-2011',
+        self.assertEquals('Protocol Excerpt-B\xc3\xa4rn, Dec 13, 2011',
                           excerpt.Title())
         self.assertEquals(u'protocol-excerpt-barn-dec-13-2011.docx',
                           excerpt.file.filename)
@@ -69,7 +69,7 @@ class TestCloseMeeting(FunctionalTestCase):
         browser.css('#pending-closed').first.click()
 
         excerpt = self.dossier.listFolderContents()[-2]
-        self.assertEquals('Protocol Excerpt-barn-dec-13-2011',
+        self.assertEquals('Protocol Excerpt-B\xc3\xa4rn, Dec 13, 2011',
                           excerpt.Title())
         self.assertEquals(u'protocol-excerpt-barn-dec-13-2011.docx',
                           excerpt.file.filename)
@@ -100,7 +100,7 @@ class TestCloseMeeting(FunctionalTestCase):
         browser.open(self.proposal_a, view=u'tabbedview_view-overview')
         link = browser.css('#excerptBox a').first
         self.assertEquals(excerpt.absolute_url(), link.get('href'))
-        self.assertEquals('Protocol Excerpt-barn-dec-13-2011', link.text)
+        self.assertEquals(u'Protocol Excerpt-B\xe4rn, Dec 13, 2011', link.text)
 
     @browsing
     def test_states_are_updated(self, browser):

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -116,7 +116,8 @@ class TestExcerpt(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('.excerpts li a')),
                          'generated document should be linked')
-        self.assertIsNotNone(browser.find('protocol-excerpt-barn-dec-13-2011'))
+
+        self.assertIsNotNone(browser.find(u'Protocol Excerpt-B\xe4rn, Dec 13, 2011'))
 
     @browsing
     def test_manual_excerpt_form_redirects_to_meeting_on_abort(self, browser):

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -110,7 +110,7 @@ class TestProtocol(FunctionalTestCase):
     def test_protocol_document_is_locked_by_system_once_generated(self, browser):
         self.setup_generated_protocol(browser)
 
-        browser.find('Protocol-there-jan-01-2013').click()
+        browser.find('Protocol-There, Jan 01, 2013').click()
         document = browser.context
         lockable = ILockable(document)
 
@@ -129,7 +129,7 @@ class TestProtocol(FunctionalTestCase):
 
         browser.open(self.meeting.get_url())
 
-        browser.find('Protocol-there-jan-01-2013').click()
+        browser.find('Protocol-There, Jan 01, 2013').click()
         document = browser.context
         lockable = ILockable(document)
 


### PR DESCRIPTION
Aktuell ist der Titel eines Protokollauszugs 

> Protokollauszug-[Sitzungstitel, Sitzungsdatum].

Neu weist der Titel folgendes Format auf:

> [Titel Antrag] - [Sitzungstitel, Sitzungsdatum].

![bildschirmfoto 2016-02-12 um 09 42 42](https://cloud.githubusercontent.com/assets/557005/13002219/0dce95d6-d16d-11e5-8cd0-1c81dc4e5282.png)

closes #1569 