### PR TITLE
Added an automatic history for disposition objects.

### DIFF
--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -3,6 +3,7 @@ from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition import _
 from opengever.disposition.interfaces import IDisposition
+from opengever.disposition.interfaces import IHistoryStorage
 from opengever.tabbedview.browser.base import OpengeverTab
 from plone import api
 from plone.protect.utils import addTokenToUrl
@@ -59,3 +60,6 @@ class DispositionOverview(grok.View, OpengeverTab):
 
     def appraisal_buttons_available(self):
         return api.content.get_state(self.context) == 'disposition-state-in-progress'
+
+    def get_history(self):
+        return IHistoryStorage(self.context).get_history()

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -81,37 +81,73 @@
 
      </li>
   </ul>
-</div>
-
-<div class="actionButtons">
-  <ul class="transitions">
-    <li tal:repeat="transition view/get_transitions" >
-      <a tal:condition="transition/url"
-         tal:attributes="href transition/url;
-                         title transition/title;
-                         id transition/id | nothing;
-                         class string: ${transition/id} button"
-         i18n:attributes="title">
-        <span tal:content="transition/title" class="transition actionText"
-              i18n:translate="" i18n:domain="plone">
-        </span>
-      </a>
-    </li>
-  </ul>
-  <ul class="actions">
-    <tal:repeat tal:repeat="action view/get_actions">
-      <li tal:condition="action/visible">
-        <a class="button"
-           tal:attributes="href action/url;
-                           title action/label;
-                           class python: 'button {}'.format(action.get('class'));
-                           id action/id | nothing;"
+  <div class="actionButtons">
+    <ul class="transitions">
+      <li tal:repeat="transition view/get_transitions" >
+        <a tal:condition="transition/url"
+           tal:attributes="href transition/url;
+                           title transition/title;
+                           id transition/id | nothing;
+                           class string: ${transition/id} button"
            i18n:attributes="title">
-          <span tal:content="action/label" class="actionText"
+          <span tal:content="transition/title" class="transition actionText"
                 i18n:translate="" i18n:domain="plone">
           </span>
         </a>
       </li>
-    </tal:repeat>
-  </ul>
+    </ul>
+    <ul class="actions clearfix">
+      <tal:repeat tal:repeat="action view/get_actions">
+        <li tal:condition="action/visible">
+          <a class="button"
+             tal:attributes="href action/url;
+                             title action/label;
+                             class python: 'button {}'.format(action.get('class'));
+                             id action/id | nothing;"
+             i18n:attributes="title">
+            <span tal:content="action/label" class="actionText"
+                  i18n:translate="" i18n:domain="plone">
+            </span>
+          </a>
+        </li>
+      </tal:repeat>
+    </ul>
+  </div>
+
+  <div class="progress">
+    <h3 i18n:translate="progress">Progress:</h3>
+
+    <div class="answers">
+      <tal:repeat tal:repeat="entry view/get_history">
+        <div class="answer" tal:attributes="class string:answer ${entry/css_class}">
+          <div class="answerType">&nbsp;</div>
+          <div class="answerBody">
+            <div class="date" tal:content="entry/date" />
+            <h3 tal:content="structure entry/msg" i18n:translate="">
+              History Transition
+            </h3>
+            <div class="details collapsible">
+              <div class="collapsible-header">
+                <span i18n:translate="label_details">Details:</span>
+              </div>
+              <div class="collapsible-content">
+                <ul>
+                  <li tal:repeat="detail entry/details">
+                    <span tal:content="detail/reference_number" />
+                    <span tal:content="detail/title" />
+                    <span tal:condition="detail/appraisal"
+                          i18n:translate="label_archive">Archive</span>
+                    <span tal:condition="not: detail/appraisal"
+                          i18n:translate="label_dont_archive">Don't Archive</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div style="clear:both"><!-- --></div>
+      </tal:repeat>
+    </div>
+  </div>
+
 </div>

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -59,7 +59,7 @@ class DossierRepresentation(object):
             'appraisal': self.appraisal})
 
 
-class RemovedDossierRepresentation(object):
+class RemovedDossierRepresentation(DossierRepresentation):
 
     def __init__(self, dossier_mapping, disposition):
         self.title = dossier_mapping.get('title')

