### PR TITLE
API Docs: Add some code examples (Python)

### DIFF
--- a/docs/api/_static/custom.css
+++ b/docs/api/_static/custom.css
@@ -97,3 +97,19 @@ blockquote {
 #schemas #kontakt > h3 {
     background-image: url('img/contact.png');
 }
+
+
+/* Collapsibles */
+
+.collapsible .header {
+    display: block;
+    clear: both;
+}
+
+.collapsible .header:after {
+    content: " ▶";
+}
+
+.collapsible .header.open:after {
+    content: " ▼";
+}

--- a/docs/api/_static/custom.js
+++ b/docs/api/_static/custom.js
@@ -1,3 +1,17 @@
+// Red 'required' indicator for fields in schema docs
+
 $(function() {
     $('span.required').parents('.attribute').find('dt > code').addClass('required-marker');
+});
+
+
+// Collapsibles
+
+$(function() {
+    $(".collapsible > *").hide();
+    $(".collapsible .header").show();
+    $(".collapsible .header").click(function() {
+        $(this).parent().children().not(".header").toggle();
+        $(this).parent().children(".header").toggleClass("open");
+    });
 });

--- a/docs/api/basics.rst
+++ b/docs/api/basics.rst
@@ -39,6 +39,8 @@ Die URL eines Requests ist bestimmt durch das Objekt, für welches eine
 Operation durchgeführt werden soll. Diese URL ist in der Regel für das
 entsprechende Objekt in der Adresszeile des Browsers sichtbar.
 
+.. _basics-headers:
+
 Headers
 ^^^^^^^
 
@@ -117,6 +119,7 @@ Key           Bedeutung               Beschreibung
 
 ------
 
+.. _basics-authentication:
 
 Authentisierung
 ---------------
@@ -134,9 +137,11 @@ Für HTTP Basic Auth muss ein `Authorization` Header im Request gesetzt werden:
   Accept: application/json
 
 Die HTTP Client Libraries bieten üblicherweise Hilfsfunktionen an, um diesen
-Header basierend auf Benutzername und Passwort zu generieren
-(siehe Code-Beispiele).
+Header basierend auf Benutzername und Passwort zu generieren.
 
+**Code-Beispiel (Python)**: Session erzeugen und Headers setzen
+
+.. literalinclude:: examples/example_session.py
 
 
 .. _RESTful: https://de.wikipedia.org/wiki/Representational_State_Transfer

--- a/docs/api/docs_changelog.rst
+++ b/docs/api/docs_changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2016-04-15
+----------
+
+- Code-Beispiele (Python) hinzugefügt
+
 2016-04-08
 ----------
 

--- a/docs/api/examples/example_get.py
+++ b/docs/api/examples/example_get.py
@@ -1,0 +1,3 @@
+url = 'https://example.org/ordnungssystem/fuehrung/'
+response = session.get(url)
+title = response.json()['title']

--- a/docs/api/examples/example_patch.py
+++ b/docs/api/examples/example_patch.py
@@ -1,0 +1,6 @@
+dossier_data = {
+    "title": "Neuer Titel"
+}
+
+url = 'https://example.org/ordnungssystem/fuehrung/dossier-42'
+response = session.patch(url, json=dossier_data)

--- a/docs/api/examples/example_post.py
+++ b/docs/api/examples/example_post.py
@@ -1,0 +1,12 @@
+dossier_data = {
+    "@type": "opengever.dossier.businesscasedossier",
+    "title": "Ein neues Dossier via API",
+    "responsible": "peter.muster",
+    "custody_period": 30,
+    "archival_value": "unchecked",
+    "retention_period": 10,
+}
+
+url = 'https://example.org/ordnungssystem/fuehrung/'
+response = session.post(url, json=dossier_data)
+new_dossier_url = response.headers['Location']

--- a/docs/api/examples/example_session.py
+++ b/docs/api/examples/example_session.py
@@ -1,0 +1,5 @@
+import requests
+
+session = requests.Session()
+session.auth = ('username', 'password')
+session.headers.update({'Accept': 'application/json'})

