### PR TITLE
Boost bumblebee overlay rendering performance 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Boost bumblebee overlay performance by omitting diazo and improving
+  template condition expressions with nocall:.
+  [deiferni]
+
 - Dont quote advanced parameters twice.
   Fixes a bug where certain terms would not be found.
   [deiferni]

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -26,6 +26,9 @@ class BumblebeeOverlayMixin(object):
         if not is_bumblebee_feature_enabled():
             raise NotFound
 
+        # we only render an html fragment, no reason to waste time on diazo
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+
         return super(BumblebeeOverlayMixin, self).__call__()
 
     def get_preview_pdf_url(self):

--- a/opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt
+++ b/opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt
@@ -1,6 +1,6 @@
 <div id="file-preview" i18n:domain="opengever.bumblebee">
   <aside class="sidebar">
-    <header tal:condition="context/file">
+    <header tal:condition="nocall: context/file">
       <span tal:attributes="class string:file-mimetype ${view/get_mime_type_css_class}" />
       <div>
         <span class="title" tal:content="view/get_file_title" />
@@ -13,11 +13,11 @@
           <span class="title" i18n:translate="">Creator:</span>
           <span class="value" tal:content="structure view/get_creator_link"></span>
         </li>
-        <li tal:define="date view/get_document_date" tal:condition="date" class="detailItem">
+        <li tal:define="date view/get_document_date" tal:condition="nocall: date" class="detailItem">
           <span class="title" i18n:translate="">Document date:</span>
           <span class="value" tal:content="date"></span>
         </li>
-        <li tal:define="dossier view/get_containing_dossier" tal:condition="dossier" class="detailItem">
+        <li tal:define="dossier view/get_containing_dossier" tal:condition="nocall: dossier" class="detailItem">
            <span class="title" i18n:translate="">Dossier:</span>
            <a class="value" tal:attributes="href dossier/absolute_url" tal:content="dossier/Title"></a>
         </li>
@@ -33,37 +33,37 @@
     </main>
     <footer>
       <ul class="file-actions">
-        <li tal:define="link view/get_detail_view_url" tal:condition="link">
+        <li tal:define="link view/get_detail_view_url" tal:condition="nocall: link">
           <a id="action-view"
              tal:attributes="href link"
              i18n:translate="">Open detail view</a>
         </li>
-        <li id="action-download" tal:define="link view/get_download_copy_link" tal:condition="link" tal:content="structure link">
+        <li id="action-download" tal:define="link view/get_download_copy_link" tal:condition="nocall: link" tal:content="structure link">
         </li>
-        <li tal:define="link view/get_open_as_pdf_link" tal:condition="link">
+        <li tal:define="link view/get_open_as_pdf_link" tal:condition="nocall: link">
           <a id="action-pdf"
              tal:attributes="href link"
              i18n:translate="">Open as PDF</a>
         </li>
-        <li tal:define="link view/get_edit_metadata_url" tal:condition="link">
+        <li tal:define="link view/get_edit_metadata_url" tal:condition="nocall: link">
           <a id="action-edit"
              tal:attributes="href link"
              i18n:domain="plone"
              i18n:translate="">Edit metadata</a>
         </li>
-        <li tal:define="link view/get_checkout_url" tal:condition="link">
+        <li tal:define="link view/get_checkout_url" tal:condition="nocall: link">
           <a id="action-checkout"
              tal:attributes="href link"
              i18n:domain="plone"
              i18n:translate="">Checkout and edit</a>
         </li>
-        <li tal:define="link view/get_checkin_without_comment_url" tal:condition="link">
+        <li tal:define="link view/get_checkin_without_comment_url" tal:condition="nocall: link">
           <a id="action-checkin"
              tal:attributes="href link"
              i18n:domain="opengever.document"
              i18n:translate="">Checkin without comment</a>
         </li>
-        <li tal:define="link view/get_checkin_with_comment_url" tal:condition="link">
+        <li tal:define="link view/get_checkin_with_comment_url" tal:condition="nocall: link">
           <a id="action-checkin"
              tal:attributes="href link"
              i18n:domain="opengever.document"


### PR DESCRIPTION
- Omit diazo
- use `nocall:` in `tal:condition` to avoid rendering the whole dossier overview 😞 

This improves the overlay rendering time from ~600ms to ~75ms

Fixes #1837.