### PR TITLE
Allow revision for decided agenda-items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Improve agenda-item workflow, allow decided agenda-items to be re-opened for
+  revision. Also update excerpts when the agenda-item is revised.
+  [phgross, deiferni]
+
 - Add a fix for links from Microsoft Office applications.
   The fix hacks around office's behavior to resolve links prior to opening
   a browser. This lead to an "insufficient privileges" page being displayed if

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -43,7 +43,7 @@ class Transporter(object):
     """
 
     def transport_to(self, obj, target_cid, container_path,
-                     view='transporter-receive-object'):
+                     view='transporter-receive-object', **data):
         """ Copies an *object* to another client (*target_cid*).
         """
 
@@ -52,6 +52,7 @@ class Transporter(object):
         request_data = {
             REQUEST_KEY: jsondata,
             }
+        request_data.update(**data)
 
         return dispatch_json_request(
             target_cid, '@@{}'.format(view),

--- a/opengever/meeting/browser/excerpt.py
+++ b/opengever/meeting/browser/excerpt.py
@@ -1,0 +1,43 @@
+from five import grok
+from opengever.base.oguid import Oguid
+from opengever.base.security import elevated_privileges
+from opengever.base.transport import Transporter
+from opengever.meeting import _
+from plone import api
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zExceptions import NotFound
+from zExceptions import Unauthorized
+from zope.i18n import translate
+import json
+
+
+class UpdateDossierExcerpt(grok.View):
+    """Receives a JSON serialized excerpt and updates the excerpt referenced
+    by the oguid parameter.
+
+    """
+    grok.name('update-dossier-excerpt')
+    grok.require('zope2.View')
+    grok.context(IPloneSiteRoot)
+
+    def render(self):
+        oguid_str = self.request.get('oguid')
+        if not oguid_str:
+            raise NotFound()
+
+        oguid = Oguid.parse(oguid_str)
+
+        with elevated_privileges():
+            document = oguid.resolve_object()
+            if document.is_checked_out():
+                raise Unauthorized()
+
+            transporter = Transporter()
+            transporter.update(document, self.request)
+
+            repository = api.portal.get_tool('portal_repository')
+            comment = translate(
+                _(u"Updated with a newer excerpt version."),
+                context=self.request)
+            repository.save(obj=document, comment=comment)
+        return json.dumps({})

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -53,9 +53,9 @@ class IAgendaItemActions(Interface):
         """Decide the current agendaitem and decide the meeting.
         """
 
-    def revise():
-        """Revise the current agendaitem. Means set workflow state back
-        to pending for the current agendaitem.
+    def reopen():
+        """Reioeb the current agendaitem and make it available for editing
+        again.
         """
 
 
@@ -127,9 +127,9 @@ class AgendaItemsView(BrowserView):
             if item.is_decide_possible():
                 data['decide_link'] = meeting.get_url(
                     view='agenda_items/{}/decide'.format(item.agenda_item_id))
-            if item.is_revise_possible():
-                data['revise_link'] = meeting.get_url(
-                    view='agenda_items/{}/revise'.format(item.agenda_item_id))
+            if item.is_reopen_possible():
+                data['reopen_link'] = meeting.get_url(
+                    view='agenda_items/{}/reopen'.format(item.agenda_item_id))
 
             agenda_items.append(data)
 
@@ -222,9 +222,9 @@ class AgendaItemsView(BrowserView):
 
         return response.dump()
 
-    def revise(self):
-        """Revise the current agendaitem. Means set workflow state back
-        to pending for the current agendaitem.
+    def reopen(self):
+        """Reopen the current agendaitem. Set the workflow state to revision
+        to indicate that editing is possible again.
         """
         if not self.context.model.is_editable():
             raise Unauthorized("Editing is not allowed")
@@ -233,11 +233,11 @@ class AgendaItemsView(BrowserView):
         if not agenda_item:
             raise NotFound
 
-        agenda_item.revise()
+        agenda_item.reopen()
 
         return JSONResponse(self.request).info(
-            _(u'agenda_item_revised',
-              default=u'Agenda Item successfully revised.')).dump()
+            _(u'agenda_item_reopened',
+              default=u'Agenda Item successfully reopened.')).dump()
 
     def schedule_paragraph(self):
         """Schedule the given Paragraph (request parameter `title`) for the current

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -11,7 +11,6 @@ from zope.interface import Interface
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces.browser import IBrowserView
 import json
-import transaction
 
 
 class IAgendaItemActions(Interface):
@@ -54,8 +53,13 @@ class IAgendaItemActions(Interface):
         """
 
     def reopen():
-        """Reioeb the current agendaitem and make it available for editing
+        """Reopen the current agendaitem and make it available for editing
         again.
+        """
+
+    def revise():
+        """Revise a reopened agenda-item by updating excerpts and prevent
+        further editing.
         """
 
 
@@ -102,17 +106,7 @@ class AgendaItemsView(BrowserView):
             'css_class': get_css_class(excerpt),
             }
 
-    def has_documents(self, item):
-        if not item.has_proposal:
-            return False
-
-        return bool(item.proposal.submitted_documents or
-                item.proposal.submitted_excerpt_document)
-
-    def list(self):
-        """Returns json list of all agendaitems for the current
-        context (meeting).
-        """
+    def _get_agenda_items(self):
         meeting = self.context.model
         agenda_items = []
         for item in meeting.agenda_items:
@@ -130,10 +124,26 @@ class AgendaItemsView(BrowserView):
             if item.is_reopen_possible():
                 data['reopen_link'] = meeting.get_url(
                     view='agenda_items/{}/reopen'.format(item.agenda_item_id))
+            if item.is_revise_possible():
+                data['revise_link'] = meeting.get_url(
+                    view='agenda_items/{}/revise'.format(item.agenda_item_id))
 
             agenda_items.append(data)
+        return agenda_items
 
