### PR TITLE
Fix tests for GeverJSONSummarySerializer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fix tests for GeverJSONSummarySerializer: The `member` attribute
+  has been renamed to `items` in plone/plone.restapi#107.
+  [lgraf]
+
 - Add 'open as pdf' link in the bumblebee overlay.
   [elioschmutz]
 

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -40,14 +40,14 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
 
     def test_portal_type_is_included(self):
         response = self.api.get('/ordnungssystem')
-        repofolder_summary = response.json()['member'][0]
+        repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
             {u'@type': u'opengever.repository.repositoryfolder'},
             repofolder_summary)
 
         response = self.api.get('/ordnungssystem/ordnungsposition')
-        dossier_summary = response.json()['member'][0]
+        dossier_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
             {u'@type': u'opengever.dossier.businesscasedossier'},
@@ -56,7 +56,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
     def test_translated_title_contained_in_summary_if_obj_translated(self):
         response = self.api.get(
             '/ordnungssystem', headers={'Accept-Language': 'de-ch'})
-        repofolder_summary = response.json()['member'][0]
+        repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
             {u'title': u'Ordnungsposition'},
@@ -64,7 +64,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
 
         response = self.api.get(
             '/ordnungssystem', headers={'Accept-Language': 'fr-ch'})
-        repofolder_summary = response.json()['member'][0]
+        repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
             {u'title': u'Position'},
@@ -72,7 +72,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
 
     def test_translated_titles_default_to_german(self):
         response = self.api.get('/ordnungssystem')
-        repofolder_summary = response.json()['member'][0]
+        repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
             {u'title': u'Ordnungsposition'},
@@ -80,7 +80,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
 
     def test_regular_title_in_summary_if_obj_not_translated(self):
         response = self.api.get('/ordnungssystem/ordnungsposition')
-        dossier_summary = response.json()['member'][0]
+        dossier_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
             {u'title': u'Mein Dossier'},


### PR DESCRIPTION
Fix tests for `GeverJSONSummarySerializer`: The `member` attribute has been renamed to `items` in plone/plone.restapi#107.

@deiferni