### PR TITLE
Permanently lock submitted documents after proposal submission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Lock submitted documents after proposal submission.
+  [deiferni]
+
 - Fix links to checkin actions from overlay.
   [deiferni]
 

--- a/opengever/locking/info.py
+++ b/opengever/locking/info.py
@@ -1,6 +1,8 @@
 from opengever.base.oguid import Oguid
+from opengever.locking.lock import LOCK_TYPE_MEETING_SUBMITTED_LOCK
 from opengever.locking.lock import LOCK_TYPE_SYS_LOCK
 from opengever.meeting.model import GeneratedProtocol
+from opengever.meeting.model import SubmittedDocument
 from plone.locking.browser.info import LockInfoViewlet
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
@@ -9,26 +11,43 @@ class GeverLockInfoViewlet(LockInfoViewlet):
     """Locking Info Viewlet which renders different templates
     for different locking types.
     """
-    meeting_lock_template = ViewPageTemplateFile('templates/meeting_lock.pt')
+    meeting_lock_template = ViewPageTemplateFile(
+        'templates/meeting_lock.pt')
+    submitted_document_lock_template = ViewPageTemplateFile(
+        'templates/submitted_document_lock_template.pt')
+
+    # templates seem to be converted to BoundPageTemplate with acquisition
+    # magic, thus we cannot put the ViewPageTemplateFile instances directly
+    # into the mapping
+    custom_templates = {
+        LOCK_TYPE_SYS_LOCK: 'meeting_lock_template',
+        LOCK_TYPE_MEETING_SUBMITTED_LOCK: 'submitted_document_lock_template',
+    }
 
     def render(self):
-        if self.is_meeting_lock():
-            return self.meeting_lock_template()
+        custom_template_name = self.custom_templates.get(
+            self.get_lock_type_name())
+        if custom_template_name:
+            return getattr(self, custom_template_name)()
 
         return super(GeverLockInfoViewlet, self).render()
 
-    def is_meeting_lock(self):
+    def get_lock_type_name(self):
         lock_info = self.lock_info()
         if not lock_info:
-            return False
+            return None
 
         lock_type = lock_info.get('type')
         if not lock_type:
-            return False
+            return None
 
-        return lock_type.__name__ == LOCK_TYPE_SYS_LOCK
+        return lock_type.__name__
 
     def get_related_meeting_from_protocol(self):
         oguid = Oguid.for_object(self.context)
         protocol = GeneratedProtocol.get_one(oguid=oguid)
         return protocol.meeting
+
+    def get_source_document_from_submitted_document(self):
+        document = SubmittedDocument.query.get_by_target(self.context)
+        return document.resolve_source()if document else None

--- a/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-02 10:03+0000\n"
+"POT-Creation-Date: 2016-06-08 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,17 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
-#: ./opengever/locking/templates/protocol_lock.pt:12
+#: ./opengever/locking/templates/meeting_lock.pt:12
 msgid "description_locked_by_meeting"
 msgstr "Das Protokoll bleibt gesperrt bis die Sitzung ${meeting} abgeschlossen wurde."
+
+#. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
+#: ./opengever/locking/templates/submitted_document_lock_template.pt:12
+msgid "description_locked_linked_submitted_document"
+msgstr "Dieses Dokument wurde als Kopie von ${document} eingereicht und kann nicht direkt bearbeitet werden."
+
+#. Default: "This document has been submitted as a copy and cannot be edited directly."
+#: ./opengever/locking/templates/submitted_document_lock_template.pt:17
+msgid "description_locked_submitted_document"
+msgstr "Dieses Dokument wurde als Kopie eingereicht und kann nicht direkt bearbeitet werden"
 

--- a/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-02 10:03+0000\n"
+"POT-Creation-Date: 2016-06-08 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,17 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
-#: ./opengever/locking/templates/protocol_lock.pt:12
+#: ./opengever/locking/templates/meeting_lock.pt:12
 msgid "description_locked_by_meeting"
