### PR TITLE
Getting default with AQ: Change lookup order so adapting context to schema interface is tried first

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Getting default with AQ: Change lookup order so that we first
+  try to properly adapt the context to the schema interface.
+  [lgraf]
+
 - Reworked the trigger tasktemplatefolder form:
   Replaced old custom form with a z3c wizard-form and allow to attach documents.
   [phgross]

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -121,20 +121,21 @@ def create_restricted_vocabulary(field, options,
                 obj = context.aq_inner.aq_parent
             while not ISiteRoot.providedBy(obj):
                 try:
-                    return self.field.get(obj)
+                    interface_ = self.field.interface
                 except AttributeError:
+                    pass
+                else:
                     try:
-                        interface_ = self.field.interface
-                    except AttributeError:
-                        pass
-                    else:
+                        adpt = interface_(obj)
+                    except TypeError:
+                        # could not adapt
                         try:
-                            adpt = interface_(obj)
-                        except TypeError:
-                             # could not adapt
+                            return self.field.get(obj)
+                        except AttributeError:
                             pass
-                        else:
-                            return self.field.get(adpt)
+                    else:
+                        return self.field.get(adpt)
+
                 obj = obj.aq_inner.aq_parent
             return self.field.default
 


### PR DESCRIPTION
Getting default with AQ: Change lookup order so that we first try to properly adapt the context to the schema interface with `field.get(ISchema(obj))`, and only if that fails, try a simple `field.get(obj)`.

Previously this was reversed, and lead to `field.get(obj)` returning bogus values with the `DexterityContent.__getattr__` from `plone.dexterity == 2.3.0`.