### PR TITLE
Link "Dokument als PDF öffnen" im Overlay hinzugefügt

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Add 'open as pdf' link in the bumblebee overlay.
+  [elioschmutz]
+
 - Add Visual Search (Bumblebee) integration using ftw.bumblebee.
 
   This new feature can be toggled with a feature flag.

--- a/opengever/bumblebee/__init__.py
+++ b/opengever/bumblebee/__init__.py
@@ -18,7 +18,7 @@ def is_bumblebee_feature_enabled():
         'is_feature_enabled', interface=IGeverBumblebeeSettings)
 
 
-def get_representation_url_by_object(format_name, obj):
+def get_representation_url_by_object(format_name, obj, filename=''):
     """Returns the bumblebee representation url of the object.
 
     Bumblebee will return the representation if the obj has a checksum.
@@ -29,7 +29,7 @@ def get_representation_url_by_object(format_name, obj):
     That means, our obj is only preserved as paper and we have to return
     a special placeholder image for these documents
     """
-    return representation_url_by_object(format_name, obj) or \
+    return representation_url_by_object(format_name, obj, filename) or \
         get_not_digitally_available_placeholder_image_url()
 
 

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -14,6 +14,7 @@ from zExceptions import NotFound
 from zope.component import getAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
+import os
 
 
 class BumblebeeOverlayMixin(object):
@@ -86,7 +87,17 @@ class BumblebeeOverlayMixin(object):
         if not mimetypeitem or not is_mimetype_supported(mimetypeitem[0]):
             return None
 
-        return get_representation_url_by_object('pdf', obj=self.context)
+        return get_representation_url_by_object(
+            'pdf', obj=self.context, filename=self.get_pdf_filename())
+
+    def get_pdf_filename(self):
+        file_ = self.context.file
+        if not file_:
+            # Bumblebee will use a placeholder filename
+            return None
+
+        filename, extenstion = os.path.splitext(file_.filename)
+        return '{}.pdf'.format(filename)
 
     def get_edit_metadata_url(self):
         if not api.user.has_permission(

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -1,5 +1,6 @@
 from five import grok
 from ftw.bumblebee.interfaces import IBumblebeeable
+from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
@@ -79,6 +80,13 @@ class BumblebeeOverlayMixin(object):
             additional_classes=[''],
             include_token=True
             )
