### PR TITLE
Add gever layout policy to add feature-bumblebee body class if bumblebeefeature is enabled

### DIFF
--- a/opengever/core/configure.zcml
+++ b/opengever/core/configure.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="opengever.core">
+
+    <browser:page
+        name="plone_layout"
+        for="*"
+        permission="zope.Public"
+        class=".layout.GeverLayoutPolicy"
+        allowed_interface="plone.app.layout.globals.interfaces.ILayoutPolicy"
+        layer="opengever.base.interfaces.IOpengeverBaseLayer"
+        />
+
+</configure>

--- a/opengever/core/layout.py
+++ b/opengever/core/layout.py
@@ -1,0 +1,18 @@
+from opengever.bumblebee import is_bumblebee_feature_enabled
+from plone.app.layout.globals.layout import LayoutPolicy
+
+
+class GeverLayoutPolicy(LayoutPolicy):
+    """Adds gever specific layout configurations
+    """
+
+    def bodyClass(self, template, view):
+        """Extends the default body class with the `feature-bumblebee` class, if
+        the bumblebeefeature is enabled.
+        """
+        body_class = super(GeverLayoutPolicy, self).bodyClass(template, view)
+
+        if is_bumblebee_feature_enabled():
+            body_class = ' '.join((body_class, 'feature-bumblebee'))
+
+        return body_class

--- a/opengever/core/tests/test_layout.py
+++ b/opengever/core/tests/test_layout.py
@@ -1,0 +1,24 @@
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+from opengever.testing import FunctionalTestCase
+
+
+class TestGeverLayoutPolicy(FunctionalTestCase):
+    @browsing
+    def test_bumblebee_feature_body_class_is_not_present_if_feature_is_disabled(self, browser):
+        browser.login().visit()
+        self.assertNotIn(
+            'feature-bumblebee',
+            browser.css('body').first.get('class').split(' '))
+
+
+class TestGeverLayoutPolicyBumblebeeFeature(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    @browsing
+    def test_bumblebee_feature_body_class_is_present_if_feature_is_enabled(self, browser):
+        browser.login().visit()
+        self.assertIn(
+            'feature-bumblebee',
+            browser.css('body').first.get('class').split(' '))

--- a/opengever/document/browser/layout.py
+++ b/opengever/document/browser/layout.py
@@ -1,7 +1,7 @@
-from plone.app.layout.globals.layout import LayoutPolicy
+from opengever.core.layout import GeverLayoutPolicy
 
 
-class DocumentishLayoutPolicy(LayoutPolicy):
+class DocumentishLayoutPolicy(GeverLayoutPolicy):
 
     def bodyClass(self, template, view):
         """Extends the default body class with the `removed` class, when

--- a/opengever/meeting/browser/layout.py
+++ b/opengever/meeting/browser/layout.py
@@ -1,9 +1,9 @@
+from opengever.core.layout import GeverLayoutPolicy
 from opengever.meeting.browser.meetings.meeting import MeetingView
 from opengever.meeting.browser.members import MemberView
-from plone.app.layout.globals.layout import LayoutPolicy
 
 
-class CommitteeLayoutPolicy(LayoutPolicy):
+class CommitteeLayoutPolicy(GeverLayoutPolicy):
 
     def bodyClass(self, template, view):
         """Extends the default bodyClass if the current view is one of the

--- a/opengever/task/layout.py
+++ b/opengever/task/layout.py
@@ -1,7 +1,7 @@
-from plone.app.layout.globals.layout import LayoutPolicy
+from opengever.core.layout import GeverLayoutPolicy
 
 
-class TaskLayoutPolicy(LayoutPolicy):
+class TaskLayoutPolicy(GeverLayoutPolicy):
 
     def bodyClass(self, template, view):
         """Extends default body class with the subtask class, for subtasks.


### PR DESCRIPTION
Dieser PR fügt eine GEVER Base Layout-Policy hinzu.

Die GEVER-Policy fügt eine CSS Klasse in den Body wenn das Bumblebeefeature aktiviert ist.

Diese Änderung wird v.a. für https://github.com/4teamwork/plonetheme.teamraum/pull/421 benötigt.

closes #1761 