### PR TITLE
Make proposals cancellable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Make proposals cancellable.
+  Add model workflow to cancel/reactivate proposals.
+  Add statefilter for a dossiers proposals tab to only display
+  active proposals.
+  [deiferni]
+
 - Enables to replace a checked out document by Drag'n'Drop.
   [phgross]
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-25 06:22+0000\n"
+"POT-Creation-Date: 2016-05-26 11:46+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -357,7 +357,7 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
 #. Default: "Active"
-#: ./opengever/meeting/model/committee.py:28
+#: ./opengever/meeting/model/committee.py:30
 #: ./opengever/meeting/model/period.py:20
 msgid "active"
 msgstr "Aktiv"
@@ -431,9 +431,19 @@ msgstr "Weiter"
 msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
+#. Default: "Cancel"
+#: ./opengever/meeting/model/proposal.py:164
+msgid "cancel"
+msgstr "Stornieren"
+
+#. Default: "Cancelled"
+#: ./opengever/meeting/model/proposal.py:144
+msgid "cancelled"
+msgstr "Storniert"
+
 #. Default: "Close meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:58
-#: ./opengever/meeting/model/meeting.py:79
+#: ./opengever/meeting/model/meeting.py:76
 msgid "close_meeting"
 msgstr "Abschliessen"
 
@@ -443,7 +453,7 @@ msgid "close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:73
+#: ./opengever/meeting/model/meeting.py:70
 #: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr "geschlossen"
@@ -528,7 +538,7 @@ msgstr "Bis"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:36
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py:162
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -539,7 +549,7 @@ msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:142
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -575,7 +585,7 @@ msgid "heading_reject_proposal_form"
 msgstr "Antrag zurückweisen"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:69
 msgid "held"
 msgstr "Durchgeführt"
 
@@ -606,12 +616,12 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:81
+#: ./opengever/meeting/model/meeting.py:78
 msgid "hold"
 msgstr "Sitzung durchführen"
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py:31
 msgid "inactive"
 msgstr "Inaktiv"
 
@@ -635,12 +645,12 @@ msgid "label_close"
 msgstr "Schliessen"
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committee.py:77
+#: ./opengever/meeting/browser/committee.py:89
 msgid "label_committe_deactivated"
 msgstr "Gremium erfolgreich deaktiviert."
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committee.py:133
+#: ./opengever/meeting/browser/committee.py:111
 msgid "label_committe_reactivated"
 msgstr "Gremium erfolgreich reaktiviert."
 
@@ -669,12 +679,12 @@ msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:39
+#: ./opengever/meeting/browser/committee.py:38
 msgid "label_current_members"
 msgstr "Aktuelle Mitglieder"
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:24
+#: ./opengever/meeting/browser/committee.py:23
 msgid "label_current_period"
 msgstr "Aktuelle Periode"
 
@@ -693,7 +703,7 @@ msgid "label_date_to"
 msgstr "Bis"
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:36
+#: ./opengever/meeting/model/committee.py:37
 msgid "label_deactivate"
 msgstr "Gremium deaktivieren"
 
@@ -930,7 +940,7 @@ msgid "label_publish_in"
 msgstr "Veröffentlichung in"
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:40
+#: ./opengever/meeting/model/committee.py:41
 msgid "label_reactivate"
 msgstr "Gremium reaktivieren"
 
@@ -1010,12 +1020,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich detraktandieren?"
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:33
+#: ./opengever/meeting/browser/committee.py:32
 msgid "label_unscheduled_proposals"
 msgstr "Nicht traktandierte Anträge"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:28
+#: ./opengever/meeting/browser/committee.py:27
 msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
@@ -1064,12 +1074,12 @@ msgid "msg_hold_meeting_dialog"
 msgstr "Beim Abschluss dieses Traktandums wird die Sitzung in den Status `Durchgeführt`  versetzt. Anschliessend kann die Traktandenliste nicht mehr bearbeitet werden."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:41
