### PR TITLE
No longer omit the documents archival file

### DIFF
--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -36,11 +36,16 @@ class IDocumentMetadata(form.Schema):
             u'document_author',
             u'digitally_available',
             u'preserved_as_paper',
-            u'archival_file',
             u'thumbnail',
             u'preview',
             ],
         )
+
+    form.fieldset(
+        u'archive_file',
+        label=_(u'fieldset_archive_file', u'Archive file'),
+        fields=[u'archival_file']
+    )
 
     dexteritytextindexer.searchable('description')
     description = schema.Text(
@@ -124,7 +129,6 @@ class IDocumentMetadata(form.Schema):
         default=True,
         )
 
-    form.omitted('archival_file')
     archival_file = NamedBlobFile(
         title=_(u'label_archival_file', default='Archival File'),
         description=_(u'help_archival_file', default=''),

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-04-29 05:41+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -169,7 +169,7 @@ msgid "description_download_confirmation"
 msgstr "Sie sind dabei, eine Kopie des Dokuments ${filename} herunterzuladen."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:171
+#: ./opengever/document/behaviors/metadata.py:175
 msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
@@ -182,6 +182,11 @@ msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mai
 #: ./opengever/document/document.py:68
 msgid "error_title_or_file_required"
 msgstr "Ein Titel oder eine Datei muss angegeben werden."
+
+#. Default: "Archive file"
+#: ./opengever/document/behaviors/metadata.py:46
+msgid "fieldset_archive_file"
+msgstr "Archiv Datei"
 
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:27
@@ -211,12 +216,12 @@ msgid "heading_checkin_comment_form"
 msgstr "Dokumente einchecken"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:130
+#: ./opengever/document/behaviors/metadata.py:134
 msgid "help_archival_file"
 msgstr "Archivtaugliche Version der Originaldatei"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:105
+#: ./opengever/document/behaviors/metadata.py:110
 msgid "help_author"
 msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachname Vorname aufgelöst)."
 
@@ -225,25 +230,25 @@ msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachnam
 msgid "help_checkin_journal_comment"
 msgstr "Was wurde am Dokument geändert?"
 
-#: ./opengever/document/behaviors/metadata.py:89
+#: ./opengever/document/behaviors/metadata.py:94
 msgid "help_delivery_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg versandt worden ist"
 
 #. Default: "A short summary of the content."
-#: ./opengever/document/behaviors/metadata.py:48
+#: ./opengever/document/behaviors/metadata.py:53
 msgid "help_description"
 msgstr ""
 
 #. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py:119
 msgid "help_digitally_available"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py:78
 msgid "help_document_date"
 msgstr "Datum, an dem das Dokument erstellt worden ist"
 
-#: ./opengever/document/behaviors/metadata.py:95
+#: ./opengever/document/behaviors/metadata.py:100
 msgid "help_document_type"
 msgstr ""
 
@@ -253,30 +258,30 @@ msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:65
+#: ./opengever/document/behaviors/metadata.py:70
 msgid "help_foreign_reference"
 msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
-#: ./opengever/document/behaviors/metadata.py:56
+#: ./opengever/document/behaviors/metadata.py:61
 msgid "help_keywords"
 msgstr ""
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:122
+#: ./opengever/document/behaviors/metadata.py:127
 msgid "help_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:144
+#: ./opengever/document/behaviors/metadata.py:148
 msgid "help_preview"
 msgstr "Online Voransicht des Originaldokuments"
 
-#: ./opengever/document/behaviors/metadata.py:81
+#: ./opengever/document/behaviors/metadata.py:86
 msgid "help_receipt_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg angekommen ist"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:137
+#: ./opengever/document/behaviors/metadata.py:141
 msgid "help_thumbnail"
 msgstr ""
 
@@ -291,12 +296,12 @@ msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:129
+#: ./opengever/document/behaviors/metadata.py:133
 msgid "label_archival_file"
 msgstr "Archivierte Datei"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:104
