### PR TITLE
Add lock-info and checkout-info viewlets to bumblebee-overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Add lock-info and checkout-info viewlets to bumblebee-overlay.
+  [elioschmutz]
+
 - Lock excerpts in the dossiers and sync updates to the
   excerpt in a meeting/submitted proposal to the excerpt copy
   in the dossier.

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -5,7 +5,9 @@ from opengever.base.interfaces import ISequenceNumber
 from opengever.bumblebee import get_representation_url_by_object
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
+from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.locking.info import GeverLockInfoViewlet
 from opengever.ogds.base.actor import Actor
 from plone import api
 from plone.protect import createToken
@@ -116,6 +118,16 @@ class BumblebeeBaseDocumentOverlay(object):
             has_file = hasattr(self.context, 'file') and self.context.file
             self._file = self.context.file if has_file else None
         return self._file
+
+    def render_checked_out_viewlet(self):
+        viewlet = CheckedOutViewlet(self.context, self.request, None, None)
+        viewlet.update()
+        return viewlet.render()
+
+    def render_lock_info_viewlet(self):
+        viewlet = GeverLockInfoViewlet(self.context, self.request, None, None)
+        viewlet.update()
+        return viewlet.render()
 
     def _get_pdf_filename(self):
         if not self.has_file():

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -70,6 +70,10 @@
              i18n:translate="">Checkin with comment</a>
         </li>
       </ul>
+      <div class="info-viewlets">
+        <div tal:replace="structure view/overlay/render_checked_out_viewlet" />
+        <div tal:replace="structure view/overlay/render_lock_info_viewlet" />
+      </div>
     </footer>
   </aside>
   <div class="preview">

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -111,3 +111,15 @@ class IBumblebeeOverlay(Interface):
 
         Returns None if there is no file.
         """
+
+    def render_checked_out_viewlet():
+        """Renders the checked out viewlet.
+
+        Returns html.
+        """
+
+    def render_lock_info_viewlet():
+        """Renders the lock info viewlet.
+
+        Returns html.
+        """


### PR DESCRIPTION
Dieser PR fügt das Lock-Info Viewlet sowie das Checkout-Info-Viewlet dem Bumblebee-Overlay hinzu.

![bildschirmfoto 2016-06-15 um 17 12 37](https://cloud.githubusercontent.com/assets/557005/16087141/3f6cbfac-3322-11e6-863f-c7b855c7261e.png)

![bildschirmfoto 2016-06-15 um 17 12 56](https://cloud.githubusercontent.com/assets/557005/16087140/3f6dc92e-3322-11e6-92c9-4e61cb605fa2.png)