--- a/opengever/disposition/history.py
+++ b/opengever/disposition/history.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+from five import grok
+from opengever.disposition import _
+from opengever.disposition.interfaces import IDisposition
+from opengever.disposition.interfaces import IHistoryStorage
+from opengever.ogds.base.actor import Actor
+from persistent.dict import PersistentDict
+from persistent.list import PersistentList
+from plone import api
+from zope.annotation.interfaces import IAnnotations
+
+
+class HistoryEntry(object):
+
+    registry = None
+
+    @classmethod
+    def add_description(cls, subcls):
+        if not cls.registry:
+            cls.registry = {}
+
+        if hasattr(subcls, 'transition'):
+            cls.registry[subcls.transition] = subcls
+        else:
+            for transition_id in subcls.transitions:
+                cls.registry[transition_id] = subcls
+
+    @classmethod
+    def get(cls, mapping):
+        description = cls.registry.get(mapping.get('transition'))
+        if not description:
+            raise ValueError(
+                'No specific entry found for {}'.format(
+                    mapping.get('transition')))
+
+        return description(mapping)
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    @property
+    def transition(self):
+        return self.mapping.get('transition')
+
+    @property
+    def date(self):
+        return api.portal.get_localized_time(
+            datetime=self.mapping.get('date'), long_format=True)
+
+    def msg(self):
+        _('msg_disposition_updated', default=u'Updated by ${user}')
+        return self.msg_mapping.get(self.transition)
+
+    @property
+    def _msg_mapping(self):
+        return {'user': Actor.lookup(self.mapping.get('actor_id')).get_link()}
+
+    def details(self):
+        return self.mapping.get('dossiers')
+
+
+class Added(HistoryEntry):
+    transition = 'added'
+    css_class = 'add'
+
+    def msg(self):
+        return _('msg_disposition_added', default=u'Added by ${user}',
+                 mapping=self._msg_mapping)
+
+HistoryEntry.add_description(Added)
+
+
+class Edited(HistoryEntry):
+    transition = 'edited'
+    css_class = 'edit'
+
+    def msg(self):
+        return _('msg_disposition_edited',
+                 default=u'Edited by ${user}',
+                 mapping=self._msg_mapping)
+
+HistoryEntry.add_description(Edited)
+
+
+class Appraised(HistoryEntry):
+    transition = 'disposition-transition-appraise'
+    css_class = 'appraise'
+
+    def msg(self):
+        return _('msg_disposition_appraised',
+                 default=u'Appraisal finalized by ${user}',
+                 mapping=self._msg_mapping)
+
+HistoryEntry.add_description(Appraised)
+
+
+class Disposed(HistoryEntry):
+    transition = 'disposition-transition-dispose'
+    css_class = 'dispose'
+
+    def msg(self):
+        return _('msg_disposition_disposed',
+                 default=u'Disposition disposed for the archive by ${user}',
+                 mapping=self._msg_mapping)
+
+HistoryEntry.add_description(Disposed)
+
+
+class Archived(HistoryEntry):
+    transition = 'disposition-transition-archive'
+    css_class = 'archive'
+
+    def msg(self):
+        return _('msg_disposition_archived',
+                 default=u'The archiving confirmed by ${user}',
+                 mapping=self._msg_mapping)
+
+HistoryEntry.add_description(Archived)
+
+
+class Closed(HistoryEntry):
+    transition = 'disposition-transition-close'
+    css_class = 'close'
+
+    def msg(self):
+        return _(
+            'msg_disposition_close',
+            default=u'Disposition closed and all dossiers destroyed by ${user}',
+            mapping=self._msg_mapping)
+
+HistoryEntry.add_description(Closed)
+
+
+class HistoryStorage(grok.Adapter):
+    grok.provides(IHistoryStorage)
+    grok.context(IDisposition)
+
+    key = 'disposition_history'
+
+    def __init__(self, context):
+        super(HistoryStorage, self).__init__(context)
+        self._annotations = IAnnotations(self.context)
+        if self.key not in self._annotations.keys():
+            self._annotations[self.key] = PersistentList()
+
+    @property
+    def _storage(self):
+        return self._annotations[self.key]
+
+    def add(self, transition, actor_id, dossiers):
+        """Adds a new history entry to the storage.
+        transition: string
+        actor_id: user_id as string
+        dossiers: a list of dossier representations.
+        """
+
+        dossier_list = PersistentList(
+            [dossier.get_storage_representation() for dossier in dossiers])
+        self._storage.append(
+            PersistentDict({'transition': transition,
+                            'actor_id': actor_id,
+                            'date': datetime.now(),
+                            'dossiers': dossier_list}))
+
+    def get_history(self):
+        entries = [HistoryEntry.get(mapping) for mapping in self._storage]
+        entries.reverse()
+        return entries

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -5,5 +5,9 @@ class IAppraisal(Interface):
     """The appraisal adapter Interface."""
 
 
