### PR TITLE
Fixed ReindexObjectProvidesAfterAddingIBumblebeeableInterface upgradestep

### DIFF
--- a/opengever/document/upgrades/20160601180404_reindex_object_provides_after_adding_i_bumblebeeable_interface/upgrade.py
+++ b/opengever/document/upgrades/20160601180404_reindex_object_provides_after_adding_i_bumblebeeable_interface/upgrade.py
@@ -12,4 +12,5 @@ class ReindexObjectProvidesAfterAddingIBumblebeeableInterface(UpgradeStep):
         msg = 'Reindex object_provides for documents.'
 
         for obj in self.objects(query, msg):
-            catalog.reindexObject(obj, idxs=['object_provides'])
+            catalog.reindexObject(obj, idxs=['object_provides'],
+                                  update_metadata=False)


### PR DESCRIPTION
The existing upgradestep, which was introduced with #1877, also updates the metadata. This is unnecessary because there is only a index `object_provides` but not a metadata.

@deiferni 