### PR TITLE
Update GeverBumblebeeService for the new ftw.bumblebee version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Update Bumblebee integration for API v3 support.
+  [phgross]
+
 - Add batching for the bumblebee gallery-view.
   [elioschmutz]
 

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -44,6 +44,7 @@ ALLOWED_ENDPOINTS = set([
     'update_sync_stamp',
     'watcher-feed',
     'zauth',
+    'bumblebee_download',
 ])
 
 

--- a/opengever/bumblebee/service.py
+++ b/opengever/bumblebee/service.py
@@ -1,13 +1,12 @@
-from ftw.bumblebee.service import BumblebeeService
+from ftw.bumblebee.service import BumblebeeServiceV3
 from opengever.bumblebee import is_bumblebee_feature_enabled
 
 
-class GeverBumblebeeService(BumblebeeService):
-    """Only queues conversions when the bumblebee feature is enabled."""
+class GeverBumblebeeService(BumblebeeServiceV3):
+    """Only queues storings when the bumblebee feature is enabled."""
 
-    def queue_conversion(self, queue, version_id=None):
+    def queue_storing(self, queue):
         if not is_bumblebee_feature_enabled():
             return False
 
-        return super(GeverBumblebeeService, self).queue_conversion(
-            queue, version_id=version_id)
+        return super(GeverBumblebeeService, self).queue_storing(queue)

--- a/opengever/bumblebee/tests/test_overlay.py
+++ b/opengever/bumblebee/tests/test_overlay.py
@@ -228,7 +228,7 @@ class TestGetOpenAsPdfLink(FunctionalTestCase):
         view = MockOverlayView(document, self.request)
 
         self.assertIn(
-            '/YnVtYmxlYmVl/api/v2/resource/', view.get_open_as_pdf_link())
+            '/YnVtYmxlYmVl/api/v3/resource/', view.get_open_as_pdf_link())
 
     def test_returns_none_if_no_mimetype_is_available(self):
         dossier = create(Builder('dossier'))

--- a/opengever/bumblebee/tests/test_utils.py
+++ b/opengever/bumblebee/tests/test_utils.py
@@ -35,7 +35,7 @@ class TestGetRepresentationUrlByObject(FunctionalTestCase):
                               u'example.docx'))
 
         self.assertIn(
-            '/YnVtYmxlYmVl/api/v2/resource/',
+            '/YnVtYmxlYmVl/api/v3/resource/',
             get_representation_url_by_object('thumbnail', document))
 
     def test_returns_not_digitally_available_placeholder_image_if_no_ckecksum_is_available(self):
@@ -57,7 +57,7 @@ class TestGetRepresentationUrlByBrain(FunctionalTestCase):
         brain = obj2brain(document)
 
         self.assertIn(
-            '/YnVtYmxlYmVl/api/v2/resource/',
+            '/YnVtYmxlYmVl/api/v3/resource/',
             get_representation_url_by_brain('thumbnail', brain))
 
     def test_returns_not_digitally_available_placeholder_image_if_no_ckecksum_is_available(self):

--- a/sources.cfg
+++ b/sources.cfg
@@ -11,6 +11,7 @@ development-packages =
   ftw.showroom
 # https://github.com/4teamwork/ftw.table/pull/41
   ftw.table
+  ftw.bumblebee
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
With https://github.com/4teamwork/ftw.bumblebee/pull/75 ftw.bumblebee switched to the Bumblebee API v3, therefore we need to updated the `GeverBumblebeeService` as well.


@elioschmutz @deiferni 