### PR TITLE
Fix wrong from/to column labels in meeting overviews.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Fix wrong from/to column labels in meeting overviews.
+  [deiferni]
+
 - Meeting: fix an issue with e-mail addresses that contain non-ascii characters.
   [deiferni]
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -480,7 +480,7 @@ msgstr "Vorname"
 #. Default: "From"
 #: ./opengever/meeting/tabs/meetinglisting.py:61
 msgid "column_from"
-msgstr "Bis"
+msgstr "Von"
 
 #. Default: "Lastname"
 #: ./opengever/meeting/tabs/memberlisting.py:30
@@ -523,7 +523,7 @@ msgstr "Titel"
 #. Default: "To"
 #: ./opengever/meeting/tabs/meetinglisting.py:66
 msgid "column_to"
-msgstr "Von"
+msgstr "Bis"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:36


### PR DESCRIPTION
This PR fixes the german translations for from/to column labels. Fixes #1659.

![screen shot 2016-04-14 at 16 13 01](https://cloud.githubusercontent.com/assets/736583/14531037/0061187c-025c-11e6-9635-e3378a73026c.png)

