### PR TITLE
Fix bug in redirect when no templatedossier is found.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Fix bug in redirect when no templatedossier is found.
+  [phgross]
+
 - Create and update proposals and documents with elevated privileges,
   when submitting proposal, add or update submitted documents or
   copy back excerpt documents.

--- a/opengever/dossier/templatedossier/form.py
+++ b/opengever/dossier/templatedossier/form.py
@@ -101,8 +101,7 @@ class TemplateDocumentFormView(grok.View):
             status = IStatusMessage(self.request)
             status.addStatusMessage(
                 _("Not found the templatedossier"), type="error")
-            return self.context.request.RESPONSE.redirect(
-                self.context.absolute_url())
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
 
         self.templatedossier_path = '/'.join(
             template_dossier.getPhysicalPath())

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
+from ftw.testbrowser.pages.statusmessages import error_messages
 from ooxml_docprops import read_properties
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.dossier.docprops import TemporaryDocFile
@@ -20,6 +21,19 @@ from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 import transaction
+
+
+class TestNoTemplateDossier(FunctionalTestCase):
+
+    @browsing
+    def test_shows_message_when_no_templatedossier_is_found(self, browser):
+        dossier = create(Builder('dossier'))
+
+        browser.login().open(dossier, view='document_with_template')
+
+        self.assertEquals(
+            ['Not found the templatedossier'], error_messages())
+
 
 class TestDocumentWithTemplateForm(FunctionalTestCase):
 


### PR DESCRIPTION
Traceback:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module opengever.dossier.templatedossier.form, line 67, in __call__
  Module opengever.dossier.templatedossier.form, line 104, in render_form
AttributeError: request
```

@lukasgraf please have a 👀 