### PR TITLE
Use correct message type when submitting proposals.

### DIFF
--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -44,7 +44,7 @@ class Submit(Transition):
 
         msg = _(u'msg_proposal_submitted',
                 default=u'Proposal successfully submitted.')
-        api.portal.show_message(msg, request=getRequest(), type='error')
+        api.portal.show_message(msg, request=getRequest())
 
 
 class Reject(Transition):

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -301,6 +301,8 @@ class TestProposal(FunctionalTestCase):
         browser.open(proposal, view='tabbedview_view-overview')
         browser.css('#pending-submitted').first.click()
 
+        self.assertEqual(['Proposal successfully submitted.'], info_messages())
+
         proposal_model = proposal.load_model()
 
         # submitted proposal created


### PR DESCRIPTION
Fixes #1861.

Fixes an unreleased error that was introduced recently with https://github.com/4teamwork/opengever.core/pull/1849, no changelog entry should be necessary.