### PR TITLE
Lock excerpt copies in the dossiers indefinitely

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Lock excerpts in the dossiers and sync updates to the
+  excerpt in a meeting/submitted proposal to the excerpt copy
+  in the dossier.
+  [deiferni]
+
 - Simplify protocol download button in meeting view.
   Only download the exisiting protocol without regenerating it with sablon.
   [phgross]

--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -95,14 +95,6 @@ class TestTransporter(FunctionalTestCase):
         with self.assertRaises(Unauthorized):
             Transporter().transport_to(task, 'client1', target_path)
 
-        Transporter().transport_to_with_elevated_privileges(
-            task, 'client1', target_path)
-
-    def test_keyword_argument_view_is_not_allowed_when_transporting_with_elevated_privileges_(self):
-
-        with self.assertRaises(ValueError) as cm:
-            Transporter().transport_to_with_elevated_privileges(
-                object(), 'client1', '/ordnungssytem', view='submit-proposal')
-
-        self.assertEquals('Keyword argument `view` not allowed.',
-                          str(cm.exception))
+        Transporter().transport_to(
+            task, 'client1', target_path,
+            view='transporter-privileged-receive-object')

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -59,16 +59,6 @@ class Transporter(object):
             target_cid, '@@{}'.format(view),
             path=container_path, data=request_data)
 
