### PR TITLE
Only show active sub-dossiers in dossier navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.7.5 (unreleased)
 ------------------
 
+- Only show active sub-dossiers in dossier navigation.
+  [deiferni]
+
 - Clean up our monkey patches.
   [lgraf]
 

--- a/opengever/dossier/browser/navigation.py
+++ b/opengever/dossier/browser/navigation.py
@@ -1,7 +1,8 @@
 from opengever.base.browser.navigation import make_tree_by_url
+from opengever.dossier.base import DOSSIER_STATES_OPEN
+from plone import api
 from Products.Five import BrowserView
 import json
-from plone import api
 
 
 class JSONNavigation(BrowserView):
@@ -31,7 +32,8 @@ class JSONNavigation(BrowserView):
     def _tree(self):
         subdossier_nodes = map(
             self._brain_to_node,
-            self.context.get_subdossiers(sort_on='sortable_title'))
+            self.context.get_subdossiers(sort_on='sortable_title',
+                                         review_state=DOSSIER_STATES_OPEN))
         nodes = [self._context_as_node()] + subdossier_nodes
 
         return make_tree_by_url(nodes)

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -72,3 +72,45 @@ class TestNavigation(FunctionalTestCase):
                          }],
               }],
             browser.json)
+
+    @browsing
+    def test_only_show_active_subdossiers(self, browser):
+        sub1 = create(Builder('dossier')
+                      .titled(u'active')
+                      .having(description=u'The active sub-dossier')
+                      .within(self.main_dossier))
+
+        sub2 = create(Builder('dossier')
+                      .titled(u'archived')
+                      .having(description=u'The archived sub-dossier')
+                      .in_state('dossier-state-archived')
+                      .within(self.main_dossier))
+
+        sub3 = create(Builder('dossier')
+                      .titled(u'inactive(storniert)')
+                      .having(description=u'The inactive sub-dossier')
+                      .in_state('dossier-state-inactive')
+                      .within(self.main_dossier))
+
+        sub4 = create(Builder('dossier')
+                      .titled(u'resolved(abgeschlossen)')
+                      .having(description=u'The resolved sub-dossier')
+                      .in_state('dossier-state-resolved')
+                      .within(self.main_dossier))
+
+        browser.login().visit(self.main_dossier,
+                              view='dossier_navigation.json')
+        self.assert_json_equal(
+            [{"text": "Main",
+              "description": "The main dossier",
+              "uid": IUUID(self.main_dossier),
+              "url": self.main_dossier.absolute_url(),
+              "nodes": [
+                        {"text": "active",
+                         "description": "The active sub-dossier",
+                         "nodes": [],
+                         "uid": IUUID(sub1),
+                         "url": sub1.absolute_url(),
+                         }]
+              }],
+            browser.json)


### PR DESCRIPTION
See https://feedback.onegovgever.ch/t/auflistung-von-abgeschlossenen-subdossiers/148.

This was requested by many of our customers. It improves
navigating a dossier with many sub-dossier.

Closes #1705.