### PR TITLE
Initialize the showroom correctly for dynamically loaded items in the search-view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Initialize the showroom correctly for dynamically loaded items in the search-view.
+  [elioschmutz]
+
 - Reindex documents after adding ftw.bumblebee.interfaces.IBumblebeeable to
   make sure object_provides is up to date.
   [deiferni]

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -47,6 +47,25 @@
   function init() {
     showroom = Showroom([], { 'tail': tail });
     updateShowroom();
+
+    // The search.js does not trigger an event after reloading the searchview.
+    // The only possiblity to update the showroom is to listen on the ajaxComplete
+    // event which will be triggered after every ajax request.
+    //
+    // First we have to check if we are really on the search-site to register
+    // the event-listener.
+    //
+    // If the event have been triggered, it is possible that it has been triggered
+    // by the showroom itself. If we do an updateShowroom while the overlay is open,
+    // we will destroy it. So we have to do this check first before updating
+    // the showroom.
+    if ($('#search-results').length) {
+      $( document ).ajaxComplete(function(event, jqXHR, params) {
+        if(params.url.indexOf("@@updated_search") !== -1) {
+          updateShowroom();
+        }
+      });
+    }
   }
 
   function updateShowroom() {


### PR DESCRIPTION
Suchresultate wurden nach dem Sortieren oder erneutem Suchen in der Search-View nicht mehr als Showroom-Items initialisiert.

Dieser PR behebt diese Probleme.

![record](https://cloud.githubusercontent.com/assets/557005/15747546/75201b0e-28db-11e6-97b3-fc7762056066.gif)
