### PR TITLE
Fix GeverJSONSummarySerializer tests:

### DIFF
--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -59,7 +59,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
         repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'Ordnungsposition'},
+            {u'title': u'1. Ordnungsposition'},
             repofolder_summary)
 
         response = self.api.get(
@@ -67,7 +67,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
         repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'Position'},
+            {u'title': u'1. Position'},
             repofolder_summary)
 
     def test_translated_titles_default_to_german(self):
@@ -75,7 +75,7 @@ class TestGeverJSONSummarySerializer(FunctionalTestCase):
         repofolder_summary = response.json()['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'Ordnungsposition'},
+            {u'title': u'1. Ordnungsposition'},
             repofolder_summary)
 
     def test_regular_title_in_summary_if_obj_not_translated(self):


### PR DESCRIPTION
With [commit `bf146b` in `plone.restapi`](https://github.com/plone/plone.restapi/commit/bf146b04197acd8addfdd9fe5673f54d5473872c) the behavior for listing folder contents was changed. It now uses catalog queries instead of `obj.objectValues()`. This means that our repositoryfolders' titles will be fetched from the brains, not the objects any more.

That in turn means that we'll have the title prefixed with the reference number in listings, because the pure title isn't available on brains in opengever. (`brain.Title`, `brain.title_de` and `brain.title_fr` are all prefixed).

So `1. Repositoryfolder Title` instead of `Repositoryfolder Title`. We agreed this can be considered correct behavior, so this PR updates the tests accordingly.

@deiferni @phgross 