### PR TITLE
Add previews on versions tab

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.9.1 (unreleased)
 ------------------
 
-- Implement bumblebee preview images in versions-tab.
+- Implement bumblebee overlay for the versions-tab.
   [elioschmutz]
 
 4.9.0 (2016-06-28)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 4.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Implement bumblebee preview images in versions-tab.
+  [elioschmutz]
 
 4.9.0 (2016-06-28)
 ------------------

--- a/opengever/bumblebee/__init__.py
+++ b/opengever/bumblebee/__init__.py
@@ -1,9 +1,12 @@
 from ftw.bumblebee.utils import get_representation_url_by_brain as representation_url_by_brain
 from ftw.bumblebee.utils import get_representation_url_by_object as representation_url_by_object
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
-from opengever.mail.mail import IOGMailMarker
 from plone import api
 from zope.globalrequest import getRequest
+from zope.i18nmessageid import MessageFactory
+
+
+_ = MessageFactory('opengever.bumblebee')
 
 
 BUMBLEBEE_VIEW_COOKIE_NAME = 'bumblebee-view'

--- a/opengever/bumblebee/browser/configure.zcml
+++ b/opengever/bumblebee/browser/configure.zcml
@@ -35,4 +35,10 @@
       factory=".overlay.BumblebeeMailOverlay"
       />
 
+  <adapter
+      for="opengever.document.document.IDocumentSchema
+           opengever.bumblebee.interfaces.IVersionedContextMarker"
+      factory=".overlay.BumblebeeDocumentVersionOverlay"
+      />
+
 </configure>

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -1,16 +1,23 @@
+from Acquisition import aq_parent
 from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.protect import unprotected_write
+from opengever.bumblebee import _
 from opengever.bumblebee import get_representation_url_by_object
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
+from opengever.bumblebee.interfaces import IVersionedContextMarker
+from opengever.document.browser.versions_tab import translate_link
 from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.locking.info import GeverLockInfoViewlet
 from opengever.ogds.base.actor import Actor
 from plone import api
 from plone.protect import createToken
+from plone.protect.utils import addTokenToUrl
+from Products.CMFEditions.interfaces.IArchivist import ArchivistRetrieveError
 from Products.Five import BrowserView
 from zExceptions import NotFound
 from zope.component import getAdapter
@@ -18,6 +25,7 @@ from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.i18n import translate
+from zope.interface import alsoProvides
 from zope.interface import implements
 import os
 
