### PR TITLE
Removed the archived state from the DOSSIER_STATES_CLOSED list.

### DIFF
--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -34,7 +34,6 @@ DOSSIER_STATES_OPEN = [
 ]
 
 DOSSIER_STATES_CLOSED = [
-    'dossier-state-archived',
     'dossier-state-inactive',
     'dossier-state-resolved'
 ]

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -102,3 +102,20 @@ class TestDossierListing(FunctionalTestCase):
         table = browser.css('.listing').first
         self.assertEquals(['Dossier C'],
                           [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_expired_filters_exclude_archived_dossiers(self, browser):
+        create(Builder('dossier')
+               .within(self.repository)
+               .titled(u'Dossier D')
+               .as_expired()
+               .in_state('dossier-state-archived'))
+
+        browser.login().open(
+            self.repository,
+            view='tabbedview_view-dossiers',
+            data={'dossier_state_filter': 'filter_retention_expired'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Dossier B', 'Dossier C'],
+                          [row.get('Title') for row in table.dicts()])


### PR DESCRIPTION
This fix an issue that archived dossiers are wrongly be listed in the dossier listing when the expired filter is active. Furthermore also the check show_modfiy_public_trial_link Dossier base class should exclude the archived state.