+#: ./opengever/meeting/model/proposal.py:36
 msgid "msg_inactive_committee_selected"
 msgstr "Das ausgewählte Gremium wurde deaktiviert, der Antrag konnte nicht eingereicht werden."
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:59
+#: ./opengever/meeting/model/meeting.py:56
 msgid "msg_meeting_successfully_closed"
 msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollauszüge wurden generiert und an die Urprungsdossiers zurückgespielt."
 
@@ -1079,12 +1089,22 @@ msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committee.py:104
+#: ./opengever/meeting/browser/committee.py:72
 msgid "msg_pending_meetings"
 msgstr "Nicht alle Sitzungen sind abgeschlossen."
 
+#. Default: "Proposal cancelled successfully."
+#: ./opengever/meeting/model/proposal.py:63
+msgid "msg_proposal_cancelled"
+msgstr "Der Antrag wurde storniert."
+
+#. Default: "Proposal reactivated successfully."
+#: ./opengever/meeting/model/proposal.py:74
+msgid "msg_proposal_reactivated"
+msgstr "Der Antrag wurde wieder eröffnet."
+
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:50
+#: ./opengever/meeting/model/proposal.py:45
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
 
@@ -1094,7 +1114,7 @@ msgid "msg_successfully_deleted"
 msgstr "Das Objekt wurde erfolgreich gelöscht"
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committee.py:114
+#: ./opengever/meeting/browser/committee.py:80
 msgid "msg_unscheduled_proposals"
 msgstr "Es gibt nicht traktandierte Anträge, die diesem Gremium zugewiesen sind."
 
@@ -1114,14 +1134,19 @@ msgstr "Teilnehmende"
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
-#: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:119
+#: ./opengever/meeting/model/meeting.py:68
+#: ./opengever/meeting/model/proposal.py:137
 msgid "pending"
 msgstr "In Bearbeitung"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:126
 msgid "presidency"
 msgstr "Vorsitz"
+
+#. Default: "Proposal cancelled by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:191
+msgid "proposal_history_label_cancelled"
+msgstr "Storniert durch ${user}"
 
 #. Default: "Created by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:63
@@ -1142,6 +1167,11 @@ msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_document_updated"
 msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
+
+#. Default: "Proposal reactivated by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:203
+msgid "proposal_history_label_reactivated"
+msgstr "Wieder eröffnet durch ${user}"
 
 #. Default: "Rejected by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:87
@@ -1183,9 +1213,14 @@ msgstr "Protokoll"
 msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
+#. Default: "Reactivate"
+#: ./opengever/meeting/model/proposal.py:166
+msgid "reactivate"
+msgstr "Wieder eröffnen"
+
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/proposal.py:156
 msgid "reject"
 msgstr "Zurückweisen"
 
@@ -1205,12 +1240,12 @@ msgid "revision"
 msgstr "Überarbeitung"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:158
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:123
+#: ./opengever/meeting/model/proposal.py:141
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1223,12 +1258,12 @@ msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:133
+#: ./opengever/meeting/model/proposal.py:154
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:121
+#: ./opengever/meeting/model/proposal.py:139
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1247,7 +1282,7 @@ msgid "time"
 msgstr "Zeit"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:139
+#: ./opengever/meeting/model/proposal.py:160
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-25 06:22+0000\n"
+"POT-Creation-Date: 2016-05-26 11:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -357,7 +357,7 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
 #. Default: "Active"
-#: ./opengever/meeting/model/committee.py:28
+#: ./opengever/meeting/model/committee.py:30
 #: ./opengever/meeting/model/period.py:20
 msgid "active"
 msgstr ""
@@ -431,9 +431,19 @@ msgstr ""
 msgid "button_submit_attachments"
 msgstr ""
 
+#. Default: "Cancel"
+#: ./opengever/meeting/model/proposal.py:164
+msgid "cancel"
+msgstr ""
+
+#. Default: "Cancelled"
+#: ./opengever/meeting/model/proposal.py:144
+msgid "cancelled"
+msgstr ""
+
 #. Default: "Close meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:58