@@ -27,10 +35,11 @@ class BumblebeeBaseDocumentOverlay(object):
     """
     implements(IBumblebeeOverlay)
 
+    version_id = None
+
     def __init__(self, context, request):
+        self.context = context
         self.request = request
-        self.context = self._get_context(
-            context, request.get('version_id', None))
 
     def get_preview_pdf_url(self):
         return get_representation_url_by_object('preview', self.context)
@@ -130,6 +139,14 @@ class BumblebeeBaseDocumentOverlay(object):
         viewlet.update()
         return viewlet.render()
 
+    def is_versioned_context(self):
+        return self.version_id is not None
+
+    def get_revert_link(self):
+        if self.is_versioned_context():
+            return self._get_revert_link()
+        return None
+
     def _get_pdf_filename(self):
         if not self.has_file():
             # Bumblebee will use a placeholder filename
@@ -168,12 +185,16 @@ class BumblebeeBaseDocumentOverlay(object):
             checkin_view,
             createToken())
 
-    def _get_context(self, context, version_id):
-        if not version_id:
-            return context
+    def _get_revert_link(self):
+        url = '{}/revert-file-to-version?version_id={}'.format(
+            self.context.absolute_url(),
+            self.version_id)
 
-        prtool = api.portal.get_tool('portal_repository')
-        return prtool.retrieve(context, version_id).object
+        url = addTokenToUrl(url)
+
+        return translate_link(
+            url, _(u'label_revert', default=u'Revert document'),
+            css_class='standalone function-revert')
 
 
 class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
@@ -211,6 +232,34 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
         return self._file
 
 
+class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
+    """Bumblebee overlay for versioned documents
+    """
+    def get_checkout_url(self):
+        return None
+
+    def get_open_as_pdf_url(self):
+        return None
+
+    def get_checkin_without_comment_url(self):
+        return None
+
+    def get_checkin_with_comment_url(self):
+        return None
+
+    def get_edit_metadata_url(self):
+        return None
+
+    def get_detail_view_url(self):
+        return None
+
+    def render_checked_out_viewlet(self):
+        return ''
+
+    def render_lock_info_viewlet(self):
+        return ''
+
+
 class BumblebeeOverlayBaseView(BrowserView):
     """Baseview for the bumblebeeoverlay.
     """
@@ -222,12 +271,42 @@ class BumblebeeOverlayBaseView(BrowserView):
         if not is_bumblebee_feature_enabled():
             raise NotFound
 
+        overlay_context = self.context
+        version_id = self._get_version_id()
+
+        if version_id is not None:
+            overlay_context = self._retrieve_version(overlay_context, version_id)
+            alsoProvides(self.request, IVersionedContextMarker)
+
         self.overlay = getMultiAdapter(
-            (self.context, self.request), IBumblebeeOverlay)
+            (overlay_context, self.request), IBumblebeeOverlay)
+        self.overlay.version_id = version_id
 
         # we only render an html fragment, no reason to waste time on diazo
         self.request.response.setHeader('X-Theme-Disabled', 'True')
         return super(BumblebeeOverlayBaseView, self).__call__()
+
+    def _get_version_id(self):
+        version_id = self.request.get('version_id')
+        if not version_id:
+            return None
+
+        if not version_id.isdigit():
+            return NotFound
+
+        return int(version_id)
+
+    def _retrieve_version(self, context, version_id):
+        prtool = api.portal.get_tool('portal_repository')
+
+        try:
+            # CMFEditions causes writes to the parent when retrieving versions
+            unprotected_write(aq_parent(context))
+            return prtool.retrieve(context, version_id).object
+
+        except ArchivistRetrieveError:
+            # Version does not exists.
+            raise NotFound
 
 
 class BumblebeeOverlayListingView(BumblebeeOverlayBaseView):

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -28,8 +28,9 @@ class BumblebeeBaseDocumentOverlay(object):
     implements(IBumblebeeOverlay)
 
     def __init__(self, context, request):
-        self.context = context
         self.request = request
+        self.context = self._get_context(
+            context, request.get('version_id', None))
 
     def get_preview_pdf_url(self):
         return get_representation_url_by_object('preview', self.context)
@@ -166,6 +167,13 @@ class BumblebeeBaseDocumentOverlay(object):
             self.context.absolute_url(),
             checkin_view,
             createToken())
+
+    def _get_context(self, context, version_id):
+        if not version_id:
+            return context
+
+        prtool = api.portal.get_tool('portal_repository')
+        return prtool.retrieve(context, version_id).object
 
 
 class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -130,7 +130,7 @@
   }
 
   function updateShowroom() {
-    if(($(".template-search").length) || $(".portaltype-opengever-document-document").length) {
+    if(($(".template-search").length)) {
       initSingleShowroom();
       return;
     }

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -38,7 +38,10 @@
              tal:attributes="href link"
              i18n:translate="">Open detail view</a>
         </li>
-        <li id="action-download" tal:define="link view/overlay/get_download_copy_link" tal:condition="nocall: link" tal:content="structure link">
+        <li id="action-download"
+            tal:define="link view/overlay/get_download_copy_link"
+            tal:condition="nocall: link"
+            tal:content="structure link">
         </li>
         <li tal:define="link view/overlay/get_open_as_pdf_url" tal:condition="nocall: link">
           <a id="action-pdf"
@@ -69,10 +72,23 @@
              i18n:domain="opengever.document"
              i18n:translate="">Checkin with comment</a>
         </li>
+        <li id="action-revert"
+            tal:define="link view/overlay/get_revert_link"
+            tal:condition="nocall: link"
+            tal:content="structure link">
+        </li>
       </ul>
       <div class="info-viewlets">
         <div tal:replace="structure view/overlay/render_checked_out_viewlet" />
         <div tal:replace="structure view/overlay/render_lock_info_viewlet" />
+        <div tal:condition="view/overlay/is_versioned_context">
+          <dl class="portalMessage warning">
+            <dt i18n:domain="plone" i18n:translate="">Warning</dt>
+            <dd i18n:translate="warning_on_versioned_context">
+              You are watching a versioned file.
+            </dd>
+          </dl>
+        </div>
       </div>
     </footer>
   </aside>

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -85,7 +85,7 @@
           <dl class="portalMessage warning">
             <dt i18n:domain="plone" i18n:translate="">Warning</dt>
             <dd i18n:translate="warning_on_versioned_context">
-              You are watching a versioned file.
+              You are looking at a versioned file.
             </dd>
           </dl>
         </div>

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -1,4 +1,5 @@
 from zope import schema
+from zope.interface import Attribute
 from zope.interface import Interface
 
 
@@ -10,12 +11,21 @@ class IGeverBumblebeeSettings(Interface):
         default=False)
 
 
+class IVersionedContextMarker(Interface):
+    """Marker interface for a versioned context.
+    """
+
+
 class IBumblebeeOverlay(Interface):
     """Interface for the bumblebee overlay.
 
     This interface defines the required methods to render the bumblebee
     overlay template.
     """
+
+    version_id = Attribute(
+        "Defines which version of the file should be shown."
+        "Default: None => the actual file will be shown")
 
     def get_preview_pdf_url():
         """Returns an url to an image.
