### PR TITLE
Make transition required for the addresponse view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Make transition required for the addresponse view.
+  [deiferni]
+
 - Create example contacts and organizations when setting up a
   gever with examplecontent.
   [phgross]

--- a/opengever/task/interfaces.py
+++ b/opengever/task/interfaces.py
@@ -30,10 +30,6 @@ class IResponseAdder(IViewletManager):
 directlyProvides(IResponseAdder, ITALNamespaceData)
 
 
-class ICreateResponse(Interface):
-    pass
-
-
 class ITaskSettings(Interface):
 
     crop_length = schema.Int(title=u"Crop length", default=20)

--- a/opengever/task/interfaces.py
+++ b/opengever/task/interfaces.py
@@ -1,33 +1,5 @@
 from zope.interface import Interface
-from zope.interface import directlyProvides
-from zope.interface import Attribute
 from zope import schema
-from zope.viewlet.interfaces import IViewletManager
-from zope.contentprovider.interfaces import ITALNamespaceData
-
-
-class IResponseAdder(IViewletManager):
-
-    mimetype = Attribute("Mime type for response.")
-    use_wysiwyg = Attribute("Boolean: Use kupu-like editor.")
-
-    def transitions_for_display():
-        """Get the available transitions for this issue.
-        """
-
-    def severities_for_display():
-        """Get the available severities for this issue.
-        """
-
-    def releases_for_display():
-        """Get the releases from the project.
-        """
-
-    def managers_for_display():
-        """Get the tracker managers.
-        """
-
-directlyProvides(IResponseAdder, ITALNamespaceData)
 
 
 class ITaskSettings(Interface):

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -9,7 +9,6 @@ from opengever.task import util
 from opengever.task.activities import TaskTransitionActivity
 from opengever.task.adapters import IResponseContainer
 from opengever.task.adapters import Response
-from opengever.task.interfaces import IResponseAdder
 from opengever.task.interfaces import IWorkflowStateSyncer
 from opengever.task.permissions import DEFAULT_ISSUE_MIME_TYPE
 from opengever.task.task import ITask
@@ -290,7 +289,6 @@ class AddForm(form.AddForm, AutoExtensibleForm):
 
 
 class SingleAddFormView(layout.FormWrapper, grok.View):
-    grok.implements(IResponseAdder)
     grok.context(ITask)
     grok.name("addresponse")
     grok.require('cmf.AddPortalContent')

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -14,6 +14,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
 from z3c.relationfield.relation import RelationValue
+from zExceptions import BadRequest
 from zope.component import createObject
 from zope.component import getUtility
 from zope.component import queryUtility
@@ -100,6 +101,13 @@ class TestTaskIntegration(FunctionalTestCase):
         container = IResponseContainer(t1)
         container.add(res)
         self.failUnless(res in container)
+
+    @browsing
+    def test_addresponse_fails_without_transition(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').within(dossier).titled('some task'))
+        with self.assertRaises(BadRequest):
+            browser.login().open(task, view='addresponse')
 
     def test_task_type_category(self):
         t1 = create(Builder('task').titled('Task 1'))


### PR DESCRIPTION
The view must not be called without the transition parameter. There still _are/might be_ some old Response that contain no transition though, so we cannot make the field required safely on the Schema level.

As discussed earlier today we don't want to show a statusmessage but fail hard in case some of our code still calls the view without the now required parameter.

Also cleanup some unused code.

Closes #1991.