### PR TITLE
Make default value for IDossier.start a defaultFactory instead of a form level default

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Make default value for IDossier.start a defaultFactory instead
+  of a form level default.
+  [lgraf]
+
 - REST API: Customize summary representation to include
 
   - Translated 'title' for objects with ITranslatedTitleSupport

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -12,7 +12,7 @@ from opengever.dossier import _
 from opengever.dossier.widget import referenceNumberWidgetFactory
 from opengever.ogds.base.autocomplete_widget import AutocompleteFieldWidget
 from plone.autoform.interfaces import IFormFieldProvider
-from plone.dexterity.i18n import MessageFactory as pd_mf
+from plone.dexterity.i18n import MessageFactory as pd_mf  # noqa
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.directives import form, dexterity
 from plone.z3cform.textlines.textlines import TextLinesFieldWidget
@@ -27,12 +27,12 @@ LOG = logging.getLogger('opengever.dossier')
 
 
 class IDossierMarker(Interface, ITabbedviewUploadable):
-    """ Marker Interface for dossiers.
+    """Marker Interface for dossiers.
     """
 
 
 class IDossier(form.Schema):
-    """ Behaviour interface for dossier types providing
+    """Behaviour interface for dossier types providing
     common properties/fields.
     """
 
@@ -181,7 +181,7 @@ class IDossier(form.Schema):
     )
 
     @invariant
-    def validateStartEnd(data):
+    def validate_start_end(data):
         # Do not get the data from the context when it is not in the current
         # fields / z3cform group
         data = data._Data_data___
@@ -232,6 +232,7 @@ class AddForm(dexterity.AddForm):
 
 class EditForm(dexterity.EditForm):
     """Standard Editform, provide just a special label for subdossiers"""
+
     grok.context(IDossierMarker)
 
     def updateFields(self):

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -31,6 +31,10 @@ class IDossierMarker(Interface, ITabbedviewUploadable):
     """
 
 
+def start_date_default():
+    return date.today()
+
+
 class IDossier(form.Schema):
     """Behaviour interface for dossier types providing
     common properties/fields.
@@ -65,6 +69,7 @@ class IDossier(form.Schema):
         title=_(u'label_start', default=u'Opening Date'),
         description=_(u'help_start', default=u''),
         required=False,
+        defaultFactory=start_date_default,
     )
 
     # workaround because ftw.datepicker wasn't working on the edit form
@@ -252,8 +257,3 @@ class EditForm(dexterity.EditForm):
 
 class StartBeforeEnd(Invalid):
     __doc__ = _(u"The start or end date is invalid")
-
-
-@form.default_value(field=IDossier['start'])
-def start_date_default(data):
-    return date.today()

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -1,9 +1,10 @@
 from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testing import freeze
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
 
 
 class TestDossierContainer(FunctionalTestCase):
@@ -165,6 +166,11 @@ class TestDossierChecks(FunctionalTestCase):
 
 
 class TestDateCalculations(FunctionalTestCase):
+
+    def test_start_date_defaults_to_today(self):
+        with freeze(datetime.now()):
+            dossier = create(Builder("dossier"))
+            self.assertEqual(IDossier(dossier).start, date.today())
 
     def test_earliest_possible_is_none_for_empty_dossiers(self):
         dossier = create(Builder("dossier")


### PR DESCRIPTION
This ensures this default is also respected when programmatically creating content (REST API, `plone.api`, `ftw.builder`, `transmogrifier`, ...).

See: http://docs.plone.org/4/en/external/plone.app.dexterity/docs/advanced/defaults.html#defaults

@phgross 