### PR TITLE
	Change background color of download confirmation dialog to partial transparent black.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Change background color of download confirmation dialog to partial transparent black.
+  [Kevin Bieri, phgross]
+
 - Fix document overview.
   [Kevin Bieri]
 

--- a/opengever/base/browser/resources/prepoverlay.js
+++ b/opengever/base/browser/resources/prepoverlay.js
@@ -1,19 +1,20 @@
 $(function() {
-    $('.link-overlay').live('click', function(event) {
+  $('.link-overlay').live('click', function(event) {
 
-        event.preventDefault();
+    event.preventDefault();
 
-        var events = $(this).data('events');
+    var events = $(this).data('events');
 
-        if (!events || !events.click) {
-             $(this).prepOverlay({
-                 subtype:'ajax',
-                 urlmatch:'$',
-                 urlreplace:''
-             });
+    if (!events || !events.click) {
+      $(this).prepOverlay({
+        subtype: 'ajax',
+        urlmatch: '$',
+        urlreplace: '',
+        config: { expose: { color: "#000" } }
+      });
 
-            $(this).trigger('click');
-        }
+      $(this).trigger('click');
+    }
 
-    });
+  });
 });

--- a/opengever/base/browser/resources/prepoverlay.js
+++ b/opengever/base/browser/resources/prepoverlay.js
@@ -3,15 +3,25 @@ $(function() {
 
     event.preventDefault();
 
+    var config = {
+      subtype: 'ajax',
+      urlmatch: '$',
+      urlreplace: '',
+      config: {
+        mask: {
+          color: "#fff"
+        }
+      }
+    };
+
+    if($(event.currentTarget).hasClass("modal")) {
+      config.config.mask.color = "#000";
+    }
+
     var events = $(this).data('events');
 
     if (!events || !events.click) {
-      $(this).prepOverlay({
-        subtype: 'ajax',
-        urlmatch: '$',
-        urlreplace: '',
-        config: { expose: { color: "#000" } }
-      });
+      $(this).prepOverlay(config);
 
       $(this).trigger('click');
     }

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -127,7 +127,7 @@ class DownloadConfirmationHelper(object):
                      viewname='download', include_token=False):
         if self.is_active():
             viewname = 'file_download_confirmation'
-            clazz = 'link-overlay {0}'.format(' '.join(additional_classes))
+            clazz = 'link-overlay modal {0}'.format(' '.join(additional_classes))
         else:
             clazz = ' '.join(additional_classes)
 

--- a/opengever/document/browser/templates/file.pt
+++ b/opengever/document/browser/templates/file.pt
@@ -50,7 +50,7 @@
           </tal:cond>
           <tal:cond tal:condition="not: copy_download_available">
             &nbsp;|&nbsp;
-            <span class="function-download-copy-inactive link-overlay discreet"
+            <span class="function-download-copy-inactive link-overlay modal discreet"
                   i18n:translate="label_download_copy">Download copy</span>
           </tal:cond>
         </div>

--- a/opengever/document/widgets/no_download_input.pt
+++ b/opengever/document/widgets/no_download_input.pt
@@ -27,7 +27,7 @@
                 allow_nochange view/allow_nochange;">
     <span tal:condition="python: exists and action=='nochange'">
         <span tal:attributes="class context/css_class"></span>
-        <a class="link-overlay" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
+        <a class="link-overlay modal" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
         <span class="discreet"> &mdash;
             <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB
         </span>


### PR DESCRIPTION
Change background color of download confirmation dialog to partial transparent black.

The rest of the overlays keep their color (partially transparent white).