### PR TITLE
Docs: Add standalone Sphinx docs buildout

### DIFF
--- a/sphinx-standalone.cfg
+++ b/sphinx-standalone.cfg
@@ -1,0 +1,2 @@
+[buildout]
+extends = sphinx.cfg

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -28,7 +28,10 @@ inline =
 
     set -euo pipefail
 
-    ZOPE_PY="${buildout:bin-directory}/${zopepy:interpreter}"
+    # XXX: Hardcoded 'zopepy' in order to avoid dependency on
+    # the [zopypy] section for sphinx-standalone.cfg. This should
+    # later be solved by making the schema-docs update optional 
+    ZOPE_PY="${buildout:bin-directory}/zopepy"
     BUILDOUT_DIR="${buildout:directory}"
     export SPHINXBUILD="${buildout:bin-directory}/sphinx-build"
 
@@ -70,7 +73,6 @@ inline =
 
     set -euo pipefail
 
-    ZOPE_PY="${buildout:bin-directory}/${zopepy:interpreter}"
     BUILDOUT_DIR="${buildout:directory}"
     export SPHINXBUILD="${buildout:bin-directory}/sphinx-build"
 


### PR DESCRIPTION
Add buildout that allows to build a standalone Sphinx docs development environment (without `opengever.core`, Plone, etc.)