### PR TITLE
Beschlossene Traktanden dürfen nicht mehr bearbeitet werden können.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Disable editing of decided agenda-items in protocol view.
+  [elioschmutz]
+
 - Avoid infinite loop in BasicReferenceNumber.get_parent_numbers() if context
   is not acquisition wrapped.
   [lgraf]

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -272,6 +272,10 @@ class EditProtocol(AutoExtensibleForm, ModelEditForm):
         return self.model.get_url()
 
     def is_field_visible(self, field, agenda_item):
+        field_value = getattr(agenda_item, field.get('name'))
+        if agenda_item.is_decided() and not field_value:
+            return False
+
         if field['needs_proposal']:
             return agenda_item.has_proposal
         else:

--- a/opengever/meeting/browser/meetings/templates/protocol.pt
+++ b/opengever/meeting/browser/meetings/templates/protocol.pt
@@ -81,18 +81,23 @@
                     </span>
                   </h2>
                   <metal:block tal:repeat="field view/agenda_item_fields">
-                    <metal:block tal:define="field_name field/name;"
-                                 tal:condition="python: view.is_field_visible(field, protocol)">
-                      <label tal:attributes="for string:${name}-${field_name};
-                                             id string:${name}-${field_name}-label"
-                             tal:content="field/label"></label>
-                      <metal:block tal:define="id string:${name}-${field_name};
-                                               name string:${name}.${field_name}:record;
-                                               value python:getattr(protocol, field_name);
-                                               autofocus repeat/field/start">
-                        <metal:use use-macro="context/@@gever-macros/render_trix_editor">
-                        </metal:use>
-                      </metal:block>
+                    <metal:block tal:condition="python: view.is_field_visible(field, protocol)">
+                      <tal:agendaitem define="field_name field/name;
+                                              field_value python:getattr(protocol, field_name)">
+                        <label tal:attributes="for string:${name}-${field_name};
+                                               id string:${name}-${field_name}-label"
+                               tal:content="field/label"></label>
+
+                        <span class="readonly" tal:content="structure field_value"
+                              tal:condition="protocol/is_decided"></span>
+                        <metal:block tal:define="id string:${name}-${field_name};
+                                                 name string:${name}.${field_name}:record;
+                                                 value field_value;
+                                                 autofocus repeat/field/start"
+                                     tal:condition="not: protocol/is_decided">
+                          <metal:use use-macro="context/@@gever-macros/render_trix_editor"></metal:use>
+                        </metal:block>
+                      </tal:agendaitem>
                     </metal:block>
                   </metal:block>
                 </div>

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -251,6 +251,11 @@ class AgendaItem(Base):
             return self.get_state() == self.STATE_PENDING
         return False
 
+    def is_decided(self):
+        if not self.is_paragraph:
+            return self.get_state() == self.STATE_DECIDED
+        return False
+
     def decide(self):
         if self.get_state() == self.STATE_DECIDED:
             return

--- a/opengever/meeting/tests/test_unit_agenda_item.py
+++ b/opengever/meeting/tests/test_unit_agenda_item.py
@@ -93,6 +93,25 @@ class TestUnitAgendaItem(TestCase):
 
         self.assertFalse(item.is_decide_possible())
 
+    def test_is_decided_is_false_if_the_agendaitem_is_not_decided(self):
+        agenda_item = create(Builder('agenda_item')
+                             .having(title=u'Simple', meeting=self.meeting))
+
+        self.assertFalse(agenda_item.is_decided())
+
+    def test_is_decided_is_true_if_the_agendatiem_is_decided(self):
+        agenda_item = create(Builder('agenda_item')
+                             .having(title=u'Simple', meeting=self.meeting))
+
+        agenda_item.workflow_state = 'decided'
+        self.assertTrue(agenda_item.is_decided())
+
+    def test_is_decided_is_false_for_paragraphs(self):
+        agenda_item = create(Builder('agenda_item')
+                             .having(is_paragraph=True, meeting=self.meeting))
+
+        self.assertFalse(agenda_item.is_decided())
+
     def test_get_state(self):
         item = self.simple_agenda_item
         self.assertEquals(item.STATE_PENDING, item.get_state())


### PR DESCRIPTION
Bisher konnte ein beschlossenes Traktandum weiterhin in der Protokollansicht bearbeitet werden.

<img width="730" alt="bildschirmfoto 2016-02-18 um 10 32 37" src="https://cloud.githubusercontent.com/assets/557005/13139111/36822ce6-d62b-11e5-91b1-ba86c90a151f.png">

Dieser PR verhindert das weitere Bearbeiten eines Traktandums nachdem dieses beschlossen wurde. Anstatt des Editors wird das Feld als Text angezeigt. Leere Felder werden mit einem Defaultwert '-' angezeigt.

<img width="738" alt="bildschirmfoto 2016-02-18 um 10 31 55" src="https://cloud.githubusercontent.com/assets/557005/13139141/5932b95e-d62b-11e5-8c1e-ecd342250149.png">

closes #1594 