### PR TITLE
Fix broken TranslatedTitleBrain - return utf-8 instead of unicode

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Fix broken TranslatedTitleBrain. It has to return utf-8 instead of unicode.
+  [elioschmutz]
+
 - Only groups where the user is a member are available to select when creating/editing committees.
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Remove unused fallback method for TranslatedTitleBrain (it has never worked so far).
+  [elioschmutz]
+
 - Fix broken TranslatedTitleBrain. It has to return utf-8 instead of unicode.
   [elioschmutz]
 

--- a/opengever/base/brain.py
+++ b/opengever/base/brain.py
@@ -22,6 +22,8 @@ def useBrains(self, brains):
             if not title:
                 title = super(TranslatedTitleBrain, self).Title
 
+            if isinstance(title, unicode):
+                return title.encode('utf-8')
             return title
 
     self._v_result_class = TranslatedTitleBrain

--- a/opengever/base/brain.py
+++ b/opengever/base/brain.py
@@ -1,4 +1,3 @@
-from opengever.base.behaviors.translated_title import TranslatedTitle
 from opengever.base.utils import get_preferred_language_code
 
 
@@ -16,10 +15,9 @@ def useBrains(self, brains):
         def Title(self):
             code = get_preferred_language_code()
             title = getattr(self, 'title_%s' % code, None)
-            if not title:
-                title = getattr(self, TranslatedTitle.FALLBACK_LANGUAGE, None)
 
-            if not title:
+            if title is None:
+                # non-translated content
                 title = super(TranslatedTitleBrain, self).Title
 
             if isinstance(title, unicode):

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -122,7 +122,7 @@ class TestTranslatedTitle(FunctionalTestCase):
 
         set_preferred_language(self.portal.REQUEST, 'fr-ch')
 
-        self.assertEquals(u"syst\xe8me d'ordre",
+        self.assertEquals("syst\xc3\xa8me d'ordre",
                           obj2brain(repository_root).Title)
 
     @browsing
@@ -136,12 +136,12 @@ class TestTranslatedTitle(FunctionalTestCase):
 
     @browsing
     def test_Title_on_brains_use_Title_as_fallback_when_no_language_title_exists(self, browser):
-        dossier = create(Builder('dossier').titled(u"Ablage"))
+        dossier = create(Builder('dossier').titled(u'F\xfchrung'))
         set_preferred_language(self.portal.REQUEST, 'de')
-        self.assertEquals(u"Ablage", obj2brain(dossier).Title)
+        self.assertEquals("F\xc3\xbchrung", obj2brain(dossier).Title)
 
         set_preferred_language(self.portal.REQUEST, 'fr')
-        self.assertEquals(u"Ablage", obj2brain(dossier).Title)
+        self.assertEquals("F\xc3\xbchrung", obj2brain(dossier).Title)
 
 
 class TestTranslatedTitleAddForm(FunctionalTestCase):

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -126,15 +126,6 @@ class TestTranslatedTitle(FunctionalTestCase):
                           obj2brain(repository_root).Title)
 
     @browsing
-    def test_Title_on_brains_use_german_title_as_fallback(self, browser):
-        repository_root = create(Builder('repository_root')
-                                 .having(title_de=u"Ablage"))
-
-        set_preferred_language(self.portal.REQUEST, 'fr-ch')
-
-        self.assertEquals(u"Ablage", obj2brain(repository_root).Title)
-
-    @browsing
     def test_Title_on_brains_use_Title_as_fallback_when_no_language_title_exists(self, browser):
         dossier = create(Builder('dossier').titled(u'F\xfchrung'))
         set_preferred_language(self.portal.REQUEST, 'de')


### PR DESCRIPTION
Das Problem tritt auf wenn ein Repositoryfolder mit Umlauten und ein Dossier mit Umlauten existieren und beide Objekte im Resultat vorhanden sind.

Das Problem liegt im ``TranslatedTitleBrain`` Catalog-Brain:

https://github.com/4teamwork/opengever.core/blob/master/opengever/base/brain.py#L16

Die Funktion muss UTF-8 zurück geben da per default die Titel-Funktion UTF-8 zurück gibt.

- [x] ``TranslatedTitleBrain`` muss UTF-8 zurück geben