### PR TITLE
Dokumentversand: Kopie ablegen bei geschlossenen Dossiers ist nicht mehr möglich.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Prevent creating a mail-copy in the dossier when sending documents
+  from a closed dossiers.
+  [elioschmutz]
+
 - Add a custom handler to force a page reload (and thus force a
   redirect to the login form) when tabbed-view requests are redirected to
   the gever portal.

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-03-02 12:42+0000\n"
 "PO-Revision-Date: 2014-08-05 10:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ./opengever/mail/browser/send_document.py:48
+#: ./opengever/mail/browser/send_document.py:53
 msgid "No Mail Address"
 msgstr "Keine E-Mail Adresse"
 
@@ -26,7 +26,7 @@ msgstr "Keine E-Mail Adresse"
 msgid "Save attachments"
 msgstr "Anhänge speichern"
 
-#: ./opengever/mail/browser/send_document.py:314
+#: ./opengever/mail/browser/send_document.py:336
 msgid "Sent mail filed as '${title}'."
 msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 
@@ -34,17 +34,17 @@ msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 msgid "The files you selected are larger than the maximum size"
 msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maximalgrösse."
 
-#: ./opengever/mail/browser/send_document.py:124
+#: ./opengever/mail/browser/send_document.py:129
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:177
+#: ./opengever/mail/browser/send_document.py:199
 msgid "button_send"
 msgstr "Senden"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:234
+#: ./opengever/mail/browser/send_document.py:256
 msgid "cancel_back"
 msgstr "Abbrechen"
 
@@ -78,12 +78,17 @@ msgid "error_no_attachments_to_extract"
 msgstr "Diese E-Mail hat keine Anhänge, die extrahiert werden könnten."
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:68
+#: ./opengever/mail/browser/send_document.py:73
 msgid "extern_receiver"
 msgstr "Externer Empfänger"
 
+#. Default: "(only possible for open dossiers)"
+#: ./opengever/mail/browser/send_document.py:189
+msgid "file_copy_widget_disabled_hint_text"
+msgstr "(nur für aktive Dossiers möglich)"
+
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:157
+#: ./opengever/mail/browser/send_document.py:162
 msgid "heading_send_as_email"
 msgstr "Dokumente als E-Mail versenden"
 
@@ -98,20 +103,20 @@ msgid "help_delete_action"
 msgstr "Wählen Sie aus, ob und welche Anhänge aus dieser E-Mail gelöscht werden sollen."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:69
+#: ./opengever/mail/browser/send_document.py:74
 msgid "help_extern_receiver"
 msgstr "E-Mail Adressen der externen Empfänger manuell eintragen. Pro Zeile eine Adresse eingeben."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:56
+#: ./opengever/mail/browser/send_document.py:61
 msgid "help_intern_receiver"
 msgstr "Live Search: Nachname/Vorname der internen Mitarbeiter oder Kontakte eingeben. Mehrauswahl möglich."
 
-#: ./opengever/mail/browser/send_document.py:84
+#: ./opengever/mail/browser/send_document.py:89
 msgid "help_message"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:78
+#: ./opengever/mail/browser/send_document.py:83
 msgid "help_subject"
 msgstr ""
 
@@ -121,12 +126,12 @@ msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:224
+#: ./opengever/mail/browser/send_document.py:246
 msgid "info_mail_sent"
 msgstr "E-Mail wurde versendet."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:55
+#: ./opengever/mail/browser/send_document.py:60
 msgid "intern_receiver"
 msgstr "Interne Empfänger"
 
@@ -156,17 +161,17 @@ msgid "label_delete_action_selected"
 msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:89
+#: ./opengever/mail/browser/send_document.py:94
 msgid "label_documents"
 msgstr "Anhänge"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:107
+#: ./opengever/mail/browser/send_document.py:112
 msgid "label_documents_as_link"
 msgstr "Dokumente nur als Link versenden."
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:113
+#: ./opengever/mail/browser/send_document.py:118
 msgid "label_file_copy_in_dossier"
 msgstr "Kopie des versandten Mails in Dossier ablegen"
 
@@ -176,7 +181,7 @@ msgid "label_journal_initialized"
 msgstr "Dokument migriert"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:83
+#: ./opengever/mail/browser/send_document.py:88
 msgid "label_message"
 msgstr "Mitteilung"
 
@@ -186,12 +191,12 @@ msgid "label_org_message"
 msgstr "Originalnachricht"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:279
+#: ./opengever/mail/browser/send_document.py:301
 msgid "label_see_attachment"
 msgstr "siehe Anhänge"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:77
+#: ./opengever/mail/browser/send_document.py:82
 msgid "label_subject"
 msgstr "Betreff"
 
@@ -200,7 +205,7 @@ msgstr "Betreff"
 msgid "label_title"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:60
