### PR TITLE
Remove i18n markup for strings in opengever.setup:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Remove i18n markup for strings in opengever.setup:
+  We're never going to translate those.
+  [lgraf]
+
 - Remove empty help texts (field descriptions that were i18nized
   but never got translated).
   [lgraf]

--- a/opengever/setup/browser/adddeployment.pt
+++ b/opengever/setup/browser/adddeployment.pt
@@ -3,14 +3,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
-      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      lang="en"
-      i18n:domain="opengever.setup">
+      lang="en">
 
   <head>
     <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 
-    <title i18n:translate="">Deploy OneGov GEVER</title>
+    <title>Deploy OneGov GEVER</title>
 
     <link rel="stylesheet" type="text/css" href="/++resource++plone-admin-ui.css" />
     <link rel="stylesheet" type="text/css" href="/++resource++adddeployment.css" />
@@ -42,13 +40,13 @@
                       extension_profiles profiles/extensions;
                       advanced request/advanced|nothing;">
 
-      <h1 i18n:translate="">Install OneGov GEVER</h1>
+      <h1>Install OneGov GEVER</h1>
 
       <fieldset class="config">
-        <legend i18n:translate="">Installation configuration</legend>
+        <legend>Installation configuration</legend>
 
         <div class="field">
-          <label for="policy" i18n:translate="">Deployment profile</label>
+          <label for="policy">Deployment profile</label>
           <div class="formHelp"></div>
           <select name="policy" autofocus="autofocus">
             <option tal:repeat="item view/get_deployment_profiles"
@@ -72,10 +70,10 @@
         </div>
 
         <div class="field" id="ldap_profile_selector">
-          <label for="ldap" i18n:translate="">LDAP configuration profile</label>
+          <label for="ldap">LDAP configuration profile</label>
           <div class="formHelp"></div>
           <select name="ldap">
-            <option value="" i18n:translate="">- skip LDAP -</option>
+            <option value="">- skip LDAP -</option>
             <option tal:repeat="item view/get_ldap_profiles"
                     tal:content="python:item[0]"
                     tal:attributes="value python:item[1];
@@ -85,44 +83,44 @@
         </div>
 
         <div class="field">
-          <label for="sync_ogds" i18n:translate="">
+          <label for="sync_ogds">
             Import LDAP-users into OGDS
           </label>
           <div class="formHelp"></div>
           <input type="checkbox" name="sync_ogds:boolean"
                  id="sync_ogds"
                  tal:attributes="checked python:'checked' if view.is_development_mode else ''"/>
-          <span i18n:translate="">
+          <span>
             Import users from LDAP into OGDS?
           </span>
         </div>
 
       </fieldset>
       <fieldset class="config">
-        <legend i18n:translate="">Development options</legend>
+        <legend>Development options</legend>
 
         <div class="field">
-          <label for="dev_mode" i18n:translate="">
+          <label for="dev_mode">
             Development mode
           </label>
           <div class="formHelp"></div>
           <input type="checkbox" name="dev_mode:boolean"
                  id="dev_mode"
                  tal:attributes="checked python:'checked' if view.is_development_mode else ''"/>
-          <span i18n:translate="" class="dev_mode_label">
+          <span class="dev_mode_label">
             Use "og_demo-ftw_users" group for OrgUnits and local role configuration
           </span>
         </div>
 
         <div class="field">
-          <label for="purge_sql" i18n:translate="">
+          <label for="purge_sql">
             Purge SQL
           </label>
           <div class="formHelp"></div>
           <input type="checkbox" name="purge_sql:boolean"
                  id="purge_sql"
                  tal:attributes="checked python:'checked' if view.is_development_mode else ''"/>
-          <span i18n:translate="" class="purge_sql_label">
+          <span class="purge_sql_label">
             Purge SQL completely before setup
           </span>
         </div>
@@ -131,8 +129,7 @@
 
       <div class="formControls">
         <input type="hidden" name="form.submitted:boolean" value="True" />
