### PR TITLE
Don't allow protocols for a meeting to be generated twice.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Don't allow protocols for a meeting to be generated twice.
+  [deiferni]
+
 - Configure offset for showroom overlay.
   [deiferni]
 

--- a/opengever/meeting/browser/protocol.py
+++ b/opengever/meeting/browser/protocol.py
@@ -29,7 +29,7 @@ class GenerateProtocol(grok.View):
         if not meeting_id:
             raise NotFound
 
-        meeting = Meeting.get(meeting_id)
+        meeting = Meeting.query.with_for_update().get(meeting_id)
         if not meeting:
             raise NotFound
 

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -6,6 +6,7 @@ from opengever.base.transport import REQUEST_KEY
 from opengever.base.transport import Transporter
 from opengever.locking.lock import SYS_LOCK
 from opengever.meeting import _
+from opengever.meeting.exceptions import ProtocolAlreadyGenerated
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.model.generateddocument import GeneratedProtocol
 from opengever.meeting.model.proposalhistory import Submitted, DocumentUpdated, DocumentSubmitted
@@ -35,6 +36,8 @@ class ProtocolOperations(object):
         return ProtocolData(meeting)
 
     def create_database_entry(self, meeting, document):
+        if meeting.protocol_document is not None:
+            raise ProtocolAlreadyGenerated()
         protocol_document = GeneratedProtocol(
             oguid=Oguid.for_object(document),
             generated_version=document.get_current_version())

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -2,3 +2,9 @@ class NoSubmittedDocument(Exception):
     """A document could not be updates remotely since it is not a submitted
     document.
     """
+
+
+class ProtocolAlreadyGenerated(Exception):
+    """The protocol could not be generated since another protocl is already
+    present.
+    """

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 19:25+0000\n"
+"POT-Creation-Date: 2016-07-05 11:55+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,20 +17,20 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:362
+#: ./opengever/meeting/command.py:365
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:289
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
 msgid "Actions"
 msgstr "Aktionen"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:69
+#: ./opengever/meeting/browser/meetings/meeting.py:71
 msgid "Add Dossier for Meeting"
 msgstr "Sitzungsdossier hinzufügen"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:68
+#: ./opengever/meeting/browser/meetings/meeting.py:70
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
@@ -57,16 +57,16 @@ msgstr "Neue Periode hinzufügen"
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:396
+#: ./opengever/meeting/command.py:399
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:238
 msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:411
+#: ./opengever/meeting/browser/meetings/meeting.py:416
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -122,11 +122,11 @@ msgstr "Traktandum löschen"
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ./opengever/meeting/command.py:325
+#: ./opengever/meeting/command.py:328
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:283
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -134,19 +134,19 @@ msgstr "Dokumente"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/meeting/command.py:98
+#: ./opengever/meeting/command.py:101
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich generiert."
 
-#: ./opengever/meeting/command.py:103
+#: ./opengever/meeting/command.py:106
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/command.py:162
+#: ./opengever/meeting/command.py:165
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:167
+#: ./opengever/meeting/command.py:170
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -155,7 +155,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -167,7 +167,7 @@ msgstr "Export-Einstellungen"
 msgid "Generate excerpts for all proposals"
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt"
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:90
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:86
 msgid "History"
 msgstr "Verlauf"
 
@@ -220,7 +220,7 @@ msgstr "Sitzungsdossier"
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:286
+#: ./opengever/meeting/browser/meetings/meeting.py:288
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
@@ -232,7 +232,7 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:286
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:281
 msgid "Number"
 msgstr "Nummer"
 
@@ -240,11 +240,11 @@ msgstr "Nummer"
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:279
 msgid "Order"
 msgstr "Sortierung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:258
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:253
 msgid "Paragraph:"
 msgstr "Abschnitt:"
 
@@ -266,7 +266,7 @@ msgstr "Eigenschaften"
 msgid "Proposal"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:263
 msgid "Proposals:"
 msgstr "Anträge"
 
