### PR TITLE
Run "cleanup jobs" when resolving a dossier.

### DIFF
--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -7,6 +7,7 @@ from five import grok
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -277,6 +278,20 @@ class DossierContainer(Container):
             return self.get_retention_expiration_date() <= date.today()
 
         return False
+
+    def purge_trash(self):
+        """Delete all trashed documents inside the dossier (recursive).
+        """
+        trashed_docs = api.content.find(
+            context=self,
+            depth=-1,
+            object_provides=[IBaseDocument],
+            trashed=True)
+
+        if trashed_docs:
+            with elevated_privileges():
+                api.content.delete(
+                    objects=[brain.getObject() for brain in trashed_docs])
 
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -7,7 +7,6 @@ from five import grok
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
-from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -278,20 +277,6 @@ class DossierContainer(Container):
             return self.get_retention_expiration_date() <= date.today()
 
         return False
-
-    def purge_trash(self):
-        """Delete all trashed documents inside the dossier (recursive).
-        """
-        trashed_docs = api.content.find(
-            context=self,
-            depth=-1,
-            object_provides=[IBaseDocument],
-            trashed=True)
-
-        if trashed_docs:
-            with elevated_privileges():
-                api.content.delete(
-                    objects=[brain.getObject() for brain in trashed_docs])
 
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -116,3 +116,11 @@ def reindex_containing_dossier(dossier, event):
                         if brain.portal_type in ['opengever.task.task',
                             'opengever.inbox.forwarding']:
                             sync_task(brain.getObject(), event)
+
+
+@grok.subscribe(IDossierMarker, IActionSucceededEvent)
+def run_cleanup_jobs(dossier, event):
+    if event.action != 'dossier-transition-resolve':
+        return
+
+    DossierResolver(dossier).after_resolve_jobs()

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -4,6 +4,7 @@ from OFS.interfaces import IObjectWillBeMovedEvent
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.dossier.behaviors.dossier import IDossierMarker, IDossier
+from opengever.dossier.resolve import DossierResolver
 from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from plone import api
@@ -123,4 +124,4 @@ def run_cleanup_jobs(dossier, event):
     if event.action != 'dossier-transition-resolve':
         return
 
-    DossierResolver(dossier).after_resolve_jobs()
+    DossierResolver(dossier).after_resolve()

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -175,3 +175,20 @@ class IDocPropertyProvider(Interface):
     def get_properties():
         """Return a dictionary of DocProperties for the adapted object.
         """
+
+
+class IDossierResolveProperties(Interface):
+    """Dossier resolving configuration.
+    """
+
+    purge_trash_enabled = schema.Bool(
+        title=u'Enable `purge trash` option.',
+        description=u'Select if the trashed documents should be deleteted '
+        'when a dossier gets resolved.',
+        default=True)
+
+    journal_pdf_enabled = schema.Bool(
+        title=u'Enable `journal pdf` option.',
+        description=u'Select if a pdf representation of the dossier journal '
+        'should be added automatically to the dossier when it gets resolved.',
+        default=True)

--- a/opengever/dossier/profiles/default/registry.xml
+++ b/opengever/dossier/profiles/default/registry.xml
@@ -2,4 +2,5 @@
   <records interface="opengever.dossier.interfaces.IDossierContainerTypes" />
   <records interface="opengever.dossier.interfaces.IDossierParticipants" />
   <records interface="opengever.dossier.interfaces.ITemplateDossierProperties" />
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
 </registry>

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -8,6 +8,7 @@ from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
+from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.interfaces import IDossierResolver
 from plone import api
 from Products.CMFCore.utils import getToolByName
@@ -100,6 +101,10 @@ class DossierResolver(grok.Adapter):
     preconditions_fulfilled = False
     enddates_valid = False
 