--- a/docs/api/examples/index.rst
+++ b/docs/api/examples/index.rst
@@ -1,0 +1,38 @@
+Code-Beispiele
+==============
+
+Folgend eine gesammelte Übersicht über Code-Beispiele (in Python), welche in
+anderen Bereichen der Dokumentation verwendet werden.
+
+Alle diese Beispiele haben gemeinsam, dass eine ``session`` vorbereitet und
+verwendet werden muss, welche die richtigen ``Authorization`` und ``Accept``
+Headers setzt:
+
+.. literalinclude:: example_session.py
+
+Siehe :ref:`basics-headers` und :ref:`basics-authentication`
+
+
+Inhalte lesen (GET)
+-------------------
+
+.. literalinclude:: example_get.py
+
+
+Inhalte erstellen (POST)
+------------------------
+
+.. literalinclude:: example_post.py
+
+
+Inhalte bearbeiten (PATCH)
+--------------------------
+
+.. literalinclude:: example_patch.py
+
+
+Stichwortverzeichnis
+====================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ Inhalt:
    operations.rst
    exploring.rst
    content_types.rst
+   examples/index.rst
    docs_changelog.rst
 
 

--- a/docs/api/operations.rst
+++ b/docs/api/operations.rst
@@ -99,9 +99,13 @@ Unterobjekte enthält (direkte children des Objekts).
         "title": "Ein Geschäftsdossier"
       }
 
-**Code-Beispiel (Python)**
+.. container:: collapsible
 
-.. literalinclude:: examples/example_get.py
+    .. container:: header
+
+       **Code-Beispiel (Python)**
+
+    .. literalinclude:: examples/example_get.py
 
 
 Inhalte erstellen (POST)
@@ -146,9 +150,13 @@ mitgegeben werden.
 Im ``Location`` Header der Response ist die URL des neu erstellen Objekts zu
 finden.
 
-**Code-Beispiel (Python)**
+.. container:: collapsible
 
-.. literalinclude:: examples/example_post.py
+    .. container:: header
+
+       **Code-Beispiel (Python)**
+
+    .. literalinclude:: examples/example_post.py
 
 
 Inhalte bearbeiten (PATCH)
@@ -181,6 +189,10 @@ Um ein oder mehrere Attribute eines Objekts zu aktualisieren, wird ein
 
       null
 
-**Code-Beispiel (Python)**
+.. container:: collapsible
 
-.. literalinclude:: examples/example_patch.py
+    .. container:: header
+
+       **Code-Beispiel (Python)**
+
+    .. literalinclude:: examples/example_patch.py

--- a/docs/api/operations.rst
+++ b/docs/api/operations.rst
@@ -99,6 +99,10 @@ Unterobjekte enthält (direkte children des Objekts).
         "title": "Ein Geschäftsdossier"
       }
 
+**Code-Beispiel (Python)**
+
+.. literalinclude:: examples/example_get.py
+
 
 Inhalte erstellen (POST)
 ------------------------
@@ -142,6 +146,10 @@ mitgegeben werden.
 Im ``Location`` Header der Response ist die URL des neu erstellen Objekts zu
 finden.
 
+**Code-Beispiel (Python)**
+
+.. literalinclude:: examples/example_post.py
+
 
 Inhalte bearbeiten (PATCH)
 --------------------------
@@ -173,3 +181,6 @@ Um ein oder mehrere Attribute eines Objekts zu aktualisieren, wird ein
 
       null
 
+**Code-Beispiel (Python)**
+
+.. literalinclude:: examples/example_patch.py


### PR DESCRIPTION
Add some code examples in Python for the basic operations. As currently published on https://docs.onegovgever.ch/operations/

*(The CSS and JS for collapsibles will eventually go into a separate package `opengever.sphinx` as part of the theme, but I haven't gotten around to creating that package/repo just yet.)*

@deiferni 