### PR TITLE
Take existing date from server to feed the datetimepicker.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.2 (unreleased)
 ------------------
 
+- Keep existing date on a protocol instead of creating a new one.
+  [Kevin Bieri]
+
 - Fix timezone mess in datetimepicker.
   [Kevin Bieri]
 

--- a/opengever/meeting/browser/resources/datetimepicker.js
+++ b/opengever/meeting/browser/resources/datetimepicker.js
@@ -144,8 +144,40 @@
       $("#form-widgets-end-min").attr("value", endDate.getMinutes());
     };
 
+    var parsePloneWidgetStart = function() {
+      var startDate = new Date();
+
+      startDate.setDate($("#form-widgets-start-day").attr("value"));
+      startDate.setMonth($("#form-widgets-start-month").attr("value") - 1);
+      startDate.setFullYear($("#form-widgets-start-year").attr("value"));
+      startDate.setHours($("#form-widgets-start-hour").attr("value"));
+      startDate.setMinutes($("#form-widgets-start-min").attr("value"));
+
+      return startDate;
+    };
+
+    var parsePloneWidgetEnd = function() {
+      var endDate = new Date();
+
+      endDate.setDate($("#form-widgets-end-day").attr("value"));
+      endDate.setMonth($("#form-widgets-end-month").attr("value") - 1);
+      endDate.setFullYear($("#form-widgets-end-year").attr("value"));
+      endDate.setHours($("#form-widgets-end-hour").attr("value"));
+      endDate.setMinutes($("#form-widgets-end-min").attr("value"));
+
+      return endDate;
+    };
+
     range.start.on("changeDate", applyPloneWidget);
     range.end.on("changeDate", applyPloneWidget);
+
+    if($("#form-widgets-start-day").attr("value")) {
+      range.start.setDate(parsePloneWidgetStart());
+    }
+
+    if($("#form-widgets-end-day").attr("value")) {
+      range.end.setDate(parsePloneWidgetEnd());
+    }
 
     applyPloneWidget();
 


### PR DESCRIPTION
Depends on https://github.com/4teamwork/opengever.core/pull/1642

When the user wants to edit a protocol the datetimepicker always
sets a new date instead of taking the existing date from the server.

So check if the datefileds are prefilled before inserting a new date.
A new date should only get inserted when creating a new meeting.