### PR TITLE
TranslatedTitleBrain: Also use Missing.Value as indicator to use regular title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+-  TranslatedTitleBrain: Also use Missing.Value as indicator that a brain
+   has no translated title, and should therefore return the regular title.
+   [lgraf]
+
 - Make default value for IDossier.start a defaultFactory instead
   of a form level default.
   [lgraf]

--- a/opengever/base/brain.py
+++ b/opengever/base/brain.py
@@ -1,4 +1,5 @@
 from opengever.base.utils import get_preferred_language_code
+import Missing
 
 
 def useBrains(self, brains):
@@ -16,7 +17,7 @@ def useBrains(self, brains):
             code = get_preferred_language_code()
             title = getattr(self, 'title_%s' % code, None)
 
-            if title is None:
+            if title in (None, Missing.Value):
                 # non-translated content
                 title = super(TranslatedTitleBrain, self).Title
 


### PR DESCRIPTION
TranslatedTitleBrain: Also use `Missing.Value` as indicator that a brain has no translated title, and should therefore return the regular title.

Objects that existed before the TranslatedTitle behavior was activated will have `Missing.Value` indexed for `title_de` and `title_fr` metadata. The existing check for `None` will therefore fail for those objects. 