### PR TITLE
Fixed icon tooltip in document listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Fixed icon tooltip in document listings.
+  [phgross]
+
 - Adjust registered bumblebee-events.
   The bumblebee events changed. So we have to change this in opengever.core too.
   [elioschmutz]

--- a/opengever/tabbedview/browser/tooltip_source.py
+++ b/opengever/tabbedview/browser/tooltip_source.py
@@ -20,7 +20,7 @@ class OpengeverTabbedviewTooltipSource(object):
     def tooltips(self):
         return [{
             'selector': u'.tabbedview-tooltip',
-            'condition': '#documents_overview, #mydocuments_overview, ' \
+            'condition': '#documents-proxy_overview, #mydocuments-proxy_overview, ' \
                          '#relateddocuments_overview',
             'content': u'.tabbedview-tooltip-data',
         }]


### PR DESCRIPTION
With the bumblebee integration all document listings, gets wrapped in to a proxy view. Therefore the tooltip condition has to be changed to the proxy identifier as well.

@deiferni 