### PR TITLE
Implement dossier destruction when closing a disposition.

### DIFF
--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -7,9 +7,14 @@
       <div class="list-group-cell data-cell">
         <h3 class="title">
           <span class="reference_number" tal:content="dossier/reference_number"/>
-          <a href="#" tal:attributes="href dossier/url" tal:content="dossier/title" />
+
+          <a href="#" tal:condition="dossier/url"
+             tal:attributes="href dossier/url" tal:content="dossier/title" />
+
+          <span tal:condition="not: dossier/url" tal:content="dossier/title" />
+
         </h3>
-        <div class="meta">
+        <div class="meta" tal:condition="dossier/additional_metadata_available">
           <span class="meta-value date_period">
             <span i18n:translate="period">Period</span>:
             <span tal:content="python: view.get_localized_time(dossier.start)"/>

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -2,10 +2,13 @@ from collective import dexteritytextindexer
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.security import elevated_privileges
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
 from opengever.disposition.interfaces import IDisposition
 from opengever.dossier.behaviors.dossier import IDossier
+from persistent.dict import PersistentDict
+from persistent.list import PersistentList
 from plone import api
 from plone.dexterity.content import Container
 from plone.directives import form
@@ -13,6 +16,7 @@ from plone.formwidget.contenttree import ObjPathSourceBinder
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
+from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.interface import implements
 from zope.interface import Invalid
@@ -37,6 +41,15 @@ class DossierRepresentation(object):
         self.archival_value = ILifeCycle(dossier).archival_value
         self.archival_value_annotation = ILifeCycle(dossier).archival_value_annotation
         self.appraisal = IAppraisal(disposition).get(dossier)
+
+    def get_storage_representation(self):
+        """Returns a PersistentDict with the most important values.
+        """
+        return PersistentDict({
+            'title': self.title,
+            'intid': self.intid,
+            'reference_number': self.reference_number,
+            'appraisal': self.appraisal})
 
 
 class IDispositionSchema(form.Schema):
@@ -80,6 +93,7 @@ class Disposition(Container):
     implements(IDisposition)
 
     _dossiers = []
+    destroyed_key = 'destroyed_dossiers'
 
     def __init__(self, *args, **kwargs):
         super(Disposition, self).__init__(*args, **kwargs)
@@ -108,6 +122,19 @@ class Disposition(Container):
 
         self.update_added_dossiers(new - old)
         self.update_dropped_dossiers(old - new)
+
+    def get_destroyed_dossiers(self):
+        annotations = IAnnotations(self)
+        if not annotations.get(self.destroyed_key):
+            return None
+        return annotations.get(self.destroyed_key)
+
+    def set_destroyed_dossiers(self, dossiers):
+        value = PersistentList([
+            DossierRepresentation(dossier, self).get_storage_representation()
+            for dossier in dossiers])
+
+        IAnnotations(self)[self.destroyed_key] = value
 
     def get_dossier_representations(self):
         return [DossierRepresentation(rel.to_object, self)
@@ -145,3 +172,9 @@ class Disposition(Container):
         workflow_id = workflow.getWorkflowsFor(dossier)[0].getId()
         history = workflow.getHistoryOf(workflow_id,dossier)
         return history[1].get('review_state')
+
+    def destroy_dossiers(self):
+        dossiers = [relation.to_object for relation in self.dossiers]
+        self.set_destroyed_dossiers(dossiers)
+        with elevated_privileges():
+            api.content.delete(objects=dossiers)

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -10,3 +10,6 @@ def disposition_state_changed(context, event):
 
     if event.action == 'disposition-transition-archive':
         context.mark_dossiers_as_archived()
+
+    if event.action == 'disposition-transition-close':
+        context.destroy_dossiers()

--- a/opengever/disposition/tests/test_destruction.py
+++ b/opengever/disposition/tests/test_destruction.py
@@ -1,0 +1,86 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
+from opengever.testing import FunctionalTestCase
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+from plone import api
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+
+
+class TestDestruction(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDestruction, self).setUp()
+        self.root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository').within(self.root))
+        self.dossier1 = create(Builder('dossier')
+                               .titled(u'D\xf6ssier 1')
+                               .having(archival_value=ARCHIVAL_VALUE_UNWORTHY)
+                               .as_expired()
+                               .within(self.repository))
+        self.dossier2 = create(Builder('dossier')
+                               .titled(u'D\xf6ssier 2')
+                               .as_expired()
+                               .within(self.repository))
+        self.dossier3 = create(Builder('dossier')
+                               .titled(u'D\xf6ssier 3')
+                               .as_expired()
+                               .within(self.repository))
+
+        intids = getUtility(IIntIds)
+        self.dossier_intids = [intids.getId(self.dossier1),
+                               intids.getId(self.dossier2),
+                               intids.getId(self.dossier3)]
+
+        self.disposition = create(Builder('disposition')
+                                  .having(dossiers=[self.dossier1,
+                                                    self.dossier2,
+                                                    self.dossier3])
+                                  .in_state('disposition-state-archived')
+                                  .within(self.root))
+
+        self.grant(
+            'Contributor', 'Editor', 'Reader', 'Reviewer', 'Records Manager')
+        self.disposition.mark_dossiers_as_archived()
+
+    def test_removed_dossiers_are_added_to_destroyed_dossier_list(self):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-close')
+
+        expected = [
+            {'intid': self.dossier_intids[0],
+             'title': u'D\xf6ssier 1',
+             'appraisal': False,
+             'reference_number': 'Client1 1 / 1'},
+            {'intid': self.dossier_intids[1],
+             'title': u'D\xf6ssier 2',
+             'appraisal': True,
+             'reference_number': 'Client1 1 / 2'},
+            {'intid': self.dossier_intids[2],
+             'title': u'D\xf6ssier 3',
+             'appraisal': True,
+             'reference_number': 'Client1 1 / 3'}]
+
+        self.assertEquals(expected,
+                          list(self.disposition.get_destroyed_dossiers()))
+
+    def test_destroyed_dossier_list_is_persistent(self):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-close')
+
+        self.assertEquals(PersistentList,
+                          type(self.disposition.get_destroyed_dossiers()))
+        self.assertEquals(PersistentMapping,
+                          type(self.disposition.get_destroyed_dossiers()[0]))
+
+    def test_when_closing_all_dossier_gets_removed(self):
+        self.assertEquals(
+            [self.dossier1, self.dossier2, self.dossier3],
+            self.repository.listFolderContents())
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-close')
+
+        self.assertEquals([], self.repository.listFolderContents())


### PR DESCRIPTION
Additional informations:
 - Before the dossier destruction the most important information of each dossier is saved in a Persistentlist in the annotations of the disposition object.
 - The removal of the dossiers itself is done with elevated_privileges.

Furthermore the disposition overview handles closed disposition specially:
 - Dossiers aren't linked
 - Additional metadata of each dossier is not displayed.
 - Data is fetched from the `get_destroyed_dossiers` storage (Annotations)

Not implemented yet:
 - Separate permission `Destroy GEVER Dossiers` and a check.
 - Separate Removal options.