+class IHistoryStorage(Interface):
+    """The history storage adapter Interface."""
+
+
 class IDisposition(Interface):
     """The appraisal adapter Interface."""

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-28 18:23+0000\n"
+"POT-Creation-Date: 2016-05-03 11:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,36 +40,51 @@ msgid "document_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/disposition.py:112
+#: ./opengever/disposition/disposition.py:113
 msgid "error_retention_period_not_expired"
 msgstr "Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen."
 
-#: ./opengever/disposition/disposition.py:85
+#: ./opengever/disposition/disposition.py:86
 msgid "help_reference"
 msgstr ""
+
+#. Default: "Archive"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:138
+msgid "label_archive"
+msgstr "Archivieren"
+
+#. Default: "Details:"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:131
+msgid "label_details"
+msgstr "Details:"
 
 #. Default: "Disposition"
 #: ./opengever/disposition/disposition.py:131
 msgid "label_disposition"
 msgstr "Angebot"
 
+#. Default: "Don't Archive"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:140
+msgid "label_dont_archive"
+msgstr "Nicht archvieren"
+
 #. Default: "Dossiers"
-#: ./opengever/disposition/disposition.py:90
+#: ./opengever/disposition/disposition.py:91
 msgid "label_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Export appraisal list"
-#: ./opengever/disposition/browser/overview.py:43
+#: ./opengever/disposition/browser/overview.py:44
 msgid "label_export_appraisal_list"
 msgstr "Bewertungsliste exportieren"
 
 #. Default: "Reference"
-#: ./opengever/disposition/disposition.py:84
+#: ./opengever/disposition/disposition.py:85
 msgid "label_reference"
 msgstr "Referenz"
 
 #. Default: "SIP download"
-#: ./opengever/disposition/browser/overview.py:49
+#: ./opengever/disposition/browser/overview.py:50
 msgid "label_sip_download"
 msgstr "SIP herunterladen"
 
@@ -78,7 +93,47 @@ msgstr "SIP herunterladen"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "Added by ${user}"
+#: ./opengever/disposition/history.py:67
+msgid "msg_disposition_added"
+msgstr "Hinzugefügt durch ${user}"
+
+#. Default: "Appraisal finalized by ${user}"
+#: ./opengever/disposition/history.py:90
+msgid "msg_disposition_appraised"
+msgstr "Bewertung finalisiert durch ${user}"
+
+#. Default: "The archiving confirmed by ${user}"
+#: ./opengever/disposition/history.py:114
+msgid "msg_disposition_archived"
+msgstr "Archivierung bestätigt durch ${user}"
+
+#. Default: "Disposition closed and all dossiers destroyed by ${user}"
+#: ./opengever/disposition/history.py:126
+msgid "msg_disposition_close"
+msgstr "Angebot abgeschlossen und alle Dossiers vernicht durch ${user}"
+
+#. Default: "Disposition disposed for the archive by ${user}"
+#: ./opengever/disposition/history.py:102
+msgid "msg_disposition_disposed"
+msgstr "Für die Archivierung angeboten durch ${user}"
+
+#. Default: "Edited by ${user}"
+#: ./opengever/disposition/history.py:78
+msgid "msg_disposition_edited"
+msgstr "Editiert durch ${user}"
+
+#. Default: "Updated by ${user}"
+#: ./opengever/disposition/history.py:51
+msgid "msg_disposition_updated"
+msgstr "Aktualisiert durch ${user}"
+
 #. Default: "Period"
 #: ./opengever/disposition/browser/overview_templates/overview.pt:19
 msgid "period"
 msgstr "Periode"
