### PR TITLE
Implement sorter for 'no_client_id_grouped_by_three' reference number formatter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.1 (unreleased)
 ------------------
 
+- Implement sorter for 'no_client_id_grouped_by_three' reference number formatter.
+  [lgraf]
+
 - Activate "remove GEVER content" by default for new policies.
   [deiferni]
 

--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -122,8 +122,10 @@ class GroupedByThreeReferenceFormatter(DottedReferenceFormatter):
 
         clientid_repository_separator = u' '
 
-        # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
+        # 'OG 010.123.43-1.1-7'  -->  '010.123.43-1.1-7'
         clientid, remainder = value.split(clientid_repository_separator, 1)
+
+        # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
         refnums_part, remainder = remainder.split(self.repository_dossier_seperator, 1)
 
         # Return a tuple with the different parts separated.
@@ -196,3 +198,30 @@ class NoClientIdGroupedByThreeFormatter(GroupedByThreeReferenceFormatter):
                 self.document_number(numbers))
 
         return reference_number.encode('utf-8')
+
+    def sorter(self, brain_or_value):
+        if not isinstance(brain_or_value, basestring):
+            # It's a brain
+            value = brain_or_value.reference
+        else:
+            # It's already a string value
+            value = brain_or_value
+
+        # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
+        refnums_part, remainder = value.split(self.repository_dossier_seperator, 1)
+
+        # Return a tuple with the different parts separated.
+        # Cast document and (sub)dossier parts to integers to achieve proper
+        # sorting, but keep the refnum part as a string because it is already
+        # zero-padded and sorting it numerically would yield wrong results.
+
+        if remainder.count(self.dossier_document_seperator) > 0:
+            # Document Reference Number
+            dossier_part, document_part = remainder.split(self.dossier_document_seperator, 1)
+            subdossier_parts = [int(d) for d in dossier_part.split('.')]
+            return (refnums_part, tuple(subdossier_parts), int(document_part))
+        else:
+            # Dossier Reference Number
+            dossier_part = remainder
+            subdossier_parts = [int(d) for d in dossier_part.split('.')]
+            return (refnums_part, tuple(subdossier_parts))

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -191,6 +191,50 @@ class TestGroupedbyThreeFormatter(FunctionalTestCase):
             'OG 573.2-4.6.2-27', self.formatter.complete_number(numbers))
 
 
