### PR TITLE
Remove empty help texts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Remove empty help texts (field descriptions that were i18nized
+  but never got translated).
+  [lgraf]
+
 - Fixed bumblebee overlay browse functionality for the document extjs listing.
   [phgross]
 

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/advancedsearch/advanced_search.py
+++ b/opengever/advancedsearch/advanced_search.py
@@ -160,14 +160,12 @@ class IAdvancedSearch(directives_form.Schema):
     directives_form.widget(responsible=AutocompleteFieldWidget)
     responsible = schema.Choice(
         title=_('label_reponsible', default='Responsible'),
-        description=_('help_responsible', default=''),
         vocabulary=u'opengever.ogds.base.AllUsersVocabulary',
         required=False,
     )
 
     dossier_review_state = schema.List(
         title=_('label_review_state', default='State'),
-        description=_('help_review_state', default=''),
         value_type=schema.Choice(
             source=get_possible_dossier_states,
         ),
@@ -210,21 +208,18 @@ class IAdvancedSearch(directives_form.Schema):
 
     document_author = schema.TextLine(
         title=_('label_document_author', default='Document author'),
-        description=_('help_document_author', default=''),
         required=False,
     )
 
     directives_form.widget(responsible=AutocompleteFieldWidget)
     checked_out = schema.Choice(
         title=_('label_checked_out', default='Checked out by'),
-        description=_('help_checked_out', default=''),
         vocabulary=u'opengever.ogds.base.UsersVocabulary',
         required=False,
     )
 
     trashed = schema.Bool(
         title=_('label_trashed', default='Also search in the recycle bin'),
-        description=_('help_trashed', default=''),
         required=False,
     )
 
@@ -251,7 +246,6 @@ class IAdvancedSearch(directives_form.Schema):
 
     task_type = schema.Choice(
         title=_('label_tasktype', default=''),
-        description=_('help_tasktyp', default=''),
         source=getTaskTypeVocabulary,
         required=False,
     )

--- a/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-12-06 12:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 18:55+0000\n"
 "PO-Revision-Date: 2012-12-06 12:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,12 +15,12 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:273
+#: ./opengever/advancedsearch/advanced_search.py:267
 msgid "advanced_search"
 msgstr "Erweiterte Suche"
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:457
+#: ./opengever/advancedsearch/advanced_search.py:451
 msgid "button_search"
 msgstr "Suchen"
 
@@ -32,15 +32,7 @@ msgstr "Dokument"
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/advancedsearch/advanced_search.py:220
-msgid "help_checked_out"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:213
-msgid "help_document_author"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:235
+#: ./opengever/advancedsearch/advanced_search.py:230
 msgid "help_issuer"
 msgstr "Auftraggeber auswählen"
 
@@ -50,7 +42,7 @@ msgid "help_portal_type"
 msgstr "Wählen Sie den Inhaltstyp aus, nach dem gesucht werden soll."
 
 #. Default: "Select the contenttype to be searched for.It searches only items from the current client."
-#: ./opengever/advancedsearch/advanced_search.py:355
+#: ./opengever/advancedsearch/advanced_search.py:349
 msgid "help_portal_type_multiclient_setup"
 msgstr ""
 "Wählen Sie den Inhaltstyp aus, nach dem gesucht werden soll.\n"
@@ -60,11 +52,7 @@ msgstr ""
 msgid "help_reference_number"
 msgstr "Aktenzeichen angeben (z.B: OG 2.4 / 1 / 3)"
 
-#: ./opengever/advancedsearch/advanced_search.py:163
-msgid "help_responsible"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:170
+#: ./opengever/advancedsearch/advanced_search.py:254
 msgid "help_review_state"
 msgstr ""
 
@@ -76,45 +64,37 @@ msgstr "Suchbegriffe eingeben."
 msgid "help_sequence_number"
 msgstr "Genaue Laufnummer eingeben."
 
-#: ./opengever/advancedsearch/advanced_search.py:254
-msgid "help_tasktyp"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:227
-msgid "help_trashed"
-msgstr ""
-
 #. Default: "Advanced Search…"
 #: ./opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py:97
 msgid "label_advanced_search"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:219
+#: ./opengever/advancedsearch/advanced_search.py:216
 msgid "label_checked_out"
 msgstr "Ausgecheckt von"
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:241
+#: ./opengever/advancedsearch/advanced_search.py:236
 msgid "label_deadline"
 msgstr "Frist"
 
-#: ./opengever/advancedsearch/advanced_search.py:247
+#: ./opengever/advancedsearch/advanced_search.py:242
 msgid "label_deadline_2"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:190
+#: ./opengever/advancedsearch/advanced_search.py:188
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:212
+#: ./opengever/advancedsearch/advanced_search.py:210
 msgid "label_document_author"
 msgstr "Autor des Dokuments"
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:201
+#: ./opengever/advancedsearch/advanced_search.py:199
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
@@ -129,7 +109,7 @@ msgid "label_from"
 msgstr "Von"
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:234
+#: ./opengever/advancedsearch/advanced_search.py:229
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -144,7 +124,7 @@ msgid "label_portal_type"
 msgstr "Inhaltstyp"
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:179
+#: ./opengever/advancedsearch/advanced_search.py:177
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
@@ -159,7 +139,7 @@ msgid "label_reponsible"
 msgstr "Federführung"
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py:168
 msgid "label_review_state"
 msgstr "Status"
 
@@ -183,7 +163,7 @@ msgstr ""
 msgid "label_start"
 msgstr "Startdatum"
 
-#: ./opengever/advancedsearch/advanced_search.py:253
+#: ./opengever/advancedsearch/advanced_search.py:248
 msgid "label_tasktype"
 msgstr "Auftragstyp"
 
@@ -193,7 +173,7 @@ msgid "label_to"
 msgstr "Bis"
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:226
+#: ./opengever/advancedsearch/advanced_search.py:222
 msgid "label_trashed"
 msgstr "Papierkorb auch durchsuchen"
 

--- a/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2013-06-05 09:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 18:55+0000\n"
 "PO-Revision-Date: 2013-06-05 09:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,12 +15,12 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:273
+#: ./opengever/advancedsearch/advanced_search.py:267
 msgid "advanced_search"
 msgstr "Recherche avancée"
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:457
+#: ./opengever/advancedsearch/advanced_search.py:451
 msgid "button_search"
 msgstr "Rechercher"
 
@@ -32,15 +32,7 @@ msgstr "Document"
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/advancedsearch/advanced_search.py:220
-msgid "help_checked_out"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:213
-msgid "help_document_author"
-msgstr "Auteur du document"
-
-#: ./opengever/advancedsearch/advanced_search.py:235
+#: ./opengever/advancedsearch/advanced_search.py:230
 msgid "help_issuer"
 msgstr "Choix du client"
 
@@ -50,7 +42,7 @@ msgid "help_portal_type"
 msgstr "Choix du type de contenu à rechercher."
 
 #. Default: "Select the contenttype to be searched for.It searches only items from the current client."
-#: ./opengever/advancedsearch/advanced_search.py:355
+#: ./opengever/advancedsearch/advanced_search.py:349
 msgid "help_portal_type_multiclient_setup"
 msgstr "Choix du type de contenu à rechercher. Ne sont parcourus que les contenus du mandant actuel."
 
@@ -58,11 +50,7 @@ msgstr "Choix du type de contenu à rechercher. Ne sont parcourus que les conten
 msgid "help_reference_number"
 msgstr "Saisir le numéro de référence"
 
-#: ./opengever/advancedsearch/advanced_search.py:163
-msgid "help_responsible"
-msgstr "Responsable"
-
-#: ./opengever/advancedsearch/advanced_search.py:170
+#: ./opengever/advancedsearch/advanced_search.py:254
 msgid "help_review_state"
 msgstr "Etat de révision"
 
@@ -74,45 +62,37 @@ msgstr "Saisir les critères de recherche"
 msgid "help_sequence_number"
 msgstr "Saisir le numéro courant"
 
-#: ./opengever/advancedsearch/advanced_search.py:254
-msgid "help_tasktyp"
-msgstr "Type de tâche"
-
-#: ./opengever/advancedsearch/advanced_search.py:227
-msgid "help_trashed"
-msgstr ""
-
 #. Default: "Advanced Search…"
 #: ./opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py:97
 msgid "label_advanced_search"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:219
+#: ./opengever/advancedsearch/advanced_search.py:216
 msgid "label_checked_out"
 msgstr "Checkout fait par"
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:241
+#: ./opengever/advancedsearch/advanced_search.py:236
 msgid "label_deadline"
 msgstr "Délai"
 
-#: ./opengever/advancedsearch/advanced_search.py:247
+#: ./opengever/advancedsearch/advanced_search.py:242
 msgid "label_deadline_2"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:190
+#: ./opengever/advancedsearch/advanced_search.py:188
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:212
+#: ./opengever/advancedsearch/advanced_search.py:210
 msgid "label_document_author"
 msgstr "Auteur du document"
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:201
+#: ./opengever/advancedsearch/advanced_search.py:199
 msgid "label_document_date"
 msgstr "Date du document"
 
@@ -127,7 +107,7 @@ msgid "label_from"
 msgstr "de"
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:234
+#: ./opengever/advancedsearch/advanced_search.py:229
 msgid "label_issuer"
 msgstr "Mandataire"
 
@@ -142,7 +122,7 @@ msgid "label_portal_type"
 msgstr "Type de contenu"
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:179
+#: ./opengever/advancedsearch/advanced_search.py:177
 msgid "label_receipt_date"
 msgstr "Date de réception"
 
@@ -157,7 +137,7 @@ msgid "label_reponsible"
 msgstr "Responsable"
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py:168
 msgid "label_review_state"
 msgstr "Etat"
 
@@ -181,7 +161,7 @@ msgstr ""
 msgid "label_start"
 msgstr "Date de début"
 
-#: ./opengever/advancedsearch/advanced_search.py:253
+#: ./opengever/advancedsearch/advanced_search.py:248
 msgid "label_tasktype"
 msgstr "Type de mandat"
 
@@ -191,7 +171,7 @@ msgid "label_to"
 msgstr "à"
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:226
+#: ./opengever/advancedsearch/advanced_search.py:222
 msgid "label_trashed"
 msgstr "Parcourir également la corbeille"
 

--- a/opengever/advancedsearch/locales/opengever.advancedsearch.pot
+++ b/opengever/advancedsearch/locales/opengever.advancedsearch.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 18:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,12 +18,12 @@ msgstr ""
 "Domain: opengever.advancedsearch\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:273
+#: ./opengever/advancedsearch/advanced_search.py:267
 msgid "advanced_search"
 msgstr ""
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:457
+#: ./opengever/advancedsearch/advanced_search.py:451
 msgid "button_search"
 msgstr ""
 
@@ -35,15 +35,7 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:220
-msgid "help_checked_out"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:213
-msgid "help_document_author"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:235
+#: ./opengever/advancedsearch/advanced_search.py:230
 msgid "help_issuer"
 msgstr ""
 
@@ -53,7 +45,7 @@ msgid "help_portal_type"
 msgstr ""
 
 #. Default: "Select the contenttype to be searched for.It searches only items from the current client."
-#: ./opengever/advancedsearch/advanced_search.py:355
+#: ./opengever/advancedsearch/advanced_search.py:349
 msgid "help_portal_type_multiclient_setup"
 msgstr ""
 
@@ -61,11 +53,7 @@ msgstr ""
 msgid "help_reference_number"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:163
-msgid "help_responsible"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:170
+#: ./opengever/advancedsearch/advanced_search.py:254
 msgid "help_review_state"
 msgstr ""
 
@@ -77,45 +65,37 @@ msgstr ""
 msgid "help_sequence_number"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:254
-msgid "help_tasktyp"
-msgstr ""
-
-#: ./opengever/advancedsearch/advanced_search.py:227
-msgid "help_trashed"
-msgstr ""
-
 #. Default: "Advanced Search…"
 #: ./opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py:97
 msgid "label_advanced_search"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:219
+#: ./opengever/advancedsearch/advanced_search.py:216
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:241
+#: ./opengever/advancedsearch/advanced_search.py:236
 msgid "label_deadline"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:247
+#: ./opengever/advancedsearch/advanced_search.py:242
 msgid "label_deadline_2"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:190
+#: ./opengever/advancedsearch/advanced_search.py:188
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:212
+#: ./opengever/advancedsearch/advanced_search.py:210
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:201
+#: ./opengever/advancedsearch/advanced_search.py:199
 msgid "label_document_date"
 msgstr ""
 
@@ -130,7 +110,7 @@ msgid "label_from"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:234
+#: ./opengever/advancedsearch/advanced_search.py:229
 msgid "label_issuer"
 msgstr ""
 
@@ -145,7 +125,7 @@ msgid "label_portal_type"
 msgstr ""
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:179
+#: ./opengever/advancedsearch/advanced_search.py:177
 msgid "label_receipt_date"
 msgstr ""
 
@@ -160,7 +140,7 @@ msgid "label_reponsible"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py:168
 msgid "label_review_state"
 msgstr ""
 
@@ -184,7 +164,7 @@ msgstr ""
 msgid "label_start"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:253
+#: ./opengever/advancedsearch/advanced_search.py:248
 msgid "label_tasktype"
 msgstr ""
 
@@ -194,7 +174,7 @@ msgid "label_to"
 msgstr ""
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:226
+#: ./opengever/advancedsearch/advanced_search.py:222
 msgid "label_trashed"
 msgstr ""
 

--- a/opengever/advancedsearch/locales/opengever.advancedsearch.pot
+++ b/opengever/advancedsearch/locales/opengever.advancedsearch.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/base/behaviors/base.py
+++ b/opengever/base/behaviors/base.py
@@ -28,7 +28,6 @@ class IOpenGeverBase(form.Schema):
     dexteritytextindexer.searchable('description')
     description = schema.Text(
         title=_(u'label_description', default=u'Description'),
-        description=_(u'help_description', default=u''),
         required=False,
         missing_value=u'',
         default=u'',

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -94,7 +94,6 @@ class IClassificationSettings(Interface):
     public_trial_default_value = schema.Choice(
         title=_(u'label_public_trial_default_value',
                 default=u'Public Trial default value'),
-        description=_(u'help_public_trial_default_value', default=u''),
         source=u'classification_public_trial_vocabulary',
         required=True,
         default=PUBLIC_TRIAL_UNCHECKED

--- a/opengever/base/behaviors/creator.py
+++ b/opengever/base/behaviors/creator.py
@@ -16,7 +16,6 @@ class ICreator(form.Schema):
     form.omitted('creators')
     creators = schema.Tuple(
         title=_(u'label_creators', u'Creators'),
-        description=_(u'help_creators', u''),
         value_type=schema.TextLine(),
         required=False,
         missing_value=(),

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -48,7 +48,6 @@ class ILifeCycle(form.Schema):
     retention_period_annotation = schema.Text(
         title=_(u'label_retention_period_annotation',
                 default=u'retentionPeriodAnnotation'),
-        description=_(u'help_retention_period_annotation', default=u''),
         required=False
     )
 
@@ -64,7 +63,6 @@ class ILifeCycle(form.Schema):
     archival_value_annotation = schema.Text(
         title=_(u'label_archival_value_annotation',
                 default=u'archivalValueAnnotation'),
-        description=_(u'help_archival_value_annotation', default=u''),
         required=False
     )
 
@@ -80,7 +78,6 @@ class ILifeCycle(form.Schema):
     form.widget(date_of_cassation=DatePickerFieldWidget)
     date_of_cassation = schema.Date(
         title=_(u'label_dateofcassation', default=u'Date of cassation'),
-        description=_(u'help_dateofcassation', default=u''),
         required=False,
     )
 
@@ -88,7 +85,6 @@ class ILifeCycle(form.Schema):
     form.widget(date_of_submission=DatePickerFieldWidget)
     date_of_submission = schema.Date(
         title=_(u'label_dateofsubmission', default=u'Date of submission'),
-        description=_(u'help_dateofsubmission', default=u''),
         required=False,
     )
 

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-29 15:22+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -190,7 +190,7 @@ msgid "label_confirm_action"
 msgstr "Aktion bestätigen"
 
 #. Default: "Created"
-#: ./opengever/base/viewlets/byline.py:60
+#: ./opengever/base/viewlets/byline.py:67
 msgid "label_created"
 msgstr "Erstellt am"
 
@@ -215,7 +215,7 @@ msgid "label_dateofsubmission"
 msgstr "Anbietezeitpunkt"
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:110
+#: ./opengever/base/browser/templates/gever-macros.pt:114
 msgid "label_default_error_message"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -225,17 +225,17 @@ msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Dossier:"
-#: ./opengever/base/browser/search.pt:309
+#: ./opengever/base/browser/search.pt:311
 msgid "label_dossier"
 msgstr "Dossier:"
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/base/subscribers.py:59
+#: ./opengever/base/subscribers.py:60
 msgid "label_initial_version_copied"
 msgstr "Dokument kopiert (Initialversion)"
 
 #. Default: "Last modified"
-#: ./opengever/base/viewlets/byline.py:65
+#: ./opengever/base/viewlets/byline.py:72
 msgid "label_last_modified"
 msgstr "Zuletzt verändert"
 
@@ -275,7 +275,7 @@ msgid "label_search"
 msgstr "Suche"
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:109
+#: ./opengever/base/browser/templates/gever-macros.pt:113
 msgid "label_severity_error"
 msgstr "Fehler"
 
@@ -370,7 +370,7 @@ msgstr "Haben Sie nicht gefunden, wonach Sie gesucht haben? Die ${advanced_searc
 msgid "search_results_advanced_link"
 msgstr "erweiterte Suche"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:92
+#: ./opengever/base/browser/templates/gever-macros.pt:96
 msgid "show all"
 msgstr "Alle anzeigen"
 

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:06+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -101,38 +101,18 @@ msgid "fieldset_lifecycle"
 msgstr "Lebenszyklus"
 
 #. Default: "Archival value code"
-#: ./opengever/base/behaviors/lifecycle.py:58
+#: ./opengever/base/behaviors/lifecycle.py:57
 msgid "help_archival_value"
 msgstr "Archivwürdigkeit"
-
-#: ./opengever/base/behaviors/lifecycle.py:67
-msgid "help_archival_value_annotation"
-msgstr ""
 
 #. Default: ""
 #: ./opengever/base/behaviors/classification.py:54
 msgid "help_classification"
 msgstr "Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen"
 
-#: ./opengever/base/behaviors/creator.py:19
-msgid "help_creators"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:74
+#: ./opengever/base/behaviors/lifecycle.py:72
 msgid "help_custody_period"
 msgstr "Dauer, während der nach der Archivierung die Dokumente vor öffentlicher Einsichtnahme geschützt sind"
-
-#: ./opengever/base/behaviors/lifecycle.py:83
-msgid "help_dateofcassation"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:91
-msgid "help_dateofsubmission"
-msgstr ""
-
-#: ./opengever/base/behaviors/base.py:31
-msgid "help_description"
-msgstr ""
 
 #. Default: ""
 #: ./opengever/base/behaviors/classification.py:61
@@ -143,10 +123,6 @@ msgstr "Markierung, die angibt, ob die Unterlagen besonders schützenswerte Pers
 msgid "help_public_trial"
 msgstr "Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht"
 
-#: ./opengever/base/behaviors/classification.py:97
-msgid "help_public_trial_default_value"
-msgstr ""
-
 #: ./opengever/base/behaviors/classification.py:76
 msgid "help_public_trial_statement"
 msgstr "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier"
@@ -155,22 +131,18 @@ msgstr "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdo
 msgid "help_retention_period"
 msgstr "Zeitraum zwischen dem jüngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses für die Geschäftstätigkeit der Verwaltungseinheit nicht mehr benötigt wird"
 
-#: ./opengever/base/behaviors/lifecycle.py:51
-msgid "help_retention_period_annotation"
-msgstr ""
-
 #. Default: "-- Already removed object --"
 #: ./opengever/base/adapters.py:199
 msgid "label_already_removed"
 msgstr "-- Bereits gelöscht --"
 
 #. Default: "Archival value"
-#: ./opengever/base/behaviors/lifecycle.py:57
+#: ./opengever/base/behaviors/lifecycle.py:56
 msgid "label_archival_value"
 msgstr "Archivwürdigkeit"
 
 #. Default: "archivalValueAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:65
+#: ./opengever/base/behaviors/lifecycle.py:64
 msgid "label_archival_value_annotation"
 msgstr "Kommentar zur Archivwürdigkeit"
 
@@ -200,17 +172,17 @@ msgid "label_creators"
 msgstr "Autoren"
 
 #. Default: "Custody period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:73
+#: ./opengever/base/behaviors/lifecycle.py:71
 msgid "label_custody_period"
 msgstr "Archivische Schutzfrist (Jahre)"
 
 #. Default: "Date of cassation"
-#: ./opengever/base/behaviors/lifecycle.py:82
+#: ./opengever/base/behaviors/lifecycle.py:80
 msgid "label_dateofcassation"
 msgstr "Kassationsdatum"
 
 #. Default: "Date of submission"
-#: ./opengever/base/behaviors/lifecycle.py:90
+#: ./opengever/base/behaviors/lifecycle.py:87
 msgid "label_dateofsubmission"
 msgstr "Anbietezeitpunkt"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:06+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,37 +100,17 @@ msgid "fieldset_lifecycle"
 msgstr "Cycle de vie"
 
 #. Default: "Archival value code"
-#: ./opengever/base/behaviors/lifecycle.py:58
+#: ./opengever/base/behaviors/lifecycle.py:57
 msgid "help_archival_value"
 msgstr "Valeur archivistique"
-
-#: ./opengever/base/behaviors/lifecycle.py:67
-msgid "help_archival_value_annotation"
-msgstr ""
 
 #: ./opengever/base/behaviors/classification.py:54
 msgid "help_classification"
 msgstr "Classification permettant la protection des documents contre la consultation non-autorisée "
 
-#: ./opengever/base/behaviors/creator.py:19
-msgid "help_creators"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:74
+#: ./opengever/base/behaviors/lifecycle.py:72
 msgid "help_custody_period"
 msgstr "Délai de protection"
-
-#: ./opengever/base/behaviors/lifecycle.py:83
-msgid "help_dateofcassation"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:91
-msgid "help_dateofsubmission"
-msgstr ""
-
-#: ./opengever/base/behaviors/base.py:31
-msgid "help_description"
-msgstr ""
 
 #: ./opengever/base/behaviors/classification.py:61
 msgid "help_privacy_layer"
@@ -140,10 +120,6 @@ msgstr "Marquage des documents contenant des données sensibles (loi sur la prot
 msgid "help_public_trial"
 msgstr "Mention, si les documents sont accessibles ou non selon la loi sur la protection des données"
 
-#: ./opengever/base/behaviors/classification.py:97
-msgid "help_public_trial_default_value"
-msgstr ""
-
 #: ./opengever/base/behaviors/classification.py:76
 msgid "help_public_trial_statement"
 msgstr "Date de la requête, requérant, date de la décision, Référence vers le dossier de la requête GEVER"
@@ -152,22 +128,18 @@ msgstr "Date de la requête, requérant, date de la décision, Référence vers 
 msgid "help_retention_period"
 msgstr "Durée entre la date du document plus récent contenu dans un dossier et la date à partir de laquelle le document n'est plus requis pour les activités administratives"
 
-#: ./opengever/base/behaviors/lifecycle.py:51
-msgid "help_retention_period_annotation"
-msgstr ""
-
 #. Default: "-- Already removed object --"
 #: ./opengever/base/adapters.py:199
 msgid "label_already_removed"
 msgstr "-- Déjà annulé --"
 
 #. Default: "Archival value"
-#: ./opengever/base/behaviors/lifecycle.py:57
+#: ./opengever/base/behaviors/lifecycle.py:56
 msgid "label_archival_value"
 msgstr "Valeur archivistique"
 
 #. Default: "archivalValueAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:65
+#: ./opengever/base/behaviors/lifecycle.py:64
 msgid "label_archival_value_annotation"
 msgstr "Commentaire concernant la valeur archivistique"
 
@@ -197,17 +169,17 @@ msgid "label_creators"
 msgstr "Auteurs"
 
 #. Default: "Custody period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:73
+#: ./opengever/base/behaviors/lifecycle.py:71
 msgid "label_custody_period"
 msgstr "Délai de protection archivistique"
 
 #. Default: "Date of cassation"
-#: ./opengever/base/behaviors/lifecycle.py:82
+#: ./opengever/base/behaviors/lifecycle.py:80
 msgid "label_dateofcassation"
 msgstr "Date d'élimination"
 
 #. Default: "Date of submission"
-#: ./opengever/base/behaviors/lifecycle.py:90
+#: ./opengever/base/behaviors/lifecycle.py:87
 msgid "label_dateofsubmission"
 msgstr "Date de proposition (des documents)"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-29 15:22+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-08-30 15:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -187,7 +187,7 @@ msgid "label_confirm_action"
 msgstr "Confirmer l'action"
 
 #. Default: "Created"
-#: ./opengever/base/viewlets/byline.py:60
+#: ./opengever/base/viewlets/byline.py:67
 msgid "label_created"
 msgstr "Créé le"
 
@@ -212,7 +212,7 @@ msgid "label_dateofsubmission"
 msgstr "Date de proposition (des documents)"
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:110
+#: ./opengever/base/browser/templates/gever-macros.pt:114
 msgid "label_default_error_message"
 msgstr ""
 
@@ -222,17 +222,17 @@ msgid "label_description"
 msgstr "Description"
 
 #. Default: "Dossier:"
-#: ./opengever/base/browser/search.pt:309
+#: ./opengever/base/browser/search.pt:311
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/base/subscribers.py:59
+#: ./opengever/base/subscribers.py:60
 msgid "label_initial_version_copied"
 msgstr "Version initiale (documents copiés)"
 
 #. Default: "Last modified"
-#: ./opengever/base/viewlets/byline.py:65
+#: ./opengever/base/viewlets/byline.py:72
 msgid "label_last_modified"
 msgstr "Dernière modification"
 
@@ -272,7 +272,7 @@ msgid "label_search"
 msgstr "Recherche"
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:109
+#: ./opengever/base/browser/templates/gever-macros.pt:113
 msgid "label_severity_error"
 msgstr ""
 
@@ -367,7 +367,7 @@ msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search}
 msgid "search_results_advanced_link"
 msgstr "Recherche avancée"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:92
+#: ./opengever/base/browser/templates/gever-macros.pt:96
 msgid "show all"
 msgstr "Tout afficher"
 

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,36 +100,16 @@ msgid "fieldset_lifecycle"
 msgstr ""
 
 #. Default: "Archival value code"
-#: ./opengever/base/behaviors/lifecycle.py:58
+#: ./opengever/base/behaviors/lifecycle.py:57
 msgid "help_archival_value"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:67
-msgid "help_archival_value_annotation"
 msgstr ""
 
 #: ./opengever/base/behaviors/classification.py:54
 msgid "help_classification"
 msgstr ""
 
-#: ./opengever/base/behaviors/creator.py:19
-msgid "help_creators"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:74
+#: ./opengever/base/behaviors/lifecycle.py:72
 msgid "help_custody_period"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:83
-msgid "help_dateofcassation"
-msgstr ""
-
-#: ./opengever/base/behaviors/lifecycle.py:91
-msgid "help_dateofsubmission"
-msgstr ""
-
-#: ./opengever/base/behaviors/base.py:31
-msgid "help_description"
 msgstr ""
 
 #: ./opengever/base/behaviors/classification.py:61
@@ -140,10 +120,6 @@ msgstr ""
 msgid "help_public_trial"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:97
-msgid "help_public_trial_default_value"
-msgstr ""
-
 #: ./opengever/base/behaviors/classification.py:76
 msgid "help_public_trial_statement"
 msgstr ""
@@ -152,22 +128,18 @@ msgstr ""
 msgid "help_retention_period"
 msgstr ""
 
-#: ./opengever/base/behaviors/lifecycle.py:51
-msgid "help_retention_period_annotation"
-msgstr ""
-
 #. Default: "-- Already removed object --"
 #: ./opengever/base/adapters.py:199
 msgid "label_already_removed"
 msgstr ""
 
 #. Default: "Archival value"
-#: ./opengever/base/behaviors/lifecycle.py:57
+#: ./opengever/base/behaviors/lifecycle.py:56
 msgid "label_archival_value"
 msgstr ""
 
 #. Default: "archivalValueAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:65
+#: ./opengever/base/behaviors/lifecycle.py:64
 msgid "label_archival_value_annotation"
 msgstr ""
 
@@ -197,17 +169,17 @@ msgid "label_creators"
 msgstr ""
 
 #. Default: "Custody period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:73
+#: ./opengever/base/behaviors/lifecycle.py:71
 msgid "label_custody_period"
 msgstr ""
 
 #. Default: "Date of cassation"
-#: ./opengever/base/behaviors/lifecycle.py:82
+#: ./opengever/base/behaviors/lifecycle.py:80
 msgid "label_dateofcassation"
 msgstr ""
 
 #. Default: "Date of submission"
-#: ./opengever/base/behaviors/lifecycle.py:90
+#: ./opengever/base/behaviors/lifecycle.py:87
 msgid "label_dateofsubmission"
 msgstr ""
 

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-29 15:22+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -187,7 +187,7 @@ msgid "label_confirm_action"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/base/viewlets/byline.py:60
+#: ./opengever/base/viewlets/byline.py:67
 msgid "label_created"
 msgstr ""
 
@@ -212,7 +212,7 @@ msgid "label_dateofsubmission"
 msgstr ""
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:110
+#: ./opengever/base/browser/templates/gever-macros.pt:114
 msgid "label_default_error_message"
 msgstr ""
 
@@ -222,17 +222,17 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Dossier:"
-#: ./opengever/base/browser/search.pt:309
+#: ./opengever/base/browser/search.pt:311
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/base/subscribers.py:59
+#: ./opengever/base/subscribers.py:60
 msgid "label_initial_version_copied"
 msgstr ""
 
 #. Default: "Last modified"
-#: ./opengever/base/viewlets/byline.py:65
+#: ./opengever/base/viewlets/byline.py:72
 msgid "label_last_modified"
 msgstr ""
 
@@ -272,7 +272,7 @@ msgid "label_search"
 msgstr ""
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:109
+#: ./opengever/base/browser/templates/gever-macros.pt:113
 msgid "label_severity_error"
 msgstr ""
 
@@ -366,7 +366,7 @@ msgstr ""
 msgid "search_results_advanced_link"
 msgstr ""
 
-#: ./opengever/base/browser/templates/gever-macros.pt:92
+#: ./opengever/base/browser/templates/gever-macros.pt:96
 msgid "show all"
 msgstr ""
 

--- a/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-20 12:19+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,41 +14,41 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:13
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:13
 msgid "Creator:"
 msgstr "Ersteller:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:17
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:17
 msgid "Document date:"
 msgstr "Dokumentdatum:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:21
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:21
 msgid "Dossier:"
 msgstr "Dossier:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:44
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:44
 msgid "Open as PDF"
 msgstr "Dokument als PDF öffnen"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:37
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:37
 msgid "Open detail view"
 msgstr "Detailansicht öffnen"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:29
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:29
 msgid "Reference number:"
 msgstr "Aktenzeichen:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:25
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:25
 msgid "Sequence number:"
 msgstr "Laufnummer:"
 
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:78
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:82
 msgid "showroom_nav_button_next"
 msgstr "Weiter"
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:76
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:80
 msgid "showroom_nav_button_prev"
 msgstr "Zurück"
 

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-20 12:19+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,41 +14,41 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:13
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:13
 msgid "Creator:"
 msgstr "Créateur:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:17
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:17
 msgid "Document date:"
 msgstr "Date du document:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:21
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:21
 msgid "Dossier:"
 msgstr "Dossier:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:44
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:44
 msgid "Open as PDF"
 msgstr "Ouvrir le document en PDF"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:37
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:37
 msgid "Open detail view"
 msgstr "Ouvrir vue détaillée"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:29
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:29
 msgid "Reference number:"
 msgstr "Numéro de référence:"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:25
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:25
 msgid "Sequence number:"
 msgstr "Numéro courant:"
 
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:78
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:82
 msgid "showroom_nav_button_next"
 msgstr ""
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:76
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:80
 msgid "showroom_nav_button_prev"
 msgstr ""
 

--- a/opengever/bumblebee/locales/opengever.bumblebee.pot
+++ b/opengever/bumblebee/locales/opengever.bumblebee.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-20 12:19+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,41 +17,41 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.bumblebee\n"
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:13
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:13
 msgid "Creator:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:17
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:17
 msgid "Document date:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:21
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:21
 msgid "Dossier:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:44
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:44
 msgid "Open as PDF"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:37
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:37
 msgid "Open detail view"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:29
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:29
 msgid "Reference number:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:25
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:25
 msgid "Sequence number:"
 msgstr ""
 
 #. Default: "Next"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:78
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:82
 msgid "showroom_nav_button_next"
 msgstr ""
 
 #. Default: "Previous"
-#: ./opengever/bumblebee/browser/overlay_templates/bumblebeeoverlayview.pt:76
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:80
 msgid "showroom_nav_button_prev"
 msgstr ""
 

--- a/opengever/contact/contact.py
+++ b/opengever/contact/contact.py
@@ -62,20 +62,17 @@ class IContact(form.Schema):
 
     salutation = schema.TextLine(
         title = _(u'label_salutation', default=u'Salutation'),
-        description = _(u'help_salutation', default=u''),
         required = False,
         )
 
     academic_title = schema.TextLine(
         title = _(u'label_academic_title', default=u'Academic title'),
-        description = _(u'help_academic_title', default=u''),
         required = False,
         )
 
     dexteritytextindexer.searchable('lastname')
     lastname = schema.TextLine(
         title = _(u'label_lastname', default=u'Lastname'),
-        description = _(u'help_lastname', default=u''),
         required = True,
         max_length=LASTNAME_LENGTH,
         )
@@ -83,70 +80,59 @@ class IContact(form.Schema):
     dexteritytextindexer.searchable('firstname')
     firstname = schema.TextLine(
         title = _(u'label_firstname', default=u'Firstname'),
-        description = _(u'help_firstname', default=u''),
         required = True,
         max_length=FIRSTNAME_LENGTH,
         )
 
     company = schema.TextLine(
         title = _(u'label_company', default=u"Company"),
-        description = _(u'help_company', default=u''),
         required = False,
         )
 
     department = schema.TextLine(
         title = _(u'label_department', default=u'Department'),
-        description = _(u'help_department', default=u''),
         required = False,
         )
 
     function = schema.TextLine(
         title = _(u'lable_function', default=u'Function'),
-        description = _(u'help_function', default=u''),
         required = False,
         )
 
     email = schema.TextLine(
         title = _(u'label_email', default=u'email'),
-        description = _(u'help_email', default=u''),
         required = False,
         max_length=EMAIL_LENGTH,
         )
 
     email2 = schema.TextLine(
         title = _(u'label_email2', default=u'Email 2'),
-        description = _('help_email2', default=u''),
         required = False,
         max_length=EMAIL_LENGTH,
         )
 
     url = schema.URI(
         title = _(u'label_url', default=u'Url'),
-        description = _(u'help_url', default=u''),
         required = False,
         )
 
     phone_office = schema.TextLine(
         title = _(u'label_phone_office', default=u'Phone office'),
-        description = _(u'help_phone_office', default=u''),
         required = False,
         )
 
     phone_fax = schema.TextLine(
         title = _(u'label_phone_fax', default=u'Fax'),
-        description = _(u'help_phone_fax', default=u''),
         required = False,
         )
 
     phone_mobile = schema.TextLine(
         title = _(u'label_phone_mobile', default=u'Mobile'),
-        description = _(u'help_phone_mobile', default=u''),
         required = False,
         )
 
     phone_home = schema.TextLine(
         title = _(u'label_phone_home', default=u'Phone home'),
-        description = _(u'help_phone_home', default=u''),
         required = False,
         )
 
@@ -157,37 +143,31 @@ class IContact(form.Schema):
 
     description = schema.Text(
         title=_(u'label_description', default=u'Description'),
-        description = _(u'help_description', default=u''),
         required=False,
         )
 
     address1 = schema.TextLine(
         title = _(u'label_address1', default=u'Address 1'),
-        description = _(u'help_address1', default=u''),
         required = False,
         )
 
     address2 = schema.TextLine(
         title = _(u'label_address2', default=u'Address 2'),
-        description = _(u'help_address2', default=u''),
         required = False,
         )
 
     zip_code = schema.TextLine(
         title = _(u'label_zip', default=u'ZIP'),
-        description = _(u'help_zip', default=u''),
         required = False,
         )
 
     city = schema.TextLine(
         title = _(u'label_city', default=u'City'),
-        description = _(u'help_city', default=u''),
         required = False,
         )
 
     country = schema.TextLine(
         title = _(u'label_country', default=u'Country'),
-        description = _(u'help_country', default=u''),
         required = False,
         )
 

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -159,7 +159,7 @@ msgstr "Beschreibung"
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:110
-#: ./opengever/contact/contactfolder.py:86
+#: ./opengever/contact/contactfolder.py:85
 msgid "label_email"
 msgstr "E-Mail 1"
 
@@ -170,13 +170,13 @@ msgstr "E-Mail 2"
 
 #. Default: "Firstname"
 #: ./opengever/contact/contact.py:85
-#: ./opengever/contact/contactfolder.py:81
+#: ./opengever/contact/contactfolder.py:80
 msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Lastname"
 #: ./opengever/contact/contact.py:77
-#: ./opengever/contact/contactfolder.py:76
+#: ./opengever/contact/contactfolder.py:75
 msgid "label_lastname"
 msgstr "Nachname"
 
@@ -197,7 +197,7 @@ msgstr "Telefon Mobile"
 
 #. Default: "Phone office"
 #: ./opengever/contact/contact.py:130
-#: ./opengever/contact/contactfolder.py:91
+#: ./opengever/contact/contactfolder.py:90
 msgid "label_phone_office"
 msgstr "Telefon Arbeit"
 

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 18:42+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/contact/contact.py:207
+#: ./opengever/contact/contact.py:187
 #: ./opengever/contact/profiles/default/types/opengever.contact.contact.xml
 msgid "Contact"
 msgstr "Kontakt"
@@ -32,177 +32,97 @@ msgstr "Kontaktordner"
 msgid "address"
 msgstr "Adresse"
 
-#: ./opengever/contact/contact.py:71
-msgid "help_academic_title"
-msgstr ""
-
-#: ./opengever/contact/contact.py:166
-msgid "help_address1"
-msgstr ""
-
-#: ./opengever/contact/contact.py:172
-msgid "help_address2"
-msgstr ""
-
-#: ./opengever/contact/contact.py:184
-msgid "help_city"
-msgstr ""
-
-#: ./opengever/contact/contact.py:93
-msgid "help_company"
-msgstr ""
-
-#: ./opengever/contact/contact.py:190
-msgid "help_country"
-msgstr ""
-
-#: ./opengever/contact/contact.py:99
-msgid "help_department"
-msgstr ""
-
-#: ./opengever/contact/contact.py:160
-msgid "help_description"
-msgstr ""
-
-#: ./opengever/contact/contact.py:111
-msgid "help_email"
-msgstr ""
-
-#: ./opengever/contact/contact.py:118
-msgid "help_email2"
-msgstr ""
-
-#: ./opengever/contact/contact.py:86
-msgid "help_firstname"
-msgstr ""
-
-#: ./opengever/contact/contact.py:105
-msgid "help_function"
-msgstr ""
-
-#: ./opengever/contact/contact.py:78
-msgid "help_lastname"
-msgstr ""
-
-#: ./opengever/contact/contact.py:137
-msgid "help_phone_fax"
-msgstr ""
-
-#: ./opengever/contact/contact.py:149
-msgid "help_phone_home"
-msgstr ""
-
-#: ./opengever/contact/contact.py:143
-msgid "help_phone_mobile"
-msgstr ""
-
-#: ./opengever/contact/contact.py:131
-msgid "help_phone_office"
-msgstr ""
-
-#: ./opengever/contact/contact.py:65
-msgid "help_salutation"
-msgstr ""
-
-#: ./opengever/contact/contact.py:125
-msgid "help_url"
-msgstr ""
-
-#: ./opengever/contact/contact.py:178
-msgid "help_zip"
-msgstr ""
-
 #. Default: "Internet"
 #: ./opengever/contact/contact.py:35
 msgid "internet"
 msgstr "Internet"
 
 #. Default: "Academic title"
-#: ./opengever/contact/contact.py:70
+#: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr "Titel"
 
 #. Default: "Address 1"
-#: ./opengever/contact/contact.py:165
+#: ./opengever/contact/contact.py:150
 msgid "label_address1"
 msgstr "Adresse (Strasse / Nr.)"
 
 #. Default: "Address 2"
-#: ./opengever/contact/contact.py:171
+#: ./opengever/contact/contact.py:155
 msgid "label_address2"
 msgstr "Adresszusatz"
 
 #. Default: "City"
-#: ./opengever/contact/contact.py:183
+#: ./opengever/contact/contact.py:165
 msgid "label_city"
 msgstr "Ort"
 
 #. Default: "Company"
-#: ./opengever/contact/contact.py:92
+#: ./opengever/contact/contact.py:88
 msgid "label_company"
 msgstr "Firma"
 
 #. Default: "Country"
-#: ./opengever/contact/contact.py:189
+#: ./opengever/contact/contact.py:170
 msgid "label_country"
 msgstr "Land"
 
 #. Default: "Department"
-#: ./opengever/contact/contact.py:98
+#: ./opengever/contact/contact.py:93
 msgid "label_department"
 msgstr "Abteilung"
 
 #. Default: "Description"
-#: ./opengever/contact/contact.py:159
+#: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "email"
-#: ./opengever/contact/contact.py:110
+#: ./opengever/contact/contact.py:103
 #: ./opengever/contact/contactfolder.py:85
 msgid "label_email"
 msgstr "E-Mail 1"
 
 #. Default: "Email 2"
-#: ./opengever/contact/contact.py:117
+#: ./opengever/contact/contact.py:109
 msgid "label_email2"
 msgstr "E-Mail 2"
 
 #. Default: "Firstname"
-#: ./opengever/contact/contact.py:85
+#: ./opengever/contact/contact.py:82
 #: ./opengever/contact/contactfolder.py:80
 msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Lastname"
-#: ./opengever/contact/contact.py:77
+#: ./opengever/contact/contact.py:75
 #: ./opengever/contact/contactfolder.py:75
 msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Fax"
-#: ./opengever/contact/contact.py:136
+#: ./opengever/contact/contact.py:125
 msgid "label_phone_fax"
 msgstr "Fax Arbeit"
 
 #. Default: "Phone home"
-#: ./opengever/contact/contact.py:148
+#: ./opengever/contact/contact.py:135
 msgid "label_phone_home"
 msgstr "Telefon Privat"
 
 #. Default: "Mobile"
-#: ./opengever/contact/contact.py:142
+#: ./opengever/contact/contact.py:130
 msgid "label_phone_mobile"
 msgstr "Telefon Mobile"
 
 #. Default: "Phone office"
-#: ./opengever/contact/contact.py:130
+#: ./opengever/contact/contact.py:120
 #: ./opengever/contact/contactfolder.py:90
 msgid "label_phone_office"
 msgstr "Telefon Arbeit"
 
 #. Default: "Picture"
-#: ./opengever/contact/contact.py:154
+#: ./opengever/contact/contact.py:140
 msgid "label_picture"
 msgstr "Bild"
 
@@ -212,17 +132,17 @@ msgid "label_salutation"
 msgstr "Anrede"
 
 #. Default: "Url"
-#: ./opengever/contact/contact.py:124
+#: ./opengever/contact/contact.py:115
 msgid "label_url"
 msgstr "URL"
 
 #. Default: "ZIP"
-#: ./opengever/contact/contact.py:177
+#: ./opengever/contact/contact.py:160
 msgid "label_zip"
 msgstr "PLZ"
 
 #. Default: "Function"
-#: ./opengever/contact/contact.py:104
+#: ./opengever/contact/contact.py:98
 msgid "lable_function"
 msgstr "Funktion"
 

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgstr "Description"
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:110
-#: ./opengever/contact/contactfolder.py:86
+#: ./opengever/contact/contactfolder.py:85
 msgid "label_email"
 msgstr "Email 1"
 
@@ -170,13 +170,13 @@ msgstr "Email 2"
 
 #. Default: "Firstname"
 #: ./opengever/contact/contact.py:85
-#: ./opengever/contact/contactfolder.py:81
+#: ./opengever/contact/contactfolder.py:80
 msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Lastname"
 #: ./opengever/contact/contact.py:77
-#: ./opengever/contact/contactfolder.py:76
+#: ./opengever/contact/contactfolder.py:75
 msgid "label_lastname"
 msgstr "Nom"
 
@@ -197,7 +197,7 @@ msgstr "Téléphone mobile"
 
 #. Default: "Phone office"
 #: ./opengever/contact/contact.py:130
-#: ./opengever/contact/contactfolder.py:91
+#: ./opengever/contact/contactfolder.py:90
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 18:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/contact/contact.py:207
+#: ./opengever/contact/contact.py:187
 #: ./opengever/contact/profiles/default/types/opengever.contact.contact.xml
 msgid "Contact"
 msgstr "Contact"
@@ -32,177 +32,97 @@ msgstr "Répertoire de contact"
 msgid "address"
 msgstr "Adresse"
 
-#: ./opengever/contact/contact.py:71
-msgid "help_academic_title"
-msgstr ""
-
-#: ./opengever/contact/contact.py:166
-msgid "help_address1"
-msgstr ""
-
-#: ./opengever/contact/contact.py:172
-msgid "help_address2"
-msgstr ""
-
-#: ./opengever/contact/contact.py:184
-msgid "help_city"
-msgstr ""
-
-#: ./opengever/contact/contact.py:93
-msgid "help_company"
-msgstr ""
-
-#: ./opengever/contact/contact.py:190
-msgid "help_country"
-msgstr ""
-
-#: ./opengever/contact/contact.py:99
-msgid "help_department"
-msgstr ""
-
-#: ./opengever/contact/contact.py:160
-msgid "help_description"
-msgstr ""
-
-#: ./opengever/contact/contact.py:111
-msgid "help_email"
-msgstr ""
-
-#: ./opengever/contact/contact.py:118
-msgid "help_email2"
-msgstr ""
-
-#: ./opengever/contact/contact.py:86
-msgid "help_firstname"
-msgstr ""
-
-#: ./opengever/contact/contact.py:105
-msgid "help_function"
-msgstr ""
-
-#: ./opengever/contact/contact.py:78
-msgid "help_lastname"
-msgstr ""
-
-#: ./opengever/contact/contact.py:137
-msgid "help_phone_fax"
-msgstr ""
-
-#: ./opengever/contact/contact.py:149
-msgid "help_phone_home"
-msgstr ""
-
-#: ./opengever/contact/contact.py:143
-msgid "help_phone_mobile"
-msgstr ""
-
-#: ./opengever/contact/contact.py:131
-msgid "help_phone_office"
-msgstr ""
-
-#: ./opengever/contact/contact.py:65
-msgid "help_salutation"
-msgstr ""
-
-#: ./opengever/contact/contact.py:125
-msgid "help_url"
-msgstr ""
-
-#: ./opengever/contact/contact.py:178
-msgid "help_zip"
-msgstr ""
-
 #. Default: "Internet"
 #: ./opengever/contact/contact.py:35
 msgid "internet"
 msgstr "Site internet"
 
 #. Default: "Academic title"
-#: ./opengever/contact/contact.py:70
+#: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr "Titre"
 
 #. Default: "Address 1"
-#: ./opengever/contact/contact.py:165
+#: ./opengever/contact/contact.py:150
 msgid "label_address1"
 msgstr "Adresse (rue / n°)"
 
 #. Default: "Address 2"
-#: ./opengever/contact/contact.py:171
+#: ./opengever/contact/contact.py:155
 msgid "label_address2"
 msgstr "Complément d'adresse"
 
 #. Default: "City"
-#: ./opengever/contact/contact.py:183
+#: ./opengever/contact/contact.py:165
 msgid "label_city"
 msgstr "Localité"
 
 #. Default: "Company"
-#: ./opengever/contact/contact.py:92
+#: ./opengever/contact/contact.py:88
 msgid "label_company"
 msgstr "Entreprise"
 
 #. Default: "Country"
-#: ./opengever/contact/contact.py:189
+#: ./opengever/contact/contact.py:170
 msgid "label_country"
 msgstr "Pays"
 
 #. Default: "Department"
-#: ./opengever/contact/contact.py:98
+#: ./opengever/contact/contact.py:93
 msgid "label_department"
 msgstr "Service"
 
 #. Default: "Description"
-#: ./opengever/contact/contact.py:159
+#: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "email"
-#: ./opengever/contact/contact.py:110
+#: ./opengever/contact/contact.py:103
 #: ./opengever/contact/contactfolder.py:85
 msgid "label_email"
 msgstr "Email 1"
 
 #. Default: "Email 2"
-#: ./opengever/contact/contact.py:117
+#: ./opengever/contact/contact.py:109
 msgid "label_email2"
 msgstr "Email 2"
 
 #. Default: "Firstname"
-#: ./opengever/contact/contact.py:85
+#: ./opengever/contact/contact.py:82
 #: ./opengever/contact/contactfolder.py:80
 msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Lastname"
-#: ./opengever/contact/contact.py:77
+#: ./opengever/contact/contact.py:75
 #: ./opengever/contact/contactfolder.py:75
 msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Fax"
-#: ./opengever/contact/contact.py:136
+#: ./opengever/contact/contact.py:125
 msgid "label_phone_fax"
 msgstr "Fax professionnel"
 
 #. Default: "Phone home"
-#: ./opengever/contact/contact.py:148
+#: ./opengever/contact/contact.py:135
 msgid "label_phone_home"
 msgstr "Téléphone privé"
 
 #. Default: "Mobile"
-#: ./opengever/contact/contact.py:142
+#: ./opengever/contact/contact.py:130
 msgid "label_phone_mobile"
 msgstr "Téléphone mobile"
 
 #. Default: "Phone office"
-#: ./opengever/contact/contact.py:130
+#: ./opengever/contact/contact.py:120
 #: ./opengever/contact/contactfolder.py:90
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 
 #. Default: "Picture"
-#: ./opengever/contact/contact.py:154
+#: ./opengever/contact/contact.py:140
 msgid "label_picture"
 msgstr "Image"
 
@@ -212,17 +132,17 @@ msgid "label_salutation"
 msgstr "Titre"
 
 #. Default: "Url"
-#: ./opengever/contact/contact.py:124
+#: ./opengever/contact/contact.py:115
 msgid "label_url"
 msgstr "Adresse URL"
 
 #. Default: "ZIP"
-#: ./opengever/contact/contact.py:177
+#: ./opengever/contact/contact.py:160
 msgid "label_zip"
 msgstr "NP"
 
 #. Default: "Function"
-#: ./opengever/contact/contact.py:104
+#: ./opengever/contact/contact.py:98
 msgid "lable_function"
 msgstr "Fonction"
 

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 18:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.contact\n"
 
-#: ./opengever/contact/contact.py:207
+#: ./opengever/contact/contact.py:187
 #: ./opengever/contact/profiles/default/types/opengever.contact.contact.xml
 msgid "Contact"
 msgstr ""
@@ -35,177 +35,97 @@ msgstr ""
 msgid "address"
 msgstr ""
 
-#: ./opengever/contact/contact.py:71
-msgid "help_academic_title"
-msgstr ""
-
-#: ./opengever/contact/contact.py:166
-msgid "help_address1"
-msgstr ""
-
-#: ./opengever/contact/contact.py:172
-msgid "help_address2"
-msgstr ""
-
-#: ./opengever/contact/contact.py:184
-msgid "help_city"
-msgstr ""
-
-#: ./opengever/contact/contact.py:93
-msgid "help_company"
-msgstr ""
-
-#: ./opengever/contact/contact.py:190
-msgid "help_country"
-msgstr ""
-
-#: ./opengever/contact/contact.py:99
-msgid "help_department"
-msgstr ""
-
-#: ./opengever/contact/contact.py:160
-msgid "help_description"
-msgstr ""
-
-#: ./opengever/contact/contact.py:111
-msgid "help_email"
-msgstr ""
-
-#: ./opengever/contact/contact.py:118
-msgid "help_email2"
-msgstr ""
-
-#: ./opengever/contact/contact.py:86
-msgid "help_firstname"
-msgstr ""
-
-#: ./opengever/contact/contact.py:105
-msgid "help_function"
-msgstr ""
-
-#: ./opengever/contact/contact.py:78
-msgid "help_lastname"
-msgstr ""
-
-#: ./opengever/contact/contact.py:137
-msgid "help_phone_fax"
-msgstr ""
-
-#: ./opengever/contact/contact.py:149
-msgid "help_phone_home"
-msgstr ""
-
-#: ./opengever/contact/contact.py:143
-msgid "help_phone_mobile"
-msgstr ""
-
-#: ./opengever/contact/contact.py:131
-msgid "help_phone_office"
-msgstr ""
-
-#: ./opengever/contact/contact.py:65
-msgid "help_salutation"
-msgstr ""
-
-#: ./opengever/contact/contact.py:125
-msgid "help_url"
-msgstr ""
-
-#: ./opengever/contact/contact.py:178
-msgid "help_zip"
-msgstr ""
-
 #. Default: "Internet"
 #: ./opengever/contact/contact.py:35
 msgid "internet"
 msgstr ""
 
 #. Default: "Academic title"
-#: ./opengever/contact/contact.py:70
+#: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr ""
 
 #. Default: "Address 1"
-#: ./opengever/contact/contact.py:165
+#: ./opengever/contact/contact.py:150
 msgid "label_address1"
 msgstr ""
 
 #. Default: "Address 2"
-#: ./opengever/contact/contact.py:171
+#: ./opengever/contact/contact.py:155
 msgid "label_address2"
 msgstr ""
 
 #. Default: "City"
-#: ./opengever/contact/contact.py:183
+#: ./opengever/contact/contact.py:165
 msgid "label_city"
 msgstr ""
 
 #. Default: "Company"
-#: ./opengever/contact/contact.py:92
+#: ./opengever/contact/contact.py:88
 msgid "label_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./opengever/contact/contact.py:189
+#: ./opengever/contact/contact.py:170
 msgid "label_country"
 msgstr ""
 
 #. Default: "Department"
-#: ./opengever/contact/contact.py:98
+#: ./opengever/contact/contact.py:93
 msgid "label_department"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/contact/contact.py:159
+#: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr ""
 
 #. Default: "email"
-#: ./opengever/contact/contact.py:110
+#: ./opengever/contact/contact.py:103
 #: ./opengever/contact/contactfolder.py:85
 msgid "label_email"
 msgstr ""
 
 #. Default: "Email 2"
-#: ./opengever/contact/contact.py:117
+#: ./opengever/contact/contact.py:109
 msgid "label_email2"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/contact/contact.py:85
+#: ./opengever/contact/contact.py:82
 #: ./opengever/contact/contactfolder.py:80
 msgid "label_firstname"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/contact/contact.py:77
+#: ./opengever/contact/contact.py:75
 #: ./opengever/contact/contactfolder.py:75
 msgid "label_lastname"
 msgstr ""
 
 #. Default: "Fax"
-#: ./opengever/contact/contact.py:136
+#: ./opengever/contact/contact.py:125
 msgid "label_phone_fax"
 msgstr ""
 
 #. Default: "Phone home"
-#: ./opengever/contact/contact.py:148
+#: ./opengever/contact/contact.py:135
 msgid "label_phone_home"
 msgstr ""
 
 #. Default: "Mobile"
-#: ./opengever/contact/contact.py:142
+#: ./opengever/contact/contact.py:130
 msgid "label_phone_mobile"
 msgstr ""
 
 #. Default: "Phone office"
-#: ./opengever/contact/contact.py:130
+#: ./opengever/contact/contact.py:120
 #: ./opengever/contact/contactfolder.py:90
 msgid "label_phone_office"
 msgstr ""
 
 #. Default: "Picture"
-#: ./opengever/contact/contact.py:154
+#: ./opengever/contact/contact.py:140
 msgid "label_picture"
 msgstr ""
 
@@ -215,17 +135,17 @@ msgid "label_salutation"
 msgstr ""
 
 #. Default: "Url"
-#: ./opengever/contact/contact.py:124
+#: ./opengever/contact/contact.py:115
 msgid "label_url"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./opengever/contact/contact.py:177
+#: ./opengever/contact/contact.py:160
 msgid "label_zip"
 msgstr ""
 
 #. Default: "Function"
-#: ./opengever/contact/contact.py:104
+#: ./opengever/contact/contact.py:98
 msgid "lable_function"
 msgstr ""
 

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,7 +162,7 @@ msgstr ""
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:110
-#: ./opengever/contact/contactfolder.py:86
+#: ./opengever/contact/contactfolder.py:85
 msgid "label_email"
 msgstr ""
 
@@ -173,13 +173,13 @@ msgstr ""
 
 #. Default: "Firstname"
 #: ./opengever/contact/contact.py:85
-#: ./opengever/contact/contactfolder.py:81
+#: ./opengever/contact/contactfolder.py:80
 msgid "label_firstname"
 msgstr ""
 
 #. Default: "Lastname"
 #: ./opengever/contact/contact.py:77
-#: ./opengever/contact/contactfolder.py:76
+#: ./opengever/contact/contactfolder.py:75
 msgid "label_lastname"
 msgstr ""
 
@@ -200,7 +200,7 @@ msgstr ""
 
 #. Default: "Phone office"
 #: ./opengever/contact/contact.py:130
-#: ./opengever/contact/contactfolder.py:91
+#: ./opengever/contact/contactfolder.py:90
 msgid "label_phone_office"
 msgstr ""
 

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -57,7 +57,6 @@ class IDocumentMetadata(form.Schema):
     dexteritytextindexer.searchable('description')
     description = schema.Text(
         title=_(u'label_description', default=u'Description'),
-        description=_(u'help_description', default=u''),
         required=False,
         )
 
@@ -65,7 +64,6 @@ class IDocumentMetadata(form.Schema):
     form.widget(keywords=TextLinesFieldWidget)
     keywords = schema.Tuple(
         title=_(u'label_keywords', default=u'Keywords'),
-        description=_(u'help_keywords', default=u''),
         value_type=schema.TextLine(),
         required=False,
         missing_value=(),
@@ -105,7 +103,6 @@ class IDocumentMetadata(form.Schema):
 
     document_type = schema.Choice(
         title=_(u'label_document_type', default='Document Type'),
-        description=_(u'help_document_type', default=''),
         source=wrap_vocabulary('opengever.document.document_types',
                     visible_terms_from_registry='opengever.document' +
                             '.interfaces.IDocumentType.document_types'),
@@ -124,8 +121,6 @@ class IDocumentMetadata(form.Schema):
     form.mode(digitally_available='hidden')
     digitally_available = schema.Bool(
         title=_(u'label_digitally_available', default='Digital Available'),
-        description=_(u'help_digitally_available',
-            default='Is the Document Digital Availabe'),
         required=False,
         )
 
@@ -147,7 +142,6 @@ class IDocumentMetadata(form.Schema):
     form.omitted('thumbnail')
     thumbnail = NamedBlobFile(
         title=_(u'label_thumbnail', default='Thumbnail'),
-        description=_(u'help_thumbnail', default=''),
         required=False,
         )
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -76,7 +76,7 @@ msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
 msgid "Create Task"
 msgstr "Aufgabe erstellen"
 
-#: ./opengever/document/browser/overview.py:189
+#: ./opengever/document/browser/overview.py:191
 msgid "Current version: ${version}"
 msgstr "Aktuelle Version: ${version}"
 
@@ -92,7 +92,7 @@ msgstr "Diese Meldung nicht mehr anzeigen."
 msgid "Logout"
 msgstr "GEVER verlassen"
 
-#: ./opengever/document/checkout/manager.py:282
+#: ./opengever/document/checkout/manager.py:289
 #: ./opengever/document/checkout/revert.py:26
 msgid "Reverted file to version ${version_id}"
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
@@ -107,11 +107,11 @@ msgstr "Als E-Mail versenden"
 msgid "Submit additional documents"
 msgstr "Zusätzliche Anhänge einreichen"
 
-#: ./opengever/document/browser/overview.py:185
+#: ./opengever/document/browser/overview.py:187
 msgid "Submitted version: ${version}"
 msgstr "Eingereichte Version: ${version}"
 
-#: ./opengever/document/browser/overview.py:160
+#: ./opengever/document/browser/overview.py:162
 msgid "Submitted with"
 msgstr "Eingereicht bei"
 
@@ -169,24 +169,24 @@ msgid "description_download_confirmation"
 msgstr "Sie sind dabei, eine Kopie des Dokuments ${filename} herunterzuladen."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:171
+#: ./opengever/document/behaviors/metadata.py:184
 msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:91
+#: ./opengever/document/document.py:94
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py:71
 msgid "error_title_or_file_required"
 msgstr "Ein Titel oder eine Datei muss angegeben werden."
 
 #. Default: "Common"
-#: ./opengever/document/behaviors/metadata.py:27
+#: ./opengever/document/behaviors/metadata.py:39
 #: ./opengever/document/behaviors/related_docs.py:38
-#: ./opengever/document/document.py:44
+#: ./opengever/document/document.py:47
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -211,12 +211,12 @@ msgid "heading_checkin_comment_form"
 msgstr "Dokumente einchecken"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:130
+#: ./opengever/document/behaviors/metadata.py:143
 msgid "help_archival_file"
 msgstr "Archivtaugliche Version der Originaldatei"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:105
+#: ./opengever/document/behaviors/metadata.py:118
 msgid "help_author"
 msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachname Vorname aufgelöst)."
 
@@ -225,58 +225,58 @@ msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachnam
 msgid "help_checkin_journal_comment"
 msgstr "Was wurde am Dokument geändert?"
 
-#: ./opengever/document/behaviors/metadata.py:89
+#: ./opengever/document/behaviors/metadata.py:102
 msgid "help_delivery_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg versandt worden ist"
 
 #. Default: "A short summary of the content."
-#: ./opengever/document/behaviors/metadata.py:48
+#: ./opengever/document/behaviors/metadata.py:60
 msgid "help_description"
 msgstr ""
 
 #. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py:127
 msgid "help_digitally_available"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py:85
 msgid "help_document_date"
 msgstr "Datum, an dem das Dokument erstellt worden ist"
 
-#: ./opengever/document/behaviors/metadata.py:95
+#: ./opengever/document/behaviors/metadata.py:108
 msgid "help_document_type"
 msgstr ""
 
 #. Default: ""
-#: ./opengever/document/document.py:61
+#: ./opengever/document/document.py:64
 msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:65
+#: ./opengever/document/behaviors/metadata.py:77
 msgid "help_foreign_reference"
 msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
-#: ./opengever/document/behaviors/metadata.py:56
+#: ./opengever/document/behaviors/metadata.py:68
 msgid "help_keywords"
 msgstr ""
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:122
+#: ./opengever/document/behaviors/metadata.py:135
 msgid "help_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:144
+#: ./opengever/document/behaviors/metadata.py:157
 msgid "help_preview"
 msgstr "Online Voransicht des Originaldokuments"
 
-#: ./opengever/document/behaviors/metadata.py:81
+#: ./opengever/document/behaviors/metadata.py:94
 msgid "help_receipt_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg angekommen ist"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:137
+#: ./opengever/document/behaviors/metadata.py:150
 msgid "help_thumbnail"
 msgstr ""
 
@@ -291,12 +291,12 @@ msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:129
+#: ./opengever/document/behaviors/metadata.py:142
 msgid "label_archival_file"
 msgstr "Archivierte Datei"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:104
+#: ./opengever/document/behaviors/metadata.py:117
 msgid "label_author"
 msgstr "Autor"
 
@@ -310,7 +310,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:143
+#: ./opengever/document/browser/overview.py:145
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr "Ausgecheckt"
@@ -331,7 +331,7 @@ msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:139
+#: ./opengever/document/browser/overview.py:141
 msgid "label_creator"
 msgstr "Ersteller"
 
@@ -341,27 +341,27 @@ msgid "label_date"
 msgstr "Datum"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:88
+#: ./opengever/document/behaviors/metadata.py:101
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:47
+#: ./opengever/document/behaviors/metadata.py:59
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:113
+#: ./opengever/document/behaviors/metadata.py:126
 msgid "label_digitally_available"
 msgstr "Digital verfügbar"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py:84
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:107
 msgid "label_document_type"
 msgstr "Dokumenttyp"
 
@@ -377,23 +377,23 @@ msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:145
-#: ./opengever/document/document.py:60
+#: ./opengever/document/browser/overview.py:147
+#: ./opengever/document/document.py:63
 msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:64
+#: ./opengever/document/behaviors/metadata.py:76
 msgid "label_foreign_reference"
 msgstr "Fremdzeichen"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:55
+#: ./opengever/document/behaviors/metadata.py:67
 msgid "label_keywords"
 msgstr "Schlagworte"
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:83
+#: ./opengever/document/browser/overview.py:85
 msgid "label_no"
 msgstr "Nein"
 
@@ -407,17 +407,17 @@ msgid "label_pdf_preview"
 msgstr "PDF Vorschau"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:121
+#: ./opengever/document/behaviors/metadata.py:134
 msgid "label_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:156
 msgid "label_preview"
 msgstr "Vorschau"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:80
+#: ./opengever/document/behaviors/metadata.py:93
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
@@ -447,12 +447,12 @@ msgid "label_start_byline"
 msgstr "Dokumentdatum"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:136
+#: ./opengever/document/behaviors/metadata.py:149
 msgid "label_thumbnail"
 msgstr "Kurzbild"
 
 #. Default: "Title"
-#: ./opengever/document/document.py:54
+#: ./opengever/document/document.py:57
 msgid "label_title"
 msgstr "Titel"
 
@@ -462,7 +462,7 @@ msgid "label_version"
 msgstr "Version"
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py:84
 msgid "label_yes"
 msgstr "Ja"
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:18+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -169,7 +169,7 @@ msgid "description_download_confirmation"
 msgstr "Sie sind dabei, eine Kopie des Dokuments ${filename} herunterzuladen."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:184
+#: ./opengever/document/behaviors/metadata.py:178
 msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
@@ -211,12 +211,12 @@ msgid "heading_checkin_comment_form"
 msgstr "Dokumente einchecken"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:138
 msgid "help_archival_file"
 msgstr "Archivtaugliche Version der Originaldatei"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:118
+#: ./opengever/document/behaviors/metadata.py:115
 msgid "help_author"
 msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachname Vorname aufgelöst)."
 
@@ -225,27 +225,13 @@ msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachnam
 msgid "help_checkin_journal_comment"
 msgstr "Was wurde am Dokument geändert?"
 
-#: ./opengever/document/behaviors/metadata.py:102
+#: ./opengever/document/behaviors/metadata.py:100
 msgid "help_delivery_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg versandt worden ist"
 
-#. Default: "A short summary of the content."
-#: ./opengever/document/behaviors/metadata.py:60
-msgid "help_description"
-msgstr ""
-
-#. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:127
-msgid "help_digitally_available"
-msgstr ""
-
-#: ./opengever/document/behaviors/metadata.py:85
+#: ./opengever/document/behaviors/metadata.py:83
 msgid "help_document_date"
 msgstr "Datum, an dem das Dokument erstellt worden ist"
-
-#: ./opengever/document/behaviors/metadata.py:108
-msgid "help_document_type"
-msgstr ""
 
 #. Default: ""
 #: ./opengever/document/document.py:64
@@ -253,32 +239,23 @@ msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:77
+#: ./opengever/document/behaviors/metadata.py:75
 msgid "help_foreign_reference"
 msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
-#: ./opengever/document/behaviors/metadata.py:68
-msgid "help_keywords"
-msgstr ""
-
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:135
+#: ./opengever/document/behaviors/metadata.py:130
 msgid "help_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:157
+#: ./opengever/document/behaviors/metadata.py:151
 msgid "help_preview"
 msgstr "Online Voransicht des Originaldokuments"
 
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:92
 msgid "help_receipt_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg angekommen ist"
-
-#. Default: ""
-#: ./opengever/document/behaviors/metadata.py:150
-msgid "help_thumbnail"
-msgstr ""
 
 #. Default: "Initial version"
 #: ./opengever/document/checkout/handlers.py:45
@@ -291,12 +268,12 @@ msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:142
+#: ./opengever/document/behaviors/metadata.py:137
 msgid "label_archival_file"
 msgstr "Archivierte Datei"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:117
+#: ./opengever/document/behaviors/metadata.py:114
 msgid "label_author"
 msgstr "Autor"
 
@@ -341,7 +318,7 @@ msgid "label_date"
 msgstr "Datum"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:101
+#: ./opengever/document/behaviors/metadata.py:99
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
@@ -351,17 +328,17 @@ msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:126
+#: ./opengever/document/behaviors/metadata.py:123
 msgid "label_digitally_available"
 msgstr "Digital verfügbar"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:84
+#: ./opengever/document/behaviors/metadata.py:82
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:107
+#: ./opengever/document/behaviors/metadata.py:105
 msgid "label_document_type"
 msgstr "Dokumenttyp"
 
@@ -383,12 +360,12 @@ msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:76
+#: ./opengever/document/behaviors/metadata.py:74
 msgid "label_foreign_reference"
 msgstr "Fremdzeichen"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:67
+#: ./opengever/document/behaviors/metadata.py:66
 msgid "label_keywords"
 msgstr "Schlagworte"
 
@@ -407,17 +384,17 @@ msgid "label_pdf_preview"
 msgstr "PDF Vorschau"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:134
+#: ./opengever/document/behaviors/metadata.py:129
 msgid "label_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:156
+#: ./opengever/document/behaviors/metadata.py:150
 msgid "label_preview"
 msgstr "Vorschau"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:93
+#: ./opengever/document/behaviors/metadata.py:91
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
@@ -447,7 +424,7 @@ msgid "label_start_byline"
 msgstr "Dokumentdatum"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:149
+#: ./opengever/document/behaviors/metadata.py:144
 msgid "label_thumbnail"
 msgstr "Kurzbild"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:18+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,7 +166,7 @@ msgid "description_download_confirmation"
 msgstr "Vous étes en train de télécharger une copie du document ${filename}."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:184
+#: ./opengever/document/behaviors/metadata.py:178
 msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
@@ -207,12 +207,12 @@ msgstr "Remplacer par un nouveau fichier"
 msgid "heading_checkin_comment_form"
 msgstr "Faire le checkin des documents."
 
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:138
 msgid "help_archival_file"
 msgstr "Version en format d'archivage du fichier original"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:118
+#: ./opengever/document/behaviors/metadata.py:115
 msgid "help_author"
 msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d'après le nom le prénom)"
 
@@ -221,54 +221,33 @@ msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d
 msgid "help_checkin_journal_comment"
 msgstr "Modification(s) faite(s) dans le document ?"
 
-#: ./opengever/document/behaviors/metadata.py:102
+#: ./opengever/document/behaviors/metadata.py:100
 msgid "help_delivery_date"
 msgstr "Date, à laquelle le document a été envoyé par écrit"
 
-#: ./opengever/document/behaviors/metadata.py:60
-msgid "help_description"
-msgstr ""
-
-#. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:127
-msgid "help_digitally_available"
-msgstr "Est-ce que le document numérisé est disponible ?"
-
-#: ./opengever/document/behaviors/metadata.py:85
+#: ./opengever/document/behaviors/metadata.py:83
 msgid "help_document_date"
 msgstr "Date de création du document"
-
-#: ./opengever/document/behaviors/metadata.py:108
-msgid "help_document_type"
-msgstr ""
 
 #: ./opengever/document/document.py:64
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
-#: ./opengever/document/behaviors/metadata.py:77
+#: ./opengever/document/behaviors/metadata.py:75
 msgid "help_foreign_reference"
 msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
-#: ./opengever/document/behaviors/metadata.py:68
-msgid "help_keywords"
-msgstr ""
-
-#: ./opengever/document/behaviors/metadata.py:135
+#: ./opengever/document/behaviors/metadata.py:130
 msgid "help_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
-#: ./opengever/document/behaviors/metadata.py:157
+#: ./opengever/document/behaviors/metadata.py:151
 msgid "help_preview"
 msgstr "Aperçu en ligne du document original"
 
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:92
 msgid "help_receipt_date"
 msgstr "Date de réception du document écrit"
-
-#: ./opengever/document/behaviors/metadata.py:150
-msgid "help_thumbnail"
-msgstr ""
 
 #. Default: "Initial version"
 #: ./opengever/document/checkout/handlers.py:45
@@ -281,12 +260,12 @@ msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:142
+#: ./opengever/document/behaviors/metadata.py:137
 msgid "label_archival_file"
 msgstr "Fichier archivé"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:117
+#: ./opengever/document/behaviors/metadata.py:114
 msgid "label_author"
 msgstr "Auteur"
 
@@ -331,7 +310,7 @@ msgid "label_date"
 msgstr "Date"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:101
+#: ./opengever/document/behaviors/metadata.py:99
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
@@ -341,17 +320,17 @@ msgid "label_description"
 msgstr "Description"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:126
+#: ./opengever/document/behaviors/metadata.py:123
 msgid "label_digitally_available"
 msgstr "Disponble sous forme numérique"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:84
+#: ./opengever/document/behaviors/metadata.py:82
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:107
+#: ./opengever/document/behaviors/metadata.py:105
 msgid "label_document_type"
 msgstr "Type de document"
 
@@ -373,12 +352,12 @@ msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:76
+#: ./opengever/document/behaviors/metadata.py:74
 msgid "label_foreign_reference"
 msgstr "Code externe"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:67
+#: ./opengever/document/behaviors/metadata.py:66
 msgid "label_keywords"
 msgstr "Mots-clés"
 
@@ -397,17 +376,17 @@ msgid "label_pdf_preview"
 msgstr "Aucun résultat trouvé"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:134
+#: ./opengever/document/behaviors/metadata.py:129
 msgid "label_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:156
+#: ./opengever/document/behaviors/metadata.py:150
 msgid "label_preview"
 msgstr "Aperçu"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:93
+#: ./opengever/document/behaviors/metadata.py:91
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
@@ -437,7 +416,7 @@ msgid "label_start_byline"
 msgstr "Date du document"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:149
+#: ./opengever/document/behaviors/metadata.py:144
 msgid "label_thumbnail"
 msgstr "Vignette"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -74,7 +74,7 @@ msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti"
 msgid "Create Task"
 msgstr "Créer une tâche"
 
-#: ./opengever/document/browser/overview.py:189
+#: ./opengever/document/browser/overview.py:191
 msgid "Current version: ${version}"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr "Ne plus afficher ce message."
 msgid "Logout"
 msgstr "Quitter GEVER"
 
-#: ./opengever/document/checkout/manager.py:282
+#: ./opengever/document/checkout/manager.py:289
 #: ./opengever/document/checkout/revert.py:26
 msgid "Reverted file to version ${version_id}"
 msgstr "Retour à la version ${version_id}  du document"
@@ -104,11 +104,11 @@ msgstr "Envoyer par E-Mail"
 msgid "Submit additional documents"
 msgstr "Soumettre des documents additionnels"
 
-#: ./opengever/document/browser/overview.py:185
+#: ./opengever/document/browser/overview.py:187
 msgid "Submitted version: ${version}"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:160
+#: ./opengever/document/browser/overview.py:162
 msgid "Submitted with"
 msgstr ""
 
@@ -166,24 +166,24 @@ msgid "description_download_confirmation"
 msgstr "Vous étes en train de télécharger une copie du document ${filename}."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:171
+#: ./opengever/document/behaviors/metadata.py:184
 msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:91
+#: ./opengever/document/document.py:94
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py:71
 msgid "error_title_or_file_required"
 msgstr "Un titre ou un fichier est requis."
 
 #. Default: "Common"
-#: ./opengever/document/behaviors/metadata.py:27
+#: ./opengever/document/behaviors/metadata.py:39
 #: ./opengever/document/behaviors/related_docs.py:38
-#: ./opengever/document/document.py:44
+#: ./opengever/document/document.py:47
 msgid "fieldset_common"
 msgstr "En général"
 
@@ -207,12 +207,12 @@ msgstr "Remplacer par un nouveau fichier"
 msgid "heading_checkin_comment_form"
 msgstr "Faire le checkin des documents."
 
-#: ./opengever/document/behaviors/metadata.py:130
+#: ./opengever/document/behaviors/metadata.py:143
 msgid "help_archival_file"
 msgstr "Version en format d'archivage du fichier original"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:105
+#: ./opengever/document/behaviors/metadata.py:118
 msgid "help_author"
 msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d'après le nom le prénom)"
 
@@ -221,52 +221,52 @@ msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d
 msgid "help_checkin_journal_comment"
 msgstr "Modification(s) faite(s) dans le document ?"
 
-#: ./opengever/document/behaviors/metadata.py:89
+#: ./opengever/document/behaviors/metadata.py:102
 msgid "help_delivery_date"
 msgstr "Date, à laquelle le document a été envoyé par écrit"
 
-#: ./opengever/document/behaviors/metadata.py:48
+#: ./opengever/document/behaviors/metadata.py:60
 msgid "help_description"
 msgstr ""
 
 #. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py:127
 msgid "help_digitally_available"
 msgstr "Est-ce que le document numérisé est disponible ?"
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py:85
 msgid "help_document_date"
 msgstr "Date de création du document"
 
-#: ./opengever/document/behaviors/metadata.py:95
+#: ./opengever/document/behaviors/metadata.py:108
 msgid "help_document_type"
 msgstr ""
 
-#: ./opengever/document/document.py:61
+#: ./opengever/document/document.py:64
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
-#: ./opengever/document/behaviors/metadata.py:65
+#: ./opengever/document/behaviors/metadata.py:77
 msgid "help_foreign_reference"
 msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
-#: ./opengever/document/behaviors/metadata.py:56
+#: ./opengever/document/behaviors/metadata.py:68
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:122
+#: ./opengever/document/behaviors/metadata.py:135
 msgid "help_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
-#: ./opengever/document/behaviors/metadata.py:144
+#: ./opengever/document/behaviors/metadata.py:157
 msgid "help_preview"
 msgstr "Aperçu en ligne du document original"
 
-#: ./opengever/document/behaviors/metadata.py:81
+#: ./opengever/document/behaviors/metadata.py:94
 msgid "help_receipt_date"
 msgstr "Date de réception du document écrit"
 
-#: ./opengever/document/behaviors/metadata.py:137
+#: ./opengever/document/behaviors/metadata.py:150
 msgid "help_thumbnail"
 msgstr ""
 
@@ -281,12 +281,12 @@ msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:129
+#: ./opengever/document/behaviors/metadata.py:142
 msgid "label_archival_file"
 msgstr "Fichier archivé"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:104
+#: ./opengever/document/behaviors/metadata.py:117
 msgid "label_author"
 msgstr "Auteur"
 
@@ -300,7 +300,7 @@ msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:143
+#: ./opengever/document/browser/overview.py:145
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr "Avec checkout"
@@ -321,7 +321,7 @@ msgid "label_comment"
 msgstr "commentaire"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:139
+#: ./opengever/document/browser/overview.py:141
 msgid "label_creator"
 msgstr "Créateur"
 
@@ -331,27 +331,27 @@ msgid "label_date"
 msgstr "Date"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:88
+#: ./opengever/document/behaviors/metadata.py:101
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:47
+#: ./opengever/document/behaviors/metadata.py:59
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:113
+#: ./opengever/document/behaviors/metadata.py:126
 msgid "label_digitally_available"
 msgstr "Disponble sous forme numérique"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py:84
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:107
 msgid "label_document_type"
 msgstr "Type de document"
 
@@ -367,23 +367,23 @@ msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:145
-#: ./opengever/document/document.py:60
+#: ./opengever/document/browser/overview.py:147
+#: ./opengever/document/document.py:63
 msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:64
+#: ./opengever/document/behaviors/metadata.py:76
 msgid "label_foreign_reference"
 msgstr "Code externe"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:55
+#: ./opengever/document/behaviors/metadata.py:67
 msgid "label_keywords"
 msgstr "Mots-clés"
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:83
+#: ./opengever/document/browser/overview.py:85
 msgid "label_no"
 msgstr "Non"
 
@@ -397,17 +397,17 @@ msgid "label_pdf_preview"
 msgstr "Aucun résultat trouvé"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:121
+#: ./opengever/document/behaviors/metadata.py:134
 msgid "label_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:156
 msgid "label_preview"
 msgstr "Aperçu"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:80
+#: ./opengever/document/behaviors/metadata.py:93
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
@@ -437,12 +437,12 @@ msgid "label_start_byline"
 msgstr "Date du document"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:136
+#: ./opengever/document/behaviors/metadata.py:149
 msgid "label_thumbnail"
 msgstr "Vignette"
 
 #. Default: "Title"
-#: ./opengever/document/document.py:54
+#: ./opengever/document/document.py:57
 msgid "label_title"
 msgstr "Titre"
 
@@ -452,7 +452,7 @@ msgid "label_version"
 msgstr "Version"
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py:84
 msgid "label_yes"
 msgstr "Oui"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Create Task"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:189
+#: ./opengever/document/browser/overview.py:191
 msgid "Current version: ${version}"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: ./opengever/document/checkout/manager.py:282
+#: ./opengever/document/checkout/manager.py:289
 #: ./opengever/document/checkout/revert.py:26
 msgid "Reverted file to version ${version_id}"
 msgstr ""
@@ -107,11 +107,11 @@ msgstr ""
 msgid "Submit additional documents"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:185
+#: ./opengever/document/browser/overview.py:187
 msgid "Submitted version: ${version}"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:160
+#: ./opengever/document/browser/overview.py:162
 msgid "Submitted with"
 msgstr ""
 
@@ -169,24 +169,24 @@ msgid "description_download_confirmation"
 msgstr ""
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:171
+#: ./opengever/document/behaviors/metadata.py:184
 msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:91
+#: ./opengever/document/document.py:94
 msgid "error_mail_upload"
 msgstr ""
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py:71
 msgid "error_title_or_file_required"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/document/behaviors/metadata.py:27
+#: ./opengever/document/behaviors/metadata.py:39
 #: ./opengever/document/behaviors/related_docs.py:38
-#: ./opengever/document/document.py:44
+#: ./opengever/document/document.py:47
 msgid "fieldset_common"
 msgstr ""
 
@@ -210,12 +210,12 @@ msgstr ""
 msgid "heading_checkin_comment_form"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:130
+#: ./opengever/document/behaviors/metadata.py:143
 msgid "help_archival_file"
 msgstr ""
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:105
+#: ./opengever/document/behaviors/metadata.py:118
 msgid "help_author"
 msgstr ""
 
@@ -224,52 +224,52 @@ msgstr ""
 msgid "help_checkin_journal_comment"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:89
+#: ./opengever/document/behaviors/metadata.py:102
 msgid "help_delivery_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:48
+#: ./opengever/document/behaviors/metadata.py:60
 msgid "help_description"
 msgstr ""
 
 #. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py:127
 msgid "help_digitally_available"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py:85
 msgid "help_document_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:95
+#: ./opengever/document/behaviors/metadata.py:108
 msgid "help_document_type"
 msgstr ""
 
-#: ./opengever/document/document.py:61
+#: ./opengever/document/document.py:64
 msgid "help_file"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:65
+#: ./opengever/document/behaviors/metadata.py:77
 msgid "help_foreign_reference"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:56
+#: ./opengever/document/behaviors/metadata.py:68
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:122
+#: ./opengever/document/behaviors/metadata.py:135
 msgid "help_preserved_as_paper"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:144
+#: ./opengever/document/behaviors/metadata.py:157
 msgid "help_preview"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:81
+#: ./opengever/document/behaviors/metadata.py:94
 msgid "help_receipt_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:137
+#: ./opengever/document/behaviors/metadata.py:150
 msgid "help_thumbnail"
 msgstr ""
 
@@ -284,12 +284,12 @@ msgid "label_actor"
 msgstr ""
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:129
+#: ./opengever/document/behaviors/metadata.py:142
 msgid "label_archival_file"
 msgstr ""
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:104
+#: ./opengever/document/behaviors/metadata.py:117
 msgid "label_author"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:143
+#: ./opengever/document/browser/overview.py:145
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr ""
@@ -324,7 +324,7 @@ msgid "label_comment"
 msgstr ""
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:139
+#: ./opengever/document/browser/overview.py:141
 msgid "label_creator"
 msgstr ""
 
@@ -334,27 +334,27 @@ msgid "label_date"
 msgstr ""
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:88
+#: ./opengever/document/behaviors/metadata.py:101
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:47
+#: ./opengever/document/behaviors/metadata.py:59
 msgid "label_description"
 msgstr ""
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:113
+#: ./opengever/document/behaviors/metadata.py:126
 msgid "label_digitally_available"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py:84
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:107
 msgid "label_document_type"
 msgstr ""
 
@@ -370,23 +370,23 @@ msgid "label_download_copy"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:145
-#: ./opengever/document/document.py:60
+#: ./opengever/document/browser/overview.py:147
+#: ./opengever/document/document.py:63
 msgid "label_file"
 msgstr ""
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:64
+#: ./opengever/document/behaviors/metadata.py:76
 msgid "label_foreign_reference"
 msgstr ""
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:55
+#: ./opengever/document/behaviors/metadata.py:67
 msgid "label_keywords"
 msgstr ""
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:83
+#: ./opengever/document/browser/overview.py:85
 msgid "label_no"
 msgstr ""
 
@@ -400,17 +400,17 @@ msgid "label_pdf_preview"
 msgstr ""
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:121
+#: ./opengever/document/behaviors/metadata.py:134
 msgid "label_preserved_as_paper"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:156
 msgid "label_preview"
 msgstr ""
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:80
+#: ./opengever/document/behaviors/metadata.py:93
 msgid "label_receipt_date"
 msgstr ""
 
@@ -440,12 +440,12 @@ msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:136
+#: ./opengever/document/behaviors/metadata.py:149
 msgid "label_thumbnail"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/document/document.py:54
+#: ./opengever/document/document.py:57
 msgid "label_title"
 msgstr ""
 
@@ -455,7 +455,7 @@ msgid "label_version"
 msgstr ""
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py:84
 msgid "label_yes"
 msgstr ""
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -169,7 +169,7 @@ msgid "description_download_confirmation"
 msgstr ""
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:184
+#: ./opengever/document/behaviors/metadata.py:178
 msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
@@ -210,12 +210,12 @@ msgstr ""
 msgid "heading_checkin_comment_form"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:143
+#: ./opengever/document/behaviors/metadata.py:138
 msgid "help_archival_file"
 msgstr ""
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:118
+#: ./opengever/document/behaviors/metadata.py:115
 msgid "help_author"
 msgstr ""
 
@@ -224,53 +224,32 @@ msgstr ""
 msgid "help_checkin_journal_comment"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:102
+#: ./opengever/document/behaviors/metadata.py:100
 msgid "help_delivery_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:60
-msgid "help_description"
-msgstr ""
-
-#. Default: "Is the Document Digital Availabe"
-#: ./opengever/document/behaviors/metadata.py:127
-msgid "help_digitally_available"
-msgstr ""
-
-#: ./opengever/document/behaviors/metadata.py:85
+#: ./opengever/document/behaviors/metadata.py:83
 msgid "help_document_date"
-msgstr ""
-
-#: ./opengever/document/behaviors/metadata.py:108
-msgid "help_document_type"
 msgstr ""
 
 #: ./opengever/document/document.py:64
 msgid "help_file"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:77
+#: ./opengever/document/behaviors/metadata.py:75
 msgid "help_foreign_reference"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:68
-msgid "help_keywords"
-msgstr ""
-
-#: ./opengever/document/behaviors/metadata.py:135
+#: ./opengever/document/behaviors/metadata.py:130
 msgid "help_preserved_as_paper"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:157
+#: ./opengever/document/behaviors/metadata.py:151
 msgid "help_preview"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:94
+#: ./opengever/document/behaviors/metadata.py:92
 msgid "help_receipt_date"
-msgstr ""
-
-#: ./opengever/document/behaviors/metadata.py:150
-msgid "help_thumbnail"
 msgstr ""
 
 #. Default: "Initial version"
@@ -284,12 +263,12 @@ msgid "label_actor"
 msgstr ""
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:142
+#: ./opengever/document/behaviors/metadata.py:137
 msgid "label_archival_file"
 msgstr ""
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:117
+#: ./opengever/document/behaviors/metadata.py:114
 msgid "label_author"
 msgstr ""
 
@@ -334,7 +313,7 @@ msgid "label_date"
 msgstr ""
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:101
+#: ./opengever/document/behaviors/metadata.py:99
 msgid "label_delivery_date"
 msgstr ""
 
@@ -344,17 +323,17 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:126
+#: ./opengever/document/behaviors/metadata.py:123
 msgid "label_digitally_available"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:84
+#: ./opengever/document/behaviors/metadata.py:82
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:107
+#: ./opengever/document/behaviors/metadata.py:105
 msgid "label_document_type"
 msgstr ""
 
@@ -376,12 +355,12 @@ msgid "label_file"
 msgstr ""
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:76
+#: ./opengever/document/behaviors/metadata.py:74
 msgid "label_foreign_reference"
 msgstr ""
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:67
+#: ./opengever/document/behaviors/metadata.py:66
 msgid "label_keywords"
 msgstr ""
 
@@ -400,17 +379,17 @@ msgid "label_pdf_preview"
 msgstr ""
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:134
+#: ./opengever/document/behaviors/metadata.py:129
 msgid "label_preserved_as_paper"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:156
+#: ./opengever/document/behaviors/metadata.py:150
 msgid "label_preview"
 msgstr ""
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:93
+#: ./opengever/document/behaviors/metadata.py:91
 msgid "label_receipt_date"
 msgstr ""
 
@@ -440,7 +419,7 @@ msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:149
+#: ./opengever/document/behaviors/metadata.py:144
 msgid "label_thumbnail"
 msgstr ""
 

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -187,7 +187,6 @@ class IArchiveFormSchema(directives_form.Schema):
 
     dossier_enddate = schema.Date(
         title=_(u'label_end', default=u'Closing Date'),
-        description=_(u'help_end', default=u''),
         required=True,
         defaultFactory=dossier_enddate_default,
     )

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -67,7 +67,6 @@ class IDossier(form.Schema):
     form.widget(start=DatePickerFieldWidget)
     start = schema.Date(
         title=_(u'label_start', default=u'Opening Date'),
-        description=_(u'help_start', default=u''),
         required=False,
         defaultFactory=start_date_default,
     )
@@ -76,20 +75,17 @@ class IDossier(form.Schema):
     form.widget(end=DatePickerFieldWidget)
     end = schema.Date(
         title=_(u'label_end', default=u'Closing Date'),
-        description=_(u'help_end', default=u''),
         required=False,
     )
 
     comments = schema.Text(
         title=_(u'label_comments', default=u'Comments'),
-        description=_(u'help_comments', default=u''),
         required=False,
     )
 
     form.widget(responsible=AutocompleteFieldWidget)
     responsible = schema.Choice(
         title=_(u"label_responsible", default="Responsible"),
-        description=_(u"help_responsible", default=""),
         vocabulary=u'opengever.ogds.base.AssignedUsersVocabulary',
         required=True,
     )
@@ -109,7 +105,6 @@ class IDossier(form.Schema):
 
     filing_prefix = schema.Choice(
         title=_(u'filing_prefix', default="filing prefix"),
-        description=_(u'help_filing_prefix', default=""),
         source=wrap_vocabulary(
             'opengever.dossier.type_prefixes',
             visible_terms_from_registry="opengever.dossier"
@@ -123,7 +118,6 @@ class IDossier(form.Schema):
     temporary_former_reference_number = schema.TextLine(
         title=_(u'temporary_former_reference_number',
                 default="Temporary former reference number"),
-        description=_(u'help_temporary_former_reference_number', default=u''),
         required=False,
     )
 
@@ -174,14 +168,12 @@ class IDossier(form.Schema):
     former_reference_number = schema.TextLine(
         title=_(u'label_former_reference_number',
                 default=u'Reference Number'),
-        description=_(u'help_former_reference_number', default=u''),
         required=False,
     )
 
     form.widget(reference_number=referenceNumberWidgetFactory)
     reference_number = schema.TextLine(
         title=_(u'label_reference_number', default=u'Reference Number'),
-        description=_(u'help_reference_number ', default=u''),
         required=False,
     )
 

--- a/opengever/dossier/behaviors/filing.py
+++ b/opengever/dossier/behaviors/filing.py
@@ -21,7 +21,6 @@ class IFilingNumber(form.Schema):
     form.omitted('filing_no')
     filing_no = schema.TextLine(
         title=_(u'filing_no', default="Filing number"),
-        description=_(u'help_filing_no', default=u''),
         required=False,
         )
 

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -96,7 +96,6 @@ class IParticipation(form.Schema):
 
     roles = schema.List(
         title=_(u'label_roles', default=u'Roles'),
-        description=_(u'help_roles', default=u''),
         value_type=schema.Choice(
             source=wrap_vocabulary(
                 'opengever.dossier.participation_roles',

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-16 16:20+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -100,7 +100,7 @@ msgstr "Neuste Dokumente"
 msgid "Newest tasks"
 msgstr "Neuste Aufgaben"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:27
+#: ./opengever/dossier/browser/overview_templates/overview.pt:28
 msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:12+0000\n"
 "PO-Revision-Date: 2015-01-22 17:49+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -26,7 +26,7 @@ msgstr "Geschäftsdossier hinzufügen"
 msgid "Add Participant"
 msgstr "Beteiligung hinzufügen"
 
-#: ./opengever/dossier/behaviors/dossier.py:230
+#: ./opengever/dossier/behaviors/dossier.py:222
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
@@ -63,7 +63,7 @@ msgstr "Dossier-Struktur"
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
-#: ./opengever/dossier/behaviors/dossier.py:252
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
@@ -157,7 +157,7 @@ msgstr "Das Dossier wurde aktiviert."
 msgid "The Dossier has been deactivated"
 msgstr "Das Dossier wurde storniert."
 
-#: ./opengever/dossier/archive.py:289
+#: ./opengever/dossier/archive.py:288
 msgid "The Dossier has been resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen"
 
@@ -173,7 +173,7 @@ msgstr "Das Dossier enthält aktive Anträge."
 msgid "The dossier has been succesfully resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 
-#: ./opengever/dossier/archive.py:260
+#: ./opengever/dossier/archive.py:259
 msgid "The filing number has been given"
 msgstr "Die Ablagenummer wurde vergeben."
 
@@ -189,11 +189,11 @@ msgstr "Das angegeben Ablagejahr ist ungültig."
 msgid "The selected objects can't be found, please try it again."
 msgstr "Die selektierten Objekte konnten nicht gefunden werden, bitte versuchen Sie es erneut."
 
-#: ./opengever/dossier/behaviors/dossier.py:200
+#: ./opengever/dossier/behaviors/dossier.py:192
 msgid "The start date must be before the end date."
 msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 
-#: ./opengever/dossier/behaviors/dossier.py:259
+#: ./opengever/dossier/behaviors/dossier.py:251
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
@@ -205,7 +205,7 @@ msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier storniert ist."
 
-#: ./opengever/dossier/archive.py:216
+#: ./opengever/dossier/archive.py:215
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."
 
@@ -217,18 +217,18 @@ msgid "additional_attributes"
 msgstr "Zusatzattribute"
 
 #. Default: "Add"
-#: ./opengever/dossier/behaviors/participation.py:154
+#: ./opengever/dossier/behaviors/participation.py:153
 msgid "button_add"
 msgstr "Erstellen"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:233
+#: ./opengever/dossier/archive.py:232
 msgid "button_archive"
 msgstr "Speichern"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:292
-#: ./opengever/dossier/behaviors/participation.py:167
+#: ./opengever/dossier/archive.py:291
+#: ./opengever/dossier/behaviors/participation.py:166
 #: ./opengever/dossier/move_items.py:126
 msgid "button_cancel"
 msgstr "Abbrechen"
@@ -272,13 +272,13 @@ msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/behaviors/dossier.py:95
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Ablage"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:203
+#: ./opengever/dossier/archive.py:202
 msgid "filing_action"
 msgstr "Aktion"
 
@@ -310,17 +310,17 @@ msgstr "Ablagenummer"
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/behaviors/dossier.py:107
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:196
+#: ./opengever/dossier/archive.py:195
 msgid "filing_year"
 msgstr "Ablage Jahr"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:225
+#: ./opengever/dossier/archive.py:224
 msgid "heading_archive_form"
 msgstr "Dossier ablegen"
 
@@ -329,19 +329,15 @@ msgstr "Dossier ablegen"
 msgid "heading_move_items"
 msgstr "Elemente verschieben"
 
-#: ./opengever/dossier/behaviors/dossier.py:85
-msgid "help_comments"
-msgstr ""
-
 #: ./opengever/dossier/behaviors/participation.py:92
 msgid "help_contact"
 msgstr "Wählen Sie einen Benutzer oder einen Kontakt aus."
 
-#: ./opengever/dossier/behaviors/dossier.py:149
+#: ./opengever/dossier/behaviors/dossier.py:143
 msgid "help_container_location"
 msgstr "Standortangabe des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
-#: ./opengever/dossier/behaviors/dossier.py:132
+#: ./opengever/dossier/behaviors/dossier.py:126
 msgid "help_container_type"
 msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
@@ -350,63 +346,25 @@ msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 msgid "help_destination"
 msgstr "Live Search: Durchsuchen Sie diesen Mandanten"
 
-#: ./opengever/dossier/archive.py:190
-#: ./opengever/dossier/behaviors/dossier.py:79
-msgid "help_end"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/filing.py:24
-msgid "help_filing_no"
-msgstr ""
-
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
 msgstr "Geben Sie die vollständige Ablagenummer an."
-
-#: ./opengever/dossier/behaviors/dossier.py:112
-msgid "help_filing_prefix"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:177
-msgid "help_former_reference_number"
-msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:58
 msgid "help_keywords"
 msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
 
-#: ./opengever/dossier/behaviors/dossier.py:143
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_number_of_containers"
 msgstr "Anzahl Behälter, die ein (grosses) Dossier in Papierform enthalten"
 
-#: ./opengever/dossier/behaviors/dossier.py:184
-msgid "help_reference_number "
-msgstr ""
-
-#. Default: "Select the responsible manager"
-#: ./opengever/dossier/behaviors/dossier.py:92
-msgid "help_responsible"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/participation.py:99
-msgid "help_roles"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:70
-msgid "help_start"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:126
-msgid "help_temporary_former_reference_number"
-msgstr ""
-
 #. Default: "Participation created"
-#: ./opengever/dossier/behaviors/participation.py:162
+#: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
 msgstr "Die Beteiligung wurde gespeichert."
 
 #. Default: "Removed participations"
-#: ./opengever/dossier/behaviors/participation.py:207
+#: ./opengever/dossier/behaviors/participation.py:206
 msgid "info_removed_participations"
 msgstr "Die Beteiligungen wurde entfernt."
 
@@ -421,7 +379,7 @@ msgid "label_by_author"
 msgstr "Federführend: ${author}"
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:84
+#: ./opengever/dossier/behaviors/dossier.py:82
 msgid "label_comments"
 msgstr "Kommentar"
 
@@ -431,12 +389,12 @@ msgid "label_contact"
 msgstr "Person"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py:142
 msgid "label_container_location"
 msgstr "Behältnis-Standort"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:131
+#: ./opengever/dossier/behaviors/dossier.py:125
 msgid "label_container_type"
 msgstr "Behältnis-Art"
 
@@ -462,7 +420,7 @@ msgstr "E-Mail"
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:78
+#: ./opengever/dossier/behaviors/dossier.py:77
 #: ./opengever/dossier/browser/report.py:39
 msgid "label_end"
 msgstr "Ende"
@@ -484,7 +442,7 @@ msgid "label_filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:175
+#: ./opengever/dossier/behaviors/dossier.py:169
 msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
@@ -509,29 +467,29 @@ msgid "label_no_reference_number"
 msgstr "Die Archivnummer wird erst beim Erstellen generiert."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:141
+#: ./opengever/dossier/behaviors/dossier.py:135
 msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
 #. Default: "Participation"
-#: ./opengever/dossier/behaviors/participation.py:149
+#: ./opengever/dossier/behaviors/participation.py:148
 msgid "label_participation"
 msgstr "Beteiligung"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:183
+#: ./opengever/dossier/behaviors/dossier.py:176
 #: ./opengever/dossier/browser/report.py:48
 #: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:154
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "label_related_dossier"
 msgstr "Verwandte Dossiers"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:91
+#: ./opengever/dossier/behaviors/dossier.py:88
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:42
 msgid "label_responsible"
@@ -633,7 +591,7 @@ msgid "tasks"
 msgstr "Aufgaben"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:124
+#: ./opengever/dossier/behaviors/dossier.py:119
 msgid "temporary_former_reference_number"
 msgstr ""
 
@@ -647,7 +605,7 @@ msgid "time_expired"
 msgstr "abgelaufen"
 
 #. Default: "You didn't select any participants."
-#: ./opengever/dossier/behaviors/participation.py:197
+#: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:12+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr "Insérer un dossier d'affaire"
 msgid "Add Participant"
 msgstr "Participant"
 
-#: ./opengever/dossier/behaviors/dossier.py:230
+#: ./opengever/dossier/behaviors/dossier.py:222
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès"
 
-#: ./opengever/dossier/behaviors/dossier.py:252
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
@@ -153,7 +153,7 @@ msgstr "Le dossier a été activé."
 msgid "The Dossier has been deactivated"
 msgstr "Le dossier a été annulé."
 
-#: ./opengever/dossier/archive.py:289
+#: ./opengever/dossier/archive.py:288
 msgid "The Dossier has been resolved"
 msgstr "Dossier a été fermé avec succès"
 
@@ -169,7 +169,7 @@ msgstr ""
 msgid "The dossier has been succesfully resolved"
 msgstr "Le dossier a été fermé avec succès"
 
-#: ./opengever/dossier/archive.py:260
+#: ./opengever/dossier/archive.py:259
 msgid "The filing number has been given"
 msgstr "Le numéro d'inventaire va être attribué"
 
@@ -185,11 +185,11 @@ msgstr "L'année de dépôt attribuée n'est pas valable"
 msgid "The selected objects can't be found, please try it again."
 msgstr "Impossible de trouver les objets sélectionnés, merci de réessayer."
 
-#: ./opengever/dossier/behaviors/dossier.py:200
+#: ./opengever/dossier/behaviors/dossier.py:192
 msgid "The start date must be before the end date."
 msgstr "La date de début doit être plus récente que la date de clôture."
 
-#: ./opengever/dossier/behaviors/dossier.py:259
+#: ./opengever/dossier/behaviors/dossier.py:251
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
@@ -201,7 +201,7 @@ msgstr "Le sous-dossier a été fermé avec succès"
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Ce sous-dossier ne peut pas être réactivé parce que le dossier prinicipal a été annulé."
 
-#: ./opengever/dossier/archive.py:216
+#: ./opengever/dossier/archive.py:215
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution de numéro d'inventaire, tous les champs sont obligatoires"
 
@@ -213,18 +213,18 @@ msgid "additional_attributes"
 msgstr "Attributs supplémentaires"
 
 #. Default: "Add"
-#: ./opengever/dossier/behaviors/participation.py:154
+#: ./opengever/dossier/behaviors/participation.py:153
 msgid "button_add"
 msgstr "Etablir"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:233
+#: ./opengever/dossier/archive.py:232
 msgid "button_archive"
 msgstr "Enregistrer"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:292
-#: ./opengever/dossier/behaviors/participation.py:167
+#: ./opengever/dossier/archive.py:291
+#: ./opengever/dossier/behaviors/participation.py:166
 #: ./opengever/dossier/move_items.py:126
 msgid "button_cancel"
 msgstr "Annuler"
@@ -268,13 +268,13 @@ msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun objet."
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/behaviors/dossier.py:95
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Classeur"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:203
+#: ./opengever/dossier/archive.py:202
 msgid "filing_action"
 msgstr "Action"
 
@@ -306,17 +306,17 @@ msgstr "Numéro d'inventaire"
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/behaviors/dossier.py:107
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:196
+#: ./opengever/dossier/archive.py:195
 msgid "filing_year"
 msgstr "Année de dépôt"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:225
+#: ./opengever/dossier/archive.py:224
 msgid "heading_archive_form"
 msgstr "Classer le dossier"
 
@@ -325,19 +325,15 @@ msgstr "Classer le dossier"
 msgid "heading_move_items"
 msgstr "Déplacer des éléments"
 
-#: ./opengever/dossier/behaviors/dossier.py:85
-msgid "help_comments"
-msgstr ""
-
 #: ./opengever/dossier/behaviors/participation.py:92
 msgid "help_contact"
 msgstr "Choix d'un utilisateur ou un contact."
 
-#: ./opengever/dossier/behaviors/dossier.py:149
+#: ./opengever/dossier/behaviors/dossier.py:143
 msgid "help_container_location"
 msgstr "Emplacement du dossier imprimé"
 
-#: ./opengever/dossier/behaviors/dossier.py:132
+#: ./opengever/dossier/behaviors/dossier.py:126
 msgid "help_container_type"
 msgstr "Type de conteneur du dossier imprimé"
 
@@ -346,63 +342,25 @@ msgstr "Type de conteneur du dossier imprimé"
 msgid "help_destination"
 msgstr "Recherche en direct: Recherche de ce client"
 
-#: ./opengever/dossier/archive.py:190
-#: ./opengever/dossier/behaviors/dossier.py:79
-msgid "help_end"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/filing.py:24
-msgid "help_filing_no"
-msgstr ""
-
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
 msgstr "Saisir le numéro d'inventaire complet"
-
-#: ./opengever/dossier/behaviors/dossier.py:112
-msgid "help_filing_prefix"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:177
-msgid "help_former_reference_number"
-msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:58
 msgid "help_keywords"
 msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de la position"
 
-#: ./opengever/dossier/behaviors/dossier.py:143
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_number_of_containers"
 msgstr "Nombre de conteneurs contenant des dossiers imprimés (volumineux)"
 
-#: ./opengever/dossier/behaviors/dossier.py:184
-msgid "help_reference_number "
-msgstr ""
-
-#. Default: "Select the responsible manager"
-#: ./opengever/dossier/behaviors/dossier.py:92
-msgid "help_responsible"
-msgstr "Responsable"
-
-#: ./opengever/dossier/behaviors/participation.py:99
-msgid "help_roles"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:70
-msgid "help_start"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:126
-msgid "help_temporary_former_reference_number"
-msgstr ""
-
 #. Default: "Participation created"
-#: ./opengever/dossier/behaviors/participation.py:162
+#: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
 msgstr "Participation enregistrée"
 
 #. Default: "Removed participations"
-#: ./opengever/dossier/behaviors/participation.py:207
+#: ./opengever/dossier/behaviors/participation.py:206
 msgid "info_removed_participations"
 msgstr "Participations enlevées"
 
@@ -417,7 +375,7 @@ msgid "label_by_author"
 msgstr "Responsable: ${author}"
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:84
+#: ./opengever/dossier/behaviors/dossier.py:82
 msgid "label_comments"
 msgstr "Commentaire"
 
@@ -427,12 +385,12 @@ msgid "label_contact"
 msgstr "Personne"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py:142
 msgid "label_container_location"
 msgstr "Emplacement du conteneur"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:131
+#: ./opengever/dossier/behaviors/dossier.py:125
 msgid "label_container_type"
 msgstr "Type de conteneur"
 
@@ -458,7 +416,7 @@ msgstr "Email"
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:78
+#: ./opengever/dossier/behaviors/dossier.py:77
 #: ./opengever/dossier/browser/report.py:39
 msgid "label_end"
 msgstr "Date de fin :"
@@ -480,7 +438,7 @@ msgid "label_filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:175
+#: ./opengever/dossier/behaviors/dossier.py:169
 msgid "label_former_reference_number"
 msgstr "Ancienne numéro référence"
 
@@ -505,29 +463,29 @@ msgid "label_no_reference_number"
 msgstr "Le numéro de classement est généré lors de la création du document."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:141
+#: ./opengever/dossier/behaviors/dossier.py:135
 msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
 #. Default: "Participation"
-#: ./opengever/dossier/behaviors/participation.py:149
+#: ./opengever/dossier/behaviors/participation.py:148
 msgid "label_participation"
 msgstr "Participation"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:183
+#: ./opengever/dossier/behaviors/dossier.py:176
 #: ./opengever/dossier/browser/report.py:48
 #: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:154
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "label_related_dossier"
 msgstr "Dossiers liés"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:91
+#: ./opengever/dossier/behaviors/dossier.py:88
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:42
 msgid "label_responsible"
@@ -629,7 +587,7 @@ msgid "tasks"
 msgstr "Tâches"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:124
+#: ./opengever/dossier/behaviors/dossier.py:119
 msgid "temporary_former_reference_number"
 msgstr "Ancien numéro de référence temporaire"
 
@@ -643,7 +601,7 @@ msgid "time_expired"
 msgstr "Périmé"
 
 #. Default: "You didn't select any participants."
-#: ./opengever/dossier/behaviors/participation.py:197
+#: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-16 16:20+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-09-10 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,7 +98,7 @@ msgstr "Derniers documents"
 msgid "Newest tasks"
 msgstr "Dernières tâches"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:27
+#: ./opengever/dossier/browser/overview_templates/overview.pt:28
 msgid "No Subdossiers"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-16 16:20+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,7 +101,7 @@ msgstr ""
 msgid "Newest tasks"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:27
+#: ./opengever/dossier/browser/overview_templates/overview.pt:28
 msgid "No Subdossiers"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Add Participant"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:230
+#: ./opengever/dossier/behaviors/dossier.py:222
 msgid "Add Subdossier"
 msgstr ""
 
@@ -64,7 +64,7 @@ msgstr ""
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:252
+#: ./opengever/dossier/behaviors/dossier.py:244
 msgid "Edit Subdossier"
 msgstr ""
 
@@ -156,7 +156,7 @@ msgstr ""
 msgid "The Dossier has been deactivated"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:289
+#: ./opengever/dossier/archive.py:288
 msgid "The Dossier has been resolved"
 msgstr ""
 
@@ -172,7 +172,7 @@ msgstr ""
 msgid "The dossier has been succesfully resolved"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:260
+#: ./opengever/dossier/archive.py:259
 msgid "The filing number has been given"
 msgstr ""
 
@@ -188,11 +188,11 @@ msgstr ""
 msgid "The selected objects can't be found, please try it again."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:200
+#: ./opengever/dossier/behaviors/dossier.py:192
 msgid "The start date must be before the end date."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:259
+#: ./opengever/dossier/behaviors/dossier.py:251
 msgid "The start or end date is invalid"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:216
+#: ./opengever/dossier/archive.py:215
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""
 
@@ -216,18 +216,18 @@ msgid "additional_attributes"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/dossier/behaviors/participation.py:154
+#: ./opengever/dossier/behaviors/participation.py:153
 msgid "button_add"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:233
+#: ./opengever/dossier/archive.py:232
 msgid "button_archive"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:292
-#: ./opengever/dossier/behaviors/participation.py:167
+#: ./opengever/dossier/archive.py:291
+#: ./opengever/dossier/behaviors/participation.py:166
 #: ./opengever/dossier/move_items.py:126
 msgid "button_cancel"
 msgstr ""
@@ -271,13 +271,13 @@ msgid "error_no_items"
 msgstr ""
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/behaviors/dossier.py:95
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:203
+#: ./opengever/dossier/archive.py:202
 msgid "filing_action"
 msgstr ""
 
@@ -309,17 +309,17 @@ msgstr ""
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/behaviors/dossier.py:107
 msgid "filing_prefix"
 msgstr ""
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:196
+#: ./opengever/dossier/archive.py:195
 msgid "filing_year"
 msgstr ""
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:225
+#: ./opengever/dossier/archive.py:224
 msgid "heading_archive_form"
 msgstr ""
 
@@ -328,19 +328,15 @@ msgstr ""
 msgid "heading_move_items"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:85
-msgid "help_comments"
-msgstr ""
-
 #: ./opengever/dossier/behaviors/participation.py:92
 msgid "help_contact"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:149
+#: ./opengever/dossier/behaviors/dossier.py:143
 msgid "help_container_location"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:132
+#: ./opengever/dossier/behaviors/dossier.py:126
 msgid "help_container_type"
 msgstr ""
 
@@ -349,62 +345,25 @@ msgstr ""
 msgid "help_destination"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:190
-#: ./opengever/dossier/behaviors/dossier.py:79
-msgid "help_end"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/filing.py:24
-msgid "help_filing_no"
-msgstr ""
-
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:112
-msgid "help_filing_prefix"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:177
-msgid "help_former_reference_number"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:58
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:143
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_number_of_containers"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:184
-msgid "help_reference_number "
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:92
-msgid "help_responsible"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/participation.py:99
-msgid "help_roles"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:70
-msgid "help_start"
-msgstr ""
-
-#: ./opengever/dossier/behaviors/dossier.py:126
-msgid "help_temporary_former_reference_number"
-msgstr ""
-
 #. Default: "Participation created"
-#: ./opengever/dossier/behaviors/participation.py:162
+#: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
 msgstr ""
 
 #. Default: "Removed participations"
-#: ./opengever/dossier/behaviors/participation.py:207
+#: ./opengever/dossier/behaviors/participation.py:206
 msgid "info_removed_participations"
 msgstr ""
 
@@ -419,7 +378,7 @@ msgid "label_by_author"
 msgstr ""
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:84
+#: ./opengever/dossier/behaviors/dossier.py:82
 msgid "label_comments"
 msgstr ""
 
@@ -429,12 +388,12 @@ msgid "label_contact"
 msgstr ""
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py:142
 msgid "label_container_location"
 msgstr ""
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:131
+#: ./opengever/dossier/behaviors/dossier.py:125
 msgid "label_container_type"
 msgstr ""
 
@@ -460,7 +419,7 @@ msgstr ""
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:78
+#: ./opengever/dossier/behaviors/dossier.py:77
 #: ./opengever/dossier/browser/report.py:39
 msgid "label_end"
 msgstr ""
@@ -482,7 +441,7 @@ msgid "label_filing_number"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:175
+#: ./opengever/dossier/behaviors/dossier.py:169
 msgid "label_former_reference_number"
 msgstr ""
 
@@ -507,29 +466,29 @@ msgid "label_no_reference_number"
 msgstr ""
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:141
+#: ./opengever/dossier/behaviors/dossier.py:135
 msgid "label_number_of_containers"
 msgstr ""
 
 #. Default: "Participation"
-#: ./opengever/dossier/behaviors/participation.py:149
+#: ./opengever/dossier/behaviors/participation.py:148
 msgid "label_participation"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:183
+#: ./opengever/dossier/behaviors/dossier.py:176
 #: ./opengever/dossier/browser/report.py:48
 #: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:154
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "label_related_dossier"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:91
+#: ./opengever/dossier/behaviors/dossier.py:88
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:42
 msgid "label_responsible"
@@ -631,7 +590,7 @@ msgid "tasks"
 msgstr ""
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:124
+#: ./opengever/dossier/behaviors/dossier.py:119
 msgid "temporary_former_reference_number"
 msgstr ""
 
@@ -645,7 +604,7 @@ msgid "time_expired"
 msgstr ""
 
 #. Default: "You didn't select any participants."
-#: ./opengever/dossier/behaviors/participation.py:197
+#: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr ""
 

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-02-22 11:55+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/globalindex/browser/report.py:93
+#: ./opengever/globalindex/browser/report.py:92
 msgid "Could not generate the report"
 msgstr "Aufgaben Export konnte nicht erstellt werden."
 
@@ -24,57 +24,57 @@ msgid "Export selection"
 msgstr "Auswahl exportieren"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/globalindex/browser/report.py:50
+#: ./opengever/globalindex/browser/report.py:49
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:24
+#: ./opengever/globalindex/browser/report.py:23
 msgid "forwarding_task_type"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:76
+#: ./opengever/globalindex/browser/report.py:75
 msgid "label_admin_unit_id"
 msgstr "Verwaltungseinheit"
 
-#: ./opengever/globalindex/browser/report.py:67
+#: ./opengever/globalindex/browser/report.py:66
 msgid "label_completed"
 msgstr "Erledigt am"
 
-#: ./opengever/globalindex/browser/report.py:65
+#: ./opengever/globalindex/browser/report.py:64
 msgid "label_deadline"
 msgstr "Frist"
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py:68
 msgid "label_dossier_title"
 msgstr "Dossier Titel"
 
-#: ./opengever/globalindex/browser/report.py:70
+#: ./opengever/globalindex/browser/report.py:69
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
-#: ./opengever/globalindex/browser/report.py:72
+#: ./opengever/globalindex/browser/report.py:71
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
-#: ./opengever/globalindex/browser/report.py:77
+#: ./opengever/globalindex/browser/report.py:76
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py:60
 msgid "label_task_title"
 msgstr "Aufgabentitel"
 
-#: ./opengever/globalindex/browser/report.py:74
+#: ./opengever/globalindex/browser/report.py:73
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:85
+#: ./opengever/globalindex/browser/report.py:84
 msgid "label_tasks"
 msgstr "Tasks"
 
-#: ./opengever/globalindex/browser/report.py:62
+#: ./opengever/globalindex/browser/report.py:61
 msgid "review_state"
 msgstr "Status"
 

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/globalindex/browser/report.py:93
+#: ./opengever/globalindex/browser/report.py:92
 msgid "Could not generate the report"
 msgstr "Impossible de générer l'export de tâches"
 
@@ -24,57 +24,57 @@ msgid "Export selection"
 msgstr "Exporter choix"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/globalindex/browser/report.py:50
+#: ./opengever/globalindex/browser/report.py:49
 msgid "error_no_items"
 msgstr "Aucun élément sélectionné"
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:24
+#: ./opengever/globalindex/browser/report.py:23
 msgid "forwarding_task_type"
 msgstr "Faire suivre"
 
-#: ./opengever/globalindex/browser/report.py:76
+#: ./opengever/globalindex/browser/report.py:75
 msgid "label_admin_unit_id"
 msgstr "Unité administrative"
 
-#: ./opengever/globalindex/browser/report.py:67
+#: ./opengever/globalindex/browser/report.py:66
 msgid "label_completed"
 msgstr "Accompli le"
 
-#: ./opengever/globalindex/browser/report.py:65
+#: ./opengever/globalindex/browser/report.py:64
 msgid "label_deadline"
 msgstr "Délai"
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py:68
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
 
-#: ./opengever/globalindex/browser/report.py:70
+#: ./opengever/globalindex/browser/report.py:69
 msgid "label_issuer"
 msgstr "Client"
 
-#: ./opengever/globalindex/browser/report.py:72
+#: ./opengever/globalindex/browser/report.py:71
 msgid "label_responsible"
 msgstr "Mandataire"
 
-#: ./opengever/globalindex/browser/report.py:77
+#: ./opengever/globalindex/browser/report.py:76
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py:60
 msgid "label_task_title"
 msgstr "Titre de tâche"
 
-#: ./opengever/globalindex/browser/report.py:74
+#: ./opengever/globalindex/browser/report.py:73
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:85
+#: ./opengever/globalindex/browser/report.py:84
 msgid "label_tasks"
 msgstr "Mandats"
 
-#: ./opengever/globalindex/browser/report.py:62
+#: ./opengever/globalindex/browser/report.py:61
 msgid "review_state"
 msgstr "Etat"
 

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.globalindex\n"
 
-#: ./opengever/globalindex/browser/report.py:93
+#: ./opengever/globalindex/browser/report.py:92
 msgid "Could not generate the report"
 msgstr ""
 
@@ -27,57 +27,57 @@ msgid "Export selection"
 msgstr ""
 
 #. Default: "You have not selected any Items"
-#: ./opengever/globalindex/browser/report.py:50
+#: ./opengever/globalindex/browser/report.py:49
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:24
+#: ./opengever/globalindex/browser/report.py:23
 msgid "forwarding_task_type"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:76
+#: ./opengever/globalindex/browser/report.py:75
 msgid "label_admin_unit_id"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:67
+#: ./opengever/globalindex/browser/report.py:66
 msgid "label_completed"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:65
+#: ./opengever/globalindex/browser/report.py:64
 msgid "label_deadline"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py:68
 msgid "label_dossier_title"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:70
+#: ./opengever/globalindex/browser/report.py:69
 msgid "label_issuer"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:72
+#: ./opengever/globalindex/browser/report.py:71
 msgid "label_responsible"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:77
+#: ./opengever/globalindex/browser/report.py:76
 msgid "label_sequence_number"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py:60
 msgid "label_task_title"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:74
+#: ./opengever/globalindex/browser/report.py:73
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:85
+#: ./opengever/globalindex/browser/report.py:84
 msgid "label_tasks"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:62
+#: ./opengever/globalindex/browser/report.py:61
 msgid "review_state"
 msgstr ""
 

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2015-03-30 08:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2014-11-03 14:10+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -20,7 +20,7 @@ msgid "heading_journal"
 msgstr "Journal"
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:69
+#: ./opengever/journal/tab.py:68
 msgid "label_actor"
 msgstr "Geändert von"
 
@@ -30,7 +30,7 @@ msgid "label_attachments_deleted"
 msgstr "Attachments gelöscht: ${filenames}"
 
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:73
+#: ./opengever/journal/tab.py:72
 msgid "label_comments"
 msgstr "Kommentare"
 
@@ -205,12 +205,12 @@ msgid "label_task_modified"
 msgstr "Aufgabe modifiziert: ${title}"
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:61
+#: ./opengever/journal/tab.py:60
 msgid "label_time"
 msgstr "Zeitpunkt"
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:65
+#: ./opengever/journal/tab.py:64
 msgid "label_title"
 msgstr "Titel"
 

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,7 @@ msgid "heading_journal"
 msgstr "Historique"
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:69
+#: ./opengever/journal/tab.py:68
 msgid "label_actor"
 msgstr "Modifier le"
 
@@ -30,7 +30,7 @@ msgid "label_attachments_deleted"
 msgstr "Fichiers attachés effacés: ${filenames}"
 
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:73
+#: ./opengever/journal/tab.py:72
 msgid "label_comments"
 msgstr "Commentaire"
 
@@ -205,12 +205,12 @@ msgid "label_task_modified"
 msgstr "Tâche modifiée : ${title}"
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:61
+#: ./opengever/journal/tab.py:60
 msgid "label_time"
 msgstr "Date"
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:65
+#: ./opengever/journal/tab.py:64
 msgid "label_title"
 msgstr "Titre"
 

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,7 +23,7 @@ msgid "heading_journal"
 msgstr ""
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:69
+#: ./opengever/journal/tab.py:68
 msgid "label_actor"
 msgstr ""
 
@@ -33,7 +33,7 @@ msgid "label_attachments_deleted"
 msgstr ""
 
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:73
+#: ./opengever/journal/tab.py:72
 msgid "label_comments"
 msgstr ""
 
@@ -208,12 +208,12 @@ msgid "label_task_modified"
 msgstr ""
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:61
+#: ./opengever/journal/tab.py:60
 msgid "label_time"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:65
+#: ./opengever/journal/tab.py:64
 msgid "label_title"
 msgstr ""
 

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-15 07:51+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-15 07:51+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/locking/locales/opengever.locking.pot
+++ b/opengever/locking/locales/opengever.locking.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-15 07:51+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -80,13 +80,11 @@ class ISendDocumentSchema(Interface):
 
     subject = schema.TextLine(
         title=_(u'label_subject', default=u'Subject'),
-        description=_(u'help_subject', default=u''),
         required=True,
         )
 
     message = schema.Text(
         title=_(u'label_message', default=u'Message'),
-        description=_(u'help_message', default=u''),
         required=True,
         )
 

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:08+0000\n"
 "PO-Revision-Date: 2014-08-05 10:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Keine E-Mail Adresse"
 msgid "Save attachments"
 msgstr "Anhänge speichern"
 
-#: ./opengever/mail/browser/send_document.py:336
+#: ./opengever/mail/browser/send_document.py:334
 msgid "Sent mail filed as '${title}'."
 msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 
@@ -34,17 +34,17 @@ msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 msgid "The files you selected are larger than the maximum size"
 msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maximalgrösse."
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py:127
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:199
+#: ./opengever/mail/browser/send_document.py:197
 msgid "button_send"
 msgstr "Senden"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py:254
 msgid "cancel_back"
 msgstr "Abbrechen"
 
@@ -83,12 +83,12 @@ msgid "extern_receiver"
 msgstr "Externer Empfänger"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:189
+#: ./opengever/mail/browser/send_document.py:187
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(nur für aktive Dossiers möglich)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:160
 msgid "heading_send_as_email"
 msgstr "Dokumente als E-Mail versenden"
 
@@ -112,21 +112,13 @@ msgstr "E-Mail Adressen der externen Empfänger manuell eintragen. Pro Zeile ein
 msgid "help_intern_receiver"
 msgstr "Live Search: Nachname/Vorname der internen Mitarbeiter oder Kontakte eingeben. Mehrauswahl möglich."
 
-#: ./opengever/mail/browser/send_document.py:89
-msgid "help_message"
-msgstr ""
-
-#: ./opengever/mail/browser/send_document.py:83
-msgid "help_subject"
-msgstr ""
-
 #. Default: "Created document ${title}"
 #: ./opengever/mail/browser/extract_attachments.py:150
 msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py:244
 msgid "info_mail_sent"
 msgstr "E-Mail wurde versendet."
 
@@ -161,17 +153,17 @@ msgid "label_delete_action_selected"
 msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:94
+#: ./opengever/mail/browser/send_document.py:92
 msgid "label_documents"
 msgstr "Anhänge"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:112
+#: ./opengever/mail/browser/send_document.py:110
 msgid "label_documents_as_link"
 msgstr "Dokumente nur als Link versenden."
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:118
+#: ./opengever/mail/browser/send_document.py:116
 msgid "label_file_copy_in_dossier"
 msgstr "Kopie des versandten Mails in Dossier ablegen"
 
@@ -181,7 +173,7 @@ msgid "label_journal_initialized"
 msgstr "Dokument migriert"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:88
+#: ./opengever/mail/browser/send_document.py:87
 msgid "label_message"
 msgstr "Mitteilung"
 
@@ -191,7 +183,7 @@ msgid "label_org_message"
 msgstr "Originalnachricht"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:301
+#: ./opengever/mail/browser/send_document.py:299
 msgid "label_see_attachment"
 msgstr "siehe Anhänge"
 

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-02 12:42+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2014-08-05 10:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:08+0000\n"
 "PO-Revision-Date: 2012-09-06 13:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr "Pas d'adresse Email"
 msgid "Save attachments"
 msgstr "Extraire documents"
 
-#: ./opengever/mail/browser/send_document.py:336
+#: ./opengever/mail/browser/send_document.py:334
 msgid "Sent mail filed as '${title}'."
 msgstr "Email envoyé classé sous '${title}'"
 
@@ -34,17 +34,17 @@ msgstr "Email envoyé classé sous '${title}'"
 msgid "The files you selected are larger than the maximum size"
 msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permise."
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py:127
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse Email interne ou externe"
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:199
+#: ./opengever/mail/browser/send_document.py:197
 msgid "button_send"
 msgstr "Envoyer"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py:254
 msgid "cancel_back"
 msgstr "Annuler"
 
@@ -83,12 +83,12 @@ msgid "extern_receiver"
 msgstr "Destinataire externe"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:189
+#: ./opengever/mail/browser/send_document.py:187
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(possible uniquement pour les dossiers ouverts)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:160
 msgid "heading_send_as_email"
 msgstr "Envoyer les documents comme Email"
 
@@ -112,21 +112,13 @@ msgstr "Ajouter les adresses email des destinataires externes. Une adresse par l
 msgid "help_intern_receiver"
 msgstr "Recherche en direct : Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible. "
 
-#: ./opengever/mail/browser/send_document.py:89
-msgid "help_message"
-msgstr ""
-
-#: ./opengever/mail/browser/send_document.py:83
-msgid "help_subject"
-msgstr ""
-
 #. Default: "Created document ${title}"
 #: ./opengever/mail/browser/extract_attachments.py:150
 msgid "info_extracted_document"
 msgstr "Document créé : ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py:244
 msgid "info_mail_sent"
 msgstr "Email envoyé."
 
@@ -161,17 +153,17 @@ msgid "label_delete_action_selected"
 msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:94
+#: ./opengever/mail/browser/send_document.py:92
 msgid "label_documents"
 msgstr "Fichiers attachés"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:112
+#: ./opengever/mail/browser/send_document.py:110
 msgid "label_documents_as_link"
 msgstr "Envoyer seulement le lien du document"
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:118
+#: ./opengever/mail/browser/send_document.py:116
 msgid "label_file_copy_in_dossier"
 msgstr "Classer une copie de l'email envoyé dans le dossier"
 
@@ -181,7 +173,7 @@ msgid "label_journal_initialized"
 msgstr "Document migré"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:88
+#: ./opengever/mail/browser/send_document.py:87
 msgid "label_message"
 msgstr "Message"
 
@@ -191,7 +183,7 @@ msgid "label_org_message"
 msgstr "Message original"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:301
+#: ./opengever/mail/browser/send_document.py:299
 msgid "label_see_attachment"
 msgstr "Voir  fichiers attachés"
 

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-02 12:42+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-09-06 13:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-03-02 12:42+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Save attachments"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:336
+#: ./opengever/mail/browser/send_document.py:334
 msgid "Sent mail filed as '${title}'."
 msgstr ""
 
@@ -37,17 +37,17 @@ msgstr ""
 msgid "The files you selected are larger than the maximum size"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py:127
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr ""
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:199
+#: ./opengever/mail/browser/send_document.py:197
 msgid "button_send"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py:254
 msgid "cancel_back"
 msgstr ""
 
@@ -86,12 +86,12 @@ msgid "extern_receiver"
 msgstr ""
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:189
+#: ./opengever/mail/browser/send_document.py:187
 msgid "file_copy_widget_disabled_hint_text"
 msgstr ""
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:160
 msgid "heading_send_as_email"
 msgstr ""
 
@@ -115,21 +115,13 @@ msgstr ""
 msgid "help_intern_receiver"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:89
-msgid "help_message"
-msgstr ""
-
-#: ./opengever/mail/browser/send_document.py:83
-msgid "help_subject"
-msgstr ""
-
 #. Default: "Created document ${title}"
 #: ./opengever/mail/browser/extract_attachments.py:150
 msgid "info_extracted_document"
 msgstr ""
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py:244
 msgid "info_mail_sent"
 msgstr ""
 
@@ -164,17 +156,17 @@ msgid "label_delete_action_selected"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/mail/browser/send_document.py:94
+#: ./opengever/mail/browser/send_document.py:92
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:112
+#: ./opengever/mail/browser/send_document.py:110
 msgid "label_documents_as_link"
 msgstr ""
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:118
+#: ./opengever/mail/browser/send_document.py:116
 msgid "label_file_copy_in_dossier"
 msgstr ""
 
@@ -184,7 +176,7 @@ msgid "label_journal_initialized"
 msgstr ""
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:88
+#: ./opengever/mail/browser/send_document.py:87
 msgid "label_message"
 msgstr ""
 
@@ -194,7 +186,7 @@ msgid "label_org_message"
 msgstr ""
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:301
+#: ./opengever/mail/browser/send_document.py:299
 msgid "label_see_attachment"
 msgstr ""
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:25+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -589,18 +589,6 @@ msgstr "Antrag zurückweisen"
 msgid "held"
 msgstr "Durchgeführt"
 
-#: ./opengever/meeting/proposal.py:123
-msgid "help_considerations"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:111
-msgid "help_initial_position"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:117
-msgid "help_proposed_action"
-msgstr ""
-
 #. Default: "Describe why the proposal is rejected"
 #: ./opengever/meeting/browser/proposaltransitions.py:51
 msgid "help_reject_proposal_text"
@@ -610,10 +598,6 @@ msgstr "Beschreiben Sie warum der Antrag zurückgewiesen wird"
 #: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt werden soll."
-
-#: ./opengever/meeting/proposal.py:99
-msgid "help_title"
-msgstr ""
 
 #. Default: "Hold meeting"
 #: ./opengever/meeting/model/meeting.py:78
@@ -641,7 +625,7 @@ msgstr "Vorlage Traktandenliste"
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
 #: ./opengever/meeting/browser/submitdocuments.py:36
-#: ./opengever/meeting/proposal.py:152
+#: ./opengever/meeting/proposal.py:148
 msgid "label_attachments"
 msgstr "Anhänge"
 
@@ -681,7 +665,7 @@ msgstr "Das Protokoll wurde in der Zwischenzeit bearbeitet. Wenn Sie Ihre Änder
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
-#: ./opengever/meeting/proposal.py:122
+#: ./opengever/meeting/proposal.py:119
 msgid "label_considerations"
 msgstr "Erwägungen"
 
@@ -732,7 +716,7 @@ msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:138
-#: ./opengever/meeting/proposal.py:211
+#: ./opengever/meeting/proposal.py:207
 msgid "label_decision"
 msgstr "Beschluss"
 
@@ -742,7 +726,7 @@ msgid "label_decision_draft"
 msgstr "Beschlussentwurf"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:226
+#: ./opengever/meeting/proposal.py:222
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
@@ -764,17 +748,17 @@ msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:306
+#: ./opengever/meeting/proposal.py:302
 msgid "label_discussion"
 msgstr "Diskussion"
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:289
+#: ./opengever/meeting/proposal.py:285
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:381
+#: ./opengever/meeting/proposal.py:377
 msgid "label_dossier_not_available"
 msgstr "Dossier nicht verfügbar"
 
@@ -890,7 +874,7 @@ msgid "label_main_attributes"
 msgstr "Eigenschaften"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:196
+#: ./opengever/meeting/proposal.py:192
 msgid "label_meeting"
 msgstr "Sitzung"
 
@@ -1052,7 +1036,7 @@ msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:223
+#: ./opengever/meeting/proposal.py:219
 msgid "label_workflow_state"
 msgstr "Status"
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-08 07:40+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:410
+#: ./opengever/meeting/browser/meetings/meeting.py:411
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -344,11 +344,11 @@ msgstr "Traktandum detraktandieren"
 msgid "Update or create the protocol"
 msgstr "Das Protokoll wird erstellt oder aktualisiert"
 
-#: ./opengever/meeting/browser/submitdocuments.py:196
+#: ./opengever/meeting/browser/submitdocuments.py:200
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
-#: ./opengever/meeting/browser/excerpt.py:40
+#: ./opengever/meeting/browser/excerpt.py:44
 msgid "Updated with a newer excerpt version."
 msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
 
@@ -427,7 +427,7 @@ msgstr "Weiter"
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:74
+#: ./opengever/meeting/browser/submitdocuments.py:78
 msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
@@ -640,7 +640,7 @@ msgstr "Vorlage Traktandenliste"
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
-#: ./opengever/meeting/browser/submitdocuments.py:32
+#: ./opengever/meeting/browser/submitdocuments.py:36
 #: ./opengever/meeting/proposal.py:152
 msgid "label_attachments"
 msgstr "Anhänge"
@@ -726,7 +726,7 @@ msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:358
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
@@ -747,7 +747,7 @@ msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:356
+#: ./opengever/meeting/browser/meetings/meeting.py:357
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -788,12 +788,12 @@ msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:355
+#: ./opengever/meeting/browser/meetings/meeting.py:356
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:353
+#: ./opengever/meeting/browser/meetings/meeting.py:354
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
@@ -803,7 +803,7 @@ msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:354
+#: ./opengever/meeting/browser/meetings/meeting.py:355
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -915,7 +915,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:378
+#: ./opengever/meeting/browser/meetings/meeting.py:379
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -977,12 +977,12 @@ msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:364
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
@@ -998,7 +998,7 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:377
+#: ./opengever/meeting/browser/meetings/meeting.py:378
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:250
 msgid "label_schedule"
 msgstr "Traktandieren"
@@ -1312,3 +1312,4 @@ msgstr "Zeit"
 #: ./opengever/meeting/model/proposal.py:163
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
+

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -589,18 +589,6 @@ msgstr ""
 msgid "held"
 msgstr "Conduit"
 
-#: ./opengever/meeting/proposal.py:123
-msgid "help_considerations"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:111
-msgid "help_initial_position"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:117
-msgid "help_proposed_action"
-msgstr ""
-
 #. Default: "Describe why the proposal is rejected"
 #: ./opengever/meeting/browser/proposaltransitions.py:51
 msgid "help_reject_proposal_text"
@@ -609,10 +597,6 @@ msgstr ""
 #. Default: "Select the target dossier where the excerpts should be created."
 #: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:99
-msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
@@ -641,7 +625,7 @@ msgstr ""
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
 #: ./opengever/meeting/browser/submitdocuments.py:36
-#: ./opengever/meeting/proposal.py:152
+#: ./opengever/meeting/proposal.py:148
 msgid "label_attachments"
 msgstr ""
 
@@ -681,7 +665,7 @@ msgstr ""
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
-#: ./opengever/meeting/proposal.py:122
+#: ./opengever/meeting/proposal.py:119
 msgid "label_considerations"
 msgstr "Considérations"
 
@@ -732,7 +716,7 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:138
-#: ./opengever/meeting/proposal.py:211
+#: ./opengever/meeting/proposal.py:207
 msgid "label_decision"
 msgstr ""
 
@@ -742,7 +726,7 @@ msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:226
+#: ./opengever/meeting/proposal.py:222
 msgid "label_decision_number"
 msgstr ""
 
@@ -764,17 +748,17 @@ msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:306
+#: ./opengever/meeting/proposal.py:302
 msgid "label_discussion"
 msgstr "Discussion"
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:289
+#: ./opengever/meeting/proposal.py:285
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:381
+#: ./opengever/meeting/proposal.py:377
 msgid "label_dossier_not_available"
 msgstr "Dossier indisponible"
 
@@ -890,7 +874,7 @@ msgid "label_main_attributes"
 msgstr "Propriétés"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:196
+#: ./opengever/meeting/proposal.py:192
 msgid "label_meeting"
 msgstr "Séance"
 
@@ -1052,7 +1036,7 @@ msgid "label_upcoming_meetings"
 msgstr "Prochaines séances"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:223
+#: ./opengever/meeting/proposal.py:219
 msgid "label_workflow_state"
 msgstr "Etat"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-08 07:40+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:410
+#: ./opengever/meeting/browser/meetings/meeting.py:411
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -344,11 +344,11 @@ msgstr ""
 msgid "Update or create the protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:196
+#: ./opengever/meeting/browser/submitdocuments.py:200
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
 
-#: ./opengever/meeting/browser/excerpt.py:40
+#: ./opengever/meeting/browser/excerpt.py:44
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
@@ -427,7 +427,7 @@ msgstr ""
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:74
+#: ./opengever/meeting/browser/submitdocuments.py:78
 msgid "button_submit_attachments"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgstr ""
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
-#: ./opengever/meeting/browser/submitdocuments.py:32
+#: ./opengever/meeting/browser/submitdocuments.py:36
 #: ./opengever/meeting/proposal.py:152
 msgid "label_attachments"
 msgstr ""
@@ -726,7 +726,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:358
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_decide_action"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:356
+#: ./opengever/meeting/browser/meetings/meeting.py:357
 msgid "label_delete_action"
 msgstr ""
 
@@ -788,12 +788,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:355
+#: ./opengever/meeting/browser/meetings/meeting.py:356
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:353
+#: ./opengever/meeting/browser/meetings/meeting.py:354
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -803,7 +803,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:354
+#: ./opengever/meeting/browser/meetings/meeting.py:355
 msgid "label_edit_save"
 msgstr ""
 
@@ -915,7 +915,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:378
+#: ./opengever/meeting/browser/meetings/meeting.py:379
 msgid "label_no_proposals"
 msgstr ""
 
@@ -977,12 +977,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:364
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_revise_action"
 msgstr ""
 
@@ -998,7 +998,7 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:377
+#: ./opengever/meeting/browser/meetings/meeting.py:378
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:250
 msgid "label_schedule"
 msgstr ""

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -588,18 +588,6 @@ msgstr ""
 msgid "held"
 msgstr ""
 
-#: ./opengever/meeting/proposal.py:123
-msgid "help_considerations"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:111
-msgid "help_initial_position"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:117
-msgid "help_proposed_action"
-msgstr ""
-
 #. Default: "Describe why the proposal is rejected"
 #: ./opengever/meeting/browser/proposaltransitions.py:51
 msgid "help_reject_proposal_text"
@@ -608,10 +596,6 @@ msgstr ""
 #. Default: "Select the target dossier where the excerpts should be created."
 #: ./opengever/meeting/browser/meetings/excerpt.py:24
 msgid "help_select_dossier"
-msgstr ""
-
-#: ./opengever/meeting/proposal.py:99
-msgid "help_title"
 msgstr ""
 
 #. Default: "Hold meeting"
@@ -640,7 +624,7 @@ msgstr ""
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
 #: ./opengever/meeting/browser/submitdocuments.py:36
-#: ./opengever/meeting/proposal.py:152
+#: ./opengever/meeting/proposal.py:148
 msgid "label_attachments"
 msgstr ""
 
@@ -680,7 +664,7 @@ msgstr ""
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
-#: ./opengever/meeting/proposal.py:122
+#: ./opengever/meeting/proposal.py:119
 msgid "label_considerations"
 msgstr ""
 
@@ -731,7 +715,7 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:138
-#: ./opengever/meeting/proposal.py:211
+#: ./opengever/meeting/proposal.py:207
 msgid "label_decision"
 msgstr ""
 
@@ -741,7 +725,7 @@ msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:226
+#: ./opengever/meeting/proposal.py:222
 msgid "label_decision_number"
 msgstr ""
 
@@ -763,17 +747,17 @@ msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:306
+#: ./opengever/meeting/proposal.py:302
 msgid "label_discussion"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:289
+#: ./opengever/meeting/proposal.py:285
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:381
+#: ./opengever/meeting/proposal.py:377
 msgid "label_dossier_not_available"
 msgstr ""
 
@@ -889,7 +873,7 @@ msgid "label_main_attributes"
 msgstr ""
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:196
+#: ./opengever/meeting/proposal.py:192
 msgid "label_meeting"
 msgstr ""
 
@@ -1051,7 +1035,7 @@ msgid "label_upcoming_meetings"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:223
+#: ./opengever/meeting/proposal.py:219
 msgid "label_workflow_state"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-08 07:40+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,7 +65,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:410
+#: ./opengever/meeting/browser/meetings/meeting.py:411
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -343,11 +343,11 @@ msgstr ""
 msgid "Update or create the protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:196
+#: ./opengever/meeting/browser/submitdocuments.py:200
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
-#: ./opengever/meeting/browser/excerpt.py:40
+#: ./opengever/meeting/browser/excerpt.py:44
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
@@ -426,7 +426,7 @@ msgstr ""
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:74
+#: ./opengever/meeting/browser/submitdocuments.py:78
 msgid "button_submit_attachments"
 msgstr ""
 
@@ -639,7 +639,7 @@ msgstr ""
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:26
-#: ./opengever/meeting/browser/submitdocuments.py:32
+#: ./opengever/meeting/browser/submitdocuments.py:36
 #: ./opengever/meeting/proposal.py:152
 msgid "label_attachments"
 msgstr ""
@@ -725,7 +725,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:358
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_decide_action"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:356
+#: ./opengever/meeting/browser/meetings/meeting.py:357
 msgid "label_delete_action"
 msgstr ""
 
@@ -787,12 +787,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:355
+#: ./opengever/meeting/browser/meetings/meeting.py:356
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:353
+#: ./opengever/meeting/browser/meetings/meeting.py:354
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -802,7 +802,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:354
+#: ./opengever/meeting/browser/meetings/meeting.py:355
 msgid "label_edit_save"
 msgstr ""
 
@@ -914,7 +914,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:378
+#: ./opengever/meeting/browser/meetings/meeting.py:379
 msgid "label_no_proposals"
 msgstr ""
 
@@ -976,12 +976,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:364
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_revise_action"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:377
+#: ./opengever/meeting/browser/meetings/meeting.py:378
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:250
 msgid "label_schedule"
 msgstr ""

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -96,7 +96,6 @@ class ISubmittedProposalModel(Interface):
 
     title = schema.TextLine(
         title=_(u"label_title", default=u"Title"),
-        description=_('help_title', default=u""),
         required=True,
         max_length=256,
         )
@@ -108,19 +107,16 @@ class ISubmittedProposalModel(Interface):
 
     initial_position = schema.Text(
         title=_('label_initial_position', default=u"Initial position"),
-        description=_("help_initial_position", default=u""),
         required=False,
         )
 
     proposed_action = schema.Text(
         title=_('label_proposed_action', default=u"Proposed action"),
-        description=_("help_proposed_action", default=u""),
         required=False,
         )
 
     considerations = schema.Text(
         title=_('label_considerations', default=u"Considerations"),
-        description=_("help_considerations", default=u""),
         required=False,
         )
 

--- a/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2010-12-22 10:37+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/ogds/base/locales/opengever.ogds.base.pot
+++ b/opengever/ogds/base/locales/opengever.ogds.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/portlets/tree/locales/de/LC_MESSAGES/opengever.portlets.tree.po
+++ b/opengever/portlets/tree/locales/de/LC_MESSAGES/opengever.portlets.tree.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/portlets/tree/treeportlet.pt:14
+#: ./opengever/portlets/tree/treeportlet.pt:15
 msgid "Favorites"
 msgstr "Favoriten"
 
@@ -23,7 +23,7 @@ msgid "label_add_to_favorites"
 msgstr "Als Favorit markieren"
 
 #. Default: "Help"
-#: ./opengever/portlets/tree/treeportlet.pt:35
+#: ./opengever/portlets/tree/treeportlet.pt:36
 msgid "label_help"
 msgstr "Hilfe"
 
@@ -32,27 +32,27 @@ msgid "label_remove_from_favorites"
 msgstr "Aus Favoriten entfernen"
 
 #. Default: "No favorites set yet."
-#: ./opengever/portlets/tree/treeportlet.pt:27
+#: ./opengever/portlets/tree/treeportlet.pt:28
 msgid "tree_favorites_empty"
 msgstr "Es wurden noch keine Ordnungspositionen als Favorit markiert."
 
 #. Default: "When hovering over a repository folder, the icon for marking folders as favorites (${icon}) appears at the right side. Clicking this icon adds the folder as favorite here."
-#: ./opengever/portlets/tree/treeportlet.pt:44
+#: ./opengever/portlets/tree/treeportlet.pt:45
 msgid "tree_favorites_help_adding"
 msgstr "Wird der Mauszeiger im Ordnungssystem über Ordnungspositionen bewegt, so erscheint auf der rechten Seite das Symbol zum Markieren von Favoriten (${icon}). Wird auf dieses Symbol geklickt, so erscheint diese Ordnungsposition im Reiter \"Favoriten\"."
 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
-#: ./opengever/portlets/tree/treeportlet.pt:52
+#: ./opengever/portlets/tree/treeportlet.pt:53
 msgid "tree_favorites_help_marked"
 msgstr "Die von Ihnen als Favoriten markierten Ordnungspositionen werden im Ordnungssystem-Reiter mit einem entsprechenden Symbol (${icon}) markiert."
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
-#: ./opengever/portlets/tree/treeportlet.pt:59
+#: ./opengever/portlets/tree/treeportlet.pt:60
 msgid "tree_favorites_help_removing"
 msgstr "Um einen Favoriten zu entfernen, wechseln Sie zurück in den Reiter «Ordnungssystem» und klicken Sie auf das Symbol zum Entfernen von Favoriten (${icon})."
 
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
-#: ./opengever/portlets/tree/treeportlet.pt:38
+#: ./opengever/portlets/tree/treeportlet.pt:39
 msgid "tree_favorites_help_summary"
 msgstr "Das Markieren und Entfernen von Favoriten geschieht über den Ordnungssystem-Reiter."
 

--- a/opengever/portlets/tree/locales/fr/LC_MESSAGES/opengever.portlets.tree.po
+++ b/opengever/portlets/tree/locales/fr/LC_MESSAGES/opengever.portlets.tree.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/portlets/tree/treeportlet.pt:14
+#: ./opengever/portlets/tree/treeportlet.pt:15
 msgid "Favorites"
 msgstr "Favoris"
 
@@ -23,7 +23,7 @@ msgid "label_add_to_favorites"
 msgstr "Ajouter aux favoris"
 
 #. Default: "Help"
-#: ./opengever/portlets/tree/treeportlet.pt:35
+#: ./opengever/portlets/tree/treeportlet.pt:36
 msgid "label_help"
 msgstr "Aide"
 
@@ -32,27 +32,27 @@ msgid "label_remove_from_favorites"
 msgstr "Effacer des favoris"
 
 #. Default: "No favorites set yet."
-#: ./opengever/portlets/tree/treeportlet.pt:27
+#: ./opengever/portlets/tree/treeportlet.pt:28
 msgid "tree_favorites_empty"
 msgstr "Il n'y a encore aucun numéro de classement épinglé en favoris."
 
 #. Default: "When hovering over a repository folder, the icon for marking folders as favorites (${icon}) appears at the right side. Clicking this icon adds the folder as favorite here."
-#: ./opengever/portlets/tree/treeportlet.pt:44
+#: ./opengever/portlets/tree/treeportlet.pt:45
 msgid "tree_favorites_help_adding"
 msgstr "En survolant les numéros de classement dans le plan de classement avec le pointeur de la souris, le symbole pour marquer les favoris (${icon}) s'affiche à droite. En cliquant sur ce symbole, ce numéro de classement apparaît dans l'onglet \"Favoris\"."
 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
-#: ./opengever/portlets/tree/treeportlet.pt:52
+#: ./opengever/portlets/tree/treeportlet.pt:53
 msgid "tree_favorites_help_marked"
 msgstr "Vos numéros de classement choisis comme favoris sont épinglés dans l'onglet du plan de classement avec le symbole correspondant (${icon})"
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
-#: ./opengever/portlets/tree/treeportlet.pt:59
+#: ./opengever/portlets/tree/treeportlet.pt:60
 msgid "tree_favorites_help_removing"
 msgstr "Pour effacer un favori, retournez sur l'onglet \"Plan de classement\" et cliquez sur le symbole pour effacer les favoris (${icon})."
 
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
-#: ./opengever/portlets/tree/treeportlet.pt:38
+#: ./opengever/portlets/tree/treeportlet.pt:39
 msgid "tree_favorites_help_summary"
 msgstr "L'ajout ou la suppression des favoris se fait dans l'onglet plan de classement"
 

--- a/opengever/portlets/tree/locales/opengever.portlets.tree.pot
+++ b/opengever/portlets/tree/locales/opengever.portlets.tree.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.portlets.tree\n"
 
-#: ./opengever/portlets/tree/treeportlet.pt:14
+#: ./opengever/portlets/tree/treeportlet.pt:15
 msgid "Favorites"
 msgstr ""
 
@@ -26,7 +26,7 @@ msgid "label_add_to_favorites"
 msgstr ""
 
 #. Default: "Help"
-#: ./opengever/portlets/tree/treeportlet.pt:35
+#: ./opengever/portlets/tree/treeportlet.pt:36
 msgid "label_help"
 msgstr ""
 
@@ -35,27 +35,27 @@ msgid "label_remove_from_favorites"
 msgstr ""
 
 #. Default: "No favorites set yet."
-#: ./opengever/portlets/tree/treeportlet.pt:27
+#: ./opengever/portlets/tree/treeportlet.pt:28
 msgid "tree_favorites_empty"
 msgstr ""
 
 #. Default: "When hovering over a repository folder, the icon for marking folders as favorites (${icon}) appears at the right side. Clicking this icon adds the folder as favorite here."
-#: ./opengever/portlets/tree/treeportlet.pt:44
+#: ./opengever/portlets/tree/treeportlet.pt:45
 msgid "tree_favorites_help_adding"
 msgstr ""
 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
-#: ./opengever/portlets/tree/treeportlet.pt:52
+#: ./opengever/portlets/tree/treeportlet.pt:53
 msgid "tree_favorites_help_marked"
 msgstr ""
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
-#: ./opengever/portlets/tree/treeportlet.pt:59
+#: ./opengever/portlets/tree/treeportlet.pt:60
 msgid "tree_favorites_help_removing"
 msgstr ""
 
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
-#: ./opengever/portlets/tree/treeportlet.pt:38
+#: ./opengever/portlets/tree/treeportlet.pt:39
 msgid "tree_favorites_help_summary"
 msgstr ""
 

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -40,7 +40,6 @@ class IReferenceNumberPrefix(form.Schema):
         title=_(
             u'label_reference_number_prefix',
             default=u'Reference Prefix'),
-        description=_(u'help_reference_number_prefix', default=u''),
         required=False,
         defaultFactory=reference_number_prefix_default,
         )

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -46,12 +46,12 @@ msgid "empty_repository"
 msgstr "Keine untergeordnete Ordnungspositionen verfügbar."
 
 #. Default: "A Sibling with the same reference number is existing"
-#: ./opengever/repository/behaviors/referenceprefix.py:64
+#: ./opengever/repository/behaviors/referenceprefix.py:73
 msgid "error_sibling_reference_number_existing"
 msgstr "Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf gleicher Stufe"
 
 #. Default: "Common"
-#: ./opengever/repository/behaviors/referenceprefix.py:19
+#: ./opengever/repository/behaviors/referenceprefix.py:33
 #: ./opengever/repository/behaviors/responsibleorg.py:12
 #: ./opengever/repository/repositoryfolder.py:28
 msgid "fieldset_common"
@@ -75,7 +75,7 @@ msgstr ""
 msgid "help_location"
 msgstr ""
 
-#: ./opengever/repository/behaviors/referenceprefix.py:29
+#: ./opengever/repository/behaviors/referenceprefix.py:43
 msgid "help_reference_number_prefix"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgid "label_location"
 msgstr "Standort"
 
 #. Default: "Reference Prefix"
-#: ./opengever/repository/behaviors/referenceprefix.py:26
+#: ./opengever/repository/behaviors/referenceprefix.py:40
 msgid "label_reference_number_prefix"
 msgstr "Präfix des Aktenzeichens"
 
@@ -165,7 +165,7 @@ msgid "label_warning"
 msgstr "Warnung"
 
 #. Default: "State"
-#: ./opengever/repository/viewlets/byline.py:17
+#: ./opengever/repository/viewlets/byline.py:24
 msgid "label_workflow_state"
 msgstr "Status"
 

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:01+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -46,7 +46,7 @@ msgid "empty_repository"
 msgstr "Keine untergeordnete Ordnungspositionen verfügbar."
 
 #. Default: "A Sibling with the same reference number is existing"
-#: ./opengever/repository/behaviors/referenceprefix.py:73
+#: ./opengever/repository/behaviors/referenceprefix.py:72
 msgid "error_sibling_reference_number_existing"
 msgstr "Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf gleicher Stufe"
 
@@ -58,7 +58,7 @@ msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:83
+#: ./opengever/repository/repositoryfolder.py:78
 msgid "help_addable_dossier_types"
 msgstr "Wählen Sie die Spezialdossiers aus, die in dieser Ordnungsposition erlaubt sind."
 
@@ -67,38 +67,8 @@ msgstr "Wählen Sie die Spezialdossiers aus, die in dieser Ordnungsposition erla
 msgid "help_description"
 msgstr "Eine kurze Beschreibung des Inhalts."
 
-#: ./opengever/repository/repositoryfolder.py:75
-msgid "help_former_reference"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:61
-msgid "help_location"
-msgstr ""
-
-#: ./opengever/repository/behaviors/referenceprefix.py:43
-msgid "help_reference_number_prefix"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:69
-msgid "help_referenced_activity"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:49
-#: ./opengever/repository/repositoryroot.py:21
-msgid "help_valid_from"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:55
-#: ./opengever/repository/repositoryroot.py:27
-msgid "help_valid_until"
-msgstr ""
-
-#: ./opengever/repository/repositoryroot.py:33
-msgid "help_version"
-msgstr ""
-
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:81
+#: ./opengever/repository/repositoryfolder.py:76
 msgid "label_addable_dossier_types"
 msgstr "Erlaubte Spezialdossiers"
 
@@ -118,12 +88,12 @@ msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:74
+#: ./opengever/repository/repositoryfolder.py:70
 msgid "label_former_reference"
 msgstr "Früheres Zeichen"
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:60
+#: ./opengever/repository/repositoryfolder.py:58
 msgid "label_location"
 msgstr "Standort"
 
@@ -133,7 +103,7 @@ msgid "label_reference_number_prefix"
 msgstr "Präfix des Aktenzeichens"
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:66
+#: ./opengever/repository/repositoryfolder.py:63
 msgid "label_referenced_activity"
 msgstr "Leistung"
 
@@ -149,13 +119,13 @@ msgid "label_valid_from"
 msgstr "Gültig ab"
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:54
-#: ./opengever/repository/repositoryroot.py:26
+#: ./opengever/repository/repositoryfolder.py:53
+#: ./opengever/repository/repositoryroot.py:25
 msgid "label_valid_until"
 msgstr "Gültig bis"
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:32
+#: ./opengever/repository/repositoryroot.py:30
 msgid "label_version"
 msgstr "Version"
 

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,12 +42,12 @@ msgid "empty_repository"
 msgstr "Pas de numéros de classement disponible dans cette subdivison."
 
 #. Default: "A Sibling with the same reference number is existing"
-#: ./opengever/repository/behaviors/referenceprefix.py:64
+#: ./opengever/repository/behaviors/referenceprefix.py:73
 msgid "error_sibling_reference_number_existing"
 msgstr "A ce niveau du classement ce numéro de référence existe déjà."
 
 #. Default: "Common"
-#: ./opengever/repository/behaviors/referenceprefix.py:19
+#: ./opengever/repository/behaviors/referenceprefix.py:33
 #: ./opengever/repository/behaviors/responsibleorg.py:12
 #: ./opengever/repository/repositoryfolder.py:28
 msgid "fieldset_common"
@@ -71,7 +71,7 @@ msgstr ""
 msgid "help_location"
 msgstr ""
 
-#: ./opengever/repository/behaviors/referenceprefix.py:29
+#: ./opengever/repository/behaviors/referenceprefix.py:43
 msgid "help_reference_number_prefix"
 msgstr ""
 
@@ -124,7 +124,7 @@ msgid "label_location"
 msgstr "Site"
 
 #. Default: "Reference Prefix"
-#: ./opengever/repository/behaviors/referenceprefix.py:26
+#: ./opengever/repository/behaviors/referenceprefix.py:40
 msgid "label_reference_number_prefix"
 msgstr "Préfixe référence"
 
@@ -161,7 +161,7 @@ msgid "label_warning"
 msgstr "Avertissement"
 
 #. Default: "State"
-#: ./opengever/repository/viewlets/byline.py:17
+#: ./opengever/repository/viewlets/byline.py:24
 msgid "label_workflow_state"
 msgstr "Etat"
 

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,7 +42,7 @@ msgid "empty_repository"
 msgstr "Pas de numéros de classement disponible dans cette subdivison."
 
 #. Default: "A Sibling with the same reference number is existing"
-#: ./opengever/repository/behaviors/referenceprefix.py:73
+#: ./opengever/repository/behaviors/referenceprefix.py:72
 msgid "error_sibling_reference_number_existing"
 msgstr "A ce niveau du classement ce numéro de référence existe déjà."
 
@@ -54,7 +54,7 @@ msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:83
+#: ./opengever/repository/repositoryfolder.py:78
 msgid "help_addable_dossier_types"
 msgstr "Sélectionnez les types de dossiers à ajouter pour cette position du classeur"
 
@@ -63,38 +63,8 @@ msgstr "Sélectionnez les types de dossiers à ajouter pour cette position du cl
 msgid "help_description"
 msgstr "Brève description du contenu."
 
-#: ./opengever/repository/repositoryfolder.py:75
-msgid "help_former_reference"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:61
-msgid "help_location"
-msgstr ""
-
-#: ./opengever/repository/behaviors/referenceprefix.py:43
-msgid "help_reference_number_prefix"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:69
-msgid "help_referenced_activity"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:49
-#: ./opengever/repository/repositoryroot.py:21
-msgid "help_valid_from"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:55
-#: ./opengever/repository/repositoryroot.py:27
-msgid "help_valid_until"
-msgstr ""
-
-#: ./opengever/repository/repositoryroot.py:33
-msgid "help_version"
-msgstr ""
-
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:81
+#: ./opengever/repository/repositoryfolder.py:76
 msgid "label_addable_dossier_types"
 msgstr "Types de dossiers à ajouter"
 
@@ -114,12 +84,12 @@ msgid "label_description"
 msgstr "Description"
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:74
+#: ./opengever/repository/repositoryfolder.py:70
 msgid "label_former_reference"
 msgstr "Ancien numéro de référence"
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:60
+#: ./opengever/repository/repositoryfolder.py:58
 msgid "label_location"
 msgstr "Site"
 
@@ -129,7 +99,7 @@ msgid "label_reference_number_prefix"
 msgstr "Préfixe référence"
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:66
+#: ./opengever/repository/repositoryfolder.py:63
 msgid "label_referenced_activity"
 msgstr "Performance"
 
@@ -145,13 +115,13 @@ msgid "label_valid_from"
 msgstr "Valable de :"
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:54
-#: ./opengever/repository/repositoryroot.py:26
+#: ./opengever/repository/repositoryfolder.py:53
+#: ./opengever/repository/repositoryroot.py:25
 msgid "label_valid_until"
 msgstr "Valable jusqu'à :"
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:32
+#: ./opengever/repository/repositoryroot.py:30
 msgid "label_version"
 msgstr "Version"
 

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgid "empty_repository"
 msgstr ""
 
 #. Default: "A Sibling with the same reference number is existing"
-#: ./opengever/repository/behaviors/referenceprefix.py:73
+#: ./opengever/repository/behaviors/referenceprefix.py:72
 msgid "error_sibling_reference_number_existing"
 msgstr ""
 
@@ -57,7 +57,7 @@ msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:83
+#: ./opengever/repository/repositoryfolder.py:78
 msgid "help_addable_dossier_types"
 msgstr ""
 
@@ -66,38 +66,8 @@ msgstr ""
 msgid "help_description"
 msgstr ""
 
-#: ./opengever/repository/repositoryfolder.py:75
-msgid "help_former_reference"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:61
-msgid "help_location"
-msgstr ""
-
-#: ./opengever/repository/behaviors/referenceprefix.py:43
-msgid "help_reference_number_prefix"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:69
-msgid "help_referenced_activity"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:49
-#: ./opengever/repository/repositoryroot.py:21
-msgid "help_valid_from"
-msgstr ""
-
-#: ./opengever/repository/repositoryfolder.py:55
-#: ./opengever/repository/repositoryroot.py:27
-msgid "help_valid_until"
-msgstr ""
-
-#: ./opengever/repository/repositoryroot.py:33
-msgid "help_version"
-msgstr ""
-
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:81
+#: ./opengever/repository/repositoryfolder.py:76
 msgid "label_addable_dossier_types"
 msgstr ""
 
@@ -117,12 +87,12 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:74
+#: ./opengever/repository/repositoryfolder.py:70
 msgid "label_former_reference"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:60
+#: ./opengever/repository/repositoryfolder.py:58
 msgid "label_location"
 msgstr ""
 
@@ -132,7 +102,7 @@ msgid "label_reference_number_prefix"
 msgstr ""
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:66
+#: ./opengever/repository/repositoryfolder.py:63
 msgid "label_referenced_activity"
 msgstr ""
 
@@ -148,13 +118,13 @@ msgid "label_valid_from"
 msgstr ""
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:54
-#: ./opengever/repository/repositoryroot.py:26
+#: ./opengever/repository/repositoryfolder.py:53
+#: ./opengever/repository/repositoryroot.py:25
 msgid "label_valid_until"
 msgstr ""
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:32
+#: ./opengever/repository/repositoryroot.py:30
 msgid "label_version"
 msgstr ""
 

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,12 +45,12 @@ msgid "empty_repository"
 msgstr ""
 
 #. Default: "A Sibling with the same reference number is existing"
-#: ./opengever/repository/behaviors/referenceprefix.py:64
+#: ./opengever/repository/behaviors/referenceprefix.py:73
 msgid "error_sibling_reference_number_existing"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/repository/behaviors/referenceprefix.py:19
+#: ./opengever/repository/behaviors/referenceprefix.py:33
 #: ./opengever/repository/behaviors/responsibleorg.py:12
 #: ./opengever/repository/repositoryfolder.py:28
 msgid "fieldset_common"
@@ -74,7 +74,7 @@ msgstr ""
 msgid "help_location"
 msgstr ""
 
-#: ./opengever/repository/behaviors/referenceprefix.py:29
+#: ./opengever/repository/behaviors/referenceprefix.py:43
 msgid "help_reference_number_prefix"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgid "label_location"
 msgstr ""
 
 #. Default: "Reference Prefix"
-#: ./opengever/repository/behaviors/referenceprefix.py:26
+#: ./opengever/repository/behaviors/referenceprefix.py:40
 msgid "label_reference_number_prefix"
 msgstr ""
 
@@ -164,7 +164,7 @@ msgid "label_warning"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/repository/viewlets/byline.py:17
+#: ./opengever/repository/viewlets/byline.py:24
 msgid "label_workflow_state"
 msgstr ""
 

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -46,19 +46,16 @@ class IRepositoryFolderSchema(form.Schema):
 
     valid_from = schema.Date(
         title=_(u'label_valid_from', default=u'Valid from'),
-        description=_(u'help_valid_from', default=u''),
         required=False,
         )
 
     valid_until = schema.Date(
         title=_(u'label_valid_until', default=u'Valid until'),
-        description=_(u'help_valid_until', default=u''),
         required=False,
         )
 
     location = schema.TextLine(
         title=_(u'label_location', default=u'Location'),
-        description=_(u'help_location', default=u''),
         required=False,
         )
 
@@ -66,13 +63,11 @@ class IRepositoryFolderSchema(form.Schema):
         title=_(
             u'label_referenced_activity',
             default=u'Referenced activity'),
-        description=_(u'help_referenced_activity', default=u''),
         required=False,
         )
 
     former_reference = schema.TextLine(
         title=_(u'label_former_reference', default=u'Former reference'),
-        description=_(u'help_former_reference', default=u''),
         required=False,
         )
 

--- a/opengever/repository/repositoryroot.py
+++ b/opengever/repository/repositoryroot.py
@@ -18,19 +18,16 @@ class IRepositoryRoot(form.Schema):
 
     valid_from = schema.Date(
         title=_(u'label_valid_from', default=u'Valid from'),
-        description=_(u'help_valid_from', default=u''),
         required=False,
         )
 
     valid_until = schema.Date(
         title=_(u'label_valid_until', default=u'Valid until'),
-        description=_(u'help_valid_until', default=u''),
         required=False,
         )
 
     version = schema.TextLine(
         title=_(u'label_version', default=u'Version'),
-        description=_(u'help_version', default=''),
         required=False,
         )
 

--- a/opengever/setup/locales/de/LC_MESSAGES/opengever.setup.po
+++ b/opengever/setup/locales/de/LC_MESSAGES/opengever.setup.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/setup/locales/fr/LC_MESSAGES/opengever.setup.po
+++ b/opengever/setup/locales/fr/LC_MESSAGES/opengever.setup.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/setup/locales/opengever.setup.pot
+++ b/opengever/setup/locales/opengever.setup.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/sharing/locales/de/LC_MESSAGES/opengever.sharing.po
+++ b/opengever/sharing/locales/de/LC_MESSAGES/opengever.sharing.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/sharing/locales/fr/LC_MESSAGES/opengever.sharing.po
+++ b/opengever/sharing/locales/fr/LC_MESSAGES/opengever.sharing.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/sharing/locales/opengever.sharing.pot
+++ b/opengever/sharing/locales/opengever.sharing.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-07 15:59+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:168
+#: ./opengever/tabbedview/browser/tabs.py:175
 msgid "Active"
 msgstr "Aktiv"
 
@@ -53,7 +53,7 @@ msgstr "Akteur"
 msgid "additional_contact"
 msgstr "Zusätzliches"
 
-#: ./opengever/tabbedview/browser/tabs.py:165
+#: ./opengever/tabbedview/browser/tabs.py:172
 #: ./opengever/tabbedview/browser/tasklisting.py:64
 msgid "all"
 msgstr "Alle"
@@ -81,42 +81,42 @@ msgid "checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:92
+#: ./opengever/tabbedview/browser/tasklisting.py:91
 msgid "column_date_of_completion"
 msgstr "Erledigt am"
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:88
+#: ./opengever/tabbedview/browser/tasklisting.py:87
 msgid "column_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:105
+#: ./opengever/tabbedview/browser/tasklisting.py:104
 msgid "column_issued_at"
 msgstr "Erstellt am"
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:112
+#: ./opengever/tabbedview/browser/tasklisting.py:111
 msgid "column_issuing_org_unit"
 msgstr "Organisationseinheit"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:76
+#: ./opengever/tabbedview/browser/tasklisting.py:75
 msgid "column_review_state"
 msgstr "Status"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:118
+#: ./opengever/tabbedview/browser/tasklisting.py:117
 msgid "column_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:84
+#: ./opengever/tabbedview/browser/tasklisting.py:83
 msgid "column_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:80
+#: ./opengever/tabbedview/browser/tasklisting.py:79
 msgid "column_title"
 msgstr "Titel"
 
@@ -131,7 +131,7 @@ msgid "contact"
 msgstr "Beteiligter"
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:109
+#: ./opengever/tabbedview/browser/tasklisting.py:108
 msgid "containing_dossier"
 msgstr "Dossier"
 
@@ -154,7 +154,7 @@ msgid "document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:84
+#: ./opengever/tabbedview/browser/tabs.py:91
 msgid "document_sequence_number"
 msgstr "Laufnummer"
 
@@ -169,11 +169,13 @@ msgstr "Mehr anzeigen"
 
 #. Default: "Gallery"
 #: ./opengever/tabbedview/browser/bumblebee_gallery.pt:3
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:11
 msgid "documents_pill_documents"
 msgstr "Galerieansicht"
 
 #. Default: "List"
 #: ./opengever/tabbedview/browser/bumblebee_gallery.pt:4
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:17
 msgid "documents_pill_list"
 msgstr "Listenansicht"
 
@@ -210,12 +212,12 @@ msgid "label_active"
 msgstr "Aktiv"
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:111
+#: ./opengever/tabbedview/browser/tabs.py:118
 msgid "label_checked_out"
 msgstr "In Bearbeitung"
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:107
+#: ./opengever/tabbedview/browser/tabs.py:114
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
@@ -230,27 +232,27 @@ msgid "label_directorate_user"
 msgstr "Direktion"
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:94
+#: ./opengever/tabbedview/browser/tabs.py:101
 msgid "label_document_author"
 msgstr "Autor"
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:99
+#: ./opengever/tabbedview/browser/tabs.py:106
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:196
+#: ./opengever/tabbedview/browser/tabs.py:203
 msgid "label_dossier_responsible"
 msgstr "Federführung"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:205
+#: ./opengever/tabbedview/browser/tabs.py:212
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:101
+#: ./opengever/tabbedview/browser/tasklisting.py:100
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -275,42 +277,42 @@ msgid "label_pending"
 msgstr "Pendent"
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:119
+#: ./opengever/tabbedview/browser/tabs.py:126
 msgid "label_public_trial"
 msgstr "Öffentlichkeitsstatus"
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:103
+#: ./opengever/tabbedview/browser/tabs.py:110
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:184
+#: ./opengever/tabbedview/browser/tabs.py:191
 msgid "label_reference"
 msgstr "Aktenzeichen"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:97
+#: ./opengever/tabbedview/browser/tasklisting.py:96
 msgid "label_responsible_task"
 msgstr "Auftragnehmer"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:192
+#: ./opengever/tabbedview/browser/tabs.py:199
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:201
+#: ./opengever/tabbedview/browser/tabs.py:208
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:115
+#: ./opengever/tabbedview/browser/tabs.py:122
 msgid "label_subdossier"
 msgstr "Subdossier"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:89
+#: ./opengever/tabbedview/browser/tabs.py:96
 msgid "label_title"
 msgstr "Titel"
 
@@ -433,3 +435,4 @@ msgstr "Titel"
 
 msgid "trash"
 msgstr "Papierkorb"
+

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-07 15:59+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2013-03-27 11:23+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:168
+#: ./opengever/tabbedview/browser/tabs.py:175
 msgid "Active"
 msgstr "Actif"
 
@@ -50,7 +50,7 @@ msgstr "Acteur"
 msgid "additional_contact"
 msgstr "Additionnel"
 
-#: ./opengever/tabbedview/browser/tabs.py:165
+#: ./opengever/tabbedview/browser/tabs.py:172
 #: ./opengever/tabbedview/browser/tasklisting.py:64
 msgid "all"
 msgstr "Tous"
@@ -78,42 +78,42 @@ msgid "checkout_and_edit"
 msgstr "Checkout et modifier"
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:92
+#: ./opengever/tabbedview/browser/tasklisting.py:91
 msgid "column_date_of_completion"
 msgstr "Accompli le"
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:88
+#: ./opengever/tabbedview/browser/tasklisting.py:87
 msgid "column_deadline"
 msgstr "A accomplir jusqu'au"
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:105
+#: ./opengever/tabbedview/browser/tasklisting.py:104
 msgid "column_issued_at"
 msgstr "Créé le"
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:112
+#: ./opengever/tabbedview/browser/tasklisting.py:111
 msgid "column_issuing_org_unit"
 msgstr "Unité d'organisation"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:76
+#: ./opengever/tabbedview/browser/tasklisting.py:75
 msgid "column_review_state"
 msgstr "Etat"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:118
+#: ./opengever/tabbedview/browser/tasklisting.py:117
 msgid "column_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:84
+#: ./opengever/tabbedview/browser/tasklisting.py:83
 msgid "column_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:80
+#: ./opengever/tabbedview/browser/tasklisting.py:79
 msgid "column_title"
 msgstr "Titre"
 
@@ -127,7 +127,7 @@ msgid "contact"
 msgstr "Participant"
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:109
+#: ./opengever/tabbedview/browser/tasklisting.py:108
 msgid "containing_dossier"
 msgstr "Dossier"
 
@@ -150,7 +150,7 @@ msgid "document_date"
 msgstr "Date du document"
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:84
+#: ./opengever/tabbedview/browser/tabs.py:91
 msgid "document_sequence_number"
 msgstr "Numéro courant"
 
@@ -164,11 +164,13 @@ msgstr "Montre plus"
 
 #. Default: "Gallery"
 #: ./opengever/tabbedview/browser/bumblebee_gallery.pt:3
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:11
 msgid "documents_pill_documents"
 msgstr "Galerie"
 
 #. Default: "List"
 #: ./opengever/tabbedview/browser/bumblebee_gallery.pt:4
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:17
 msgid "documents_pill_list"
 msgstr "Liste"
 
@@ -202,12 +204,12 @@ msgid "label_active"
 msgstr "Actif"
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:111
+#: ./opengever/tabbedview/browser/tabs.py:118
 msgid "label_checked_out"
 msgstr "En traitement"
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:107
+#: ./opengever/tabbedview/browser/tabs.py:114
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
@@ -222,27 +224,27 @@ msgid "label_directorate_user"
 msgstr "Direction"
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:94
+#: ./opengever/tabbedview/browser/tabs.py:101
 msgid "label_document_author"
 msgstr "Auteur"
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:99
+#: ./opengever/tabbedview/browser/tabs.py:106
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:196
+#: ./opengever/tabbedview/browser/tabs.py:203
 msgid "label_dossier_responsible"
 msgstr "Responsable"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:205
+#: ./opengever/tabbedview/browser/tabs.py:212
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:101
+#: ./opengever/tabbedview/browser/tasklisting.py:100
 msgid "label_issuer"
 msgstr "Mandant"
 
@@ -267,42 +269,42 @@ msgid "label_pending"
 msgstr "En suspens"
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:119
+#: ./opengever/tabbedview/browser/tabs.py:126
 msgid "label_public_trial"
 msgstr "Statut public"
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:103
+#: ./opengever/tabbedview/browser/tabs.py:110
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:184
+#: ./opengever/tabbedview/browser/tabs.py:191
 msgid "label_reference"
 msgstr "Numéro de référence"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:97
+#: ./opengever/tabbedview/browser/tasklisting.py:96
 msgid "label_responsible_task"
 msgstr "Mandataire"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:192
+#: ./opengever/tabbedview/browser/tabs.py:199
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:201
+#: ./opengever/tabbedview/browser/tabs.py:208
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:115
+#: ./opengever/tabbedview/browser/tabs.py:122
 msgid "label_subdossier"
 msgstr "Sous-dossier"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:89
+#: ./opengever/tabbedview/browser/tabs.py:96
 msgid "label_title"
 msgstr "Titre"
 
@@ -413,3 +415,4 @@ msgstr "Titre"
 
 msgid "trash"
 msgstr "Corbeille"
+

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-07 15:59+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: opengever.tabbedview\n"
 "X-Poedit-Language: German\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:168
+#: ./opengever/tabbedview/browser/tabs.py:175
 msgid "Active"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "additional_contact"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:165
+#: ./opengever/tabbedview/browser/tabs.py:172
 #: ./opengever/tabbedview/browser/tasklisting.py:64
 msgid "all"
 msgstr ""
@@ -79,42 +79,42 @@ msgid "checkout_and_edit"
 msgstr ""
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:92
+#: ./opengever/tabbedview/browser/tasklisting.py:91
 msgid "column_date_of_completion"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:88
+#: ./opengever/tabbedview/browser/tasklisting.py:87
 msgid "column_deadline"
 msgstr ""
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:105
+#: ./opengever/tabbedview/browser/tasklisting.py:104
 msgid "column_issued_at"
 msgstr ""
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:112
+#: ./opengever/tabbedview/browser/tasklisting.py:111
 msgid "column_issuing_org_unit"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:76
+#: ./opengever/tabbedview/browser/tasklisting.py:75
 msgid "column_review_state"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:118
+#: ./opengever/tabbedview/browser/tasklisting.py:117
 msgid "column_sequence_number"
 msgstr ""
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:84
+#: ./opengever/tabbedview/browser/tasklisting.py:83
 msgid "column_task_type"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:80
+#: ./opengever/tabbedview/browser/tasklisting.py:79
 msgid "column_title"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgid "contact"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:109
+#: ./opengever/tabbedview/browser/tasklisting.py:108
 msgid "containing_dossier"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgid "document_date"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:84
+#: ./opengever/tabbedview/browser/tabs.py:91
 msgid "document_sequence_number"
 msgstr ""
 
@@ -165,11 +165,13 @@ msgstr ""
 
 #. Default: "Gallery"
 #: ./opengever/tabbedview/browser/bumblebee_gallery.pt:3
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:11
 msgid "documents_pill_documents"
 msgstr ""
 
 #. Default: "List"
 #: ./opengever/tabbedview/browser/bumblebee_gallery.pt:4
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:17
 msgid "documents_pill_list"
 msgstr ""
 
@@ -203,12 +205,12 @@ msgid "label_active"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:111
+#: ./opengever/tabbedview/browser/tabs.py:118
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:107
+#: ./opengever/tabbedview/browser/tabs.py:114
 msgid "label_delivery_date"
 msgstr ""
 
@@ -223,27 +225,27 @@ msgid "label_directorate_user"
 msgstr ""
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:94
+#: ./opengever/tabbedview/browser/tabs.py:101
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:99
+#: ./opengever/tabbedview/browser/tabs.py:106
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:196
+#: ./opengever/tabbedview/browser/tabs.py:203
 msgid "label_dossier_responsible"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:205
+#: ./opengever/tabbedview/browser/tabs.py:212
 msgid "label_end"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:101
+#: ./opengever/tabbedview/browser/tasklisting.py:100
 msgid "label_issuer"
 msgstr ""
 
@@ -268,42 +270,42 @@ msgid "label_pending"
 msgstr ""
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:119
+#: ./opengever/tabbedview/browser/tabs.py:126
 msgid "label_public_trial"
 msgstr ""
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:103
+#: ./opengever/tabbedview/browser/tabs.py:110
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:184
+#: ./opengever/tabbedview/browser/tabs.py:191
 msgid "label_reference"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:97
+#: ./opengever/tabbedview/browser/tasklisting.py:96
 msgid "label_responsible_task"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:192
+#: ./opengever/tabbedview/browser/tabs.py:199
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:201
+#: ./opengever/tabbedview/browser/tabs.py:208
 msgid "label_start"
 msgstr ""
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:115
+#: ./opengever/tabbedview/browser/tabs.py:122
 msgid "label_subdossier"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:89
+#: ./opengever/tabbedview/browser/tabs.py:96
 msgid "label_title"
 msgstr ""
 

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -28,7 +28,6 @@ class IAssignSchema(form.Schema):
     # hidden
     transition = schema.Choice(
         title=_("label_transition", default="Transition"),
-        description=_(u"help_transition", default=""),
         source=getTransitionVocab,
         required=True,
         )
@@ -50,7 +49,6 @@ class IAssignSchema(form.Schema):
 
     text = schema.Text(
         title=_('label_response', default="Response"),
-        description=_('help_response', default=""),
         required=False,
         )
 

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -102,7 +102,6 @@ class ICompleteSuccessorTaskSchema(Schema):
     # hidden: used to pass on the transition
     transition = schema.Choice(
         title=_("label_transition", default="Transition"),
-        description=_(u"help_transition", default=""),
         source=util.getTransitionVocab,
         required=True)
 

--- a/opengever/task/browser/delegate/metadata.py
+++ b/opengever/task/browser/delegate/metadata.py
@@ -25,7 +25,6 @@ class IUpdateMetadata(Schema):
 
     issuer = schema.Choice(
         title=_(u"label_issuer", default=u"Issuer"),
-        description=_('help_issuer', default=u""),
         vocabulary=u'opengever.ogds.base.ContactsAndUsersVocabulary',
         required=True)
 

--- a/opengever/task/browser/modify_deadline.py
+++ b/opengever/task/browser/modify_deadline.py
@@ -23,7 +23,6 @@ class IModifyDeadlineSchema(form.Schema):
     # hidden
     transition = schema.Choice(
         title=_("label_transition", default="Transition"),
-        description=_(u"help_transition", default=""),
         source=getTransitionVocab,
         required=True,
         )
@@ -31,13 +30,11 @@ class IModifyDeadlineSchema(form.Schema):
     form.widget(new_deadline=DatePickerFieldWidget)
     new_deadline = schema.Date(
         title=_(u"label_new_deadline", default=u"New Deadline"),
-        description=_(u"help_new_deadline", default=u""),
         required=True,
         )
 
     text = schema.Text(
         title=_('label_response', default="Response"),
-        description=_('help_response', default=""),
         required=False,
         )
 

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -226,12 +226,12 @@ msgid "existing_dossier"
 msgstr "bestehendes Dossier"
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:68
+#: ./opengever/task/task.py:73
 msgid "fieldset_additional"
 msgstr "Erweitert"
 
 #. Default: "Common"
-#: ./opengever/task/task.py:53
+#: ./opengever/task/task.py:58
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -287,42 +287,42 @@ msgid "help_complete_task_response"
 msgstr "Der hier eingegebene Text erscheint in der Antwort, die die Aufgabe abschliesst."
 
 #: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:132
+#: ./opengever/task/task.py:138
 msgid "help_date_of_completion"
 msgstr "Das Datum an dem die Aufgabe beendet wurde"
 
 #. Default: "Deadline"
 #: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:125
+#: ./opengever/task/task.py:130
 msgid "help_deadline"
 msgstr "Tragen Sie ein Datum ein, bis wann die Aufgabe erledigt werden muss"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:196
 msgid "help_effectiveCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:190
 msgid "help_effectiveDuration"
 msgstr "Dauer in h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:184
 msgid "help_expectedCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:172
+#: ./opengever/task/task.py:178
 msgid "help_expectedDuration"
 msgstr "Dauer in h"
 
-#: ./opengever/task/task.py:166
+#: ./opengever/task/task.py:172
 msgid "help_expectedStartOfWork"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:90
+#: ./opengever/task/task.py:95
 msgid "help_issuer"
 msgstr ""
 
@@ -330,7 +330,7 @@ msgstr ""
 msgid "help_new_deadline"
 msgstr ""
 
-#: ./opengever/task/task.py:197
+#: ./opengever/task/task.py:203
 msgid "help_predecessor"
 msgstr ""
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "help_response"
 msgstr ""
 
-#: ./opengever/task/task.py:117
+#: ./opengever/task/task.py:122
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person aus, die dem oben gewählten Mandanten angehört."
 
 #: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:109
+#: ./opengever/task/task.py:114
 msgid "help_responsible_client"
 msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer."
 
@@ -354,17 +354,17 @@ msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den A
 msgid "help_responsible_single_client_setup"
 msgstr "Wählen Sie die verantwortliche Person aus"
 
-#: ./opengever/task/task.py:98
+#: ./opengever/task/task.py:103
 msgid "help_task_type"
 msgstr "Wählen Sie den Auftragstyp"
 
 #: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:140
+#: ./opengever/task/task.py:146
 msgid "help_text"
 msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein"
 
 #: ./opengever/task/browser/delegate/metadata.py:23
-#: ./opengever/task/task.py:82
+#: ./opengever/task/task.py:87
 msgid "help_title"
 msgstr "Der Name der Aufgabe"
 
@@ -445,7 +445,7 @@ msgstr "erstellt am"
 #. Default: "Date of completion"
 #: ./opengever/task/browser/overview.py:102
 #: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:131
+#: ./opengever/task/task.py:137
 msgid "label_date_of_completion"
 msgstr "Erledigungsdatum"
 
@@ -472,12 +472,12 @@ msgid "label_edit_response_not_allowed"
 msgstr "Sie sind nicht berechtigt diese Antwort zu löschen"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:189
+#: ./opengever/task/task.py:195
 msgid "label_effectiveCost"
 msgstr "Effektive Kosten (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:183
+#: ./opengever/task/task.py:189
 msgid "label_effectiveDuration"
 msgstr "Effektive Dauer (h)"
 
@@ -487,24 +487,24 @@ msgid "label_enter_response"
 msgstr "Bitte tragen sie ihre Antwort unten ein"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:177
+#: ./opengever/task/task.py:183
 msgid "label_expectedCost"
 msgstr "Geschätzte Kosten (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:171
+#: ./opengever/task/task.py:177
 msgid "label_expectedDuration"
 msgstr "Geschätzte Dauer (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:165
+#: ./opengever/task/task.py:171
 msgid "label_expectedStartOfWork"
 msgstr "Beginn der Arbeit"
 
 #. Default: "Issuer"
 #: ./opengever/task/browser/delegate/metadata.py:27
 #: ./opengever/task/browser/overview.py:91
-#: ./opengever/task/task.py:89
+#: ./opengever/task/task.py:94
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -529,7 +529,7 @@ msgid "label_parent_dossier_title"
 msgstr "Dossiertitel"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:196
+#: ./opengever/task/task.py:202
 msgid "label_predecessor"
 msgstr "Vorgänger"
 
@@ -541,13 +541,13 @@ msgstr "Ursprüngliche Aufgabe"
 #. Default: "Related Items"
 #: ./opengever/task/browser/complete.py:215
 #: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:145
+#: ./opengever/task/task.py:151
 msgid "label_related_items"
 msgstr "Verweise"
 
 #. Default: "Responsible Client"
 #: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:107
+#: ./opengever/task/task.py:112
 msgid "label_resonsible_client"
 msgstr "Mandant des Auftragnehmers"
 
@@ -599,7 +599,7 @@ msgstr "Aufgabentitel"
 #. Default: "Task Type"
 #: ./opengever/task/activities.py:136
 #: ./opengever/task/browser/overview.py:77
-#: ./opengever/task/task.py:97
+#: ./opengever/task/task.py:102
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
@@ -612,7 +612,7 @@ msgstr "Beschreibung"
 
 #. Default: "Title"
 #: ./opengever/task/browser/delegate/metadata.py:22
-#: ./opengever/task/task.py:81
+#: ./opengever/task/task.py:86
 msgid "label_title"
 msgstr "Titel"
 

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:23+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -18,11 +18,11 @@ msgstr ""
 msgid "${num} documents were copied."
 msgstr "${num} Dokumente wurden kopiert."
 
-#: ./opengever/task/browser/delegate/metadata.py:80
+#: ./opengever/task/browser/delegate/metadata.py:79
 msgid "${subtask_num} subtasks were create."
 msgstr "${subtask_num} Unteraufgaben wurden erstellt."
 
-#: ./opengever/task/response.py:350
+#: ./opengever/task/response.py:349
 msgid "Changes saved to response id ${response_id}."
 msgstr "Änderungen an der Antwort ${response_id} wurden gespeichert"
 
@@ -34,29 +34,29 @@ msgstr "Löschen"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/task/response.py:251
+#: ./opengever/task/response.py:250
 #: ./opengever/task/statesyncer.py:145
 #: ./opengever/task/util.py:162
 msgid "Issue state"
 msgstr "Status"
 
-#: ./opengever/task/response.py:378
+#: ./opengever/task/response.py:377
 msgid "No response selected for removal."
 msgstr "Es wurde keine Antwort fürs Löschen selektiert"
 
-#: ./opengever/task/response.py:341
+#: ./opengever/task/response.py:340
 msgid "No response selected for saving."
 msgstr "Es wurde keine Antwort fürs Speichern selektiert"
 
-#: ./opengever/task/response.py:400
+#: ./opengever/task/response.py:399
 msgid "Removed response id ${response_id}."
 msgstr "Antwort ${response_id} gelöscht"
 
-#: ./opengever/task/response.py:393
+#: ./opengever/task/response.py:392
 msgid "Response id ${response_id} does not exist so it cannot be removed."
 msgstr "Antowrt ${response_id} existiert nicht und konnte deshalb nicht gelöscht werden"
 
-#: ./opengever/task/response.py:385
+#: ./opengever/task/response.py:384
 msgid "Response id ${response_id} is no integer so it cannot be removed."
 msgstr "Antwort id ${response_id} ist keine Zahl und konnte deshalb nicht gelöscht werden"
 
@@ -72,7 +72,7 @@ msgstr "Unteraufgabe"
 msgid "Task"
 msgstr "Aufgabe"
 
-#: ./opengever/task/browser/complete.py:133
+#: ./opengever/task/browser/complete.py:132
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr "Die Dokumente wurde an den Auftraggeber geliefert und die Aufgaben wurden abgeschlossen."
 
@@ -105,11 +105,11 @@ msgstr "Die Aufgabe wurde akzeptiert."
 msgid "The task has been copied to the selected dossier and accepted."
 msgstr "Die Aufgabe wurde kopiert und akzeptiert."
 
-#: ./opengever/task/response.py:372
+#: ./opengever/task/response.py:371
 msgid "You are not allowed to delete responses."
 msgstr "Sie haben keine Berechtigung Antworten zu löschen"
 
-#: ./opengever/task/response.py:335
+#: ./opengever/task/response.py:334
 msgid "You are not allowed to edit responses."
 msgstr "Sie haben keine Berechtigung Antworten zu editieren"
 
@@ -156,12 +156,12 @@ msgid "accept_method_participate"
 msgstr "direkt im Dossier des Auftraggebers bearbeiten."
 
 #. Default: "RE"
-#: ./opengever/task/browser/complete.py:308
+#: ./opengever/task/browser/complete.py:307
 msgid "answer_prefix"
 msgstr "AW"
 
 #. Default: "Assign"
-#: ./opengever/task/browser/assign.py:78
+#: ./opengever/task/browser/assign.py:76
 msgid "button_assign"
 msgstr "Zuweisen"
 
@@ -187,11 +187,11 @@ msgid "button_save"
 msgstr "Speichern"
 
 #. Default: "Cancel"
-#: ./opengever/task/response.py:271
+#: ./opengever/task/response.py:270
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: ./opengever/task/response.py:210
+#: ./opengever/task/response.py:209
 msgid "date_of_completion"
 msgstr "Erledigungsdatum"
 
@@ -216,7 +216,7 @@ msgid "error_checked_out_document"
 msgstr "Die folgenden Dokumente (${title}) müssen noch eingecheckt werden."
 
 #. Default: "No changes: same responsible selected"
-#: ./opengever/task/browser/assign.py:85
+#: ./opengever/task/browser/assign.py:83
 msgid "error_same_responsible"
 msgstr "Keine Änderung, da kein anderer Auftragnehmer ausgewählt wurde."
 
@@ -286,80 +286,57 @@ msgstr "Wählen Sie die Dokumente aus, die Sie dem Auftraggeber liefern wollen. 
 msgid "help_complete_task_response"
 msgstr "Der hier eingegebene Text erscheint in der Antwort, die die Aufgabe abschliesst."
 
-#: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:138
+#: ./opengever/task/response.py:59
+#: ./opengever/task/task.py:137
 msgid "help_date_of_completion"
 msgstr "Das Datum an dem die Aufgabe beendet wurde"
 
 #. Default: "Deadline"
-#: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:130
+#: ./opengever/task/browser/delegate/metadata.py:33
+#: ./opengever/task/task.py:129
 msgid "help_deadline"
 msgstr "Tragen Sie ein Datum ein, bis wann die Aufgabe erledigt werden muss"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:196
+#: ./opengever/task/task.py:194
 msgid "help_effectiveCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:188
 msgid "help_effectiveDuration"
 msgstr "Dauer in h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:182
 msgid "help_expectedCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:176
 msgid "help_expectedDuration"
 msgstr "Dauer in h"
 
-#: ./opengever/task/task.py:172
-msgid "help_expectedStartOfWork"
-msgstr ""
-
-#: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:95
-msgid "help_issuer"
-msgstr ""
-
-#: ./opengever/task/browser/modify_deadline.py:34
-msgid "help_new_deadline"
-msgstr ""
-
-#: ./opengever/task/task.py:203
-msgid "help_predecessor"
-msgstr ""
-
-#: ./opengever/task/browser/assign.py:53
-#: ./opengever/task/browser/modify_deadline.py:40
-#: ./opengever/task/response.py:54
-msgid "help_response"
-msgstr ""
-
-#: ./opengever/task/task.py:122
+#: ./opengever/task/task.py:121
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person aus, die dem oben gewählten Mandanten angehört."
 
-#: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:114
+#: ./opengever/task/browser/assign.py:38
+#: ./opengever/task/task.py:113
 msgid "help_responsible_client"
 msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer."
 
-#: ./opengever/task/browser/assign.py:46
+#: ./opengever/task/browser/assign.py:45
 #: ./opengever/task/form.py:41
 msgid "help_responsible_single_client_setup"
 msgstr "Wählen Sie die verantwortliche Person aus"
 
-#: ./opengever/task/task.py:103
+#: ./opengever/task/task.py:102
 msgid "help_task_type"
 msgstr "Wählen Sie den Auftragstyp"
 
-#: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:146
+#: ./opengever/task/browser/delegate/metadata.py:38
+#: ./opengever/task/task.py:145
 msgid "help_text"
 msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein"
 
@@ -368,9 +345,7 @@ msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein"
 msgid "help_title"
 msgstr "Der Name der Aufgabe"
 
-#: ./opengever/task/browser/assign.py:31
-#: ./opengever/task/browser/complete.py:105
-#: ./opengever/task/browser/modify_deadline.py:26
+#: ./opengever/task/response.py:47
 msgid "help_transition"
 msgstr ""
 
@@ -444,14 +419,14 @@ msgstr "erstellt am"
 
 #. Default: "Date of completion"
 #: ./opengever/task/browser/overview.py:102
-#: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:137
+#: ./opengever/task/response.py:58
+#: ./opengever/task/task.py:136
 msgid "label_date_of_completion"
 msgstr "Erledigungsdatum"
 
 #. Default: "Deadline"
 #: ./opengever/task/activities.py:134
-#: ./opengever/task/browser/delegate/metadata.py:33
+#: ./opengever/task/browser/delegate/metadata.py:32
 #: ./opengever/task/browser/overview.py:86
 msgid "label_deadline"
 msgstr "Zu erledigen bis"
@@ -472,12 +447,12 @@ msgid "label_edit_response_not_allowed"
 msgstr "Sie sind nicht berechtigt diese Antwort zu löschen"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:195
+#: ./opengever/task/task.py:193
 msgid "label_effectiveCost"
 msgstr "Effektive Kosten (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:189
+#: ./opengever/task/task.py:187
 msgid "label_effectiveDuration"
 msgstr "Effektive Dauer (h)"
 
@@ -487,17 +462,17 @@ msgid "label_enter_response"
 msgstr "Bitte tragen sie ihre Antwort unten ein"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:183
+#: ./opengever/task/task.py:181
 msgid "label_expectedCost"
 msgstr "Geschätzte Kosten (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:177
+#: ./opengever/task/task.py:175
 msgid "label_expectedDuration"
 msgstr "Geschätzte Dauer (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:171
+#: ./opengever/task/task.py:170
 msgid "label_expectedStartOfWork"
 msgstr "Beginn der Arbeit"
 
@@ -519,7 +494,7 @@ msgid "label_main_attributes"
 msgstr "Eigenschaften"
 
 #. Default: "New Deadline"
-#: ./opengever/task/browser/modify_deadline.py:33
+#: ./opengever/task/browser/modify_deadline.py:32
 msgid "label_new_deadline"
 msgstr "Neue Frist"
 
@@ -529,7 +504,7 @@ msgid "label_parent_dossier_title"
 msgstr "Dossiertitel"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:202
+#: ./opengever/task/task.py:200
 msgid "label_predecessor"
 msgstr "Vorgänger"
 
@@ -539,27 +514,27 @@ msgid "label_predecessor_task"
 msgstr "Ursprüngliche Aufgabe"
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py:215
-#: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:151
+#: ./opengever/task/browser/complete.py:214
+#: ./opengever/task/response.py:64
+#: ./opengever/task/task.py:150
 msgid "label_related_items"
 msgstr "Verweise"
 
 #. Default: "Responsible Client"
-#: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:112
+#: ./opengever/task/browser/assign.py:36
+#: ./opengever/task/task.py:111
 msgid "label_resonsible_client"
 msgstr "Mandant des Auftragnehmers"
 
 #. Default: "Response"
 #: ./opengever/task/browser/accept/main.py:101
-#: ./opengever/task/browser/assign.py:52
+#: ./opengever/task/browser/assign.py:51
 #: ./opengever/task/browser/assign_dossier.py:60
 msgid "label_response"
 msgstr "Antworttext"
 
 #. Default: "Responsible"
-#: ./opengever/task/browser/assign.py:45
+#: ./opengever/task/browser/assign.py:44
 #: ./opengever/task/browser/overview.py:97
 #: ./opengever/task/statesyncer.py:136
 msgid "label_responsible"
@@ -599,13 +574,13 @@ msgstr "Aufgabentitel"
 #. Default: "Task Type"
 #: ./opengever/task/activities.py:136
 #: ./opengever/task/browser/overview.py:77
-#: ./opengever/task/task.py:102
+#: ./opengever/task/task.py:101
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Text"
 #: ./opengever/task/activities.py:140
-#: ./opengever/task/browser/delegate/metadata.py:38
+#: ./opengever/task/browser/delegate/metadata.py:37
 #: ./opengever/task/browser/overview.py:73
 msgid "label_text"
 msgstr "Beschreibung"
@@ -634,7 +609,7 @@ msgid "label_workflow_state_byline"
 msgstr "Status"
 
 #. Default: "Deadline successfully changed."
-#: ./opengever/task/browser/modify_deadline.py:73
+#: ./opengever/task/browser/modify_deadline.py:70
 msgid "msg_deadline_change_successfull"
 msgstr "Frist wurde erfolgreich angepasst."
 
@@ -657,12 +632,12 @@ msgid "response_label_response"
 msgstr "Antwort"
 
 #. Default: "The given deadline, is the current one."
-#: ./opengever/task/browser/modify_deadline.py:65
+#: ./opengever/task/browser/modify_deadline.py:62
 msgid "same_deadline_error"
 msgstr "Die angegebene Frist ist die aktuelle."
 
 #. Default: "Save"
-#: ./opengever/task/response.py:166
+#: ./opengever/task/response.py:165
 msgid "save"
 msgstr "Speichern"
 
@@ -701,7 +676,7 @@ msgid "title_accept_task"
 msgstr "Aufgabe akzeptieren"
 
 #. Default: "Assign task"
-#: ./opengever/task/browser/assign.py:72
+#: ./opengever/task/browser/assign.py:70
 msgid "title_assign_task"
 msgstr "Neu zuweisen"
 
@@ -716,7 +691,7 @@ msgid "title_close_task"
 msgstr "Aufgabe abschliessen"
 
 #. Default: "Complete task"
-#: ./opengever/task/browser/complete.py:118
+#: ./opengever/task/browser/complete.py:117
 msgid "title_complete_task"
 msgstr "Aufgabe erledigen / abschliessen"
 
@@ -736,7 +711,7 @@ msgid "title_error_no_response"
 msgstr "Fehler: keine Antworten zum editieren gefunden"
 
 #. Default: "Modify deadline"
-#: ./opengever/task/browser/modify_deadline.py:51
+#: ./opengever/task/browser/modify_deadline.py:48
 msgid "title_modify_deadline"
 msgstr "Frist ändern"
 
@@ -908,12 +883,12 @@ msgstr "Dokument von Aufgabe kopiert (Aufgabe akzeptiert)"
 
 #. Default: "Document copied from task (task closed)"
 #: ./opengever/task/browser/close.py:242
-#: ./opengever/task/browser/complete.py:297
+#: ./opengever/task/browser/complete.py:296
 msgid "version_message_closed_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe abgeschlossen)"
 
 #. Default: "Document copied from task (task resolved)"
-#: ./opengever/task/browser/complete.py:291
+#: ./opengever/task/browser/complete.py:290
 msgid "version_message_resolved_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe erledigt)"
 

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:23+0000\n"
 "PO-Revision-Date: 2015-02-17 18:42+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 msgid "${num} documents were copied."
 msgstr "${num} document(s) a (ont) été copié(s)."
 
-#: ./opengever/task/browser/delegate/metadata.py:80
+#: ./opengever/task/browser/delegate/metadata.py:79
 msgid "${subtask_num} subtasks were create."
 msgstr "${subtask_num} sous-tâche(s) a (ont) été créé(es)."
 
-#: ./opengever/task/response.py:350
+#: ./opengever/task/response.py:349
 msgid "Changes saved to response id ${response_id}."
 msgstr "Modifications de la réponse ${response_id} ont été sauvegardées"
 
@@ -34,29 +34,29 @@ msgstr "Effacer"
 msgid "Edit"
 msgstr "Modifier"
 
-#: ./opengever/task/response.py:251
+#: ./opengever/task/response.py:250
 #: ./opengever/task/statesyncer.py:145
 #: ./opengever/task/util.py:162
 msgid "Issue state"
 msgstr "Etat"
 
-#: ./opengever/task/response.py:378
+#: ./opengever/task/response.py:377
 msgid "No response selected for removal."
 msgstr "Aucune réponse séléctionnée pour l'effaçement"
 
-#: ./opengever/task/response.py:341
+#: ./opengever/task/response.py:340
 msgid "No response selected for saving."
 msgstr "Aucune réponse séléctionnée pour la sauvegarde"
 
-#: ./opengever/task/response.py:400
+#: ./opengever/task/response.py:399
 msgid "Removed response id ${response_id}."
 msgstr "Réponse ${response_id} effacée"
 
-#: ./opengever/task/response.py:393
+#: ./opengever/task/response.py:392
 msgid "Response id ${response_id} does not exist so it cannot be removed."
 msgstr "Réponse ${response_id} inexistante et ne peut être effacée"
 
-#: ./opengever/task/response.py:385
+#: ./opengever/task/response.py:384
 msgid "Response id ${response_id} is no integer so it cannot be removed."
 msgstr "Réponse ${response_id} n'est pas un chiffre et ne peut être effacé"
 
@@ -72,7 +72,7 @@ msgstr "Sous-tâche"
 msgid "Task"
 msgstr "Tâche"
 
-#: ./opengever/task/browser/complete.py:133
+#: ./opengever/task/browser/complete.py:132
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr "Les documents sont transmis au mandataire et les tâches sont fermées."
 
@@ -105,11 +105,11 @@ msgstr "La tâche a été accepté."
 msgid "The task has been copied to the selected dossier and accepted."
 msgstr "La tâche a été copiée et acceptée."
 
-#: ./opengever/task/response.py:372
+#: ./opengever/task/response.py:371
 msgid "You are not allowed to delete responses."
 msgstr "Vous n'étes pas l'autorisation d'effacer ces réponses"
 
-#: ./opengever/task/response.py:335
+#: ./opengever/task/response.py:334
 msgid "You are not allowed to edit responses."
 msgstr "Vous n'étes pas l'autorisation pour éditer ces réponses"
 
@@ -156,12 +156,12 @@ msgid "accept_method_participate"
 msgstr "Modifier directement dans le dossier du mandataire"
 
 #. Default: "RE"
-#: ./opengever/task/browser/complete.py:308
+#: ./opengever/task/browser/complete.py:307
 msgid "answer_prefix"
 msgstr "Rép"
 
 #. Default: "Assign"
-#: ./opengever/task/browser/assign.py:78
+#: ./opengever/task/browser/assign.py:76
 msgid "button_assign"
 msgstr "Attribuer"
 
@@ -187,11 +187,11 @@ msgid "button_save"
 msgstr "Sauvegarder"
 
 #. Default: "Cancel"
-#: ./opengever/task/response.py:271
+#: ./opengever/task/response.py:270
 msgid "cancel"
 msgstr "Annuler"
 
-#: ./opengever/task/response.py:210
+#: ./opengever/task/response.py:209
 msgid "date_of_completion"
 msgstr "Date d'accomplissement"
 
@@ -216,7 +216,7 @@ msgid "error_checked_out_document"
 msgstr "Les documents suivants (${title}) sont en checkout. Vous devez faire un checkin pour pouvoir les déposer."
 
 #. Default: "No changes: same responsible selected"
-#: ./opengever/task/browser/assign.py:85
+#: ./opengever/task/browser/assign.py:83
 msgid "error_same_responsible"
 msgstr "Pas de changement: mandataire identique séléctionné"
 
@@ -286,79 +286,56 @@ msgstr "Choix des documents à livrer au mandataire. Ils seront ensuite attaché
 msgid "help_complete_task_response"
 msgstr "Le texte saisi ici apparaît dans la réponse qui clôture cette tâche."
 
-#: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:138
+#: ./opengever/task/response.py:59
+#: ./opengever/task/task.py:137
 msgid "help_date_of_completion"
 msgstr "Date d'achèvement de la tâche"
 
-#: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:130
+#: ./opengever/task/browser/delegate/metadata.py:33
+#: ./opengever/task/task.py:129
 msgid "help_deadline"
 msgstr "Saisissez la date d'achèvement de la tâche"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:196
+#: ./opengever/task/task.py:194
 msgid "help_effectiveCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:188
 msgid "help_effectiveDuration"
 msgstr "Durée effective en h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:182
 msgid "help_expectedCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:176
 msgid "help_expectedDuration"
 msgstr "Durée effective en h"
 
-#: ./opengever/task/task.py:172
-msgid "help_expectedStartOfWork"
-msgstr ""
-
-#: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:95
-msgid "help_issuer"
-msgstr ""
-
-#: ./opengever/task/browser/modify_deadline.py:34
-msgid "help_new_deadline"
-msgstr ""
-
-#: ./opengever/task/task.py:203
-msgid "help_predecessor"
-msgstr ""
-
-#: ./opengever/task/browser/assign.py:53
-#: ./opengever/task/browser/modify_deadline.py:40
-#: ./opengever/task/response.py:54
-msgid "help_response"
-msgstr ""
-
-#: ./opengever/task/task.py:122
+#: ./opengever/task/task.py:121
 msgid "help_responsible"
 msgstr "Choix de la personne responsable, membre du client mentionné ci-dessus"
 
-#: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:114
+#: ./opengever/task/browser/assign.py:38
+#: ./opengever/task/task.py:113
 msgid "help_responsible_client"
 msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire"
 
-#: ./opengever/task/browser/assign.py:46
+#: ./opengever/task/browser/assign.py:45
 #: ./opengever/task/form.py:41
 msgid "help_responsible_single_client_setup"
 msgstr "Choix de la personne responsable"
 
-#: ./opengever/task/task.py:103
+#: ./opengever/task/task.py:102
 msgid "help_task_type"
 msgstr "Choix du type de mandat"
 
-#: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:146
+#: ./opengever/task/browser/delegate/metadata.py:38
+#: ./opengever/task/task.py:145
 msgid "help_text"
 msgstr "Saisissez une instruction de travail détaillée ou un commentaire"
 
@@ -367,9 +344,7 @@ msgstr "Saisissez une instruction de travail détaillée ou un commentaire"
 msgid "help_title"
 msgstr "Nom de la tâche"
 
-#: ./opengever/task/browser/assign.py:31
-#: ./opengever/task/browser/complete.py:105
-#: ./opengever/task/browser/modify_deadline.py:26
+#: ./opengever/task/response.py:47
 msgid "help_transition"
 msgstr ""
 
@@ -443,14 +418,14 @@ msgstr "Créé le"
 
 #. Default: "Date of completion"
 #: ./opengever/task/browser/overview.py:102
-#: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:137
+#: ./opengever/task/response.py:58
+#: ./opengever/task/task.py:136
 msgid "label_date_of_completion"
 msgstr "Date de réalisation"
 
 #. Default: "Deadline"
 #: ./opengever/task/activities.py:134
-#: ./opengever/task/browser/delegate/metadata.py:33
+#: ./opengever/task/browser/delegate/metadata.py:32
 #: ./opengever/task/browser/overview.py:86
 msgid "label_deadline"
 msgstr "A réaliser jusqu'au"
@@ -471,12 +446,12 @@ msgid "label_edit_response_not_allowed"
 msgstr "Vous n'avez pas les droits pour effacer cette réponse"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:195
+#: ./opengever/task/task.py:193
 msgid "label_effectiveCost"
 msgstr "Coûts effectifs (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:189
+#: ./opengever/task/task.py:187
 msgid "label_effectiveDuration"
 msgstr "Durée effective (h)"
 
@@ -486,17 +461,17 @@ msgid "label_enter_response"
 msgstr "Saisissez votre réponse ci-dessous"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:183
+#: ./opengever/task/task.py:181
 msgid "label_expectedCost"
 msgstr "Coûts estimés (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:177
+#: ./opengever/task/task.py:175
 msgid "label_expectedDuration"
 msgstr "Durée estimées (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:171
+#: ./opengever/task/task.py:170
 msgid "label_expectedStartOfWork"
 msgstr "Début du travail"
 
@@ -518,7 +493,7 @@ msgid "label_main_attributes"
 msgstr "Attributs"
 
 #. Default: "New Deadline"
-#: ./opengever/task/browser/modify_deadline.py:33
+#: ./opengever/task/browser/modify_deadline.py:32
 msgid "label_new_deadline"
 msgstr "Nouveau délai"
 
@@ -528,7 +503,7 @@ msgid "label_parent_dossier_title"
 msgstr "Titre de la dossier"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:202
+#: ./opengever/task/task.py:200
 msgid "label_predecessor"
 msgstr "Prédécesseur"
 
@@ -538,27 +513,27 @@ msgid "label_predecessor_task"
 msgstr "Tâche initiale"
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py:215
-#: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:151
+#: ./opengever/task/browser/complete.py:214
+#: ./opengever/task/response.py:64
+#: ./opengever/task/task.py:150
 msgid "label_related_items"
 msgstr "Renvois"
 
 #. Default: "Responsible Client"
-#: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:112
+#: ./opengever/task/browser/assign.py:36
+#: ./opengever/task/task.py:111
 msgid "label_resonsible_client"
 msgstr "Mandataire du client"
 
 #. Default: "Response"
 #: ./opengever/task/browser/accept/main.py:101
-#: ./opengever/task/browser/assign.py:52
+#: ./opengever/task/browser/assign.py:51
 #: ./opengever/task/browser/assign_dossier.py:60
 msgid "label_response"
 msgstr "Response"
 
 #. Default: "Responsible"
-#: ./opengever/task/browser/assign.py:45
+#: ./opengever/task/browser/assign.py:44
 #: ./opengever/task/browser/overview.py:97
 #: ./opengever/task/statesyncer.py:136
 msgid "label_responsible"
@@ -598,13 +573,13 @@ msgstr "Titre de la tâche"
 #. Default: "Task Type"
 #: ./opengever/task/activities.py:136
 #: ./opengever/task/browser/overview.py:77
-#: ./opengever/task/task.py:102
+#: ./opengever/task/task.py:101
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Text"
 #: ./opengever/task/activities.py:140
-#: ./opengever/task/browser/delegate/metadata.py:38
+#: ./opengever/task/browser/delegate/metadata.py:37
 #: ./opengever/task/browser/overview.py:73
 msgid "label_text"
 msgstr "Description"
@@ -633,7 +608,7 @@ msgid "label_workflow_state_byline"
 msgstr "Etat"
 
 #. Default: "Deadline successfully changed."
-#: ./opengever/task/browser/modify_deadline.py:73
+#: ./opengever/task/browser/modify_deadline.py:70
 msgid "msg_deadline_change_successfull"
 msgstr "Le délai a été modifié avec succès."
 
@@ -656,12 +631,12 @@ msgid "response_label_response"
 msgstr "Réponse"
 
 #. Default: "The given deadline, is the current one."
-#: ./opengever/task/browser/modify_deadline.py:65
+#: ./opengever/task/browser/modify_deadline.py:62
 msgid "same_deadline_error"
 msgstr "Le délai saisi est celui qui court actuellement."
 
 #. Default: "Save"
-#: ./opengever/task/response.py:166
+#: ./opengever/task/response.py:165
 msgid "save"
 msgstr "Enregistrer"
 
@@ -700,7 +675,7 @@ msgid "title_accept_task"
 msgstr "Accepter la tâche"
 
 #. Default: "Assign task"
-#: ./opengever/task/browser/assign.py:72
+#: ./opengever/task/browser/assign.py:70
 msgid "title_assign_task"
 msgstr "Attribuer à nouveau"
 
@@ -715,7 +690,7 @@ msgid "title_close_task"
 msgstr "Fermer la tâche"
 
 #. Default: "Complete task"
-#: ./opengever/task/browser/complete.py:118
+#: ./opengever/task/browser/complete.py:117
 msgid "title_complete_task"
 msgstr "Accomplir / Fermer la tâche"
 
@@ -735,7 +710,7 @@ msgid "title_error_no_response"
 msgstr "Erreur: Aucune réponse à éditer n'a été trouvée"
 
 #. Default: "Modify deadline"
-#: ./opengever/task/browser/modify_deadline.py:51
+#: ./opengever/task/browser/modify_deadline.py:48
 msgid "title_modify_deadline"
 msgstr "Changer le délai"
 
@@ -907,12 +882,12 @@ msgstr "Document copié de la tâche (Tâche accepté)"
 
 #. Default: "Document copied from task (task closed)"
 #: ./opengever/task/browser/close.py:242
-#: ./opengever/task/browser/complete.py:297
+#: ./opengever/task/browser/complete.py:296
 msgid "version_message_closed_task"
 msgstr "Document copié de la tâche (tâche finie)"
 
 #. Default: "Document copied from task (task resolved)"
-#: ./opengever/task/browser/complete.py:291
+#: ./opengever/task/browser/complete.py:290
 msgid "version_message_resolved_task"
 msgstr "Document copié de la tâche (tâche achevée)"
 

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2015-02-17 18:42+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -226,12 +226,12 @@ msgid "existing_dossier"
 msgstr "Dossier existant"
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:68
+#: ./opengever/task/task.py:73
 msgid "fieldset_additional"
 msgstr "Avancé"
 
 #. Default: "Common"
-#: ./opengever/task/task.py:53
+#: ./opengever/task/task.py:58
 msgid "fieldset_common"
 msgstr "En général"
 
@@ -287,41 +287,41 @@ msgid "help_complete_task_response"
 msgstr "Le texte saisi ici apparaît dans la réponse qui clôture cette tâche."
 
 #: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:132
+#: ./opengever/task/task.py:138
 msgid "help_date_of_completion"
 msgstr "Date d'achèvement de la tâche"
 
 #: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:125
+#: ./opengever/task/task.py:130
 msgid "help_deadline"
 msgstr "Saisissez la date d'achèvement de la tâche"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:196
 msgid "help_effectiveCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:190
 msgid "help_effectiveDuration"
 msgstr "Durée effective en h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:184
 msgid "help_expectedCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:172
+#: ./opengever/task/task.py:178
 msgid "help_expectedDuration"
 msgstr "Durée effective en h"
 
-#: ./opengever/task/task.py:166
+#: ./opengever/task/task.py:172
 msgid "help_expectedStartOfWork"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:90
+#: ./opengever/task/task.py:95
 msgid "help_issuer"
 msgstr ""
 
@@ -329,7 +329,7 @@ msgstr ""
 msgid "help_new_deadline"
 msgstr ""
 
-#: ./opengever/task/task.py:197
+#: ./opengever/task/task.py:203
 msgid "help_predecessor"
 msgstr ""
 
@@ -339,12 +339,12 @@ msgstr ""
 msgid "help_response"
 msgstr ""
 
-#: ./opengever/task/task.py:117
+#: ./opengever/task/task.py:122
 msgid "help_responsible"
 msgstr "Choix de la personne responsable, membre du client mentionné ci-dessus"
 
 #: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:109
+#: ./opengever/task/task.py:114
 msgid "help_responsible_client"
 msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire"
 
@@ -353,17 +353,17 @@ msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire"
 msgid "help_responsible_single_client_setup"
 msgstr "Choix de la personne responsable"
 
-#: ./opengever/task/task.py:98
+#: ./opengever/task/task.py:103
 msgid "help_task_type"
 msgstr "Choix du type de mandat"
 
 #: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:140
+#: ./opengever/task/task.py:146
 msgid "help_text"
 msgstr "Saisissez une instruction de travail détaillée ou un commentaire"
 
 #: ./opengever/task/browser/delegate/metadata.py:23
-#: ./opengever/task/task.py:82
+#: ./opengever/task/task.py:87
 msgid "help_title"
 msgstr "Nom de la tâche"
 
@@ -444,7 +444,7 @@ msgstr "Créé le"
 #. Default: "Date of completion"
 #: ./opengever/task/browser/overview.py:102
 #: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:131
+#: ./opengever/task/task.py:137
 msgid "label_date_of_completion"
 msgstr "Date de réalisation"
 
@@ -471,12 +471,12 @@ msgid "label_edit_response_not_allowed"
 msgstr "Vous n'avez pas les droits pour effacer cette réponse"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:189
+#: ./opengever/task/task.py:195
 msgid "label_effectiveCost"
 msgstr "Coûts effectifs (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:183
+#: ./opengever/task/task.py:189
 msgid "label_effectiveDuration"
 msgstr "Durée effective (h)"
 
@@ -486,24 +486,24 @@ msgid "label_enter_response"
 msgstr "Saisissez votre réponse ci-dessous"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:177
+#: ./opengever/task/task.py:183
 msgid "label_expectedCost"
 msgstr "Coûts estimés (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:171
+#: ./opengever/task/task.py:177
 msgid "label_expectedDuration"
 msgstr "Durée estimées (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:165
+#: ./opengever/task/task.py:171
 msgid "label_expectedStartOfWork"
 msgstr "Début du travail"
 
 #. Default: "Issuer"
 #: ./opengever/task/browser/delegate/metadata.py:27
 #: ./opengever/task/browser/overview.py:91
-#: ./opengever/task/task.py:89
+#: ./opengever/task/task.py:94
 msgid "label_issuer"
 msgstr "Mandant"
 
@@ -528,7 +528,7 @@ msgid "label_parent_dossier_title"
 msgstr "Titre de la dossier"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:196
+#: ./opengever/task/task.py:202
 msgid "label_predecessor"
 msgstr "Prédécesseur"
 
@@ -540,13 +540,13 @@ msgstr "Tâche initiale"
 #. Default: "Related Items"
 #: ./opengever/task/browser/complete.py:215
 #: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:145
+#: ./opengever/task/task.py:151
 msgid "label_related_items"
 msgstr "Renvois"
 
 #. Default: "Responsible Client"
 #: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:107
+#: ./opengever/task/task.py:112
 msgid "label_resonsible_client"
 msgstr "Mandataire du client"
 
@@ -598,7 +598,7 @@ msgstr "Titre de la tâche"
 #. Default: "Task Type"
 #: ./opengever/task/activities.py:136
 #: ./opengever/task/browser/overview.py:77
-#: ./opengever/task/task.py:97
+#: ./opengever/task/task.py:102
 msgid "label_task_type"
 msgstr "Type de mandat"
 
@@ -611,7 +611,7 @@ msgstr "Description"
 
 #. Default: "Title"
 #: ./opengever/task/browser/delegate/metadata.py:22
-#: ./opengever/task/task.py:81
+#: ./opengever/task/task.py:86
 msgid "label_title"
 msgstr "Titre"
 

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-26 19:23+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -19,11 +19,11 @@ msgstr ""
 msgid "${num} documents were copied."
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:80
+#: ./opengever/task/browser/delegate/metadata.py:79
 msgid "${subtask_num} subtasks were create."
 msgstr ""
 
-#: ./opengever/task/response.py:350
+#: ./opengever/task/response.py:349
 msgid "Changes saved to response id ${response_id}."
 msgstr ""
 
@@ -35,29 +35,29 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/task/response.py:251
+#: ./opengever/task/response.py:250
 #: ./opengever/task/statesyncer.py:145
 #: ./opengever/task/util.py:162
 msgid "Issue state"
 msgstr ""
 
-#: ./opengever/task/response.py:378
+#: ./opengever/task/response.py:377
 msgid "No response selected for removal."
 msgstr ""
 
-#: ./opengever/task/response.py:341
+#: ./opengever/task/response.py:340
 msgid "No response selected for saving."
 msgstr ""
 
-#: ./opengever/task/response.py:400
+#: ./opengever/task/response.py:399
 msgid "Removed response id ${response_id}."
 msgstr ""
 
-#: ./opengever/task/response.py:393
+#: ./opengever/task/response.py:392
 msgid "Response id ${response_id} does not exist so it cannot be removed."
 msgstr ""
 
-#: ./opengever/task/response.py:385
+#: ./opengever/task/response.py:384
 msgid "Response id ${response_id} is no integer so it cannot be removed."
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: ./opengever/task/browser/complete.py:133
+#: ./opengever/task/browser/complete.py:132
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr ""
 
@@ -106,11 +106,11 @@ msgstr ""
 msgid "The task has been copied to the selected dossier and accepted."
 msgstr ""
 
-#: ./opengever/task/response.py:372
+#: ./opengever/task/response.py:371
 msgid "You are not allowed to delete responses."
 msgstr ""
 
-#: ./opengever/task/response.py:335
+#: ./opengever/task/response.py:334
 msgid "You are not allowed to edit responses."
 msgstr ""
 
@@ -157,12 +157,12 @@ msgid "accept_method_participate"
 msgstr ""
 
 #. Default: "RE"
-#: ./opengever/task/browser/complete.py:308
+#: ./opengever/task/browser/complete.py:307
 msgid "answer_prefix"
 msgstr ""
 
 #. Default: "Assign"
-#: ./opengever/task/browser/assign.py:78
+#: ./opengever/task/browser/assign.py:76
 msgid "button_assign"
 msgstr ""
 
@@ -188,11 +188,11 @@ msgid "button_save"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/task/response.py:271
+#: ./opengever/task/response.py:270
 msgid "cancel"
 msgstr ""
 
-#: ./opengever/task/response.py:210
+#: ./opengever/task/response.py:209
 msgid "date_of_completion"
 msgstr ""
 
@@ -217,7 +217,7 @@ msgid "error_checked_out_document"
 msgstr ""
 
 #. Default: "No changes: same responsible selected"
-#: ./opengever/task/browser/assign.py:85
+#: ./opengever/task/browser/assign.py:83
 msgid "error_same_responsible"
 msgstr ""
 
@@ -287,79 +287,56 @@ msgstr ""
 msgid "help_complete_task_response"
 msgstr ""
 
-#: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:138
+#: ./opengever/task/response.py:59
+#: ./opengever/task/task.py:137
 msgid "help_date_of_completion"
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:130
+#: ./opengever/task/browser/delegate/metadata.py:33
+#: ./opengever/task/task.py:129
 msgid "help_deadline"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:196
+#: ./opengever/task/task.py:194
 msgid "help_effectiveCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:188
 msgid "help_effectiveDuration"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:182
 msgid "help_expectedCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:176
 msgid "help_expectedDuration"
 msgstr ""
 
-#: ./opengever/task/task.py:172
-msgid "help_expectedStartOfWork"
-msgstr ""
-
-#: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:95
-msgid "help_issuer"
-msgstr ""
-
-#: ./opengever/task/browser/modify_deadline.py:34
-msgid "help_new_deadline"
-msgstr ""
-
-#: ./opengever/task/task.py:203
-msgid "help_predecessor"
-msgstr ""
-
-#: ./opengever/task/browser/assign.py:53
-#: ./opengever/task/browser/modify_deadline.py:40
-#: ./opengever/task/response.py:54
-msgid "help_response"
-msgstr ""
-
-#: ./opengever/task/task.py:122
+#: ./opengever/task/task.py:121
 msgid "help_responsible"
 msgstr ""
 
-#: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:114
+#: ./opengever/task/browser/assign.py:38
+#: ./opengever/task/task.py:113
 msgid "help_responsible_client"
 msgstr ""
 
-#: ./opengever/task/browser/assign.py:46
+#: ./opengever/task/browser/assign.py:45
 #: ./opengever/task/form.py:41
 msgid "help_responsible_single_client_setup"
 msgstr ""
 
-#: ./opengever/task/task.py:103
+#: ./opengever/task/task.py:102
 msgid "help_task_type"
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:146
+#: ./opengever/task/browser/delegate/metadata.py:38
+#: ./opengever/task/task.py:145
 msgid "help_text"
 msgstr ""
 
@@ -368,9 +345,7 @@ msgstr ""
 msgid "help_title"
 msgstr ""
 
-#: ./opengever/task/browser/assign.py:31
-#: ./opengever/task/browser/complete.py:105
-#: ./opengever/task/browser/modify_deadline.py:26
+#: ./opengever/task/response.py:47
 msgid "help_transition"
 msgstr ""
 
@@ -444,14 +419,14 @@ msgstr ""
 
 #. Default: "Date of completion"
 #: ./opengever/task/browser/overview.py:102
-#: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:137
+#: ./opengever/task/response.py:58
+#: ./opengever/task/task.py:136
 msgid "label_date_of_completion"
 msgstr ""
 
 #. Default: "Deadline"
 #: ./opengever/task/activities.py:134
-#: ./opengever/task/browser/delegate/metadata.py:33
+#: ./opengever/task/browser/delegate/metadata.py:32
 #: ./opengever/task/browser/overview.py:86
 msgid "label_deadline"
 msgstr ""
@@ -472,12 +447,12 @@ msgid "label_edit_response_not_allowed"
 msgstr ""
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:195
+#: ./opengever/task/task.py:193
 msgid "label_effectiveCost"
 msgstr ""
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:189
+#: ./opengever/task/task.py:187
 msgid "label_effectiveDuration"
 msgstr ""
 
@@ -487,17 +462,17 @@ msgid "label_enter_response"
 msgstr ""
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:183
+#: ./opengever/task/task.py:181
 msgid "label_expectedCost"
 msgstr ""
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:177
+#: ./opengever/task/task.py:175
 msgid "label_expectedDuration"
 msgstr ""
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:171
+#: ./opengever/task/task.py:170
 msgid "label_expectedStartOfWork"
 msgstr ""
 
@@ -519,7 +494,7 @@ msgid "label_main_attributes"
 msgstr ""
 
 #. Default: "New Deadline"
-#: ./opengever/task/browser/modify_deadline.py:33
+#: ./opengever/task/browser/modify_deadline.py:32
 msgid "label_new_deadline"
 msgstr ""
 
@@ -528,7 +503,7 @@ msgid "label_parent_dossier_title"
 msgstr ""
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:202
+#: ./opengever/task/task.py:200
 msgid "label_predecessor"
 msgstr ""
 
@@ -538,27 +513,27 @@ msgid "label_predecessor_task"
 msgstr ""
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py:215
-#: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:151
+#: ./opengever/task/browser/complete.py:214
+#: ./opengever/task/response.py:64
+#: ./opengever/task/task.py:150
 msgid "label_related_items"
 msgstr ""
 
 #. Default: "Responsible Client"
-#: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:112
+#: ./opengever/task/browser/assign.py:36
+#: ./opengever/task/task.py:111
 msgid "label_resonsible_client"
 msgstr ""
 
 #. Default: "Response"
 #: ./opengever/task/browser/accept/main.py:101
-#: ./opengever/task/browser/assign.py:52
+#: ./opengever/task/browser/assign.py:51
 #: ./opengever/task/browser/assign_dossier.py:60
 msgid "label_response"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/task/browser/assign.py:45
+#: ./opengever/task/browser/assign.py:44
 #: ./opengever/task/browser/overview.py:97
 #: ./opengever/task/statesyncer.py:136
 msgid "label_responsible"
@@ -598,13 +573,13 @@ msgstr ""
 #. Default: "Task Type"
 #: ./opengever/task/activities.py:136
 #: ./opengever/task/browser/overview.py:77
-#: ./opengever/task/task.py:102
+#: ./opengever/task/task.py:101
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Text"
 #: ./opengever/task/activities.py:140
-#: ./opengever/task/browser/delegate/metadata.py:38
+#: ./opengever/task/browser/delegate/metadata.py:37
 #: ./opengever/task/browser/overview.py:73
 msgid "label_text"
 msgstr ""
@@ -632,7 +607,7 @@ msgid "label_workflow_state_byline"
 msgstr ""
 
 #. Default: "Deadline successfully changed."
-#: ./opengever/task/browser/modify_deadline.py:73
+#: ./opengever/task/browser/modify_deadline.py:70
 msgid "msg_deadline_change_successfull"
 msgstr ""
 
@@ -655,12 +630,12 @@ msgid "response_label_response"
 msgstr ""
 
 #. Default: "The given deadline, is the current one."
-#: ./opengever/task/browser/modify_deadline.py:65
+#: ./opengever/task/browser/modify_deadline.py:62
 msgid "same_deadline_error"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/task/response.py:166
+#: ./opengever/task/response.py:165
 msgid "save"
 msgstr ""
 
@@ -699,7 +674,7 @@ msgid "title_accept_task"
 msgstr ""
 
 #. Default: "Assign task"
-#: ./opengever/task/browser/assign.py:72
+#: ./opengever/task/browser/assign.py:70
 msgid "title_assign_task"
 msgstr ""
 
@@ -714,7 +689,7 @@ msgid "title_close_task"
 msgstr ""
 
 #. Default: "Complete task"
-#: ./opengever/task/browser/complete.py:118
+#: ./opengever/task/browser/complete.py:117
 msgid "title_complete_task"
 msgstr ""
 
@@ -734,7 +709,7 @@ msgid "title_error_no_response"
 msgstr ""
 
 #. Default: "Modify deadline"
-#: ./opengever/task/browser/modify_deadline.py:51
+#: ./opengever/task/browser/modify_deadline.py:48
 msgid "title_modify_deadline"
 msgstr ""
 
@@ -906,12 +881,12 @@ msgstr ""
 
 #. Default: "Document copied from task (task closed)"
 #: ./opengever/task/browser/close.py:242
-#: ./opengever/task/browser/complete.py:297
+#: ./opengever/task/browser/complete.py:296
 msgid "version_message_closed_task"
 msgstr ""
 
 #. Default: "Document copied from task (task resolved)"
-#: ./opengever/task/browser/complete.py:291
+#: ./opengever/task/browser/complete.py:290
 msgid "version_message_resolved_task"
 msgstr ""
 

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -227,12 +227,12 @@ msgid "existing_dossier"
 msgstr ""
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:68
+#: ./opengever/task/task.py:73
 msgid "fieldset_additional"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/task/task.py:53
+#: ./opengever/task/task.py:58
 msgid "fieldset_common"
 msgstr ""
 
@@ -288,41 +288,41 @@ msgid "help_complete_task_response"
 msgstr ""
 
 #: ./opengever/task/response.py:60
-#: ./opengever/task/task.py:132
+#: ./opengever/task/task.py:138
 msgid "help_date_of_completion"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/task.py:125
+#: ./opengever/task/task.py:130
 msgid "help_deadline"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:190
+#: ./opengever/task/task.py:196
 msgid "help_effectiveCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:184
+#: ./opengever/task/task.py:190
 msgid "help_effectiveDuration"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:178
+#: ./opengever/task/task.py:184
 msgid "help_expectedCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:172
+#: ./opengever/task/task.py:178
 msgid "help_expectedDuration"
 msgstr ""
 
-#: ./opengever/task/task.py:166
+#: ./opengever/task/task.py:172
 msgid "help_expectedStartOfWork"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:28
-#: ./opengever/task/task.py:90
+#: ./opengever/task/task.py:95
 msgid "help_issuer"
 msgstr ""
 
@@ -330,7 +330,7 @@ msgstr ""
 msgid "help_new_deadline"
 msgstr ""
 
-#: ./opengever/task/task.py:197
+#: ./opengever/task/task.py:203
 msgid "help_predecessor"
 msgstr ""
 
@@ -340,12 +340,12 @@ msgstr ""
 msgid "help_response"
 msgstr ""
 
-#: ./opengever/task/task.py:117
+#: ./opengever/task/task.py:122
 msgid "help_responsible"
 msgstr ""
 
 #: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/task.py:109
+#: ./opengever/task/task.py:114
 msgid "help_responsible_client"
 msgstr ""
 
@@ -354,17 +354,17 @@ msgstr ""
 msgid "help_responsible_single_client_setup"
 msgstr ""
 
-#: ./opengever/task/task.py:98
+#: ./opengever/task/task.py:103
 msgid "help_task_type"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/task.py:140
+#: ./opengever/task/task.py:146
 msgid "help_text"
 msgstr ""
 
 #: ./opengever/task/browser/delegate/metadata.py:23
-#: ./opengever/task/task.py:82
+#: ./opengever/task/task.py:87
 msgid "help_title"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 #. Default: "Date of completion"
 #: ./opengever/task/browser/overview.py:102
 #: ./opengever/task/response.py:59
-#: ./opengever/task/task.py:131
+#: ./opengever/task/task.py:137
 msgid "label_date_of_completion"
 msgstr ""
 
@@ -472,12 +472,12 @@ msgid "label_edit_response_not_allowed"
 msgstr ""
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:189
+#: ./opengever/task/task.py:195
 msgid "label_effectiveCost"
 msgstr ""
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:183
+#: ./opengever/task/task.py:189
 msgid "label_effectiveDuration"
 msgstr ""
 
@@ -487,24 +487,24 @@ msgid "label_enter_response"
 msgstr ""
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:177
+#: ./opengever/task/task.py:183
 msgid "label_expectedCost"
 msgstr ""
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:171
+#: ./opengever/task/task.py:177
 msgid "label_expectedDuration"
 msgstr ""
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:165
+#: ./opengever/task/task.py:171
 msgid "label_expectedStartOfWork"
 msgstr ""
 
 #. Default: "Issuer"
 #: ./opengever/task/browser/delegate/metadata.py:27
 #: ./opengever/task/browser/overview.py:91
-#: ./opengever/task/task.py:89
+#: ./opengever/task/task.py:94
 msgid "label_issuer"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgid "label_parent_dossier_title"
 msgstr ""
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:196
+#: ./opengever/task/task.py:202
 msgid "label_predecessor"
 msgstr ""
 
@@ -540,13 +540,13 @@ msgstr ""
 #. Default: "Related Items"
 #: ./opengever/task/browser/complete.py:215
 #: ./opengever/task/response.py:65
-#: ./opengever/task/task.py:145
+#: ./opengever/task/task.py:151
 msgid "label_related_items"
 msgstr ""
 
 #. Default: "Responsible Client"
 #: ./opengever/task/browser/assign.py:37
-#: ./opengever/task/task.py:107
+#: ./opengever/task/task.py:112
 msgid "label_resonsible_client"
 msgstr ""
 
@@ -598,7 +598,7 @@ msgstr ""
 #. Default: "Task Type"
 #: ./opengever/task/activities.py:136
 #: ./opengever/task/browser/overview.py:77
-#: ./opengever/task/task.py:97
+#: ./opengever/task/task.py:102
 msgid "label_task_type"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/task/browser/delegate/metadata.py:22
-#: ./opengever/task/task.py:81
+#: ./opengever/task/task.py:86
 msgid "label_title"
 msgstr ""
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -51,7 +51,6 @@ class IResponse(Interface):
 
     text = schema.Text(
         title=_('label_response', default="Response"),
-        description=_('help_response', default=""),
         required=False,
         )
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -92,7 +92,6 @@ class ITask(form.Schema):
     form.widget(issuer=AutocompleteFieldWidget)
     issuer = schema.Choice(
         title=_(u"label_issuer", default=u"Issuer"),
-        description=_('help_issuer', default=u""),
         vocabulary=u'opengever.ogds.base.ContactsAndUsersVocabulary',
         required=True,
         )
@@ -169,7 +168,6 @@ class ITask(form.Schema):
     form.widget(expectedStartOfWork=DatePickerFieldWidget)
     expectedStartOfWork = schema.Date(
         title=_(u"label_expectedStartOfWork", default="Start with work"),
-        description=_(u"help_expectedStartOfWork", default=""),
         required=False,
         )
 
@@ -200,7 +198,6 @@ class ITask(form.Schema):
     form.omitted('predecessor')
     predecessor = schema.TextLine(
         title=_(u'label_predecessor', default=u'Predecessor'),
-        description=_(u'help_predecessor', default=u''),
         required=False)
 
 

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -188,7 +188,6 @@ msgstr "Auswahl Standardablauf"
 
 #. Default: "Tasktemplates"
 #: ./opengever/tasktemplates/browser/trigger.py:164
-#, fuzzy
 msgid "label_tasktemplates"
 msgstr "Aufgabenvorlage"
 

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-06-17 10:21+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -33,17 +33,17 @@ msgid "add tasktemplate"
 msgstr "Aufgabenvorlage hinzufügen"
 
 #. Default: "Cancel"
-#: ./opengever/tasktemplates/browser/trigger.py:129
+#: ./opengever/tasktemplates/browser/trigger.py:127
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/trigger.py:117
+#: ./opengever/tasktemplates/browser/trigger.py:115
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Trigger"
-#: ./opengever/tasktemplates/browser/trigger.py:209
+#: ./opengever/tasktemplates/browser/trigger.py:207
 msgid "button_trigger"
 msgstr "Auslösen"
 
@@ -132,7 +132,7 @@ msgid "label_preselected"
 msgstr "Vorselektiert"
 
 #. Default: "Related documents"
-#: ./opengever/tasktemplates/browser/trigger.py:75
+#: ./opengever/tasktemplates/browser/trigger.py:73
 msgid "label_related_documents"
 msgstr "Verweise"
 
@@ -157,12 +157,12 @@ msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Select tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:96
+#: ./opengever/tasktemplates/browser/trigger.py:94
 msgid "label_select_tasktemplatefolder"
 msgstr "Auswahl Standardablauf"
 
 #. Default: "Select tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:177
+#: ./opengever/tasktemplates/browser/trigger.py:175
 msgid "label_select_tasktemplates"
 msgstr "Auswahl Aufgabenvorlagen"
 
@@ -172,22 +172,22 @@ msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Tasktemplate selection"
-#: ./opengever/tasktemplates/browser/trigger.py:50
+#: ./opengever/tasktemplates/browser/trigger.py:48
 msgid "label_tasktemplate_selection"
 msgstr "Auswahl Aufgabenvorlagen"
 
 #. Default: "Tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:69
+#: ./opengever/tasktemplates/browser/trigger.py:67
 msgid "label_tasktemplatefolder"
 msgstr "Standardablauf"
 
 #. Default: "Tasktemplatefolder selection"
-#: ./opengever/tasktemplates/browser/trigger.py:46
+#: ./opengever/tasktemplates/browser/trigger.py:44
 msgid "label_tasktemplatefolder_selection"
 msgstr "Auswahl Standardablauf"
 
 #. Default: "Tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:166
+#: ./opengever/tasktemplates/browser/trigger.py:164
 #, fuzzy
 msgid "label_tasktemplates"
 msgstr "Aufgabenvorlage"
@@ -216,13 +216,13 @@ msgstr "Sie haben keine Vorlagen ausgewählt."
 
 #. Default: "tasks created"
 #: ./opengever/tasktemplates/browser/form.py:307
-#: ./opengever/tasktemplates/browser/trigger.py:223
+#: ./opengever/tasktemplates/browser/trigger.py:221
 msgid "message_tasks_created"
 msgstr "Alle Aufgaben aus gewähltem Standardablauf wurden erstellt."
 
 #. Default: "Currently there are no activetask template folders registered."
 #: ./opengever/tasktemplates/browser/form.py:144
-#: ./opengever/tasktemplates/browser/trigger.py:109
+#: ./opengever/tasktemplates/browser/trigger.py:107
 msgid "msg_no_active_tasktemplatefolders"
 msgstr "Zurzeit sind keine aktiven Standardabläufe hinterlegt."
 
@@ -234,3 +234,4 @@ msgstr "Ja"
 #: ./opengever/tasktemplates/browser/form.pt:33
 msgid "select tasks"
 msgstr "Aufgaben auswählen"
+

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-17 10:21+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,17 +33,17 @@ msgid "add tasktemplate"
 msgstr "Ajouter un modèle de tâches"
 
 #. Default: "Cancel"
-#: ./opengever/tasktemplates/browser/trigger.py:129
+#: ./opengever/tasktemplates/browser/trigger.py:127
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/trigger.py:117
+#: ./opengever/tasktemplates/browser/trigger.py:115
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Trigger"
-#: ./opengever/tasktemplates/browser/trigger.py:209
+#: ./opengever/tasktemplates/browser/trigger.py:207
 msgid "button_trigger"
 msgstr ""
 
@@ -132,7 +132,7 @@ msgid "label_preselected"
 msgstr "Préséléctionné"
 
 #. Default: "Related documents"
-#: ./opengever/tasktemplates/browser/trigger.py:75
+#: ./opengever/tasktemplates/browser/trigger.py:73
 msgid "label_related_documents"
 msgstr ""
 
@@ -157,12 +157,12 @@ msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Select tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:96
+#: ./opengever/tasktemplates/browser/trigger.py:94
 msgid "label_select_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Select tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:177
+#: ./opengever/tasktemplates/browser/trigger.py:175
 msgid "label_select_tasktemplates"
 msgstr ""
 
@@ -172,22 +172,22 @@ msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Tasktemplate selection"
-#: ./opengever/tasktemplates/browser/trigger.py:50
+#: ./opengever/tasktemplates/browser/trigger.py:48
 msgid "label_tasktemplate_selection"
 msgstr ""
 
 #. Default: "Tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:69
+#: ./opengever/tasktemplates/browser/trigger.py:67
 msgid "label_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Tasktemplatefolder selection"
-#: ./opengever/tasktemplates/browser/trigger.py:46
+#: ./opengever/tasktemplates/browser/trigger.py:44
 msgid "label_tasktemplatefolder_selection"
 msgstr ""
 
 #. Default: "Tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:166
+#: ./opengever/tasktemplates/browser/trigger.py:164
 msgid "label_tasktemplates"
 msgstr ""
 
@@ -215,13 +215,13 @@ msgstr "Vous n'avez sélectionné aucun modèle."
 
 #. Default: "tasks created"
 #: ./opengever/tasktemplates/browser/form.py:307
-#: ./opengever/tasktemplates/browser/trigger.py:223
+#: ./opengever/tasktemplates/browser/trigger.py:221
 msgid "message_tasks_created"
 msgstr "Toutes les tâches du procédé standard ont été créées"
 
 #. Default: "Currently there are no activetask template folders registered."
 #: ./opengever/tasktemplates/browser/form.py:144
-#: ./opengever/tasktemplates/browser/trigger.py:109
+#: ./opengever/tasktemplates/browser/trigger.py:107
 msgid "msg_no_active_tasktemplatefolders"
 msgstr ""
 

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-17 10:21+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,17 +36,17 @@ msgid "add tasktemplate"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/tasktemplates/browser/trigger.py:129
+#: ./opengever/tasktemplates/browser/trigger.py:127
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/trigger.py:117
+#: ./opengever/tasktemplates/browser/trigger.py:115
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Trigger"
-#: ./opengever/tasktemplates/browser/trigger.py:209
+#: ./opengever/tasktemplates/browser/trigger.py:207
 msgid "button_trigger"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid "label_preselected"
 msgstr ""
 
 #. Default: "Related documents"
-#: ./opengever/tasktemplates/browser/trigger.py:75
+#: ./opengever/tasktemplates/browser/trigger.py:73
 msgid "label_related_documents"
 msgstr ""
 
@@ -160,12 +160,12 @@ msgid "label_review_state"
 msgstr ""
 
 #. Default: "Select tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:96
+#: ./opengever/tasktemplates/browser/trigger.py:94
 msgid "label_select_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Select tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:177
+#: ./opengever/tasktemplates/browser/trigger.py:175
 msgid "label_select_tasktemplates"
 msgstr ""
 
@@ -175,22 +175,22 @@ msgid "label_task_type"
 msgstr ""
 
 #. Default: "Tasktemplate selection"
-#: ./opengever/tasktemplates/browser/trigger.py:50
+#: ./opengever/tasktemplates/browser/trigger.py:48
 msgid "label_tasktemplate_selection"
 msgstr ""
 
 #. Default: "Tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:69
+#: ./opengever/tasktemplates/browser/trigger.py:67
 msgid "label_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Tasktemplatefolder selection"
-#: ./opengever/tasktemplates/browser/trigger.py:46
+#: ./opengever/tasktemplates/browser/trigger.py:44
 msgid "label_tasktemplatefolder_selection"
 msgstr ""
 
 #. Default: "Tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:166
+#: ./opengever/tasktemplates/browser/trigger.py:164
 msgid "label_tasktemplates"
 msgstr ""
 
@@ -218,13 +218,13 @@ msgstr ""
 
 #. Default: "tasks created"
 #: ./opengever/tasktemplates/browser/form.py:307
-#: ./opengever/tasktemplates/browser/trigger.py:223
+#: ./opengever/tasktemplates/browser/trigger.py:221
 msgid "message_tasks_created"
 msgstr ""
 
 #. Default: "Currently there are no activetask template folders registered."
 #: ./opengever/tasktemplates/browser/form.py:144
-#: ./opengever/tasktemplates/browser/trigger.py:109
+#: ./opengever/tasktemplates/browser/trigger.py:107
 msgid "msg_no_active_tasktemplatefolders"
 msgstr ""
 

--- a/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: opengever.trash 1.0\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: 2014-11-18 17:19+0100\n"
 "Last-Translator: Julian Infanger <julian.infangner.@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,15 +15,15 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
-#: ./opengever/trash/trash.py:118
+#: ./opengever/trash/trash.py:124
 msgid "You have not selected any items"
 msgstr "Sie haben keine Objekte ausgewählt"
 
-#: ./opengever/trash/trash.py:93
+#: ./opengever/trash/trash.py:99
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "Das Objekt ${obj} wurde bereits in den Papierkorb verschoben"
 
-#: ./opengever/trash/trash.py:102
+#: ./opengever/trash/trash.py:108
 msgid "could not trash the object ${obj}, it is checked out"
 msgstr "Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist ausgecheckt."
 
@@ -92,7 +92,7 @@ msgstr "Das Dokument ist noch nicht im Papierkorb"
 msgid "remove"
 msgstr "Löschen"
 
-#: ./opengever/trash/trash.py:112
+#: ./opengever/trash/trash.py:118
 msgid "the object ${obj} trashed"
 msgstr "Das Objekt ${obj} wurde in den Papierkorb verschoben."
 

--- a/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,15 +14,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/trash/trash.py:118
+#: ./opengever/trash/trash.py:124
 msgid "You have not selected any items"
 msgstr "Vous n'avez sélectionné aucun objet."
 
-#: ./opengever/trash/trash.py:93
+#: ./opengever/trash/trash.py:99
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "L'objet a été déplacé vers la corbeille"
 
-#: ./opengever/trash/trash.py:102
+#: ./opengever/trash/trash.py:108
 msgid "could not trash the object ${obj}, it is checked out"
 msgstr "L'objet ${obj} a un checkout. Vous ne pouvez pas le supprimer"
 
@@ -91,7 +91,7 @@ msgstr "Le documents n'est pas encore dans la corbeille."
 msgid "remove"
 msgstr "Effacer"
 
-#: ./opengever/trash/trash.py:112
+#: ./opengever/trash/trash.py:118
 msgid "the object ${obj} trashed"
 msgstr "L'objet ${obj} a été déplacé dans la corbeille"
 

--- a/opengever/trash/locales/opengever.trash.pot
+++ b/opengever/trash/locales/opengever.trash.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-22 14:43+0000\n"
+"POT-Creation-Date: 2016-06-26 18:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.trash\n"
 
-#: ./opengever/trash/trash.py:118
+#: ./opengever/trash/trash.py:124
 msgid "You have not selected any items"
 msgstr ""
 
-#: ./opengever/trash/trash.py:93
+#: ./opengever/trash/trash.py:99
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr ""
 
-#: ./opengever/trash/trash.py:102
+#: ./opengever/trash/trash.py:108
 msgid "could not trash the object ${obj}, it is checked out"
 msgstr ""
 
@@ -94,7 +94,7 @@ msgstr ""
 msgid "remove"
 msgstr ""
 
-#: ./opengever/trash/trash.py:112
+#: ./opengever/trash/trash.py:118
 msgid "the object ${obj} trashed"
 msgstr ""
 


### PR DESCRIPTION
This will remove empty help texts (field descriptions that were i18nized but never got translated).

There's still a few more untranslated messages, but this for now only deals with the `help_` texts. In a few cases, some french translations existed that got removed - these were pretty redundant however, or affected fields that were never shown to the user anyway (hidden from form).

@phgross 