@@ -122,4 +132,12 @@ class IBumblebeeOverlay(Interface):
         """Renders the lock info viewlet.
 
         Returns html.
+        """
+
+    def get_revert_link():
+        """Returns the url to retrieve the document.
+        """
+
+    def is_versioned_context():
+        """Returns True if the context is a versioned context.
         """

--- a/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-28 07:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Dokumentdatum:"
 msgid "Dossier:"
 msgstr "Dossier:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:44
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:47
 msgid "Open as PDF"
 msgstr "Dokument als PDF öffnen"
 
@@ -42,13 +42,23 @@ msgstr "Aktenzeichen:"
 msgid "Sequence number:"
 msgstr "Laufnummer:"
 
+#. Default: "Revert document"
+#: ./opengever/bumblebee/browser/overlay.py:196
+msgid "label_revert"
+msgstr "Dokument zurücksetzen"
+
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:82
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:98
 msgid "showroom_nav_button_next"
 msgstr "Weiter"
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:80
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:96
 msgid "showroom_nav_button_prev"
 msgstr "Zurück"
+
+#. Default: "You are looking at a versioned file."
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:87
+msgid "warning_on_versioned_context"
+msgstr "Sie sehen sich ein versioniertes Dokument an."
 

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-28 07:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Date du document:"
 msgid "Dossier:"
 msgstr "Dossier:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:44
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:47
 msgid "Open as PDF"
 msgstr "Ouvrir le document en PDF"
 
@@ -42,13 +42,23 @@ msgstr "Numéro de référence:"
 msgid "Sequence number:"
 msgstr "Numéro courant:"
 
+#. Default: "Revert document"
+#: ./opengever/bumblebee/browser/overlay.py:196
+msgid "label_revert"
+msgstr "Reculer le document"
+
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:82
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:98
 msgid "showroom_nav_button_next"
 msgstr ""
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:80
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:96
 msgid "showroom_nav_button_prev"
 msgstr ""
+
+#. Default: "You are looking at a versioned file."
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:87
+msgid "warning_on_versioned_context"
+msgstr "Vous regardez un fichier versionné."
 

--- a/opengever/bumblebee/locales/opengever.bumblebee.pot
+++ b/opengever/bumblebee/locales/opengever.bumblebee.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-28 07:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Dossier:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:44
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:47
 msgid "Open as PDF"
 msgstr ""
 
@@ -45,13 +45,23 @@ msgstr ""
 msgid "Sequence number:"
 msgstr ""
 
+#. Default: "Revert document"
+#: ./opengever/bumblebee/browser/overlay.py:196
+msgid "label_revert"
+msgstr ""
+
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:82
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:98
 msgid "showroom_nav_button_next"
 msgstr ""
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:80
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:96
 msgid "showroom_nav_button_prev"
