### PR TITLE
Fixes an issue with broken db-migrations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Fixes an issue with broken db-migrations.
+  Don't load proposal model in upgrade steps but use sqlalchemy expression
+  api for database access.
+  [deiferni]
+
 - Activate notification-center by default.
   [elioschmutz]
 

--- a/opengever/meeting/upgrades/to4603.py
+++ b/opengever/meeting/upgrades/to4603.py
@@ -1,18 +1,39 @@
-from ftw.upgrade import UpgradeStep
-from opengever.base.interfaces import IReferenceNumber
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.oguid import Oguid
+from opengever.core.upgrade import SQLUpgradeStep
+from sqlalchemy import and_
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
 
-class UpdateProposalDossierReferenceNumber(UpgradeStep):
+
+proposals_table = table(
+    'proposals',
+    column('id'),
+    column('dossier_reference_number'),
+    column('int_id'),
+    column('admin_unit_id'),
+)
+
+
+class UpdateProposalDossierReferenceNumber(SQLUpgradeStep):
     """With the upgradestep 4602 the column dossier_reference_number was
     introduced and filled with a placeholder. This upgradestep now replaces
     the placeholders with the correct value."""
 
-    def __call__(self):
+    def migrate(self):
         query = {'portal_type': 'opengever.meeting.proposal'}
         for proposal in self.objects(query, 'Update dossier_reference_number'):
-            model = proposal.load_model()
-            model.dossier_reference_number = self.get_reference_number(proposal)
+            oguid = Oguid.for_object(proposal)
+            dossier_reference_number = self.get_reference_number(proposal)
+
+            self.execute(proposals_table.update().values(
+                dossier_reference_number=dossier_reference_number).where(
+                and_(
+                    proposals_table.columns.int_id == oguid.int_id,
+                    proposals_table.columns.admin_unit_id == oguid.admin_unit_id,
+                )))
 
     def get_reference_number(self, proposal):
         main_dossier = aq_parent(aq_inner(proposal)).get_main_dossier()

--- a/opengever/meeting/upgrades/to4633.py
+++ b/opengever/meeting/upgrades/to4633.py
@@ -1,20 +1,40 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from ftw.upgrade import UpgradeStep
+from opengever.base.oguid import Oguid
 from opengever.base.utils import get_preferred_language_code
+from opengever.core.upgrade import SQLUpgradeStep
+from sqlalchemy import and_
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
 
 
-class UpdateRepositoryFolderTitle(UpgradeStep):
+proposals_table = table(
+    'proposals',
+    column('id'),
+    column('repository_folder_title'),
+    column('int_id'),
+    column('admin_unit_id'),
+)
+
+
+class UpdateRepositoryFolderTitle(SQLUpgradeStep):
     """With the upgradestep 4632 the column repository_folder_title was
     introduced and filled with a placeholder. This upgradestep now replaces
     the placeholders with the correct value.
 
     """
-    def __call__(self):
+    def migrate(self):
         query = {'portal_type': 'opengever.meeting.proposal'}
-        for proposal in self.objects(query, 'Update repository_folder_title'):
-            model = proposal.load_model()
-            model.repository_folder_title = self.get_repo_folder_title(proposal)
+        for proposal in self.objects(query, 'Update dossier_reference_number'):
+            oguid = Oguid.for_object(proposal)
+            repository_folder_title = self.get_repo_folder_title(proposal)
+
+            self.execute(proposals_table.update().values(
+                repository_folder_title=repository_folder_title).where(
+                and_(
+                    proposals_table.columns.int_id == oguid.int_id,
+                    proposals_table.columns.admin_unit_id == oguid.admin_unit_id,
+                )))
 
     def get_repo_folder_title(self, proposal):
         main_dossier = aq_parent(aq_inner(proposal)).get_main_dossier()


### PR DESCRIPTION
Don't load proposal model in upgrade steps but use sqlalchemy expression api for database access. This ensures that migrations also run in the future, when the model changes.

Also add a separate base-class for sql-based migrations that need to run once per plone site/admin-unit and not only once per cluster.

Fixes #1605