+    def get_property(self, name):
+        return api.portal.get_registry_record(
+            name, interface=IDossierResolveProperties)
+
     def is_resolve_possible(self):
         """Check if all preconditions are fulfilled.
         Return a list of errors, or a empty list when resolving is possible.
@@ -155,6 +160,9 @@ class DossierResolver(grok.Adapter):
     def purge_trash(self):
         """Delete all trashed documents inside the dossier (recursive).
         """
+        if not self.get_property('purge_trash_enabled'):
+            return
+
         trashed_docs = api.content.find(
             context=self.context,
             depth=-1,
@@ -170,6 +178,9 @@ class DossierResolver(grok.Adapter):
         """Creates a pdf representation of the dossier journal, and add it to
         the dossier as a normal document.
         """
+        if not self.get_property('journal_pdf_enabled'):
+            return
+
         view = self.context.unrestrictedTraverse('pdf-dossier-journal')
         today = api.portal.get_localized_time(datetime=datetime.today())
         filename = u'Journal {}.pdf'.format(today)

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -1,10 +1,13 @@
 from five import grok
+from opengever.base.security import elevated_privileges
+from opengever.document.behaviors import IBaseDocument
 from opengever.dossier import _
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.interfaces import IDossierResolver
+from plone import api
 from Products.CMFCore.utils import getToolByName
 
 
@@ -133,6 +136,31 @@ class DossierResolver(grok.Adapter):
             raise TypeError
         else:
             Resolver(self.context).resolve_dossier(end_date=end_date)
+
+    def after_resolve(self):
+        """After resovling a dossier, some cleanup jobs have to be done or be
+        triggered:
+
+        - Remove all trashed documents.
+        - (Trigger PDF-A conversion).
+        - Generate a PDF output of the journal.
+        """
+
+        self.purge_trash()
+
+    def purge_trash(self):
+        """Delete all trashed documents inside the dossier (recursive).
+        """
+        trashed_docs = api.content.find(
+            context=self.context,
+            depth=-1,
+            object_provides=[IBaseDocument],
+            trashed=True)
+
+        if trashed_docs:
+            with elevated_privileges():
+                api.content.delete(
+                    objects=[brain.getObject() for brain in trashed_docs])
 
     def is_reactivate_possible(self):
         parent = self.context.get_parent_dossier()

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from five import grok
+from opengever.base.command import CreateDocumentCommand
 from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier import _
@@ -9,6 +11,7 @@ from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.interfaces import IDossierResolver
 from plone import api
 from Products.CMFCore.utils import getToolByName
+from zope.i18n import translate
 
 
 NOT_SUPPLIED_OBJECTS = _(
@@ -147,6 +150,7 @@ class DossierResolver(grok.Adapter):
         """
 
         self.purge_trash()
