### PR TITLE
Editierbarer Titel für Sitzungsobjekte hinzugefügt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add an editable title to meeting objects.
+  The user can set the title for a meeting manually now. Per default,
+  the title will be the name of the committee and the date.
+  [elioschmutz]
+
 - Disable editing of decided agenda-items in protocol view.
   [elioschmutz]
 

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -133,12 +133,16 @@ class MeetingExampleContentCreator(object):
             datetime.combine(date.today() + timedelta(days=delta), time(10, 0)))
         end = self.tz.localize(
             datetime.combine(date.today() + timedelta(days=delta), time(12, 0)))
+        title = "Gemeindeversammlung, {}".format(
+            api.portal.get_localized_time(datetime=start))
+
         dossier = create(Builder('meeting_dossier')
                          .having(title=u'Meeting {}'.format(
                              api.portal.get_localized_time(start)),)
                          .within(self.repository_folder_meeting))
         meeting = create(Builder('meeting')
-                         .having(committee=self.committee_assembly_model,
+                         .having(title=title,
+                                 committee=self.committee_assembly_model,
                                  location=u'Bern',
                                  start=start,
                                  end=end,)

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -1,3 +1,5 @@
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from five import grok
 from opengever.base.browser.helper import get_css_class
 from opengever.base.browser.wizard import BaseWizardStepForm
@@ -17,8 +19,6 @@ from plone import api
 from plone.dexterity.i18n import MessageFactory as pd_mf
 from plone.directives import form
 from plone.z3cform.layout import FormWrapper
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.form import Form
@@ -27,11 +27,23 @@ from zope import schema
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+from zope.interface import provider
+from zope.schema.interfaces import IContextAwareDefaultFactory
 import json
+
+
+@provider(IContextAwareDefaultFactory)
+def default_title(context):
+    return context.Title()
 
 
 class IMeetingModel(form.Schema):
     """Meeting model schema interface."""
+
+    title = schema.TextLine(
+        title=_(u"label_title", default=u"Title"),
+        defaultFactory=default_title,
+        required=True)
 
     committee = schema.Choice(
         title=_('label_committee', default=u'Committee'),
@@ -185,8 +197,8 @@ class AddMeetingWizardStepView(FormWrapper, grok.View):
     form = AddMeetingWizardStep
 
     def __init__(self, *args, **kwargs):
-         FormWrapper.__init__(self, *args, **kwargs)
-         grok.View.__init__(self, *args, **kwargs)
+        FormWrapper.__init__(self, *args, **kwargs)
+        grok.View.__init__(self, *args, **kwargs)
 
 
 class AddMeetingDossierView(WizzardWrappedAddForm):

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -25,6 +25,10 @@ from zope import schema
 class IMeetingMetadata(form.Schema):
     """Schema interface for meeting metadata."""
 
+    title = schema.TextLine(
+        title=_(u"label_title", default=u"Title"),
+        required=True)
+
     presidency = schema.Choice(
         title=_('label_presidency', default=u'Presidency'),
         source=get_committee_member_vocabulary,

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -355,6 +355,49 @@
 
   }
 
+  function CommitteeController() {
+
+    global.Controller.call(this);
+
+    var title = $("#form-widgets-title");
+    var autoUpdate = true;
+    var initialTitle = title.val();
+
+    var formatDate = function(date) { return $.datepicker.formatDate('dd.mm.yy', date); };
+
+    var applyTimezone = function(date) {
+      return new Date(date.setTime(date.getTime() + (date.getTimezoneOffset() * 60 * 1000)));
+    };
+
+    function applyDate(date) {
+      if (!autoUpdate) {
+        return false;
+      }
+      title.val(initialTitle + ", " + formatDate(date));
+    }
+
+    this.trackDate = function(target, event) { applyDate(applyTimezone(event.date)); };
+
+    this.unbindDate = function() { autoUpdate = false; };
+
+    this.events = [
+      {
+        method: "changeDate",
+        target: "#formfield-form-widgets-start .spv-datetime-widget",
+        callback: this.trackDate
+      },
+      {
+        method: "input",
+        target: "#form-widgets-title",
+        callback: this.unbindDate
+      }
+    ];
+
+    this.init();
+    applyDate(new Date());
+
+  }
+
   $(function() {
 
     if($("#opengever_meeting_meeting").length) {
@@ -364,6 +407,10 @@
 
       proposalsController.connectedTo = [agendaItemController];
       agendaItemController.connectedTo = [proposalsController];
+    }
+
+    if ($(".template-add-meeting").length) {
+      var committeecontroller = new CommitteeController();
     }
 
     global.autosize($('body.template-opengever-meeting-proposal textarea'));

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -91,6 +91,7 @@ class Meeting(Base):
     committee_id = Column(Integer, ForeignKey('committees.id'), nullable=False)
     committee = relationship("Committee", backref='meetings')
     location = Column(String(256))
+    title = Column(UnicodeCoercingText)
     start = Column('start_datetime', UTCDateTime(timezone=True), nullable=False)
     end = Column('end_datetime', UTCDateTime(timezone=True))
     workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False,
@@ -289,10 +290,7 @@ class Meeting(Base):
         self.modified = utcnow_tz_aware()
 
     def get_title(self):
-        if self.location:
-            return u"{}, {}".format(self.location, self.get_date())
-        else:
-            return self.get_date()
+        return self.title
 
     def get_date(self):
         return api.portal.get_localized_time(datetime=self.start)

--- a/opengever/meeting/tests/test_close.py
+++ b/opengever/meeting/tests/test_close.py
@@ -55,9 +55,9 @@ class TestCloseMeeting(FunctionalTestCase):
 
         submitted_proposal = self.proposal_a.load_model().resolve_sumitted_proposal()
         excerpt = submitted_proposal.listFolderContents()[0]
-        self.assertEquals('Proposal A - B\xc3\xa4rn, Dec 13, 2011',
+        self.assertEquals('Proposal A - C\xc3\xb6mmunity meeting',
                           excerpt.Title())
-        self.assertEquals(u'proposal-a-barn-dec-13-2011.docx',
+        self.assertEquals(u'proposal-a-community-meeting.docx',
                           excerpt.file.filename)
 
         generated_document = self.proposal_a.load_model().submitted_excerpt_document
@@ -69,9 +69,9 @@ class TestCloseMeeting(FunctionalTestCase):
         browser.css('#pending-closed').first.click()
 
         excerpt = self.dossier.listFolderContents()[-2]
-        self.assertEquals('Proposal A - B\xc3\xa4rn, Dec 13, 2011',
+        self.assertEquals('Proposal A - C\xc3\xb6mmunity meeting',
                           excerpt.Title())
-        self.assertEquals(u'proposal-a-barn-dec-13-2011.docx',
+        self.assertEquals(u'proposal-a-community-meeting.docx',
                           excerpt.file.filename)
 
         generated_document = self.proposal_a.load_model().excerpt_document
@@ -100,7 +100,7 @@ class TestCloseMeeting(FunctionalTestCase):
         browser.open(self.proposal_a, view=u'tabbedview_view-overview')
         link = browser.css('#excerptBox a').first
         self.assertEquals(excerpt.absolute_url(), link.get('href'))
-        self.assertEquals(u'Proposal A - B\xe4rn, Dec 13, 2011', link.text)
+        self.assertEquals(u'Proposal A - C\xf6mmunity meeting', link.text)
 
     @browsing
     def test_states_are_updated(self, browser):

--- a/opengever/meeting/tests/test_committee_tabs.py
+++ b/opengever/meeting/tests/test_committee_tabs.py
@@ -37,14 +37,14 @@ class TestCommitteeTabs(FunctionalTestCase):
         table = browser.css('.listing').first
 
         self.assertEquals([
-            {'Title': u'B\xe4rn, Dec 13, 2011',
+            {'Title': u'C\xf6mmunity meeting',
              'State': u'Pending',
              'Date': 'Dec 13, 2011',
              'Location': u'B\xe4rn',
              'From': '09:30 AM',
              'To': '11:45 AM',
              'Dossier': u'D\xf6ssier'},
-            {'Title': u'B\xe4rn, Dec 13, 2011',
+            {'Title': u'C\xf6mmunity meeting',
              'State': u'Pending',
              'Date': 'Dec 13, 2011',
              'Location': u'B\xe4rn',

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -86,7 +86,7 @@ class TestExcerpt(FunctionalTestCase):
         browser.css('.generate-excerpt').first.click()
 
         title_field = browser.find('Title')
-        self.assertEqual(u'Protocol Excerpt-B\xe4rn, Dec 13, 2011',
+        self.assertEqual(u'Protocol Excerpt-C\xf6mmunity meeting',
                          title_field.value)
 
         dossier_field = browser.find('form.widgets.dossier')
@@ -102,7 +102,7 @@ class TestExcerpt(FunctionalTestCase):
                       'Target dossier': self.dossier})
         browser.find('Save').click()
 
-        self.assertEqual([u'Excerpt for meeting B\xe4rn, Dec 13, 2011 has '
+        self.assertEqual([u'Excerpt for meeting C\xf6mmunity meeting has '
                           'been generated successfully'],
                          info_messages())
         # refresh
@@ -117,7 +117,7 @@ class TestExcerpt(FunctionalTestCase):
         self.assertEqual(1, len(browser.css('.excerpts li a')),
                          'generated document should be linked')
 
-        self.assertIsNotNone(browser.find(u'Protocol Excerpt-B\xe4rn, Dec 13, 2011'))
+        self.assertIsNotNone(browser.find(u'Protocol Excerpt-C\xf6mmunity meeting'))
 
     @browsing
     def test_manual_excerpt_form_redirects_to_meeting_on_abort(self, browser):

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -44,7 +44,8 @@ class TestMeetingLocking(FunctionalTestCase):
 
         self.committee_model = self.committee.load_model()
         self.meeting = create(Builder('meeting')
-                              .having(committee=self.committee_model,
+                              .having(title="My meeting",
+                                      committee=self.committee_model,
                                       location='Somewhere')
                               .link_with(self.meeting_dossier))
         self.proposal_model = self.proposal.load_model()

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -47,12 +47,8 @@ class TestMeeting(FunctionalTestCase):
 
     def test_meeting_title(self):
         self.assertEqual(
-            u'Bern, Oct 18, 2013',
-            Meeting(location=u'Bern', start=self.localized_datetime(2013, 10, 18)).get_title())
-
-        self.assertEqual(
-            u'Oct 18, 2013',
-            Meeting(start=self.localized_datetime(2013, 10, 18)).get_title())
+            u'My Title',
+            Meeting(title="My Title").get_title())
 
     def test_meeting_link(self):
         meeting = create(Builder('meeting').having(
@@ -64,8 +60,8 @@ class TestMeeting(FunctionalTestCase):
             'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/view',
             link.get('href'))
         self.assertEqual('contenttype-opengever-meeting-meeting', link.get('class'))
-        self.assertEqual(u'B\xe4rn, Dec 13, 2011', link.get('title'))
-        self.assertEqual(u'B\xe4rn, Dec 13, 2011', link.text)
+        self.assertEqual(u'C\xf6mmunity meeting', link.get('title'))
+        self.assertEqual(u'C\xf6mmunity meeting', link.text)
 
     @browsing
     def test_add_meeting_and_dossier(self, browser):
@@ -125,7 +121,7 @@ class TestMeeting(FunctionalTestCase):
         # javascript redirects upon close, we need to do so manually here ...
         browser.open(meeting.get_url())
         self.assertEqual(
-            [u'The meeting B\xe4rn, Dec 13, 2011 has been successfully '
+            [u'The meeting C\xf6mmunity meeting has been successfully '
              u'closed, the excerpts have been generated and sent back to the '
              u'initial dossier.'],
             info_messages())

--- a/opengever/meeting/tests/test_meeting_dossier_overview.py
+++ b/opengever/meeting/tests/test_meeting_dossier_overview.py
@@ -26,5 +26,5 @@ class TestMeetingDossierOverview(TestOverview):
     def test_meeting_is_linked_on_overview(self, browser):
         browser.login().open(self.dossier, view='tabbedview_view-overview')
 
-        link_node = browser.find(u'B\xe4rn, Dec 13, 2011')
+        link_node = browser.find(u'C\xf6mmunity meeting')
         self.assertEqual(self.meeting.get_url(), link_node.get('href'))

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -120,7 +120,7 @@ class TestMeetingView(FunctionalTestCase):
     def test_accessing_the_meeting_directly_shows_meeting_view(self, browser):
         browser.login().open(self.meeting.get_url(view=None))
 
-        self.assertEquals(['There, Jan 01, 2013'], browser.css('h1').text)
+        self.assertEquals([u'C\xf6mmunity meeting'], browser.css('h1').text)
 
     @browsing
     def test_participants_listing_precidency_is_existing(self, browser):

--- a/opengever/meeting/tests/test_pathbar.py
+++ b/opengever/meeting/tests/test_pathbar.py
@@ -33,7 +33,7 @@ class TestPathBar(FunctionalTestCase):
         browser.login().open(meeting.get_url())
         self.assertEqual(
             ['Client1', 'opengever-meeting-committeecontainer',
-             'My Committee', u'B\xe4rn, Dec 13, 2011'],
+             'My Committee', u'C\xf6mmunity meeting'],
             browser.css('#portal-breadcrumbs a').text)
 
     @browsing

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -75,7 +75,7 @@ class TestDossierProposalListing(ProposalListingTests):
               'Reference Number': '1',
               'Comittee': 'My committee',
               'Title': 'My Proposal',
-              'Meeting': u'B\xe4rn, Dec 13, 2011'}],
+              'Meeting': u'C\xf6mmunity meeting'}],
             table.dicts())
 
 
@@ -135,5 +135,5 @@ class TestSubmittedProposals(ProposalListingTests):
               'Reference Number': '1',
               'Comittee': 'My committee',
               'Title': 'My Proposal',
-              'Meeting': u'B\xe4rn, Dec 13, 2011'}],
+              'Meeting': u'C\xf6mmunity meeting'}],
             table.dicts())

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -133,7 +133,7 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertEqual(
-            u'Scheduled for meeting B\xe4rn, Dec 13, 2011 by Test User (test_user_1_)',
+            u'Scheduled for meeting C\xf6mmunity meeting by Test User (test_user_1_)',
             self.get_latest_history_entry_text(browser))
 
     @browsing
@@ -146,5 +146,5 @@ class TestProposalHistory(FunctionalTestCase):
 
         self.open_overview(browser)
         self.assertEqual(
-            u'Removed from schedule of meeting B\xe4rn, Dec 13, 2011 by Test User (test_user_1_)',
+            u'Removed from schedule of meeting C\xf6mmunity meeting by Test User (test_user_1_)',
             self.get_latest_history_entry_text(browser))

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -58,7 +58,8 @@ class TestProtocol(FunctionalTestCase):
 
         self.committee_model = self.committee.load_model()
         self.meeting = create(Builder('meeting')
-                              .having(committee=self.committee_model,
+                              .having(title='My meeting',
+                                      committee=self.committee_model,
                                       start=self.localized_datetime(2013, 1, 1, 10, 45),
                                       location='There',
                                       protocol_start_page_number=42)
@@ -110,7 +111,7 @@ class TestProtocol(FunctionalTestCase):
     def test_protocol_document_is_locked_by_system_once_generated(self, browser):
         self.setup_generated_protocol(browser)
 
-        browser.find('Protocol-There, Jan 01, 2013').click()
+        browser.find('Protocol-My meeting').click()
         document = browser.context
         lockable = ILockable(document)
 
@@ -129,7 +130,7 @@ class TestProtocol(FunctionalTestCase):
 
         browser.open(self.meeting.get_url())
 
-        browser.find('Protocol-There, Jan 01, 2013').click()
+        browser.find('Protocol-My meeting').click()
         document = browser.context
         lockable = ILockable(document)
 
@@ -220,7 +221,8 @@ class TestProtocol(FunctionalTestCase):
         self.assertIsNotNone(self.meeting.modified)
         prev_modified = self.meeting.modified
 
-        browser.fill({'Legal basis': 'Yes we can',
+        browser.fill({'Title': 'The Meeting',
+                      'Legal basis': 'Yes we can',
                       'Initial position': 'Still the same',
                       'Considerations': 'It is important',
                       'Proposed action': 'Accept it',
@@ -238,6 +240,7 @@ class TestProtocol(FunctionalTestCase):
 
         meeting = Meeting.query.get(self.meeting.meeting_id)
         self.assertGreater(meeting.modified, prev_modified)
+        self.assertEqual('The Meeting', meeting.title)
 
         proposal = Proposal.query.get(self.proposal_model.proposal_id)
         self.assertEqual('Yes we can', proposal.legal_basis)
@@ -349,7 +352,7 @@ class TestProtocol(FunctionalTestCase):
         browser.css('a[href*="@@generate_protocol"]').first.click()
 
         self.assertEquals(
-            ['Protocol for meeting There, Jan 01, 2013 '
+            ['Protocol for meeting My meeting '
              'has been generated successfully'],
             info_messages())
 

--- a/opengever/meeting/upgrades/20160218114243_add_title_column_to_meeting/upgrade.py
+++ b/opengever/meeting/upgrades/20160218114243_add_title_column_to_meeting/upgrade.py
@@ -1,0 +1,48 @@
+from opengever.core.upgrade import SchemaMigration
+from plone import api
+from sqlalchemy import Column
+from sqlalchemy import Text
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+meeting_table = table("meetings",
+                      column("id"),
+                      column("title"),
+                      column("location"),
+                      column("start_datetime"))
+
+
+class AddTitleColumnToMeeting(SchemaMigration):
+    """Add title column to meeting.
+    """
+
+    def migrate(self):
+        self.add_column()
+        self.migrate_data()
+        self.make_column_non_nullable()
+
+    def add_column(self):
+        self.op.add_column(
+            'meetings',
+            Column('title', Text, nullable=True))
+
+    def migrate_data(self):
+        for meeting in self.execute(meeting_table.select()):
+            self._set_title(meeting)
+
+    def _set_title(self, meeting):
+        self.execute(meeting_table
+                     .update()
+                     .where(meeting_table.c.id == meeting.id)
+                     .values(title=self._generate_title(meeting)))
+
+    def _generate_title(self, meeting):
+        date = api.portal.get_localized_time(datetime=meeting.start_datetime)
+        if meeting.location:
+            return u"{}, {}".format(meeting.location, date)
+        return date
+
+    def make_column_non_nullable(self):
+        self.op.alter_column('meetings', 'title',
+                             existing_type=Text, nullable=False)

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -207,6 +207,7 @@ class MeetingBuilder(SqlObjectBuilder):
         self.arguments['start'] = localized_datetime(2011, 12, 13, 9, 30)
         self.arguments['end'] = localized_datetime(2011, 12, 13, 11, 45)
         self.arguments['location'] = u'B\xe4rn'
+        self.arguments['title'] = u'C\xf6mmunity meeting'
 
     def before_create(self):
         committee = self.arguments.get('committee')


### PR DESCRIPTION
Der User kann den Sitzungstitel nun manuell setzten.

Der Titel wir standardmässig mit folgendem Format ausgefüllt: [Kommisionstitel], [Datum]

Solange der Benutzer den Titel nicht verändert, wird dieser mit dem Startdatum synchronisiert.
Änder also der Benutzer das Startdatum, wird das Datum im Titel automatisch aktualisiert.

![test1](https://cloud.githubusercontent.com/assets/557005/13149089/6468d792-d660-11e5-9eb7-4dc79a414fec.gif)

Der Titel kann auch nachträglich über die Protokollverwaltung geändert werden.

closes #1360 