### PR TITLE
Fix select all

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fix error: AttributeError: 'DocumentsProxy' object has no attribute 'select_all'.
+  [elioschmutz]
+
 - Fix public_trial indexer.
   (Adapt object to behavior interface before accessing attribute)
   [lgraf]

--- a/opengever/dossier/tests/test_tabbedviewstatestorage.py
+++ b/opengever/dossier/tests/test_tabbedviewstatestorage.py
@@ -1,7 +1,50 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.testing import FunctionalTestCase
 from ftw.dictstorage.interfaces import IDictStorage
+from ftw.tabbedview.interfaces import IGridStateStorageKeyGenerator
+from opengever.tabbedview.interfaces import ITabbedViewProxy
+from opengever.testing import FunctionalTestCase
+from zope.component import getMultiAdapter
+
+
+class TestDossierGridStateStorageKeyGenerator(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDossierGridStateStorageKeyGenerator, self).setUp()
+
+        self.repo, self.repo_folder = create(Builder('repository_tree'))
+
+        self.dossier = create(
+            Builder("dossier")
+            .titled(u"Testd\xf6ssier XY")
+            .within(self.repo_folder))
+
+    def test_get_key_returns_proxy_view_without_postfix_on_dossier(self):
+        view = self.dossier.restrictedTraverse('tabbedview_view-documents-proxy')
+
+        self.assertTrue(ITabbedViewProxy.providedBy(view))
+
+        generator = getMultiAdapter((self.dossier, view, self.request),
+                                    IGridStateStorageKeyGenerator)
+
+        self.assertEqual(
+            'ftw.tabbedview-openever.dossier-tabbedview_view-documents-test_user_1_',
+            generator.get_key())
+
+
+class TestFrontPageDossierGridStateStorageKeyGenerator(FunctionalTestCase):
+
+    def test_get_key_returns_proxy_view_without_postfix_on_front_page(self):
+        view = self.portal.restrictedTraverse('tabbedview_view-mydocuments-proxy')
+
+        self.assertTrue(ITabbedViewProxy.providedBy(view))
+
+        generator = getMultiAdapter((self.portal, view, self.request),
+                                    IGridStateStorageKeyGenerator)
+
+        self.assertEqual(
+            'ftw.tabbedview-openever.dossier-tabbedview_view-mydocuments-test_user_1_',
+            generator.get_key())
 
 
 class TestGeverTabbedviewDictStorage(FunctionalTestCase):
@@ -16,13 +59,11 @@ class TestGeverTabbedviewDictStorage(FunctionalTestCase):
             .titled(u"Testd\xf6ssier XY")
             .within(self.repo_folder))
 
-        self.document = create(Builder("document").within(self.dossier))
-
     def test_call_storage_with_proxy_will_change_context_to_subview(self):