-        <input type="submit" name="submit" value="Install OneGov GEVER"
-               i18n:attributes="value;" />
+        <input type="submit" name="submit" value="Install OneGov GEVER" />
         <a class="backlink" href="/manage_main">back to Manage</a>
       </div>
     </form>

--- a/opengever/setup/locales/de/LC_MESSAGES/opengever.setup.po
+++ b/opengever/setup/locales/de/LC_MESSAGES/opengever.setup.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-27 09:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,59 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/setup/browser/adddeployment.pt:78
-msgid "- skip LDAP -"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:13
-msgid "Deploy OneGov GEVER"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:51
-msgid "Deployment profile"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:105
-msgid "Development mode"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:102
-msgid "Development options"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:88
-msgid "Import LDAP-users into OGDS"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:95
-msgid "Import users from LDAP into OGDS?"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:45
-msgid "Install OneGov GEVER"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:48
-msgid "Installation configuration"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:75
-msgid "LDAP configuration profile"
-msgstr ""
-
 #: ./opengever/setup/profiles/casauth/actions.xml
 msgid "My portal"
 msgstr "Mein Portal"
-
-#: ./opengever/setup/browser/adddeployment.pt:118
-msgid "Purge SQL"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:125
-msgid "Purge SQL completely before setup"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:112
-msgid "Use \"og_demo-ftw_users\" group for OrgUnits and local role configuration"
-msgstr ""
 

--- a/opengever/setup/locales/fr/LC_MESSAGES/opengever.setup.po
+++ b/opengever/setup/locales/fr/LC_MESSAGES/opengever.setup.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-27 09:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,59 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/setup/browser/adddeployment.pt:78
-msgid "- skip LDAP -"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:13
-msgid "Deploy OneGov GEVER"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:51
-msgid "Deployment profile"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:105
-msgid "Development mode"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:102
-msgid "Development options"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:88
-msgid "Import LDAP-users into OGDS"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:95
-msgid "Import users from LDAP into OGDS?"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:45
-msgid "Install OneGov GEVER"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:48
-msgid "Installation configuration"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:75
-msgid "LDAP configuration profile"
-msgstr ""
-
 #: ./opengever/setup/profiles/casauth/actions.xml
 msgid "My portal"
 msgstr "Mon portail"
-
-#: ./opengever/setup/browser/adddeployment.pt:118
-msgid "Purge SQL"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:125
-msgid "Purge SQL completely before setup"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:112
-msgid "Use \"og_demo-ftw_users\" group for OrgUnits and local role configuration"
-msgstr ""
 

--- a/opengever/setup/locales/opengever.setup.pot
+++ b/opengever/setup/locales/opengever.setup.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 18:26+0000\n"
+"POT-Creation-Date: 2016-06-27 09:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,59 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.setup\n"
 
-#: ./opengever/setup/browser/adddeployment.pt:78
-msgid "- skip LDAP -"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:13
-msgid "Deploy OneGov GEVER"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:51
-msgid "Deployment profile"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:105
-msgid "Development mode"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:102
-msgid "Development options"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:88
-msgid "Import LDAP-users into OGDS"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:95
-msgid "Import users from LDAP into OGDS?"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:45
-msgid "Install OneGov GEVER"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:48
-msgid "Installation configuration"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:75
-msgid "LDAP configuration profile"
-msgstr ""
-
 #: ./opengever/setup/profiles/casauth/actions.xml
 msgid "My portal"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:118
-msgid "Purge SQL"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:125
-msgid "Purge SQL completely before setup"
-msgstr ""
-
-#: ./opengever/setup/browser/adddeployment.pt:112
-msgid "Use \"og_demo-ftw_users\" group for OrgUnits and local role configuration"
 msgstr ""
 


### PR DESCRIPTION
Remove i18n markup for strings in opengever.setup: we're never going to translate those.

@phgross @deiferni 