### PR TITLE
Avoid some more infinite loops for non-acquisition wrapped contexts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Avoid infinite loops in find_parent_dossier() and set_default_with_acquisition()
+  if context is not acquisition wrapped.
+  [lgraf]
+
 - Add an editable title to meeting objects.
   The user can set the title for a meeting manually now. Per default,
   the title will be the name of the committee and the date.

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -157,7 +157,7 @@ def set_default_with_acquisition(field, default=None):
     def default_value_generator(data):
         obj = data.context
         # try to get it from context or a parent
-        while not ISiteRoot.providedBy(obj):
+        while obj and not ISiteRoot.providedBy(obj):
             try:
                 interface_ = data.field.interface
             except AttributeError:

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -48,7 +48,7 @@ def find_parent_dossier(content):
     if IPloneSiteRoot.providedBy(content):
         raise ValueError('Site root passed as argument.')
 
-    while not IDossierMarker.providedBy(content):
+    while content and not IDossierMarker.providedBy(content):
         content = aq_parent(aq_inner(content))
         if IPloneSiteRoot.providedBy(content):
             raise ValueError('Site root reached while searching '


### PR DESCRIPTION
Avoid infinite loops in `find_parent_dossier()` and `set_default_with_acquisition()` if context is not acquisition wrapped.

@deiferni 