+msgstr ""
+
+#. Default: "You are looking at a versioned file."
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:87
+msgid "warning_on_versioned_context"
 msgstr ""
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document_version.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document_version.py
@@ -1,0 +1,28 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.bumblebee.browser.overlay import BumblebeeDocumentVersionOverlay
+from opengever.bumblebee.interfaces import IBumblebeeOverlay
+from opengever.bumblebee.interfaces import IVersionedContextMarker
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+from opengever.testing import FunctionalTestCase
+from zope.component import getMultiAdapter
+from zope.interface import alsoProvides
+from zope.interface.verify import verifyClass
+
+
+class TestAdapterRegisteredProperly(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def test_get_overlay_adapter_for_documents(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+
+        alsoProvides(self.request, IVersionedContextMarker)
+
+        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+
+        self.assertIsInstance(adapter, BumblebeeDocumentVersionOverlay)
+
+    def test_verify_implemented_interfaces(self):
+        verifyClass(IBumblebeeOverlay, BumblebeeDocumentVersionOverlay)

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -2,10 +2,12 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testbrowser import browsing
+from opengever.bumblebee.browser.overlay import BumblebeeOverlayBaseView
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
+from opengever.testing.helpers import create_document_version
 from zExceptions import NotFound
-from opengever.bumblebee.browser.overlay import BumblebeeOverlayBaseView
+import transaction
 
 
 class TestBumblebeeOverlayListing(FunctionalTestCase):
@@ -111,6 +113,25 @@ class TestBumblebeeOverlayListing(FunctionalTestCase):
              'Edit metadata'],
             browser.css('.file-actions a').text)
 
+    @browsing
+    def test_actions_with_versioned_document(self, browser):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier)
+                          .attach_file_containing(
+                              bumblebee_asset('example.docx').bytes(),
+                              u'example.docx'))
+
+        create_document_version(document, version_id=1)
+        transaction.commit()
+
+        browser.login().visit(document, view="bumblebee-overlay-document?version_id=1")
+
+        self.assertEqual(
+            ['Download copy',
+             'Revert document'],
+            browser.css('.file-actions a').text)
+
 
 class TestBumblebeeOverlayDocument(FunctionalTestCase):
 
@@ -209,6 +230,25 @@ class TestBumblebeeOverlayDocument(FunctionalTestCase):
             ['Download copy',
              'Open as PDF',
              'Edit metadata'],
+            browser.css('.file-actions a').text)
+
+    @browsing
+    def test_actions_with_versioned_document(self, browser):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier)
+                          .attach_file_containing(
+                              bumblebee_asset('example.docx').bytes(),
+                              u'example.docx'))
+
+        create_document_version(document, version_id=1)
+        transaction.commit()
+
+        browser.login().visit(document, view="bumblebee-overlay-document?version_id=1")
+
+        self.assertEqual(
+            ['Download copy',
+             'Revert document'],
             browser.css('.file-actions a').text)
 
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 19:18+0000\n"
+"POT-Creation-Date: 2016-06-28 07:24+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -154,7 +154,7 @@ msgid "button_checkin"
 msgstr "Einchecken"
 
 #. Default: "PDF"
-#: ./opengever/document/browser/versions_tab.py:147
+#: ./opengever/document/browser/versions_tab.py:150
 msgid "button_pdf"
 msgstr "PDF Vorschau"
 
@@ -263,7 +263,7 @@ msgid "initial_document_version_change_note"
 msgstr "Dokument erstellt (Initialversion)"
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:283
+#: ./opengever/document/browser/versions_tab.py:286
 msgid "label_actor"
 msgstr "Geändert von"
 
@@ -303,7 +303,7 @@ msgid "label_checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:291
+#: ./opengever/document/browser/versions_tab.py:294
 msgid "label_comment"
 msgstr "Kommentar"
 
@@ -313,7 +313,7 @@ msgid "label_creator"
 msgstr "Ersteller"
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:287
+#: ./opengever/document/browser/versions_tab.py:290
 msgid "label_date"
 msgstr "Datum"
 
@@ -390,6 +390,7 @@ msgstr "In Papierform aufbewahrt"
 
 #. Default: "Preview"
 #: ./opengever/document/behaviors/metadata.py:150
+#: ./opengever/document/browser/versions_tab.py:311
 msgid "label_preview"
 msgstr "Vorschau"
 
@@ -409,8 +410,13 @@ msgid "label_related_documents"
 msgstr "Verwandte Dokumente"
 
 #. Default: "reset"