+        self.create_journal_pdf()
 
     def purge_trash(self):
         """Delete all trashed documents inside the dossier (recursive).
@@ -161,6 +165,22 @@ class DossierResolver(grok.Adapter):
             with elevated_privileges():
                 api.content.delete(
                     objects=[brain.getObject() for brain in trashed_docs])
+
+    def create_journal_pdf(self):
+        """Creates a pdf representation of the dossier journal, and add it to
+        the dossier as a normal document.
+        """
+        view = self.context.unrestrictedTraverse('pdf-dossier-journal')
+        today = api.portal.get_localized_time(datetime=datetime.today())
+        filename = u'Journal {}.pdf'.format(today)
+        title = _(u'title_dossier_journal', default=u'Dossier Journal {today}',
+                  mapping={'today': today})
+
+        with elevated_privileges():
+            CreateDocumentCommand(
+                self.context, filename, view.get_data(),
+                title=translate(title, context=self.context.REQUEST),
+                content_type='application/pdf').execute()
 
     def is_reactivate_possible(self):
         parent = self.context.get_parent_dossier()

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -11,11 +11,12 @@ from opengever.dossier.resolve import NOT_CLOSED_TASKS
 from opengever.dossier.resolve import NOT_SUPPLIED_OBJECTS
 from opengever.dossier.resolve import ResolveConditions, Resolver
 from opengever.testing import FunctionalTestCase
+from plone import api
 from plone.app.testing import applyProfile
 from plone.protect import createToken
 from zope.interface import implements
 from zope.interface.verify import verifyClass
-
+import transaction
 
 TEST_DATE = date(2012, 3, 1)
 
@@ -51,6 +52,42 @@ class TestResolvingDossiers(FunctionalTestCase):
         self.browser.assert_url(subdossier.absolute_url())
         self.browser.assert_portal_message(
             'The subdossier has been succesfully resolved')
+
+
+class TestResolveJobs(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestResolveJobs, self).setUp()
+        self.dossier = create(Builder('dossier'))
+        self.grant('Contributor', 'Editor', 'Reader', 'Reviewer')
+        self.catalog = api.portal.get_tool('portal_catalog')
+
+    def test_all_trashed_documents_are_deleted_when_resolving_a_dossier(self):
+        doc1 = create(Builder('document').within(self.dossier))
+        create(Builder('document').within(self.dossier).trashed())
+
+        api.content.transition(obj=self.dossier,
+                               transition='dossier-transition-resolve')
+        transaction.commit()
+
+        docs = self.catalog.unrestrictedSearchResults(
+            path='/'.join(self.dossier.getPhysicalPath()))
+        self.assertEquals([self.dossier, doc1],
+                          [brain.getObject() for brain in docs])
+
+    def test_purge_trashs_recursive(self):
+        subdossier = create(Builder('dossier').within(self.dossier))
+        doc1 = create(Builder('document').within(subdossier))
+        create(Builder('document').within(subdossier).trashed())
+
+        api.content.transition(obj=self.dossier,
+                               transition='dossier-transition-resolve')
+        transaction.commit()
+
+        docs = self.catalog.unrestrictedSearchResults(
+            path='/'.join(self.dossier.getPhysicalPath()))
+        self.assertEquals([self.dossier, subdossier, doc1],
+                          [brain.getObject() for brain in docs])
 
 
 class TestResolvingDossiersWithFilingNumberSupport(FunctionalTestCase):

--- a/opengever/dossier/upgrades/20160512161209_add_dossier_resolve_properties/registry.xml
+++ b/opengever/dossier/upgrades/20160512161209_add_dossier_resolve_properties/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+</registry>

--- a/opengever/dossier/upgrades/20160512161209_add_dossier_resolve_properties/upgrade.py
+++ b/opengever/dossier/upgrades/20160512161209_add_dossier_resolve_properties/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDossierResolveProperties(UpgradeStep):
+    """Add dossier resolve properties.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/latex/dossierjournal.py
+++ b/opengever/latex/dossierjournal.py
@@ -1,0 +1,66 @@
+from copy import deepcopy
+from five import grok
+from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
+from ftw.journal.interfaces import IAnnotationsJournalizable
+from ftw.pdfgenerator.browser.views import ExportPDFView
+from ftw.pdfgenerator.interfaces import ILaTeXLayout
+from ftw.pdfgenerator.interfaces import ILaTeXView
+from ftw.pdfgenerator.utils import provide_request_layer
+from ftw.pdfgenerator.view import MakoLaTeXView
+from opengever.latex import _
+from opengever.latex.interfaces import ILandscapeLayer
+from opengever.latex.listing import ILaTexListing
+from zope.annotation.interfaces import IAnnotations
+from zope.component import getMultiAdapter
+from zope.i18n import translate
+from zope.interface import Interface
+
+
+class IDossierJournalLayer(ILandscapeLayer):
+    """Dossier listing request layer.
+    - Select landsacpe layout by subclassing ILandscapeLayer
+    - Select view
+    """
+
+
+class DossierJournalPDFView(grok.View, ExportPDFView):
+    grok.name('pdf-dossier-journal')
+    grok.context(Interface)
+    grok.require('zope2.View')
+
+    request_layer = IDossierJournalLayer
+
+    def render(self):
+        # use the landscape layout
+        # let the request provide IDossierListingLayer
+        provide_request_layer(self.request, self.request_layer)
+
+        return ExportPDFView.__call__(self)
+
+
+class DossierListingLaTeXView(grok.MultiAdapter, MakoLaTeXView):
+    grok.provides(ILaTeXView)
+    grok.adapts(Interface, IDossierJournalLayer, ILaTeXLayout)
+
+    template_directories = ['templates', ]
+    template_name = 'dossierjournal.tex'
+
+    def get_render_arguments(self):
+        self.layout.show_organisation = True
+
+        dossier_listing = getMultiAdapter((self.context, self.request, self),
+                                          ILaTexListing, name='journal')
+
+        return {
+            'label': translate(
+                _('label_dossier_journal', default=u'Dossier journal'),
+                context=self.request),
+            'listing': dossier_listing.get_listing(self.get_journal_data())}
+
+    def get_journal_data(self):
+        if IAnnotationsJournalizable.providedBy(self.context):
+            annotations = IAnnotations(self.context)
+            data = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, [])
+            return deepcopy(data)
+
+        return []

