### PR TITLE
No longer set start-page for documents generated as protocol excerpts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.7.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer set start-page for documents generated as protocol excerpts.
+  [deiferni]
 
 
 4.7.3 (2016-03-17)

--- a/opengever/meeting/protocol.py
+++ b/opengever/meeting/protocol.py
@@ -1,4 +1,3 @@
-from opengever.base.utils import escape_html
 from opengever.meeting import _
 from opengever.meeting.model.membership import Membership
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -135,3 +134,7 @@ class ExcerptProtocolData(ProtocolData):
                 _(u'protocol_excerpt', default=u'Protocol-Excerpt'),
                 context=getRequest())
         }
+
+    def add_settings(self):
+        """Do not add the start-page setting for excertps."""
+        pass

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.model import create_session
 from opengever.meeting.browser.sablontemplate import SAMPLE_MEETING_DATA
+from opengever.meeting.protocol import ExcerptProtocolData
 from opengever.meeting.protocol import ProtocolData
 from opengever.testing import FunctionalTestCase
 
@@ -79,3 +80,35 @@ class TestProtocolJsonData(FunctionalTestCase):
             {'members': [{'fullname': u'Peter M\xfcller', 'role': None},
                          {'fullname': u'Franz M\xfcller (mueller@example.com)', 'role': None}]},
             ProtocolData(self.meeting).add_members())
+
+
+class TestExcerptJsonData(FunctionalTestCase):
+
+    maxDiff = None
+
+    def setUp(self):
+        super(TestExcerptJsonData, self).setUp()
+        self.proposal = create(
+            Builder('proposal_model')
+            .having(title=u'Strafbefehl wegen Bauens ohne Bewilligung'))
+        self.committee = create(Builder('committee_model')
+                                .having(title=u'Gemeinderat'))
+        self.meeting = create(Builder('meeting').having(
+            committee=self.committee,
+            protocol_start_page_number=13,
+            meeting_number=11,))
+
+    def test_excerpt_json_does_not_contain_start_page(self):
+        data = ExcerptProtocolData(self.meeting).data
+        self.assertEqual({
+            'agenda_items': [],
+            'protocol': {'type': u'Protocol-Excerpt'},
+            'participants': {'other': [], 'members': []},
+            'committee': {'name': u'Gemeinderat'},
+            'mandant': {'name': u'Client1'},
+            'meeting': {'date': u'Dec 13, 2011',
+                        'start_time': u'09:30 AM',
+                        'end_time': u'11:45 AM',
+                        'number': 11}},
+            data
+        )


### PR DESCRIPTION
With this PR excerpts genrated with sablon start with page number 1.

Closes #1641.