+class TestNoClientIDGroupedbyThreeFormatter(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNoClientIDGroupedbyThreeFormatter, self).setUp()
+
+        self.formatter = queryAdapter(
+            self.portal, IReferenceNumberFormatter,
+            name='no_client_id_grouped_by_three')
+
+    def test_group_repositories_by_three_and_seperate_with_a_dot(self):
+        numbers = {'repository': [u'5', u'7', u'3', u'2'], }
+
+        self.assertEquals(
+            '573.2', self.formatter.repository_number(numbers))
+
+    def test_separate_dossiers_and_subdossiers_with_a_dot(self):
+        numbers = {'dossier': [u'4', u'6', u'2'], }
+
+        self.assertEquals(
+            '4.6.2', self.formatter.dossier_number(numbers))
+
+    def test_repository_part_is_separated_with_space(self):
+        numbers = {'site': ['OG', ],
+                   'repository': [u'5', u'7', u'3', u'2']}
+
+        self.assertEquals(
+            '573.2', self.formatter.complete_number(numbers))
+
+    def test_dossier_part_is_separated_with_hyphen(self):
+        numbers = {'repository': [u'5', u'7', u'3', u'2'],
+                   'dossier': [u'4', u'6', u'2']}
+
+        self.assertEquals(
+            '573.2-4.6.2', self.formatter.complete_number(numbers))
+
+    def test_document_part_is_separated_with_hyphen_and_spaces(self):
+        numbers = {'repository': [u'5', u'7', u'3', u'2'],
+                   'dossier': [u'4', u'6', u'2'],
+                   'document': [u'27']}
+
+        self.assertEquals(
+            '573.2-4.6.2-27', self.formatter.complete_number(numbers))
+
+
 class TestDottedFormatSorter(TestDottedFormatter):
     def test_orders_first_level_refnums_correctly(self):
         expected = ['OG 1.9.9 / 9.9.9',
@@ -317,6 +361,75 @@ class TestGroupedbyThreeFormatSorter(TestGroupedbyThreeFormatter):
         unordered = ['OG 99.9-9.9.9-3',
                      'OG 99.9-9.9.9-1',
                      'OG 99.9-9.9.9-11']
+
+        actual = sorted(unordered, key=self.formatter.sorter)
+        self.assertEquals(expected, actual)
+
+
+class TestNoClientIDGBTSorter(TestNoClientIDGroupedbyThreeFormatter):
+
+    def test_orders_first_level_refnums_correctly(self):
+        expected = ['01.0-9.9.9-99',
+                    '010.0-9.9.9-99',
+                    '011.0-9.9.9-99',
+                    '02.0-9.9.9-99',
+                    '020.0-9.9.9-99',
+                    '021.0-9.9.9-99']
+
+        unordered = ['021.0-9.9.9-99',
+                     '010.0-9.9.9-99',
+                     '020.0-9.9.9-99',
+                     '011.0-9.9.9-99',
+                     '02.0-9.9.9-99',
+                     '01.0-9.9.9-99']
+
+        actual = sorted(unordered, key=self.formatter.sorter)
+        self.assertEquals(expected, actual)
+
+    def test_orders_second_level_refnums_correctly(self):
+        expected = ['021.1-9.9.9-99',
+                    '021.11-9.9.9-99',
+                    '021.111-9.9.9-99']
+
+        unordered = ['021.11-9.9.9-99',
+                     '021.1-9.9.9-99',
+                     '021.111-9.9.9-99']
+
+        actual = sorted(unordered, key=self.formatter.sorter)
+        self.assertEquals(expected, actual)
+
+    def test_orders_main_dossiers_correctly(self):
+        expected = ['99.9-1.1-99',
+                    '99.9-3.1-99',
+                    '99.9-11.1-99']
+
+        unordered = ['99.9-3.1-99',
+                     '99.9-1.1-99',
+                     '99.9-11.1-99']
+
+        actual = sorted(unordered, key=self.formatter.sorter)
+        self.assertEquals(expected, actual)
+
+    def test_orders_subdossiers_correctly(self):
+        expected = ['99.9-9.1-99',
+                    '99.9-9.3-99',
+                    '99.9-9.11-99']
+
+        unordered = ['99.9-9.3-99',
+                     '99.9-9.1-99',
+                     '99.9-9.11-99']
+
+        actual = sorted(unordered, key=self.formatter.sorter)
+        self.assertEquals(expected, actual)
+
+    def test_orders_documents_correctly(self):
+        expected = ['99.9-9.9.9-1',
+                    '99.9-9.9.9-3',
+                    '99.9-9.9.9-11']
+
+        unordered = ['99.9-9.9.9-3',
+                     '99.9-9.9.9-1',
+                     '99.9-9.9.9-11']
 
         actual = sorted(unordered, key=self.formatter.sorter)
         self.assertEquals(expected, actual)


### PR DESCRIPTION
Because it has no leading `client_id`, the `no_client_id_grouped_by_three` formatter also needs its own sorting logic.

The `sorter()` method is an exact copy of the one from its superclass, minus the [line that tries to split by client ID](https://github.com/4teamwork/opengever.core/blob/f0d1e0ef7f5667fe70c47d7b8cf08c857063c272/opengever/base/reference_formatter.py#L126).

Only verified via tests, haven't actually tested this on a real site yet.

Also see: https://github.com/4teamwork/opengever.core/issues/1561 (We should probably use a `sortable_reference` index instead of sorting on demand).