### PR TITLE
Added SIP Download action

### DIFF
--- a/opengever/disposition/browser/configure.zcml
+++ b/opengever/disposition/browser/configure.zcml
@@ -10,7 +10,7 @@
 
   <browser:page
     class=".ech0160_export.ECH0160ExportView"
-    for="*"
+    for="opengever.disposition.interfaces.IDisposition"
     name="ech0160_export"
     permission="zope2.View"/>
 

--- a/opengever/disposition/browser/ech0160_export.py
+++ b/opengever/disposition/browser/ech0160_export.py
@@ -1,11 +1,9 @@
 from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
-from Products.Five import BrowserView
-from ZPublisher.Iterators import IStreamIterator
 from opengever.disposition.ech0160 import model
 from opengever.disposition.ech0160.bindings import arelda
 from opengever.disposition.ech0160.utils import file_checksum
 from opengever.ogds.base.utils import get_current_org_unit
+from Products.Five import BrowserView
 from pyxb.namespace import XMLSchema_instance as xsi
 from pyxb.utils.domutils import BindingDOMSupport
 from tempfile import TemporaryFile
@@ -13,6 +11,7 @@ from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 from zope.component import queryMultiAdapter
 from zope.interface import implements
+from ZPublisher.Iterators import IStreamIterator
 import os.path
 
 schemas_path = os.path.join(
@@ -51,16 +50,10 @@ class ECH0160ExportView(BrowserView):
         doc.ablieferung.provenienz.aktenbildnerName = u'Grossrat des Kantons'
         doc.ablieferung.provenienz.registratur = u'Ratsinformationssystem'
 
-        catalog = getToolByName(self.context, 'portal_catalog')
-        dossiers = catalog(
-            portal_type='opengever.dossier.businesscasedossier',
-            # UID='84bd8defbef3426b9f4fac396d691d8b',
-        )
-
         repo = model.Repository()
         content = model.ContentRootFolder(sip_folder_name)
-        for dossier in dossiers:
-            d = model.Dossier(dossier.getObject())
+        for relation in self.context.dossiers:
+            d = model.Dossier(relation.to_object)
             repo.add_dossier(d)
             content.add_dossier(d)
 

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -1,6 +1,7 @@
 from five import grok
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.disposition import _
 from opengever.disposition.interfaces import IDisposition
 from opengever.tabbedview.browser.base import OpengeverTab
 from plone import api
@@ -35,3 +36,16 @@ class DispositionOverview(grok.View, OpengeverTab):
         wftool = api.portal.get_tool(name='portal_workflow')
         infos = wftool.listActionInfos(object=self.context, check_condition=False)
         return infos
+
+    def get_actions(self):
+        return [
+            {'id': 'sip_download',
+             'label': _('label_sip_download', default=u'SIP download'),
+             'url': '{}/ech0160_export'.format(self.context.absolute_url()),
+             'visible': self.sip_download_available()},
+        ]
+
+    def sip_download_available(self):
+        """TODO: Should be protected with a own permission.
+        """
+        return api.content.get_state(self.context) == 'disposition-state-appraised'

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -56,3 +56,6 @@ class DispositionOverview(grok.View, OpengeverTab):
         """TODO: Should be protected with a own permission.
         """
         return api.content.get_state(self.context) == 'disposition-state-appraised'
+
+    def appraisal_buttons_available(self):
+        return api.content.get_state(self.context) == 'disposition-state-in-progress'

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -39,10 +39,17 @@ class DispositionOverview(grok.View, OpengeverTab):
 
     def get_actions(self):
         return [
+            {'id': 'export_appraisal_list',
+             'label': _('label_export_appraisal_list',
+                        default=u'Export appraisal list'),
+             'url': '{}/xlsx'.format(self.context.absolute_url()),
+             'visible': True,
+             'class': 'appraisal_list'},
             {'id': 'sip_download',
              'label': _('label_sip_download', default=u'SIP download'),
              'url': '{}/ech0160_export'.format(self.context.absolute_url()),
-             'visible': self.sip_download_available()},
+             'visible': self.sip_download_available(),
+             'class': 'sip_download'},
         ]
 
     def sip_download_available(self):

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -75,4 +75,18 @@
       </a>
     </li>
   </ul>
+  <ul class="actions">
+    <li tal:repeat="action view/get_actions" >
+      <a class="button"
+         tal:condition="action/visible"
+         tal:attributes="href action/url;
+                         title action/label;
+                         id action/id | nothing;"
+         i18n:attributes="title">
+        <span tal:content="action/label" class="actionText"
+              i18n:translate="" i18n:domain="plone">
+        </span>
+      </a>
+    </li>
+  </ul>
 </div>

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -35,7 +35,8 @@
 
       <div class="list-group-cell action-cell">
 
-        <div class="button-group appraisal-button-group">
+        <div class="button-group appraisal-button-group"
+             tal:condition="view/appraisal_buttons_available">
 
           <a href="#"
              class="button"
@@ -52,6 +53,23 @@
              i18n:translate="">
             Don't archive
           </a>
