### PR TITLE
GEVER-Inhaltstypen IBumblebeeable machen

### DIFF
--- a/opengever/bumblebee/overrides.zcml
+++ b/opengever/bumblebee/overrides.zcml
@@ -1,0 +1,14 @@
+<configure
+      xmlns="http://namespaces.zope.org/zope"
+      xmlns:i18n="http://namespaces.zope.org/i18n"
+      i18n_domain="opengever.base">
+
+  <adapter
+      for="ftw.bumblebee.interfaces.IBumblebeeable"
+      factory=".service.GeverBumblebeeService" />
+
+</configure>
+
+
+
+

--- a/opengever/bumblebee/overrides.zcml
+++ b/opengever/bumblebee/overrides.zcml
@@ -8,7 +8,3 @@
       factory=".service.GeverBumblebeeService" />
 
 </configure>
-
-
-
-

--- a/opengever/bumblebee/service.py
+++ b/opengever/bumblebee/service.py
@@ -1,0 +1,13 @@
+from ftw.bumblebee.service import BumblebeeService
+from opengever.bumblebee import is_bumblebee_feature_enabled
+
+
+class GeverBumblebeeService(BumblebeeService):
+    """Only queues conversions when the bumblebee feature is enabled."""
+
+    def queue_conversion(self, queue, version_id=None):
+        if not is_bumblebee_feature_enabled():
+            return False
+
+        return super(GeverBumblebeeService, self).queue_conversion(
+            queue, version_id=version_id)

--- a/opengever/document/profiles/default/types/opengever.document.document.xml
+++ b/opengever/document/profiles/default/types/opengever.document.document.xml
@@ -33,6 +33,7 @@
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.document.behaviors.IBaseDocument" />
     <element value="opengever.document.behaviors.metadata.IDocumentMetadata" />
+    <element value="ftw.bumblebee.interfaces.IBumblebeeable" />
   </property>
 
   <!-- View information -->

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -1,0 +1,23 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
+from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
+from ftw.bumblebee import utils as bumblebee_utils
+
+
+class TestBumblebee(FunctionalTestCase):
+    """Test integration of ftw.bumblebee."""
+
+    def setUp(self):
+        super(TestBumblebee, self).setUp()
+
+        self.document = create(Builder('document')
+                               .attach_file_containing(
+                                   bumblebee_asset('example.docx').bytes(),
+                                   u'example.docx'))
+
+    def test_bumblebee_checksum_is_calculated_for_opengever_docs(self):
+        self.assertEquals(
+            DOCX_CHECKSUM,
+            bumblebee_utils.get_document_checksum(self.document))

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -4,6 +4,7 @@ from opengever.testing import FunctionalTestCase
 from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.bumblebee import utils as bumblebee_utils
+from plone.rfc822.interfaces import IPrimaryFieldInfo
 
 
 class TestBumblebee(FunctionalTestCase):
@@ -21,3 +22,7 @@ class TestBumblebee(FunctionalTestCase):
         self.assertEquals(
             DOCX_CHECKSUM,
             bumblebee_utils.get_document_checksum(self.document))
+
+    def test_opengever_documents_have_a_primary_field(self):
+        fieldinfo = IPrimaryFieldInfo(self.document)
+        self.assertEqual('file', fieldinfo.fieldname)

--- a/opengever/document/upgrades/20160418132407_add_bumblebee_support_for_documents/types/opengever.document.document.xml
+++ b/opengever/document/upgrades/20160418132407_add_bumblebee_support_for_documents/types/opengever.document.document.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="opengever.document.document" meta_type="Dexterity FTI"
+        i18n:domain="opengever.document" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="ftw.bumblebee.interfaces.IBumblebeeable" />
+  </property>
+
+</object>

--- a/opengever/document/upgrades/20160418132407_add_bumblebee_support_for_documents/upgrade.py
+++ b/opengever/document/upgrades/20160418132407_add_bumblebee_support_for_documents/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddBumblebeeSupportForDocuments(UpgradeStep):
+    """Add bumblebee support for documents.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,6 +9,7 @@ development-packages =
   plone.rest
 # https://github.com/4teamwork/opengever.core/issues/1512
   opengever.ogds.models
+# https://github.com/4teamwork/opengever.core/issues/1680
   ftw.bumblebee
 
 auto-checkout = ${buildout:development-packages}
@@ -16,6 +17,3 @@ auto-checkout = ${buildout:development-packages}
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
 
-[branches]
-# TMP DONT MERGE ME!
-ftw.bumblebee = es-dexterity-support

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,8 +9,13 @@ development-packages =
   plone.rest
 # https://github.com/4teamwork/opengever.core/issues/1512
   opengever.ogds.models
+  ftw.bumblebee
 
 auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
+
+[branches]
+# TMP DONT MERGE ME!
+ftw.bumblebee = es-dexterity-support


### PR DESCRIPTION
Dieser PR bringt folgende Neuerungen:

- das IBumblebeeable behavior wird dem Typ `opengever.document.document` hinzugefügt
- Der Bumblebeeservice zum hinzufügen von Jobs wird mit einem Feature-Flag-Check erweitert

closes #1680