### PR TITLE
Enables to replace a document per Drag'n'Drop

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Enables to replace a checked out document by Drag'n'Drop.
+  [phgross]
+
 - Redirect to meeting tab when a meeting has been created.
   [deiferni]
 

--- a/opengever/document/browser/configure.zcml
+++ b/opengever/document/browser/configure.zcml
@@ -27,4 +27,12 @@
         allowed_interface="plone.app.layout.globals.interfaces.ILayoutPolicy"
         />
 
+    <browser:page
+        for="opengever.document.document.IDocumentSchema"
+        name="tabbed_view"
+        class=".tabbed.DocumentTabbedView"
+        permission="zope2.View"
+        allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+        />
+
 </configure>

--- a/opengever/document/browser/tabbed.py
+++ b/opengever/document/browser/tabbed.py
@@ -1,0 +1,15 @@
+from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.document.interfaces import ICheckinCheckoutManager
+from zope.component import getMultiAdapter
+
+
+class DocumentTabbedView(TabbedView):
+
+    def show_uploadbox(self):
+        manager = getMultiAdapter((self.context, self.context.REQUEST),
+                                  ICheckinCheckoutManager)
+
+        if not manager.is_file_upload_allowed():
+            return False
+
+        return super(DocumentTabbedView, self).show_uploadbox()

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -10,6 +10,7 @@ from opengever.document.events import ObjectCheckoutCanceledEvent
 from opengever.document.events import ObjectRevertedToVersion
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.trash.trash import ITrashed
+from plone import api
 from plone.locking.interfaces import IRefreshableLockable
 from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
@@ -36,6 +37,12 @@ class CheckinCheckoutManager(grok.MultiAdapter):
         returns `None`.
         """
         return self.annotations.get(CHECKIN_CHECKOUT_ANNOTATIONS_KEY, None)
+
+    def is_checked_out_by_current_user(self):
+        return self.get_checked_out_by() == api.user.get_current().getId()
+
+    def is_file_change_allowed(self):
+        return self.is_checked_out_by_current_user() and not self.is_locked()
 
     def is_checkout_allowed(self):
         """Checks whether checkout is allowed for the current user on the

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -41,7 +41,7 @@ class CheckinCheckoutManager(grok.MultiAdapter):
     def is_checked_out_by_current_user(self):
         return self.get_checked_out_by() == api.user.get_current().getId()
 
-    def is_file_change_allowed(self):
+    def is_file_upload_allowed(self):
         return self.is_checked_out_by_current_user() and not self.is_locked()
 
     def is_checkout_allowed(self):

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -14,7 +14,8 @@ from plone import api
 from plone.autoform import directives as form_directives
 from plone.dexterity.content import Item
 from plone.directives import form
-from plone.namedfile.field import NamedBlobFile
+from plone.namedfile import field
+from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.common import MimeTypeException
 from z3c.form import validator
@@ -58,7 +59,7 @@ class IDocumentSchema(form.Schema):
 
     form.primary('file')
     form_directives.order_after(file='IDocumentMetadata.document_author')
