### PR TITLE
No longer attempt to parse temporary excel files while creating repos.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- No longer attempt to parse temporary excel files while creating repositories.
+  [deiferni]
+
 - Redirect to the members listingtab after adding a new member instead of the members detailview.
   [phgross]
 

--- a/opengever/setup/sections/xlssource.py
+++ b/opengever/setup/sections/xlssource.py
@@ -60,7 +60,7 @@ class XlsSource(object):
 
         files = sorted(os.listdir(self.path))
         for repo_num, filename in enumerate(reversed(files)):
-            if filename.startswith('.') or not filename.endswith('.xlsx'):
+            if not self.is_parsable(filename):
                 continue
 
             xls_path = os.path.join(self.path, filename)
@@ -73,6 +73,20 @@ class XlsSource(object):
             keys, sheet_data = self.read_excel_file(xls_path)
             for rownum, row in enumerate(sheet_data):
                 yield self.process_row(row, rownum, keys, repository_id)
+
+    def is_parsable(self, filename):
+        """Return wheter we should attempt to parse the file based on its
+        filename.
+
+        Microsoft office crates temp files in the same directory and prefixes
+        them with a tilde.
+        """
+        if filename.startswith('.') or filename.startswith('~'):
+            return False
+        if not filename.endswith('.xlsx'):
+            return False
+
+        return True
 
     def read_excel_file(self, xls_path):
         tables = xlrd_xls2array(xls_path)


### PR DESCRIPTION
For each open file MS office creates a temp file in the same directory. The temp file's filename starts with a tilde, but ends with the same file extension as the original file (`.xlsx`). Currently our import section attempts to parse these files which leads to an error.

This PR changes the behavior of the excel import section to also skip MS office temp files.

Tested and confirmed running with: 

```bash
foo.bar               ordnungssystem.xlsx   ~$ordnungssystem.xlsx ~blub.xlsx
```