--- a/opengever/latex/dossierjournal.py
+++ b/opengever/latex/dossierjournal.py
@@ -5,6 +5,7 @@ from ftw.journal.interfaces import IAnnotationsJournalizable
 from ftw.pdfgenerator.browser.views import ExportPDFView
 from ftw.pdfgenerator.interfaces import ILaTeXLayout
 from ftw.pdfgenerator.interfaces import ILaTeXView
+from ftw.pdfgenerator.interfaces import IPDFAssembler
 from ftw.pdfgenerator.utils import provide_request_layer
 from ftw.pdfgenerator.view import MakoLaTeXView
 from opengever.latex import _
@@ -36,6 +37,14 @@ class DossierJournalPDFView(grok.View, ExportPDFView):
         provide_request_layer(self.request, self.request_layer)
 
         return ExportPDFView.__call__(self)
+
+    def get_data(self):
+        # let the request provide IDossierListingLayer
+        provide_request_layer(self.request, self.request_layer)
+
+        assembler = getMultiAdapter((self.context, self.request),
+                                    IPDFAssembler)
+        return assembler.build_pdf()
 
 
 class DossierListingLaTeXView(grok.MultiAdapter, MakoLaTeXView):

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from five import grok
 from ftw.table import helper
 from opengever.base.interfaces import IReferenceNumber
+from opengever.journal.tab import title_helper
 from opengever.latex import _
 from opengever.latex.utils import get_issuer_of_task
 from opengever.latex.utils import get_responsible_of_task
@@ -11,6 +12,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.task.helper import task_type_helper
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import Interface
+from opengever.journal import _ as journal_mf
 
 
 class Column(object):
@@ -277,4 +279,39 @@ class TasksLaTeXListing(DossiersLaTeXListing):
                    _('label_deadline', default='Deadline'),
                    '15%',
                    lambda item: helper.readable_date(item, item.deadline))
+        ]
+
+
+
+class JournalLaTeXListing(LaTexListing):
+    grok.provides(ILaTexListing)
+    grok.adapts(Interface, Interface, Interface)
+    grok.name('journal')
+
+    template = ViewPageTemplateFile('templates/listing.pt')
+
+    def get_actor_label(self, item):
+        return Actor.lookup(item.get('actor')).get_label()
+
+    def get_columns(self):
+        return [
+            Column('time',
+                   journal_mf('label_time', default=u'Time'),
+                   '10%',
+                   lambda brain: helper.readable_date_time(brain, brain.get('time'))),
+
+            Column('title',
+                   journal_mf('label_titel', default=u'Title'),
+                   '45%',
+                   lambda brain: title_helper(brain, brain['action'].get('title'))),
+
+            Column('actor',
+                   journal_mf('label_actor', default=u'Changed by'),
+                   '15%',
+                   self.get_actor_label),
+
+            Column('comments',
+                   journal_mf('label_comments', default='Comments'),
+                   '30%',
+                   lambda brain: brain.get('comments'))
         ]

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-05-12 09:03+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,22 +27,22 @@ msgid "Print selection (PDF)"
 msgstr "Auswahl drucken (PDF)"
 
 #. Default: "Deadline"
-#: ./opengever/latex/listing.py:277
+#: ./opengever/latex/listing.py:279
 msgid "label_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Delivery date"
-#: ./opengever/latex/listing.py:230
+#: ./opengever/latex/listing.py:232
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Document author"
-#: ./opengever/latex/listing.py:235
+#: ./opengever/latex/listing.py:237
 msgid "label_document_author"
 msgstr "Autor"
 
 #. Default: "Document date"
-#: ./opengever/latex/listing.py:220
+#: ./opengever/latex/listing.py:222
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
@@ -51,14 +51,19 @@ msgstr "Dokumentdatum"
 msgid "label_documents"
 msgstr "Dokumente"
 
+#. Default: "Dossier journal"
+#: ./opengever/latex/dossierjournal.py:54
+msgid "label_dossier_journal"
+msgstr "Dossier Journal"
+
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py:128
-#: ./opengever/latex/listing.py:186
+#: ./opengever/latex/listing.py:188
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Issuer"
-#: ./opengever/latex/listing.py:257
+#: ./opengever/latex/listing.py:259
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -68,13 +73,13 @@ msgid "label_participants"
 msgstr "Beteiligung"
 
 #. Default: "Receipt date"