-#: ./opengever/meeting/model/meeting.py:79
+#: ./opengever/meeting/model/meeting.py:76
 msgid "close_meeting"
 msgstr ""
 
@@ -443,7 +453,7 @@ msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:73
+#: ./opengever/meeting/model/meeting.py:70
 #: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr "Fermé"
@@ -528,7 +538,7 @@ msgstr "Jusqu'à"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:36
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py:162
 msgid "decide"
 msgstr "Décider"
 
@@ -539,7 +549,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:142
 msgid "decided"
 msgstr "Décidé"
 
@@ -575,7 +585,7 @@ msgid "heading_reject_proposal_form"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:69
 msgid "held"
 msgstr "Conduit"
 
@@ -606,12 +616,12 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:81
+#: ./opengever/meeting/model/meeting.py:78
 msgid "hold"
 msgstr ""
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py:31
 msgid "inactive"
 msgstr ""
 
@@ -635,12 +645,12 @@ msgid "label_close"
 msgstr ""
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committee.py:77
+#: ./opengever/meeting/browser/committee.py:89
 msgid "label_committe_deactivated"
 msgstr ""
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committee.py:133
+#: ./opengever/meeting/browser/committee.py:111
 msgid "label_committe_reactivated"
 msgstr ""
 
@@ -669,12 +679,12 @@ msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:39
+#: ./opengever/meeting/browser/committee.py:38
 msgid "label_current_members"
 msgstr "Membres actuels"
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:24
+#: ./opengever/meeting/browser/committee.py:23
 msgid "label_current_period"
 msgstr ""
 
@@ -693,7 +703,7 @@ msgid "label_date_to"
 msgstr "Jusqu'à"
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:36
+#: ./opengever/meeting/model/committee.py:37
 msgid "label_deactivate"
 msgstr ""
 
@@ -930,7 +940,7 @@ msgid "label_publish_in"
 msgstr ""
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:40
+#: ./opengever/meeting/model/committee.py:41
 msgid "label_reactivate"
 msgstr ""
 
@@ -1010,12 +1020,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:33
+#: ./opengever/meeting/browser/committee.py:32
 msgid "label_unscheduled_proposals"
 msgstr "Propositions imprévues"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:28
+#: ./opengever/meeting/browser/committee.py:27
 msgid "label_upcoming_meetings"
 msgstr "Prochaines séances"
 
@@ -1064,12 +1074,12 @@ msgid "msg_hold_meeting_dialog"
 msgstr ""
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:41
+#: ./opengever/meeting/model/proposal.py:36
 msgid "msg_inactive_committee_selected"
 msgstr ""
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:59
+#: ./opengever/meeting/model/meeting.py:56
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 
@@ -1079,12 +1089,22 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committee.py:104
+#: ./opengever/meeting/browser/committee.py:72
 msgid "msg_pending_meetings"
 msgstr ""
 
+#. Default: "Proposal cancelled successfully."
+#: ./opengever/meeting/model/proposal.py:63
+msgid "msg_proposal_cancelled"
+msgstr ""
+
+#. Default: "Proposal reactivated successfully."
+#: ./opengever/meeting/model/proposal.py:74
+msgid "msg_proposal_reactivated"
+msgstr ""
+
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:50
+#: ./opengever/meeting/model/proposal.py:45
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1094,7 +1114,7 @@ msgid "msg_successfully_deleted"
 msgstr ""
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committee.py:114
+#: ./opengever/meeting/browser/committee.py:80
 msgid "msg_unscheduled_proposals"
 msgstr ""
 
@@ -1114,13 +1134,18 @@ msgstr ""
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
-#: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:119
+#: ./opengever/meeting/model/meeting.py:68
+#: ./opengever/meeting/model/proposal.py:137
 msgid "pending"
 msgstr "En modification"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:126
 msgid "presidency"