+#: ./opengever/document/behaviors/metadata.py:109
 msgid "label_author"
 msgstr "Autor"
 
@@ -341,27 +346,27 @@ msgid "label_date"
 msgstr "Datum"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:88
+#: ./opengever/document/behaviors/metadata.py:93
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:47
+#: ./opengever/document/behaviors/metadata.py:52
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:113
+#: ./opengever/document/behaviors/metadata.py:118
 msgid "label_digitally_available"
 msgstr "Digital verfügbar"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py:77
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:99
 msgid "label_document_type"
 msgstr "Dokumenttyp"
 
@@ -383,12 +388,12 @@ msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:64
+#: ./opengever/document/behaviors/metadata.py:69
 msgid "label_foreign_reference"
 msgstr "Fremdzeichen"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:55
+#: ./opengever/document/behaviors/metadata.py:60
 msgid "label_keywords"
 msgstr "Schlagworte"
 
@@ -407,17 +412,17 @@ msgid "label_pdf_preview"
 msgstr "PDF Vorschau"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:121
+#: ./opengever/document/behaviors/metadata.py:126
 msgid "label_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:147
 msgid "label_preview"
 msgstr "Vorschau"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:80
+#: ./opengever/document/behaviors/metadata.py:85
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
@@ -447,7 +452,7 @@ msgid "label_start_byline"
 msgstr "Dokumentdatum"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:136
+#: ./opengever/document/behaviors/metadata.py:140
 msgid "label_thumbnail"
 msgstr "Kurzbild"
 
@@ -500,4 +505,3 @@ msgstr "Mit Kommentar"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Ohne Kommentar"
-

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-04-29 05:41+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,7 +166,7 @@ msgid "description_download_confirmation"
 msgstr "Vous étes en train de télécharger une copie du document ${filename}."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:171
+#: ./opengever/document/behaviors/metadata.py:175
 msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
@@ -179,6 +179,11 @@ msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire
 #: ./opengever/document/document.py:68
 msgid "error_title_or_file_required"
 msgstr "Un titre ou un fichier est requis."
+
+#. Default: "Archive file"
+#: ./opengever/document/behaviors/metadata.py:46
+msgid "fieldset_archive_file"
+msgstr ""
 
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:27
@@ -207,12 +212,12 @@ msgstr "Remplacer par un nouveau fichier"
 msgid "heading_checkin_comment_form"
 msgstr "Faire le checkin des documents."
 
-#: ./opengever/document/behaviors/metadata.py:130
+#: ./opengever/document/behaviors/metadata.py:134
 msgid "help_archival_file"
 msgstr "Version en format d'archivage du fichier original"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:105
+#: ./opengever/document/behaviors/metadata.py:110
 msgid "help_author"
 msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d'après le nom le prénom)"
 
@@ -221,24 +226,24 @@ msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d
 msgid "help_checkin_journal_comment"
 msgstr "Modification(s) faite(s) dans le document ?"
 
-#: ./opengever/document/behaviors/metadata.py:89
+#: ./opengever/document/behaviors/metadata.py:94
 msgid "help_delivery_date"
 msgstr "Date, à laquelle le document a été envoyé par écrit"
 
-#: ./opengever/document/behaviors/metadata.py:48
+#: ./opengever/document/behaviors/metadata.py:53
 msgid "help_description"
 msgstr ""
 
 #. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py:119
 msgid "help_digitally_available"
 msgstr "Est-ce que le document numérisé est disponible ?"
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py:78
 msgid "help_document_date"
 msgstr "Date de création du document"
 
-#: ./opengever/document/behaviors/metadata.py:95
+#: ./opengever/document/behaviors/metadata.py:100
 msgid "help_document_type"
 msgstr ""
 
@@ -246,27 +251,27 @@ msgstr ""
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
-#: ./opengever/document/behaviors/metadata.py:65
+#: ./opengever/document/behaviors/metadata.py:70
 msgid "help_foreign_reference"
 msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
