### PR TITLE
Display repositoryfolder description above the byline.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Display repositoryfolder description above the byline.
+  [phgross]
+
 - Change background color of download confirmation dialog to partial transparent black.
   [Kevin Bieri, phgross]
 

--- a/opengever/base/viewlets/byline.pt
+++ b/opengever/base/viewlets/byline.pt
@@ -2,6 +2,11 @@
      id="plone-document-byline"
      tal:condition="view/show">
 
+  <div class="description"
+       tal:condition="view/show_description"
+       tal:content="view/get_description"
+       tal:attributes="title view/get_description" />
+
   <ul tal:define="css_class view/get_css_class">
     <tal:repeat tal:repeat="item view/get_items">
       <li tal:attributes="class item/class" tal:condition="item/content">

--- a/opengever/base/viewlets/byline.py
+++ b/opengever/base/viewlets/byline.py
@@ -19,6 +19,13 @@ class BylineBase(content.DocumentBylineViewlet):
     def get_css_class(self):
         return get_css_class(self.context)
 
+    @property
+    def show_description(self):
+        return False
+
+    def get_description(self):
+        return None
+
     @memoize
     def sequence_number(self):
         seqNumb = getUtility(ISequenceNumber)

--- a/opengever/repository/tests/test_repositoryfolder_byline.py
+++ b/opengever/repository/tests/test_repositoryfolder_byline.py
@@ -1,10 +1,12 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
 from opengever.base.behaviors.classification import PRIVACY_LAYER_NO
 from opengever.base.tests.byline_base_test import TestBylineBase
 from opengever.testing import create_ogds_user
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
+import transaction
 
 
 class TestRepositoryfolderByline(TestBylineBase):
@@ -31,3 +33,19 @@ class TestRepositoryfolderByline(TestBylineBase):
         self.assertIsNone(
             public_trial,
             "Public trial must NOT be part of repository byline any more")
+
+    @browsing
+    def test_description_is_shown_when_exists(self, browser):
+        self.repo.description = u'Etiam ultricies nisi vel augue.'
+        transaction.commit()
+
+        browser.login().open(self.repo)
+
+        self.assertEquals([u'Etiam ultricies nisi vel augue.'],
+                          browser.css('.documentByLine .description').text)
+
+    @browsing
+    def test_description_div_is_not_shown_when_no_description_exist(self, browser):
+        browser.login().open(self.repo)
+
+        self.assertEquals([], browser.css('.documentByLine .description'))

--- a/opengever/repository/viewlets/byline.py
+++ b/opengever/repository/viewlets/byline.py
@@ -6,6 +6,13 @@ from zope.i18n import translate
 
 class RepositoryByline(BylineBase):
 
+    @property
+    def show_description(self):
+        return bool(self.context.description)
+
+    def get_description(self):
+        return self.context.description
+
     def privacy_layer(self):
         return translate(self.context.privacy_layer,
                          context=self.request,


### PR DESCRIPTION
It only displays one line of the description (crop it when its to long), but the complete description is available as a tooltip text.

<img width="1184" alt="bildschirmfoto 2016-06-10 um 08 20 14" src="https://cloud.githubusercontent.com/assets/485755/15955940/529215a0-2ee5-11e6-94bd-9be34c76997a.png">
<img width="1183" alt="bildschirmfoto 2016-06-10 um 08 20 29" src="https://cloud.githubusercontent.com/assets/485755/15955943/54b441e6-2ee5-11e6-8289-4dbda9b6f045.png">

Fixes #1706.

@deiferni please have a look