+msgstr ""
+
+#. Default: "Proposal cancelled by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:191
+msgid "proposal_history_label_cancelled"
 msgstr ""
 
 #. Default: "Created by ${user}"
@@ -1142,6 +1167,11 @@ msgstr "Document ${title} soumis en version ${version} par ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_document_updated"
 msgstr "Document soumis ${title} actualisé en version ${version} par ${user}"
+
+#. Default: "Proposal reactivated by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:203
+msgid "proposal_history_label_reactivated"
+msgstr ""
 
 #. Default: "Rejected by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:87
@@ -1183,9 +1213,14 @@ msgstr "Procès-verbal"
 msgid "protocol_excerpt"
 msgstr ""
 
+#. Default: "Reactivate"
+#: ./opengever/meeting/model/proposal.py:166
+msgid "reactivate"
+msgstr ""
+
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/proposal.py:156
 msgid "reject"
 msgstr ""
 
@@ -1205,12 +1240,12 @@ msgid "revision"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:158
 msgid "schedule"
 msgstr "Mettre à l`ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:123
+#: ./opengever/meeting/model/proposal.py:141
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1223,12 +1258,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:133
+#: ./opengever/meeting/model/proposal.py:154
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:121
+#: ./opengever/meeting/model/proposal.py:139
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1247,7 +1282,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:139
+#: ./opengever/meeting/model/proposal.py:160
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-25 06:22+0000\n"
+"POT-Creation-Date: 2016-05-26 11:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -356,7 +356,7 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/meeting/model/committee.py:28
+#: ./opengever/meeting/model/committee.py:30
 #: ./opengever/meeting/model/period.py:20
 msgid "active"
 msgstr ""
@@ -430,9 +430,19 @@ msgstr ""
 msgid "button_submit_attachments"
 msgstr ""
 
+#. Default: "Cancel"
+#: ./opengever/meeting/model/proposal.py:164
+msgid "cancel"
+msgstr ""
+
+#. Default: "Cancelled"
+#: ./opengever/meeting/model/proposal.py:144
+msgid "cancelled"
+msgstr ""
+
 #. Default: "Close meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:58
-#: ./opengever/meeting/model/meeting.py:79
+#: ./opengever/meeting/model/meeting.py:76
 msgid "close_meeting"
 msgstr ""
 
@@ -442,7 +452,7 @@ msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:73
+#: ./opengever/meeting/model/meeting.py:70
 #: ./opengever/meeting/model/period.py:21
 msgid "closed"
 msgstr ""
@@ -527,7 +537,7 @@ msgstr ""
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:36
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py:162
 msgid "decide"
 msgstr ""
 
@@ -538,7 +548,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/proposal.py:124
+#: ./opengever/meeting/model/proposal.py:142
 msgid "decided"
 msgstr ""
 
@@ -574,7 +584,7 @@ msgid "heading_reject_proposal_form"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:69
 msgid "held"
 msgstr ""
 
@@ -605,12 +615,12 @@ msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:81
+#: ./opengever/meeting/model/meeting.py:78
 msgid "hold"
 msgstr ""
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py:31
 msgid "inactive"
 msgstr ""
 
@@ -634,12 +644,12 @@ msgid "label_close"
 msgstr ""
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committee.py:77
+#: ./opengever/meeting/browser/committee.py:89
 msgid "label_committe_deactivated"
 msgstr ""
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committee.py:133
+#: ./opengever/meeting/browser/committee.py:111
 msgid "label_committe_reactivated"
 msgstr ""
 
@@ -668,12 +678,12 @@ msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:39
+#: ./opengever/meeting/browser/committee.py:38
 msgid "label_current_members"
 msgstr ""
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:24
+#: ./opengever/meeting/browser/committee.py:23
 msgid "label_current_period"
 msgstr ""
 
