### PR TITLE
Fixed textfiltering for task listings on PostgreSQL.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fixed textfiltering for task listings on PostgreSQL.
+  [phgross]
+
 - Prevent updating bumblebee checksum for checked out documents.
   This no longer updates the preview pdf and thumbnails for checked
   out documents and prevents that other users can see the working

--- a/opengever/tabbedview/sqlsource.py
+++ b/opengever/tabbedview/sqlsource.py
@@ -3,8 +3,10 @@ from ftw.table.interfaces import ITableSource
 from opengever.tabbedview import GeverTableSource
 from opengever.tabbedview.interfaces import IGeverTableSourceConfig
 from sqlalchemy import or_
+from sqlalchemy import String
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql.expression import asc
+from sqlalchemy.sql.expression import cast
 from sqlalchemy.sql.expression import column
 from sqlalchemy.sql.expression import desc
 from zope.interface import Interface
@@ -77,8 +79,9 @@ class SqlTableSource(GeverTableSource):
                 # Issue #759
                 query.session
 
-                query = query.filter(
-                    or_(*[field.like(term) for field in self.searchable_columns]))
+                query = query.filter(or_(
+                    *[cast(field, String).like(term)
+                      for field in self.searchable_columns]))
 
         return query
 

--- a/opengever/tabbedview/tests/test_sqlsource.py
+++ b/opengever/tabbedview/tests/test_sqlsource.py
@@ -1,0 +1,72 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestTextFilter(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestTextFilter, self).setUp()
+
+        self.dossier = create(Builder('dossier'))
+        self.task1 = create(Builder('task')
+                            .within(self.dossier)
+                            .having(text=u'\xfcberpr\xfcfung')
+                            .titled('Task A'))
+        self.task2 = create(Builder('task')
+                            .within(self.dossier)
+                            .titled('Closed Task B'))
+        self.task3 = create(Builder('task')
+                            .within(self.dossier)
+                            .titled('Task C'))
+
+    @browsing
+    def test_filtering_on_title(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks',
+            data={'searchable_text': 'Task'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Task A', 'Closed Task B', 'Task C'],
+                          [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_filtering_on_title_with_multiple_terms(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks',
+            data={'searchable_text': 'Task Closed'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Closed Task B'],
+                          [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_filtering_on_text(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks',
+            data={'searchable_text': u'\xfcberp'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Task A'],
+                          [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_filtering_on_integer_columns(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks',
+            data={'searchable_text': '3'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Task C'],
+                          [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_filtering_on_multiple_attributes(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks',
+            data={'searchable_text': 'Task 3'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Task C'],
+                          [row.get('Title') for row in table.dicts()])


### PR DESCRIPTION
When using PostgreSQL as OGDS and GlobalIndex Database the tabbedview textfilter has not worked because the sequence_number column is part of the listings searchable_columns. The LIKE operator does not work for Integer columns on PostgresSql, therefore we had to extend the query with a Cast.

Fixes #1884.
@deiferni I've found a better way to fix that issue ... 😄 

Note: Sadly all the tests has no value on working on PostgreSQL, because we use SQLite on the testsetup. 😏 