@@ -279,11 +279,11 @@ msgstr "Protokoll"
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
-#: ./opengever/meeting/command.py:45
+#: ./opengever/meeting/command.py:48
 msgid "Protocol for meeting ${title} has been generated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:50
+#: ./opengever/meeting/command.py:53
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -316,11 +316,11 @@ msgstr "Mehr anzeigen"
 msgid "Submitted Proposal"
 msgstr "Eingereichten Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:242
 msgid "Text:"
 msgstr "Freitext:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:238
+#: ./opengever/meeting/browser/meetings/meeting.py:240
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
@@ -328,7 +328,7 @@ msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich ers
 msgid "The proposal has been rejected successfully"
 msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:282
 msgid "Title"
 msgstr "Titel"
 
@@ -352,7 +352,7 @@ msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier übe
 msgid "Updated with a newer excerpt version."
 msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
 
-#: ./opengever/meeting/command.py:257
+#: ./opengever/meeting/command.py:260
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
@@ -363,54 +363,54 @@ msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:224
+#: ./opengever/meeting/browser/meetings/agendaitem.py:218
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:200
+#: ./opengever/meeting/browser/meetings/agendaitem.py:194
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:229
+#: ./opengever/meeting/browser/meetings/agendaitem.py:223
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:159
+#: ./opengever/meeting/browser/meetings/agendaitem.py:153
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:221
+#: ./opengever/meeting/browser/meetings/agendaitem.py:215
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:249
+#: ./opengever/meeting/browser/meetings/agendaitem.py:243
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:266
+#: ./opengever/meeting/browser/meetings/agendaitem.py:260
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:176
+#: ./opengever/meeting/browser/meetings/agendaitem.py:170
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:181
+#: ./opengever/meeting/browser/meetings/agendaitem.py:175
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:184
+#: ./opengever/meeting/browser/meetings/meeting.py:186
 msgid "button_cancel"
 msgstr "Abbrechen"
 
@@ -421,7 +421,7 @@ msgstr "Periode abschliessen"
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:168
+#: ./opengever/meeting/browser/meetings/meeting.py:170
 msgid "button_continue"
 msgstr "Weiter"
 
@@ -567,7 +567,7 @@ msgstr "Dossier"
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:219
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
@@ -612,7 +612,7 @@ msgstr "Inaktiv"
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:171
 #: ./opengever/meeting/model/meeting.py:252
-#: ./opengever/meeting/protocol.py:160
+#: ./opengever/meeting/protocol.py:161
 msgid "label_agendaitem_list"
 msgstr "Traktandenliste"
 
@@ -652,7 +652,7 @@ msgid "label_committe_reactivated"
 msgstr "Gremium erfolgreich reaktiviert."
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:49
+#: ./opengever/meeting/browser/meetings/meeting.py:51
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
@@ -710,7 +710,7 @@ msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:364
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
@@ -731,7 +731,7 @@ msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:357
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -772,12 +772,12 @@ msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:356
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:354
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
@@ -787,7 +787,7 @@ msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:355
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -798,18 +798,18 @@ msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:63
+#: ./opengever/meeting/browser/meetings/meeting.py:65
 #: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:71
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:67
 msgid "label_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:270
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -831,7 +831,7 @@ msgid "label_initial_position"
 msgstr "Ausgangslage"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:261
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:256
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -863,7 +863,7 @@ msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:54
+#: ./opengever/meeting/browser/meetings/meeting.py:56
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Sitzungsort"
@@ -889,7 +889,7 @@ msgid "label_next_meeting"
 msgstr "Nächste Sitzung:"
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:222
 msgid "label_no_excerpts"
 msgstr "Es wurden noch keine zusätzlichen Protokollauszüge generiert."
 
@@ -899,7 +899,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:379
+#: ./opengever/meeting/browser/meetings/meeting.py:384
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -961,12 +961,12 @@ msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:367
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py:370
 msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