-#: ./opengever/latex/listing.py:225
+#: ./opengever/latex/listing.py:227
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference number"
 #: ./opengever/latex/dossierdetails.py:106
-#: ./opengever/latex/listing.py:153
+#: ./opengever/latex/listing.py:155
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
@@ -84,19 +89,19 @@ msgid "label_repository"
 msgstr "Ordnungsposition"
 
 #. Default: "Repositoryfolder"
-#: ./opengever/latex/listing.py:161
+#: ./opengever/latex/listing.py:163
 msgid "label_repository_title"
 msgstr "Ordnungspos."
 
 #. Default: "Responsible"
 #: ./opengever/latex/dossierdetails.py:122
-#: ./opengever/latex/listing.py:171
+#: ./opengever/latex/listing.py:173
 msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "State"
 #: ./opengever/latex/dossierdetails.py:135
-#: ./opengever/latex/listing.py:176
+#: ./opengever/latex/listing.py:178
 msgid "label_review_state"
 msgstr "Status"
 
@@ -107,7 +112,7 @@ msgstr "Laufnummer"
 
 #. Default: "Start"
 #: ./opengever/latex/dossierdetails.py:125
-#: ./opengever/latex/listing.py:181
+#: ./opengever/latex/listing.py:183
 msgid "label_start"
 msgstr "Beginn"
 
@@ -122,12 +127,12 @@ msgid "label_subdossiers"
 msgstr "Subdossiers"
 
 #. Default: "Responsible"
-#: ./opengever/latex/listing.py:263
+#: ./opengever/latex/listing.py:265
 msgid "label_task_responsible"
 msgstr "Auftragnehmer"
 
 #. Default: "Task type"
-#: ./opengever/latex/listing.py:252
+#: ./opengever/latex/listing.py:254
 msgid "label_task_type"
 msgstr "Art"
 
@@ -138,12 +143,11 @@ msgstr "Aufgaben"
 
 #. Default: "Title"
 #: ./opengever/latex/dossierdetails.py:116
-#: ./opengever/latex/listing.py:166
+#: ./opengever/latex/listing.py:168
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "No."
-#: ./opengever/latex/listing.py:157
+#: ./opengever/latex/listing.py:159
 msgid "short_label_sequence_number"
 msgstr "Nr."
-

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-05-12 09:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,22 +27,22 @@ msgid "Print selection (PDF)"
 msgstr "Imprimer"
 
 #. Default: "Deadline"
-#: ./opengever/latex/listing.py:277
+#: ./opengever/latex/listing.py:279
 msgid "label_deadline"
 msgstr "A réaliser jusqu'au"
 
 #. Default: "Delivery date"
-#: ./opengever/latex/listing.py:230
+#: ./opengever/latex/listing.py:232
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Document author"
-#: ./opengever/latex/listing.py:235
+#: ./opengever/latex/listing.py:237
 msgid "label_document_author"
 msgstr "Auteur"
 
 #. Default: "Document date"
-#: ./opengever/latex/listing.py:220
+#: ./opengever/latex/listing.py:222
 msgid "label_document_date"
 msgstr "Date du document"
 
@@ -51,14 +51,19 @@ msgstr "Date du document"
 msgid "label_documents"
 msgstr "Documents"
 
+#. Default: "Dossier journal"
+#: ./opengever/latex/dossierjournal.py:54
+msgid "label_dossier_journal"
+msgstr ""
+
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py:128
-#: ./opengever/latex/listing.py:186
+#: ./opengever/latex/listing.py:188
 msgid "label_end"
 msgstr "Date de fin"
 
 #. Default: "Issuer"
-#: ./opengever/latex/listing.py:257
+#: ./opengever/latex/listing.py:259
 msgid "label_issuer"
 msgstr "Mandant"
 
@@ -68,13 +73,13 @@ msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Receipt date"
-#: ./opengever/latex/listing.py:225
+#: ./opengever/latex/listing.py:227
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference number"
 #: ./opengever/latex/dossierdetails.py:106