+#: ./opengever/mail/browser/send_document.py:65
 msgid "mails"
 msgstr "E-Mails"
 
@@ -209,7 +214,7 @@ msgstr "E-Mails"
 msgid "no_message"
 msgstr "Keine Nachricht"
 
-#: ./opengever/mail/browser/send_document.py:72
+#: ./opengever/mail/browser/send_document.py:77
 msgid "receiver"
 msgstr "Empfänger"
 

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-03-02 12:42+0000\n"
 "PO-Revision-Date: 2012-09-06 13:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ./opengever/mail/browser/send_document.py:48
+#: ./opengever/mail/browser/send_document.py:53
 msgid "No Mail Address"
 msgstr "Pas d'adresse Email"
 
@@ -26,7 +26,7 @@ msgstr "Pas d'adresse Email"
 msgid "Save attachments"
 msgstr "Extraire documents"
 
-#: ./opengever/mail/browser/send_document.py:314
+#: ./opengever/mail/browser/send_document.py:336
 msgid "Sent mail filed as '${title}'."
 msgstr "Email envoyé classé sous '${title}'"
 
@@ -34,17 +34,17 @@ msgstr "Email envoyé classé sous '${title}'"
 msgid "The files you selected are larger than the maximum size"
 msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permise."
 
-#: ./opengever/mail/browser/send_document.py:124
+#: ./opengever/mail/browser/send_document.py:129
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse Email interne ou externe"
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:177
+#: ./opengever/mail/browser/send_document.py:199
 msgid "button_send"
 msgstr "Envoyer"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:234
+#: ./opengever/mail/browser/send_document.py:256
 msgid "cancel_back"
 msgstr "Annuler"
 
@@ -78,12 +78,17 @@ msgid "error_no_attachments_to_extract"
 msgstr "Cet Email n'a pas d'annexe à extraire"
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:68
+#: ./opengever/mail/browser/send_document.py:73
 msgid "extern_receiver"
 msgstr "Destinataire externe"
 
+#. Default: "(only possible for open dossiers)"
+#: ./opengever/mail/browser/send_document.py:189
+msgid "file_copy_widget_disabled_hint_text"
+msgstr "(possible uniquement pour les dossiers ouverts)"
+
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:157
+#: ./opengever/mail/browser/send_document.py:162
 msgid "heading_send_as_email"
 msgstr "Envoyer les documents comme Email"
 
@@ -98,20 +103,20 @@ msgid "help_delete_action"
 msgstr "Sélectionnez les annexes à effacer."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:69
+#: ./opengever/mail/browser/send_document.py:74
 msgid "help_extern_receiver"
 msgstr "Ajouter les adresses email des destinataires externes. Une adresse par ligne."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:56
+#: ./opengever/mail/browser/send_document.py:61
 msgid "help_intern_receiver"
 msgstr "Recherche en direct : Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible. "
 
-#: ./opengever/mail/browser/send_document.py:84
+#: ./opengever/mail/browser/send_document.py:89
 msgid "help_message"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:78
+#: ./opengever/mail/browser/send_document.py:83
 msgid "help_subject"
 msgstr ""
 
@@ -121,12 +126,12 @@ msgid "info_extracted_document"
 msgstr "Document créé : ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:224
+#: ./opengever/mail/browser/send_document.py:246
 msgid "info_mail_sent"
 msgstr "Email envoyé."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:55
+#: ./opengever/mail/browser/send_document.py:60
 msgid "intern_receiver"
 msgstr "Destinataires internes"
 
@@ -156,17 +161,17 @@ msgid "label_delete_action_selected"
 msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:89
+#: ./opengever/mail/browser/send_document.py:94
 msgid "label_documents"
 msgstr "Fichiers attachés"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:107
+#: ./opengever/mail/browser/send_document.py:112
 msgid "label_documents_as_link"
 msgstr "Envoyer seulement le lien du document"
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:113
+#: ./opengever/mail/browser/send_document.py:118
 msgid "label_file_copy_in_dossier"
 msgstr "Classer une copie de l'email envoyé dans le dossier"
 
@@ -176,7 +181,7 @@ msgid "label_journal_initialized"
 msgstr "Document migré"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:83
+#: ./opengever/mail/browser/send_document.py:88
 msgid "label_message"
 msgstr "Message"
 
@@ -186,12 +191,12 @@ msgid "label_org_message"
 msgstr "Message original"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:279
+#: ./opengever/mail/browser/send_document.py:301
 msgid "label_see_attachment"
 msgstr "Voir  fichiers attachés"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:77
+#: ./opengever/mail/browser/send_document.py:82
 msgid "label_subject"
 msgstr "Objet"
 
@@ -200,7 +205,7 @@ msgstr "Objet"
 msgid "label_title"
 msgstr "Titre"
 
