### PR TITLE
Show correct total document size in the showroom overlay if opening files from the list-view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Show correct total document size in the showroom overlay if opening files
+  from the list-view.
+  [elioschmutz]
+
 - Fix: Add GeverTabbedviewDictStorage adapter to handle bumblebee proxy views.
   Normally, the tabbedview is storing the last state (i.e. sorting) per user per tab.
   Since bumblebee requires a proxy view to determine if the list or the gallery should be

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -68,12 +68,32 @@
     }
   }
 
+  function getNumberOfDocuments(fallback_value) {
+    var galleryDocuments = $(".preview-listing").data('number-of-documents')
+
+    if ( $.isNumeric(galleryDocuments) ) {
+      // we are in gallery_view
+      return galleryDocuments;
+    }
+
+    if ( window.store ) {
+      // The store-attribute comes from ftw.table. If it's available,
+      // we are on a list view.
+      var listDocuments = store.totalLength
+      if ( $.isNumeric(listDocuments)) {
+        return listDocuments;
+      }
+    }
+    // we are somewhere else i.e. search view
+    return fallback_value;
+  }
+
   function updateShowroom() {
     var items = document.querySelectorAll(".showroom-item");
     var previewListing = $(".preview-listing");
 
     endpoint = previewListing.data("fetch-url");
-    numberOfDocuments = previewListing.data('number-of-documents') || items.length;
+    numberOfDocuments = getNumberOfDocuments(fallback_value=items.length);
     toggleShowMoreButton();
     scanForBrokenImages(".preview-listing");
 


### PR DESCRIPTION
Zeigt in der Listenansicht die korrekte Anzahl von Dokumenten im Shorwoomoverlay an.

![record](https://cloud.githubusercontent.com/assets/557005/15737488/8490b006-28a6-11e6-86f8-a56c3269dfb5.gif)

closes #1835 