@@ -982,8 +982,8 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:378
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:250
+#: ./opengever/meeting/browser/meetings/meeting.py:383
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -998,14 +998,14 @@ msgid "label_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:59
+#: ./opengever/meeting/browser/meetings/meeting.py:61
 #: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/meeting.py:46
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titel"
@@ -1074,6 +1074,11 @@ msgstr "Eintrag erzeugt"
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
+#. Default: "The protocol for meeting ${title} has already been generated."
+#: ./opengever/meeting/browser/protocol.py:51
+msgid "msg_error_protocol_already_generated"
+msgstr "Das Protokoll für die Sitzung ${title} wurde schon erstellt."
+
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:80
 msgid "msg_hold_meeting_dialog"
@@ -1135,7 +1140,7 @@ msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:281
+#: ./opengever/meeting/browser/meetings/agendaitem.py:275
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
@@ -1220,7 +1225,7 @@ msgid "protocol"
 msgstr "Protokoll"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:146
+#: ./opengever/meeting/protocol.py:147
 msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
@@ -1284,7 +1289,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:295
+#: ./opengever/meeting/browser/meetings/agendaitem.py:289
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 19:25+0000\n"
+"POT-Creation-Date: 2016-07-05 11:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,20 +17,20 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:362
+#: ./opengever/meeting/command.py:365
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:289
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:69
+#: ./opengever/meeting/browser/meetings/meeting.py:71
 msgid "Add Dossier for Meeting"
 msgstr ""
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:68
+#: ./opengever/meeting/browser/meetings/meeting.py:70
 msgid "Add Meeting"
 msgstr "Ajouter la séance"
 
@@ -57,16 +57,16 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:396
+#: ./opengever/meeting/command.py:399
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:238
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:411
+#: ./opengever/meeting/browser/meetings/meeting.py:416
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -122,11 +122,11 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:325
+#: ./opengever/meeting/command.py:328
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:283
 msgid "Documents"
 msgstr ""
 
@@ -134,19 +134,19 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:98
+#: ./opengever/meeting/command.py:101
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:103
+#: ./opengever/meeting/command.py:106
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:162
+#: ./opengever/meeting/command.py:165
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:167
+#: ./opengever/meeting/command.py:170
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
 msgid "Excerpts"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:90
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:86
 msgid "History"
 msgstr "Historique"
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:286
+#: ./opengever/meeting/browser/meetings/meeting.py:288
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:286
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:281
 msgid "Number"
 msgstr ""
 
@@ -240,11 +240,11 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:279
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:258
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:253
 msgid "Paragraph:"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgstr "Propriétés"
 msgid "Proposal"
 msgstr "Proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:263
 msgid "Proposals:"
 msgstr ""
 
@@ -279,11 +279,11 @@ msgstr "Procès-verbal"
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:45
+#: ./opengever/meeting/command.py:48
 msgid "Protocol for meeting ${title} has been generated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 
-#: ./opengever/meeting/command.py:50
+#: ./opengever/meeting/command.py:53
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
@@ -316,11 +316,11 @@ msgstr "Afficher plus"
 msgid "Submitted Proposal"
 msgstr "Proposition soumise"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:242
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:238
+#: ./opengever/meeting/browser/meetings/meeting.py:240
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -328,7 +328,7 @@ msgstr ""
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:282
 msgid "Title"
 msgstr ""
 
@@ -352,7 +352,7 @@ msgstr "Le document a été écrasé par une version plus récente du dossier pr
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:257
+#: ./opengever/meeting/command.py:260
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
@@ -363,54 +363,54 @@ msgid "active"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:224
+#: ./opengever/meeting/browser/meetings/agendaitem.py:218
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:200
+#: ./opengever/meeting/browser/meetings/agendaitem.py:194
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:229
+#: ./opengever/meeting/browser/meetings/agendaitem.py:223
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:159
+#: ./opengever/meeting/browser/meetings/agendaitem.py:153
 msgid "agenda_item_order_updated"
 msgstr "Les points de l'ordre du jour ont été actualisés."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:221
