### PR TITLE
Add BTree consistency check and correction to the CleanupRelationsCatalog upgradestep.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.9.1 (unreleased)
 ------------------
 
+- Add BTree consistency check to the CleanupRelationsCatalog upgradestep and
+  fix the BTree if necessary.
+  [phgross]
+
 - Implement bumblebee overlay for the versions-tab.
   [elioschmutz]
 

--- a/opengever/base/upgrades/to4502.py
+++ b/opengever/base/upgrades/to4502.py
@@ -1,7 +1,10 @@
+from BTrees.check import check
 from ftw.upgrade import UpgradeStep
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
+import logging
 
+logger = logging.getLogger('opengever.base')
 
 TO_REMOVE = ['plone.directives.form.schema.Schema',
              'plone.app.kss.interfaces.IPortalObject']
@@ -19,6 +22,21 @@ class CleanupRelationsCatalog(UpgradeStep):
                 ['from_interfaces_flattened', 'to_interfaces_flattened'])
 
     def cleanup_to_mapping(self, iface_name, mapping_key):
+        # Check the BTree consistency, to avoid key errors when deleting
+        # entries in the BTree.
+        # If the check method detects an inconsistency, we fix the Btree by
+        # creating a copy of it.
+        #
+        # See http://do3.cc/blog/2012/09/264/debugging-zcrelations---broken-btrees/
+        # for more information.
+        try:
+            check(self.catalog._name_TO_mapping[mapping_key])
+        except AssertionError:
+            btree = self.catalog._name_TO_mapping[mapping_key]
+            self.catalog._name_TO_mapping[mapping_key] = btree.__class__(btree)
+            logger.warning(
+                'Inconsistent BTree detected and fixed by recreating it.')
+
         for iface in self.catalog._name_TO_mapping[mapping_key].keys():
             if '{}.{}'.format(iface.__module__, iface.__name__) == iface_name:
                 del self.catalog._name_TO_mapping[mapping_key][iface]


### PR DESCRIPTION
Problems detected while upgrading to newest GEVER Release on the PHVS Testsystem.

See http://do3.cc/blog/2012/09/264/debugging-zcrelations---broken-btrees/ for more information.

@lukasgraf as discussed 