-#: ./opengever/document/behaviors/metadata.py:56
+#: ./opengever/document/behaviors/metadata.py:61
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:122
+#: ./opengever/document/behaviors/metadata.py:127
 msgid "help_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
-#: ./opengever/document/behaviors/metadata.py:144
+#: ./opengever/document/behaviors/metadata.py:148
 msgid "help_preview"
 msgstr "Aperçu en ligne du document original"
 
-#: ./opengever/document/behaviors/metadata.py:81
+#: ./opengever/document/behaviors/metadata.py:86
 msgid "help_receipt_date"
 msgstr "Date de réception du document écrit"
 
-#: ./opengever/document/behaviors/metadata.py:137
+#: ./opengever/document/behaviors/metadata.py:141
 msgid "help_thumbnail"
 msgstr ""
 
@@ -281,12 +286,12 @@ msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:129
+#: ./opengever/document/behaviors/metadata.py:133
 msgid "label_archival_file"
 msgstr "Fichier archivé"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:104
+#: ./opengever/document/behaviors/metadata.py:109
 msgid "label_author"
 msgstr "Auteur"
 
@@ -331,27 +336,27 @@ msgid "label_date"
 msgstr "Date"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:88
+#: ./opengever/document/behaviors/metadata.py:93
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:47
+#: ./opengever/document/behaviors/metadata.py:52
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:113
+#: ./opengever/document/behaviors/metadata.py:118
 msgid "label_digitally_available"
 msgstr "Disponble sous forme numérique"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py:77
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:99
 msgid "label_document_type"
 msgstr "Type de document"
 
@@ -373,12 +378,12 @@ msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:64
+#: ./opengever/document/behaviors/metadata.py:69
 msgid "label_foreign_reference"
 msgstr "Code externe"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:55
+#: ./opengever/document/behaviors/metadata.py:60
 msgid "label_keywords"
 msgstr "Mots-clés"
 
@@ -397,17 +402,17 @@ msgid "label_pdf_preview"
 msgstr "Aucun résultat trouvé"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:121
+#: ./opengever/document/behaviors/metadata.py:126
 msgid "label_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:147
 msgid "label_preview"
 msgstr "Aperçu"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:80
+#: ./opengever/document/behaviors/metadata.py:85
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
@@ -437,7 +442,7 @@ msgid "label_start_byline"
 msgstr "Date du document"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:136
+#: ./opengever/document/behaviors/metadata.py:140
 msgid "label_thumbnail"
 msgstr "Vignette"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-04-29 05:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -169,7 +169,7 @@ msgid "description_download_confirmation"
 msgstr ""
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:171
+#: ./opengever/document/behaviors/metadata.py:175
 msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
@@ -181,6 +181,11 @@ msgstr ""
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py:68
 msgid "error_title_or_file_required"
+msgstr ""
+
+#. Default: "Archive file"
+#: ./opengever/document/behaviors/metadata.py:46
+msgid "fieldset_archive_file"
 msgstr ""
 
 #. Default: "Common"
@@ -210,12 +215,12 @@ msgstr ""
 msgid "heading_checkin_comment_form"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:130
+#: ./opengever/document/behaviors/metadata.py:134
 msgid "help_archival_file"
 msgstr ""
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:105
+#: ./opengever/document/behaviors/metadata.py:110
 msgid "help_author"
 msgstr ""
 
@@ -224,24 +229,24 @@ msgstr ""
 msgid "help_checkin_journal_comment"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:89
+#: ./opengever/document/behaviors/metadata.py:94
 msgid "help_delivery_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:48
+#: ./opengever/document/behaviors/metadata.py:53
 msgid "help_description"
 msgstr ""
 
 #. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py:119
 msgid "help_digitally_available"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py:78
 msgid "help_document_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:95
+#: ./opengever/document/behaviors/metadata.py:100
 msgid "help_document_type"
 msgstr ""
 
@@ -249,27 +254,27 @@ msgstr ""
 msgid "help_file"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:65
+#: ./opengever/document/behaviors/metadata.py:70
 msgid "help_foreign_reference"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:56
