### PR TITLE
Add no_client_id_grouped_by_three reference number formatter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.6.4 (unreleased)
 ------------------
 
+- Add no_client_id_grouped_by_three reference number formatter.
+  [deiferni]
+
 - Make sure IRedirector JS redirects aren't unconditionally trigged when the
   user is on the @@confirm-action view.
   [lgraf]

--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -168,3 +168,31 @@ class NoClientIdDottedReferenceFormatter(DottedReferenceFormatter):
                     self.document_number(numbers))
 
             return reference_number.encode('utf-8')
+
+
+# XXX Refactor me and avoid copy-paste of complete_number.
+class NoClientIdGroupedByThreeFormatter(GroupedByThreeReferenceFormatter):
+    grok.name('no_client_id_grouped_by_three')
+
+    def complete_number(self, numbers):
+        """GroupedByThreeFormatter which omits client id.
+        """
+
+        reference_number = u''
+
+        if self.repository_number(numbers):
+            reference_number = self.repository_number(numbers)
+
+        if self.dossier_number(numbers):
+            reference_number = u'%s%s%s' % (
+                reference_number,
+                self.repository_dossier_seperator,
+                self.dossier_number(numbers))
+
+        if self.document_number(numbers):
+            reference_number = u'%s%s%s' % (
+                reference_number,
+                self.dossier_document_seperator,
+                self.document_number(numbers))
+
+        return reference_number.encode('utf-8')

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -96,6 +96,15 @@ class TestReferenceNumberAdapter(FunctionalTestCase):
             '2.4.7 / 8.2',
             IReferenceNumber(self.subdossier).get_number())
 
+    def test_use_no_client_id_grouped_by_three_formatter(self):
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IReferenceNumberSettings)
+        proxy.formatter = 'no_client_id_grouped_by_three'
+
+        self.assertEquals(
+            '247-8.2',
+            IReferenceNumber(self.subdossier).get_number())
+
 
 class TestDottedFormatter(FunctionalTestCase):
 


### PR DESCRIPTION
Add a reference number formatter which omits the client id but behaves the same as `grouped_by_three` otherwise.

This is done minimally invasive without touching existing code, at the cost of some duplication.
