### PR TITLE
Use global pagesize parameter for batchsize in gallery-view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Use global pagesize parameter for batchsize in gallery-view.
+  [elioschmutz]
+
 - Make proposals cancellable.
   Add model workflow to cancel/reactivate proposals.
   Add statefilter for a dossiers proposals tab to only display

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -20,8 +20,6 @@ class BumblebeeGalleryMixin(object):
 
     object_provides = 'ftw.bumblebee.interfaces.IBumblebeeable'
 
-    amount_preloaded_documents = 24
-
     def __call__(self, *args, **kwargs):
         if not is_bumblebee_feature_enabled():
             raise NotFound
@@ -47,7 +45,7 @@ class BumblebeeGalleryMixin(object):
         brains = self.get_brains()
 
         from_batch_id = int(self.request.get('documentPointer', 0))
-        to_batch_id = from_batch_id + self.amount_preloaded_documents
+        to_batch_id = from_batch_id + self.pagesize
 
         for brain in brains[from_batch_id:to_batch_id]:
             yield {

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.tabbedview.interfaces import ITabbedView
 from ftw.testbrowser import browsing
 from opengever.bumblebee import BUMBLEBEE_VIEW_COOKIE_NAME
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
@@ -260,13 +261,12 @@ class TestBumblebeeGalleryMixinPreviews(FunctionalTestCase):
             [document1.UID(), document2.UID()],
             [item.get('uid') for item in view.previews()])
 
-    def test_stream_length_is_configurable(self):
+    def test_stream_length_is_configurable_through_tabbedview_pagesize(self):
         dossier = create(Builder('dossier'))
+        api.portal.set_registry_record('batch_size', 2, interface=ITabbedView)
 
         view = getMultiAdapter(
             (dossier, self.request), name="tabbedview_view-documents-gallery")
-
-        view.amount_preloaded_documents = 2
 
         document0 = create(Builder('document').within(dossier))
         document1 = create(Builder('document').within(dossier))


### PR DESCRIPTION
Durch diesen PR wird in der Galerieansicht keine eigene Batch-Size mehr verwendet.
Neu wird das globale tabbedview-pagesize attribut verwendet.

Somit hat die Galerieansicht die gleiche Batch-Size wie die Listenansicht.

closes #1860 