### PR TITLE
Introduce [api] extra to pull in plone.restapi and use it for tests and development

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -25,6 +25,7 @@ ogds-db-driver = psycopg2
 zserver-threads = 4
 user = zopemaster:admin
 eggs +=
+    opengever.core[api]
     plonetheme.teamraum
     opengever.maintenance
     ${buildout:ogds-db-driver}

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Introduce [api] extra that pulls in plone.restapi (and plone.rest).
+  [lgraf]
+
 - Change title and filename for generated excerpts.
   Old title format: Protocolexcerpt-[meetingtitle, meetingdate]
   New title format: [excerpttitle] - [meetingtitle, meetingdate].

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,11 @@ import os
 version = '4.6.4.dev0'
 maintainer = '4teamwork AG'
 
+
+api_require = [
+    'plone.restapi',
+]
+
 tests_require = [
     'Products.CMFPlone',
     'ftw.journal',
@@ -141,7 +146,10 @@ setup(name='opengever.core',
         # -*- Extra requirements: -*-
         ],
       tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      extras_require=dict(
+          tests=tests_require,
+          api=api_require,
+      ),
       entry_points="""
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]

--- a/sources.cfg
+++ b/sources.cfg
@@ -6,6 +6,8 @@ development-packages =
   opengever.maintenance
   collective.js.timeago
   plonetheme.teamraum
+  plone.restapi
+  plone.rest
 
 auto-checkout = ${buildout:development-packages}
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -11,6 +11,8 @@ package-namespace = opengever
 find-links +=
     http://psc.4teamwork.ch/simple
 
+test-egg = opengever.core[api, tests]
+
 [test]
 arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
 


### PR DESCRIPTION
This is the first step for integrating [`plone.restapi`](https://github.com/plone/plone.restapi) into `opengever.core`.

This introduces an `[api]` extra for `opengever.core`, and uses it for tests and development.

For now, both `plone.rest` and `plone.restapi` will be used from source:
- plone.restapi doesn't have a release yet
- plone.rest is still changing heavily, we want to stay current for now