+#: ./opengever/meeting/browser/meetings/agendaitem.py:215
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:249
+#: ./opengever/meeting/browser/meetings/agendaitem.py:243
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:266
+#: ./opengever/meeting/browser/meetings/agendaitem.py:260
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:176
+#: ./opengever/meeting/browser/meetings/agendaitem.py:170
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:181
+#: ./opengever/meeting/browser/meetings/agendaitem.py:175
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:184
+#: ./opengever/meeting/browser/meetings/meeting.py:186
 msgid "button_cancel"
 msgstr "Annuler"
 
@@ -421,7 +421,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:168
+#: ./opengever/meeting/browser/meetings/meeting.py:170
 msgid "button_continue"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "download protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:219
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
 msgid "generate new excerpt"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgstr ""
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:171
 #: ./opengever/meeting/model/meeting.py:252
-#: ./opengever/meeting/protocol.py:160
+#: ./opengever/meeting/protocol.py:161
 msgid "label_agendaitem_list"
 msgstr ""
 
@@ -652,7 +652,7 @@ msgid "label_committe_reactivated"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:49
+#: ./opengever/meeting/browser/meetings/meeting.py:51
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
@@ -710,7 +710,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:364
 msgid "label_decide_action"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:357
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_delete_action"
 msgstr ""
 
@@ -772,12 +772,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:356
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:354
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:355
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_edit_save"
 msgstr ""
 
@@ -798,18 +798,18 @@ msgid "label_email"
 msgstr "Email"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:63
+#: ./opengever/meeting/browser/meetings/meeting.py:65
 #: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:71
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:67
 msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:270
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgid "label_initial_position"
 msgstr "Situation initiale"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:261
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:256
 msgid "label_insert"
 msgstr ""
 
@@ -863,7 +863,7 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:54
+#: ./opengever/meeting/browser/meetings/meeting.py:56
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Site"
@@ -889,7 +889,7 @@ msgid "label_next_meeting"
 msgstr "Prochaine séance:"
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:222
 msgid "label_no_excerpts"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:379
+#: ./opengever/meeting/browser/meetings/meeting.py:384
 msgid "label_no_proposals"
 msgstr ""
 
@@ -961,12 +961,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:367
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py:370
 msgid "label_revise_action"
 msgstr ""
 
@@ -982,8 +982,8 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:378
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:250
+#: ./opengever/meeting/browser/meetings/meeting.py:383
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "label_schedule"
 msgstr ""
 
@@ -998,14 +998,14 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:59
+#: ./opengever/meeting/browser/meetings/meeting.py:61
 #: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/meeting.py:46
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titre"
@@ -1074,6 +1074,11 @@ msgstr "Enregistrement créé"
 msgid "message_write_conflict"
 msgstr ""
 
+#. Default: "The protocol for meeting ${title} has already been generated."
+#: ./opengever/meeting/browser/protocol.py:51
+msgid "msg_error_protocol_already_generated"
+msgstr ""
+
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:80
 msgid "msg_hold_meeting_dialog"
@@ -1135,7 +1140,7 @@ msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:281
+#: ./opengever/meeting/browser/meetings/agendaitem.py:275
 msgid "paragraph_added"
 msgstr ""
 
@@ -1220,7 +1225,7 @@ msgid "protocol"
 msgstr "Procès-verbal"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:146
+#: ./opengever/meeting/protocol.py:147
 msgid "protocol_excerpt"
 msgstr ""
 
@@ -1284,7 +1289,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:295
+#: ./opengever/meeting/browser/meetings/agendaitem.py:289
 msgid "text_added"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-06-26 19:25+0000\n"
+"POT-Creation-Date: 2016-07-05 11:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:362
+#: ./opengever/meeting/command.py:365
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:289
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:69
+#: ./opengever/meeting/browser/meetings/meeting.py:71
 msgid "Add Dossier for Meeting"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:68
