### PR TITLE
Sortierreihenfolge wird im Dokumenttab wieder persistiert.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fix: Add GeverTabbedviewDictStorage adapter to handle bumblebee proxy views.
+  Normally, the tabbedview is storing the last state (i.e. sorting) per user per tab.
+  Since bumblebee requires a proxy view to determine if the list or the gallery should be
+  rendered, the mechanism to store and get the state was broken.
+  [elioschmutz]
+
 - Initialize the showroom correctly for dynamically loaded items in the search-view.
   [elioschmutz]
 

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -31,4 +31,10 @@
       provides="z3c.form.interfaces.IValidator"
       />
 
+  <adapter
+      factory=".tabbedviewstatestorage.GeverTabbedviewDictStorage"
+      provides="ftw.dictstorage.interfaces.IDictStorage"
+      for="zope.browser.interfaces.IBrowserView"
+      />
+
 </configure>

--- a/opengever/dossier/tabbedviewstatestorage.py
+++ b/opengever/dossier/tabbedviewstatestorage.py
@@ -1,9 +1,13 @@
-from Products.CMFCore.utils import getToolByName
 from five import grok
+from ftw.dictstorage.base import DictStorage
 from ftw.tabbedview.interfaces import IGridStateStorageKeyGenerator
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from zope.publisher.interfaces.browser import IBrowserView
+from opengever.tabbedview.interfaces import ITabbedViewProxy
+from Products.CMFCore.utils import getToolByName
 from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.publisher.interfaces.browser import IBrowserView
+
+PROXY_VIEW_POSTFIX = "-proxy"
 
 
 class DossierGridStateStorageKeyGenerator(grok.MultiAdapter):
@@ -36,3 +40,58 @@ class DossierGridStateStorageKeyGenerator(grok.MultiAdapter):
 
         # concatenate with "-"
         return '-'.join(key)
+
+
+class GeverTabbedviewDictStorage(DictStorage):
+    """The tabbedview uses the view as context to
+    get and store the tabbedview-state.
+
+    For the normal use, this works properly.
+
+    Since the bumblebee-integration we need a special case.
+
+    We have a proxy view which defines if the list or gallery
+    shoud be displayed. So we have a master-view for two subviews.
+
+    If the tabbedview will get the state while viewing a tab,
+    it will call the DictStorage with the subview as the context.
+
+    If it wants to store a new state, the tabbedview calls
+    the DictStorage with the master-view.
+
+    So we don't have the same config while storing and getting
+    the state.
+
+    To handle this, we have to change the accesskey and the
+    context to the subview.
+    """
+
+    def __init__(self, context):
+        context = self.change_proxy_context(context)
+        super(GeverTabbedviewDictStorage, self).__init__(context)
+
+    def __getitem__(self, key, default=None):
+        key = self.strip_proxy_postfix(key)
+        return super(GeverTabbedviewDictStorage, self).__getitem__(key, default)
+
+    def __setitem__(self, key, value):
+        key = self.strip_proxy_postfix(key)
+        return super(GeverTabbedviewDictStorage, self).__setitem__(key, value)
+
+    def __delitem__(self, key):
+        key = self.strip_proxy_postfix(key)
+        return super(GeverTabbedviewDictStorage, self).__setitem__(key)
+
+    def strip_proxy_postfix(self, value):
+        if ITabbedViewProxy.providedBy(self.context):
+            return value.rstrip(PROXY_VIEW_POSTFIX, '')
+
+    def change_proxy_context(self, view):
+        if ITabbedViewProxy.providedBy(view):
+            non_proxy_view_name = self.strip_proxy_postfix(view.__name__)
+            view = view.context.restrictedTraverse(non_proxy_view_name)
+
+        return view
+
+    get = __getitem__
+    set = __setitem__

--- a/opengever/dossier/tests/test_tabbedviewstatestorage.py
+++ b/opengever/dossier/tests/test_tabbedviewstatestorage.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from ftw.dictstorage.interfaces import IDictStorage
+
+
+class TestGeverTabbedviewDictStorage(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestGeverTabbedviewDictStorage, self).setUp()
+
+        self.repo, self.repo_folder = create(Builder('repository_tree'))
+
+        self.dossier = create(
+            Builder("dossier")
+            .titled(u"Testd\xf6ssier XY")
+            .within(self.repo_folder))
+
+        self.document = create(Builder("document").within(self.dossier))
+
+    def test_call_storage_with_proxy_will_change_context_to_subview(self):
+        proxy_view = self.document.restrictedTraverse(
+            'tabbedview_view-documents-proxy')
+
+        sub_view = self.document.restrictedTraverse(
+            'tabbedview_view-documents')
+
+        self.assertNotIsInstance(
+            IDictStorage(sub_view).context, proxy_view.__class__)
+        self.assertIsInstance(
+            IDictStorage(sub_view).context, sub_view.__class__)
+
+    def test_call_storage_with_subview_will_not_change_context(self):
+        sub_view = self.document.restrictedTraverse(
+            'tabbedview_view-documents')
+
+        self.assertIsInstance(
+            IDictStorage(sub_view).context, sub_view.__class__)

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -26,6 +26,7 @@ from opengever.tabbedview.helper import linked_trashed_document_with_tooltip
 from opengever.tabbedview.helper import readable_ogds_author
 from opengever.tabbedview.helper import readable_ogds_user
 from opengever.tabbedview.helper import workflow_state
+from opengever.tabbedview.interfaces import ITabbedViewProxy
 from plone.dexterity.interfaces import IDexterityContainer
 from Products.Five.browser.pagetemplatefile import BoundPageTemplate
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
@@ -45,6 +46,7 @@ class DocumentsProxy(grok.View):
     """
     grok.name('tabbedview_view-documents-proxy')
     grok.context(ITabbedView)
+    grok.implements(ITabbedViewProxy)
     grok.require('zope2.View')
 
     listview = "tabbedview_view-documents"

--- a/opengever/tabbedview/interfaces.py
+++ b/opengever/tabbedview/interfaces.py
@@ -13,3 +13,9 @@ class IGeverTableSourceConfig(ITableSourceConfig):
 
 class IGeverCatalogTableSourceConfig(IGeverTableSourceConfig, ICatalogTableSourceConfig):
     pass
+
+
+class ITabbedViewProxy(Interface):
+    """A tabbedview-view providing this interfaces is a master-tab
+    which defines which sub-view should be rendered (bumblebee).
+    """


### PR DESCRIPTION
Dieser PR fixt das problem, dass Tablestates für das Dokumenttab nicht mehr persistiert wurden.

closes #1850 