-        return JSONResponse(self.request).data(items=agenda_items).dump()
+    def has_documents(self, item):
+        if not item.has_proposal:
+            return False
+
+        return bool(item.proposal.submitted_documents or
+                item.proposal.submitted_excerpt_document)
+
+    def list(self):
+        """Returns json list of all agendaitems for the current
+        context (meeting).
+        """
+
+        return JSONResponse(self.request).data(items=self._get_agenda_items()).dump()
 
     def update_order(self):
         """Updates the order of the agendaitems. The new sortOrder is expected
@@ -238,6 +248,23 @@ class AgendaItemsView(BrowserView):
         return JSONResponse(self.request).info(
             _(u'agenda_item_reopened',
               default=u'Agenda Item successfully reopened.')).dump()
+
+    def revise(self):
+        """Revise the current agendaitem. Set the workflow state to decided
+        to indicate that editing is no longer possible.
+        """
+        if not self.context.model.is_editable():
+            raise Unauthorized("Editing is not allowed")
+
+        agenda_item = meeting_service().fetch_agenda_item(self.agenda_item_id)
+        if not agenda_item:
+            raise NotFound
+
+        agenda_item.revise()
+
+        return JSONResponse(self.request).info(
+            _(u'agenda_item_revised',
+              default=u'Agenda Item revised successfully.')).dump()
 
     def schedule_paragraph(self):
         """Schedule the given Paragraph (request parameter `title`) for the current

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -116,8 +116,11 @@ AGENDAITEMS_TEMPLATE = '''
           {{#if decide_link}}
             <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
           {{/if}}
-          {{#if reopen}}
-            <a href="{{reopen}}" title="%(label_reopen_action)s" class="button reopen-agenda-item"><span></span></a>
+          {{#if reopen_link}}
+            <a href="{{reopen_link}}" title="%(label_reopen_action)s" class="button reopen-agenda-item"><span></span></a>
+          {{/if}}
+          {{#if revise_link}}
+            <a href="{{revise_link}}" title="%(label_revise_action)s" class="button revise-agenda-item"><span></span></a>
           {{/if}}
         </div>
       </td>
@@ -351,12 +354,18 @@ class MeetingView(BrowserView):
         label_reopen_action = translate(
             _('label_reopen_action', default='Reopen this agenda item'),
             context=self.request)
-        return AGENDAITEMS_TEMPLATE  % {'label_edit_cancel': label_edit_cancel,
-                                        'label_edit_save': label_edit_save,
-                                        'label_edit_action': label_edit_action,
-                                        'label_delete_action': label_delete_action,
-                                        'label_decide_action': label_decide_action,
-                                        'label_reopen_action': label_reopen_action}
+        label_revise_action = translate(
+            _('label_revise_action', default='Revise this agenda item'),
+            context=self.request)
+        return AGENDAITEMS_TEMPLATE % {
+            'label_edit_cancel': label_edit_cancel,
+            'label_edit_save': label_edit_save,
+            'label_edit_action': label_edit_action,
+            'label_delete_action': label_delete_action,
+            'label_decide_action': label_decide_action,
+            'label_reopen_action': label_reopen_action,
+            'label_revise_action': label_revise_action,
+        }
 
     def render_handlebars_proposals_template(self):
         label_schedule = translate(_('label_schedule', default='Schedule'), context=self.request)
@@ -365,10 +374,10 @@ class MeetingView(BrowserView):
                                      'label_no_proposals': label_no_proposals}
 
     def json_is_editable(self):
-        return json.dumps(self.model.is_editable());
+        return json.dumps(self.model.is_editable())
 
     def json_is_agendalist_editable(self):
-        return json.dumps(self.model.is_agendalist_editable());
+        return json.dumps(self.model.is_agendalist_editable())
 
     @property
     def url_update_agenda_item_order(self):

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -116,6 +116,9 @@ AGENDAITEMS_TEMPLATE = '''
           {{#if decide_link}}
             <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
           {{/if}}
+          {{#if revise_link}}
+            <a href="{{revise_link}}" title="%(label_revise_action)s" class="button revise-agenda-item"><span></span></a>
+          {{/if}}
         </div>
       </td>
       {{/if}}
@@ -345,11 +348,15 @@ class MeetingView(BrowserView):
         label_decide_action = translate(
             _('label_decide_action', default='Decide this agenda item'),
             context=self.request)
+        label_revise_action = translate(
+            _('label_revise_action', default='Revise this agenda item'),
+            context=self.request)
         return AGENDAITEMS_TEMPLATE  % {'label_edit_cancel': label_edit_cancel,
                                         'label_edit_save': label_edit_save,
                                         'label_edit_action': label_edit_action,
                                         'label_delete_action': label_delete_action,
-                                        'label_decide_action': label_decide_action}
+                                        'label_decide_action': label_decide_action,
+                                        'label_revise_action': label_revise_action}
 
     def render_handlebars_proposals_template(self):
         label_schedule = translate(_('label_schedule', default='Schedule'), context=self.request)

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -116,8 +116,8 @@ AGENDAITEMS_TEMPLATE = '''
           {{#if decide_link}}
             <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
           {{/if}}
-          {{#if revise_link}}
-            <a href="{{revise_link}}" title="%(label_revise_action)s" class="button revise-agenda-item"><span></span></a>
+          {{#if reopen}}
+            <a href="{{reopen}}" title="%(label_reopen_action)s" class="button reopen-agenda-item"><span></span></a>
           {{/if}}
         </div>
       </td>
@@ -348,15 +348,15 @@ class MeetingView(BrowserView):
         label_decide_action = translate(
             _('label_decide_action', default='Decide this agenda item'),
             context=self.request)
-        label_revise_action = translate(
-            _('label_revise_action', default='Revise this agenda item'),
+        label_reopen_action = translate(
+            _('label_reopen_action', default='Reopen this agenda item'),
             context=self.request)
         return AGENDAITEMS_TEMPLATE  % {'label_edit_cancel': label_edit_cancel,
                                         'label_edit_save': label_edit_save,
                                         'label_edit_action': label_edit_action,
                                         'label_delete_action': label_delete_action,
                                         'label_decide_action': label_decide_action,
-                                        'label_revise_action': label_revise_action}
+                                        'label_reopen_action': label_reopen_action}
 
     def render_handlebars_proposals_template(self):
         label_schedule = translate(_('label_schedule', default='Schedule'), context=self.request)

--- a/opengever/meeting/browser/protocol.py
+++ b/opengever/meeting/browser/protocol.py
@@ -90,7 +90,7 @@ class UpdateProtocol(grok.View):
         generated_doc = self.get_generated_document()
 
         command = UpdateGeneratedDocumentCommand(
-            generated_doc, self.operations)
+            generated_doc, meeting, self.operations)
         command.execute()
         command.show_message()
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -202,9 +202,14 @@
     this.reopen = function(target){
       target.addClass('loading');
       return $.post(target.attr("href"))
-        .done(function() { global.location.reload(); })
         .always(function() { target.removeClass("loading"); });
     }
+
+    this.revise = function(target){
+      target.addClass('loading');
+      return $.post(target.attr("href"))
+        .always(function() { target.removeClass("loading"); });
+    };
 
     this.events = [
       {
@@ -229,6 +234,14 @@
         method: "click",
         target: ".reopen-agenda-item",
         callback: this.reopen,
+        options: {
+          update: true
+        }
+      },
+      {
+        method: "click",
+        target: ".revise-agenda-item",
+        callback: this.revise,
         options: {
           update: true
         }

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -199,6 +199,13 @@
 
     this.declineDecide = function() { holdDialog.close(); };
 
+    this.reopen = function(target){
+      target.addClass('loading');
+      return $.post(target.attr("href"))
+        .done(function() { global.location.reload(); })
+        .always(function() { target.removeClass("loading"); });
+    }
+
     this.events = [
       {
         method: "click",
@@ -220,8 +227,8 @@
       },
       {
         method: "click",
-        target: ".revise-agenda-item",
-        callback: this.revise,
+        target: ".reopen-agenda-item",
+        callback: this.reopen,
         options: {
           update: true
         }

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -219,6 +219,14 @@
         }
       },
       {
+        method: "click",
+        target: ".revise-agenda-item",
+        callback: this.revise,
+        options: {
+          update: true
+        }
+      },
+      {
         method: "sortupdate",
         target: "#agenda_items tbody",
         callback: this.updateSortOrder,

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
@@ -220,9 +218,9 @@ class CreateGeneratedDocumentCommand(CreateDocumentCommand):
 
 class UpdateGeneratedDocumentCommand(object):
 
-    def __init__(self, generated_document, document_operations):
+    def __init__(self, generated_document, meeting, document_operations):
         self.generated_document = generated_document
-        self.meeting = generated_document.meeting
+        self.meeting = meeting
         self.document_operations = document_operations
 
     def generate_file_data(self):
@@ -255,6 +253,27 @@ class UpdateGeneratedDocumentCommand(object):
         api.portal.show_message(
             self.document_operations.get_updated_message(self.meeting),
             portal.REQUEST)
+
+
+class UpdateExcerptInDossierCommand(object):
+    """Update an excerpt that has already been stored in a dossier from an
+    excerpt that is stored in a submitted proposal.
+
+    """
+    def __init__(self, proposal):
+        self.proposal = proposal
+        self.excerpt = proposal.excerpt_document
+        self.submitted_excerpt = proposal.submitted_excerpt_document
+        self.document = self.submitted_excerpt.resolve_document()
+
+    def execute(self):
+        #XXX handle errors when executing across admin units.
+        Transporter().transport_to(
+            self.document,
+            self.excerpt.admin_unit_id,
+            '',
+            view='update-dossier-excerpt',
+            oguid=self.excerpt.oguid.id)
 
 
 class CreateSubmittedProposalCommand(object):

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-15 13:10+0000\n"
+"POT-Creation-Date: 2016-02-25 10:15+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:309
+#: ./opengever/meeting/command.py:346
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
@@ -25,12 +25,12 @@ msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 msgid "Actions"
 msgstr "Aktionen"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:69
 msgid "Add Dossier for Meeting"
 msgstr "Sitzungsdossier hinzufügen"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:56
+#: ./opengever/meeting/browser/meetings/meeting.py:68
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
@@ -57,7 +57,7 @@ msgstr "Neue Periode hinzufügen"
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:342
+#: ./opengever/meeting/command.py:379
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:376
+#: ./opengever/meeting/browser/meetings/meeting.py:404
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -122,7 +122,7 @@ msgstr "Traktandum löschen"
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ./opengever/meeting/command.py:272
+#: ./opengever/meeting/command.py:309
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
@@ -134,11 +134,19 @@ msgstr "Dokumente"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/meeting/command.py:84
+#: ./opengever/meeting/command.py:82
+msgid "Excerpt for agenda item ${title} has been generated successfully"
+msgstr "Protokollauszug für Traktandum ${title} wurde erfolgreich erstellt."
+
+#: ./opengever/meeting/command.py:87
+msgid "Excerpt for agenda item ${title} has been updated successfully"
+msgstr "Protokollauszug für Traktandum ${title} wurde erfolgreich aktualisiert."
+
+#: ./opengever/meeting/command.py:146
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:89
+#: ./opengever/meeting/command.py:151
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -212,7 +220,7 @@ msgstr "Sitzungsdossier"
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:265
+#: ./opengever/meeting/browser/meetings/meeting.py:283
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
@@ -263,19 +271,19 @@ msgid "Proposals:"
 msgstr "Anträge"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:169
-#: ./opengever/meeting/model/meeting.py:244
+#: ./opengever/meeting/model/meeting.py:245
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:247
+#: ./opengever/meeting/model/meeting.py:248
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
-#: ./opengever/meeting/command.py:46
+#: ./opengever/meeting/command.py:44
 msgid "Protocol for meeting ${title} has been generated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:51
+#: ./opengever/meeting/command.py:49
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -291,7 +299,7 @@ msgstr "Sablon Vorlage"
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:200
+#: ./opengever/meeting/browser/meetings/protocol.py:204
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Speichern"
@@ -312,7 +320,7 @@ msgstr "Eingereichten Antrag"
 msgid "Text:"
 msgstr "Freitext:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:219
+#: ./opengever/meeting/browser/meetings/meeting.py:237
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
@@ -340,7 +348,11 @@ msgstr "Das Protokoll wird erstellt oder aktualisiert"
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
-#: ./opengever/meeting/command.py:225
+#: ./opengever/meeting/browser/excerpt.py:40
+msgid "Updated with a newer excerpt version."
+msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
+
+#: ./opengever/meeting/command.py:241
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
@@ -350,44 +362,54 @@ msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:206
+#: ./opengever/meeting/browser/meetings/agendaitem.py:224
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:182
+#: ./opengever/meeting/browser/meetings/agendaitem.py:200
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:211
+#: ./opengever/meeting/browser/meetings/agendaitem.py:229
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:141
+#: ./opengever/meeting/browser/meetings/agendaitem.py:159
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:203
+#: ./opengever/meeting/browser/meetings/agendaitem.py:221
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
+#. Default: "Agenda Item successfully reopened."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:249
+msgid "agenda_item_reopened"
+msgstr "Das Traktandum wurde wieder eröffnet."
+
+#. Default: "Agenda Item revised successfully."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:266
+msgid "agenda_item_revised"
+msgstr "Das Traktandum wurde erfolgreich überarbeitet."
+
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:158
+#: ./opengever/meeting/browser/meetings/agendaitem.py:176
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:163
+#: ./opengever/meeting/browser/meetings/agendaitem.py:181
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:166
+#: ./opengever/meeting/browser/meetings/meeting.py:184
 msgid "button_cancel"
 msgstr "Abbrechen"
 
@@ -398,7 +420,7 @@ msgstr "Periode abschliessen"
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:150
+#: ./opengever/meeting/browser/meetings/meeting.py:168
 msgid "button_continue"
 msgstr "Weiter"
 
@@ -504,8 +526,8 @@ msgid "column_to"
 msgstr "Von"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:35
-#: ./opengever/meeting/model/proposal.py:132
+#: ./opengever/meeting/model/agendaitem.py:36
+#: ./opengever/meeting/model/proposal.py:134
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -516,7 +538,7 @@ msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/proposal.py:117
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -602,25 +624,25 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:235
+#: ./opengever/meeting/browser/meetings/protocol.py:239
 msgid "label_close"
 msgstr "Schliessen"
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:37
+#: ./opengever/meeting/browser/meetings/meeting.py:49
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
 msgstr "Gremium"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:132
 #: ./opengever/meeting/proposal.py:117
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
+#: ./opengever/meeting/browser/meetings/protocol.py:147
 #: ./opengever/meeting/proposal.py:78
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
@@ -655,12 +677,12 @@ msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:352
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:138
 #: ./opengever/meeting/proposal.py:198
 msgid "label_decision"
 msgstr "Beschluss"
@@ -671,7 +693,7 @@ msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:332
+#: ./opengever/meeting/browser/meetings/meeting.py:350
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -681,13 +703,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:144
 #: ./opengever/meeting/proposal.py:73
 msgid "label_disclose_to"
 msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:135
 #: ./opengever/meeting/proposal.py:293
 msgid "label_discussion"
 msgstr "Diskussion"
@@ -708,12 +730,12 @@ msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:331
+#: ./opengever/meeting/browser/meetings/meeting.py:349
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:329
+#: ./opengever/meeting/browser/meetings/meeting.py:347
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
@@ -723,7 +745,7 @@ msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:330
+#: ./opengever/meeting/browser/meetings/meeting.py:348
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -734,8 +756,8 @@ msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:67
+#: ./opengever/meeting/browser/meetings/meeting.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr "Ende"
 
@@ -761,7 +783,7 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
+#: ./opengever/meeting/browser/meetings/protocol.py:126
 #: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr "Ausgangslage"
@@ -778,7 +800,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
+#: ./opengever/meeting/browser/meetings/protocol.py:123
 #: ./opengever/meeting/proposal.py:53
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
@@ -794,8 +816,8 @@ msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:58
+#: ./opengever/meeting/browser/meetings/meeting.py:54
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Sitzungsort"
 
@@ -830,7 +852,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:344
+#: ./opengever/meeting/browser/meetings/meeting.py:372
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -840,17 +862,17 @@ msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:48
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:40
+#: ./opengever/meeting/browser/meetings/protocol.py:44
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_presidency"
 msgstr "Vorsitz"
 
@@ -860,18 +882,18 @@ msgid "label_proposal_id"
 msgstr "Laufnummer"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:129
 #: ./opengever/meeting/proposal.py:63
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py:56
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:141
 #: ./opengever/meeting/proposal.py:68
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
@@ -886,6 +908,16 @@ msgstr "Kommentar"
 msgid "label_remove"
 msgstr "Löschen"
 
+#. Default: "Reopen this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:355
+msgid "label_reopen_action"
+msgstr "Traktandum wieder eröffnen"
+
+#. Default: "Revise this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:358
+msgid "label_revise_action"
+msgstr "Traktandum überarbeiten"
+
 #. Default: "Role"
 #: ./opengever/meeting/browser/memberships.py:35
 #: ./opengever/meeting/browser/templates/member.pt:52
@@ -898,13 +930,13 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:343
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
 msgid "label_schedule"
 msgstr "Traktandieren"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:34
+#: ./opengever/meeting/browser/meetings/protocol.py:38
 msgid "label_secretary"
 msgstr "Protokollführung"
 
@@ -914,15 +946,15 @@ msgid "label_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:63
+#: ./opengever/meeting/browser/meetings/meeting.py:59
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/periods.py:23
-#: ./opengever/meeting/committee.py:75
+#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titel"
 
@@ -970,13 +1002,13 @@ msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:257
+#: ./opengever/meeting/browser/meetings/protocol.py:261
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/protocol.py:249
+#: ./opengever/meeting/browser/meetings/protocol.py:253
 msgid "message_locked_by_another_user"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde von ${username} gesperrt."
 
@@ -986,7 +1018,7 @@ msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:243
+#: ./opengever/meeting/browser/meetings/protocol.py:247
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
@@ -1006,7 +1038,7 @@ msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:41
+#: ./opengever/meeting/model/proposal.py:43
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
 
@@ -1021,7 +1053,7 @@ msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:229
+#: ./opengever/meeting/browser/meetings/agendaitem.py:281
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
@@ -1032,7 +1064,7 @@ msgstr "Teilnehmende"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
 #: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:112
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -1092,17 +1124,32 @@ msgstr "Protokollauszug"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:126
+#: ./opengever/meeting/model/proposal.py:128
 msgid "reject"
 msgstr "Zurückweisen"
 
+#. Default: "Reopen"
+#: ./opengever/meeting/model/agendaitem.py:38
+msgid "reopen"
+msgstr "Wieder eröffnen"
+
+#. Default: "Revise"
+#: ./opengever/meeting/model/agendaitem.py:40
+msgid "revise"
+msgstr "Überarbeiten"
+
+#. Default: "Revision"
+#: ./opengever/meeting/model/agendaitem.py:31
+msgid "revision"
+msgstr "Überarbeitung"
+
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:128
+#: ./opengever/meeting/model/proposal.py:130
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:114
+#: ./opengever/meeting/model/proposal.py:116
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1115,12 +1162,12 @@ msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:126
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/model/proposal.py:114
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1130,7 +1177,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:243
+#: ./opengever/meeting/browser/meetings/agendaitem.py:295
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
@@ -1139,7 +1186,7 @@ msgid "time"
 msgstr "Zeit"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/proposal.py:132
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-25 10:15+0000\n"
+"POT-Creation-Date: 2016-02-25 15:36+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1101,6 +1101,16 @@ msgstr "Zurückgewiesen von ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:114
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Von der Traktandenliste der Sitzung ${meeting} entfernt durch ${user}"
+
+#. Default: "Proposal reopened by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:167
+msgid "proposal_history_label_reopened"
+msgstr "Antrag zur Überarbeitung wiedereröffnet durch ${user}"
+
+#. Default: "Proposal revised by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:179
+msgid "proposal_history_label_revised"
+msgstr "Antragsbeschluss überarbeitet durch ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:100

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-25 10:15+0000\n"
+"POT-Creation-Date: 2016-02-25 15:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1101,6 +1101,16 @@ msgstr ""
 #: ./opengever/meeting/model/proposalhistory.py:114
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Enlevé de l'ordre du jour de la séance ${meeting} par ${user}"
+
+#. Default: "Proposal reopened by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:167
+msgid "proposal_history_label_reopened"
+msgstr ""
+
+#. Default: "Proposal revised by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:179
+msgid "proposal_history_label_revised"
+msgstr ""
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:100

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-15 13:10+0000\n"
+"POT-Creation-Date: 2016-02-25 10:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:309
+#: ./opengever/meeting/command.py:346
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
@@ -25,12 +25,12 @@ msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:69
 msgid "Add Dossier for Meeting"
 msgstr ""
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:56
+#: ./opengever/meeting/browser/meetings/meeting.py:68
 msgid "Add Meeting"
 msgstr "Ajouter la séance"
 
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:342
+#: ./opengever/meeting/command.py:379
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:376
+#: ./opengever/meeting/browser/meetings/meeting.py:404
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -122,7 +122,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:272
+#: ./opengever/meeting/command.py:309
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
@@ -134,11 +134,19 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:84
+#: ./opengever/meeting/command.py:82
+msgid "Excerpt for agenda item ${title} has been generated successfully"
+msgstr ""
+
+#: ./opengever/meeting/command.py:87
+msgid "Excerpt for agenda item ${title} has been updated successfully"
+msgstr ""
+
+#: ./opengever/meeting/command.py:146
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:89
+#: ./opengever/meeting/command.py:151
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -212,7 +220,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:265
+#: ./opengever/meeting/browser/meetings/meeting.py:283
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -263,19 +271,19 @@ msgid "Proposals:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:169
-#: ./opengever/meeting/model/meeting.py:244
+#: ./opengever/meeting/model/meeting.py:245
 msgid "Protocol"
 msgstr "Procès-verbal"
 
-#: ./opengever/meeting/model/meeting.py:247
+#: ./opengever/meeting/model/meeting.py:248
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:46
+#: ./opengever/meeting/command.py:44
 msgid "Protocol for meeting ${title} has been generated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 
-#: ./opengever/meeting/command.py:51
+#: ./opengever/meeting/command.py:49
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
@@ -291,7 +299,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:200
+#: ./opengever/meeting/browser/meetings/protocol.py:204
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr "Enregistrer"
@@ -312,7 +320,7 @@ msgstr "Proposition soumise"
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:219
+#: ./opengever/meeting/browser/meetings/meeting.py:237
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -340,7 +348,11 @@ msgstr ""
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
 
-#: ./opengever/meeting/command.py:225
+#: ./opengever/meeting/browser/excerpt.py:40
+msgid "Updated with a newer excerpt version."
+msgstr ""
+
+#: ./opengever/meeting/command.py:241
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
@@ -350,44 +362,54 @@ msgid "active"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:206
+#: ./opengever/meeting/browser/meetings/agendaitem.py:224
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:182
+#: ./opengever/meeting/browser/meetings/agendaitem.py:200
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:211
+#: ./opengever/meeting/browser/meetings/agendaitem.py:229
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:141
+#: ./opengever/meeting/browser/meetings/agendaitem.py:159
 msgid "agenda_item_order_updated"
 msgstr "Les points de l'ordre du jour ont été actualisés."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:203
+#: ./opengever/meeting/browser/meetings/agendaitem.py:221
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
+#. Default: "Agenda Item successfully reopened."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:249
+msgid "agenda_item_reopened"
+msgstr ""
+
+#. Default: "Agenda Item revised successfully."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:266
+msgid "agenda_item_revised"
+msgstr ""
+
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:158
+#: ./opengever/meeting/browser/meetings/agendaitem.py:176
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:163
+#: ./opengever/meeting/browser/meetings/agendaitem.py:181
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:166
+#: ./opengever/meeting/browser/meetings/meeting.py:184
 msgid "button_cancel"
 msgstr "Annuler"
 
@@ -398,7 +420,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:150
+#: ./opengever/meeting/browser/meetings/meeting.py:168
 msgid "button_continue"
 msgstr ""
 
@@ -504,8 +526,8 @@ msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:35
-#: ./opengever/meeting/model/proposal.py:132
+#: ./opengever/meeting/model/agendaitem.py:36
+#: ./opengever/meeting/model/proposal.py:134
 msgid "decide"
 msgstr "Décider"
 
@@ -516,7 +538,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/proposal.py:117
 msgid "decided"
 msgstr "Décidé"
 
@@ -602,25 +624,25 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:235
+#: ./opengever/meeting/browser/meetings/protocol.py:239
 msgid "label_close"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:37
+#: ./opengever/meeting/browser/meetings/meeting.py:49
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
 msgstr "Commission"
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:132
 #: ./opengever/meeting/proposal.py:117
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
+#: ./opengever/meeting/browser/meetings/protocol.py:147
 #: ./opengever/meeting/proposal.py:78
 msgid "label_copy_for_attention"
 msgstr ""
@@ -655,12 +677,12 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:352
 msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:138
 #: ./opengever/meeting/proposal.py:198
 msgid "label_decision"
 msgstr ""
@@ -671,7 +693,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:332
+#: ./opengever/meeting/browser/meetings/meeting.py:350
 msgid "label_delete_action"
 msgstr ""
 
@@ -681,13 +703,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:144
 #: ./opengever/meeting/proposal.py:73
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:135
 #: ./opengever/meeting/proposal.py:293
 msgid "label_discussion"
 msgstr "Discussion"
@@ -708,12 +730,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:331
+#: ./opengever/meeting/browser/meetings/meeting.py:349
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:329
+#: ./opengever/meeting/browser/meetings/meeting.py:347
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -723,7 +745,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:330
+#: ./opengever/meeting/browser/meetings/meeting.py:348
 msgid "label_edit_save"
 msgstr ""
 
@@ -734,8 +756,8 @@ msgid "label_email"
 msgstr "Email"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:67
+#: ./opengever/meeting/browser/meetings/meeting.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr "Fin"
 
@@ -761,7 +783,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
+#: ./opengever/meeting/browser/meetings/protocol.py:126
 #: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr "Situation initiale"
@@ -778,7 +800,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
+#: ./opengever/meeting/browser/meetings/protocol.py:123
 #: ./opengever/meeting/proposal.py:53
 msgid "label_legal_basis"
 msgstr "Base légale"
@@ -794,8 +816,8 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:58
+#: ./opengever/meeting/browser/meetings/meeting.py:54
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Site"
 
@@ -830,7 +852,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:344
+#: ./opengever/meeting/browser/meetings/meeting.py:372
 msgid "label_no_proposals"
 msgstr ""
 
@@ -840,17 +862,17 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:48
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:40
+#: ./opengever/meeting/browser/meetings/protocol.py:44
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_presidency"
 msgstr "Présidence"
 
@@ -860,18 +882,18 @@ msgid "label_proposal_id"
 msgstr "Numéro de référence"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:129
 #: ./opengever/meeting/proposal.py:63
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py:56
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:141
 #: ./opengever/meeting/proposal.py:68
 msgid "label_publish_in"
 msgstr ""
@@ -886,6 +908,16 @@ msgstr ""
 msgid "label_remove"
 msgstr ""
 
+#. Default: "Reopen this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:355
+msgid "label_reopen_action"
+msgstr ""
+
+#. Default: "Revise this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:358
+msgid "label_revise_action"
+msgstr ""
+
 #. Default: "Role"
 #: ./opengever/meeting/browser/memberships.py:35
 #: ./opengever/meeting/browser/templates/member.pt:52
@@ -898,13 +930,13 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:343
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
 msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:34
+#: ./opengever/meeting/browser/meetings/protocol.py:38
 msgid "label_secretary"
 msgstr "Secrétaire"
 
@@ -914,15 +946,15 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:63
+#: ./opengever/meeting/browser/meetings/meeting.py:59
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/periods.py:23
-#: ./opengever/meeting/committee.py:75
+#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titre"
 
@@ -970,13 +1002,13 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:257
+#: ./opengever/meeting/browser/meetings/protocol.py:261
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/protocol.py:249
+#: ./opengever/meeting/browser/meetings/protocol.py:253
 msgid "message_locked_by_another_user"
 msgstr ""
 
@@ -986,7 +1018,7 @@ msgid "message_record_created"
 msgstr "Enregistrement créé"
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:243
+#: ./opengever/meeting/browser/meetings/protocol.py:247
 msgid "message_write_conflict"
 msgstr ""
 
@@ -1006,7 +1038,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:41
+#: ./opengever/meeting/model/proposal.py:43
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1021,7 +1053,7 @@ msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:229
+#: ./opengever/meeting/browser/meetings/agendaitem.py:281
 msgid "paragraph_added"
 msgstr ""
 
@@ -1032,7 +1064,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
 #: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:112
 msgid "pending"
 msgstr "En modification"
 
@@ -1092,17 +1124,32 @@ msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:126
+#: ./opengever/meeting/model/proposal.py:128
 msgid "reject"
 msgstr ""
 
+#. Default: "Reopen"
+#: ./opengever/meeting/model/agendaitem.py:38
+msgid "reopen"
+msgstr ""
+
+#. Default: "Revise"
+#: ./opengever/meeting/model/agendaitem.py:40
+msgid "revise"
+msgstr ""
+
+#. Default: "Revision"
+#: ./opengever/meeting/model/agendaitem.py:31
+msgid "revision"
+msgstr ""
+
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:128
+#: ./opengever/meeting/model/proposal.py:130
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:114
+#: ./opengever/meeting/model/proposal.py:116
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1115,12 +1162,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:126
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/model/proposal.py:114
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1130,7 +1177,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:243
+#: ./opengever/meeting/browser/meetings/agendaitem.py:295
 msgid "text_added"
 msgstr ""
 
@@ -1139,7 +1186,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/proposal.py:132
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-25 10:15+0000\n"
+"POT-Creation-Date: 2016-02-25 15:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1099,6 +1099,16 @@ msgstr ""
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:114
 msgid "proposal_history_label_remove_scheduled"
+msgstr ""
+
+#. Default: "Proposal reopened by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:167
+msgid "proposal_history_label_reopened"
+msgstr ""
+
+#. Default: "Proposal revised by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:179
+msgid "proposal_history_label_revised"
 msgstr ""
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-15 13:10+0000\n"
+"POT-Creation-Date: 2016-02-25 10:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:309
+#: ./opengever/meeting/command.py:346
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
@@ -25,11 +25,11 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:69
 msgid "Add Dossier for Meeting"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:56
+#: ./opengever/meeting/browser/meetings/meeting.py:68
 msgid "Add Meeting"
 msgstr ""
 
@@ -56,7 +56,7 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:342
+#: ./opengever/meeting/command.py:379
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
@@ -65,7 +65,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:376
+#: ./opengever/meeting/browser/meetings/meeting.py:404
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:272
+#: ./opengever/meeting/command.py:309
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
@@ -133,11 +133,19 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:84
+#: ./opengever/meeting/command.py:82
+msgid "Excerpt for agenda item ${title} has been generated successfully"
+msgstr ""
+
+#: ./opengever/meeting/command.py:87
+msgid "Excerpt for agenda item ${title} has been updated successfully"
+msgstr ""
+
+#: ./opengever/meeting/command.py:146
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:89
+#: ./opengever/meeting/command.py:151
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -211,7 +219,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:265
+#: ./opengever/meeting/browser/meetings/meeting.py:283
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -262,19 +270,19 @@ msgid "Proposals:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:169
-#: ./opengever/meeting/model/meeting.py:244
+#: ./opengever/meeting/model/meeting.py:245
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:247
+#: ./opengever/meeting/model/meeting.py:248
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:46
+#: ./opengever/meeting/command.py:44
 msgid "Protocol for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:51
+#: ./opengever/meeting/command.py:49
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -290,7 +298,7 @@ msgstr ""
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:200
+#: ./opengever/meeting/browser/meetings/protocol.py:204
 #: ./opengever/meeting/form.py:42
 msgid "Save"
 msgstr ""
@@ -311,7 +319,7 @@ msgstr ""
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:219
+#: ./opengever/meeting/browser/meetings/meeting.py:237
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -339,7 +347,11 @@ msgstr ""
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
-#: ./opengever/meeting/command.py:225
+#: ./opengever/meeting/browser/excerpt.py:40
+msgid "Updated with a newer excerpt version."
+msgstr ""
+
+#: ./opengever/meeting/command.py:241
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
@@ -349,44 +361,54 @@ msgid "active"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:206
+#: ./opengever/meeting/browser/meetings/agendaitem.py:224
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:182
+#: ./opengever/meeting/browser/meetings/agendaitem.py:200
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:211
+#: ./opengever/meeting/browser/meetings/agendaitem.py:229
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:141
+#: ./opengever/meeting/browser/meetings/agendaitem.py:159
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:203
+#: ./opengever/meeting/browser/meetings/agendaitem.py:221
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
+#. Default: "Agenda Item successfully reopened."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:249
+msgid "agenda_item_reopened"
+msgstr ""
+
+#. Default: "Agenda Item revised successfully."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:266
+msgid "agenda_item_revised"
+msgstr ""
+
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:158
+#: ./opengever/meeting/browser/meetings/agendaitem.py:176
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:163
+#: ./opengever/meeting/browser/meetings/agendaitem.py:181
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:166
+#: ./opengever/meeting/browser/meetings/meeting.py:184
 msgid "button_cancel"
 msgstr ""
 
@@ -397,7 +419,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:150
+#: ./opengever/meeting/browser/meetings/meeting.py:168
 msgid "button_continue"
 msgstr ""
 
@@ -503,8 +525,8 @@ msgid "column_to"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:35
-#: ./opengever/meeting/model/proposal.py:132
+#: ./opengever/meeting/model/agendaitem.py:36
+#: ./opengever/meeting/model/proposal.py:134
 msgid "decide"
 msgstr ""
 
@@ -515,7 +537,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:115
+#: ./opengever/meeting/model/proposal.py:117
 msgid "decided"
 msgstr ""
 
@@ -601,25 +623,25 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:235
+#: ./opengever/meeting/browser/meetings/protocol.py:239
 msgid "label_close"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:37
+#: ./opengever/meeting/browser/meetings/meeting.py:49
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:132
 #: ./opengever/meeting/proposal.py:117
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
+#: ./opengever/meeting/browser/meetings/protocol.py:147
 #: ./opengever/meeting/proposal.py:78
 msgid "label_copy_for_attention"
 msgstr ""
@@ -654,12 +676,12 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:352
 msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:138
 #: ./opengever/meeting/proposal.py:198
 msgid "label_decision"
 msgstr ""
@@ -670,7 +692,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:332
+#: ./opengever/meeting/browser/meetings/meeting.py:350
 msgid "label_delete_action"
 msgstr ""
 
@@ -680,13 +702,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:144
 #: ./opengever/meeting/proposal.py:73
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:135
 #: ./opengever/meeting/proposal.py:293
 msgid "label_discussion"
 msgstr ""
@@ -707,12 +729,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:331
+#: ./opengever/meeting/browser/meetings/meeting.py:349
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:329
+#: ./opengever/meeting/browser/meetings/meeting.py:347
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -722,7 +744,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:330
+#: ./opengever/meeting/browser/meetings/meeting.py:348
 msgid "label_edit_save"
 msgstr ""
 
@@ -733,8 +755,8 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:51
-#: ./opengever/meeting/browser/meetings/protocol.py:67
+#: ./opengever/meeting/browser/meetings/meeting.py:63
+#: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr ""
 
@@ -760,7 +782,7 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:122
+#: ./opengever/meeting/browser/meetings/protocol.py:126
 #: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr ""
@@ -777,7 +799,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:119
+#: ./opengever/meeting/browser/meetings/protocol.py:123
 #: ./opengever/meeting/proposal.py:53
 msgid "label_legal_basis"
 msgstr ""
@@ -793,8 +815,8 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:42
-#: ./opengever/meeting/browser/meetings/protocol.py:58
+#: ./opengever/meeting/browser/meetings/meeting.py:54
+#: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr ""
 
@@ -829,7 +851,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:344
+#: ./opengever/meeting/browser/meetings/meeting.py:372
 msgid "label_no_proposals"
 msgstr ""
 
@@ -839,17 +861,17 @@ msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:48
+#: ./opengever/meeting/browser/meetings/protocol.py:52
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:40
+#: ./opengever/meeting/browser/meetings/protocol.py:44
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/protocol.py:33
 msgid "label_presidency"
 msgstr ""
 
@@ -859,18 +881,18 @@ msgid "label_proposal_id"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:129
 #: ./opengever/meeting/proposal.py:63
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py:56
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:141
 #: ./opengever/meeting/proposal.py:68
 msgid "label_publish_in"
 msgstr ""
@@ -885,6 +907,16 @@ msgstr ""
 msgid "label_remove"
 msgstr ""
 
+#. Default: "Reopen this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:355
+msgid "label_reopen_action"
+msgstr ""
+
+#. Default: "Revise this agenda item"
+#: ./opengever/meeting/browser/meetings/meeting.py:358
+msgid "label_revise_action"
+msgstr ""
+
 #. Default: "Role"
 #: ./opengever/meeting/browser/memberships.py:35
 #: ./opengever/meeting/browser/templates/member.pt:52
@@ -897,13 +929,13 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:343
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
 msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:34
+#: ./opengever/meeting/browser/meetings/protocol.py:38
 msgid "label_secretary"
 msgstr ""
 
@@ -913,15 +945,15 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:47
-#: ./opengever/meeting/browser/meetings/protocol.py:63
+#: ./opengever/meeting/browser/meetings/meeting.py:59
+#: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/periods.py:23
-#: ./opengever/meeting/committee.py:75
+#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr ""
 
@@ -969,13 +1001,13 @@ msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:257
+#: ./opengever/meeting/browser/meetings/protocol.py:261
 #: ./opengever/meeting/form.py:122
 msgid "message_changes_saved"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/protocol.py:249
+#: ./opengever/meeting/browser/meetings/protocol.py:253
 msgid "message_locked_by_another_user"
 msgstr ""
 
@@ -985,7 +1017,7 @@ msgid "message_record_created"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:243
+#: ./opengever/meeting/browser/meetings/protocol.py:247
 msgid "message_write_conflict"
 msgstr ""
 
@@ -1005,7 +1037,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:41
+#: ./opengever/meeting/model/proposal.py:43
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1020,7 +1052,7 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:229
+#: ./opengever/meeting/browser/meetings/agendaitem.py:281
 msgid "paragraph_added"
 msgstr ""
 
@@ -1031,7 +1063,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
 #: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:110
+#: ./opengever/meeting/model/proposal.py:112
 msgid "pending"
 msgstr ""
 
@@ -1091,17 +1123,32 @@ msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:126
+#: ./opengever/meeting/model/proposal.py:128
 msgid "reject"
 msgstr ""
 
+#. Default: "Reopen"
+#: ./opengever/meeting/model/agendaitem.py:38
+msgid "reopen"
+msgstr ""
+
+#. Default: "Revise"
+#: ./opengever/meeting/model/agendaitem.py:40
+msgid "revise"
+msgstr ""
+
+#. Default: "Revision"
+#: ./opengever/meeting/model/agendaitem.py:31
+msgid "revision"
+msgstr ""
+
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:128
+#: ./opengever/meeting/model/proposal.py:130
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:114
+#: ./opengever/meeting/model/proposal.py:116
 msgid "scheduled"
 msgstr ""
 
@@ -1114,12 +1161,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:126
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:112
+#: ./opengever/meeting/model/proposal.py:114
 msgid "submitted"
 msgstr ""
 
@@ -1129,7 +1176,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:243
+#: ./opengever/meeting/browser/meetings/agendaitem.py:295
 msgid "text_added"
 msgstr ""
 
@@ -1138,7 +1185,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/proposal.py:132
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -32,7 +32,9 @@ class AgendaItem(Base):
     workflow = Workflow(
         [STATE_PENDING, STATE_DECIDED],
         [Transition('pending', 'decided',
-                    title=_('decide', default='Decide'))]
+                    title=_('decide', default='Decide')),
+         Transition('decided', 'pending',
+                    title=_('revise', default='Revise'))]
     )
 
     agenda_item_id = Column("id", Integer, Sequence("agendaitems_id_seq"),
@@ -267,3 +269,9 @@ class AgendaItem(Base):
             self.proposal.decide()
 
         self.workflow.execute_transition(None, self, 'pending-decided')
+
+    def revise(self):
+        self.workflow.execute_transition(None, self, 'decided-pending')
+
+    def is_revise_possible(self):
+        return self.get_state() == self.STATE_DECIDED

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -252,6 +252,20 @@ class AgendaItem(Base):
     def has_submitted_excerpt_document(self):
         return self.has_proposal and self.proposal.has_submitted_excerpt_document()
 
+    def close(self):
+        """Close the agenda item.
+
+        Can be called to close an agenda item, this puts the agenda item in
+        decided state using the correct transitions. Currently valid states
+        are:
+        decided: do nothing
+        pending: decide
+        revision: revise
+        """
+        if self.is_revise_possible():
+            self.revise()
+        self.decide()
+
     def is_decide_possible(self):
         if not self.is_paragraph:
             return self.get_state() == self.STATE_PENDING

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -274,6 +274,8 @@ class AgendaItem(Base):
         self.workflow.execute_transition(None, self, 'pending-decided')
 
     def reopen(self):
+        if self.has_proposal:
+            self.proposal.reopen(self)
         self.workflow.execute_transition(None, self, 'decided-revision')
 
     def is_reopen_possible(self):

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -28,13 +28,15 @@ class AgendaItem(Base):
     STATE_PENDING = State('pending', is_default=True,
                           title=_('pending', default='Pending'))
     STATE_DECIDED = State('decided', title=_('decided', default='Decided'))
+    STATE_REVISION = State('revision', title=_('revision', default='Revision'))
 
     workflow = Workflow(
-        [STATE_PENDING, STATE_DECIDED],
+        [STATE_PENDING, STATE_DECIDED, STATE_REVISION],
         [Transition('pending', 'decided',
                     title=_('decide', default='Decide')),
-         Transition('decided', 'pending',
-                    title=_('revise', default='Revise'))]
+         Transition('decided', 'revision',
+                    title=_('reopen', default='Reopen')),
+         ]
     )
 
     agenda_item_id = Column("id", Integer, Sequence("agendaitems_id_seq"),
@@ -270,8 +272,8 @@ class AgendaItem(Base):
 
         self.workflow.execute_transition(None, self, 'pending-decided')
 
-    def revise(self):
-        self.workflow.execute_transition(None, self, 'decided-pending')
+    def reopen(self):
+        self.workflow.execute_transition(None, self, 'decided-revision')
 
-    def is_revise_possible(self):
+    def is_reopen_possible(self):
         return self.get_state() == self.STATE_DECIDED

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -201,14 +201,14 @@ class Meeting(Base):
 
          - generate and set the meeting number
          - generate decision numbers for each agenda_item
-         - decide each agenda item (generates proposal excerpt
+         - close each agenda item (generates proposal excerpt
            and change workflow state)
          - update and unlock the protocol document
         """
 
         self.hold()
         for agenda_item in self.agenda_items:
-            agenda_item.decide()
+            agenda_item.close()
 
         self.update_protocol_document()
         self.unlock_protocol_document()

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -174,7 +174,7 @@ class Meeting(Base):
         operations = ProtocolOperations()
         if self.has_protocol_document():
             command = UpdateGeneratedDocumentCommand(
-                self.protocol_document, operations)
+                self.protocol_document, self, operations)
         else:
             command = CreateGeneratedDocumentCommand(
                 self.get_dossier(), self, operations,

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -284,6 +284,11 @@ class Proposal(Base):
     def revise(self, agenda_item):
         assert self.get_state() == self.STATE_DECIDED
         self.update_excerpt(agenda_item)
+        self.session.add(proposalhistory.ProposalRevised(proposal=self))
+
+    def reopen(self, agenda_item):
+        assert self.get_state() == self.STATE_DECIDED
+        self.session.add(proposalhistory.ProposalReopened(proposal=self))
 
     def update_excerpt(self, agenda_item):
         operations = ExcerptOperations(agenda_item)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -297,6 +297,7 @@ class Proposal(Base):
         self.generate_excerpt(agenda_item)
         document_intid = self.copy_excerpt_to_proposal_dossier()
         self.register_excerpt(document_intid)
+        self.session.add(proposalhistory.ProposalDecided(proposal=self))
         self.execute_transition('scheduled-decided')
 
     def register_excerpt(self, document_intid):
@@ -308,9 +309,7 @@ class Proposal(Base):
                                    int_id=document_intid,
                                    generated_version=version)
         self.session.add(excerpt)
-
         self.excerpt_document = excerpt
-        self.session.add(proposalhistory.ProposalDecided(proposal=self))
 
     def copy_excerpt_to_proposal_dossier(self):
         """Copies the submitted excerpt to the source dossier and returns

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -155,3 +155,27 @@ class ProposalDecided(ProposalHistory):
         return _(u'proposal_history_label_decided',
                  u'Proposal decided by ${user}',
                  mapping={'user': self.get_actor_link()})
+
+
+class ProposalReopened(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'reopened'}
+
+    css_class = 'reopened'
+
+    def message(self):
+        return _(u'proposal_history_label_reopened',
+                 u'Proposal reopened by ${user}',
+                 mapping={'user': self.get_actor_link()})
+
+
+class ProposalRevised(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'revised'}
+
+    css_class = 'revised'
+
+    def message(self):
+        return _(u'proposal_history_label_revised',
+                 u'Proposal revised by ${user}',
+                 mapping={'user': self.get_actor_link()})

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Meeting
+from opengever.meeting.model import Proposal
 from opengever.meeting.model.agendaitem import AgendaItem
 from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
@@ -316,10 +317,10 @@ class TestAgendaItemDecide(TestAgendaItem):
         self.assertEquals(None, browser.json.get('redirectUrl'))
 
 
-class TestAgendaItemRevise(TestAgendaItem):
+class TestAgendaItemReopen(TestAgendaItem):
 
     @browsing
-    def test_revise_agenda_item(self, browser):
+    def test_ropen_agenda_item(self, browser):
         proposal = create(Builder('proposal')
                           .within(self.dossier)
                           .having(committee=self.committee.load_model())
@@ -334,14 +335,14 @@ class TestAgendaItemRevise(TestAgendaItem):
 
         browser.login().open(
             self.meeting_wrapper,
-            view='agenda_items/{}/revise'.format(item.agenda_item_id))
+            view='agenda_items/{}/reopen'.format(item.agenda_item_id))
         transaction.commit()
 
-        self.assertEquals(AgendaItem.STATE_PENDING,
+        self.assertEquals(AgendaItem.STATE_REVISION,
                           AgendaItem.query.first().get_state())
-        self.assertEquals(Proposal.STATE_PENDING,
+        self.assertEquals(Proposal.STATE_DECIDED,
                           Proposal.query.first().get_state())
-        self.assertEquals([{u'message': u'Agenda Item successfully revised.',
+        self.assertEquals([{u'message': u'Agenda Item successfully reopened.',
                             u'messageClass': u'info',
                             u'messageTitle': u'Information'}],
                           browser.json.get('messages'))
@@ -350,7 +351,7 @@ class TestAgendaItemRevise(TestAgendaItem):
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
         with self.assertRaises(NotFound):
             browser.login().open(self.meeting_wrapper,
-                                 view='agenda_items/12345/revise')
+                                 view='agenda_items/12345/reopen')
 
     @browsing
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
@@ -363,8 +364,7 @@ class TestAgendaItemRevise(TestAgendaItem):
         with self.assertRaises(Unauthorized):
             browser.login().open(
                 self.meeting_wrapper,
-                view='agenda_items/{}/revise'.format(item.agenda_item_id))
-
+                view='agenda_items/{}/reopen'.format(item.agenda_item_id))
 
 
 class TestAgendaItemUpdateOrder(TestAgendaItem):

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -14,7 +14,6 @@ from zExceptions import Unauthorized
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 import json
-import transaction
 
 
 class TestAgendaItem(FunctionalTestCase):
@@ -31,7 +30,10 @@ class TestAgendaItem(FunctionalTestCase):
             Builder('dossier').within(self.repository_folder))
         self.meeting_dossier = create(
             Builder('meeting_dossier').within(self.repository_folder))
-        self.container = create(Builder('committee_container'))
+        self.excerpt_template = create(Builder('sablontemplate')
+                                       .with_asset_file('excerpt_template.docx'))
+        self.container = create(Builder('committee_container')
+                                .having(excerpt_template=self.excerpt_template))
         self.committee = create(Builder('committee').within(self.container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model())
@@ -320,7 +322,8 @@ class TestAgendaItemDecide(TestAgendaItem):
 class TestAgendaItemReopen(TestAgendaItem):
 
     @browsing
-    def test_ropen_agenda_item(self, browser):
+    def test_reopen_agenda_item(self, browser):
+
         proposal = create(Builder('proposal')
                           .within(self.dossier)
                           .having(committee=self.committee.load_model())
@@ -335,8 +338,8 @@ class TestAgendaItemReopen(TestAgendaItem):
 
         browser.login().open(
             self.meeting_wrapper,
-            view='agenda_items/{}/reopen'.format(item.agenda_item_id))
-        transaction.commit()
+            view='agenda_items/{}/reopen'.format(item.agenda_item_id),
+            data={'_authenticator': createToken()})
 
         self.assertEquals(AgendaItem.STATE_REVISION,
                           AgendaItem.query.first().get_state())
@@ -365,6 +368,81 @@ class TestAgendaItemReopen(TestAgendaItem):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/reopen'.format(item.agenda_item_id))
+
+
+class TestAgendaItemRevise(TestAgendaItem):
+
+    @browsing
+    def test_revise_agenda_item(self, browser):
+        excerpt_document = create(Builder('document')
+                                  .titled(u'Excerpt')
+                                  .attach_file_containing(u"excerpt",
+                                                          u"excerpt.docx")
+                                  .within(self.dossier))
+        submitted_excerpt_document = create(Builder('document')
+                                            .titled(u'Excerpt')
+                                            .attach_file_containing(
+                                                u"excerpt", u"excerpt.docx")
+                                            .within(self.dossier))
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .having(committee=self.committee.load_model())
+                          .as_submitted())
+
+        excerpt = create(Builder('generated_excerpt')
+                         .for_document(excerpt_document))
+        submitted_excerpt = create(Builder('generated_excerpt')
+                                   .for_document(submitted_excerpt_document))
+        proposal_model = proposal.load_model()
+        proposal_model.workflow_state = 'decided'
+        proposal_model.excerpt_document = excerpt
+        proposal_model.submitted_excerpt_document = submitted_excerpt
+
+        item = create(Builder('agenda_item').having(
+            title=u'foo',
+            meeting=self.meeting,
+            workflow_state='revision',
+            proposal=proposal.load_model()))
+
+        self.assertEqual(0, excerpt_document.get_current_version())
+        self.assertEqual(0, submitted_excerpt_document.get_current_version())
+
+        browser.login().open(
+            self.meeting_wrapper,
+            view='agenda_items/{}/revise'.format(item.agenda_item_id),
+            data={'_authenticator': createToken()})
+
+        self.assertEquals(AgendaItem.STATE_DECIDED,
+                          AgendaItem.query.first().get_state())
+        self.assertEquals(Proposal.STATE_DECIDED,
+                          Proposal.query.first().get_state())
+        self.assertEquals([{u'message': u'Agenda Item revised successfully.',
+                            u'messageClass': u'info',
+                            u'messageTitle': u'Information'}],
+                          browser.json.get('messages'))
+        self.assertEqual(1, excerpt_document.get_current_version(),
+                         "Excerpt document should be updated with a new version.")
+        self.assertEqual(1, submitted_excerpt_document.get_current_version(),
+                         "Submitted excerpt document should be updated with a new version.")
+
+    @browsing
+    def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
+        with self.assertRaises(NotFound):
+            browser.login().open(self.meeting_wrapper,
+                                 view='agenda_items/12345/revise')
+
+    @browsing
+    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+        item = create(Builder('agenda_item').having(
+            title=u'foo', meeting=self.meeting))
+        item.decide()
+
+        self.meeting.workflow_state = 'closed'
+
+        with self.assertRaises(Unauthorized):
+            browser.login().open(
+                self.meeting_wrapper,
+                view='agenda_items/{}/revise'.format(item.agenda_item_id))
 
 
 class TestAgendaItemUpdateOrder(TestAgendaItem):

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -1,6 +1,4 @@
-from datetime import date
 from datetime import datetime
-from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -109,6 +107,9 @@ class TestMeeting(FunctionalTestCase):
                          .link_with(self.meeting_dossier))
         create(Builder('agenda_item').having(meeting=meeting,
                                              title='Mach ize'))
+        create(Builder('agenda_item').having(meeting=meeting,
+                                             title='Oebbis in revision',
+                                             workflow_state='revision'))
 
         browser.login().open(meeting.get_url())
         browser.find(close_meeting_button_name).click()

--- a/opengever/meeting/tests/test_unit_agenda_item.py
+++ b/opengever/meeting/tests/test_unit_agenda_item.py
@@ -79,6 +79,38 @@ class TestUnitAgendaItem(TestCase):
                           'link': u'<a href="http://example.com/public/meetings/proposal-1" title="Pr\xf6posal">Pr\xf6posal</a>'},
                          self.proposal_agenda_item.serialize())
 
+    def test_reopen_is_only_possible_if_agenda_item_is_decided(self):
+        self.assertFalse(
+            self.simple_agenda_item.is_reopen_possible())
+
+        self.simple_agenda_item.workflow_state = 'decided'
+        self.assertTrue(
+            self.simple_agenda_item.is_reopen_possible())
+
+    def test_reopen_is_not_possible_for_paragraphs(self):
+        item = create(Builder('agenda_item')
+                      .having(is_paragraph=True, meeting=self.meeting))
+        self.assertFalse(item.is_reopen_possible())
+
+        item.workflow_state = 'decided'
+        self.assertFalse(item.is_reopen_possible())
+
+    def test_revise_is_only_possible_if_agenda_item_is_in_revision(self):
+        self.assertFalse(
+            self.simple_agenda_item.is_revise_possible())
+
+        self.simple_agenda_item.workflow_state = 'revision'
+        self.assertTrue(
+            self.simple_agenda_item.is_revise_possible())
+
+    def test_revise_is_not_possible_for_paragraphs(self):
+        item = create(Builder('agenda_item')
+                      .having(is_paragraph=True, meeting=self.meeting))
+        self.assertFalse(item.is_revise_possible())
+
+        item.workflow_state = 'revision'
+        self.assertFalse(item.is_revise_possible())
+
     def test_decide_is_only_possible_if_agenda_item_is_pending(self):
         self.assertTrue(
             self.simple_agenda_item.is_decide_possible())


### PR DESCRIPTION
Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/416

Traktanden können überarbeitet werden solange die Sitzung nicht abgeschlossen wurde.

Wieder eröffnen:
Wieder eröffnen entsperrt den Text in der Protokollmaske.

Überarbeiten:
Überarbeiten sperrt den text in der Protokollmaske, die Protokollauszüge des Antrags werden neu generiert.

![revision](https://cloud.githubusercontent.com/assets/736583/13325818/b8193c00-dbe3-11e5-8e6e-265e37b5017a.gif)

Closes #1356.