### PR TITLE
Diverse Typos korrigiert.

### DIFF
--- a/docs/intern/kurzreferenzen/administration.rst
+++ b/docs/intern/kurzreferenzen/administration.rst
@@ -87,7 +87,7 @@ Dies geschieht in Word wie folgt:
 
    |docprops-7|
 
-7. Ausgewähltes DocProperty in Anführungs - und Schlusszeichen setzen.
+7. Ausgewähltes DocProperty in Anführungs- und Schlusszeichen setzen.
 
 8. Mit “OK” bestätigen.
 
@@ -385,10 +385,10 @@ Einem Manager stehen die folgenden Plone-Views zum Debugging der Vorlagen zur
 Verfügung:
 
 - Inhaltstyp Sablon-Vorlage: ``fill_meeting_template`` füllt Beispieldaten einer
-  Sitzung in die Sab-lon-Vorlage ein. Probleme mit der Syntax der
+  Sitzung in die Sablon-Vorlage ein. Probleme mit der Syntax der
   Formatierungs-DSL werden so schnell ersichtlich.
 
-- Inhaltstyp Sitzung: ``download_protocol_json``, ermöglich es das JSON File
-  herunterzulande, das zum generieren des Dokuments aus der Sablon-Vorlage
+- Inhaltstyp Sitzung: ``download_protocol_json`` ermöglicht es, das JSON File
+  herunterzuladen, das zum Generieren des Dokuments aus der Sablon-Vorlage
   verwendet wird.
 


### PR DESCRIPTION
Diverse Schreibfehler korrigiert, gemäss Anleitung von @lukasgraf (https://intern.onegovgever.ch/meta/) vorgegangen 