### PR TITLE
Fix protocol saving on IE.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix timezone mess in datetimepicker.
+  [Kevin Bieri]
 
 
 4.7.1 (2016-03-10)

--- a/opengever/meeting/browser/resources/datetimepicker.js
+++ b/opengever/meeting/browser/resources/datetimepicker.js
@@ -41,9 +41,6 @@
     format: "dd/mm/yyyy hh:ii"
   };
 
-  // Confirmend bug in https://github.com/smalot/bootstrap-datetimepicker/issues/122
-  var applyTimezone = function(date) { return new Date(date.setTime(date.getTime() + (date.getTimezoneOffset() * 60 * 1000))); };
-
   var Datetimepicker = function(options) {
 
     var lang = $("#ploneLanguage").data("lang");
@@ -61,29 +58,23 @@
 
     this.element = $(options.target);
 
-    var roundMinutes = function(date, precision) { return new Date(date.setMinutes(Math.ceil(date.getMinutes() / precision) * precision)); };
-
-    var getUTCDate = function(date) { return new Date(date + "UTC"); };
-
-    var convertToLocalTime = function(date) { return applyTimezone(date); };
-
-    this.date = roundMinutes(getUTCDate(new Date()), options.minuteStep);
+    var roundMinutes = function(date, precision) {
+      return new Date(date.setMinutes(Math.ceil(date.getMinutes() / precision) * precision));
+    };
 
     this.element.datetimepicker(options);
 
     this.on = function(event, callback) { this.element.on(event, callback); };
 
-    this.setStartDate = function(date) { this.element.datetimepicker("setStartDate", convertToLocalTime(new Date(date))); };
+    this.setStartDate = function(date) { this.element.datetimepicker("setStartDate", date); };
 
-    this.setEndDate = function(date) { this.element.datetimepicker("setEndDate", convertToLocalTime(new Date(date))); };
+    this.setEndDate = function(date) { this.element.datetimepicker("setEndDate", date); };
 
-    this.setDate = function(date) {
-      this.date = new Date(date);
-      var localTime = convertToLocalTime(new Date(date));
-      this.element.datetimepicker("setDate", localTime);
-    };
+    this.setDate = function(date) { this.element.datetimepicker("setDate", date); };
 
-    this.setDate(this.date);
+    this.getDate = function() { return this.element.datetimepicker("getDate"); };
+
+    this.setDate(roundMinutes(new Date(), options.minuteStep));
 
   };
 
@@ -108,14 +99,14 @@
     }, this);
 
     var updateDate = $.proxy(function(date) {
-      if(options.minRange && (this.end.date - date) < (options.minRange * 60 * 60 * 1000)) {
+      if(options.minRange && (this.end.getDate() - date) < (options.minRange * 60 * 60 * 1000)) {
         adjustEndtime(date);
       }
       this.end.setStartDate(date);
       this.start.setDate(date);
     }, this);
 
-    updateDate(this.start.date);
+    updateDate(this.start.getDate());
 
     this.start.on("changeDate", function(event) { updateDate(event.date); });
     this.end.on("changeDate", function(event) { self.end.setDate(event.date); });
@@ -138,14 +129,14 @@
     });
 
     var applyPloneWidget = function() {
-      var startDate = applyTimezone(new Date(range.start.date));
+      var startDate = new Date(range.start.getDate());
       $("#form-widgets-start-day").attr("value", startDate.getDate());
       $("#form-widgets-start-month").attr("value", startDate.getMonth() + 1);
       $("#form-widgets-start-year").attr("value", startDate.getFullYear());
       $("#form-widgets-start-hour").attr("value", startDate.getHours());
       $("#form-widgets-start-min").attr("value", startDate.getMinutes());
 
-      var endDate = applyTimezone(new Date(range.end.date));
+      var endDate = new Date(range.end.getDate());
       $("#form-widgets-end-day").attr("value", endDate.getDate());
       $("#form-widgets-end-month").attr("value", endDate.getMonth() + 1);
       $("#form-widgets-end-year").attr("value", endDate.getFullYear());

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -54,15 +54,16 @@
     }
 
     this.saveProtocol = function(target) {
-      var payload = target.parents("form").serializeArray();
+      var form = target.parents("form");
+      var payload = form.serializeArray();
       payload.push({ name: "form.buttons.save", value: saveButton.val() });
       var conflictValidator = function(data) {
         if(data.hasConflict) {
           showHintForConflictChanges();
         }
         return !data.hasConflict;
-      }
-      return this.request(target.attr("action"), { method: "POST", data: payload, validator: conflictValidator })
+      };
+      return this.request(form.attr("action"), { type: "POST", data: payload, validator: conflictValidator })
               .done(function(data) {
                 if (data.redirectUrl !== undefined) {
                   meetingStorage.deleteCurrentMeeting();


### PR DESCRIPTION
Since the update to 2.3.8 of bootstrap-datetimepicker the bug here
smalot/bootstrap-datetimepicker#122 is fixed.

So we dont need the workarround applying the timezone manually.

Making a UTC date extending a datestring with `UTC` does not work on IE.
So the backend received invalid date and the protocol could not be saved.