+#: ./opengever/document/behaviors/metadata.py:61
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:122
+#: ./opengever/document/behaviors/metadata.py:127
 msgid "help_preserved_as_paper"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:144
+#: ./opengever/document/behaviors/metadata.py:148
 msgid "help_preview"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:81
+#: ./opengever/document/behaviors/metadata.py:86
 msgid "help_receipt_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:137
+#: ./opengever/document/behaviors/metadata.py:141
 msgid "help_thumbnail"
 msgstr ""
 
@@ -284,12 +289,12 @@ msgid "label_actor"
 msgstr ""
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:129
+#: ./opengever/document/behaviors/metadata.py:133
 msgid "label_archival_file"
 msgstr ""
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:104
+#: ./opengever/document/behaviors/metadata.py:109
 msgid "label_author"
 msgstr ""
 
@@ -334,27 +339,27 @@ msgid "label_date"
 msgstr ""
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:88
+#: ./opengever/document/behaviors/metadata.py:93
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:47
+#: ./opengever/document/behaviors/metadata.py:52
 msgid "label_description"
 msgstr ""
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:113
+#: ./opengever/document/behaviors/metadata.py:118
 msgid "label_digitally_available"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py:77
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:99
 msgid "label_document_type"
 msgstr ""
 
@@ -376,12 +381,12 @@ msgid "label_file"
 msgstr ""
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:64
+#: ./opengever/document/behaviors/metadata.py:69
 msgid "label_foreign_reference"
 msgstr ""
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:55
+#: ./opengever/document/behaviors/metadata.py:60
 msgid "label_keywords"
 msgstr ""
 
@@ -400,17 +405,17 @@ msgid "label_pdf_preview"
 msgstr ""
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:121
+#: ./opengever/document/behaviors/metadata.py:126
 msgid "label_preserved_as_paper"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:147
 msgid "label_preview"
 msgstr ""
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:80
+#: ./opengever/document/behaviors/metadata.py:85
 msgid "label_receipt_date"
 msgstr ""
 
@@ -440,7 +445,7 @@ msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:136
+#: ./opengever/document/behaviors/metadata.py:140
 msgid "label_thumbnail"
 msgstr ""
 

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -99,7 +99,7 @@ class TestDocument(FunctionalTestCase):
             browser.css('.documentFirstHeading').first.text)
 
         self.assertEquals(
-            ['Common', 'Classification'],
+            ['Common', 'Classification', 'Archive file'],
             browser.css('#content-core fieldset legend').text)
 
     def test_copying_a_document_prefixes_title_with_copy_of(self):
@@ -582,3 +582,21 @@ class TestPublicTrial(FunctionalTestCase):
         # check if object got indexed
         self.assertEquals('private',
                           index_data_for(self.document).get('public_trial'))
+
+
+class TestArchivalFileField(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestArchivalFileField, self).setUp()
+
+        self.dossier = create(Builder('dossier'))
+
+    @browsing
+    def test_archival_file_is_displayed_but_in_a_separate_fieldset(self, browser):
+        browser.login().open(self.dossier)
+        factoriesmenu.add('Document')
+
+        archival_file_field = browser.css(
+            '#form-widgets-IDocumentMetadata-archival_file').first
+        self.assertEquals(
+            'Archive file', archival_file_field.parent('fieldset legend').text)

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -363,7 +363,7 @@ def document_modified(context, event):
 
     for desc in event.descriptions:
         for attr in desc.attributes:
-            if attr in ('file', 'message'):
+            if attr in ('file', 'message', 'IDocumentMetadata.archival_file'):
                 file_changed = True
             elif attr in ('IClassification.public_trial', 'public_trial'):
                 # Attribute name is different when changed through regular


### PR DESCRIPTION
But display it in a separate fieldset.

![bildschirmfoto 2016-04-29 um 08 23 08](https://cloud.githubusercontent.com/assets/485755/14909424/a321801e-0de3-11e6-8396-bd1c1acf635d.png)

This changes allow the user to add archive file for documents, which the automatic conversion couldn't create a PDF-A.