### PR TITLE
Whitelist '@@health-check' view on site root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 ------------------
 
+- Whitelist '@@health-check' view on site root.
+  [lgraf]
+
 - CSRF: Whitelist context portlet assignment annotations.
   [lgraf]
 

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -45,6 +45,7 @@ ALLOWED_ENDPOINTS = set([
     'watcher-feed',
     'zauth',
     'bumblebee_download',
+    'health-check',
 ])
 
 


### PR DESCRIPTION
The `@@health-check` view (from `opengever.maintenance`) needs to be accessible for Anonymous.

@phgross 