### PR TITLE
Fixed bumblebee overlay browse functionality for the document extjs listings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fixed bumblebee overlay browse functionality for the document extjs listing.
+  [phgross]
+
 - Use non self-closing br tags in trix transform.
   [deiferni]
 

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -26,6 +26,36 @@
     });
   }
 
+  function extendShowroomQueue(pagenumber, extender){
+    var fetch_url = store.proxy.url.split('?')[0]
+    var params = {'pagenumber': pagenumber,
+                  'initialize': 0,
+                  'view_name': global.tabbedview.prop('view_name'),
+                  'tableType': 'extjs'}
+
+    $.get(fetch_url, params).done(function(data){
+      extender(data.rows.map(function(row) {
+        return $(row['sortable_title']).children("a")[0];
+      }));
+    });
+
+  }
+
+  function loadNextListingItems() {
+    var pagenumber = global.tabbedview.param('pagenumber:int') || 1;
+    extendShowroomQueue(pagenumber + 1, showroom.append);
+  }
+
+  function loadPreviousListingItems() {
+    var pagenumber = global.tabbedview.param('pagenumber:int');
+    if (!pagenumber) {
+      // If there is no pagenumber given, the listing shows the first page,
+      // so there are no previous items.
+      return
+    }
+
+    extendShowroomQueue(pagenumber - 1, showroom.prepend);
+  }
 
   function toggleShowMoreButton() {
     var button = $('.bumblebeeGalleryShowMore');
@@ -40,12 +70,23 @@
 
   function tail() {
     if(global.tabbedview) {
+      if (global.tabbedview.table.length) {
+        // document table listing
+        loadNextListingItems();
+      }
       loadNextTabbedviewItems();
     }
   }
 
+  function head() {
+    if(global.tabbedview && global.tabbedview.table.length) {
+      // document table listing
+      loadPreviousListingItems();
+    }
+  }
+
   function init() {
-    showroom = Showroom([], { 'tail': tail });
+    showroom = Showroom([], { 'tail': tail, 'head': head });
     updateShowroom();
 
     // The search.js does not trigger an event after reloading the searchview.


### PR DESCRIPTION
Fixes #1872 by implementing a special handling for extjs listing tabs in the `tail` and `head` methods, which loads and extend the next or previous batch to the showroom queue.

⚠️  Uses https://github.com/4teamwork/ftw.showroom/pull/29

@deiferni or @bierik please have a 👀 