-#: ./opengever/latex/listing.py:153
+#: ./opengever/latex/listing.py:155
 msgid "label_reference_number"
 msgstr "Numéro référence"
 
@@ -84,19 +89,19 @@ msgid "label_repository"
 msgstr "Numéro de classement"
 
 #. Default: "Repositoryfolder"
-#: ./opengever/latex/listing.py:161
+#: ./opengever/latex/listing.py:163
 msgid "label_repository_title"
 msgstr "Numéro de classement"
 
 #. Default: "Responsible"
 #: ./opengever/latex/dossierdetails.py:122
-#: ./opengever/latex/listing.py:171
+#: ./opengever/latex/listing.py:173
 msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "State"
 #: ./opengever/latex/dossierdetails.py:135
-#: ./opengever/latex/listing.py:176
+#: ./opengever/latex/listing.py:178
 msgid "label_review_state"
 msgstr "Etat"
 
@@ -107,7 +112,7 @@ msgstr "Numéro courant"
 
 #. Default: "Start"
 #: ./opengever/latex/dossierdetails.py:125
-#: ./opengever/latex/listing.py:181
+#: ./opengever/latex/listing.py:183
 msgid "label_start"
 msgstr "Date début"
 
@@ -122,12 +127,12 @@ msgid "label_subdossiers"
 msgstr "Sous-dossiers"
 
 #. Default: "Responsible"
-#: ./opengever/latex/listing.py:263
+#: ./opengever/latex/listing.py:265
 msgid "label_task_responsible"
 msgstr "Mandataire"
 
 #. Default: "Task type"
-#: ./opengever/latex/listing.py:252
+#: ./opengever/latex/listing.py:254
 msgid "label_task_type"
 msgstr "Type de mandat"
 
@@ -138,12 +143,12 @@ msgstr "Tâches"
 
 #. Default: "Title"
 #: ./opengever/latex/dossierdetails.py:116
-#: ./opengever/latex/listing.py:166
+#: ./opengever/latex/listing.py:168
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "No."
-#: ./opengever/latex/listing.py:157
+#: ./opengever/latex/listing.py:159
 msgid "short_label_sequence_number"
 msgstr "No."
 

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-05-12 09:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,22 +30,22 @@ msgid "Print selection (PDF)"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/latex/listing.py:277
+#: ./opengever/latex/listing.py:279
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Delivery date"
-#: ./opengever/latex/listing.py:230
+#: ./opengever/latex/listing.py:232
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Document author"
-#: ./opengever/latex/listing.py:235
+#: ./opengever/latex/listing.py:237
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document date"
-#: ./opengever/latex/listing.py:220
+#: ./opengever/latex/listing.py:222
 msgid "label_document_date"
 msgstr ""
 
@@ -54,14 +54,19 @@ msgstr ""
 msgid "label_documents"
 msgstr ""
 
+#. Default: "Dossier journal"
+#: ./opengever/latex/dossierjournal.py:54
+msgid "label_dossier_journal"
+msgstr ""
+
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py:128
-#: ./opengever/latex/listing.py:186
+#: ./opengever/latex/listing.py:188
 msgid "label_end"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/latex/listing.py:257
+#: ./opengever/latex/listing.py:259
 msgid "label_issuer"
 msgstr ""
 
@@ -71,13 +76,13 @@ msgid "label_participants"
 msgstr ""
 
 #. Default: "Receipt date"
-#: ./opengever/latex/listing.py:225
+#: ./opengever/latex/listing.py:227
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference number"
 #: ./opengever/latex/dossierdetails.py:106
-#: ./opengever/latex/listing.py:153
+#: ./opengever/latex/listing.py:155
 msgid "label_reference_number"
 msgstr ""
 
@@ -87,19 +92,19 @@ msgid "label_repository"
 msgstr ""
 
 #. Default: "Repositoryfolder"
-#: ./opengever/latex/listing.py:161
+#: ./opengever/latex/listing.py:163
 msgid "label_repository_title"
 msgstr ""
 
 #. Default: "Responsible"
 #: ./opengever/latex/dossierdetails.py:122
-#: ./opengever/latex/listing.py:171
+#: ./opengever/latex/listing.py:173
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "State"
 #: ./opengever/latex/dossierdetails.py:135
