### PR TITLE
Overwrite require_login script to avoid problems with links from MS office.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,14 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add a fix for links from Microsoft Office applications.
+  The fix hacks around office's behavior to resolve links prior to opening
+  a browser. This lead to an "insufficient privileges" page being displayed if
+  the user was already logged in. The fix attempts to traverse to the came_from
+  url that is available to the require_login script, and if the url is traversable
+  redirects to that location.
+  [deiferni]
+
 - Update locking message for locked protocols.
   [elioschmutz]
 

--- a/opengever/base/skins/opengever.base_scripts/require_login.py
+++ b/opengever/base/skins/opengever.base_scripts/require_login.py
@@ -1,0 +1,28 @@
+## Script (Python) "require_login"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=
+##title=Login
+##
+
+login = 'login'
+
+portal = context.portal_url.getPortalObject()
+# if cookie crumbler did a traverse instead of a redirect,
+# this would be the way to get the value of came_from
+#url = portal.getCurrentUrl()
+#context.REQUEST.set('came_from', url)
+
+if context.portal_membership.isAnonymousUser():
+    return portal.restrictedTraverse(login)()
+else:
+    expected_location = context.REQUEST.get('came_from')
+    try:
+        #XXX Attempt a traverse to the given path
+        portal.restrictedTraverse(expected_location.replace(portal.absolute_url()+'/',''))
+        container.REQUEST.RESPONSE.redirect(expected_location)
+    except:
+        return portal.restrictedTraverse('insufficient_privileges')()

--- a/opengever/base/tests/test_require_login.py
+++ b/opengever/base/tests/test_require_login.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+
+
+class TestRequireLoginScript(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRequireLoginScript, self).setUp()
+
+        self.repo, self.repo_folder = create(Builder('repository_tree'))
+        self.dossier = create(Builder('dossier').within(self.repo_folder))
+        self.document = create(
+            Builder('document')
+            .within(self.dossier)
+            .titled(u'Document1')
+            .with_dummy_content())
+
+    @browsing
+    def test_require_login_redirects_to_came_from_if_already_logged_in(self, browser):
+        browser.login().open(
+            view='require_login',
+            data={'came_from': self.document.absolute_url()})
+        self.assertEqual(browser.url, self.document.absolute_url())
+
+    @browsing
+    def test_require_login_displays_login_form_and_redirecs_upon_login(self, browser):
+        browser.open(
+            view='require_login',
+            data={'came_from': self.document.absolute_url()})
+        self.assertEqual('http://nohost/plone/require_login', browser.url)
+
+        browser.fill({'Login Name': TEST_USER_NAME,
+                      'Password': TEST_USER_PASSWORD}).submit()
+        self.assertEqual(browser.url, self.document.absolute_url())


### PR DESCRIPTION
Add fix as documented on the plone documentation:
http://docs.plone.org/develop/plone/sessions/login.html#hyperlinks-to-authenticated-plone-content-in-microsoft-office

The fix hacks around MS office's behavior to resolve links prior to opening a browser. This lead to an "insufficient privileges" page being displayed if the user was already logged in. The fix attempts to traverse to the came_from url that is available to the require_login script, and if the url is traversable redirects to that location.


Manually tested on **Windows 10**:
- [x] ie11
- [x] edge
- [x] chrome
- [x] firefox

**OSX**:
- [x] chrome
- [x] firefox
- [x] safari

Fixes #1200.