-#: ./opengever/document/browser/versions_tab.py:162
+#: ./opengever/document/browser/versions_tab.py:165
 msgid "label_reset"
+msgstr "Zurücksetzen"
+
+#. Default: "Revert"
+#: ./opengever/document/browser/versions_tab.py:307
+msgid "label_revert"
 msgstr "Zurücksetzen"
 
 #. Default: "Sequence Number"
@@ -434,7 +440,7 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:279
+#: ./opengever/document/browser/versions_tab.py:282
 msgid "label_version"
 msgstr "Version"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 19:18+0000\n"
+"POT-Creation-Date: 2016-06-28 07:24+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -151,7 +151,7 @@ msgid "button_checkin"
 msgstr "Checkin"
 
 #. Default: "PDF"
-#: ./opengever/document/browser/versions_tab.py:147
+#: ./opengever/document/browser/versions_tab.py:150
 msgid "button_pdf"
 msgstr "Aperçu pdf"
 
@@ -255,7 +255,7 @@ msgid "initial_document_version_change_note"
 msgstr "Document créé (version initiale)"
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:283
+#: ./opengever/document/browser/versions_tab.py:286
 msgid "label_actor"
 msgstr "Modifier par"
 
@@ -295,7 +295,7 @@ msgid "label_checkout_and_edit"
 msgstr "Checkout / Modifier"
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:291
+#: ./opengever/document/browser/versions_tab.py:294
 msgid "label_comment"
 msgstr "commentaire"
 
@@ -305,7 +305,7 @@ msgid "label_creator"
 msgstr "Créateur"
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:287
+#: ./opengever/document/browser/versions_tab.py:290
 msgid "label_date"
 msgstr "Date"
 
@@ -382,6 +382,7 @@ msgstr "Conserver sous forme papier"
 
 #. Default: "Preview"
 #: ./opengever/document/behaviors/metadata.py:150
+#: ./opengever/document/browser/versions_tab.py:311
 msgid "label_preview"
 msgstr "Aperçu"
 
@@ -401,9 +402,14 @@ msgid "label_related_documents"
 msgstr "Documents liés"
 
 #. Default: "reset"
-#: ./opengever/document/browser/versions_tab.py:162
+#: ./opengever/document/browser/versions_tab.py:165
 msgid "label_reset"
 msgstr "Remettre"
+
+#. Default: "Revert"
+#: ./opengever/document/browser/versions_tab.py:307
+msgid "label_revert"
+msgstr "Reculer"
 
 #. Default: "Sequence Number"
 #: ./opengever/document/viewlets/byline.py:29
@@ -426,7 +432,7 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:279
+#: ./opengever/document/browser/versions_tab.py:282
 msgid "label_version"
 msgstr "Version"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 19:18+0000\n"
+"POT-Creation-Date: 2016-06-28 07:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -154,7 +154,7 @@ msgid "button_checkin"
 msgstr ""
 
 #. Default: "PDF"
-#: ./opengever/document/browser/versions_tab.py:147
+#: ./opengever/document/browser/versions_tab.py:150
 msgid "button_pdf"
 msgstr ""
 
@@ -258,7 +258,7 @@ msgid "initial_document_version_change_note"
 msgstr ""
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:283
+#: ./opengever/document/browser/versions_tab.py:286
 msgid "label_actor"
 msgstr ""
 
@@ -298,7 +298,7 @@ msgid "label_checkout_and_edit"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:291
+#: ./opengever/document/browser/versions_tab.py:294
 msgid "label_comment"
 msgstr ""
 
@@ -308,7 +308,7 @@ msgid "label_creator"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:287
+#: ./opengever/document/browser/versions_tab.py:290
 msgid "label_date"
 msgstr ""
 
@@ -385,6 +385,7 @@ msgstr ""
 
 #. Default: "Preview"
 #: ./opengever/document/behaviors/metadata.py:150
+#: ./opengever/document/browser/versions_tab.py:311
 msgid "label_preview"
 msgstr ""
 
@@ -404,8 +405,13 @@ msgid "label_related_documents"
 msgstr ""
 
 #. Default: "reset"
-#: ./opengever/document/browser/versions_tab.py:162
+#: ./opengever/document/browser/versions_tab.py:165
 msgid "label_reset"
