### PR TITLE
Rework disposition overview

### DIFF
--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -64,3 +64,17 @@ class DispositionOverview(grok.View, OpengeverTab):
 
     def get_history(self):
         return IHistoryStorage(self.context).get_history()
+
+    def get_states(self):
+        """Return all disposition states in a orderd way.
+        Used to generate and display the status wizzard.
+        """
+
+        return ['disposition-state-in-progress',
+                'disposition-state-appraised',
+                'disposition-state-disposed',
+                'disposition-state-archived',
+                'disposition-state-closed']
+
+    def get_current_state(self):
+        return api.content.get_state(self.context)

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -1,5 +1,18 @@
 <div id="disposition_overview" i18n:domain="opengever.disposition">
 
+  <div>
+    <!-- <h3><span i18n:domain="plone" i18n:translate="State">State</span>:</h3> -->
+    <div class="workflow_wizard">
+      <ul class="wizard_steps" tal:define="current_state view/get_current_state" >
+        <li tal:repeat="state view/get_states"
+            tal:content="state"
+            tal:attributes="class python: state == current_state and 'selected' or ''"
+            i18n:domain="plone" i18n:translate="">
+        </li>
+      </ul>
+    </div>
+  </div>
+
   <ul class="list-group">
 
     <li class="list-group-item label">

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -84,7 +84,7 @@
 
      </li>
   </ul>
-  <div class="actionButtons">
+  <div class="actionButtons clearfix">
     <ul class="transitions">
       <li tal:repeat="transition view/get_transitions" >
         <a tal:condition="transition/url"
@@ -99,7 +99,7 @@
         </a>
       </li>
     </ul>
-    <ul class="actions clearfix">
+    <ul class="actions">
       <tal:repeat tal:repeat="action view/get_actions">
         <li tal:condition="action/visible">
           <a class="button"

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -1,6 +1,16 @@
 <div id="disposition_overview" i18n:domain="opengever.disposition">
 
   <ul class="list-group">
+
+    <li class="list-group-item label">
+      <div class="list-group-cell data-cell">
+        <h3 i18n:translate="label_dosisers">Dossiers</h3>
+      </div>
+      <div class="list-group-cell action-cell">
+        <h3 i18n:translate="label_archive">Archive</h3>
+      </div>
+    </li>
+
     <li tal:repeat="dossier view/get_dossiers"
         class="dispositions list-group-item">
 
@@ -48,7 +58,7 @@
 
           <a href="#"
              class="button"
-             tal:attributes="class python: dossier.appraisal and 'button active' or 'button';
+             tal:attributes="class python: dossier.appraisal and 'icon_button archive active' or 'icon_button archive';
                              data-url python: view.get_update_appraisal_url(dossier, True);"
              i18n:translate="">
             Archive
@@ -56,7 +66,7 @@
 
           <a href="#"
              class="button"
-             tal:attributes="class python: dossier.appraisal and 'button' or 'button active';
+             tal:attributes="class python: dossier.appraisal and 'not_archive icon_button' or 'not_archive icon_button active';
                              data-url python: view.get_update_appraisal_url(dossier, False);"
              i18n:translate="">
             Don't archive
@@ -66,19 +76,17 @@
 
         <div class="button-group appraisal-button-group"
              tal:condition="not: view/appraisal_buttons_available">
-
-          <span class="readonly button"
-             tal:attributes="class python: dossier.appraisal and 'readonly button active' or 'readonly button';"
-             i18n:translate="">
+          <span tal:condition="dossier/appraisal"
+                class="icon_button archive active"
+                i18n:translate="label_archive">
             Archive
           </span>
-
-          <span class="readonly button"
-                tal:attributes="class python: dossier.appraisal and 'readonly button' or 'readonly button active';"
-                i18n:translate="">
+          <span
+              tal:condition="not: dossier/appraisal"
+              class="icon_button not_archive active"
+              i18n:translate="label_dont_archive">
             Don't archive
           </span>
-
         </div>
       </div>
 

--- a/opengever/disposition/browser/overview_templates/overview.pt
+++ b/opengever/disposition/browser/overview_templates/overview.pt
@@ -29,10 +29,13 @@
             <span i18n:domain="opengever.base" i18n:translate="label_archival_value">Archival value</span>:
             <span i18n:domain="opengever.base" i18n:translate=""
                   tal:content="dossier/archival_value"/>
