### PR TITLE
Prevent anonymous access to browser views on plone site.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Fix an issue where tabs on the plone site were visible as anonymous under
+  certain circumstances.
+  [deiferni]
+
 - Add trix customizations to prevent accepting unsupported content.
   We don't support links, quotes, code-blocks and file uploads of any kind.
   [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add a custom handler to force a page reload (and thus force a
+  redirect to the login form) when tabbed-view requests are redirected to
+  the gever portal.
+  [deiferni]
+
 - Fix an issue where tabs on the plone site were visible as anonymous under
   certain circumstances.
   [deiferni]

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -2,3 +2,12 @@ $(function() {
   // set focus on first form field
   $("form#form input:text:visible, form#form textarea:visible").first().focus();
 });
+
+
+$(document).delegate('body', 'tabbedview.unknownresponse', function(event, overview, jqXHR) {
+  if (jqXHR.getResponseHeader('X-GEVER-Service') === 'Portal') {
+    // the response we got originates from a portal, we reload to show the login window
+    location.reload();
+    return false;
+  }
+});

--- a/sources.cfg
+++ b/sources.cfg
@@ -8,6 +8,7 @@ development-packages =
   plonetheme.teamraum
   plone.restapi
   plone.rest
+  ftw.tabbedview
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
This is a follow-up for #1278 to also prevent access when context does not provide `IPloneSiteRoot` but `IBrowserView` as is the case for e.g. a `TabbedView`. Fixes #1608.

It also contains a custom event handler for an event that is added in https://github.com/4teamwork/ftw.tabbedview/pull/51. It issues a page reload which then causes a redirect to the login form when we receive requests from the gever portal.

See also https://github.com/4teamwork/ftw.tabbedview/pull/51