### PR TITLE
Language Tool: Enable request content negotiation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Language Tool: Enable request content negotiation.
+  [lgraf]
+
 - Fixes sitetitle for wrapper objects.
   [phgross]
 

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -10,6 +10,7 @@ from opengever.base.model import create_session
 from opengever.meeting.interfaces import IMeetingSettings
 from opengever.ogds.base.setup import create_sql_tables
 from opengever.ogds.models import BASE
+from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -158,6 +159,7 @@ class OpengeverFixture(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         self.installOpengeverProfiles(portal)
         self.createMemberFolder(portal)
+        self.setupLanguageTool(portal)
         deactivateActivityCenter()
 
     def tearDown(self):
@@ -207,6 +209,27 @@ class OpengeverFixture(PloneSandboxLayer):
         portal.invokeFactory('Folder', 'Members')
         portal['Members'].invokeFactory('Folder', TEST_USER_ID)
         setRoles(portal, TEST_USER_ID, ['Member'])
+
+    def setupLanguageTool(self, portal):
+        """Configure the language tool as close as possible to production,
+        without breaking most of the existing tests.
+
+        For production, the language tool is configured in
+        opengever.policy.base:default, which we don't import here
+        (see comment in installOpengeverProfiles() above).
+        """
+
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.use_combined_language_codes = True
+        lang_tool.display_flags = False
+        lang_tool.start_neutral = False
+        lang_tool.use_subdomain_negotiation = False
+        lang_tool.authenticated_users_only = False
+        lang_tool.use_request_negotiation = False
+
+        # These would be (possible) production defaults, but will break tests
+        # lang_tool.setDefaultLanguage('de-ch')
+        # lang_tool.supported_langs = ['fr-ch', 'de-ch']
 
 
 class MemoryDBLayer(Layer):

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -225,7 +225,7 @@ class OpengeverFixture(PloneSandboxLayer):
         lang_tool.start_neutral = False
         lang_tool.use_subdomain_negotiation = False
         lang_tool.authenticated_users_only = False
-        lang_tool.use_request_negotiation = False
+        lang_tool.use_request_negotiation = True
 
         # These would be (possible) production defaults, but will break tests
         # lang_tool.setDefaultLanguage('de-ch')

--- a/opengever/policy/base/profiles/default/portal_languages.xml
+++ b/opengever/policy/base/profiles/default/portal_languages.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <object>
-<default_language value="de-ch"/>
-<use_combined_language_codes value="True"/>
-<display_flags value="False"/>
-<start_neutral value="False"/>
-<use_subdomain_negotiation value="False"/>
-<authenticated_users_only value="False"/>
-<supported_langs>
-<element value="de-ch"/>
-</supported_langs>
+    <default_language value="de-ch"/>
+    <use_combined_language_codes value="True"/>
+    <display_flags value="False"/>
+    <start_neutral value="False"/>
+    <use_subdomain_negotiation value="False"/>
+    <authenticated_users_only value="False"/>
+    <supported_langs>
+        <element value="de-ch"/>
+    </supported_langs>
 </object>

--- a/opengever/policy/base/profiles/default/portal_languages.xml
+++ b/opengever/policy/base/profiles/default/portal_languages.xml
@@ -6,6 +6,7 @@
     <start_neutral value="False"/>
     <use_subdomain_negotiation value="False"/>
     <authenticated_users_only value="False"/>
+    <use_request_negotiation value="True"/>
     <supported_langs>
         <element value="de-ch"/>
     </supported_langs>

--- a/opengever/policy/base/upgrades/20160412172450_language_tool__enable_request_content_negotiation/portal_languages.xml
+++ b/opengever/policy/base/upgrades/20160412172450_language_tool__enable_request_content_negotiation/portal_languages.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object>
+    <use_request_negotiation value="True"/>
+</object>

--- a/opengever/policy/base/upgrades/20160412172450_language_tool__enable_request_content_negotiation/upgrade.py
+++ b/opengever/policy/base/upgrades/20160412172450_language_tool__enable_request_content_negotiation/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnableRequestContentNegotiation(UpgradeStep):
+    """Language Tool: Enable request content negotiation.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This enables request content negotiation in the `portal_language` tool.

Later we will need this to be able to control the current language in API requests via the `Accept-Language` header.

Tested:
 - Fresh setup
 - Upgrade step
 - Language switcher still works

@deiferni @phgross 