### PR TITLE
Revert "Use defaultFactory for IClassification public_trial instead of form level defaults."

### DIFF
--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -2,12 +2,13 @@ from five import grok
 from opengever.base import _
 from opengever.base.behaviors import utils
 from opengever.base.utils import language_cache_key
-from plone import api
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
 from plone.memoize import ram
+from plone.registry.interfaces import IRegistry
 from zope import schema
+from zope.component import getUtility
 from zope.i18n import translate
 from zope.interface import alsoProvides, Interface
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
@@ -33,13 +34,6 @@ def translated_public_trial_terms(context, request):
         values[term] = translate(term, context=request,
                                  domain="opengever.base")
     return values
-
-
-def public_trial_default():
-    """Default value for `public_trial` field for new documents.
-    """
-    return api.portal.get_registry_record(
-        'public_trial_default_value', interface=IClassificationSettings)
 
 
 class IClassification(form.Schema):
@@ -74,7 +68,6 @@ class IClassification(form.Schema):
         description=_(u'help_public_trial', default=u''),
         source=u'classification_public_trial_vocabulary',
         required=True,
-        defaultFactory=public_trial_default,
     )
 
     public_trial_statement = schema.Text(
@@ -180,6 +173,18 @@ form.default_value(field=IClassification['privacy_layer'])(
         default=PRIVACY_LAYER_NO
     )
 )
+
+
+# XXX: Setting the default value in the field directly, breaks the
+# DCFieldProperty stuff. thus we implement the default value this way.
+@form.default_value(field=IClassification['public_trial'])
+def default_public_trial(data):
+    """Default value for `public_trial` field for new documents.
+    """
+    registry = getUtility(IRegistry)
+    settings = registry.forInterface(IClassificationSettings)
+    public_trial_default_value = settings.public_trial_default_value
+    return public_trial_default_value
 
 
 class Classification(metadata.MetadataBase):


### PR DESCRIPTION
This reverts commit 42462ffc32309dea09f46e8e417c452b9db27355.

Changing the default for `public_trial` from a form-level default to a `defaultFactory` has broken attribute access. (See #1918). Revert the change until we figure out why.

@phgross 