### PR TITLE
Copying proposal and meeting documents with elevated privileges.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Create and update proposals and documents with elevated privileges,
+  when submitting proposal, add or update submitted documents or
+  copy back excerpt documents.
+  [phgross]
+
 - Exclude email from sablon variable fullname and add a email variable instead.
   Note: The sablontemplates have to be updated after installing this release,
   when the email is still needed in the protocoll.

--- a/opengever/meeting/browser/createsubmittedproposal.py
+++ b/opengever/meeting/browser/createsubmittedproposal.py
@@ -1,6 +1,6 @@
 from five import grok
 from opengever.base.oguid import Oguid
-from opengever.base.security import changed_security
+from opengever.base.security import elevated_privileges
 from opengever.base.transport import REQUEST_KEY
 from opengever.meeting.proposal import SubmittedProposal
 from opengever.meeting.service import meeting_service
@@ -20,7 +20,7 @@ class CreateSubmittedProposal(grok.View):
         proposal_oguid = Oguid.parse(data['proposal_oguid'])
         proposal = meeting_service().fetch_proposal_by_oguid(proposal_oguid)
 
-        with changed_security():
+        with elevated_privileges():
             submitted_proposal = SubmittedProposal.create(proposal, committee)
 
             self.request.response.setHeader("Content-type", "application/json")

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -370,7 +370,8 @@ class CopyProposalDocumentCommand(object):
         return self._target_admin_unit_id or self._parent_action.admin_unit_id
 
     def execute(self):
-        reponse = self.copy_document(self.target_path, self.target_admin_unit_id)
+        reponse = self.copy_document(
+            self.target_path, self.target_admin_unit_id)
         self.add_database_entry(reponse, self.target_admin_unit_id)
 
     def show_message(self):
@@ -401,7 +402,7 @@ class CopyProposalDocumentCommand(object):
             document_title=self.document.title))
 
     def copy_document(self, target_path, target_admin_unit_id):
-        return OgCopyCommand(
+        return OgCopyCommandWithElevatedPrivileges(
             self.document, target_admin_unit_id, target_path).execute()
 
 
@@ -414,4 +415,10 @@ class OgCopyCommand(object):
 
     def execute(self):
         return Transporter().transport_to(
+            self.source, self.target_admin_unit_id, self.target_path)
+
+class OgCopyCommandWithElevatedPrivileges(OgCopyCommand):
+
+    def execute(self):
+        return Transporter().transport_to_with_elevated_privileges(
             self.source, self.target_admin_unit_id, self.target_path)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
@@ -8,7 +6,7 @@ from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.command import CreateGeneratedDocumentCommand
 from opengever.meeting.command import ExcerptOperations
-from opengever.meeting.command import OgCopyCommand
+from opengever.meeting.command import OgCopyCommandWithElevatedPrivileges
 from opengever.meeting.command import UpdateExcerptInDossierCommand
 from opengever.meeting.command import UpdateGeneratedDocumentCommand
 from opengever.meeting.model import AgendaItem
@@ -321,7 +319,7 @@ class Proposal(Base):
         the intid of the created document.
         """
         dossier = self.resolve_proposal().get_containing_dossier()
-        response = OgCopyCommand(
+        response = OgCopyCommandWithElevatedPrivileges(
             self.resolve_submitted_excerpt_document(),
             self.admin_unit_id,
             '/'.join(dossier.getPhysicalPath())).execute()

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -188,7 +188,6 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         browser.find('Update document in proposal').click()
         browser.find('Submit Attachments').click()
 
-        # self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
             ['A new submitted version of document A Document has been created'],
             info_messages())
@@ -269,7 +268,6 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         browser.find('Update document in proposal').click()
         browser.find('Submit Attachments').click()
 
-        # self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
             ['A new submitted version of document A Document has been created'],
             info_messages())


### PR DESCRIPTION
In the following situations GEVER currently fails with a `Unauthorized` Exception or similar problems:
- A user without any permission on the `Committee A` tries to submit an additional document to a proposal from  `Committee A`
- A user without any permission on the `Committee A` tries to update a submitted document from a proposal assigned to `Committee A`
- A User without any permission on the `Committee A` tries to submit a proposal to the `Committee A`
- A User without any permission on the proposal dossier decide the corresponding agendaitem of this proposal.

To avoid permission problems, we create and update the proposals/documents with elevated privileges.

Fixes #1266 

@deiferni 