-    file = NamedBlobFile(
+    file = field.NamedBlobFile(
         title=_(u'label_file', default='File'),
         description=_(u'help_file', default=''),
         required=False,
@@ -222,3 +223,9 @@ class Document(Item, BaseDocumentMixin):
         assert history.retrieve(current_version), \
             'missing history entry for verion {}'.format(current_version)
         return current_version
+
+    def update_file(self, filename, content_type, data):
+        self.file = NamedBlobFile(
+            data=data,
+            filename=filename,
+            contentType=content_type)

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner, aq_parent
 from collective import dexteritytextindexer
 from five import grok
 from ftw.mail.interfaces import IEmailAddress
+from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.document import _
 from opengever.document.base import BaseDocumentMixin
 from opengever.document.behaviors.related_docs import IRelatedDocuments
@@ -19,6 +20,7 @@ from Products.MimetypesRegistry.common import MimeTypeException
 from z3c.form import validator
 from zope import schema
 from zope.component import getMultiAdapter
+from zope.interface import implements
 from zope.interface import Invalid
 from zope.interface import invariant
 import logging
@@ -107,6 +109,8 @@ grok.global_adapter(UploadValidator)
 
 class Document(Item, BaseDocumentMixin):
 
+    implements(ITabbedviewUploadable)
+
     # document state's
     removed_state = 'document-state-removed'
     active_state = 'document-state-draft'
@@ -116,6 +120,13 @@ class Document(Item, BaseDocumentMixin):
 
     # disable file preview creation when modifying or creating document
     buildPreview = False
+
+    def __contains__(self, key):
+        """Used because of a the following contains check in
+        collective.quickupload (https://github.com/collective/collective.quickupload/blob/1.8.2/collective/quickupload/browser/quick_upload.py#L679)
+        """
+
+        return False
 
     def surrender(self, relative_to_portal=1):
         return super(Document, self).getIcon(

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -75,6 +75,11 @@ class ICheckinCheckoutManager(Interface):
         """Checkout the adapted document.
         """
 
+    def is_checked_out_by_current_user():
+        """Returns True if the document is checked out by the currently
+        logged in user otherwise False.
+        """
+
     def is_checkin_allowed():
         """Checks whether checkin is allowed for the current user on the
         adapted document.

--- a/opengever/document/quick_upload.py
+++ b/opengever/document/quick_upload.py
@@ -20,16 +20,16 @@ class QuickUploadFileUpdater(grok.Adapter):
         self.context = aq_inner(context)
 
     def __call__(self, filename, title, description, content_type, data, portal_type):
-        if not self.upload_allowed():
+        if not self.is_upload_allowed():
             raise Unauthorized
 
         self.update_file(filename, content_type, data)
         return {'success': self.context}
 
-    def upload_allowed(self):
+    def is_upload_allowed(self):
         manager = getMultiAdapter((self.context, self.context.REQUEST),
                                   ICheckinCheckoutManager)
-        return manager.is_file_change_allowed()
+        return manager.is_file_upload_allowed()
 
     def update_file(self, filename, content_type, data):
         self.context.file = NamedBlobFile(

--- a/opengever/document/quick_upload.py
+++ b/opengever/document/quick_upload.py
@@ -1,0 +1,45 @@
+from Acquisition import aq_inner
+from collective.quickupload.interfaces import IQuickUploadFileFactory
+from five import grok
+from opengever.document.document import IDocumentSchema
+from opengever.document.interfaces import ICheckinCheckoutManager
+from plone.namedfile.file import NamedBlobFile
+from zExceptions import Unauthorized
+from zope.component import getMultiAdapter
+import os
+
+
+class QuickUploadFileUpdater(grok.Adapter):
+    """Specific quick_upload adapter for documents, which only replace the file
+    with the uploaded one."""
+
+    grok.context(IDocumentSchema)
+    grok.implements(IQuickUploadFileFactory)
+
+    def __init__(self, context):
+        self.context = aq_inner(context)
+
+    def __call__(self, filename, title, description, content_type, data, portal_type):
+        if not self.upload_allowed():
+            raise Unauthorized
+
+        self.update_file(filename, content_type, data)
+        return {'success': self.context}
+
+    def upload_allowed(self):
+        manager = getMultiAdapter((self.context, self.context.REQUEST),
+                                  ICheckinCheckoutManager)
+        return manager.is_file_change_allowed()
+
+    def update_file(self, filename, content_type, data):
+        self.context.file = NamedBlobFile(
+            data=data,
+            filename=self.get_file_name(filename),
+            contentType=content_type)
+
+    def get_file_name(self, org_filename):
+        filename, ext = os.path.splitext(org_filename)
+        if self.context.file:
+            filename = os.path.splitext(self.context.file.filename)[0]
+
+        return ''.join([filename, ext])

--- a/opengever/document/quick_upload.py
+++ b/opengever/document/quick_upload.py
@@ -3,7 +3,6 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from five import grok
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
-from plone.namedfile.file import NamedBlobFile
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
 import os
@@ -23,19 +22,15 @@ class QuickUploadFileUpdater(grok.Adapter):
         if not self.is_upload_allowed():
             raise Unauthorized
 
-        self.update_file(filename, content_type, data)
+        self.context.update_file(
+            self.get_file_name(filename), content_type, data)
+
         return {'success': self.context}
 
     def is_upload_allowed(self):
         manager = getMultiAdapter((self.context, self.context.REQUEST),
                                   ICheckinCheckoutManager)
         return manager.is_file_upload_allowed()
-
-    def update_file(self, filename, content_type, data):
-        self.context.file = NamedBlobFile(
-            data=data,
-            filename=self.get_file_name(filename),
-            contentType=content_type)
 
     def get_file_name(self, org_filename):
         filename, ext = os.path.splitext(org_filename)

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -200,23 +200,23 @@ class TestManagerHelpers(FunctionalTestCase):
         doc = create(Builder('document'))
         self.assertFalse(self.get_manager(doc).is_checked_out_by_current_user())
 
-    def test_file_change_is_disallowed_when_document_is_locked(self):
+    def test_file_upload_is_disallowed_when_document_is_locked(self):
         doc = create(Builder('document').checked_out())
         IRefreshableLockable(doc).lock()
 
-        self.assertFalse(self.get_manager(doc).is_file_change_allowed())
+        self.assertFalse(self.get_manager(doc).is_file_upload_allowed())
 
-    def test_file_change_is_disallowed_when_document_is_checked_out_by_other_user(self):
+    def test_file_upload_is_disallowed_when_document_is_checked_out_by_other_user(self):
         doc = create(Builder('document').checked_out_by('hugo.boss'))
-        self.assertFalse(self.get_manager(doc).is_file_change_allowed())
+        self.assertFalse(self.get_manager(doc).is_file_upload_allowed())
 
-    def test_file_change_is_disallowed_when_document_is_not_checked_out(self):
+    def test_file_upload_is_disallowed_when_document_is_not_checked_out(self):
         doc = create(Builder('document'))
-        self.assertFalse(self.get_manager(doc).is_file_change_allowed())
+        self.assertFalse(self.get_manager(doc).is_file_upload_allowed())
 
-    def test_file_change_is_allowed_when_document_is_checked_out_and_not_locked(self):
+    def test_file_upload_is_allowed_when_document_is_checked_out_and_not_locked(self):
         doc = create(Builder('document').checked_out())
-        self.assertTrue(self.get_manager(doc).is_file_change_allowed())
+        self.assertTrue(self.get_manager(doc).is_file_upload_allowed())
 
 
 class TestCheckinCheckoutManager(FunctionalTestCase):

--- a/opengever/document/tests/test_quickupload.py
+++ b/opengever/document/tests/test_quickupload.py
@@ -1,0 +1,47 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from plone.locking.interfaces import IRefreshableLockable
+from zExceptions import Unauthorized
+
+
+class TestDocumentQuickupload(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDocumentQuickupload, self).setUp()
+        self.dossier = create(Builder('dossier'))
+        self.document = create(Builder('document')
+                               .titled('Anfrage Herr Meier')
+                               .checked_out()
+                               .attach_file_containing('OLD DATA')
+                               .within(self.dossier))
+
+    def test_raises_unauthorized_when_document_is_not_checked_out(self):
+        document = create(Builder('document'))
+        with self.assertRaises(Unauthorized):
+            create(Builder('quickuploaded_document')
+                   .within(document)
+                   .with_data('text'))
+
+    def test_raises_unauthorized_when_document_is_locked(self):
+        IRefreshableLockable(self.document).lock()
+
+        with self.assertRaises(Unauthorized):
+            create(Builder('quickuploaded_document')
+                   .within(self.document)
+                   .with_data('text'))
+
+    def test_file_is_updated(self):
+        create(Builder('quickuploaded_document')
+               .within(self.document)
+               .with_data('NEW DATA'))
+
+        self.assertEquals('NEW DATA', self.document.file.data)
+
+    def test_uses_existing_filename_but_new_extension(self):
+        create(Builder('quickuploaded_document')
+               .within(self.document)
+               .with_data('NEW DATA', filename='test.pdf'))
+
+        self.assertEquals('anfrage-herr-meier.pdf',
+                          self.document.file.filename)

--- a/opengever/document/tests/test_tabbed.py
+++ b/opengever/document/tests/test_tabbed.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone.locking.interfaces import IRefreshableLockable
+
+
+class TestDocumentQuickupload(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDocumentQuickupload, self).setUp()
+        self.dossier = create(Builder('dossier'))
+
+    @browsing
+    def test_upload_box_is_hidden_when_document_is_not_checked_out(self, browser):
+        document = create(Builder('document').within(self.dossier))
+
+        browser.login().open(document)
+        self.assertEquals([], browser.css('#uploadbox'),
+                          'uploadbox is wrongly displayed')
+
+    @browsing
+    def test_upload_box_is_hidden_when_document_is_locked(self, browser):
+        document = create(Builder('document').within(self.dossier))
+        IRefreshableLockable(document).lock()
+
+        browser.login().open(document)
+        self.assertEquals([], browser.css('#uploadbox'),
+                          'uploadbox is wrongly displayed')
+
+    @browsing
+    def test_upload_box_is_shown_when_document_is_checked_out_and_not_locked(self, browser):
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .checked_out())
+
+        browser.login().open(document)
+        self.assertIsNotNone(browser.css('#uploadbox'))


### PR DESCRIPTION
Drag'n' drop is only available when document is checked_out by the current user and no webdav lock (ExternalEditor/OfficeConnector) exists. For more information see #1562. 

![bildschirmfoto_2016-05-26_um_16_35_24](https://cloud.githubusercontent.com/assets/485755/15578559/320c7288-2361-11e6-8133-daf7e5d6f10e.png)


Closes #1562

@lukasgraf @deiferni 