+
+#. Default: "Progress:"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:118
+msgid "progress"
+msgstr "Verlauf:"

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-28 18:23+0000\n"
+"POT-Creation-Date: 2016-05-03 11:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,12 +40,22 @@ msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/disposition.py:112
+#: ./opengever/disposition/disposition.py:113
 msgid "error_retention_period_not_expired"
 msgstr ""
 
-#: ./opengever/disposition/disposition.py:85
+#: ./opengever/disposition/disposition.py:86
 msgid "help_reference"
+msgstr ""
+
+#. Default: "Archive"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:138
+msgid "label_archive"
+msgstr ""
+
+#. Default: "Details:"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:131
+msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
@@ -53,23 +63,28 @@ msgstr ""
 msgid "label_disposition"
 msgstr ""
 
+#. Default: "Don't Archive"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:140
+msgid "label_dont_archive"
+msgstr ""
+
 #. Default: "Dossiers"
-#: ./opengever/disposition/disposition.py:90
+#: ./opengever/disposition/disposition.py:91
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Export appraisal list"
-#: ./opengever/disposition/browser/overview.py:43
+#: ./opengever/disposition/browser/overview.py:44
 msgid "label_export_appraisal_list"
 msgstr ""
 
 #. Default: "Reference"
-#: ./opengever/disposition/disposition.py:84
+#: ./opengever/disposition/disposition.py:85
 msgid "label_reference"
 msgstr ""
 
 #. Default: "SIP download"
-#: ./opengever/disposition/browser/overview.py:49
+#: ./opengever/disposition/browser/overview.py:50
 msgid "label_sip_download"
 msgstr ""
 
@@ -78,8 +93,48 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "Added by ${user}"
+#: ./opengever/disposition/history.py:67
+msgid "msg_disposition_added"
+msgstr ""
+
+#. Default: "Appraisal finalized by ${user}"
+#: ./opengever/disposition/history.py:90
+msgid "msg_disposition_appraised"
+msgstr ""
+
+#. Default: "The archiving confirmed by ${user}"
+#: ./opengever/disposition/history.py:114
+msgid "msg_disposition_archived"
+msgstr ""
+
+#. Default: "Disposition closed and all dossiers destroyed by ${user}"
+#: ./opengever/disposition/history.py:126
+msgid "msg_disposition_close"
+msgstr ""
+
+#. Default: "Disposition disposed for the archive by ${user}"
+#: ./opengever/disposition/history.py:102
+msgid "msg_disposition_disposed"
+msgstr ""
+
+#. Default: "Edited by ${user}"
+#: ./opengever/disposition/history.py:78
+msgid "msg_disposition_edited"
+msgstr ""
+
+#. Default: "Updated by ${user}"
+#: ./opengever/disposition/history.py:51
+msgid "msg_disposition_updated"
+msgstr ""
+
 #. Default: "Period"
 #: ./opengever/disposition/browser/overview_templates/overview.pt:19
 msgid "period"
+msgstr ""
+
+#. Default: "Progress:"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:118
+msgid "progress"
 msgstr ""
 

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-28 18:23+0000\n"
+"POT-Creation-Date: 2016-05-03 11:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,12 +43,22 @@ msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/disposition.py:112
+#: ./opengever/disposition/disposition.py:113
 msgid "error_retention_period_not_expired"
 msgstr ""
 
-#: ./opengever/disposition/disposition.py:85
+#: ./opengever/disposition/disposition.py:86
 msgid "help_reference"
+msgstr ""
+
+#. Default: "Archive"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:138
+msgid "label_archive"
+msgstr ""
+
+#. Default: "Details:"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:131
+msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
@@ -56,23 +66,28 @@ msgstr ""
 msgid "label_disposition"
 msgstr ""
 
+#. Default: "Don't Archive"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:140
+msgid "label_dont_archive"
+msgstr ""
+
 #. Default: "Dossiers"
