### PR TITLE
Fix public_trial indexer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fix public_trial indexer.
+  (Adapt object to behavior interface before accessing attribute)
+  [lgraf]
+
 - Lock submitted documents after proposal submission.
   [deiferni]
 

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -1,8 +1,10 @@
 from Acquisition import aq_inner
 from collective import dexteritytextindexer
 from five import grok
+from opengever.base.behaviors.classification import IClassification
+from opengever.base.behaviors.classification import IClassificationMarker
 from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
-from opengever.document.behaviors import IBaseDocument
+from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
@@ -12,8 +14,8 @@ from Products.CMFCore.utils import getToolByName
 from ZODB.POSException import ConflictError
 from zope.component import getUtility, queryMultiAdapter, getAdapter
 from zope.interface import Interface
+
 import logging
-from opengever.document.behaviors.metadata import IDocumentMetadata
 
 
 logger = logging.getLogger('opengever.document')
@@ -153,9 +155,9 @@ def sortable_author(obj):
 grok.global_adapter(sortable_author, name='sortable_author')
 
 
-@indexer(IBaseDocument)
+@indexer(IClassificationMarker)
 def public_trial(obj):
-    public_trial = obj.public_trial
+    public_trial = IClassification(obj).public_trial
     if public_trial:
         return public_trial
 


### PR DESCRIPTION
Adapt object to behavior interface before accessing the `public_trial` attribute.

Not 100% sure yet why the old version of the indexer ever worked, but my suspicion it's due to a combination of acquisition and dexterity's `__getattr__` fallback, that lead to the value being acquired from a parent or a default value generator.

@phgross  

Fixes #1918 