+msgstr ""
+
+#. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
+#: ./opengever/locking/templates/submitted_document_lock_template.pt:12
+msgid "description_locked_linked_submitted_document"
+msgstr ""
+
+#. Default: "This document has been submitted as a copy and cannot be edited directly."
+#: ./opengever/locking/templates/submitted_document_lock_template.pt:17
+msgid "description_locked_submitted_document"
 msgstr ""
 

--- a/opengever/locking/locales/opengever.locking.pot
+++ b/opengever/locking/locales/opengever.locking.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-02 10:03+0000\n"
+"POT-Creation-Date: 2016-06-08 15:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,17 @@ msgstr ""
 "Domain: opengever.locking\n"
 
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
-#: ./opengever/locking/templates/protocol_lock.pt:12
+#: ./opengever/locking/templates/meeting_lock.pt:12
 msgid "description_locked_by_meeting"
+msgstr ""
+
+#. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
+#: ./opengever/locking/templates/submitted_document_lock_template.pt:12
+msgid "description_locked_linked_submitted_document"
+msgstr ""
+
+#. Default: "This document has been submitted as a copy and cannot be edited directly."
+#: ./opengever/locking/templates/submitted_document_lock_template.pt:17
+msgid "description_locked_submitted_document"
 msgstr ""
 

--- a/opengever/locking/lock.py
+++ b/opengever/locking/lock.py
@@ -6,3 +6,9 @@ LOCK_TYPE_SYS_LOCK = u'sys.lock'
 
 SYS_LOCK = LockType(LOCK_TYPE_SYS_LOCK, stealable=True, user_unlockable=True,
                     timeout=MAX_TIMEOUT)
+
+
+LOCK_TYPE_MEETING_SUBMITTED_LOCK = u'meeting.submitted.lock'
+MEETING_SUBMITTED_LOCK = LockType(
+    LOCK_TYPE_MEETING_SUBMITTED_LOCK,
+    stealable=True, user_unlockable=True, timeout=MAX_TIMEOUT)

--- a/opengever/locking/templates/submitted_document_lock_template.pt
+++ b/opengever/locking/templates/submitted_document_lock_template.pt
@@ -1,0 +1,24 @@
+<div id="plone-lock-status"
+     i18n:domain="opengever.locking"
+     tal:define="locked view/info/is_locked_for_current_user;
+                 document view/get_source_document_from_submitted_document;">
+  <tal:block condition="locked">
+    <dl class="portalMessage info">
+      <dt i18n:domain="plone" i18n:translate="label_locked">Locked</dt>
+      <dd>
+        <tal:author-page tal:condition="nocall: document"
+            i18n:translate="description_locked_linked_submitted_document">
+          This document has been submitted as a copy of
+          <a i18n:name="document"
+             tal:content="document/Title"
+             tal:attributes="href document/absolute_url" />
+          and cannot be edited directly.
+        </tal:author-page>
+        <tal:author-page tal:condition="not: nocall: document"
+            i18n:translate="description_locked_submitted_document">
+          This document has been submitted as a copy and cannot be edited directly.
+        </tal:author-page>
+      </dd>
+    </dl>
+  </tal:block>
+</div>

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -418,7 +418,7 @@ class CopyProposalDocumentCommand(object):
             document_title=self.document.title))
 
     def copy_document(self, target_path, target_admin_unit_id):
