### PR TITLE
Prevent updating bumblebee checksum for checked out documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Prevent updating bumblebee checksum for checked out documents.
+  This no longer updates the preview pdf and thumbnails for checked
+  out documents and prevents that other users can see the working
+  copy.
+  [deiferni]
+
 - Added new attribute decision_draft to proposal, which allows to
   prefill the agendaitem's decision.
   [phgross]

--- a/opengever/bumblebee/service.py
+++ b/opengever/bumblebee/service.py
@@ -1,5 +1,6 @@
 from ftw.bumblebee.service import BumblebeeServiceV3
 from opengever.bumblebee import is_bumblebee_feature_enabled
+from opengever.document.document import IDocumentSchema
 
 
 class GeverBumblebeeService(BumblebeeServiceV3):
@@ -11,3 +12,15 @@ class GeverBumblebeeService(BumblebeeServiceV3):
 
         return super(GeverBumblebeeService, self).queue_storing(
             queue, deferred=deferred)
+
+    def handle_document_update(self):
+        """Do nothing when attempting to update a checked out document.
+
+        This prevents that a preview of a working copy is rendered, it would
+        be visible to all the other users as well.
+        """
+        if IDocumentSchema.providedBy(self.context):
+            if self.context.is_checked_out():
+                return
+
+        return super(GeverBumblebeeService, self).handle_document_update()


### PR DESCRIPTION
This no longer updates the preview pdf and thumbnails for checked
out documents and prevents that other users can see the working copy.

Closes #1844.

See also https://github.com/4teamwork/ftw.bumblebee/pull/88