-#: ./opengever/disposition/disposition.py:90
+#: ./opengever/disposition/disposition.py:91
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Export appraisal list"
-#: ./opengever/disposition/browser/overview.py:43
+#: ./opengever/disposition/browser/overview.py:44
 msgid "label_export_appraisal_list"
 msgstr ""
 
 #. Default: "Reference"
-#: ./opengever/disposition/disposition.py:84
+#: ./opengever/disposition/disposition.py:85
 msgid "label_reference"
 msgstr ""
 
 #. Default: "SIP download"
-#: ./opengever/disposition/browser/overview.py:49
+#: ./opengever/disposition/browser/overview.py:50
 msgid "label_sip_download"
 msgstr ""
 
@@ -81,8 +96,48 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "Added by ${user}"
+#: ./opengever/disposition/history.py:67
+msgid "msg_disposition_added"
+msgstr ""
+
+#. Default: "Appraisal finalized by ${user}"
+#: ./opengever/disposition/history.py:90
+msgid "msg_disposition_appraised"
+msgstr ""
+
+#. Default: "The archiving confirmed by ${user}"
+#: ./opengever/disposition/history.py:114
+msgid "msg_disposition_archived"
+msgstr ""
+
+#. Default: "Disposition closed and all dossiers destroyed by ${user}"
+#: ./opengever/disposition/history.py:126
+msgid "msg_disposition_close"
+msgstr ""
+
+#. Default: "Disposition disposed for the archive by ${user}"
+#: ./opengever/disposition/history.py:102
+msgid "msg_disposition_disposed"
+msgstr ""
+
+#. Default: "Edited by ${user}"
+#: ./opengever/disposition/history.py:78
+msgid "msg_disposition_edited"
+msgstr ""
+
+#. Default: "Updated by ${user}"
+#: ./opengever/disposition/history.py:51
+msgid "msg_disposition_updated"
+msgstr ""
+
 #. Default: "Period"
 #: ./opengever/disposition/browser/overview_templates/overview.pt:19
 msgid "period"
