### PR TITLE
Update and document build scripts for API docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,33 @@ Alternatively it's also possible to only update a single subpackage, for example
     bin/i18n-build opengever.dossier
 
 
+Updating API docs
+-----------------
+
+In order to build the Sphinx API docs locally, use the provided
+``bin/api-docs-build`` script:
+
+.. code::
+
+    bin/api-docs-build
+
+This will build the docs (using the ``html`` target by default). If you'd like
+to build a different output format, supply it as the fist argument to the
+script (e.g. ``bin/api-docs-build latexpdf``).
+
+If you made changes to any schema interfaces that need to make their way into
+the docs, you need to run the ``bin/instance dump_schemas`` script before
+running the ``api-docs-build`` script:
+
+.. code::
+
+    bin/instance dump_schemas
+
+This will update the respective schema dumps in ``docs/schema-dumps/`` that
+are then used by the ``api-docs-build`` script to render restructured text
+schema docs.
+
+
 Scripts
 -------
 Scripts are located in ``/scripts``.

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -2,6 +2,7 @@
 parts +=
     sphinx
     api-docs-build-script
+    api-docs-build-and-publish-script
 
 [sphinx]
 recipe = zc.recipe.egg
@@ -41,6 +42,17 @@ inline =
 
 output = ${buildout:bin-directory}/api-docs-build
 mode = 755
+
+[api-docs-build-and-publish-script]
+recipe = collective.recipe.template
+inline =
+    #!/bin/bash
+    bin/api-docs-build dirhtml
+    rsync -v -a docs/api/_build/dirhtml/* zope@theta.4teamwork.ch:/var/www/docs.onegovgever.ch/
+
+output = ${buildout:bin-directory}/api-docs-build-and-publish
+mode = 755
+
 
 [versions]
 Sphinx = 1.3.5

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -14,6 +14,15 @@ eggs =
 recipe = collective.recipe.template
 inline =
     #!/bin/bash
+    #
+    # Usage:
+    # bin/api-docs-build [format]
+    #
+    # If [format] is specified, it will be passed to `make` as the target,
+    # otherwise defaults to 'html'.
+
+    if [ -z $1 ]; then FORMAT='html'; else FORMAT=$1; fi
+
     set -euo pipefail
 
     ZOPE_PY="${buildout:bin-directory}/${zopepy:interpreter}"
@@ -28,7 +37,7 @@ inline =
     # Build the Sphinx documentation
     cd docs/api
     make clean
-    make -e html
+    make -e $FORMAT
 
 output = ${buildout:bin-directory}/api-docs-build
 mode = 755


### PR DESCRIPTION
- Make build script accept format argument (default: `html`)
- Add script to publish docs
- Update `README` to document how to build API docs

@deiferni 