### PR TITLE
API docs: Add `basics` and `operations` chapters.

### DIFF
--- a/docs/api/_static/custom.css
+++ b/docs/api/_static/custom.css
@@ -29,7 +29,12 @@ dl.attribute {
 }
 
 hr {
-    margin-bottom: 3em;
+    margin-top: 2em;
+    margin-bottom: 2em;
+    border: 0;
+    height: 1px;
+    background: #333;
+    background-image: linear-gradient(to right, #ccc, #333, #ccc);
 }
 
 .field-title {
@@ -51,4 +56,11 @@ table.field-list tbody tr:first-child td {
 
 table.field-list th.field-name {
     min-width: 10em;
+}
+
+blockquote {
+  background: #f9f9f9;
+  border-left: 10px solid #ccc;
+  margin: 1.5em 10px;
+  padding: 0.5em 10px;
 }

--- a/docs/api/basics.rst
+++ b/docs/api/basics.rst
@@ -1,0 +1,145 @@
+Grundlagen
+==========
+
+Die OneGov GEVER API ist eine RESTful_ HTTP API.
+
+Dies bedeutet, dass Operationen über die API via HTTP Requests durchgeführt
+werden, welche von einem HTTP Client abgesetzt werden.
+
+  HTTP_ ist ein Protokoll für die Kommunikation zwischen einem Client und einem
+  Server, und basiert auf dem Austausch von Anfragen des Clients (**Request**)
+  und Antworten des Servers (**Response**).
+
+Die Verwendung der API funktioniert so, dass Requests auf die URL des
+entsprechenden Inhaltsobjekts gemacht werden, aber ein spezieller
+HTTP-Header verwendet wird welchen den Request als API-Request auszeichnet
+(um ihn von einem Request eines normales Browsers abzugrenzen).
+
+
+------
+
+
+Request
+-------
+
+Requests an die API setzen sich zusammen aus einem **HTTP Verb**, einer
+**URL**, **Request-Headern**, und für gewisse Typen von Requests, einem
+**Request-Body** im JSON Format.
+
+HTTP Verb
+^^^^^^^^^
+
+Im Kapitel :ref:`operations` ist beschrieben, auf welche HTTP Verben die
+verfügbaren Operationen gemappt sind.
+
+URL
+^^^
+
+Die URL eines Requests ist bestimmt durch das Objekt, für welches eine
+Operation durchgeführt werden soll. Diese URL ist in der Regel für das
+entsprechende Objekt in der Adresszeile des Browsers sichtbar.
+
+Headers
+^^^^^^^
+
+Die API verwendet JSON für die Serialisierung von Daten (für die
+Eingabe wie auch die Ausgabe).
+
+Dementsprechend muss bei der Anfrage (Request) der HTTP-Header
+``Accept: application/json`` gesetzt werden, damit ein Request an die API
+weitergeleitet wird.
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+  GET /ordnungssystem HTTP/1.1
+  Accept: application/json
+
+Dieser Header muss bei *jedem* Request auf die API gesetzt werden, und wird in
+den folgenden Beispielen daher nicht mehr immer explizit erwähnt.
+
+Body
+^^^^
+
+Bestimmte Request-Typen (``POST`` und ``PATCH``) brauchen weitere
+Informationen, welche in Form eines Request-Bodies im JSON Format mitgegeben
+werden. Wie der Inhalt dieses Bodies genau beschaffen sein muss, ist im
+Kapitel :ref:`operations` beschrieben.
+
+
+------
+
+
+Response
+--------
+
+Wenn eine Response einen Body hat, ist dies immer ein JSON-Dokument:
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+   HTTP/1.1 200 OK
+   Content-Type: application/json
+
+   {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23",
+      "@type": "opengever.dossier.businesscasedossier",
+      "title": "Titel des Objekts",
+       "...": "..."
+   }
+
+`(Gekürzt - vollständige Beispiele von konkreten Responses sind in späteren
+Abschnitten zu finden)`
+
+Die mit einem ``@`` Zeichen präfixten Keys haben eine spezielle Beduetung, und
+entsprechen nicht einem Feld auf dem Inhaltstyp, sondern sind JSON-LD_
+(Linked Data) Metadaten:
+
+============= ================= ===============================================
+Key           Bedeutung               Beschreibung
+============= ================= ===============================================
+``@context``  Kontext           Wird immer denselben Wert haben, eine URI zum
+                                Hydra Kontext - dieser Key hat für die OneGov
+                                GEVER API im Moment keine Relevanz.
+
+``@id``       Eindeutige URL    Die eindeutige URL zu einem Objekt.
+
+``@type``     Typ eines Objekts Der Typ eines Objekts. Dieser Typ entspricht
+                                einem der unter :ref:`content-types`
+                                angegebenen Typen, und lässt den Client so
+                                wissen, welche Felder mit welchen Datentypen
+                                in einer Antwort zu erwarten sind.
+============= ================= ===============================================
+
+
+------
+
+
+Authentisierung
+---------------
+
+Die Authentisierung an der API erfolgt mittels HTTP Basic Auth, unter
+Verwendung eines normalen Benutzers welcher die nötigen Berechtigungen für
+die gewünschte Operation hat.
+
+Für HTTP Basic Auth muss ein `Authorization` Header im Request gesetzt werden:
+
+.. sourcecode:: http
+
+  GET /ordnungssystem HTTP/1.1
+  Authorization: Basic Zm9vYmFyOmZvb2Jhcgo=
+  Accept: application/json
+
+Die HTTP Client Libraries bieten üblicherweise Hilfsfunktionen an, um diesen
+Header basierend auf Benutzername und Passwort zu generieren
+(siehe Code-Beispiele).
+
+
+
+.. _RESTful: https://de.wikipedia.org/wiki/Representational_State_Transfer
+.. _HTTP: https://de.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+.. _JSON-LD: http://json-ld.org/
+

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -28,7 +28,9 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+    'sphinxcontrib.httpdomain',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/api/content_types.rst
+++ b/docs/api/content_types.rst
@@ -1,3 +1,5 @@
+.. _content-types:
+
 Inhaltstypen
 ============
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,6 +6,8 @@ Inhalt:
 .. toctree::
    :maxdepth: 2
 
+   basics.rst
+   operations.rst
    exploring.rst
    content_types.rst
 

--- a/docs/api/operations.rst
+++ b/docs/api/operations.rst
@@ -1,0 +1,172 @@
+.. _operations:
+
+Operationen
+============
+
+Die möglichen Operationen auf der API sind auf HTTP Verben gemappt.
+
+
+======= ============ ==========================================================
+Verb    URL          Operation
+======= ============ ==========================================================
+GET     /{path}      Gibt die Attribute eines Objekts zurück
+POST    /{container} Erstellt ein neues Objekt in dem entsprechenden Container
+PATCH   /{path}      Aktualisiert einzelne Attribute eines Objekts
+======= ============ ==========================================================
+
+
+Inhalte lesen (GET)
+-------------------
+
+Mit einem ``GET`` Request auf die URL eines Objekts können die Daten
+(Metadaten wie auch Primärdaten) eines Objekts ausgelesen werden.
+
+Im Fall eines Objekts das "folderish" ist (ein Container), gibt es ein
+spezielles Attribut ``member``, welches eine summarische Auflistung der
+Unterobjekte enthält (direkte children des Objekts).
+
+
+.. http:get:: /(path)
+
+   Liefert die Attribute des Objekts unter `path` zurück
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET /ordnungssystem/fuehrung/dossier-23 HTTP/1.1
+      Accept: application/json
+
+   **Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23",
+        "@type": "opengever.dossier.businesscasedossier",
+        "UID": "66395be6595b4db29a3282749ed50302",
+        "archival_value": "not archival worthy",
+        "archival_value_annotation": null,
+        "classification": "unprotected",
+        "comments": null,
+        "container_location": null,
+        "container_type": null,
+        "created": "2016-01-08T09:51:40+01:00",
+        "custody_period": 30,
+        "date_of_cassation": null,
+        "date_of_submission": null,
+        "description": "",
+        "end": null,
+        "filing_prefix": null,
+        "former_reference_number": null,
+        "keywords": [],
+        "member": [
+          {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/document-259",
+            "description": null,
+            "title": "Ein Dokument"
+          },
+          {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/document-260",
+            "description": null,
+            "title": "Ein weiteres Dokument"
+          }
+        ],
+        "modified": "2016-01-19T11:15:22+01:00",
+        "number_of_containers": null,
+        "parent": {
+          "@id": "https://example.org/ordnungssystem/fuehrung",
+          "description": null,
+          "title": "Führung"
+        },
+        "privacy_layer": "privacy_layer_no",
+        "public_trial": "unchecked",
+        "public_trial_statement": null,
+        "reference_number": null,
+        "relatedDossier": null,
+        "responsible": "john.doe",
+        "retention_period": 5,
+        "retention_period_annotation": null,
+        "start": "2016-01-08",
+        "temporary_former_reference_number": null,
+        "title": "Ein Geschäftsdossier"
+      }
+
+
+Inhalte erstellen (POST)
+------------------------
+
+Um ein neues Objekt zu erstellen, muss ein ``POST`` Request auf den Container,
+der das Objekt enthalten soll, gemacht werden. Die ID des erstellten Objekts
+(z.B. 'document-26') wird vom System selbst mitbestimmt und muss nicht
+mitgegeben werden.
+
+
+.. http:post:: /(container)
+
+   Erstellt ein neues Objekt innerhalb von `container`.
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /ordnungssystem/fuehrung HTTP/1.1
+      Accept: application/json
+
+      {
+        "@type": "opengever.dossier.businesscasedossier",
+        "title": "Ein neues Geschäftsdossier",
+        "responsible": "john.doe",
+        "custody_period": 30,
+        "archival_value": "unchecked",
+        "retention_period": 5,
+      }
+
+   **Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+      Location: https://example.org/ordnungssystem/fuehrung/dossier-24
+
+      null
+
+Im ``Location`` Header der Response ist die URL des neu erstellen Objekts zu
+finden.
+
+
+Inhalte bearbeiten (PATCH)
+--------------------------
+
+Um ein oder mehrere Attribute eines Objekts zu aktualisieren, wird ein
+``PATCH`` Request verwendet.
+
+
+.. http:patch:: /(path)
+
+   Aktualisiert ein oder mehrere Attribute des Objekts unter `path`.
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      PATCH /ordnungssystem/fuehrung/dossier-24 HTTP/1.1
+      Accept: application/json
+
+      {
+        "title": "Ein umbenanntes Dossier"
+      }
+
+   **Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+
+      null
+

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -8,6 +8,7 @@ recipe = zc.recipe.egg
 eggs =
     Sphinx
     Jinja2
+    sphinxcontrib-httpdomain
 
 [api-docs-build-script]
 recipe = collective.recipe.template


### PR DESCRIPTION
Adds two more chapters to the API docs:

- **Basics** - describes how the overall interaction with the API happens
- **Operations** - Describes what HTTP Methods are mapped to which operation

@deiferni 