+msgstr ""
+
+#. Default: "Progress:"
+#: ./opengever/disposition/browser/overview_templates/overview.pt:118
+msgid "progress"
 msgstr ""
 

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -1,0 +1,184 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.disposition.history import Added
+from opengever.disposition.history import Appraised
+from opengever.disposition.history import Archived
+from opengever.disposition.history import Closed
+from opengever.disposition.history import Disposed
+from opengever.disposition.history import Edited
+from opengever.disposition.interfaces import IAppraisal
+from opengever.disposition.interfaces import IHistoryStorage
+from opengever.testing import FunctionalTestCase
+from plone import api
+from zope.i18n import translate
+import transaction
+
+
+class TestHistoryEntries(FunctionalTestCase):
+
+    user_link = '<a href="http://nohost/plone/@@user-details/test_user_1_">'\
+                'Test User (test_user_1_)</a>'
+
+    def setUp(self):
+        super(TestHistoryEntries, self).setUp()
+        self.root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository').within(self.root))
+        self.dossier1 = create(Builder('dossier')
+                               .as_expired()
+                               .within(self.repository))
+        self.dossier2 = create(Builder('dossier')
+                               .as_expired()
+                               .within(self.repository))
+
+        self.grant(
+            'Contributor', 'Editor', 'Reader', 'Reviewer', 'Records Manager')
+
+        self.disposition = create(Builder('disposition')
+                             .having(dossiers=[self.dossier1])
+                             .within(self.root))
+
+    def test_add_history_entry_when_created_a_disposition(self):
+        entry = IHistoryStorage(self.disposition).get_history()[0]
+
+        self.assertTrue(isinstance(entry, Added))
+        self.assertEquals('add', entry.css_class)
+        self.assertEquals(u'Added by {}'.format(self.user_link),
+                          translate(entry.msg(), context=self.request))
+
+    @browsing
+    def test_add_history_entry_when_editing_a_disposition(self, browser):
+        browser.login().open(self.disposition, view='edit')
+        browser.fill({'Reference': 'Ablieferung X29238',
+                      'Dossiers': [self.dossier1, self.dossier2]})
+        browser.find('Save').click()
+
+        entry = IHistoryStorage(self.disposition).get_history()[0]
+
+        self.assertTrue(isinstance(entry, Edited))
+        self.assertEquals('edit', entry.css_class)
+        self.assertEquals(u'Edited by {}'.format(self.user_link),
+                          translate(entry.msg(), context=self.request))
+
+    @browsing
+    def test_add_history_entry_when_finalize_appraisal_a_disposition(self, browser):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+
+        entry = IHistoryStorage(self.disposition).get_history()[0]
+
+        self.assertTrue(isinstance(entry, Appraised))
+        self.assertEquals('appraise', entry.css_class)
+        self.assertEquals(u'Appraisal finalized by {}'.format(self.user_link),
+                          translate(entry.msg(), context=self.request))
+
+    @browsing
+    def test_add_history_entry_when_dispose_a_disposition(self, browser):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-dispose')
+
+        entry = IHistoryStorage(self.disposition).get_history()[0]
+
+        self.assertTrue(isinstance(entry, Disposed))
+        self.assertEquals('dispose', entry.css_class)
+        self.assertEquals(
+            u'Disposition disposed for the archive by {}'.format(self.user_link),
+            translate(entry.msg(), context=self.request))
+
+    @browsing
+    def test_add_history_entry_when_archive_a_disposition(self, browser):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-dispose')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-archive')
+
+        entry = IHistoryStorage(self.disposition).get_history()[0]
+
+        self.assertTrue(isinstance(entry, Archived))
+        self.assertEquals('archive', entry.css_class)
+        self.assertEquals(
+            u'The archiving confirmed by {}'.format(self.user_link),
+            translate(entry.msg(), context=self.request))
+
+    @browsing
+    def test_add_history_entry_when_close_a_disposition(self, browser):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-dispose')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-archive')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-close')
+
+        entry = IHistoryStorage(self.disposition).get_history()[0]
+
+        self.assertTrue(isinstance(entry, Closed))
+        self.assertEquals('close', entry.css_class)
+        self.assertEquals(
+            u'Disposition closed and all dossiers destroyed by {}'.format(
+                self.user_link),
+            translate(entry.msg(), context=self.request))
+
+
+class TestHistoryListingInOverview(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestHistoryListingInOverview, self).setUp()
+        self.root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository').within(self.root))
+        self.dossier1 = create(Builder('dossier')
+                               .as_expired()
+                               .within(self.repository))
+        self.dossier2 = create(Builder('dossier')
+                               .as_expired()
+                               .within(self.repository))
+        self.grant(
+            'Contributor', 'Editor', 'Reader', 'Reviewer', 'Records Manager')
+
+        self.disposition = create(Builder('disposition')
+                             .having(dossiers=[self.dossier1, self.dossier2])
+                             .within(self.root))
+
+        IAppraisal(self.disposition).update(
+            dossier=self.dossier2, archive=False)
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+        transaction.commit()
+
+    @browsing
+    def test_is_sorted_chronological(self, browser):
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            ['Appraisal finalized by Test User (test_user_1_)',
+             'Added by Test User (test_user_1_)'],
+            browser.css('.progress .answer h3').text)
+
+    @browsing
+    def test_details_list_dossier_snapshot(self, browser):
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        appraise = browser.css('div.details ul')[0]
+        add = browser.css('div.details ul')[1]
+
+        self.assertEquals(
+            ['Client1 1 / 1 Archive', "Client1 1 / 2 Don't Archive"],
+            appraise.css('li').text)
+        self.assertEquals(
+            ['Client1 1 / 1 Archive', 'Client1 1 / 2 Archive'],
+            add.css('li').text)
+
+    @browsing
+    def test_is_marked_with_corresponding_css_class(self, browser):
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        self.assertEquals('answer appraise',
+                          browser.css('.progress .answer')[0].get('class'))
+        self.assertEquals('answer add',
+                          browser.css('.progress .answer')[1].get('class'))


### PR DESCRIPTION
The disposition history, which journalizes every status change and object edit, is displayed in the same manner as the progress view on tasks or proposals.

![bildschirmfoto 2016-05-03 um 13 47 58](https://cloud.githubusercontent.com/assets/485755/14982343/f8196d0c-1135-11e6-9baf-85635a87d57f.png)