-#: ./opengever/latex/listing.py:176
+#: ./opengever/latex/listing.py:178
 msgid "label_review_state"
 msgstr ""
 
@@ -110,7 +115,7 @@ msgstr ""
 
 #. Default: "Start"
 #: ./opengever/latex/dossierdetails.py:125
-#: ./opengever/latex/listing.py:181
+#: ./opengever/latex/listing.py:183
 msgid "label_start"
 msgstr ""
 
@@ -125,12 +130,12 @@ msgid "label_subdossiers"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/latex/listing.py:263
+#: ./opengever/latex/listing.py:265
 msgid "label_task_responsible"
 msgstr ""
 
 #. Default: "Task type"
-#: ./opengever/latex/listing.py:252
+#: ./opengever/latex/listing.py:254
 msgid "label_task_type"
 msgstr ""
 
@@ -141,12 +146,12 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/latex/dossierdetails.py:116
-#: ./opengever/latex/listing.py:166
+#: ./opengever/latex/listing.py:168
 msgid "label_title"
 msgstr ""
 
 #. Default: "No."
-#: ./opengever/latex/listing.py:157
+#: ./opengever/latex/listing.py:159
 msgid "short_label_sequence_number"
 msgstr ""
 

--- a/opengever/latex/templates/dossierjournal.tex
+++ b/opengever/latex/templates/dossierjournal.tex
@@ -1,0 +1,7 @@
+{\bf ${label}}\\%%
+\vspace{\baselineskip}
+\scriptsize
+\noindent
+
+\setlength\extrarowheight{1pt}
+${listing}

--- a/opengever/latex/tests/test_dossierjournal.py
+++ b/opengever/latex/tests/test_dossierjournal.py
@@ -1,0 +1,95 @@
+from DateTime import DateTime
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.pdfgenerator.builder import Builder as PDFBuilder
+from ftw.pdfgenerator.interfaces import ILaTeXView
+from ftw.pdfgenerator.utils import provide_request_layer
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testing import freeze
+from ftw.testing import MockTestCase
+from opengever.latex import dossierjournal
+from opengever.latex.dossierjournal import IDossierJournalLayer
+from opengever.latex.layouts.default import DefaultLayout
+from opengever.latex.testing import LATEX_ZCML_LAYER
+from opengever.testing import FunctionalTestCase
+from zope.component import getMultiAdapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class TestDossierJournalPDFView(MockTestCase):
+
+    layer = LATEX_ZCML_LAYER
+
+    def test_is_registered(self):
+        context = self.create_dummy()
+        request = self.providing_stub([IDefaultBrowserLayer])
+
+        self.replay()
+        view = getMultiAdapter((context, request), name='pdf-dossier-journal')
+        self.assertTrue(isinstance(view, dossierjournal.DossierJournalPDFView))
+
+    def test_render_adds_browser_layer(self):
+        context = request = self.create_dummy()
+
+        view = self.mocker.patch(
+            dossierjournal.DossierJournalPDFView(context, request))
+
+        self.expect(view.allow_alternate_output()).result(False)
+        self.expect(view.export())
+
+        self.replay()
+
+        view.render()
+        self.assertTrue(
+            dossierjournal.IDossierJournalLayer.providedBy(request))
+
+
+class TestDossierListingLaTeXView(FunctionalTestCase):
+
+    @browsing
+    def test_journal_listing(self, browser):
+        repo = create(Builder('repository'))
+
+        with freeze(datetime(2016, 4, 12, 10, 35)):
+            browser.login().open(repo)
+
+            factoriesmenu.add('Business Case Dossier')
+            browser.fill({'Title': u'Dossier A'})
+            browser.find('Save').click()
+            dossier = browser.context
+
+            factoriesmenu.add('Document')
+            browser.fill({'Title': u'Document A'})
+            browser.find('Save').click()
+
+            expected_date = DateTime()
+
+        provide_request_layer(dossier.REQUEST, IDossierJournalLayer)
+        layout = DefaultLayout(dossier, dossier.REQUEST, PDFBuilder())
+        dossierjournal = getMultiAdapter((dossier, dossier.REQUEST, layout),
+                                         ILaTeXView)
+
+        expected = [{'action': {'visible': True,
+                                'type': 'Dossier added',
+                                'title': u'label_dossier_added'},
+                     'comments': '',
+                     'actor': 'test_user_1_',
+                     'time': expected_date},
+
+                    {'action': {'visible': True,
+                                'type': 'Document added',
+                                'title': u'label_document_added'},
+                     'comments': '',
+                     'actor': 'test_user_1_',
+                     'time': expected_date},
+
+                    {'action': {'visible': False,
+                                'type': 'Dossier modified',
+                                'title': u'label_dossier_modified'},
+                     'comments': '',
+                     'actor': 'test_user_1_',
+                     'time': expected_date}]
+
+        self.assertEquals(expected, dossierjournal.get_journal_data())

