### PR TITLE
Activate "remove GEVER content" by default for new policies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Activate "remove GEVER content" by default for new policies.
+  [deiferni]
 
 
 4.7.0 (2016-03-07)

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/rolemap.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/rolemap.xml
@@ -1,0 +1,8 @@
+<rolemap>
+  <permissions>
+    <permission name="Remove GEVER content" acquire="True">
+      <role name="Manager"/>
+      <role name="Editor"/>
+    </permission>
+  </permissions>
+</rolemap>


### PR DESCRIPTION
SaaS customers should always be able to do so.