+#: ./opengever/meeting/browser/meetings/meeting.py:70
 msgid "Add Meeting"
 msgstr ""
 
@@ -56,16 +56,16 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:396
+#: ./opengever/meeting/command.py:399
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:238
 msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:411
+#: ./opengever/meeting/browser/meetings/meeting.py:416
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -121,11 +121,11 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:325
+#: ./opengever/meeting/command.py:328
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:283
 msgid "Documents"
 msgstr ""
 
@@ -133,19 +133,19 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:98
+#: ./opengever/meeting/command.py:101
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:103
+#: ./opengever/meeting/command.py:106
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:162
+#: ./opengever/meeting/command.py:165
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:167
+#: ./opengever/meeting/command.py:170
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
 msgid "Excerpts"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Generate excerpts for all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:90
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:86
 msgid "History"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:286
+#: ./opengever/meeting/browser/meetings/meeting.py:288
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:286
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:281
 msgid "Number"
 msgstr ""
 
@@ -239,11 +239,11 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:279
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:258
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:253
 msgid "Paragraph:"
 msgstr ""
 
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:263
 msgid "Proposals:"
 msgstr ""
 
@@ -278,11 +278,11 @@ msgstr ""
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:45
+#: ./opengever/meeting/command.py:48
 msgid "Protocol for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:50
+#: ./opengever/meeting/command.py:53
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -315,11 +315,11 @@ msgstr ""
 msgid "Submitted Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:242
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:238
+#: ./opengever/meeting/browser/meetings/meeting.py:240
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgstr ""
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:282
 msgid "Title"
 msgstr ""
 
@@ -351,7 +351,7 @@ msgstr ""
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:257
+#: ./opengever/meeting/command.py:260
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
@@ -362,54 +362,54 @@ msgid "active"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:224
+#: ./opengever/meeting/browser/meetings/agendaitem.py:218
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:200
+#: ./opengever/meeting/browser/meetings/agendaitem.py:194
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:229
+#: ./opengever/meeting/browser/meetings/agendaitem.py:223
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:159
+#: ./opengever/meeting/browser/meetings/agendaitem.py:153
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:221
+#: ./opengever/meeting/browser/meetings/agendaitem.py:215
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:249
+#: ./opengever/meeting/browser/meetings/agendaitem.py:243
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:266
+#: ./opengever/meeting/browser/meetings/agendaitem.py:260
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:176
+#: ./opengever/meeting/browser/meetings/agendaitem.py:170
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:181
+#: ./opengever/meeting/browser/meetings/agendaitem.py:175
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:184
+#: ./opengever/meeting/browser/meetings/meeting.py:186
 msgid "button_cancel"
 msgstr ""
 
@@ -420,7 +420,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:168
+#: ./opengever/meeting/browser/meetings/meeting.py:170
 msgid "button_continue"
 msgstr ""
 
@@ -566,7 +566,7 @@ msgstr ""
 msgid "download protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:219
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
 msgid "generate new excerpt"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgstr ""
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:171
 #: ./opengever/meeting/model/meeting.py:252
-#: ./opengever/meeting/protocol.py:160
+#: ./opengever/meeting/protocol.py:161
 msgid "label_agendaitem_list"
 msgstr ""
 
@@ -651,7 +651,7 @@ msgid "label_committe_reactivated"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:49
+#: ./opengever/meeting/browser/meetings/meeting.py:51
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
@@ -709,7 +709,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:364
 msgid "label_decide_action"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:357
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_delete_action"
 msgstr ""
 
@@ -771,12 +771,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:356
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:354
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:355
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_edit_save"
 msgstr ""
 
@@ -797,18 +797,18 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:63
+#: ./opengever/meeting/browser/meetings/meeting.py:65
 #: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr ""
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:71
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:67
 msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:270
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgid "label_initial_position"
 msgstr ""
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:261
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:256
 msgid "label_insert"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:54