--- a/opengever/latex/tests/test_listing.py
+++ b/opengever/latex/tests/test_listing.py
@@ -1,4 +1,5 @@
 from datetime import date
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -279,3 +280,71 @@ class TestTaskListings(FunctionalTestCase):
         task_id = self.task.get_sql_object().id
         browser.login().open(data={'pdf-tasks-listing:method': 1,
                                    'task_ids:list': task_id})
+
+
+class TestJournalListings(FunctionalTestCase):
+
+    sample_journal_entries = [
+        {'action': {'visible': True,
+                    'type': 'Dossier added',
+                    'title': u'label_dossier_added'},
+         'comments': '',
+         'actor': 'peter.mueller',
+         'time': DateTime(2016, 4, 12, 10, 7)},
+
+                {'action': {'visible': True,
+                            'type': 'Document added',
+                            'title': u'label_document_added'},
+                 'comments': '',
+                 'actor': 'hugo.boss',
+                 'time': DateTime(2016, 4, 12, 12, 10)},
+
+                {'action': {'visible': False,
+                            'type': 'Dossier modified',
+                            'title': u'label_dossier_modified'},
+                 'comments': '',
+                 'actor': 'peter.mueller',
+                 'time': DateTime(2016, 4, 25, 10, 0)},
+    ]
+
+    def setUp(self):
+        super(TestJournalListings, self).setUp()
+        dossier = create(Builder('dossier'))
+
+        self.listing = getMultiAdapter(
+            (dossier, dossier.REQUEST, self),
+            ILaTexListing, name='journal')
+        self.listing.items = self.sample_journal_entries
+
+        create(Builder('ogds_user').having(userid=u'peter.mueller',
+                                           firstname=u'Peter',
+                                           lastname=u'M\xfcller'))
+        create(Builder('ogds_user').having(userid=u'hugo.boss',
+                                           firstname=u'Hugo',
+                                           lastname=u'B\xf6ss'))
+
+    def test_labels_are_translated_and_show_as_table_headers(self):
+        table = lxml.html.fromstring(self.listing.template())
+        cols = table.xpath(CSSSelector('thead th').path)
+
+        self.assertEquals(
+            ['Time', 'Title', 'Changed by', 'Comments'],
+            [col.text_content().strip() for col in cols])
+
+    def test_shows_label_including_prinicpal_of_actor(self):
+        table = lxml.html.fromstring(self.listing.template())
+        rows = table.xpath(CSSSelector('tbody tr').path)
+
+        self.assertEquals(u'M\xfcller Peter (peter.mueller)',
+                          rows[0].xpath(CSSSelector('td').path)[2].text)
+        self.assertEquals(u'B\xf6ss Hugo (hugo.boss)',
+                          rows[1].xpath(CSSSelector('td').path)[2].text)
+
+    def test_time_is_readable(self):
+        table = lxml.html.fromstring(self.listing.template())
+        rows = table.xpath(CSSSelector('tbody tr').path)
+
+        self.assertEquals('12.04.2016 10:07',
+                          rows[0].xpath(CSSSelector('td').path)[0].text)
+        self.assertEquals('12.04.2016 12:10',
+                          rows[1].xpath(CSSSelector('td').path)[0].text)


### PR DESCRIPTION
When a dossier gets resolved the following jobs are be done now:
 - Purge the trash of the dossier (final deletion of all trashed documents)
 - A PDF representation of the dossiers journal will be generated and filed as a regular document in the dossier.

[dossier-50.pdf](https://github.com/4teamwork/opengever.core/files/261842/dossier-50.pdf)

Both actions are configurable in the portal registry, but are enabled by default.