### PR TITLE
Display search preview when bumblebee is enabled.

### DIFF
--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -289,60 +289,75 @@
                                            site_properties context/portal_properties/site_properties;
                                            use_view_action site_properties/typesUseViewActionInListings|python:();
                                            allowAnonymousViewAbout site_properties/allowAnonymousViewAbout;
-                                           show_about python:not isAnon or allowAnonymousViewAbout;">
+                                           show_about python:not isAnon or allowAnonymousViewAbout;
+                                           is_bumblebee_feature_enabled view/is_bumblebee_feature_enabled;">
                   <dl class="searchResults">
                     <tal:results repeat="item batch">
-                      <dt tal:attributes="class item/ContentTypeClass">
-                        <img tal:replace="structure item/getIcon" />
+                      <div class="searchItem">
+                        <dt tal:attributes="class item/ContentTypeClass">
+                          <img tal:replace="structure item/getIcon" />
 
-                        <a href="#"
-                           tal:define="item_url item/getURL;
+                          <a href="#"
+                             tal:define="item_url item/getURL;
+                                         item_type item/portal_type"
+                             tal:attributes="href python:item_type in use_view_action and (item_url + '/view') or item_url;
+                                             class string:state-${item/review_state};
+                                             title item/Title"
+                             tal:content="item/CroppedTitle" />
+
+                        </dt>
+                        <dd>
+                          <div class="main_dossier">
+                            <span i18n:domain="opengever.base" i18n:translate="label_dossier">Dossier:</span>
+                            <a href="#" tal:content="item/containing_dossier"
+                               tal:attributes="href item/main_dossier_link">
+                              Main dossier link
+                            </a>
+
+                          </div>
+
+                          <div class="description" tal:content="item/CroppedDescription">
+                            Cropped description
+                          </div>
+
+                          <cite class="documentLocation link-location"
+                                tal:define="breadcrumbs python: view.breadcrumbs(item);
+                                            is_rtl context/@@plone_portal_state/is_rtl;"
+                                tal:condition='breadcrumbs'>
+                            <span tal:repeat="crumb breadcrumbs"
+                                  tal:attributes="dir python:is_rtl and 'rtl' or 'ltr';">
+                              <tal:item tal:define="is_last repeat/crumb/end;
+                                                    url crumb/absolute_url;
+                                                    title crumb/Title">
+                                <a href="#"
+                                   tal:omit-tag="not: url"
+                                   tal:attributes="href url"
+                                   tal:content="title">
+                                  crumb
+                                </a>
+                                <span class="breadcrumbSeparator" tal:condition="not: is_last">
+                                  <tal:ltr condition="not: is_rtl">/</tal:ltr>
+                                  <tal:rtl condition="is_rtl">/</tal:rtl>
+                                </span>
+                              </tal:item>
+                            </span>
+
+                          </cite>
+                        </dd>
+                      </div>
+                      <div class="searchImage" tal:condition="is_bumblebee_feature_enabled">
+                        <tal:bumblebee define="preview_image_url python:view.get_preview_image_url(item)" tal:condition="preview_image_url" >
+                        <a tal:define="item_url item/getURL;
                                        item_type item/portal_type"
                            tal:attributes="href python:item_type in use_view_action and (item_url + '/view') or item_url;
-                                           class string:state-${item/review_state};
-                                           title item/Title"
-                           tal:content="item/CroppedTitle" />
+                                           title item/Title">
+                          <img class="bumblebeeSearchPreview" tal:attributes="src preview_image_url;
+                                                                              title item/title" />
+                        </a>
+                        </tal:bumblebee>
+                      </div>
+                      <div class="visualClear"><!-- --></div>
 