+msgstr ""
+
+#. Default: "Revert"
+#: ./opengever/document/browser/versions_tab.py:307
+msgid "label_revert"
 msgstr ""
 
 #. Default: "Sequence Number"
@@ -429,7 +435,7 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:279
+#: ./opengever/document/browser/versions_tab.py:282
 msgid "label_version"
 msgstr ""
 

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -76,7 +76,7 @@ class TestVersionsTabWithoutPDFConverter(TestVersionsTab):
              'Datum',
              'Kommentar',
              'Kopie herunterladen',
-             u'Zur\xfccksetzten'],
+             u'Zur\xfccksetzen'],
             column_headers)
 
     @browsing
@@ -165,7 +165,7 @@ class TestVersionsTabWithBubmelbeeActivated(TestVersionsTab):
              'Datum',
              'Kommentar',
              'Kopie herunterladen',
-             u'Zur\xfccksetzten',
+             u'Zur\xfccksetzen',
              'Vorschau'],
             column_headers)
 

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import create_document_version
 from plone import api
@@ -70,7 +71,12 @@ class TestVersionsTabWithoutPDFConverter(TestVersionsTab):
         listing = browser.css('.listing').first
         column_headers = listing.lists()[0]
         self.assertEquals(
-            ['Version', u'Ge\xe4ndert von', 'Datum', 'Kommentar', '', ''],
+            ['Version',
+             u'Ge\xe4ndert von',
+             'Datum',
+             'Kommentar',
+             'Kopie herunterladen',
+             u'Zur\xfccksetzten'],
             column_headers)
 
     @browsing
@@ -142,3 +148,34 @@ class TestVersionsTabWithPDFConverter(TestVersionsTab):
         self.assertIn('_authenticator', query)
         self.assertEquals(
             '/plone/dossier-1/document-1/download_pdf_version', url.path)
+
+
+class TestVersionsTabWithBubmelbeeActivated(TestVersionsTab):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    @browsing
+    def test_columns_are_ordered_and_translated(self, browser):
+        browser.login().open(self.document, view='tabbedview_view-versions')
+        listing = browser.css('.listing').first
+        column_headers = listing.lists()[0]
+        self.assertEquals(
+            ['Version',
+             u'Ge\xe4ndert von',
+             'Datum',
+             'Kommentar',
+             'Kopie herunterladen',
+             u'Zur\xfccksetzten',
+             'Vorschau'],
+            column_headers)
+
+    @browsing
+    def test_preview_link_is_properly_constructed(self, browser):
+        browser.login().open(self.document, view='tabbedview_view-versions')
+
+        preview_link = browser.css('.listing .showroom-item').first
+
+        self.assertEquals('Vorschau', preview_link.text)
+        self.assertIn(
+            '/plone/dossier-1/document-1/@@bumblebee-overlay-listing?version_id=3',
+            preview_link.attrib['href'])

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -217,8 +217,8 @@ def linked_version_preview(item, value):
 
     showroom_title = translate(
         _('label_showroom_version_title',
-            default='Version ${version}',
-            mapping={'version': item.version}),
+            default='Version ${version} of ${timestamp}',
+            mapping={'version': item.version, 'timestamp': item.timestamp}),
         context=getRequest()).encode('utf-8')
 
     data = {

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -211,6 +211,37 @@ def linked_trashed_document_with_tooltip(item, value):
                                          removed=removed)
 
 
