### PR TITLE
Log CSRF incidents to Sentry (if possible)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Log CSRF incidents to Sentry (if possible).
+  [lgraf]
+
 - Add committee model workflow, to allow de- or reactivating a committee.
   [phgross]
 

--- a/opengever/base/sentry.py
+++ b/opengever/base/sentry.py
@@ -1,0 +1,124 @@
+from zope.globalrequest import getRequest
+import logging
+
+try:
+    from ftw.raven.client import get_raven_client
+    from ftw.raven.reporter import get_default_tags
+    from ftw.raven.reporter import get_release
+    from ftw.raven.reporter import prepare_extra_infos
+    from ftw.raven.reporter import prepare_modules_infos
+    from ftw.raven.reporter import prepare_request_infos
+    from ftw.raven.reporter import prepare_user_infos
+    FTW_RAVEN_AVAILABLE = True
+except ImportError:
+    FTW_RAVEN_AVAILABLE = False
+
+
+log = logging.getLogger('opengever.base.sentry')
+
+
+def context_from_request(request):
+    """Find the context from the request.
+
+    Based on:
+    http://docs.plone.org/develop/plone/serving/http_request_and_response.html#published-object
+    """
+    published = request.get('PUBLISHED', None)
+    context = getattr(published, '__parent__', None)
+    if context is None:
+        try:
+            context = request.get('PARENTS', [])[0]
+        except:
+            pass
+    return context
+
+
+def url_from_request(request):
+    return request.get('ACTUAL_URL', '')
+
+
+def log_msg_to_sentry(message, context=None, request=None, url=None,
+                      data=None, extra=None, fingerprint=None):
+    """A (hopefully) fail-safe function to log a message to Sentry.
+
+    This is loosely based on ftw.raven's maybe_report_exception(), except that
+    it can be used to simply log a free-form message and optionally some
+    additional data, for cases where you don't have an actual exception.
+
+    It also allows to specifiy a fingerprint to better control Sentry's
+    grouping of messages.
+
+    This still depends on ftw.raven for extraction of some additional info.
+    If either ftw.raven isn't installed, or we can't get hold of a Sentry
+    client, this function should abort gracefully, not log to Sentry, but also
+    not cause any additional problems.
+
+    This is why everything here is written in a very defensive way, we're
+    being very paranoid and try hard not to cause any additional issues.
+    """
+    if not FTW_RAVEN_AVAILABLE:
+        log.warn('ftw.raven not installed, not logging to Sentry')
+        return False
+
+    try:
+        client = get_raven_client()
+        if client is None:
+            log.warn('Could not get raven client, not logging to Sentry')
+            return False
+
+        if request is None:
+            request = getRequest()
+
+        if context is None:
+            context = context_from_request(request)
+
+        if url is None:
+            url = url_from_request(request)
+
+        try:
+            data_dict = {
+                'request': prepare_request_infos(request),
+                'user': prepare_user_infos(context, request),
+                'extra': prepare_extra_infos(context, request),
+                'modules': prepare_modules_infos(),
+                'tags': get_default_tags(),
+            }
+
+            release = get_release()
+            if release:
+                data_dict['release'] = release
+
+            if data is not None:
+                data_dict.update(data)
+
+        except:
+            log.error('Error while preparing sentry data.')
+            raise
+
+        try:
+            kwargs = dict(
+                message=message,
+                data=data_dict,
+                extra=extra,
+                stack=False,
+            )
+
+            if fingerprint:
+                kwargs['fingerprint'] = fingerprint
+
+            client.captureMessage(**kwargs)
+        except:
+            log.error('Error while reporting to sentry.')
+            raise
+
+    except:
+        try:
+            get_raven_client().captureException(
+                data={'extra': {
+                    'raven_meta_error': 'Error occured while reporting'
+                    ' another error.'}})
+        except:
+            log.error(
+                'Failed to report error occured while reporting error.')
+            return False
+    return True


### PR DESCRIPTION
This change will cause every CSRF incident to be logged to Sentry, if possible.

It's implemented in a way that should not affect deployments that don't have `ftw.raven` and/or `sentry` installed. The CSRF incident will still be logged to a rotating file, but in a simplified way (no referrers to registered objects, cropped object representations).

A new function `log_msg_to_sentry()` is introduced in `opengever.base.sentry`, which can be used to directly log a message (and optionally some data) to Sentry, without having to have an actual exception. This function is written in a way that it should be safe to use it anywhere - it should never fail, even if `ftw.raven` or `sentry` aren't available, or some error happens during logging.

The CSRF Sentry events use a custom `fingerprint` that includes the URL. That means they should be grouped by URL, incidents happening for the same URL should be grouped into the same rollup and only one notification per unique URL should be triggered.

@deiferni @phgross since this affects a pretty critical code path, I'd appreciate a thorough review, and maybe some local tests (without Sentry).

Examples for the produced Sentry entries can be seen here: https://sentry.4teamwork.ch/sentry/onegov-gever/?query=is%3Aunresolved%20csrf (will delete those once merged).