### PR TITLE
Add link in meetingoverview from unscheduled proposals to their corresponding submitted proposals.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add link in meetingoverview from unscheduled proposals to their corresponding submitted proposals.
+  [elioschmutz]
+
 - Introduce [api] extra that pulls in plone.restapi (and plone.rest).
   [lgraf]
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -116,7 +116,7 @@ PROPOSALS_TEMPLATE = '''
 <script tal:condition="view/unscheduled_proposals" id="proposalsTemplate" type="text/x-handlebars-template">
   {{#each proposals}}
     <div class="list-group-item submit">
-      <span class="title">{{title}}</span>
+      <a href="{{submitted_proposal_url}}" class="title">{{title}}</a>
       <div class="button-group">
         <a class="button schedule-proposal" href="{{schedule_url}}">%(label_schedule)s</a>
       </div>

--- a/opengever/meeting/browser/meetings/unscheduled_proposals.py
+++ b/opengever/meeting/browser/meetings/unscheduled_proposals.py
@@ -54,6 +54,7 @@ class UnscheduledProposalsView(BrowserView):
         """
         proposals = map(lambda proposal : {
             'title': proposal.title,
+            'submitted_proposal_url': proposal.get_submitted_url(),
             'schedule_url': self.schedule_url(proposal)},
                         self.context.get_unscheduled_proposals())
 

--- a/opengever/meeting/tests/test_unscheduled_proposals.py
+++ b/opengever/meeting/tests/test_unscheduled_proposals.py
@@ -51,7 +51,6 @@ class TestUnscheduledProposals(FunctionalTestCase):
         form.fill({'proposal_id': str(proposal_model.proposal_id)}).submit()
         return proposal.load_model().agenda_item
 
-
     @browsing
     def test_list_unscheduled_proposals_returns_a_json_representation_for_all_unscheduled_proposals(self, browser):
         self.setup_proposal()
@@ -60,9 +59,11 @@ class TestUnscheduledProposals(FunctionalTestCase):
         browser.login().open(self.meeting_wrapper, view='unscheduled_proposals')
         self.assertEquals(
             [{u'schedule_url': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/unscheduled_proposals/1/schedule',
+              u'submitted_proposal_url': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/submitted-proposal-1',
               u'title': u'Fooo'},
-             {u'schedule_url': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/unscheduled_proposals/2/schedule', u'title': u'Fooo'}]
-            ,
+             {u'schedule_url': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/unscheduled_proposals/2/schedule',
+              u'submitted_proposal_url': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/submitted-proposal-2',
+              u'title': u'Fooo'}],
             browser.json.get('items'))
 
     @browsing


### PR DESCRIPTION
Fügt einen Link von nicht traktandierten eingereichten Anträgen der Sitzungsübersicht zu dem jeweiligen eingereichten Auftrag.

<img width="609" alt="bildschirmfoto 2016-02-17 um 11 01 48" src="https://cloud.githubusercontent.com/assets/557005/13105934/e57a78a0-d565-11e5-97cc-792fa3ec999a.png">

closes #1362 