-        return OgCopyCommandWithElevatedPrivileges(
+        return SubmitDocumentCommand(
             self.document, target_admin_unit_id, target_path).execute()
 
 
@@ -433,8 +433,17 @@ class OgCopyCommand(object):
         return Transporter().transport_to(
             self.source, self.target_admin_unit_id, self.target_path)
 
+
 class OgCopyCommandWithElevatedPrivileges(OgCopyCommand):
 
     def execute(self):
         return Transporter().transport_to_with_elevated_privileges(
             self.source, self.target_admin_unit_id, self.target_path)
+
+
+class SubmitDocumentCommand(OgCopyCommand):
+
+    def execute(self):
+        return Transporter().transport_to(
+            self.source, self.target_admin_unit_id, self.target_path,
+            view='recieve-submitted-document')

--- a/opengever/meeting/model/submitteddocument.py
+++ b/opengever/meeting/model/submitteddocument.py
@@ -52,3 +52,8 @@ class SubmittedDocument(Base):
 
     def resolve_submitted(self):
         return self.submitted_oguid.resolve_object()
+
+    def resolve_source(self):
+        """Resolve the source document."""
+
+        return self.oguid.resolve_object()

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -11,8 +11,10 @@ from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
 from plone import api
 from plone.app.testing import TEST_USER_ID
+from plone.locking.interfaces import ILockable
 from zExceptions import Unauthorized
 import transaction
+from opengever.locking.lock import MEETING_SUBMITTED_LOCK
 
 
 class TestProposalViewsDisabled(FunctionalTestCase):
@@ -515,7 +517,7 @@ class TestProposal(FunctionalTestCase):
         proposal_model.execute_transition('scheduled-decided')
         self.assertFalse(proposal.is_submit_additional_documents_allowed())
 
-    def test_submit_additional_document_creates_new_document(self):
+    def test_submit_additional_document_creates_new_locked_document(self):
         committee = create(Builder('committee').titled('My committee'))
         document = create(Builder('document')
                           .within(self.dossier)
@@ -537,6 +539,11 @@ class TestProposal(FunctionalTestCase):
         self.assertEqual(document.Title(), submitted_document.Title())
         self.assertEqual(document.file.filename,
                          submitted_document.file.filename)
+
+        # submitted document should be locked by custom lock
+        lockable = ILockable(submitted_document)
+        self.assertTrue(lockable.locked())
+        self.assertTrue(lockable.can_safely_unlock(MEETING_SUBMITTED_LOCK))
 
         self.assertSubmittedDocumentCreated(proposal, document, submitted_document)
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -329,6 +329,16 @@ class TestProposal(FunctionalTestCase):
 
         self.assertSubmittedDocumentCreated(proposal, document, submitted_document)
 
+        # document should have custom lock message
+        browser.open(submitted_document)
+        self.assertEqual(
+            ['This document has been submitted as a copy of A Document and '
+             'cannot be edited directly.'],
+            info_messages())
+        self.assertEqual(
+            document.absolute_url(),
+            browser.css('.portalMessage.info a').first.get('href'))
+
     @browsing
     def test_dossier_reference_number_is_set_on_creation(self, browser):
         committee = create(Builder('committee_model'))

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -72,7 +72,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
                 physical_path,
                 view='update-submitted-document')
 
-    def test_database_entry_is_deleted_when_removing_target_document(self):
+    def test_database_entry_is_deleted_when_removing_submitted_proposal(self):
         self.grant('Manager')
         proposal = create(Builder('proposal')
                           .within(self.dossier)
@@ -86,12 +86,12 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         self.assertIsNotNone(
             SubmittedDocument.query.get_by_target(submitted_document))
 
-        api.content.delete(submitted_document)
+        api.content.delete(submitted_proposal)
 
         self.assertIsNone(
             SubmittedDocument.query.get_by_target(submitted_document))
 
-    def test_database_entry_is_deleted_when_removing_source_document(self):
+    def test_database_entry_is_deleted_when_removing_proposal(self):
         self.grant('Manager')
         proposal = create(Builder('proposal')
                           .within(self.dossier)


### PR DESCRIPTION
This prevents that the document-copy is edited and gets out of  sync with its master document. Also a custom lock message is displayed for such documents.

![screen shot 2016-06-08 at 18 02 25](https://cloud.githubusercontent.com/assets/736583/15901331/2bde8a6c-2da3-11e6-89dc-e31c1cc3d43b.png)

Closes #1421.