### PR TITLE
Don't store documents that are not digitally available in bumblebee.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Don't store documents that are not digitally available in bumblebee.
+  [deiferni]
+
 - Don't allow protocols for a meeting to be generated twice.
   [deiferni]
 

--- a/opengever/bumblebee/document.py
+++ b/opengever/bumblebee/document.py
@@ -15,3 +15,7 @@ class DocumentBumblebeeDocument(DXBumblebeeDocument):
             return
 
         return super(DocumentBumblebeeDocument, self)._handle_update(force=force)
+
+    def is_convertable(self):
+        return (self.context.digitally_available and
+                super(DocumentBumblebeeDocument, self).is_convertable())

--- a/opengever/bumblebee/tests/test_document_adapter.py
+++ b/opengever/bumblebee/tests/test_document_adapter.py
@@ -1,0 +1,17 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.bumblebee.interfaces import IBumblebeeDocument
+from opengever.testing import FunctionalTestCase
+
+
+class TestDocumentAdapter(FunctionalTestCase):
+
+    def test_document_with_file_is_digitally_available(self):
+        document_with_file = create(Builder("document").with_dummy_content())
+        self.assertTrue(
+            IBumblebeeDocument(document_with_file).is_convertable())
+
+    def test_document_without_file_is_not_digitally_available(self):
+        document_without_file = create(Builder("document"))
+        self.assertFalse(
+            IBumblebeeDocument(document_without_file).is_convertable())

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -73,6 +73,11 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
             'http://nohost/plone/dossier-1/document-1/@@bumblebee-overlay-document',
             browser.css('.imageContainer').first.get('data-showroom-target'))
 
+    def test_does_not_queue_bumblebee_storing_if_not_digitally_available(self):
+        create(Builder('document'))
+        queue = get_queue()
+        self.assertEquals(0, len(queue), 'Expected no job in the queue.')
+
     def test_prevents_checked_out_document_checksum_update(self):
         document = create(Builder('document')
                           .attach_file_containing(


### PR DESCRIPTION
This has not happened anyway so far due to a side-effect of another statement. This change makes it explicit and adds tests, though.

Closes #1976.