### PR TITLE
Show hint for corrupt protocol changes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Meeting: Implement hint for conflicts while saving a protocol.
+  [Kevin Bieri]
+
 - Improve agenda-item workflow, allow decided agenda-items to be re-opened for
   revision. Also update excerpts when the agenda-item is revised.
   [phgross, deiferni]

--- a/opengever/base/browser/resources/Controller.js
+++ b/opengever/base/browser/resources/Controller.js
@@ -234,7 +234,7 @@
     var self = this;
 
     var messageFunc = function(data) {
-      if(data && !data.redirectUrl && options.showMessage) {
+      if(data && data.messages && !data.redirectUrl && options.showMessage) {
         self.messageFactory.shout(data.messages);
       }
     };

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -247,7 +247,7 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
             msg = _(u'message_write_conflict',
                     default='Your changes were not saved, the protocol has '
                             'been modified in the meantime.')
-            return JSONResponse(self.request).error(msg).dump()
+            return JSONResponse(self.request).data(hasConflict=True).dump()
 
         elif self._is_locked_by_another_user:
             msg = _(u'message_locked_by_another_user',

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -17,6 +17,10 @@
                   <metal:use use-macro="context/@@ploneform-macros/actions" />
                   <input type="submit" id="button-value-discard" value="Discard" i18n:attributes="value" />
                 </div>
+                <span id="conflict-hint" class="spv-label error">
+                  <i></i>
+                  <span i18n:translate="label_conflict_changes">The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually.</span>
+                </span>
                 <div id="changes-hint" class="spv-label warning">
                   <i></i>
                   <span i18n:translate="label_unsaved_changes">You have unsaved changes</span>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-25 15:36+0000\n"
+"POT-Creation-Date: 2016-03-03 13:58+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -136,11 +136,11 @@ msgstr "Bearbeiten"
 
 #: ./opengever/meeting/command.py:82
 msgid "Excerpt for agenda item ${title} has been generated successfully"
-msgstr "Protokollauszug für Traktandum ${title} wurde erfolgreich erstellt."
+msgstr "Der Protokollauszug für ${title} wurde erfolgreich generiert."
 
 #: ./opengever/meeting/command.py:87
 msgid "Excerpt for agenda item ${title} has been updated successfully"
-msgstr "Protokollauszug für Traktandum ${title} wurde erfolgreich aktualisiert."
+msgstr "Der Protokollauszug für ${title} wurde erfolgreich aktualisiert."
 
 #: ./opengever/meeting/command.py:146
 msgid "Excerpt for meeting ${title} has been generated successfully"
@@ -167,7 +167,7 @@ msgstr "Export-Einstellungen"
 msgid "Generate excerpts for all proposals"
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt"
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:64
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:90
 msgid "History"
 msgstr "Verlauf"
 
@@ -224,7 +224,7 @@ msgstr "Sitzungsnummer"
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:59
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:63
 msgid "Meetinginformation"
 msgstr "Sitzungsangaben"
 
@@ -344,7 +344,7 @@ msgstr "Traktandum detraktandieren"
 msgid "Update or create the protocol"
 msgstr "Das Protokoll wird erstellt oder aktualisiert"
 
-#: ./opengever/meeting/browser/submitdocuments.py:183
+#: ./opengever/meeting/browser/submitdocuments.py:194
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
@@ -426,7 +426,7 @@ msgstr "Weiter"
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:69
+#: ./opengever/meeting/browser/submitdocuments.py:73
 msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
@@ -635,6 +635,11 @@ msgstr "Schliessen"
 msgid "label_committee"
 msgstr "Gremium"
 
+#. Default: "The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually."
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+msgid "label_conflict_changes"
+msgstr "Das Protokoll wurde in der Zwischenzeit bearbeitet. Wenn Sie Ihre Änderungen beibehalten wollen, versuchen Sie die Konflikte manuell zu lösen."
+
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
 #: ./opengever/meeting/proposal.py:117
@@ -762,7 +767,7 @@ msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:45
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:71
 msgid "label_excerpt"
 msgstr "Protokollauszug"
 
@@ -964,7 +969,7 @@ msgid "label_transition_executed"
 msgstr "Statusänderung ${transition} ausgeführt"
 
 #. Default: "You have unsaved changes"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:26
 msgid "label_unsaved_changes"
 msgstr "Sie haben nicht gespeicherte lokale Änderungen"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-25 15:36+0000\n"
+"POT-Creation-Date: 2016-03-03 13:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:64
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:90
 msgid "History"
 msgstr "Historique"
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:59
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:63
 msgid "Meetinginformation"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Update or create the protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:183
+#: ./opengever/meeting/browser/submitdocuments.py:194
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
 
@@ -426,7 +426,7 @@ msgstr ""
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:69
+#: ./opengever/meeting/browser/submitdocuments.py:73
 msgid "button_submit_attachments"
 msgstr ""
 
@@ -635,6 +635,11 @@ msgstr ""
 msgid "label_committee"
 msgstr "Commission"
 
+#. Default: "The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually."
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+msgid "label_conflict_changes"
+msgstr ""
+
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
 #: ./opengever/meeting/proposal.py:117
@@ -762,7 +767,7 @@ msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:45
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:71
 msgid "label_excerpt"
 msgstr ""
 
@@ -964,7 +969,7 @@ msgid "label_transition_executed"
 msgstr ""
 
 #. Default: "You have unsaved changes"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:26
 msgid "label_unsaved_changes"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-25 15:36+0000\n"
+"POT-Creation-Date: 2016-03-03 13:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:64
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:90
 msgid "History"
 msgstr ""
 
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:59
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:63
 msgid "Meetinginformation"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Update or create the protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:183
+#: ./opengever/meeting/browser/submitdocuments.py:194
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
@@ -425,7 +425,7 @@ msgstr ""
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:69
+#: ./opengever/meeting/browser/submitdocuments.py:73
 msgid "button_submit_attachments"
 msgstr ""
 
@@ -634,6 +634,11 @@ msgstr ""
 msgid "label_committee"
 msgstr ""
 
+#. Default: "The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually."
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+msgid "label_conflict_changes"
+msgstr ""
+
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
 #: ./opengever/meeting/proposal.py:117
@@ -761,7 +766,7 @@ msgid "label_end"
 msgstr ""
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:45
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:71
 msgid "label_excerpt"
 msgstr ""
 
@@ -963,7 +968,7 @@ msgid "label_transition_executed"
 msgstr ""
 
 #. Default: "You have unsaved changes"
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt:26
 msgid "label_unsaved_changes"
 msgstr ""
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -325,14 +325,7 @@ class TestProtocol(FunctionalTestCase):
         browser.open(self.meeting.get_url(view='protocol'))
 
         browser.fill({"modified": '1'}).submit()
-        self.assertEqual({
-            u'messages': [{
-                u'messageTitle': u'Error',
-                u'message': u'Your changes were not saved, the protocol has been modified in the meantime.',
-                u'messageClass': u'error'}
-            ]},
-            browser.json
-        )
+        self.assertEqual({u'hasConflict': True}, browser.json)
 
     @browsing
     def test_protocol_cannot_be_saved_when_locked_by_another_user(self, browser):


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1579 

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/414

Im not happy about https://github.com/4teamwork/opengever.core/compare/kb_corrupt_changes?expand=1#diff-0df47629165198501befb1dd4d1fc069R20 maybe we should implement this in an other way.