@@ -692,7 +702,7 @@ msgid "label_date_to"
 msgstr ""
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:36
+#: ./opengever/meeting/model/committee.py:37
 msgid "label_deactivate"
 msgstr ""
 
@@ -929,7 +939,7 @@ msgid "label_publish_in"
 msgstr ""
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:40
+#: ./opengever/meeting/model/committee.py:41
 msgid "label_reactivate"
 msgstr ""
 
@@ -1009,12 +1019,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:33
+#: ./opengever/meeting/browser/committee.py:32
 msgid "label_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:28
+#: ./opengever/meeting/browser/committee.py:27
 msgid "label_upcoming_meetings"
 msgstr ""
 
@@ -1063,12 +1073,12 @@ msgid "msg_hold_meeting_dialog"
 msgstr ""
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:41
+#: ./opengever/meeting/model/proposal.py:36
 msgid "msg_inactive_committee_selected"
 msgstr ""
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:59
+#: ./opengever/meeting/model/meeting.py:56
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 
@@ -1078,12 +1088,22 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committee.py:104
+#: ./opengever/meeting/browser/committee.py:72
 msgid "msg_pending_meetings"
 msgstr ""
 
+#. Default: "Proposal cancelled successfully."
+#: ./opengever/meeting/model/proposal.py:63
+msgid "msg_proposal_cancelled"
+msgstr ""
+
+#. Default: "Proposal reactivated successfully."
+#: ./opengever/meeting/model/proposal.py:74
+msgid "msg_proposal_reactivated"
+msgstr ""
+
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:50
+#: ./opengever/meeting/model/proposal.py:45
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1093,7 +1113,7 @@ msgid "msg_successfully_deleted"
 msgstr ""
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committee.py:114
+#: ./opengever/meeting/browser/committee.py:80
 msgid "msg_unscheduled_proposals"
 msgstr ""
 
@@ -1113,13 +1133,18 @@ msgstr ""
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:29
-#: ./opengever/meeting/model/meeting.py:71
-#: ./opengever/meeting/model/proposal.py:119
+#: ./opengever/meeting/model/meeting.py:68
+#: ./opengever/meeting/model/proposal.py:137
 msgid "pending"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:126
 msgid "presidency"
+msgstr ""
+
+#. Default: "Proposal cancelled by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:191
+msgid "proposal_history_label_cancelled"
 msgstr ""
 
 #. Default: "Created by ${user}"
@@ -1140,6 +1165,11 @@ msgstr ""
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
 #: ./opengever/meeting/model/proposalhistory.py:141
 msgid "proposal_history_label_document_updated"
+msgstr ""
+
+#. Default: "Proposal reactivated by ${user}"
+#: ./opengever/meeting/model/proposalhistory.py:203
+msgid "proposal_history_label_reactivated"
 msgstr ""
 
 #. Default: "Rejected by ${user}"
@@ -1182,9 +1212,14 @@ msgstr ""
 msgid "protocol_excerpt"
 msgstr ""
 
+#. Default: "Reactivate"
+#: ./opengever/meeting/model/proposal.py:166
+msgid "reactivate"
+msgstr ""
+
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:61
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/proposal.py:156
 msgid "reject"
 msgstr ""
 
@@ -1204,12 +1239,12 @@ msgid "revision"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:158
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:123
+#: ./opengever/meeting/model/proposal.py:141
 msgid "scheduled"
 msgstr ""
 
@@ -1222,12 +1257,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:133
+#: ./opengever/meeting/model/proposal.py:154
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:121
+#: ./opengever/meeting/model/proposal.py:139
 msgid "submitted"
 msgstr ""
 
@@ -1246,7 +1281,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:139
+#: ./opengever/meeting/model/proposal.py:160
 msgid "un-schedule"
 msgstr ""
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -117,12 +117,15 @@ class Proposal(Base):
     STATE_SCHEDULED = State('scheduled',
                             title=_('scheduled', default='Scheduled'))
     STATE_DECIDED = State('decided', title=_('decided', default='Decided'))