+def linked_version_preview(item, value):
+    url = "{}/@@bumblebee-overlay-listing?version_id={}".format(
+        item.url, item.version)
+
+    showroom_title = translate(
+        _('label_showroom_version_title',
+            default='Version ${version}',
+            mapping={'version': item.version}),
+        context=getRequest()).encode('utf-8')
+
+    data = {
+        'url': url,
+        'showroom_url': url,
+        'showroom_title': showroom_title,
+        'title': translate(
+            _('label_preview', default='Preview'),
+            context=getRequest()).encode('utf-8')
+    }
+
+    return """
+    <div>
+        <a class="showroom-item"
+           href="{%(url)s}"
+           data-showroom-target="%(showroom_url)s"
+           data-showroom-title="%(showroom_title)s">
+        %(title)s
+        </a>
+    </div>
+    """ % data
+
+
 def _linked_bumblebee_document(item, value):
     data = {
         'url': item.getURL(),

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-28 07:25+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -70,7 +70,7 @@ msgid "button_more_actions"
 msgstr "Weitere Aktionen &#9660;"
 
 #. Default: "PDF Preview"
-#: ./opengever/tabbedview/helper.py:249
+#: ./opengever/tabbedview/helper.py:280
 msgid "button_pdf_preview"
 msgstr "PDF Vorschau"
 
@@ -276,6 +276,11 @@ msgstr "Keine Inhalte"
 msgid "label_pending"
 msgstr "Pendent"
 
+#. Default: "Preview"
+#: ./opengever/tabbedview/helper.py:227
+msgid "label_preview"
+msgstr "Vorschau"
+
 #. Default: "Public Trial"
 #: ./opengever/tabbedview/browser/tabs.py:126
 msgid "label_public_trial"
@@ -300,6 +305,11 @@ msgstr "Auftragnehmer"
 #: ./opengever/tabbedview/browser/tabs.py:199
 msgid "label_review_state"
 msgstr "Status"
+
+#. Default: "Version ${version} of ${timestamp}"
+#: ./opengever/tabbedview/helper.py:217
+msgid "label_showroom_version_title"
+msgstr "Version ${version} vom ${timestamp}"
 
 #. Default: "Start"
 #: ./opengever/tabbedview/browser/tabs.py:208

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-28 07:25+0000\n"
 "PO-Revision-Date: 2013-03-27 11:23+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,7 +67,7 @@ msgid "button_more_actions"
 msgstr "Autres actions"
 
 #. Default: "PDF Preview"
-#: ./opengever/tabbedview/helper.py:249
+#: ./opengever/tabbedview/helper.py:280
 msgid "button_pdf_preview"
 msgstr ""
 
@@ -268,6 +268,11 @@ msgstr "Aucun contenu"
 msgid "label_pending"
 msgstr "En suspens"
 
+#. Default: "Preview"
+#: ./opengever/tabbedview/helper.py:227
+msgid "label_preview"
+msgstr "Aperçu"
+
 #. Default: "Public Trial"
 #: ./opengever/tabbedview/browser/tabs.py:126
 msgid "label_public_trial"
@@ -292,6 +297,11 @@ msgstr "Mandataire"
 #: ./opengever/tabbedview/browser/tabs.py:199
 msgid "label_review_state"
 msgstr "Etat"
+
+#. Default: "Version ${version} of ${timestamp}"
+#: ./opengever/tabbedview/helper.py:217
+msgid "label_showroom_version_title"
+msgstr "Version ${version} de ${timestamp}"
 
 #. Default: "Start"
 #: ./opengever/tabbedview/browser/tabs.py:208

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-28 07:25+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -68,7 +68,7 @@ msgid "button_more_actions"
 msgstr ""
 
 #. Default: "PDF Preview"
-#: ./opengever/tabbedview/helper.py:249
+#: ./opengever/tabbedview/helper.py:280
 msgid "button_pdf_preview"
 msgstr ""
 
@@ -269,6 +269,11 @@ msgstr ""
 msgid "label_pending"
 msgstr ""
 
+#. Default: "Preview"
+#: ./opengever/tabbedview/helper.py:227
+msgid "label_preview"
+msgstr ""
+
 #. Default: "Public Trial"
 #: ./opengever/tabbedview/browser/tabs.py:126
 msgid "label_public_trial"
@@ -292,6 +297,11 @@ msgstr ""
 #. Default: "Review state"
 #: ./opengever/tabbedview/browser/tabs.py:199
 msgid "label_review_state"
+msgstr ""
+
+#. Default: "Version ${version} of ${timestamp}"
+#: ./opengever/tabbedview/helper.py:217
+msgid "label_showroom_version_title"
 msgstr ""
 
 #. Default: "Start"


### PR DESCRIPTION
This PR add the bumblebee-previews for the document-versions:

![bildschirmfoto 2016-06-24 um 16 50 53](https://cloud.githubusercontent.com/assets/557005/16341130/e1ea55a4-3a2b-11e6-99d6-7c2f432eb276.png)


closes #1670 