### PR TITLE
Fix bumblebeeability check for documents that are not digitally available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fix bumblebeeability check for documents that are not digitally available.
+  [deiferni]
+
 - Update bumblebee when documents are checked in and reverted
   to a previous version.
   [deiferni]

--- a/opengever/bumblebee/__init__.py
+++ b/opengever/bumblebee/__init__.py
@@ -5,7 +5,9 @@ from opengever.mail.mail import IOGMailMarker
 from plone import api
 from zope.globalrequest import getRequest
 
+
 BUMBLEBEE_VIEW_COOKIE_NAME = 'bumblebee-view'
+SUPPORTED_CONTENT_TYPES = ['opengever.document.document', 'ftw.mail.mail']
 
 
 def get_not_digitally_available_placeholder_image_url():
@@ -78,10 +80,11 @@ def get_prefered_listing_view():
 
 
 def is_bumblebeeable(brain):
-    """Return whether the brain has a bumblebee_checksum.
+    """Return whether the brain is bumblebeeable.
 
-    The checksum is only available for objects that provide IBumblebeeable,
-    so we use it to detect if a brain's object is IBumblebeeable without
-    loading the object.
+    Being bumblebeeable is a decision which is made on a per content-type
+    basis. Plone content-types are marked as bumblebeeable by providing a
+    marker interface. There is no metadata for object_provides on a brain
+    so we do a portal_type check instead.
     """
-    return bool(brain.bumblebee_checksum)
+    return brain.portal_type in SUPPORTED_CONTENT_TYPES

--- a/opengever/bumblebee/tests/test_utils.py
+++ b/opengever/bumblebee/tests/test_utils.py
@@ -92,26 +92,26 @@ class TestIsBumblebeeable(FunctionalTestCase):
 
         self.assertTrue(is_bumblebeeable(brain))
 
+    def test_mails_are_bumblebeeable(self):
+        mail = create(Builder('mail'))
+        brain = obj2brain(mail)
+
+        self.assertTrue(is_bumblebeeable(brain))
+
     def test_dossiers_are_not_bumblebeeable(self):
-        document = create(Builder('dossier'))
-        brain = obj2brain(document)
-
-        self.assertFalse(is_bumblebeeable(brain))
-
-    def test_mails_are_not_bumblebeeable(self):
-        document = create(Builder('mail'))
-        brain = obj2brain(document)
+        dossier = create(Builder('dossier'))
+        brain = obj2brain(dossier)
 
         self.assertFalse(is_bumblebeeable(brain))
 
     def test_repositories_are_not_bumblebeeable(self):
-        document = create(Builder('repository'))
-        brain = obj2brain(document)
+        repository = create(Builder('repository'))
+        brain = obj2brain(repository)
 
         self.assertFalse(is_bumblebeeable(brain))
 
     def test_repo_roots_are_not_bumblebeeable(self):
-        document = create(Builder('repository_root'))
-        brain = obj2brain(document)
+        repository_root = create(Builder('repository_root'))
+        brain = obj2brain(repository_root)
 
         self.assertFalse(is_bumblebeeable(brain))

--- a/opengever/bumblebee/tests/test_utils.py
+++ b/opengever/bumblebee/tests/test_utils.py
@@ -84,7 +84,7 @@ class TestGetRepresentationUrlByBrain(FunctionalTestCase):
             get_representation_url_by_brain('thumbnail', mail))
 
 
-def TestIsBumblebeeable(FunctionalTestCase):
+class TestIsBumblebeeable(FunctionalTestCase):
 
     def test_documents_are_bumblebeeable(self):
         document = create(Builder('document').with_dummy_content())


### PR DESCRIPTION
Being bumblebeeable is a decision which is made on a per content-type basis. Plone content-types are marked as bumblebeeable by providing a marker interface. There is no metadata for object_provides on a brain (only an index)  so we do a portal_type check instead.

Fixes #1905.