### PR TITLE
Let a formatter know if he is grouped_by_three.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,10 +5,11 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
-- Fix wrong from/to column labels in meeting overviews.
+- Fix an issue with importing no_client_id_grouped_by_three formatted
+  repositories.
   [deiferni]
 
-- Meeting: fix an issue with e-mail addresses that contain non-ascii characters.
+- Fix wrong from/to column labels in meeting overviews.
   [deiferni]
 
 - Meeting Protocol:

--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -11,6 +11,8 @@ class DottedReferenceFormatter(grok.Adapter):
     grok.context(Interface)
     grok.name('dotted')
 
+    is_grouped_by_three = False
+
     repository_dossier_seperator = u' / '
     dossier_document_seperator = u' / '
     repository_title_seperator = u'.'
@@ -96,6 +98,8 @@ class GroupedByThreeReferenceFormatter(DottedReferenceFormatter):
     grok.provides(IReferenceNumberFormatter)
     grok.context(Interface)
     grok.name('grouped_by_three')
+
+    is_grouped_by_three = True
 
     repository_dossier_seperator = u'-'
     dossier_document_seperator = u'-'

--- a/opengever/setup/sections/reference.py
+++ b/opengever/setup/sections/reference.py
@@ -2,12 +2,15 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberPrefix as PrefixAdapter
 from opengever.base.interfaces import IReferenceNumberSettings
+from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.i18n.normalizer.interfaces import IURLNormalizer
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
+from zope.component import queryAdapter
 from zope.component import queryUtility
 from zope.interface import classProvides, implements
 import logging
@@ -44,7 +47,8 @@ class PathFromReferenceNumberSection(object):
 
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IReferenceNumberSettings)
-        self.reference_formatter = proxy.formatter
+        self.reference_formatter = queryAdapter(
+            api.portal.get(), IReferenceNumberFormatter, name=proxy.formatter)
 
     def __iter__(self):
         self.logger.info("Building paths from reference numbers...")
@@ -89,7 +93,7 @@ class PathFromReferenceNumberSection(object):
         self.logger.info("...done!")
 
     def get_reference_number(self, refnum):
-        if self.reference_formatter == 'grouped_by_three':
+        if self.reference_formatter.is_grouped_by_three:
             cl_refnum = refnum.replace('.', '')
             return '.'.join(cl_refnum)
         return refnum


### PR DESCRIPTION
Currently we cannot import repositories formatted with the recently introduced `no_client_id_grouped_by_three` reference number formatter. This PR addresses that issue and adds support for that formatter.

Closes #1661