### PR TITLE
Extend instance eggs in development.cfg to include hotfixes.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -21,15 +21,17 @@ ogds-db-driver = psycopg2
 #ogds-dsn = ${buildout:ogds-dsn-mysql}
 #ogds-db-driver = MySQL-python
 
+instance-eggs +=
+    opengever.core[api]
+    plonetheme.teamraum
+    opengever.maintenance
+    ${buildout:ogds-db-driver}
 
 [instance]
 zserver-threads = 4
 user = zopemaster:admin
 eggs +=
-    opengever.core[api]
-    plonetheme.teamraum
-    opengever.maintenance
-    ${buildout:ogds-db-driver}
+    ${buildout:instance-eggs}
 
 zcml-additional =
     <configure


### PR DESCRIPTION
Currently we ignore inherited `instance-eggs`.