### PR TITLE
Fixes sitetitle for wrapper objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Fixes sitetitle for wrapper objects.
+  [phgross]
+
 - No longer attempt to parse temporary excel files while creating repositories.
   [deiferni]
 

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -99,4 +99,12 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:page
+      name="plone_context_state"
+      for="opengever.meeting.interfaces.IBaseWrapper"
+      permission="zope.Public"
+      class=".context.WrapperContextState"
+      allowed_interface="plone.app.layout.globals.interfaces.IContextState"
+      />
+
 </configure>

--- a/opengever/meeting/browser/context.py
+++ b/opengever/meeting/browser/context.py
@@ -1,0 +1,13 @@
+from plone.app.layout.globals.context import ContextState
+from plone.app.layout.globals.interfaces import IContextState
+from plone.memoize.view import memoize
+from zope.interface import implements
+
+
+class WrapperContextState(ContextState):
+
+    implements(IContextState)
+
+    @memoize
+    def object_title(self):
+        return self.context.get_title()

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -11,15 +11,19 @@ class IMeetingSettings(Interface):
         default=False)
 
 
-class IMeetingWrapper(Interface):
+class IBaseWrapper(Interface):
+    """Marker interface for sql object wrappers."""
+
+
+class IMeetingWrapper(IBaseWrapper):
     """Marker interface for meeting object wrappers."""
 
 
-class IMemberWrapper(Interface):
+class IMemberWrapper(IBaseWrapper):
     """Marker interface for member object wrappers."""
 
 
-class IMembershipWrapper(Interface):
+class IMembershipWrapper(IBaseWrapper):
     """Marker interface for membership object wrappers."""
 
 

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -126,6 +126,13 @@ class TestMeetingView(FunctionalTestCase):
         self.assertEquals([u'C\xf6mmunity meeting'], browser.css('h1').text)
 
     @browsing
+    def test_site_title_is_meeting_title(self, browser):
+        browser.login().open(self.meeting.get_url())
+        self.assertEquals(
+            u'C\xf6mmunity meeting \u2014 Plone site',
+            browser.css('title').first.text)
+
+    @browsing
     def test_participants_listing_precidency_is_existing(self, browser):
         browser.login().open(self.meeting.get_url())
         self.assertEquals(

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -94,6 +94,13 @@ class TestMemberView(FunctionalTestCase):
                                            date_to=date(2007, 12, 31)))
 
     @browsing
+    def test_site_title_is_member_title(self, browser):
+        browser.login().open(self.member.get_url(self.container))
+        self.assertEquals(
+            u'Peter M\xfcller \u2014 Plone site',
+            browser.css('title').first.text)
+
+    @browsing
     def test_lists_member_properties(self, browser):
         browser.login().open(self.member.get_url(self.container))
 

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -66,6 +66,19 @@ class TestMemberships(FunctionalTestCase):
             browser.css('div#content-core div.error').text)
 
     @browsing
+    def test_site_title_is_membership_title(self, browser):
+        membership = create(Builder('membership')
+                            .having(member=self.member,
+                                    committee=self.committee.load_model(),
+                                    date_from=date(2003, 01, 01),
+                                    date_to=date(2007, 12, 31)))
+
+        browser.login().open(membership.get_edit_url(self.member_wrapper))
+        self.assertEquals(
+            u'Peter M\xfcller, Jan 01, 2003 - Dec 31, 2007 \u2014 Plone site',
+            browser.css('title').first.text)
+
+    @browsing
     def test_membership_can_be_edited(self, browser):
         membership = create(Builder('membership')
                             .having(member=self.member,

--- a/opengever/meeting/wrapper.py
+++ b/opengever/meeting/wrapper.py
@@ -1,9 +1,10 @@
 from Acquisition import Implicit
 from OFS.Traversable import Traversable
 from opengever.locking.interfaces import ISQLLockable
+from opengever.meeting.interfaces import IBaseWrapper
 from opengever.meeting.interfaces import IMeetingWrapper
-from opengever.meeting.interfaces import IMemberWrapper
 from opengever.meeting.interfaces import IMembershipWrapper
+from opengever.meeting.interfaces import IMemberWrapper
 from opengever.meeting.model import Membership
 from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
 from zope.interface import implements
@@ -12,7 +13,7 @@ import ExtensionClass
 
 class BaseWrapper(ExtensionClass.Base, Implicit, Traversable):
 
-    implements(IHideFromBreadcrumbs)
+    implements(IHideFromBreadcrumbs, IBaseWrapper)
 
     default_view = 'view'
 


### PR DESCRIPTION
Customize the `object_title` method on the `plone_context_state` view for WrapperObjects, to make sure that the site title contains the Wrapper title instead of the parents id. Fixes #1691.

@lukasgraf @deiferni 