### PR TITLE
Update bumblebee documents after checkin and revert.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Update bumblebee when documents are checked in and reverted
+  to a previous version.
+  [deiferni]
+
 - Display repositoryfolder description above the byline.
   [phgross]
 

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -34,6 +34,16 @@
     <include package=".viewlets" />
     <include package=".upgrades" />
 
+    <subscriber
+        for="ftw.bumblebee.interfaces.IBumblebeeable
+             opengever.document.interfaces.IObjectCheckedInEvent"
+        handler="ftw.bumblebee.subscribers.handle_bumblebee_update" />
+
+    <subscriber
+        for="ftw.bumblebee.interfaces.IBumblebeeable
+             opengever.document.interfaces.IObjectRevertedToVersion"
+        handler="ftw.bumblebee.subscribers.handle_bumblebee_update" />
+
     <!-- Register locales translations -->
     <i18n:registerTranslations directory="locales" />
 


### PR DESCRIPTION
Register bumblebee event handler to also listen to checkin and revert events which don't fire an object-modified event.

Fixes #1914.