### PR TITLE
Add batching for the bumblebee gallery-view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Add batching for the bumblebee gallery-view.
+  [elioschmutz]
+
 - Fix tests for GeverJSONSummarySerializer: The `member` attribute
   has been renamed to `items` in plone/plone.restapi#107.
   [lgraf]

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -22,7 +22,7 @@
     if (shown >= number_of_documents) {
       button.hide();
     }else {
-      button.show();
+      button.css("display", "block");
     }
   }
 

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -1,14 +1,55 @@
 (function(global, Showroom, $) {
 
-  function init() {
-    var items = document.querySelectorAll(".showroom-item");
+  var endpoint;
+  var showroom;
+  var number_of_documents;
 
-    if (items.length) {
-      Showroom(items);
+  function loadNextItems() {
+    var data = { document_pointer: $('.imageContainer').length };
+    $.get(endpoint, data).done(function(data) {
+
+      var items = $(data).filter('.imageContainer');
+      items.insertAfter($('.imageContainer').last());
+      toggleShowMoreButton();
+      showroom.append(items);
+    });
+  }
+
+  function toggleShowMoreButton() {
+    var button = $('.showMore');
+    var shown = $('.imageContainer').length;
+
+    if (shown >= number_of_documents) {
+      button.hide();
+    }else {
+      button.show();
     }
   }
 
-  $(document).on("reload", init);
+  function tail(item) { loadNextItems(); }
+
+  function init() {
+    endpoint = $(".preview-listing").data("fetch-url");
+    number_of_documents = $('.preview-listing').data('number-of-documents');
+
+    var items = document.querySelectorAll(".showroom-item");
+
+    var config = {
+      'total': number_of_documents,
+      'tail': tail
+    };
+
+    if (items.length) {
+      showroom = Showroom(items, config);
+    }
+
+    toggleShowMoreButton();
+  }
+
+  $(document)
+    .on("reload", init)
+    .on("click", ".showMore", function() {loadNextItems(); });
+
   $(init);
 
 })(window, window.showroom, window.jQuery);

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -16,7 +16,7 @@
   }
 
   function toggleShowMoreButton() {
-    var button = $('.showMore');
+    var button = $('.bumblebeeGalleryShowMore');
     var shown = $('.imageContainer').length;
 
     if (shown >= number_of_documents) {
@@ -48,7 +48,7 @@
 
   $(document)
     .on("reload", init)
-    .on("click", ".showMore", function() {loadNextItems(); });
+    .on("click", ".bumblebeeGalleryShowMore", function() {loadNextItems(); });
 
   $(init);
 

--- a/opengever/tabbedview/browser/bumblebee_gallery.pt
+++ b/opengever/tabbedview/browser/bumblebee_gallery.pt
@@ -6,8 +6,8 @@
     <div tal:define="available view/available"
          class="preview-listing"
          tal:attributes="data-number-of-documents view/number_of_documents;
-                         data-fetch-url string:${context/absolute_url}/${view/__name__}/fetch">
-      <div tal:condition="available">
+                         data-fetch-url string:${context/absolute_url}/${view/__name__}-fetch">
+      <tal:available tal:condition="available">
 
           <tal:PREVIEWS tal:replace="structure view/previews_template"></tal:PREVIEWS>
 
@@ -17,7 +17,7 @@
             <span i18n:translate="documentsShowMore">Show more</span>
           </div>
 
-      </div>
+      </tal:available>
 
       <div tal:condition="not: available">
           <p class="no_content" i18n:translate="label_no_contents">No contents</p>

--- a/opengever/tabbedview/browser/bumblebee_gallery.pt
+++ b/opengever/tabbedview/browser/bumblebee_gallery.pt
@@ -13,9 +13,9 @@
 
           <div class="visualClear"></div>
 
-          <div class="bumblebeeGalleryShowMore">
+          <button class="bumblebeeGalleryShowMore button">
             <span i18n:translate="documentsShowMore">Show more</span>
-          </div>
+          </button>
 
       </tal:available>
 

--- a/opengever/tabbedview/browser/bumblebee_gallery.pt
+++ b/opengever/tabbedview/browser/bumblebee_gallery.pt
@@ -13,7 +13,7 @@
 
           <div class="visualClear"></div>
 
-          <div class="showMore">
+          <div class="bumblebeeGalleryShowMore">
             <span i18n:translate="documentsShowMore">Show more</span>
           </div>
 

--- a/opengever/tabbedview/browser/bumblebee_gallery.pt
+++ b/opengever/tabbedview/browser/bumblebee_gallery.pt
@@ -6,7 +6,7 @@
     <div tal:define="available view/available"
          class="preview-listing"
          tal:attributes="data-number-of-documents view/number_of_documents;
-                         data-fetch-url string:${context/absolute_url}/${view/__name__}-fetch">
+                         data-fetch-url view/get_fetch_url">
       <tal:available tal:condition="available">
 
           <tal:PREVIEWS tal:replace="structure view/previews_template"></tal:PREVIEWS>

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -33,6 +33,9 @@ class BumblebeeGalleryMixin(object):
     def list_view_name(self):
         raise NotImplementedError
 
+    def get_fetch_url(self):
+        return '{}/{}-fetch'.format(self.context.absolute_url(), self.__name__)
+
     def available(self):
         return self.number_of_documents() > 0
 

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -20,6 +20,8 @@ class BumblebeeGalleryMixin(object):
 
     object_provides = 'ftw.bumblebee.interfaces.IBumblebeeable'
 
+    amount_preloaded_documents = 24
+
     def __call__(self, *args, **kwargs):
         if not is_bumblebee_feature_enabled():
             raise NotFound
@@ -40,8 +42,10 @@ class BumblebeeGalleryMixin(object):
     def previews(self, **kwargs):
         brains = self.get_brains()
 
-        # TODO: Batching
-        for brain in brains:
+        from_batch_id = int(self.request.get('document_pointer', 0))
+        to_batch_id = from_batch_id + self.amount_preloaded_documents
+
+        for brain in brains[from_batch_id:to_batch_id]:
             yield {
                 'title': brain.Title,
                 'overlay_url': '{}/@@bumblebee-overlay-listing'.format(brain.getURL()),
@@ -57,6 +61,22 @@ class BumblebeeGalleryMixin(object):
             setattr(self, '_brains', catalog(self.table_source.build_query()))
         return getattr(self, '_brains')
 
+    def fetch(self):
+        """Action for retrieving more events (based on `next_event_id` in
+        the request) with AJAX.
+        """
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+        # The HTML stripped in order to have empty response content when
+        # there are no tags at all, so that diazo does not try to
+        # parse it.
+        if int(self.request.get('document_pointer', 0)) >= self.number_of_documents():
+            # We have to return an empty string if we have no more documents
+            # to render. Otherwise plone.protect will log a error-warning:
+            # WARNING plone.protect error parsing dom, failure to add csrf
+            # token to response
+            return ''
+        return self.previews_template().strip()
+
 
 class DocumentsGallery(BumblebeeGalleryMixin, Documents):
     grok.name('tabbedview_view-documents-gallery')
@@ -66,9 +86,41 @@ class DocumentsGallery(BumblebeeGalleryMixin, Documents):
         return "documents"
 
 
+class DocumentsGalleryFetch(DocumentsGallery):
+    """Returns the next gallery-items.
+
+    Unfortunately it's not possible to use a traversable method with
+    five.grok-views. Therefore we have to register an own browserview
+    to fetch the next gallery-items.
+
+    This browserview can be removed and implemented with allowed-attributes as
+    soon as the parent views are registered as Zope 3 BrowserViews.
+    """
+    grok.name('tabbedview_view-documents-gallery-fetch')
+
+    def __call__(self):
+        return self.fetch()
+
+
 class MyDocumentsGallery(BumblebeeGalleryMixin, MyDocuments):
     grok.name('tabbedview_view-mydocuments-gallery')
 
     @property
     def list_view_name(self):
         return "mydocuments"
+
+
+class MyDocumentsGalleryFetch(MyDocumentsGallery):
+    """Returns the next gallery-items.
+
+    Unfortunately it's not possible to use a traversable method with
+    five.grok-views. Therefore we have to register an own browserview
+    to fetch the next gallery-items.
+
+    This browserview can be removed and implemented with allowed-attributes as
+    soon as the parent views are registered as Zope 3 BrowserViews.
+    """
+    grok.name('tabbedview_view-mydocuments-gallery-fetch')
+
+    def __call__(self):
+        return self.fetch()

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -39,6 +39,30 @@ class TestBumblebeeGalleryMixinListViewName(FunctionalTestCase):
         self.assertEqual('mydocuments', view.list_view_name)
 
 
+class TestBumblebeeGalleryMixinGetFetchUrl(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def test_get_fetch_url_returns_the_url_to_fetch_new_items(self):
+        dossier = create(Builder('dossier'))
+
+        viewname = "tabbedview_view-documents-gallery"
+        view = getMultiAdapter(
+            (dossier, self.request), name=viewname)
+
+        self.assertEqual(
+            'http://nohost/plone/dossier-1/tabbedview_view-documents-gallery-fetch',
+            view.get_fetch_url())
+
+        viewname = "tabbedview_view-mydocuments-gallery"
+        view = getMultiAdapter(
+            (dossier, self.request), name=viewname)
+
+        self.assertEqual(
+            'http://nohost/plone/dossier-1/tabbedview_view-mydocuments-gallery-fetch',
+            view.get_fetch_url())
+
+
 class TestBumblebeeGalleryMixinGetBrains(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -97,6 +97,44 @@ class TestBumblebeeGalleryMixinGetBrains(FunctionalTestCase):
             "is not and IBumblebeeable object")
 
 
+class TestBumblebeeGalleryMixinFetch(FunctionalTestCase):
+
+    @browsing
+    def test_returns_new_items_as_html(self, browser):
+        dossier = create(Builder('dossier'))
+
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        browser.open_html(view.fetch())
+
+        self.assertEqual(3, len(browser.css('.imageContainer')))
+
+    def test_returns_empty_string_if_no_items_are_available(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        self.assertEqual('', view.fetch())
+
+    def test_returns_empty_string_if_pointer_does_not_point_to_any_object(self):
+        dossier = create(Builder('dossier'))
+
+        create(Builder('document').within(dossier))
+
+        self.request.set('document_pointer', 20)
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        self.assertEqual('', view.fetch())
+
+
 class TestBumblebeeGalleryMixinNumberOfDocuments(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
@@ -141,6 +179,71 @@ class TestBumblebeeGalleryMixinAvailable(FunctionalTestCase):
             (dossier, self.request), name="tabbedview_view-documents-gallery")
 
         self.assertFalse(view.available())
+
+
+class TestBumblebeeGalleryMixinPreviews(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def test_returns_streamed_dict_representations_of_brains(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        document = create(Builder('document').within(dossier))
+
+        self.assertEqual(
+            [{'uid': document.UID(),
+              'overlay_url': 'http://nohost/plone/dossier-1/document-1/@@bumblebee-overlay-listing',
+              'mime_type_css_class': 'contenttype-opengever-document-document',
+              'preview_image_url': 'http://nohost/plone/++resource++opengever.base/images/not_digitally_available.png',
+              'title': 'Testdokum\xc3\xa4nt'}],
+            list(view.previews()))
+
+    def test_return_stream_from_the_given_document_pointer(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        self.request.set('document_pointer', 1)
+
+        document0 = create(Builder('document').within(dossier))
+        document1 = create(Builder('document').within(dossier))
+        document2 = create(Builder('document').within(dossier))
+
+        self.assertEqual(
+            [document1.UID(), document2.UID()],
+            [item.get('uid') for item in view.previews()])
+
+    def test_stream_length_is_configurable(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        view.amount_preloaded_documents = 2
+
+        document0 = create(Builder('document').within(dossier))
+        document1 = create(Builder('document').within(dossier))
+        document2 = create(Builder('document').within(dossier))
+
+        self.assertEqual(
+            [document0.UID(), document1.UID()],
+            [item.get('uid') for item in view.previews()])
+
+    def test_returns_empty_list_if_pointer_does_not_point_to_any_object(self):
+        dossier = create(Builder('dossier'))
+
+        view = getMultiAdapter(
+            (dossier, self.request), name="tabbedview_view-documents-gallery")
+
+        self.request.set('document_pointer', 20)
+
+        create(Builder('document').within(dossier))
+
+        self.assertEqual([], list(view.previews()))
 
 
 class TestBumblebeeGalleryViewChooserWithoutFeature(FunctionalTestCase):
@@ -266,3 +369,35 @@ class TestBumblebeeDocumentsProxyWithActivatedFeature(FunctionalTestCase):
         self.assertEqual(
             'List',
             browser.css('.ViewChooser .active').first.text)
+
+
+class TestDocumentsGalleryFetch(FunctionalTestCase):
+
+    @browsing
+    def test_fetching_new_items_returns_html_with_items(self, browser):
+        dossier = create(Builder('dossier'))
+
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+
+        browser.login().visit(dossier, view="tabbedview_view-documents-gallery-fetch")
+
+        self.assertEqual(
+            3, len(browser.css('.imageContainer')))
+
+
+class TestMyDocumentsGalleryFetch(FunctionalTestCase):
+
+    @browsing
+    def test_fetching_new_items_returns_html_with_items(self, browser):
+        dossier = create(Builder('dossier'))
+
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+        create(Builder('document').within(dossier))
+
+        browser.login().visit(dossier, view="tabbedview_view-mydocuments-gallery-fetch")
+
+        self.assertEqual(
+            3, len(browser.css('.imageContainer')))


### PR DESCRIPTION
*Duplikat von https://github.com/4teamwork/opengever.core/pull/1815, weil Elio im Moment ein Bot ist 😠*

Dieser PR fügt ein Batching für die Galerieansicht hinzu.

Standardmässig werden 24 Dokumente vorgeladen.

Wird auf den Knopf "Mehr anzeigen" geklickt wird, oder wenn mit dem Showroom ans Ende des Batchs navigiert wird, werden neue Elemente nachgeladen.

closes #1791