### PR TITLE
Rename button to create paragraphs to "insert".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Meeting: Rename button to create paragraphs to "insert".
+  [deiferni]
+
 - Fix an issue with importing no_client_id_grouped_by_three formatted
   repositories.
   [deiferni]

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -233,8 +233,8 @@
                 <input id="schedule-paragraph" type="text" />
                 <div class="button-group">
                   <input type="submit"
-                         value="Schedule"
-                         i18n:attributes="value label_schedule"
+                         value="Insert"
+                         i18n:attributes="value label_insert"
                          tal:attributes="data-url view/url_schedule_paragraph"
                          class="schedule-paragraph allowMultiSubmit" />
                 </div>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-03 13:58+0000\n"
+"POT-Creation-Date: 2016-04-14 14:52+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,7 +150,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:47
+#: ./opengever/meeting/committee.py:53
 #: ./opengever/meeting/committeecontainer.py:25
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
@@ -207,7 +207,7 @@ msgstr "Antrag einfügen"
 msgid "Include publish in"
 msgstr "Veröffentlichung in einfügen"
 
-#: ./opengever/meeting/committee.py:53
+#: ./opengever/meeting/committee.py:59
 msgid "Linked repository folder"
 msgstr "Ablageposition"
 
@@ -287,7 +287,7 @@ msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:41
+#: ./opengever/meeting/committee.py:47
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Protocol template"
 msgstr "Vorlage Protokoll"
@@ -543,7 +543,7 @@ msgid "decided"
 msgstr "Beschlossen"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:82
+#: ./opengever/meeting/committee.py:88
 msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
@@ -783,7 +783,7 @@ msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:81
+#: ./opengever/meeting/committee.py:87
 msgid "label_group"
 msgstr "Gruppe"
 
@@ -792,6 +792,11 @@ msgstr "Gruppe"
 #: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr "Ausgangslage"
+
+#. Default: "Insert"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:235
+msgid "label_insert"
+msgstr "Einfügen"
 
 #. Default: "Last Meeting:"
 #: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:27
@@ -816,7 +821,7 @@ msgid "label_linked_meeting"
 msgstr "Sitzung"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:54
+#: ./opengever/meeting/committee.py:60
 msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
@@ -1133,7 +1138,7 @@ msgid "protocol"
 msgstr "Protokoll"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:131
+#: ./opengever/meeting/protocol.py:145
 msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-03 13:58+0000\n"
+"POT-Creation-Date: 2016-04-14 14:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:47
+#: ./opengever/meeting/committee.py:53
 #: ./opengever/meeting/committeecontainer.py:25
 msgid "Excerpt template"
 msgstr ""
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:53
+#: ./opengever/meeting/committee.py:59
 msgid "Linked repository folder"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
-#: ./opengever/meeting/committee.py:41
+#: ./opengever/meeting/committee.py:47
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Protocol template"
 msgstr ""
@@ -543,7 +543,7 @@ msgid "decided"
 msgstr "Décidé"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:82
+#: ./opengever/meeting/committee.py:88
 msgid "description_group"
 msgstr ""
 
@@ -783,7 +783,7 @@ msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:81
+#: ./opengever/meeting/committee.py:87
 msgid "label_group"
 msgstr ""
 
@@ -792,6 +792,11 @@ msgstr ""
 #: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
 msgstr "Situation initiale"
+
+#. Default: "Insert"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:235
+msgid "label_insert"
+msgstr ""
 
 #. Default: "Last Meeting:"
 #: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:27
@@ -816,7 +821,7 @@ msgid "label_linked_meeting"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:54
+#: ./opengever/meeting/committee.py:60
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -1133,7 +1138,7 @@ msgid "protocol"
 msgstr "Procès-verbal"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:131
+#: ./opengever/meeting/protocol.py:145
 msgid "protocol_excerpt"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-03 13:58+0000\n"
+"POT-Creation-Date: 2016-04-14 14:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -149,7 +149,7 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:47
+#: ./opengever/meeting/committee.py:53
 #: ./opengever/meeting/committeecontainer.py:25
 msgid "Excerpt template"
 msgstr ""
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:53
+#: ./opengever/meeting/committee.py:59
 msgid "Linked repository folder"
 msgstr ""
 
@@ -286,7 +286,7 @@ msgstr ""
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:41
+#: ./opengever/meeting/committee.py:47
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Protocol template"
 msgstr ""
@@ -542,7 +542,7 @@ msgid "decided"
 msgstr ""
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:82
+#: ./opengever/meeting/committee.py:88
 msgid "description_group"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgid "label_firstname"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:81
+#: ./opengever/meeting/committee.py:87
 msgid "label_group"
 msgstr ""
 
@@ -790,6 +790,11 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/protocol.py:126
 #: ./opengever/meeting/proposal.py:58
 msgid "label_initial_position"
+msgstr ""
+
+#. Default: "Insert"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:235
+msgid "label_insert"
 msgstr ""
 
 #. Default: "Last Meeting:"
@@ -815,7 +820,7 @@ msgid "label_linked_meeting"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:54
+#: ./opengever/meeting/committee.py:60
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -1132,7 +1137,7 @@ msgid "protocol"
 msgstr ""
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:131
+#: ./opengever/meeting/protocol.py:145
 msgid "protocol_excerpt"
 msgstr ""
 


### PR DESCRIPTION
Rename button to create paragraphs in meetings to "insert". This helps clarifying the difference between agenda-items and paragraphs.

Closes #1660.

Note that currently this breaks button alignment. I don't mind but it might be an issue?

![screen shot 2016-04-14 at 17 03 38](https://cloud.githubusercontent.com/assets/736583/14532871/e14eff2e-0262-11e6-975f-b9071047372f.png)