### PR TITLE
Fixed textfilter in the documents gallery view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fixed textfilter in the documents gallery view.
+  [phgross]
+
 - No longer hide `Open as PDF` link in the bumblebee overlay for mails.
   [phgross]
 

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -58,7 +58,8 @@ class BumblebeeGalleryMixin(object):
             }
 
     def get_brains(self):
-        self.table_source.config.filter_text = self.request.get('searchableText', '')
+        self.table_source.config.filter_text = self.request.get(
+            'searchable_text', '')
 
         if not hasattr(self, '_brains'):
             catalog = getToolByName(self.context, 'portal_catalog')

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -138,7 +138,7 @@ class TestBumblebeeGalleryMixinGetBrains(FunctionalTestCase):
                .within(dossier)
                .titled("Chuck Norris"))
 
-        view.request['searchableText'] = "James"
+        view.request['searchable_text'] = "James"
         brains = view.get_brains()
 
         self.assertEqual([document, ], [brain.getObject() for brain in brains])


### PR DESCRIPTION
The request name was wrong `SearchableText` instead of `searchable_text`. See https://github.com/4teamwork/ftw.tabbedview/blob/00c72c97507b68e1a9a86bc9068a92036feb2358/ftw/tabbedview/browser/listing.py#L171 for more information.

Fixes #1948 .

@elioschmutz or @deiferni please have a 👀 