### PR TITLE
Abgelaufene Dokumente können im Auftrag aktualisiert werden.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add a link to update an outdated document from the proposal view.
+  [elioschmutz]
+
 - Prevent creating a mail-copy in the dossier when sending documents
   from a closed dossiers.
   [elioschmutz]

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -26,12 +26,38 @@
               <th i18n:translate="label_attachments">Attachments</th>
               <td>
                 <ul>
-                  <li tal:repeat="item documents">
-                    <a href="" tal:attributes="href item/absolute_url;
-                    title python: getattr(item, 'document_date', None) and item.document_date.strftime('%d.%m.%Y') or '';
-                    class python:view.get_css_class(item)">
-                      <span class="document" tal:condition="item/absolute_url" tal:content="item/Title" />
+                  <li tal:repeat="document documents">
+
+                    <a href="" tal:attributes="href document/absolute_url;
+                    title python: getattr(document, 'document_date', None) and document.document_date.strftime('%d.%m.%Y') or '';
+                    class python:view.get_css_class(document)">
+                      <span class="document" tal:condition="document/absolute_url" tal:content="document/Title" />
                     </a>
+
+                    <tal:enable tal:condition="view/is_update_outdated_endabled">
+                      <tal:outdated
+                          tal:define="submitted_document python:view.get_submitted_document(document)"
+                          tal:condition="python: submitted_document and view.is_outdated(document, submitted_document)"
+                          i18n:domain="opengever.document">
+
+                          <span class="discreet">
+                            —
+                            <div tal:replace="python: view.render_submitted_version(submitted_document)"></div>
+                            —
+                            <div tal:replace="python: view.render_current_document_version(document)"></div>
+                          </span>
+
+                        <div class="updateActions">
+                          <a class="outdated"
+                             tal:attributes="href python: view.get_update_document_url(document);"
+                             i18n:translate="">
+                            Update document in proposal
+                          </a>
+                        </div>
+                      </tal:outdated>
+                    </tal:enable>
+
+
                   </li>
                 </ul>
               </td>

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -62,6 +62,10 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
         disable_edit_bar()
         return super(SubmitAdditionalDocuments, self).__call__()
 
+    def update(self):
+        self._preselect_proposal()
+        return super(SubmitAdditionalDocuments, self).update()
+
     def available(self):
         return is_meeting_feature_enabled() and \
             self.context.is_submit_additional_documents_allowed()
@@ -86,6 +90,13 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
 
     def nextURL(self):
         return self.context.absolute_url()
+
+    def _preselect_proposal(self):
+        document_path = self.request.get('document_path')
+        if not document_path:
+            return
+
+        self.request.set('form.widgets.additionalDocuments', document_path)
 
 
 class ISubmitDocumentsByPaths(ISubmitAdditionalDocument):


### PR DESCRIPTION
Abgelaufene Dokumente können im Auftrag aktualisiert werden.

<img width="537" alt="bildschirmfoto 2016-02-25 um 14 57 46" src="https://cloud.githubusercontent.com/assets/557005/13325999/70c7d1da-dbe4-11e5-94de-74d4384ac041.png">

SubittedProposals werden wie bisher angezeigt.

closes #936 