### PR TITLE
Decouple default values for fields from any forms

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Decouple default values for fields from any forms (as much as possible).
+  This is necessary groundwork for later changes that will make sure that
+  default values also get set during programmatic content creation.
+  [lgraf]
+
 - Refactor opengever.tabbedview:
 
   - Provide better base classes for tabs

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -131,6 +131,7 @@ grok.global_utility(
     name=u'classification_classification_vocabulary')
 
 
+# XXX: Eventually rewrite this as a context aware defaultFactory
 form.default_value(field=IClassification['classification'])(
     utils.set_default_with_acquisition(
         field=IClassification['classification'],
@@ -165,6 +166,7 @@ grok.global_utility(
     name=u'classification_privacy_layer_vocabulary')
 
 
+# XXX: Eventually rewrite this as a context aware defaultFactory
 form.default_value(field=IClassification['privacy_layer'])(
     utils.set_default_with_acquisition(
         field=IClassification['privacy_layer'],

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -2,13 +2,12 @@ from five import grok
 from opengever.base import _
 from opengever.base.behaviors import utils
 from opengever.base.utils import language_cache_key
+from plone import api
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
 from plone.memoize import ram
-from plone.registry.interfaces import IRegistry
 from zope import schema
-from zope.component import getUtility
 from zope.i18n import translate
 from zope.interface import alsoProvides, Interface
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
@@ -34,6 +33,13 @@ def translated_public_trial_terms(context, request):
         values[term] = translate(term, context=request,
                                  domain="opengever.base")
     return values
+
+
+def public_trial_default():
+    """Default value for `public_trial` field for new documents.
+    """
+    return api.portal.get_registry_record(
+        'public_trial_default_value', interface=IClassificationSettings)
 
 
 class IClassification(form.Schema):
@@ -68,6 +74,7 @@ class IClassification(form.Schema):
         description=_(u'help_public_trial', default=u''),
         source=u'classification_public_trial_vocabulary',
         required=True,
+        defaultFactory=public_trial_default,
     )
 
     public_trial_statement = schema.Text(
@@ -173,18 +180,6 @@ form.default_value(field=IClassification['privacy_layer'])(
         default=PRIVACY_LAYER_NO
     )
 )
-
-
-# XXX: Setting the default value in the field directly, breaks the
-# DCFieldProperty stuff. thus we implement the default value this way.
-@form.default_value(field=IClassification['public_trial'])
-def default_public_trial(data):
-    """Default value for `public_trial` field for new documents.
-    """
-    registry = getUtility(IRegistry)
-    settings = registry.forInterface(IClassificationSettings)
-    public_trial_default_value = settings.public_trial_default_value
-    return public_trial_default_value
 
 
 class Classification(metadata.MetadataBase):

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -178,6 +178,7 @@ grok.global_utility(
 
 
 # Default value
+# XXX: Eventually rewrite this as a context aware defaultFactory
 form.default_value(field=ILifeCycle['retention_period'])(
     utils.set_default_with_acquisition(
         field=ILifeCycle['retention_period'],
@@ -223,6 +224,7 @@ grok.global_utility(
 
 
 # Default value
+# XXX: Eventually rewrite this as a context aware defaultFactory
 form.default_value(field=ILifeCycle['custody_period'])(
     utils.set_default_with_acquisition(
         field=ILifeCycle['custody_period'],
@@ -310,6 +312,7 @@ grok.global_utility(
     name=u'lifecycle_archival_value_vocabulary')
 
 
+# XXX: Eventually rewrite this as a context aware defaultFactory
 form.default_value(field=ILifeCycle['archival_value'])(
     utils.set_default_with_acquisition(
         field=ILifeCycle['archival_value'],

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -146,6 +146,14 @@ def create_restricted_vocabulary(field, options,
     return GeneratedVocabulary
 
 
+# XXX: Eventually this should be rewritten to be compatible with the use of
+# context aware default factories.
+# The combination of acquired default values with restricted vocabularies
+# makes this tricky though. _get_acquisiton_value() in particular is
+# problematic because it needs to distinguish between "add" and "edit"
+# situations, and currently does so in a way that doesn't work for
+# programmatic content creation.
+
 def set_default_with_acquisition(field, default=None):
     """
     Sets a default value generator which uses the value

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -18,6 +18,11 @@ from zope.interface import alsoProvides
 from zope.interface import Invalid
 
 
+def document_date_default():
+    """Set today's date as the default `document_date`"""
+    return date.today()
+
+
 class IDocumentMetadata(form.Schema):
     """Schema behavior for common GEVER document metadata
     """
@@ -72,6 +77,7 @@ class IDocumentMetadata(form.Schema):
         title=_(u'label_document_date', default='Document Date'),
         description=_(u'help_document_date', default=''),
         required=False,
+        defaultFactory=document_date_default,
         )
 
     # workaround because ftw.datepicker wasn't working
@@ -190,13 +196,6 @@ validator.WidgetValidatorDiscriminators(
     )
 
 grok.global_adapter(FileOrPaperValidator)
-
-
-# Default values
-@form.default_value(field=IDocumentMetadata['document_date'])
-def default_document_date(data):
-    """Set today's date as the default `document_date`"""
-    return date.today()
 
 
 @form.default_value(field=IDocumentMetadata['preserved_as_paper'])

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -148,6 +148,20 @@ def filing_prefix_default(context):
     return None
 
 
+@provider(IContextAwareDefaultFactory)
+def filing_year_default(context):
+    """Propose default for filing_year based on the most recent date of
+    any object contained in the dossier or the dossier itself.
+
+    context: Dossier that's being archived.
+    """
+    youngest_date = context.earliest_possible_end_date()
+    if youngest_date:
+        # filing_year is of type TextLine for some reason
+        return unicode(youngest_date.year)
+    return None
+
+
 class IArchiveFormSchema(directives_form.Schema):
 
     filing_prefix = schema.Choice(
@@ -170,6 +184,7 @@ class IArchiveFormSchema(directives_form.Schema):
         title=_(u'filing_year', default="filing Year"),
         constraint=valid_filing_year,
         required=False,
+        defaultFactory=filing_year_default,
     )
 
     filing_action = schema.Choice(
@@ -191,14 +206,6 @@ class IArchiveFormSchema(directives_form.Schema):
 
 
 # defaults
-@directives_form.default_value(field=IArchiveFormSchema['filing_year'])
-def filing_year_default_value(data):
-    last_date = data.context.earliest_possible_end_date()
-    if last_date:
-        return str(last_date.year)
-    return None
-
-
 @directives_form.default_value(field=IArchiveFormSchema['dossier_enddate'])
 def default_end_date(data):
     if IDossier(data.context).end and data.context.has_valid_enddate():

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -162,6 +162,17 @@ def filing_year_default(context):
     return None
 
 
+@provider(IContextAwareDefaultFactory)
+def dossier_enddate_default(context):
+    """Suggested default for the dossier's enddate.
+
+    context: Dossier that's being archived.
+    """
+    if IDossier(context).end and context.has_valid_enddate():
+        return IDossier(context).end
+    return context.earliest_possible_end_date()
+
+
 class IArchiveFormSchema(directives_form.Schema):
 
     filing_prefix = schema.Choice(
@@ -178,6 +189,7 @@ class IArchiveFormSchema(directives_form.Schema):
         title=_(u'label_end', default=u'Closing Date'),
         description=_(u'help_end', default=u''),
         required=True,
+        defaultFactory=dossier_enddate_default,
     )
 
     filing_year = schema.TextLine(
@@ -203,14 +215,6 @@ class IArchiveFormSchema(directives_form.Schema):
                 raise Invalid(
                     _(u"When the Action give filing number is selected, \
                         all fields are required."))
-
-
-# defaults
-@directives_form.default_value(field=IArchiveFormSchema['dossier_enddate'])
-def default_end_date(data):
-    if IDossier(data.context).end and data.context.has_valid_enddate():
-        return IDossier(data.context).end
-    return data.context.earliest_possible_end_date()
 
 
 class ArchiveForm(directives_form.Form):

--- a/opengever/dossier/browser/filing_maintenance.py
+++ b/opengever/dossier/browser/filing_maintenance.py
@@ -60,20 +60,10 @@ class FilingNumberMaintenance(BrowserView):
             self.log('%s: %s' % (term.value, term.title))
 
 
-class IFilingNumberRowSchema(Interface):
-    key = schema.TextLine(title=u"Key")
-    counter = schema.Int(title=u"Increaser Value")
-
-
-class IFilingNumberCountersFormSchema(Interface):
-    counters = schema.List(
-        title=u"counters",
-        value_type=DictRow(title=u"counter", schema=IFilingNumberRowSchema)
-        )
-
-
-@form.default_value(field=IFilingNumberCountersFormSchema['counters'])
-def set_counters(data):
+def counters_default():
+    """Determine the "defaults" for the ``counter`` datagrid field in the
+    FilingNumberCountersForm (i.e. the stored counter mappings).
+    """
     portal = getUtility(ISiteRoot)
     ann = IAnnotations(portal)
 
@@ -85,6 +75,19 @@ def set_counters(data):
 
     else:
         return {}
+
+
+class IFilingNumberRowSchema(Interface):
+    key = schema.TextLine(title=u"Key")
+    counter = schema.Int(title=u"Increaser Value")
+
+
+class IFilingNumberCountersFormSchema(Interface):
+    counters = schema.List(
+        title=u"counters",
+        value_type=DictRow(title=u"counter", schema=IFilingNumberRowSchema),
+        defaultFactory=counters_default,
+        )
 
 
 class FilingNumberCountersForm(form.Form):

--- a/opengever/dossier/tests/test_archive.py
+++ b/opengever/dossier/tests/test_archive.py
@@ -11,7 +11,6 @@ from opengever.core.testing import ANNOTATION_LAYER
 from opengever.core.testing import inactivate_filing_number
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_FILING_LAYER
 from opengever.dossier.archive import Archiver
-from opengever.dossier.archive import default_end_date
 from opengever.dossier.archive import EnddateValidator
 from opengever.dossier.archive import get_filing_actions
 from opengever.dossier.archive import METHOD_FILING
@@ -247,31 +246,6 @@ class TestArchiving(MockTestCase):
         self.assertEquals(actions.by_token.keys(),[ONLY_NUMBER])
         self.assertEquals(actions.by_value.keys(),[METHOD_FILING])
 
-    def test_default_end_date(self):
-        data = self.stub()
-        dossier = self.stub_dossier()
-        self.expect(data.context).result(dossier)
-
-        with self.mocker.order():
-            self.expect(dossier.end).result(date(2012, 3, 3))
-            self.expect(dossier.has_valid_enddate()).result(True)
-            self.expect(dossier.end).result(date(2012, 3, 3))
-
-            self.expect(dossier.end).result(None)
-            self.expect(dossier.earliest_possible_end_date()).result(date(2012, 4, 4))
-
-            self.expect(dossier.end).result(date(2012, 3, 3))
-            self.expect(dossier.has_valid_enddate()).result(True)
-            self.expect(dossier.end).result(date(2012, 5, 5))
-
-            self.expect(dossier.filing_year).result(None)
-
-        self.replay()
-
-        self.assertEquals(default_end_date(data), date(2012, 3, 3))
-        self.assertEquals(default_end_date(data), date(2012, 4, 4))
-        self.assertEquals(default_end_date(data), date(2012, 5, 5))
-
 
 class TestArchiveFormDefaults(FunctionalTestCase):
 
@@ -281,6 +255,10 @@ class TestArchiveFormDefaults(FunctionalTestCase):
         super(TestArchiveFormDefaults, self).setUp()
         with freeze(FROZEN_NOW):
             self.dossier = create(Builder('dossier'))
+
+    def _get_form_date(self, browser, field_name):
+        datestr = browser.css('#form-widgets-%s' % field_name).first.value
+        return datetime.strptime(datestr, '%B %d, %Y').date()
 
     @browsing
     def test_filing_prefix_default(self, browser):
@@ -313,3 +291,43 @@ class TestArchiveFormDefaults(FunctionalTestCase):
         browser.login().open(self.dossier, view='transition-archive')
         form_default = browser.css('#form-widgets-filing_year').first.value
         self.assertEqual(doc.document_date.year, int(form_default))
+
+    @browsing
+    def test_dossier_enddate_default(self, browser):
+        # Dossier without sub-objects - earliest possible end date is dossier
+        # start date, suggested enddate should therefore default to that
+        browser.login().open(self.dossier, view='transition-archive')
+
+        form_default = self._get_form_date(browser, 'dossier_enddate')
+        self.assertEqual(IDossier(self.dossier).start, form_default)
+
+        # Document with date newer than dossier start. Suggested end date
+        # default should be that of the document (year of the youngest object)
+        doc = create(Builder('document')
+                     .within(self.dossier)
+                     .having(document_date=date(2050, 1, 1)))
+        browser.login().open(self.dossier, view='transition-archive')
+
+        form_default = self._get_form_date(browser, 'dossier_enddate')
+        self.assertEqual(doc.document_date, form_default)
+
+        # Dossier with invalid enddate (older than youngest doc) - should
+        # fall back to earliest possible enddate
+        IDossier(self.dossier).end = date(2020, 1, 1)
+        transaction.commit()
+
+        browser.login().open(self.dossier, view='transition-archive')
+
+        form_default = self._get_form_date(browser, 'dossier_enddate')
+        self.assertEqual(
+            self.dossier.earliest_possible_end_date(),
+            form_default)
+
+        # Dossier with a valid enddate - should be used as the default
+        IDossier(self.dossier).end = date(2070, 1, 1)
+        transaction.commit()
+
+        browser.login().open(self.dossier, view='transition-archive')
+
+        form_default = self._get_form_date(browser, 'dossier_enddate')
+        self.assertEqual(IDossier(self.dossier).end, form_default)

--- a/opengever/mail/upgrades/to3401.py
+++ b/opengever/mail/upgrades/to3401.py
@@ -21,6 +21,14 @@ NEW_BEHAVIORS = [
 class ActivateBehaviors(UpgradeStep):
 
     def __call__(self):
+        raise Exception(
+            "This upgrade step won't work anymore unless it's updated with"
+            "changes to default value adapters, therefore we refuse to "
+            "install it! There should not be any deployment out in the wild"
+            "any more that needs this (OpenGever KGS 2.9 or newer are fine).")
+
+        # XXX: Remove this upgrade step along with all others that aren't
+        # needed any more.
 
         fti = getUtility(IDexterityFTI, name=u'ftw.mail.mail')
         behaviors = list(fti.behaviors)

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -7,9 +7,23 @@ from z3c.form import validator, error
 from z3c.form.interfaces import IAddForm
 from zope import schema
 from zope.component import provideAdapter
-from zope.interface import Interface, alsoProvides
+from zope.interface import alsoProvides
+from zope.interface import Interface
+from zope.interface import provider
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.schema.interfaces import IContextAwareDefaultFactory
+
+
+@provider(IContextAwareDefaultFactory)
+def reference_number_prefix_default(context):
+    """Determine the default for the reference number prefix.
+
+    context: Usually the container where a new object is created (i.e.
+    default factory is called during content creation), unless the factory
+    is called from an edit or display action (which shouldn't happen).
+    """
+    return PrefixAdapter(context).get_next_number()
 
 
 class IReferenceNumberPrefix(form.Schema):
@@ -28,15 +42,10 @@ class IReferenceNumberPrefix(form.Schema):
             default=u'Reference Prefix'),
         description=_(u'help_reference_number_prefix', default=u''),
         required=False,
+        defaultFactory=reference_number_prefix_default,
         )
 
 alsoProvides(IReferenceNumberPrefix, form.IFormFieldProvider)
-
-
-@form.default_value(
-    field=IReferenceNumberPrefix['reference_number_prefix'])
-def reference_number_default_value(data):
-    return PrefixAdapter(data.context).get_next_number()
 
 
 class ReferenceNumberPrefixValidator(validator.SimpleFieldValidator):

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -26,7 +26,6 @@ from plone import api
 from plone.dexterity.content import Container
 from plone.directives import form
 from plone.indexer.interfaces import IIndexer
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import _mergedLocalRoles
 from Products.CMFCore.utils import getToolByName
@@ -44,6 +43,12 @@ from zope.schema.vocabulary import getVocabularyRegistry
 
 
 _marker = object()
+
+
+def deadline_default():
+    offset = api.portal.get_registry_record(
+        'deadline_timedelta', interface=ITaskSettings)
+    return (datetime.today() + timedelta(days=offset)).date()
 
 
 class ITask(form.Schema):
@@ -124,6 +129,7 @@ class ITask(form.Schema):
         title=_(u"label_deadline", default=u"Deadline"),
         description=_(u"help_deadline", default=u""),
         required=True,
+        defaultFactory=deadline_default,
         )
 
     form.widget(date_of_completion=DatePickerFieldWidget)
@@ -361,13 +367,6 @@ class Task(Container):
             vocabulary = util.getTaskTypeVocabulary(self)
             term = vocabulary.getTerm(self.task_type)
             return term.title
-
-
-@form.default_value(field=ITask['deadline'])
-def deadline_default_value(data):
-    registry = getUtility(IRegistry)
-    proxy = registry.forInterface(ITaskSettings)
-    return datetime.today() + timedelta(days=proxy.deadline_timedelta)
 
 
 @form.default_value(field=ITask['responsible_client'])

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -209,14 +209,6 @@ validator.WidgetValidatorDiscriminators(
 provideAdapter(NoCheckedoutDocsValidator)
 
 
-def default_issuer(data):
-    portal_state = getMultiAdapter(
-        (data.context, data.request),
-        name=u"plone_portal_state")
-    member = portal_state.member()
-    return member.getId()
-
-
 class Task(Container):
     implements(ITask, ITabbedviewUploadable)
 


### PR DESCRIPTION
Decouple default values for fields from any forms (as much as possible). This is necessary groundwork for later changes that will make sure that default values also get set during programmatic content creation.

This usually means turning something like

```python
@form.default_value(field=ISchema['fieldname'])
def fieldname_default(data):
    context = data.context
    # ...
```
into something like

```python
def fieldname_default(context):
    # ...


class ISchema(form.Schema):

    fieldname = schema.Choice(
        # ...
        defaultFactory=fieldname_default,
    )
```

Default factories are now being used for the following fields:

- `Document.preserved_as_paper`
- `ArchiveForm.filing_prefix`
- `ArchiveForm.filing_year`
- `ArchiveForm.dossier_enddate`
- `FilingNumberCountersForm.counters`
- `IReferenceNumberPrefix.reference_number_prefix`
- `ITask.deadline`
- `IClassification.public_trial`

For all of those I made sure that either a **test exists** that covers the defaults or added a **new one**. 