### PR TITLE
Avoid infinite loop in BasicReferenceNumber.get_parent_numbers()

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Avoid infinite loop in BasicReferenceNumber.get_parent_numbers() if context
+  is not acquisition wrapped.
+  [lgraf]
+
 - Fixes an issue with broken db-migrations.
   Don't load proposal model in upgrade steps but use sqlalchemy expression
   api for database access.

--- a/opengever/base/reference.py
+++ b/opengever/base/reference.py
@@ -45,7 +45,7 @@ class BasicReferenceNumber(grok.Adapter):
         self.append_local_number(numbers)
 
         parent = self.context
-        while not ISiteRoot.providedBy(parent):
+        while parent and not ISiteRoot.providedBy(parent):
             parent = aq_parent(aq_inner(parent))
             parent_reference_adapter = queryAdapter(parent, IReferenceNumber)
             if parent_reference_adapter:


### PR DESCRIPTION
This avoids an infinite loop in `BasicReferenceNumber.get_parent_numbers()` if the context is not acquisition wrapped: The loop also needs to be terminated when `aq_parent(obj)` returns `None`, which is the case for unwrapped objects.

@deiferni 