+
+    def get_open_as_pdf_link(self):
+        mimetypeitem = self.context.get_mimetype()
+        if not mimetypeitem or not is_mimetype_supported(mimetypeitem[0]):
+            return None
+
+        return get_representation_url_by_object('pdf', obj=self.context)
 
     def get_edit_metadata_url(self):
         if not api.user.has_permission(

--- a/opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt
+++ b/opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt
@@ -40,15 +40,20 @@
         </li>
         <li id="action-download" tal:define="link view/get_download_copy_link" tal:condition="link" tal:content="structure link">
         </li>
+        <li tal:define="link view/get_open_as_pdf_link" tal:condition="link">
+          <a id="action-pdf"
+             tal:attributes="href link"
+             i18n:translate="">Open as PDF</a>
+        </li>
         <li tal:define="link view/get_edit_metadata_url" tal:condition="link">
           <a id="action-edit"
-             tal:attributes="href view/get_edit_metadata_url"
+             tal:attributes="href link"
              i18n:domain="plone"
              i18n:translate="">Edit metadata</a>
         </li>
         <li tal:define="link view/get_checkout_url" tal:condition="link">
           <a id="action-checkout"
-             tal:attributes="href view/get_checkout_url"
+             tal:attributes="href link"
              i18n:domain="plone"
              i18n:translate="">Checkout and edit</a>
         </li>

--- a/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-17 14:53+0000\n"
+"POT-Creation-Date: 2016-05-20 12:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,6 +26,10 @@ msgstr "Dokumentdatum:"
 msgid "Dossier:"
 msgstr "Dossier:"
 
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:44
+msgid "Open as PDF"
+msgstr "Dokument als PDF öffnen"
+
 #: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:37
 msgid "Open detail view"
 msgstr "Detailansicht öffnen"
@@ -39,12 +43,12 @@ msgid "Sequence number:"
 msgstr "Laufnummer:"
 
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:73
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:78
 msgid "showroom_nav_button_next"
 msgstr "Weiter"
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:71
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:76
 msgid "showroom_nav_button_prev"
 msgstr "Zurück"
 

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-17 14:53+0000\n"
+"POT-Creation-Date: 2016-05-20 12:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,6 +26,10 @@ msgstr "Date du document:"
 msgid "Dossier:"
 msgstr "Dossier:"
 
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:44
+msgid "Open as PDF"
+msgstr "Ouvrir le document en PDF"
+
 #: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:37
 msgid "Open detail view"
 msgstr "Ouvrir vue détaillée"
@@ -39,12 +43,12 @@ msgid "Sequence number:"
 msgstr "Numéro courant:"
 
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:73
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:78
 msgid "showroom_nav_button_next"
 msgstr ""
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:71
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:76
 msgid "showroom_nav_button_prev"
 msgstr ""
 

--- a/opengever/bumblebee/locales/opengever.bumblebee.pot
+++ b/opengever/bumblebee/locales/opengever.bumblebee.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-17 14:53+0000\n"
+"POT-Creation-Date: 2016-05-20 12:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,6 +29,10 @@ msgstr ""
 msgid "Dossier:"
 msgstr ""
 
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:44
+msgid "Open as PDF"
+msgstr ""
+
 #: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:37
 msgid "Open detail view"
 msgstr ""
@@ -42,12 +46,12 @@ msgid "Sequence number:"
 msgstr ""
 
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:73
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:78
 msgid "showroom_nav_button_next"
 msgstr ""
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:71
+#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:76
 msgid "showroom_nav_button_prev"
 msgstr ""
 

--- a/opengever/bumblebee/tests/test_overlay.py
+++ b/opengever/bumblebee/tests/test_overlay.py
@@ -204,6 +204,41 @@ class TestGetPreviewPdfUrl(FunctionalTestCase):
         self.assertIn('not_digitally_available.png', view.get_preview_pdf_url())
 
 
+class TestGetOpenAsPdfLink(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def test_returns_pdf_url_as_string(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier)
+                          .with_dummy_content())
+
+        view = MockOverlayView(document, self.request)
+
+        self.assertIn(
+            '/YnVtYmxlYmVl/api/v2/resource/', view.get_open_as_pdf_link())
+
+    def test_returns_none_if_no_mimetype_is_available(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+
+        view = MockOverlayView(document, self.request)
+
+        self.assertIsNone(view.get_open_as_pdf_link())
+
+    def test_returns_none_if_mimetype_is_not_supported(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier)
+                          .attach_file_containing(
+                              "data", name=u"test.notsupported"))
+
+        view = MockOverlayView(document, self.request)
+
+        self.assertIsNone(view.get_open_as_pdf_link())
+
+
 class TestGetFileTitle(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER

--- a/opengever/bumblebee/tests/test_overlay.py
+++ b/opengever/bumblebee/tests/test_overlay.py
@@ -42,7 +42,11 @@ class TestBumblebeeOverlayListing(FunctionalTestCase):
         browser.login().visit(document, view="bumblebee-overlay-listing")
 
         self.assertEqual(
-            ['Open detail view', 'Download copy', 'Edit metadata', 'Checkout and edit'],
+            ['Open detail view',
+             'Download copy',
+             'Open as PDF',
+             'Edit metadata',
+             'Checkout and edit'],
             browser.css('.file-actions a').text)
 
     @browsing
@@ -71,6 +75,7 @@ class TestBumblebeeOverlayListing(FunctionalTestCase):
         self.assertEqual(
             ['Open detail view',
              'Download copy',
+             'Open as PDF',
              'Edit metadata',
              'Checkout and edit',
              'Checkin without comment',
@@ -95,6 +100,7 @@ class TestBumblebeeOverlayListing(FunctionalTestCase):
         self.assertEqual(
             ['Open detail view',
              'Download copy',
+             'Open as PDF',
              'Edit metadata'],
             browser.css('.file-actions a').text)
 
@@ -124,7 +130,10 @@ class TestBumblebeeOverlayDocument(FunctionalTestCase):
         browser.login().visit(document, view="bumblebee-overlay-document")
 
         self.assertEqual(
-            ['Download copy', 'Edit metadata', 'Checkout and edit'],
+            ['Download copy',
+             'Open as PDF',
+             'Edit metadata',
+             'Checkout and edit'],
             browser.css('.file-actions a').text)
 
     @browsing
@@ -153,6 +162,7 @@ class TestBumblebeeOverlayDocument(FunctionalTestCase):
         self.assertEqual(
             ['Open detail view',
              'Download copy',
+             'Open as PDF',
              'Edit metadata',
              'Checkout and edit',
              'Checkin without comment',
@@ -177,6 +187,7 @@ class TestBumblebeeOverlayDocument(FunctionalTestCase):
         self.assertEqual(
             ['Open detail view',
              'Download copy',
+             'Open as PDF',
              'Edit metadata'],
             browser.css('.file-actions a').text)
 
@@ -237,6 +248,32 @@ class TestGetOpenAsPdfLink(FunctionalTestCase):
         view = MockOverlayView(document, self.request)
 
         self.assertIsNone(view.get_open_as_pdf_link())
+
+
+class TestGetPdfFilename(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def test_changes_filename_extension_to_pdf_and_returns_filename(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier)
+                          .attach_file_containing(
+                              "data", name=u"test.docx"))
+
+        view = MockOverlayView(document, self.request)
+
+        self.assertEqual('testdokumant.docx', document.file.filename)
+        self.assertEqual('testdokumant.pdf', view.get_pdf_filename())
+
+    def test_returns_none_if_no_file_is_given(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier))
+
+        view = MockOverlayView(document, self.request)
+
+        self.assertIsNone(view.get_pdf_filename())
 
 
 class TestGetFileTitle(FunctionalTestCase):


### PR DESCRIPTION
Dieser PR fügt einen neuen Link "Dokument als PDF öffnen" im overlay hinzu.

![bildschirmfoto 2016-05-20 um 14 27 53](https://cloud.githubusercontent.com/assets/557005/15427741/5eb7d1c0-1e97-11e6-933c-4453019167ea.png)

Der Dateiname des PDFs ist der alte Dateinamen mit der Endung ".pdf"

closes #1799 