-        proxy_view = self.document.restrictedTraverse(
+        proxy_view = self.dossier.restrictedTraverse(
             'tabbedview_view-documents-proxy')
 
-        sub_view = self.document.restrictedTraverse(
+        sub_view = self.dossier.restrictedTraverse(
             'tabbedview_view-documents')
 
         self.assertNotIsInstance(
@@ -31,8 +72,25 @@ class TestGeverTabbedviewDictStorage(FunctionalTestCase):
             IDictStorage(sub_view).context, sub_view.__class__)
 
     def test_call_storage_with_subview_will_not_change_context(self):
-        sub_view = self.document.restrictedTraverse(
+        sub_view = self.dossier.restrictedTraverse(
             'tabbedview_view-documents')
 
         self.assertIsInstance(
             IDictStorage(sub_view).context, sub_view.__class__)
+
+    def test_strip_proxy_returns_proxy_view_without_postfix(self):
+        view = self.dossier.restrictedTraverse('tabbedview_view-documents-proxy')
+
+        self.assertTrue(ITabbedViewProxy.providedBy(view))
+        self.assertEqual(
+            'tabbedview_view-documents',
+            IDictStorage(view).strip_proxy_postfix(view, view.__name__))
+
+    def test_strip_proxy_postfix_will_replace_only_if_ITabbedViewProxy_is_provided(self):
+        view = self.dossier.restrictedTraverse('tabbedview_view-documents')
+        value = 'documents_view-documents-proxy'
+
+        self.assertFalse(ITabbedViewProxy.providedBy(view))
+        self.assertEqual(
+            'documents_view-documents-proxy',
+            IDictStorage(view).strip_proxy_postfix(view, value))

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -34,6 +34,9 @@ from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 
 
+PROXY_VIEW_POSTFIX = "-proxy"
+
+
 def translate_public_trial_options(item, value):
     portal = getSite()
     request = getRequest()
@@ -62,6 +65,10 @@ class DocumentsProxy(BaseCatalogListingTab):
                 prefered_view = self.galleryview
 
         return self.context.restrictedTraverse(prefered_view)()
+
+    @property
+    def name_without_postfix(self):
+        return self.__name__.rstrip(PROXY_VIEW_POSTFIX)
 
 
 class Documents(BaseCatalogListingTab):

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -40,7 +40,7 @@ def translate_public_trial_options(item, value):
     return portal.translate(value, context=request, domain="opengever.base")
 
 
-class DocumentsProxy(grok.View):
+class DocumentsProxy(BaseCatalogListingTab):
     """This proxyview is looking for the last used documents
     view (list or gallery) and reopens this view.
     """

--- a/opengever/tabbedview/interfaces.py
+++ b/opengever/tabbedview/interfaces.py
@@ -1,5 +1,6 @@
 from ftw.table.interfaces import ICatalogTableSourceConfig
 from ftw.table.interfaces import ITableSourceConfig
+from zope.interface import Attribute
 from zope.interface import Interface
 
 
@@ -19,3 +20,8 @@ class ITabbedViewProxy(Interface):
     """A tabbedview-view providing this interfaces is a master-tab
     which defines which sub-view should be rendered (bumblebee).
     """
+
+    name_without_postfix = Attribute(
+        "Returns the viewname without the prefix. "
+        "In some cases we need the original tabbedview-name without the"
+        "proxy prefix (i.e. to store and load the gridstate")

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -5,10 +5,13 @@ from ftw.testbrowser import browsing
 from opengever.bumblebee import BUMBLEBEE_VIEW_COOKIE_NAME
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.tabbedview.browser.bumblebee_gallery import BumblebeeGalleryMixin
+from opengever.tabbedview.browser.tabs import DocumentsProxy
+from opengever.tabbedview.interfaces import ITabbedViewProxy
 from opengever.testing import FunctionalTestCase
 from plone import api
 from zExceptions import NotFound
 from zope.component import getMultiAdapter
+from zope.interface.verify import verifyClass
 import transaction
 
 
@@ -377,6 +380,9 @@ class TestBumblebeeDocumentsProxyWithActivatedFeature(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 
+    def test_verify_class(self):
+        verifyClass(ITabbedViewProxy, DocumentsProxy)
+
     @browsing
     def test_set_cookie_to_the_last_accessed_bumblebee_view(self, browser):
         dossier = create(Builder('dossier'))
@@ -412,6 +418,14 @@ class TestBumblebeeDocumentsProxyWithActivatedFeature(FunctionalTestCase):
         self.assertEqual(
             'List',
             browser.css('.ViewChooser .active').first.text)
+
+    def test_name_without_postfix_will_replace_the_proxy_addition_on_end_of_string(self):
+        dossier = create(Builder('dossier'))
+
+        view = dossier.restrictedTraverse('tabbedview_view-documents-proxy')
+
+        self.assertEqual('tabbedview_view-documents-proxy', view.__name__)
+        self.assertEqual('tabbedview_view-documents', view.name_without_postfix)
 
 
 class TestDocumentsGalleryFetch(FunctionalTestCase):


### PR DESCRIPTION
This PR will fix error from sentry: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/673/

```bash
AttributeError: 'DocumentsProxy' object has no attribute 'select_all'
  File "ZPublisher/Publish.py", line 138, in publish
    request, bind=1)
  File "ZPublisher/mapply.py", line 77, in mapply
    if debug is not None: return debug(object,args,context)
  File "ZPublisher/Publish.py", line 48, in call_object
    result=apply(object,args) # Type s<cr> to step into published object.
  File "home/zope/eggs/ftw.tabbedview-3.5.0-py2.7.egg/ftw/tabbedview/browser/tabbed.py", line 216, in select_all
    return self.tab.select_all()
```

How to reproduce the issue:

![without_select_all](https://cloud.githubusercontent.com/assets/557005/16074960/27ccc8f4-32ed-11e6-9938-95fd5c8bb675.gif)

Behavior with the PR-Fix:

![with_select_all](https://cloud.githubusercontent.com/assets/557005/16074971/33f824fc-32ed-11e6-85c6-5479cf288649.gif)

closes #1852 