-    def transport_to_with_elevated_privileges(
-            self, obj, target_cid, container_path, **data):
-
-        if data.get('view'):
-            raise ValueError('Keyword argument `view` not allowed.')
-
-        return self.transport_to(
-            obj, target_cid, container_path,
-            view='transporter-privileged-receive-object', **data)
-
     def transport_from(self, container, source_cid, path):
         """ Copies the object under *path* from client with *source_cid* into
         the local folder *container*

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -8,7 +8,7 @@ from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import FunctionalTestCase
-from plone import api
+from opengever.testing.helpers import create_document_version
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.uuid.interfaces import IUUID
 from zope.component import getMultiAdapter
@@ -50,12 +50,6 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
 
     maxDiff = None
     layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def _create_version(self, doc, version_id, data=None):
-        repo_tool = api.portal.get_tool('portal_repository')
-        vdata = data or 'VERSION {} DATA'.format(version_id)
-        doc.file.data = vdata
-        repo_tool.save(obj=doc, comment="This is Version %s" % version_id)
 
     @browsing
     def test_document_preview_is_visible(self, browser):
@@ -137,9 +131,9 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
                           .within(dossier)
                           .attach_file_containing(
                               'foo', u'example.docx'))
-        self._create_version(document, 1,
-                             data=bumblebee_asset('example.docx').bytes())
-        self._create_version(document, 2)
+        create_document_version(document, 1,
+                                data=bumblebee_asset('example.docx').bytes())
+        create_document_version(document, 2)
         queue = get_queue()
         queue.reset()
 
@@ -160,4 +154,3 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
              'deferred': False,
              'url': '/plone/dossier-1/document-1/bumblebee_trigger_storing'},
             job)
-

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.testing import FunctionalTestCase
+from opengever.testing.helpers import create_document_version
 from plone import api
 from urlparse import parse_qs
 from urlparse import urlparse
@@ -30,7 +31,7 @@ class TestVersionsTab(FunctionalTestCase):
     def _create_doc_with_versions(self, n=3):
         doc = self._create_doc()
         for version_id in range(1, n + 1):
-            self._create_version(doc, version_id)
+            create_document_version(doc, version_id)
         return doc
 
     def _create_doc(self):
@@ -40,12 +41,6 @@ class TestVersionsTab(FunctionalTestCase):
                                              u"somefile.txt"))
         return doc
 
-    def _create_version(self, doc, version_id):
-        repo = api.portal.get_tool('portal_repository')
-        vdata = 'VERSION {} DATA'.format(version_id)
-        doc.file.data = vdata
-        repo.save(obj=doc, comment="This is Version %s" % version_id)
-
 
 class TestVersionsTabWithoutPDFConverter(TestVersionsTab):
 
@@ -54,7 +49,7 @@ class TestVersionsTabWithoutPDFConverter(TestVersionsTab):
         with freeze(datetime(2015, 01, 28, 12, 00)):
             doc = self._create_doc()
         with freeze(datetime(2015, 01, 28, 18, 30)):
-            self._create_version(doc, 1)
+            create_document_version(doc, 1)
         transaction.commit()
 
         browser.login().open(doc, view='tabbedview_view-versions')

--- a/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-08 15:31+0000\n"
+"POT-Creation-Date: 2016-06-15 07:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,6 +18,16 @@ msgstr ""
 #: ./opengever/locking/templates/meeting_lock.pt:12
 msgid "description_locked_by_meeting"
 msgstr "Das Protokoll bleibt gesperrt bis die Sitzung ${meeting} abgeschlossen wurde."
+
+#. Default: "This document is a copy of an excerpt from a meeting and cannot be edited directly."
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt:22
+msgid "description_locked_excerpt_document"
+msgstr "Dieses Dokument ist eine Kopie eines Protokollauszugs aus einer Sitzung und kann nicht direkt bearbeitet werden."
+
+#. Default: "This document is a copy of the excerpt ${document} from the meeting ${meeting} and cannot be edited directly."
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt:17
+msgid "description_locked_linked_excerpt_document"
+msgstr "Dieses Dokument ist eine Kopie des Protokollauszugs ${document} aus der Sitzung ${meeting} und kann nicht direkt bearbeitet werden."
 
 #. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
 #: ./opengever/locking/templates/submitted_document_lock_template.pt:12

--- a/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-08 15:31+0000\n"
+"POT-Creation-Date: 2016-06-15 07:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,16 @@ msgstr ""
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
 #: ./opengever/locking/templates/meeting_lock.pt:12
 msgid "description_locked_by_meeting"
+msgstr ""
+
+#. Default: "This document is a copy of an excerpt from a meeting and cannot be edited directly."
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt:22
+msgid "description_locked_excerpt_document"
+msgstr ""
+
+#. Default: "This document is a copy of the excerpt ${document} from the meeting ${meeting} and cannot be edited directly."
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt:17
+msgid "description_locked_linked_excerpt_document"
 msgstr ""
 
 #. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."

--- a/opengever/locking/locales/opengever.locking.pot
+++ b/opengever/locking/locales/opengever.locking.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-08 15:31+0000\n"
+"POT-Creation-Date: 2016-06-15 07:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,16 @@ msgstr ""
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
 #: ./opengever/locking/templates/meeting_lock.pt:12
 msgid "description_locked_by_meeting"
+msgstr ""
+
+#. Default: "This document is a copy of an excerpt from a meeting and cannot be edited directly."
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt:22
+msgid "description_locked_excerpt_document"
+msgstr ""
+
+#. Default: "This document is a copy of the excerpt ${document} from the meeting ${meeting} and cannot be edited directly."
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt:17
+msgid "description_locked_linked_excerpt_document"
 msgstr ""
 
 #. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."

--- a/opengever/locking/lock.py
+++ b/opengever/locking/lock.py
@@ -12,3 +12,9 @@ LOCK_TYPE_MEETING_SUBMITTED_LOCK = u'meeting.submitted.lock'
 MEETING_SUBMITTED_LOCK = LockType(
     LOCK_TYPE_MEETING_SUBMITTED_LOCK,
     stealable=True, user_unlockable=True, timeout=MAX_TIMEOUT)
+
+
+LOCK_TYPE_MEETING_EXCERPT_LOCK = u'meeting.excerpt.lock'
+MEETING_EXCERPT_LOCK = LockType(
+    LOCK_TYPE_MEETING_EXCERPT_LOCK,
+    stealable=True, user_unlockable=True, timeout=MAX_TIMEOUT)

--- a/opengever/locking/templates/excerpt_document_lock_template.pt
+++ b/opengever/locking/templates/excerpt_document_lock_template.pt
@@ -1,0 +1,29 @@
+<div id="plone-lock-status"
+     i18n:domain="opengever.locking"
+     tal:define="locked view/info/is_locked_for_current_user;
+                 document view/get_meeting_excerpt_from_dossier_excerpt;
+                 meeting view/get_meeting_from_dossier_excerpt;">
+  <tal:block condition="locked">
+    <dl class="portalMessage info">
+      <dt i18n:domain="plone" i18n:translate="label_locked">Locked</dt>
+      <dd>
+        <tal:author-page tal:condition="python: document and meeting"
+            i18n:translate="description_locked_linked_excerpt_document">
+          This document is a copy of the excerpt
+          <a i18n:name="document"
+             tal:content="document/Title"
+             tal:attributes="href document/absolute_url" />
+          from the meeting
+          <a i18n:name="meeting"
+             tal:content="meeting/get_title"
+             tal:attributes="href meeting/get_url" />
+          and cannot be edited directly.
+        </tal:author-page>
+        <tal:author-page tal:condition="python: not (document and meeting)"
+            i18n:translate="description_locked_excerpt_document">
+          This document is a copy of an excerpt from a meeting and cannot be edited directly.
+        </tal:author-page>
+      </dd>
+    </dl>
+  </tal:block>
+</div>

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -224,3 +224,4 @@ class RecieveSubmittedDocumentView(PrivilegedReceiveObject):
         document = super(RecieveSubmittedDocumentView, self).receive()
         ILockable(document).lock(MEETING_SUBMITTED_LOCK)
         return document
+

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -434,13 +434,6 @@ class OgCopyCommand(object):
             self.source, self.target_admin_unit_id, self.target_path)
 
 
-class OgCopyCommandWithElevatedPrivileges(OgCopyCommand):
-
-    def execute(self):
-        return Transporter().transport_to_with_elevated_privileges(
-            self.source, self.target_admin_unit_id, self.target_path)
-
-
 class SubmitDocumentCommand(OgCopyCommand):
 
     def execute(self):

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -447,3 +447,11 @@ class SubmitDocumentCommand(OgCopyCommand):
         return Transporter().transport_to(
             self.source, self.target_admin_unit_id, self.target_path,
             view='recieve-submitted-document')
+
+
+class CreateExcerptCommand(OgCopyCommand):
+
+    def execute(self):
+        return Transporter().transport_to(
+            self.source, self.target_admin_unit_id, self.target_path,
+            view='recieve-excerpt-document')

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -1,11 +1,18 @@
 from five import grok
 from OFS.interfaces import IObjectWillBeRemovedEvent
 from opengever.base.model import create_session
+from opengever.base.oguid import Oguid
 from opengever.document.document import IDocumentSchema
+from opengever.document.interfaces import IObjectCheckedInEvent
+from opengever.document.interfaces import IObjectRevertedToVersion
+from opengever.meeting.command import UpdateExcerptInDossierCommand
+from opengever.meeting.model import GeneratedExcerpt
+from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
 from zope.component import getUtility
 from zope.component.interfaces import ComponentLookupError
 from zope.intid.interfaces import IIntIds
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
 @grok.subscribe(IDocumentSchema, IObjectWillBeRemovedEvent)
@@ -21,3 +28,31 @@ def document_deleted(context, event):
     session = create_session()
     for doc in SubmittedDocument.query.by_document(context).all():
         session.delete(doc)
+
+
+@grok.subscribe(IDocumentSchema, IObjectModifiedEvent)
+def on_document_modified(context, event):
+    _sync_excerpt(context)
+
+
+@grok.subscribe(IDocumentSchema, IObjectCheckedInEvent)
+def on_documed_checked_in(context, event):
+    _sync_excerpt(context)
+
+
+@grok.subscribe(IDocumentSchema, IObjectRevertedToVersion)
+def on_document_reverted_to_version(context, event):
+    _sync_excerpt(context)
+
+
+def _sync_excerpt(document):
+    if document.is_checked_out():
+        return
+
+    proposal = Proposal.query.join(
+        GeneratedExcerpt, Proposal.submitted_excerpt_document).filter(
+        GeneratedExcerpt.oguid == Oguid.for_object(document)).first()
+    if not proposal:
+        return
+
+    UpdateExcerptInDossierCommand(proposal).execute()

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -368,10 +368,10 @@ class Proposal(Base):
         """Copies the submitted excerpt to the source dossier and returns
         the intid of the created document.
         """
-        from opengever.meeting.command import OgCopyCommandWithElevatedPrivileges
+        from opengever.meeting.command import CreateExcerptCommand
 
         dossier = self.resolve_proposal().get_containing_dossier()
-        response = OgCopyCommandWithElevatedPrivileges(
+        response = CreateExcerptCommand(
             self.resolve_submitted_excerpt_document(),
             self.admin_unit_id,
             '/'.join(dossier.getPhysicalPath())).execute()

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.locking.lock import MEETING_EXCERPT_LOCK
 from opengever.meeting.model import Meeting
@@ -301,10 +302,24 @@ class TestAgendaItemDecide(TestAgendaItem):
             data={'_authenticator': createToken()})
 
         agenda_item = AgendaItem.query.first()  # refresh
-        excerpt_in_dossier = agenda_item.proposal.excerpt_document.resolve_document()
+        proposal = agenda_item.proposal
+        excerpt_in_dossier = proposal.excerpt_document.resolve_document()
         lockable = ILockable(excerpt_in_dossier)
         self.assertTrue(lockable.locked())
         self.assertTrue(lockable.can_safely_unlock(MEETING_EXCERPT_LOCK))
+
+        browser.open(excerpt_in_dossier)
+        self.assertEqual(u'This document is a copy of the excerpt Fooo - '
+                         u'C\xf6mmunity meeting from the meeting C\xf6mmunity '
+                         u'meeting and cannot be edited directly.',
+                         info_messages()[0])
+        message_links = browser.css('.portalMessage.info a')
+        self.assertEqual(
+            'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/submitted-proposal-1/document-3',
+            message_links[0].get('href'))
+        self.assertEqual(
+            'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1/view',
+            message_links[1].get('href'))
 
     @browsing
     def test_decide_proposal_agenda_item_without_dossier_permission(self, browser):

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -47,12 +47,6 @@ class TestSyncExcerpt(FunctionalTestCase):
             .for_document(self.document_in_proposal))
         self.proposal.load_model().submitted_excerpt_document = self.excerpt_in_proposal
 
-    def _create_version(self, doc, version_id, data=None):
-        repo_tool = api.portal.get_tool('portal_repository')
-        vdata = data or 'VERSION {} DATA'.format(version_id)
-        doc.file.data = vdata
-        repo_tool.save(obj=doc, comment="This is Version %s" % version_id)
-
     def test_updates_excerpt_in_dossier_after_checkin(self):
         self.assertEqual(0, self.document_in_proposal.get_current_version())
         self.assertEqual(0, self.document_in_dossier.get_current_version())

--- a/opengever/meeting/upgrades/20160615142602_manage_checkin_checkout_permissions_in_submitted_proposal/upgrade.py
+++ b/opengever/meeting/upgrades/20160615142602_manage_checkin_checkout_permissions_in_submitted_proposal/upgrade.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ManageCheckinCheckoutPermissionsInSubmittedProposal(UpgradeStep):
+    """Manage checkin/checkout permissions in submitted proposal.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.update_workflow_security(
+            ['opengever_submitted_proposal_workflow'], reindex_security=False)