+
+        </div>
+
+        <div class="button-group appraisal-button-group"
+             tal:condition="not: view/appraisal_buttons_available">
+
+          <span class="readonly button"
+             tal:attributes="class python: dossier.appraisal and 'readonly button active' or 'readonly button';"
+             i18n:translate="">
+            Archive
+          </span>
+
+          <span class="readonly button"
+                tal:attributes="class python: dossier.appraisal and 'readonly button' or 'readonly button active';"
+                i18n:translate="">
+            Don't archive
+          </span>
 
         </div>
       </div>

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -76,17 +76,19 @@
     </li>
   </ul>
   <ul class="actions">
-    <li tal:repeat="action view/get_actions" >
-      <a class="button"
-         tal:condition="action/visible"
-         tal:attributes="href action/url;
-                         title action/label;
-                         id action/id | nothing;"
-         i18n:attributes="title">
-        <span tal:content="action/label" class="actionText"
-              i18n:translate="" i18n:domain="plone">
-        </span>
-      </a>
-    </li>
+    <tal:repeat tal:repeat="action view/get_actions">
+      <li tal:condition="action/visible">
+        <a class="button"
+           tal:attributes="href action/url;
+                           title action/label;
+                           class python: 'button {}'.format(action.get('class'));
+                           id action/id | nothing;"
+           i18n:attributes="title">
+          <span tal:content="action/label" class="actionText"
+                i18n:translate="" i18n:domain="plone">
+          </span>
+        </a>
+      </li>
+    </tal:repeat>
   </ul>
 </div>

--- a/opengever/disposition/profiles/default/actions.xml
+++ b/opengever/disposition/profiles/default/actions.xml
@@ -18,22 +18,4 @@
 
   </object>
 
-
-  <object name="object_buttons" meta_type="CMF Action Category">
-
-    <object name="appresial_list_as_excel" meta_type="CMF Action"
-            i18n:domain="opengever.disposition">
-      <property name="title" i18n:translate="">Export appraisal list</property>
-      <property name="description" i18n:translate=""></property>
-      <property name="url_expr">string:${object_url}/xlsx</property>
-      <property name="icon_expr"></property>
-      <property name="available_expr">python:here.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.disposition.IDisposition')</property>
-      <property name="permissions">
-        <element value="View"/>
-      </property>
-      <property name="visible">True</property>
-    </object>
-
-  </object>
-
 </object>

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -75,6 +75,23 @@ class TestDispositionOverview(FunctionalTestCase):
             browser.css('.appraisal-button-group .active')[1].text)
 
     @browsing
+    def test_appraisal_buttons_are_only_buttons_in_progress_state(self, browser):
+        self.grant('Records Manager')
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            ['Archive', "Don't archive"],
+            browser.css('.appraisal-button-group').first.css('a').text)
+        browser.find('disposition-transition-appraise').click()
+
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        self.assertEquals(
+            [], browser.css('.appraisal-button-group').first.css('a').text)
+        self.assertEquals(
+            ['Archive', "Don't archive"],
+            browser.css('.appraisal-button-group').first.css('span').text)
+
+    @browsing
     def test_update_appraisal_is_correct(self, browser):
         browser.login().open(self.disposition, view='tabbedview_view-overview')
 

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -104,3 +104,14 @@ class TestDispositionOverview(FunctionalTestCase):
         browser.login().open(self.disposition, view='tabbedview_view-overview')
         self.assertEquals(['disposition-transition-dispose'],
                           browser.css('.transitions li').text)
+
+    @browsing
+    def test_sip_download_is_active_in_appraised_state(self, browser):
+        self.grant('Records Manager')
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.find('disposition-transition-appraise').click()
+
+        browser.open(self.disposition, view='tabbedview_view-overview')
+        self.assertEquals(['SIP download'], browser.css('ul.actions li').text)
+        self.assertEquals('http://nohost/plone/disposition-1/ech0160_export',
+                          browser.find('SIP download').get('href'))

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -112,6 +112,16 @@ class TestDispositionOverview(FunctionalTestCase):
         browser.find('disposition-transition-appraise').click()
 
         browser.open(self.disposition, view='tabbedview_view-overview')
-        self.assertEquals(['SIP download'], browser.css('ul.actions li').text)
+        self.assertEquals(['Export appraisal list', 'SIP download'],
+                          browser.css('ul.actions li').text)
         self.assertEquals('http://nohost/plone/disposition-1/ech0160_export',
                           browser.find('SIP download').get('href'))
+
+    @browsing
+    def test_appraisal_list_download_is_allways_available(self, browser):
+        self.grant('Records Manager')
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        self.assertEquals(['Export appraisal list'],
+                          browser.css('ul.actions li').text)
+        self.assertEquals('http://nohost/plone/disposition-1/xlsx',
+                          browser.find('Export appraisal list').get('href'))


### PR DESCRIPTION
This PR adds the `SIP Download` action, which generates a SIP (eCH-160) Export of the selected dossiers (only dossiers with a truly appraisal).

![bildschirmfoto 2016-04-25 um 14 19 51](https://cloud.githubusercontent.com/assets/485755/14783570/cd00ccb4-0af0-11e6-8d30-4c87044f1383.png)

Additionally if moved the `Export Appraisal list` action also to the action button group.