-            (
-            <span i18n:domain="opengever.base"
-                  tal:content="dossier/archival_value_annotation"/>
-            )
+
+            <span tal:condition="dossier/archival_value_annotation">
+              (
+              <span i18n:domain="opengever.base"
+                    tal:content="dossier/archival_value_annotation"/>
+              )
+            </span>
           </span>
 
         </div>

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -59,7 +59,7 @@ class TestDispositionOverview(FunctionalTestCase):
             browser.css('.dispositions .public_trial').text)
 
         self.assertEquals(
-            ['Archival value: archival worthy ( )',
+            ['Archival value: archival worthy',
              'Archival value: not archival worthy ( In Absprache mit ARCH. )'],
             browser.css('.dispositions .archival_value').text)
 

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -70,13 +70,12 @@ class TestDispositionOverview(FunctionalTestCase):
         self.assertEquals(
             'Archive',
             browser.css('.appraisal-button-group .active')[0].text)
-
         self.assertEquals(
             "Don't archive",
             browser.css('.appraisal-button-group .active')[1].text)
 
     @browsing
-    def test_appraisal_buttons_are_only_buttons_in_progress_state(self, browser):
+    def test_appraisal_buttons_are_only_links_in_progress_state(self, browser):
         self.grant('Records Manager')
         browser.login().open(self.disposition, view='tabbedview_view-overview')
 
@@ -88,25 +87,26 @@ class TestDispositionOverview(FunctionalTestCase):
         browser.login().open(self.disposition, view='tabbedview_view-overview')
         self.assertEquals(
             [], browser.css('.appraisal-button-group').first.css('a').text)
-        self.assertEquals(
-            ['Archive', "Don't archive"],
-            browser.css('.appraisal-button-group').first.css('span').text)
+
+        buttons = browser.css('.appraisal-button-group')
+        self.assertEquals('Archive', buttons[0].text)
+        self.assertEquals("Don't archive", buttons[1].text)
 
     @browsing
     def test_update_appraisal_is_correct(self, browser):
         browser.login().open(self.disposition, view='tabbedview_view-overview')
 
         self.assertEquals(
-            "Archive",
-            browser.css('.appraisal-button-group .active')[0].text)
+            ['Archive', "Don't archive"],
+            browser.css('.appraisal-button-group .active').text)
 
-        dont_archive_button = browser.css('.appraisal-button-group .button')[1]
+        dont_archive_button = browser.css('.appraisal-button-group .archive')[1]
         browser.open(dont_archive_button.get('data-url'))
 
         browser.login().open(self.disposition, view='tabbedview_view-overview')
         self.assertEquals(
-            "Don't archive",
-            browser.css('.appraisal-button-group .active')[0].text)
+            ['Archive', 'Archive'],
+            browser.css('.appraisal-button-group .active').text)
 
     @browsing
     def test_lists_possible_transitions_in_actionmenu_as_buttons(self, browser):

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -149,6 +149,26 @@ class TestDispositionOverview(FunctionalTestCase):
             'http://nohost/plone/disposition-1/xlsx',
             browser.find('Export appraisal list as excel').get('href'))
 
+    @browsing
+    def test_states_are_displayed_in_a_wizard_in_the_process_order(self, browser):
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            ['disposition-state-in-progress',
+             'disposition-state-appraised',
+             'disposition-state-disposed',
+             'disposition-state-archived',
+             'disposition-state-closed'],
+            browser.css('.wizard_steps li').text)
+
+    @browsing
+    def test_current_state_is_selected(self, browser):
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            ['disposition-state-in-progress'],
+            browser.css('.wizard_steps li.selected').text)
+
 
 class TestClosedDispositionOverview(FunctionalTestCase):
 


### PR DESCRIPTION
- Don't display empty parentheses, when no archival_value annotation is empty.
- Split up transition and other actions.
- Replace appraisal buttons with simple icon links.
- Display a readonly state wizard.

<img width="872" alt="bildschirmfoto 2016-05-06 um 15 15 42" src="https://cloud.githubusercontent.com/assets/485755/15079937/c227465a-13bb-11e6-975a-9c58758b4600.png">

<img width="871" alt="bildschirmfoto 2016-05-06 um 12 32 55" src="https://cloud.githubusercontent.com/assets/485755/15105275/a0108052-15c0-11e6-9ed0-3b3620c8537c.png">

