### PR TITLE
CSRF: Whitelist context portlet assignment annotations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 ------------------
 
+- CSRF: Whitelist context portlet assignment annotations.
+  [lgraf]
+
 - Improve document overview functions layout.
   [elioschmutz]
 

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from opengever.base.pathfinder import PathFinder
 from opengever.base.sentry import log_msg_to_sentry
 from plone import api
+from plone.portlets.constants import CONTEXT_ASSIGNMENT_KEY
 from plone.protect.auto import ProtectTransform
 from plone.protect.auto import safeWrite
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -227,6 +228,10 @@ class OGProtectTransform(ProtectTransform):
         if IAnnotatable.providedBy(context):
             annotations = IAnnotations(context)
             unprotected_write(annotations)
+
+            if CONTEXT_ASSIGNMENT_KEY in annotations:
+                # also allow writes to context portlet assignments
+                unprotected_write(annotations[CONTEXT_ASSIGNMENT_KEY])
 
 
 class ProtectAwareAttributeAnnotations(AttributeAnnotations):


### PR DESCRIPTION
Fixes CSRF false positives on Portlet contexts like `vorlagen` or `ìnbox` when visiting them for the first time after site setup.

Fixes https://sentry.4teamwork.ch/sentry/onegov-gever/issues/806/

@phgross 