### PR TITLE
Redirect to the members listing tab after adding a new member

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Redirect to the members listingtab after adding a new member instead of the members detailview.
+  [phgross]
+
 - Various updates to API documentation.
   [lgraf]
 

--- a/opengever/meeting/browser/members.py
+++ b/opengever/meeting/browser/members.py
@@ -44,7 +44,7 @@ class AddMember(ModelAddForm):
     label = _('Add Member', default=u'Add Member')
 
     def nextURL(self):
-        return MemberView.url_for(self.context, self._created_object)
+        return '{}#members'.format(self.context.absolute_url())
 
 
 class EditMember(ModelEditForm):

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -30,7 +30,7 @@ class TestMemberListing(FunctionalTestCase):
         self.assertEquals([u'Record created'], info_messages())
 
         hans = Member.query.filter_by(firstname=u'Hanspeter').first()
-        self.assertEqual(MemberView.url_for(self.container, hans),
+        self.assertEqual('{}#members'.format(self.container.absolute_url()),
                          browser.url)
 
         self.assertIsNotNone(hans)


### PR DESCRIPTION
Instead of the MemberDetailview it redirects now to the members listing tab, after adding a Member.

Fixes #1685 

@deiferni please have a look 