### PR TITLE
Add bumblebeeoverlay for documents on the overview tab.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Add bumblebeeoverlay for documents on the overview tab.
+  [elioschmutz]
+
 - Use global pagesize parameter for batchsize in gallery-view.
   [elioschmutz]
 

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -62,6 +62,8 @@
                   <tal:brain tal:condition="python: view.get_type(item) == 'brain'">
                     <a href="" tal:attributes="href item/getURL|nothing;
                                                title item/alt|nothing;
+                                               data-showroom-target item/data-showroom-target|nothing;
+                                               data-showroom-title item/data-showroom-title|nothing;
                                                class python:view.get_item_css_classes(item)" tal:omit-tag="not: item/getURL|nothing"
                        tal:content="item/Title">
                     </a>
@@ -74,6 +76,8 @@
                     <a href=""
                        tal:attributes="href item/getURL|nothing;
                                        title item/alt|nothing;
+                                       data-showroom-target item/data-showroom-target|nothing;
+                                       data-showroom-title item/data-showroom-title|nothing;
                                        class python:'rollover-breadcrumb %s' % (item.get('css_class'))"
                        tal:omit-tag="not: item/getURL|nothing">
                     <span tal:content="item/Title" /></a>

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -54,7 +54,7 @@
     var previewListing = $(".preview-listing");
 
     endpoint = previewListing.data("fetch-url");
-    numberOfDocuments = previewListing.data('number-of-documents') || 0;
+    numberOfDocuments = previewListing.data('number-of-documents') || items.length;
     toggleShowMoreButton();
     scanForBrokenImages(".preview-listing");
 


### PR DESCRIPTION
Dokumente im Übersichts-Tab werden nun auch im Overlay geöffnet.

![record](https://cloud.githubusercontent.com/assets/557005/15675318/ba145d56-2741-11e6-865e-95acd5ae74c4.gif)

closes #1833 