-                      </dt>
-                      <dd>
-                        <div class="main_dossier">
-                          <span i18n:domain="opengever.base" i18n:translate="label_dossier">Dossier:</span>
-                          <a href="#" tal:content="item/containing_dossier"
-                             tal:attributes="href item/main_dossier_link">
-                            Main dossier link
-                          </a>
-
-                        </div>
-
-                        <div class="description" tal:content="item/CroppedDescription">
-                          Cropped description
-                        </div>
-
-                        <cite class="documentLocation link-location"
-                              tal:define="breadcrumbs python: view.breadcrumbs(item);
-                                          is_rtl context/@@plone_portal_state/is_rtl;"
-                              tal:condition='breadcrumbs'>
-                          <span tal:repeat="crumb breadcrumbs"
-                                tal:attributes="dir python:is_rtl and 'rtl' or 'ltr';">
-                            <tal:item tal:define="is_last repeat/crumb/end;
-                                                  url crumb/absolute_url;
-                                                  title crumb/Title">
-                              <a href="#"
-                                 tal:omit-tag="not: url"
-                                 tal:attributes="href url"
-                                 tal:content="title">
-                                crumb
-                              </a>
-                              <span class="breadcrumbSeparator" tal:condition="not: is_last">
-                                <tal:ltr condition="not: is_rtl">/</tal:ltr>
-                                <tal:rtl condition="is_rtl">/</tal:rtl>
-                              </span>
-                            </tal:item>
-                          </span>
-
-                        </cite>
-
-                      </dd>
                     </tal:results>
                   </dl>
                   <div metal:use-macro="context/batch_macros/macros/navigation" />

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -1,4 +1,6 @@
 from DateTime import DateTime
+from ftw.bumblebee.utils import get_representation_url_by_brain
+from opengever.bumblebee import is_bumblebee_feature_enabled
 from plone import api
 from plone.app.search.browser import EVER
 from plone.app.search.browser import quote_chars
@@ -70,6 +72,15 @@ class OpengeverSearch(Search):
             'query': query_value,
             'range': usage
         }
+
+    def is_bumblebee_feature_enabled(self):
+        return is_bumblebee_feature_enabled()
+
+    def get_preview_image_url(self, brain):
+        if not brain.bumblebee_checksum:
+            return None
+
+        return get_representation_url_by_brain('thumbnail', brain)
 
     def filter_query(self, query):
         """The filter query of the standard search view (plone.app.search)

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.testing import FunctionalTestCase
 from zope.interface import alsoProvides
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 
 
 class TestOpengeverSearch(FunctionalTestCase):
@@ -37,3 +38,27 @@ class TestOpengeverSearch(FunctionalTestCase):
 
         browser.login().open(self.portal, view='search')
         self.assertEqual(25, len(browser.css('dl.searchResults dt')))
+
+    @browsing
+    def test_no_bubmlebee_preview_rendered_when_feature_not_enabled(self, browser):
+        browser.login().open(self.portal, view='search')
+        self.assertEqual(0, len(browser.css('.searchImage')))
+
+class TestBumblebeePreview(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    @browsing
+    def test_image_previews_are_rendered_withsearch_results(self, browser):
+        document = create(Builder('document')
+                         .titled(u'Foo Document')
+                         .with_dummy_content())
+
+        browser.login().open(self.portal, view='search')
+        browser.fill({'Search Site': 'Foo Document'}).submit()
+
+        preview_image = browser.css('.searchImage').first
+        document_link = preview_image.css('a').first
+
+        self.assertEqual(document.absolute_url(), document_link.get('href'))
+        self.assertEqual('Foo Document', document_link.get('title'))

--- a/sources.cfg
+++ b/sources.cfg
@@ -19,4 +19,3 @@ auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
-


### PR DESCRIPTION
Add bumblebee preview images to search results, when the feature is enabled and an image has been generated.

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/423.

<img width="801" alt="screen shot 2016-05-04 at 10 00 23" src="https://cloud.githubusercontent.com/assets/736583/15008244/3a58ae36-11df-11e6-8853-e3f4bdaa193b.png">
