### PR TITLE
No longer hide Download PDF link in the bumblebee overlay for mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- No longer hide `Open as PDF` link in the bumblebee overlay for mails.
+  [phgross]
+
 - Implement sticky trix editor toolbars.
   [Kevin Bieri]
 

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -173,7 +173,8 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
     """
 
     def get_open_as_pdf_url(self):
-        return None
+        return get_representation_url_by_object(
+            'pdf', obj=self.context, filename=self._get_pdf_filename())
 
     def get_checkout_url(self):
         return None

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -76,7 +76,8 @@ class TestGetOpenAsPdfLink(FunctionalTestCase):
 
         adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
 
-        self.assertIsNone(adapter.get_open_as_pdf_url())
+        self.assertIn(
+            '/YnVtYmxlYmVl/api/v3/resource/', adapter.get_open_as_pdf_url())
 
 
 class TestGetCheckoutUrl(FunctionalTestCase):

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -107,6 +107,7 @@ class TestBumblebeeOverlayListing(FunctionalTestCase):
         self.assertEqual(
             ['Open detail view',
              'Download copy',
+             'Open as PDF',
              'Edit metadata'],
             browser.css('.file-actions a').text)
 
@@ -206,6 +207,7 @@ class TestBumblebeeOverlayDocument(FunctionalTestCase):
 
         self.assertEqual(
             ['Download copy',
+             'Open as PDF',
              'Edit metadata'],
             browser.css('.file-actions a').text)
 


### PR DESCRIPTION
Bumblebee supports now mail conversion. Fixes #1946.

@elioschmutz or @deiferni please have a 👀 