--- a/opengever/meeting/upgrades/20160615142602_manage_checkin_checkout_permissions_in_submitted_proposal/workflows/opengever_submitted_proposal_workflow/definition.xml
+++ b/opengever/meeting/upgrades/20160615142602_manage_checkin_checkout_permissions_in_submitted_proposal/workflows/opengever_submitted_proposal_workflow/definition.xml
@@ -37,7 +37,7 @@
  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
   <description>Previous transition</description>
   <default>
-
+   
    <expression>transition/getId|nothing</expression>
   </default>
   <guard>
@@ -46,7 +46,7 @@
  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
   <description>The ID of the user who performed the previous transition</description>
   <default>
-
+   
    <expression>user/getUserName</expression>
   </default>
   <guard>
@@ -55,7 +55,7 @@
  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
   <description>Comment about the last transition</description>
   <default>
-
+   
    <expression>python:state_change.kwargs.get('comment', '')</expression>
   </default>
   <guard>
@@ -64,7 +64,7 @@
  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
   <description>Provides access to workflow history</description>
   <default>
-
+   
    <expression>state_change/getHistory</expression>
   </default>
   <guard>
@@ -75,7 +75,7 @@
  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
   <description>When the previous transition was performed</description>
   <default>
-
+   
    <expression>state_change/getDateTime</expression>
   </default>
   <guard>

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -63,3 +63,10 @@ def add_languages(codes, support_combined=True):
         lang_tool.addSupportedLanguage(code)
 
     transaction.commit()
+
+
+def create_document_version(doc, version_id, data=None):
+    repo_tool = api.portal.get_tool('portal_repository')
+    vdata = data or 'VERSION {} DATA'.format(version_id)
+    doc.file.data = vdata
+    repo_tool.save(obj=doc, comment="This is Version %s" % version_id)


### PR DESCRIPTION
This PR locks excerpts in the dossiers and sync updates to the excerpt in a meeting/submitted proposal to the excerpt copy in the dossier.

Also fixes an issue where documents could not be checked out once inside a submitted proposal.

Closes #1803.