### PR TITLE
Don't truncate strings in sentry extra data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Increase maximum string length in sentry extra data for errors reported
+  by trix2sablon.
+  [deiferni]
+
 - Fixed textfilter in the documents gallery view.
   [phgross]
 

--- a/opengever/base/transforms/trix2sablon.py
+++ b/opengever/base/transforms/trix2sablon.py
@@ -22,6 +22,9 @@ VALID_TAGS = {
 }
 
 
+SERVER_SIDE_STRING_MAX_LENGTH = 2**14
+
+
 _transform = SafeHTML(name='trix_to_sablon', valid_tags=VALID_TAGS)
 
 
@@ -55,4 +58,5 @@ def _log_unexpected_conversion_to_sentry(converted, markup):
         'Unexpected html during trix/sablon conversion',
         request=request,
         url=request.get('ACTUAL_URL', ''),
-        extra=extra)
+        extra=extra,
+        string_max_length=SERVER_SIDE_STRING_MAX_LENGTH)


### PR DESCRIPTION
We currently need full string length for errors reported by the
trix2sablon conversion.