### PR TITLE
Filtert die Gruppen beim Hinzufügen eines Gremiums

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Only groups where the user is a member are available to select when creating/editing committees.
+  [elioschmutz]
+
 - Fix examplecontent repositories.
   [deiferni]
 

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -7,7 +7,6 @@ from opengever.meeting.committeeroles import CommitteeRoles
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.model import Committee as CommitteeModel
 from opengever.meeting.model import Meeting
-from opengever.meeting.model import Membership
 from opengever.meeting.service import meeting_service
 from opengever.meeting.sources import repository_folder_source
 from opengever.meeting.sources import sablon_template_source
@@ -26,11 +25,18 @@ from zope.schema.vocabulary import SimpleVocabulary
 @grok.provider(IContextSourceBinder)
 def get_group_vocabulary(context):
     service = ogds_service()
-    groups = []
-    for group in service.all_groups():
-        groups.append(SimpleVocabulary.createTerm(
+    userid = api.user.get_current().getId()
+    terms = []
+
+    if api.user.has_permission('cmf.ManagePortal', obj=context):
+        groups = service.all_groups()
+    else:
+        groups = service.assigned_groups(userid)
+
+    for group in groups:
+        terms.append(SimpleVocabulary.createTerm(
             group.groupid, group.groupid, group.title))
-    return SimpleVocabulary(groups)
+    return SimpleVocabulary(terms)
 
 
 class ICommittee(form.Schema):

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -1,7 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.meeting.committee import get_group_vocabulary
 from opengever.meeting.committeeroles import CommitteeRoles
 from opengever.testing import FunctionalTestCase
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 
 class TestCommitteeTabs(FunctionalTestCase):
@@ -39,3 +42,50 @@ class TestCommitteeTabs(FunctionalTestCase):
         self.assertItemsEqual(
             ['Contributor'],
             local_roles['client1_users'])
+
+
+class TestCommitteeGroupsVocabulary(FunctionalTestCase):
+
+    def test_return_empty_vocabulary_if_user_is_not_assigned_to_any_group(self):
+        container = create(Builder('committee_container'))
+
+        create(Builder('user').with_userid('hugo.boss'))
+        create(Builder('ogds_user').id('hugo.boss'))
+
+        login(self.layer['portal'], 'hugo.boss')
+
+        self.assertEqual(
+            [],
+            [term for term in get_group_vocabulary(container)])
+
+    def test_return_only_groups_where_the_user_is_assigned(self):
+        container = create(Builder('committee_container'))
+
+        create(Builder('user').with_userid('hugo.boss'))
+        ogds_user = create(Builder('ogds_user').id('hugo.boss'))
+
+        create(Builder('ogds_group').id('foo').having(users=[ogds_user, ]))
+        create(Builder('ogds_group').id('bar'))
+
+        login(self.layer['portal'], 'hugo.boss')
+
+        self.assertEqual(
+            [u'foo'],
+            [term.value for term in get_group_vocabulary(container)])
+
+    def test_return_all_groups_if_the_user_has_manager_role(self):
+        container = create(Builder('committee_container'))
+
+        create(Builder('user').with_userid('hugo.boss'))
+        ogds_user = create(Builder('ogds_user').id('hugo.boss'))
+
+        create(Builder('ogds_group').id('foo').having(users=[ogds_user, ]))
+        create(Builder('ogds_group').id('bar'))
+
+        setRoles(self.layer['portal'], 'hugo.boss', ['Manager'])
+
+        login(self.layer['portal'], 'hugo.boss')
+
+        self.assertEqual(
+            [u'client1_users', u'client1_inbox_users', u'foo', u'bar'],
+            [term.value for term in get_group_vocabulary(container)])

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,9 +7,10 @@ development-packages =
   collective.js.timeago
   plone.restapi
   plone.rest
+# https://github.com/4teamwork/opengever.core/issues/1512
+  opengever.ogds.models
 
 auto-checkout = ${buildout:development-packages}
-
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}


### PR DESCRIPTION
- [x] Bitte zuerst https://github.com/4teamwork/opengever.ogds.models/pull/38

Bisher wurde jeweils alle Gruppen zum Auswählen angezeigt.

![bildschirmfoto 2016-03-15 um 17 50 54](https://cloud.githubusercontent.com/assets/557005/13786115/8a556a76-ead6-11e5-906f-173a91290634.png)

Neu werden nur noch Gruppen angezeigt, in denen der Benutzer selbst ein Mitglied ist.

- [x] Gruppen filtern
- [x] Alle Gruppen anzeigen, wenn der Benutzer die "Manager" Rolle hat

closes #1512 