### PR TITLE
Batching für die Galerieansicht

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Add batching for the bumblebee gallery-view.
+  [elioschmutz]
+
 - Add Visual Search (Bumblebee) integration using ftw.bumblebee.
 
   This new feature can be toggled with a feature flag.

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -1,14 +1,55 @@
 (function(global, Showroom, $) {
 
-  function init() {
-    var items = document.querySelectorAll(".showroom-item");
+  var endpoint;
+  var showroom;
+  var number_of_documents;
 
-    if (items.length) {
-      Showroom(items);
+  function loadNextItems() {
+    var data = { document_pointer: $('.imageContainer').length };
+    $.get(endpoint, data).done(function(data) {
+
+      var items = $(data).filter('.imageContainer');
+      items.insertAfter($('.imageContainer').last());
+      toggleShowMoreButton();
+      showroom.append(items);
+    });
+  }
+
+  function toggleShowMoreButton() {
+    var button = $('.showMore');
+    var shown = $('.imageContainer').length;
+
+    if (shown >= number_of_documents) {
+      button.hide();
+    }else {
+      button.show();
     }
   }
 
-  $(document).on("reload", init);
+  function tail(item) { loadNextItems(); }
+
+  function init() {
+    endpoint = $(".preview-listing").data("fetch-url");
+    number_of_documents = $('.preview-listing').data('number-of-documents');
+
+    var items = document.querySelectorAll(".showroom-item");
+
+    var config = {
+      'total': number_of_documents,
+      'tail': tail
+    };
+
+    if (items.length) {
+      showroom = Showroom(items, config);
+    }
+
+    toggleShowMoreButton();
+  }
+
+  $(document)
+    .on("reload", init)
+    .on("click", ".showMore", function() {loadNextItems(); });
+
   $(init);
 
 })(window, window.showroom, window.jQuery);

--- a/opengever/tabbedview/browser/bumblebee_gallery.pt
+++ b/opengever/tabbedview/browser/bumblebee_gallery.pt
@@ -6,8 +6,8 @@
     <div tal:define="available view/available"
          class="preview-listing"
          tal:attributes="data-number-of-documents view/number_of_documents;
-                         data-fetch-url string:${context/absolute_url}/${view/__name__}/fetch">
-      <div tal:condition="available">
+                         data-fetch-url string:${context/absolute_url}/${view/__name__}-fetch">
+      <tal:available tal:condition="available">
 
           <tal:PREVIEWS tal:replace="structure view/previews_template"></tal:PREVIEWS>
 
@@ -17,7 +17,7 @@
             <span i18n:translate="documentsShowMore">Show more</span>
           </div>
 
-      </div>
+      </tal:available>
 
       <div tal:condition="not: available">
           <p class="no_content" i18n:translate="label_no_contents">No contents</p>

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -143,6 +143,71 @@ class TestBumblebeeGalleryMixinAvailable(FunctionalTestCase):
         self.assertFalse(view.available())
 
 
+class TestBumblebeeGalleryMixinPreviews(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def test_returns_streamed_dict_representations_of_brains(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        document = create(Builder('document').within(dossier))
+
+        self.assertEqual(
+            [{'uid': document.UID(),
+              'overlay_url': 'http://nohost/plone/dossier-1/document-1/@@bumblebee-overlay-listing',
+              'mime_type_css_class': 'contenttype-opengever-document-document',
+              'preview_image_url': 'http://nohost/plone/++resource++opengever.base/images/not_digitally_available.png',
+              'title': 'Testdokum\xc3\xa4nt'}],
+            list(view.previews()))
+
+    def test_return_stream_from_the_given_document_pointer(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        self.request.set('document_pointer', 1)
+
+        document0 = create(Builder('document').within(dossier))
+        document1 = create(Builder('document').within(dossier))
+        document2 = create(Builder('document').within(dossier))
+
+        self.assertEqual(
+            [document1.UID(), document2.UID()],
+            [item.get('uid') for item in view.previews()])
+
+    def test_stream_length_is_configurable(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        view.amount_preloaded_documents = 2
+
+        document0 = create(Builder('document').within(dossier))
+        document1 = create(Builder('document').within(dossier))
+        document2 = create(Builder('document').within(dossier))
+
+        self.assertEqual(
+            [document0.UID(), document1.UID()],
+            [item.get('uid') for item in view.previews()])
+
+    def test_returns_empty_list_if_pointer_does_not_point_to_any_object(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        self.request.set('document_pointer', 20)
+
+        create(Builder('document').within(dossier))
+
+        self.assertEqual([], list(view.previews()))
+
+
 class TestBumblebeeGalleryViewChooserWithoutFeature(FunctionalTestCase):
 
     @browsing
@@ -266,3 +331,35 @@ class TestBumblebeeDocumentsProxyWithActivatedFeature(FunctionalTestCase):
         self.assertEqual(
             'List',
             browser.css('.ViewChooser .active').first.text)
+
+
+class TestDocumentsGalleryFetch(FunctionalTestCase):
+
+    @browsing
+    def test_fetching_new_items_returns_html_with_items(self, browser):
+        dossier = create(Builder('dossier'))
+
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+
+        browser.login().visit(dossier, view="tabbedview_view-documents-gallery-fetch")
+
+        self.assertEqual(
+            3, len(browser.css('.imageContainer')))
+
+
+class TestMyDocumentsGalleryFetch(FunctionalTestCase):
+
+    @browsing
+    def test_fetching_new_items_returns_html_with_items(self, browser):
+        dossier = create(Builder('dossier'))
+
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+
+        browser.login().visit(dossier, view="tabbedview_view-mydocuments-gallery-fetch")
+
+        self.assertEqual(
+            3, len(browser.css('.imageContainer')))


### PR DESCRIPTION
Dieser PR fügt ein Batching für die Galerieansicht hinzu.

Standardmässig werden 24 Dokumente vorgeladen.

Wird auf den Knopf "Mehr anzeigen" geklickt wird, oder wenn mit dem Showroom ans Ende des Batchs navigiert wird, werden neue Elemente nachgeladen.

closes #1791 