-#: ./opengever/mail/browser/send_document.py:60
+#: ./opengever/mail/browser/send_document.py:65
 msgid "mails"
 msgstr "Email"
 
@@ -209,7 +214,7 @@ msgstr "Email"
 msgid "no_message"
 msgstr "Pas de message"
 
-#: ./opengever/mail/browser/send_document.py:72
+#: ./opengever/mail/browser/send_document.py:77
 msgid "receiver"
 msgstr "Destinataire"
 

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-03-02 12:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:48
+#: ./opengever/mail/browser/send_document.py:53
 msgid "No Mail Address"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Save attachments"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:314
+#: ./opengever/mail/browser/send_document.py:336
 msgid "Sent mail filed as '${title}'."
 msgstr ""
 
@@ -37,17 +37,17 @@ msgstr ""
 msgid "The files you selected are larger than the maximum size"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:124
+#: ./opengever/mail/browser/send_document.py:129
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr ""
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:177
+#: ./opengever/mail/browser/send_document.py:199
 msgid "button_send"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:234
+#: ./opengever/mail/browser/send_document.py:256
 msgid "cancel_back"
 msgstr ""
 
@@ -81,12 +81,17 @@ msgid "error_no_attachments_to_extract"
 msgstr ""
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:68
+#: ./opengever/mail/browser/send_document.py:73
 msgid "extern_receiver"
 msgstr ""
 
+#. Default: "(only possible for open dossiers)"
+#: ./opengever/mail/browser/send_document.py:189
+msgid "file_copy_widget_disabled_hint_text"
+msgstr ""
+
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:157
+#: ./opengever/mail/browser/send_document.py:162
 msgid "heading_send_as_email"
 msgstr ""
 
@@ -101,20 +106,20 @@ msgid "help_delete_action"
 msgstr ""
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:69
+#: ./opengever/mail/browser/send_document.py:74
 msgid "help_extern_receiver"
 msgstr ""
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:56
+#: ./opengever/mail/browser/send_document.py:61
 msgid "help_intern_receiver"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:84
+#: ./opengever/mail/browser/send_document.py:89
 msgid "help_message"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:78
+#: ./opengever/mail/browser/send_document.py:83
 msgid "help_subject"
 msgstr ""
 
@@ -124,12 +129,12 @@ msgid "info_extracted_document"
 msgstr ""
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:224
+#: ./opengever/mail/browser/send_document.py:246
 msgid "info_mail_sent"
 msgstr ""
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:55
+#: ./opengever/mail/browser/send_document.py:60
 msgid "intern_receiver"
 msgstr ""
 
@@ -159,17 +164,17 @@ msgid "label_delete_action_selected"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:89
+#: ./opengever/mail/browser/send_document.py:94
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:107
+#: ./opengever/mail/browser/send_document.py:112
 msgid "label_documents_as_link"
 msgstr ""
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:113
+#: ./opengever/mail/browser/send_document.py:118
 msgid "label_file_copy_in_dossier"
 msgstr ""
 
@@ -179,7 +184,7 @@ msgid "label_journal_initialized"
 msgstr ""
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:83
+#: ./opengever/mail/browser/send_document.py:88
 msgid "label_message"
 msgstr ""
 
@@ -189,12 +194,12 @@ msgid "label_org_message"
 msgstr ""
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:279
+#: ./opengever/mail/browser/send_document.py:301
 msgid "label_see_attachment"
 msgstr ""
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:77
+#: ./opengever/mail/browser/send_document.py:82
 msgid "label_subject"
 msgstr ""
 
@@ -203,7 +208,7 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:60
+#: ./opengever/mail/browser/send_document.py:65
 msgid "mails"
 msgstr ""
 
@@ -212,7 +217,7 @@ msgstr ""
 msgid "no_message"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:72
+#: ./opengever/mail/browser/send_document.py:77
 msgid "receiver"
 msgstr ""
 


### PR DESCRIPTION
Dieser PR verhindert, dass der Benutzer bei einem Mailversand die E-Mail als Dokument ablegen kann wenn das Dossier bereits geschlossen ist.

Wenn das Dossier geschlossen ist, wird die Checkbox im Formular auf `hidden` gesetzt, damit der Benutzer diese nicht mehr sieht.

Die Kopie wird schlussendlich nur erstellt, wenn das Dossier im Status 'aktiv' ist.

Ansicht bei aktivem Dossier:

<img width="506" alt="bildschirmfoto 2016-02-17 um 16 41 34" src="https://cloud.githubusercontent.com/assets/557005/13114887/c8a69404-d595-11e5-90fe-c7a5d06e7d6e.png">

Ansicht bei inaktivem Dossier:

<img width="430" alt="bildschirmfoto 2016-02-17 um 16 42 00" src="https://cloud.githubusercontent.com/assets/557005/13114894/d6669f08-d595-11e5-8350-a4fa30c7955e.png">

closes #1235 