### PR TITLE
Configure bumblebee for local development.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -51,6 +51,9 @@ zope-conf-additional +=
 environment-vars +=
     IS_DEVELOPMENT_MODE True
     SABLON_BIN ${buildout:sablon-executable}
+    BUMBLEBEE_APP_ID gever_dev
+    BUMBLEBEE_INTERNAL_PLONE_URL http://localhost:${instance:http-address}/fd
+    BUMBLEBEE_PUBLIC_URL http://localhost:3000/
 
 [test]
 initialization +=


### PR DESCRIPTION
The secret cannot be preconfigured and must be
added to a configuration file by each developer.

```
environment-vars +=
    BUMBLEBEE_SECRET thesecret
```

Closes #1809.