+    STATE_CANCELLED = State('cancelled',
+                            title=_('cancelled', default='Cancelled'))
 
     workflow = Workflow([
         STATE_PENDING,
         STATE_SUBMITTED,
         STATE_SCHEDULED,
-        STATE_DECIDED
+        STATE_DECIDED,
+        STATE_CANCELLED,
         ], [
         Submit('pending', 'submitted',
                title=_('submit', default='Submit')),
@@ -134,6 +137,10 @@ class Proposal(Base):
                    title=_('un-schedule', default='Remove from schedule')),
         Transition('scheduled', 'decided',
                    title=_('decide', default='Decide')),
+        Transition('pending', 'cancelled',
+               title=_('cancel', default='Cancel')),
+        Transition('cancelled', 'pending',
+                   title=_('reactivate', default='Reactivate')),
         ])
 
     def __repr__(self):

--- a/opengever/meeting/model/proposalhistory.py
+++ b/opengever/meeting/model/proposalhistory.py
@@ -179,3 +179,27 @@ class ProposalRevised(ProposalHistory):
         return _(u'proposal_history_label_revised',
                  u'Proposal revised by ${user}',
                  mapping={'user': self.get_actor_link()})
+
+
+class Cancelled(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'cancelled'}
+
+    css_class = 'cancelled'
+
+    def message(self):
+        return _(u'proposal_history_label_cancelled',
+                 u'Proposal cancelled by ${user}',
+                 mapping={'user': self.get_actor_link()})
+
+
+class Reactivated(ProposalHistory):
+
+    __mapper_args__ = {'polymorphic_identity': 'reactivated'}
+
+    css_class = 'reactivated'
+
+    def message(self):
+        return _(u'proposal_history_label_reactivated',
+                 u'Proposal reactivated by ${user}',
+                 mapping={'user': self.get_actor_link()})

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -42,6 +42,12 @@ class ProposalQuery(BaseQuery):
         query = self.filter(Proposal.workflow_state.in_(states))
         return query.filter(Proposal.committee == committee)
 
+    def active(self):
+        return self.filter(Proposal.workflow_state.in_([
+            Proposal.STATE_PENDING.name,
+            Proposal.STATE_SUBMITTED.name,
+            Proposal.STATE_SCHEDULED.name,
+            ]))
 
 Proposal.query_cls = ProposalQuery
 

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -384,7 +384,7 @@ class Proposal(ProposalBase):
     implements(content_schema)
 
     workflow = ProposalModel.workflow.with_visible_transitions(
-        ['pending-submitted'])
+        ['pending-submitted', 'pending-cancelled', 'cancelled-pending'])
 
     def _after_model_created(self, model_instance):
         session = create_session()

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -385,6 +385,33 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(Proposal.STATE_SUBMITTED, proposal.get_state())
 
     @browsing
+    def test_proposal_can_be_cancelled(self, browser):
+        committee = create(Builder('committee'))
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .having(title='Mach doch',
+                                  committee=committee.load_model()))
+
+        browser.login().open(proposal, view='tabbedview_view-overview')
+        browser.css('#pending-cancelled').first.click()
+
+        self.assertEqual(Proposal.STATE_CANCELLED, proposal.get_state())
+
+    @browsing
+    def test_proposal_can_be_reactivated(self, browser):
+        committee = create(Builder('committee'))
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .having(title='Mach doch',
+                                  committee=committee.load_model())
+                          .as_cancelled())
+
+        browser.login().open(proposal, view='tabbedview_view-overview')
+        browser.css('#cancelled-pending').first.click()
+
+        self.assertEqual(Proposal.STATE_PENDING, proposal.get_state())
+
+    @browsing
     def test_proposal_can_not_be_submitted_when_committee_is_inactive(self, browser):
         committee = create(Builder('committee'))
         proposal = create(Builder('proposal')

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -78,6 +78,37 @@ class TestDossierProposalListing(ProposalListingTests):
               'Meeting': u'C\xf6mmunity meeting'}],
             table.dicts())
 
