### PR TITLE
Simplify protocol download button in meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Simplify protocol download button in meeting view.
+  Only download the exisiting protocol without regenerating it with sablon.
+  [phgross]
+
 - Fix error: AttributeError: 'DocumentsProxy' object has no attribute 'select_all'.
   [elioschmutz]
 

--- a/docs/intern/kurzreferenzen/administration.rst
+++ b/docs/intern/kurzreferenzen/administration.rst
@@ -397,3 +397,6 @@ Verfügung:
   herunterzuladen, das zum Generieren des Dokuments aus der Sablon-Vorlage
   verwendet wird.
 
+- Inhaltstyp Sitzung: ``download_generated_protocol`` ermöglicht es, ein
+  Protokoll einer Sitzung zu generieren und herunterzuladen, ohne dass das
+  bestehende Protokoll (das im GEVER abgelegte Dokument) verändert wird.

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -31,9 +31,10 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <!-- registered for admin use only, not available in the UI -->
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
-      name="download_protocol"
+      name="download_generated_protocol"
       class=".protocol.DownloadGeneratedProtocol"
       permission="zope2.View"
       />

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -331,7 +331,8 @@ class MeetingView(BrowserView):
         return self.model.has_protocol_document()
 
     def url_download_protocol(self):
-        return self.model.get_url(view='download_protocol')
+        if self.has_protocol_document:
+            return self.model.protocol_document.get_download_url()
 
     def url_agendaitem_list(self):
         return self.model.get_url(view='agenda_item_list')

--- a/opengever/meeting/model/generateddocument.py
+++ b/opengever/meeting/model/generateddocument.py
@@ -51,6 +51,8 @@ class GeneratedDocument(Base):
         lockable.unlock(SYS_LOCK)
         assert not lockable.locked(), 'unexpected: could not remove lock'
 
+    def get_download_url(self):
+        return '{}/download'.format(self.resolve_document().absolute_url())
 
 class GeneratedProtocol(GeneratedDocument):
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -352,9 +352,13 @@ class TestProtocol(FunctionalTestCase):
     def test_protocol_can_be_downloaded(self, browser):
         self.setup_protocol(browser)
         browser.css('.generate-protocol').first.click()
-        browser.css('a[href$="download_protocol"]').first.click()
+
+        meeting = Meeting.query.first()
+        expected_data = meeting.protocol_document.resolve_document().file.data
+
+        browser.css('a.download-protocol-btn').first.click()
         self.assertEqual(browser.headers['content-type'], MIME_DOCX)
-        self.assertIsNotNone(browser.contents)
+        self.assertEqual(expected_data, browser.contents)
 
     @browsing
     def test_protocol_can_be_generated(self, browser):


### PR DESCRIPTION
Only download the existing protocol without regenerate or update the protocol document (with sablon).
Fixes #1515.

@deiferni 

The existing `DownloadGeneratedProtocol` view is still registered and available, but only for testing/debugging purpose, it's not available in the UI.