### PR TITLE
Fix document overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fix document overview.
+  [Kevin Bieri]
+
 - Fixed textfiltering for task listings on PostgreSQL.
   [phgross]
 

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -106,7 +106,7 @@
   }
 
   function initSingleShowroom() {
-    var items = document.querySelectorAll(".showroom-item");
+    var items = [].slice.call(document.querySelectorAll(".showroom-item"));
     var previewListing = $(".preview-listing");
 
     endpoint = previewListing.data("fetch-url");


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/1906

`NodeList` is not iterable so the `forEach` does not work here.
Convert the `NodeList` to an iterable Array to have the `forEach`.