+#: ./opengever/meeting/browser/meetings/meeting.py:56
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr ""
@@ -888,7 +888,7 @@ msgid "label_next_meeting"
 msgstr ""
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:222
 msgid "label_no_excerpts"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:379
+#: ./opengever/meeting/browser/meetings/meeting.py:384
 msgid "label_no_proposals"
 msgstr ""
 
@@ -960,12 +960,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:367
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py:370
 msgid "label_revise_action"
 msgstr ""
 
@@ -981,8 +981,8 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:378
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:250
+#: ./opengever/meeting/browser/meetings/meeting.py:383
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "label_schedule"
 msgstr ""
 
@@ -997,14 +997,14 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:59
+#: ./opengever/meeting/browser/meetings/meeting.py:61
 #: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:44
+#: ./opengever/meeting/browser/meetings/meeting.py:46
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr ""
@@ -1073,6 +1073,11 @@ msgstr ""
 msgid "message_write_conflict"
 msgstr ""
 
+#. Default: "The protocol for meeting ${title} has already been generated."
+#: ./opengever/meeting/browser/protocol.py:51
+msgid "msg_error_protocol_already_generated"
+msgstr ""
+
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:80
 msgid "msg_hold_meeting_dialog"
@@ -1134,7 +1139,7 @@ msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Paragrap successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:281
+#: ./opengever/meeting/browser/meetings/agendaitem.py:275
 msgid "paragraph_added"
 msgstr ""
 
@@ -1219,7 +1224,7 @@ msgid "protocol"
 msgstr ""
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:146
+#: ./opengever/meeting/protocol.py:147
 msgid "protocol_excerpt"
 msgstr ""
 
@@ -1283,7 +1288,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Texst successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:295
+#: ./opengever/meeting/browser/meetings/agendaitem.py:289
 msgid "text_added"
 msgstr ""
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -8,7 +8,9 @@ from opengever.base.model import create_session
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.locking.lock import SYS_LOCK
 from opengever.locking.model import Lock
+from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.command import MIME_DOCX
+from opengever.meeting.exceptions import ProtocolAlreadyGenerated
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import GeneratedProtocol
 from opengever.meeting.model import Meeting
@@ -376,6 +378,14 @@ class TestProtocol(FunctionalTestCase):
         self.assertIsNotNone(generated_document)
         self.assertEqual(0, generated_document.generated_version)
         self.assertEqual(meeting, generated_document.meeting)
+
+    @browsing
+    def test_generating_protocol_twice_raises_error(self, browser):
+        self.setup_protocol(browser)
+        browser.open(GenerateProtocol.url_for(self.meeting))
+
+        with(self.assertRaises(ProtocolAlreadyGenerated)):
+            browser.open(GenerateProtocol.url_for(self.meeting))
 
     @browsing
     def test_generated_protocol_can_be_updated(self, browser):

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testbrowser.pages.z3cform import erroneous_fields
 from opengever.base.model import create_session
@@ -380,12 +381,13 @@ class TestProtocol(FunctionalTestCase):
         self.assertEqual(meeting, generated_document.meeting)
 
     @browsing
-    def test_generating_protocol_twice_raises_error(self, browser):
+    def test_generating_protocol_twice_displays_error_message(self, browser):
         self.setup_protocol(browser)
         browser.open(GenerateProtocol.url_for(self.meeting))
 
-        with(self.assertRaises(ProtocolAlreadyGenerated)):
-            browser.open(GenerateProtocol.url_for(self.meeting))
+        browser.open(GenerateProtocol.url_for(self.meeting))
+        self.assertEqual('The protocol for meeting My meeting has already '
+                         'been generated.', error_messages()[0])
 
     @browsing
     def test_generated_protocol_can_be_updated(self, browser):


### PR DESCRIPTION
Lock the meeting row with `SELECT FOR UPDATE` while the protocol is being generated and check if the protocol is already present before generating the document from its template. This prevents multiple threads from generating a protocol twice for the same meeting.

Fixes #1992.