### PR TITLE
Adjust decision in TranslatedTitleBrain when the the language specific title should be used.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.9.0 (unreleased)
 ------------------
 
+- Adjust decision in TranslatedTitleBrain if the the language specific title
+  should be used or not. It checks now if the portal_type supports TranslatedTitle,
+  by making a lookup in the fti with the help of the brain's portal_type.
+  [phgross]
+
 - Add helper script to generate JSON files for component import
   into Weblate.
   [lgraf]

--- a/opengever/base/tests/test_navigation.py
+++ b/opengever/base/tests/test_navigation.py
@@ -4,10 +4,13 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
+from opengever.testing import set_preferred_language
 from plone.uuid.interfaces import IUUID
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
+import transaction
 
 
 class TestNavigation(FunctionalTestCase):
@@ -38,17 +41,22 @@ class TestNavigation(FunctionalTestCase):
 
     @browsing
     def test_json_is_valid(self, browser):
+        add_languages(['de-ch'])
+        transaction.commit()
+
         root = create(Builder('repository_root'))
         folder = create(Builder('repository')
-                        .titled('The Folder')
-                        .having(description='A primary folder')
+                        .having(title_de=u'The Folder',
+                                description='A primary folder')
                         .within(root))
         subfolder = create(Builder('repository')
-                           .titled('The Sub Folder')
-                           .having(description='A secondary folder')
+                           .having(title_de=u'The Sub Folder',
+                                   description='A secondary folder')
                            .within(folder))
 
-        browser.login().visit(root, view='navigation.json')
+        browser.login().open()
+        browser.click_on('DE')
+        browser.visit(root, view='navigation.json')
         self.assert_json_equal(
             [{"text": "1. The Folder",
               "description": "A primary folder",

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -4,12 +4,40 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TranslatedTitle
+from opengever.base.brain import supports_translated_title
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
 from opengever.testing import obj2brain
 from opengever.testing import set_preferred_language
 from plone import api
 import transaction
+
+
+class TestSupportTranslatedTitle(FunctionalTestCase):
+
+    def test_repositories_supports_translated_title(self):
+        self.assertTrue(
+            supports_translated_title('opengever.repository.repositoryfolder'))
+
+    def test_portal_objects_supports_translated_title(self):
+        self.assertTrue(
+            supports_translated_title('opengever.repository.repositoryroot'))
+        self.assertTrue(
+            supports_translated_title('opengever.inbox.inbox'))
+        self.assertTrue(
+            supports_translated_title('opengever.contact.contactfolder'))
+        self.assertTrue(
+            supports_translated_title('opengever.dossier.templatedossier'))
+
+    def test_content_objects_does_not_support_translated_title(self):
+        self.assertFalse(
+            supports_translated_title('opengever.dossier.businesscasedossier'))
+        self.assertFalse(
+            supports_translated_title('opengever.document.document'))
+        self.assertFalse(
+            supports_translated_title('ftw.mail.mail'))
+        self.assertFalse(
+            supports_translated_title('opengever.contact.contact'))
 
 
 class TestTranslatedTitle(FunctionalTestCase):
@@ -126,7 +154,7 @@ class TestTranslatedTitle(FunctionalTestCase):
                           obj2brain(repository_root).Title)
 
     @browsing
-    def test_Title_on_brains_use_Title_as_fallback_when_no_language_title_exists(self, browser):
+    def test_Title_on_brains_uses_Title_when_type_does_not_support_translated_title(self, browser):
         dossier = create(Builder('dossier').titled(u'F\xfchrung'))
         set_preferred_language(self.portal.REQUEST, 'de')
         self.assertEquals("F\xc3\xbchrung", obj2brain(dossier).Title)


### PR DESCRIPTION
Decide with the help of the brains portal_type if the brain should use the language specific title or not.

Because `object_provides` is only a index but not a metadata, we have to check the portal_types FTI if the object supports TranslatedTitle or not. 

To avoid performance Issues the `support_translatedtitle` check is cached.

@lukasgraf as discussed.  