### PR TITLE
Add trix configuration to prevent adding unsupported content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add trix customizations, prevent pasting links.
+  [deiferni]
+
 - Avoid infinite loops in find_parent_dossier() and set_default_with_acquisition()
   if context is not acquisition wrapped.
   [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
-- Add trix customizations, prevent pasting links and accepting file-uploads.
+- Add trix customizations to prevent accepting unsupported content.
+  We don't support links, quotes, code-blocks and file uploads of any kind.
   [deiferni]
 
 - Avoid infinite loops in find_parent_dossier() and set_default_with_acquisition()

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
-- Add trix customizations, prevent pasting links.
+- Add trix customizations, prevent pasting links and accepting file-uploads.
   [deiferni]
 
 - Avoid infinite loops in find_parent_dossier() and set_default_with_acquisition()

--- a/opengever/base/browser/resources/trix-custom.js
+++ b/opengever/base/browser/resources/trix-custom.js
@@ -1,0 +1,5 @@
+/*
+Remove links from trix document model to prevent that links can be copy-pasted
+into trix even though we have disabled the link buttons.
+ */
+delete Trix.config.textAttributes.href

--- a/opengever/base/browser/resources/trix-custom.js
+++ b/opengever/base/browser/resources/trix-custom.js
@@ -1,14 +1,26 @@
-/*
-Remove links from trix document model to prevent that links can be copy-pasted
-into trix even though we have disabled the link buttons.
- */
-delete Trix.config.textAttributes.href
+(function ($) {
 
-/*
-Prevent accepting file-uploads in trix.
- */
-$(function() {
-    $('trix-editor').on('trix-file-accept', function(event) {
-        event.preventDefault();
+    'use strict';
+
+    /*
+    Remove pre, blockquote and links from trix document model to prevent that they can
+    be inserted with copy-paste.
+     */
+    delete Trix.config.blockAttributes.code;
+    delete Trix.config.blockAttributes.quote;
+    delete Trix.config.textAttributes.href;
+
+    /*
+    Prevent accepting file-uploads and attachments in trix.
+     */
+    $(function () {
+        var trixEditor = $('trix-editor');
+        trixEditor.on('trix-file-accept', function (event) {
+            event.preventDefault();
+        });
+        trixEditor.on("trix-attachment-add", function (event) {
+            event.originalEvent.attachment.remove();
+        });
     });
-});
+
+}(jQuery));

--- a/opengever/base/browser/resources/trix-custom.js
+++ b/opengever/base/browser/resources/trix-custom.js
@@ -3,3 +3,12 @@ Remove links from trix document model to prevent that links can be copy-pasted
 into trix even though we have disabled the link buttons.
  */
 delete Trix.config.textAttributes.href
+
+/*
+Prevent accepting file-uploads in trix.
+ */
+$(function() {
+    $('trix-editor').on('trix-file-accept', function(event) {
+        event.preventDefault();
+    });
+});

--- a/opengever/base/profiles/default/jsregistry.xml
+++ b/opengever/base/profiles/default/jsregistry.xml
@@ -49,6 +49,10 @@
                 insert-after="++resource++plone.app.jquery.js" />
 
     <javascript cacheable="True" compression="none" cookable="True" enabled="on"
+                expression="" id="++resource++opengever.base/trix-custom.js" inline="False"
+                insert-after="++resource++opengever.base/trix.js" />
+
+    <javascript cacheable="True" compression="none" cookable="True" enabled="on"
                 expression="" id="++resource++opengever.base/SelectAutocomplete.js" inline="False"
                 insert-after="++resource++plone.app.jquery.js" />
 

--- a/opengever/base/upgrades/20160229120650_add_trix_customizations/jsregistry.xml
+++ b/opengever/base/upgrades/20160229120650_add_trix_customizations/jsregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+    <javascript cacheable="True" compression="none" cookable="True" enabled="on"
+                expression="" id="++resource++opengever.base/trix-custom.js" inline="False"
+                insert-after="++resource++opengever.base/trix.js" />
+
+</object>

--- a/opengever/base/upgrades/20160229120650_add_trix_customizations/upgrade.py
+++ b/opengever/base/upgrades/20160229120650_add_trix_customizations/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddTrixCustomizations(UpgradeStep):
+    """Add trix customizations.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Add trix customizations to prevent accepting unsupported content.
We don't support links, quotes, code-blocks and file uploads of any kind.

Fixes #1625.