### PR TITLE
Email-Adressen von Teilnehmern werden in Meetings angezeigt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.3 (unreleased)
 ------------------
 
+- Show email addresses of participant in a meeting or a meeting protocol.
+  [elioschmutz]
+
 - Add API documentation (Sphinx).
   [lgraf]
 

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -128,3 +128,11 @@ class TestEscapeHTML(TestCase):
     def test_escapes_ampersand(self):
         text = "Foo &Bar& Baz"
         self.assertEquals('Foo &amp;Bar&amp; Baz', escape_html(text))
+
+    def test_escapes_empty_string_returns_empty_string(self):
+        text = ''
+        self.assertEquals('', escape_html(text))
+
+    def test_escapes_none_returns_none(self):
+        text = None
+        self.assertEquals(None, escape_html(text))

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -108,6 +108,9 @@ def escape_html(text):
 
     See: https://wiki.python.org/moin/EscapingHtml
     """
+    if text is None:
+        return None
+
     # escape() and unescape() takes care of &, < and >, but not quotes
     html_escape_table = {
         '"': "&quot;",

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -1,5 +1,3 @@
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from five import grok
 from opengever.base.browser.helper import get_css_class
 from opengever.base.browser.wizard import BaseWizardStepForm
@@ -19,6 +17,8 @@ from plone import api
 from plone.dexterity.i18n import MessageFactory as pd_mf
 from plone.directives import form
 from plone.z3cform.layout import FormWrapper
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.form import Form

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -128,14 +128,14 @@
                     i18n:attributes="title"
                     title="presidency"></dt>
                 <dd tal:condition="meeting/presidency"
-                    tal:content="meeting/presidency/fullname"></dd>
+                    tal:content="structure meeting/presidency/get_title"></dd>
 
                 <dt id="meeting_secretary"
                     tal:condition="meeting/secretary"
                     i18n:attributes="title"
                     title="secretary"></dt>
                 <dd tal:condition="meeting/secretary"
-                    tal:content="meeting/secretary/fullname"></dd>
+                    tal:content="structure meeting/secretary/get_title"></dd>
 
                 <dt id="meeting_participants"
                     i18n:attributes="title"
@@ -143,7 +143,7 @@
                 <dd>
                   <ul>
                     <li tal:repeat="participant meeting/participants"
-                        tal:content="participant/fullname"></li>
+                        tal:content="structure participant/get_title"></li>
                   </ul>
                 </dd>
 

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -48,10 +48,10 @@ SAMPLE_MEETING_DATA = {
     'committee': {'name': u'Gemeinderat'},
     'participants': {
         'presidency': u'Peter M\xfcller',
-        'secretary': u'Franz M\xfcller',
+        'secretary': u'Franz M\xfcller (mueller@example.com)',
         'members': [{'fullname': u'Peter M\xfcller',
                     'role': u'F\xfcrst'},
-                   {'fullname': u'Franz M\xfcller',
+                   {'fullname': u'Franz M\xfcller (mueller@example.com)',
                     'role': None}],
         'other': [u'Hans M\xfcller', u'Heidi Muster']},
     'protocol': {'type': u'Protocol'}}

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -63,3 +63,17 @@ class Member(Base):
     def update_model(self, data):
         for key, value in data.items():
             setattr(self, key, value)
+
+    def get_title(self, show_email_as_link=True):
+        fullname = escape_html(self.fullname)
+        email = escape_html(self.email)
+
+        if not email:
+            return fullname
+
+        if show_email_as_link:
+            email = '<a href="mailto:{email}">{email}</a>'.format(email=email)
+
+        participant = u'{} ({})'.format(fullname, email)
+
+        return participant

--- a/opengever/meeting/protocol.py
+++ b/opengever/meeting/protocol.py
@@ -1,3 +1,4 @@
+from opengever.base.utils import escape_html
 from opengever.meeting import _
 from opengever.meeting.model.membership import Membership
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -65,13 +66,14 @@ class ProtocolData(object):
             membership = Membership.query.fetch_for_meeting(
                 self.meeting, participant)
             members.append({
-                "fullname": participant.fullname,
+                "fullname": participant.get_title(show_email_as_link=False),
                 "role": membership.role if membership else None
             })
 
         participants = {
             'members': members
         }
+
         return participants
 
     def add_participants(self):
@@ -83,9 +85,11 @@ class ProtocolData(object):
         participants['other'] = other_participants
 
         if self.meeting.presidency:
-            participants['presidency'] = self.meeting.presidency.fullname
+            participants['presidency'] = self.meeting.presidency.get_title(
+                show_email_as_link=False)
         if self.meeting.secretary:
-            participants['secretary'] = self.meeting.secretary.fullname
+            participants['secretary'] = self.meeting.secretary.get_title(
+                show_email_as_link=False)
 
         self.data['participants'] = participants
 

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -6,6 +6,8 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Member
+from opengever.meeting.vocabulary import get_committee_member_vocabulary
+from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
 from pyquery import PyQuery
 
@@ -127,3 +129,76 @@ class TestMeeting(FunctionalTestCase):
              u'initial dossier.'],
             info_messages())
         self.assertIsNone(browser.find(close_meeting_button_name))
+
+
+class TestCommitteeMemberVocabulary(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestCommitteeMemberVocabulary, self).setUp()
+
+        self.admin_unit.public_url = 'http://nohost/plone'
+
+        self.repo = create(Builder('repository_root'))
+        self.repository_folder = create(Builder('repository')
+                                        .within(self.repo))
+
+        self.container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee')
+                                .within(self.container)
+                                .link_with(self.repository_folder))
+
+        self.committee_model = self.committee.load_model()
+
+        self.meeting = create(Builder('meeting').having(
+            committee=self.committee_model))
+
+        self.wrapper = MeetingWrapper(self.committee, self.meeting)
+
+    def test_return_member_as_value(self):
+        member = create(Builder('member').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+
+        create(Builder('membership').having(
+            committee=self.committee_model,
+            member=member))
+
+        vocabulary = get_committee_member_vocabulary(
+            MeetingWrapper(self.committee, self.meeting))
+
+        self.assertEqual(
+            member,
+            vocabulary._terms[0].value)
+
+    def test_return_fullname_as_title(self):
+        member = create(Builder('member').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+
+        create(Builder('membership').having(
+            committee=self.committee_model,
+            member=member))
+
+        vocabulary = get_committee_member_vocabulary(
+            MeetingWrapper(self.committee, self.meeting))
+
+        self.assertEqual(
+            u'Hans M\xfcller',
+            vocabulary._terms[0].title)
+
+    def test_return_fullname_with_email_as_value(self):
+        member = create(Builder('member').having(
+            firstname=u'Hans',
+            lastname=u'M\xfcller',
+            email=u'mueller@example.com'))
+
+        create(Builder('membership').having(
+            committee=self.committee_model,
+            member=member))
+
+        vocabulary = get_committee_member_vocabulary(
+            MeetingWrapper(self.committee, self.meeting))
+
+        self.assertEqual(
+            u'Hans M\xfcller (mueller@example.com)',
+            vocabulary._terms[0].title)

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -53,13 +53,16 @@ class TestMeetingView(FunctionalTestCase):
                                         .for_document(self.excerpt))
 
         self.hugo = create(Builder('member').having(firstname=u'h\xfcgo',
-                                                    lastname="Boss"))
+                                                    lastname="Boss",
+                                                    email="boss@foo.ch"))
 
         self.sile = create(Builder('member').having(firstname="Silvia",
-                                                    lastname="Pangani"))
+                                                    lastname="Pangani",
+                                                    email="pangani@foo.ch"))
 
         self.peter = create(Builder('member').having(firstname="Peter",
-                                                     lastname="Meter"))
+                                                     lastname="Meter",
+                                                     email="meter@foo.ch"))
 
         self.hans = create(Builder('member').having(firstname="Hans",
                                                     lastname="Besen"))
@@ -125,7 +128,9 @@ class TestMeetingView(FunctionalTestCase):
     @browsing
     def test_participants_listing_precidency_is_existing(self, browser):
         browser.login().open(self.meeting.get_url())
-        self.assertEquals([u'h\xfcgo Boss'], browser.css("#meeting_presidency + dd").text)
+        self.assertEquals(
+            [u'h\xfcgo Boss (boss@foo.ch)'],
+            browser.css("#meeting_presidency + dd").text)
 
     @browsing
     def test_participants_listing_no_precidency_must_not_raise(self, browser):
@@ -137,7 +142,9 @@ class TestMeetingView(FunctionalTestCase):
     @browsing
     def test_participants_listing_secretary_is_existing(self, browser):
         browser.login().open(self.meeting.get_url())
-        self.assertEquals(['Silvia Pangani'], browser.css("#meeting_secretary + dd").text)
+        self.assertEquals(
+            [u'Silvia Pangani (pangani@foo.ch)'],
+            browser.css("#meeting_secretary + dd").text)
 
     @browsing
     def test_participants_listing_no_secretary_must_not_raise(self, browser):
@@ -149,8 +156,9 @@ class TestMeetingView(FunctionalTestCase):
     @browsing
     def test_participants_listing_participants_is_existing(self, browser):
         browser.login().open(self.meeting.get_url())
-        self.assertEquals(['Peter Meter Hans Besen Roland Kuppler'],
-                          browser.css("#meeting_participants + dd").text)
+        self.assertEquals(
+            ['Peter Meter (meter@foo.ch) Hans Besen Roland Kuppler'],
+            browser.css("#meeting_participants + dd").text)
 
     @browsing
     def test_participants_listing_empty_participants_must_not_raise(self, browser):

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -459,3 +459,41 @@ class TestProtocol(FunctionalTestCase):
             2, len(browser.css('.trix-input')),
             'Each field should be loaded with the trix editor because '
             'the agenda_item is not decided yet')
+
+
+class TestFormatParticipant(FunctionalTestCase):
+
+    def test_return_fullname_if_no_email(self):
+        member = create(Builder('member').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+
+        self.assertEqual(u'Hans M\xfcller', member.get_title())
+
+    def test_return_fullname_with_email(self):
+        member = create(Builder('member').having(
+            firstname=u'Hans',
+            lastname=u'M\xfcller',
+            email=u'hans.mueller@example.com'))
+
+        self.assertEqual(
+            u'Hans M\xfcller (<a href="mailto:hans.mueller@example.com">hans.mueller@example.com</a>)',
+            member.get_title())
+
+    def test_return_fullname_without_linked_email(self):
+        member = create(Builder('member').having(
+            firstname=u'Hans',
+            lastname=u'M\xfcller',
+            email=u'hans.mueller@example.com'))
+
+        self.assertEqual(
+            u'Hans M\xfcller (hans.mueller@example.com)',
+            member.get_title(show_email_as_link=False))
+
+    def test_result_is_html_escaped(self):
+        member = create(Builder('member').having(
+            firstname=u'<script></script>Hans',
+            lastname=u'M\xfcller'))
+
+        self.assertEqual(
+            u'&lt;script&gt;&lt;/script&gt;Hans M\xfcller',
+            member.get_title())

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -30,7 +30,8 @@ class TestProtocolJsonData(FunctionalTestCase):
         self.member_peter = create(Builder('member'))
         self.member_franz = create(Builder('member')
                                    .having(firstname=u'Franz',
-                                           lastname=u'M\xfcller'))
+                                           lastname=u'M\xfcller',
+                                           email="mueller@example.com"))
         self.membership_peter = create(Builder('membership').having(
             member=self.member_peter,
             committee=self.committee,
@@ -76,5 +77,5 @@ class TestProtocolJsonData(FunctionalTestCase):
 
         self.assertEquals(
             {'members': [{'fullname': u'Peter M\xfcller', 'role': None},
-                         {'fullname': u'Franz M\xfcller', 'role': None}]},
+                         {'fullname': u'Franz M\xfcller (mueller@example.com)', 'role': None}]},
             ProtocolData(self.meeting).add_members())

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -2,11 +2,11 @@ from five import grok
 from opengever.meeting.model import Member
 from opengever.meeting.model import Membership
 from opengever.meeting.service import meeting_service
+from plone import api
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
-from plone import api
 
 
 class CommitteeVocabulary(grok.GlobalUtility):
@@ -44,9 +44,10 @@ def get_committee_member_vocabulary(meetingwrapper):
     for membership in Membership.query.for_meeting(meeting):
         member = membership.member
         members.append(
-            SimpleVocabulary.createTerm(member,
-                                        str(member.member_id),
-                                        member.fullname))
+            SimpleVocabulary.createTerm(
+                member,
+                str(member.member_id),
+                member.get_title(show_email_as_link=False)))
 
     return SimpleVocabulary(members)
 


### PR DESCRIPTION
Emailadressen werden nun zusätzlich zum Namen an folgenden Orten angezeigt:

Sitzung
----------

<img width="314" alt="bildschirmfoto 2016-03-02 um 15 21 35" src="https://cloud.githubusercontent.com/assets/557005/13466375/f57c44ce-e099-11e5-85fb-410940626032.png">

Protokoll bearbeiten
---------------------------
<img width="448" alt="bildschirmfoto 2016-03-02 um 15 53 47" src="https://cloud.githubusercontent.com/assets/557005/13466401/0fcbd6d2-e09a-11e5-95a8-e2b02ec0d669.png">

Protokoll
------------
<img width="735" alt="bildschirmfoto 2016-03-02 um 15 22 09" src="https://cloud.githubusercontent.com/assets/557005/13466385/fe1b26b8-e099-11e5-9098-af14f250b8b4.png">