+    @browsing
+    def test_only_shows_active_proposals_by_default(self, browser):
+        cancelled_proposal = create(
+            Builder('proposal')
+            .within(self.dossier)
+            .titled(u'Cancelled Proposal')
+            .having(committee=self.committee.load_model())
+            .as_cancelled())
+
+        browser.login().open(self.dossier,
+                             view='tabbedview_view-proposals')
+        table = browser.css('.listing').first
+        self.assertEquals([u'My Proposal'],
+                          [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_all_filter_shows_all_proposals(self, browser):
+        cancelled_proposal = create(
+            Builder('proposal')
+            .within(self.dossier)
+            .titled(u'Cancelled Proposal')
+            .having(committee=self.committee.load_model())
+            .as_cancelled())
+
+        browser.login().open(self.dossier,
+                             view='tabbedview_view-proposals',
+                             data={'proposal_state_filter': 'filter_all'})
+        table = browser.css('.listing').first
+        self.assertEquals([u'Cancelled Proposal', u'My Proposal'],
+                          [row.get('Title') for row in table.dicts()])
+
 
 class TestSubmittedProposals(ProposalListingTests):
 

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -95,6 +95,25 @@ class TestProposalHistory(FunctionalTestCase):
             self.get_history_entries_text(browser)[0])
 
     @browsing
+    def test_cancelling_and_reactivating_proposal_creates_history_entry(self, browser):
+        browser.login()
+        self.open_overview(browser)
+
+        # cancel proposal
+        browser.css('#pending-cancelled').first.click()
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Proposal cancelled by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))
+
+        # reactivate proposal
+        browser.css('#cancelled-pending').first.click()
+        self.open_overview(browser)
+        self.assertEqual(
+            u'Proposal reactivated by Test User (test_user_1_)',
+            self.get_latest_history_entry_text(browser))
+
+    @browsing
     def test_submitting_additional_document_creates_history_entry(self, browser):
         self.submit_proposal()
         document = create(Builder('document')

--- a/opengever/meeting/tests/test_unit_proposal.py
+++ b/opengever/meeting/tests/test_unit_proposal.py
@@ -58,3 +58,24 @@ class TestUnitProposal(TestCase):
         self.assertEqual(
             proposal,
             Proposal.query.by_admin_unit(AdminUnit(unit_id='unita')).first())
+
+    def test_active_query_returns_only_active_proposals(self):
+        pending_proposal = create(Builder('proposal_model').having(
+            int_id=1, workflow_state=Proposal.STATE_PENDING.name,
+            ))
+        submitted_proposal = create(Builder('proposal_model').having(
+            int_id=2, workflow_state=Proposal.STATE_SUBMITTED.name,
+            ))
+        scheduled_proposal = create(Builder('proposal_model').having(
+            int_id=3, workflow_state=Proposal.STATE_SCHEDULED.name,
+            ))
+        decided_proposal = create(Builder('proposal_model').having(
+            int_id=4, workflow_state=Proposal.STATE_DECIDED.name,
+            ))
+        cancelled_proposal = create(Builder('proposal_model').having(
+            int_id=5, workflow_state=Proposal.STATE_CANCELLED.name,
+            ))
+
+        self.assertItemsEqual(
+            [pending_proposal, submitted_proposal, scheduled_proposal],
+            Proposal.query.active().all())

--- a/opengever/tabbedview/browser/selection_with_filters.pt
+++ b/opengever/tabbedview/browser/selection_with_filters.pt
@@ -1,21 +1,22 @@
-<div tal:condition="view/show_selects" class="tabbedview_select"
+<div class="tabbedview_select"
      tal:define="filterlist_name python: view.filterlist_name;
                  filter_id python: view.request.get(filterlist_name)"
      tal:attributes="id filterlist_name"
      i18n:domain="ftw.tabbedview">
 
-    <span i18n:translate="">Choose:</span>
-    <a href="javascript:tabbedview.select_all()" i18n:translate="">
-        all (<span i18n:name="amount" tal:replace="python:len(view.contents)" />)</a>,
-    <a href="javascript:tabbedview.select_none()" i18n:translate="">none</a>
-    <span class="select_folder" style="display:none" i18n:translate="">
-        All visible entries chosen <a href="#" i18n:translate="">Show all in this Folder</a>
-    </span>
+    <tal:condition tal:condition="view/show_selects">
+      <span i18n:translate="">Choose:</span>
+      <a href="javascript:tabbedview.select_all()" i18n:translate="">
+          all (<span i18n:name="amount" tal:replace="python:len(view.contents)" />)</a>,
+      <a href="javascript:tabbedview.select_none()" i18n:translate="">none</a>
+      <span class="select_folder" style="display:none" i18n:translate="">
+          All visible entries chosen <a href="#" i18n:translate="">Show all in this Folder</a>
+      </span>
+    </tal:condition>
 
     <span tal:condition="view/filterlist_available"
           tal:attributes="id filterlist_name" class="state_filters">
-
-      <span> | </span>
+      <span tal:condition="view/show_selects"> | </span>
 
       <span i18n:translate="" i18n:domain="opengever.tabbedview">State</span>
 

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -250,6 +250,12 @@ class Tasks(GlobalTaskListingTab):
         return Task.query.by_container(self.context, get_current_admin_unit())
 
 
+class ActiveProposalFilter(Filter):
+
+    def update_query(self, query):
+        return query.active()
+
+
 class Proposals(ProposalListingTab):
 
     grok.name('tabbedview_view-proposals')
@@ -258,6 +264,23 @@ class Proposals(ProposalListingTab):
     enabled_actions = []
     major_actions = []
     sort_on = 'title'
+    show_selects = False
+
+    selection = ViewPageTemplateFile("selection_with_filters.pt")
+    template = ViewPageTemplateFile("generic_with_filters.pt")
+
+    model = Proposal
+
+    filterlist_name = 'proposal_state_filter'
+    filterlist_available = True
+
+    filterlist = FilterList(
+        Filter('filter_all', _('all')),
+        ActiveProposalFilter(
+            'filter_active',
+            _('Active'),
+            default=True)
+    )
 
     def get_base_query(self):
         return Proposal.query.by_container(

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -266,7 +266,7 @@ class ProposalBuilder(DexterityBuilder):
         self.arguments = {'title': 'Fooo',
                           'language': TranslatedTitle.FALLBACK_LANGUAGE}
         self.model_arguments = None
-        self._submitted = False
+        self._transition = None
 
     def before_create(self):
         self.arguments, self.model_arguments = Proposal.partition_data(
@@ -275,8 +275,8 @@ class ProposalBuilder(DexterityBuilder):
     def after_create(self, obj):
         obj.create_model(self.model_arguments, self.container)
 
-        if self._submitted:
-            obj.execute_transition('pending-submitted')
+        if self._transition:
+            obj.execute_transition(self._transition)
 
         super(ProposalBuilder, self).after_create(obj)
 
@@ -284,7 +284,11 @@ class ProposalBuilder(DexterityBuilder):
         return self.having(relatedItems=documents)
 
     def as_submitted(self):
-        self._submitted = True
+        self._transition = 'pending-submitted'
+        return self
+
+    def as_cancelled(self):
+        self._transition = 'pending-cancelled'
         return self
 
 builder_registry.register('proposal', ProposalBuilder)


### PR DESCRIPTION
Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/431 for styling

This PR makes proposals cancellable.

- Add model workflow to cancel/reactivate proposals.
- Add a statefilter for  the proposals tab in a dossier to only display active proposals.

![screen shot 2016-05-26 at 14 41 48](https://cloud.githubusercontent.com/assets/736583/15574864/0a977aba-2350-11e6-818b-76e7dac7867d.png)

Closes #1804.