### PR TITLE
Make sure Dexterity default values are persisted

### DIFF
--- a/opengever/base/default_values.py
+++ b/opengever/base/default_values.py
@@ -1,0 +1,234 @@
+"""
+This module contains functions to help fix issues around Dexterity's
+behavior regarding default values.
+
+Default values not being persisted
+----------------------------------
+
+In some cases, default values that have been prefilled in a z3c.form form won't
+get persisted in the DB, causing an object's fields to "retroactively change"
+once the default[Factory] for a field is changed.
+
+Both these cases share a similar pattern: z3c.form checks whether a field's
+value has changed or not, and only writes fields whose values it believes
+have changed. However, that check gets fooled by __getattr__ fallbacks in
+DexterityContent and AnnotationsFactoryImpl that don't raise AttributeError,
+but return the field's default or missing_value respectively.
+
+1) - AttributeStorage
+
+Given:
+
+- Field in base schema or a behavior using AttributeStorage
+- Field has a default or a defaultFactory
+
+Steps to reproduce:
+
+- Add a new object using the z3c.form add form, leaving the field at its
+  prefilled default value (Add & immediately save)
+- Change the field's default or defaultFactory in the code
+
+=> The field's value will not have been persisted.
+
+(When displaying the field or reading it programmatically, the new default
+will be returned, indicating that the old default has never been persisted.)
+
+This happens because z3c.form checks whether a field has been changed or not
+when applying changes, and only saves values that are different
+(see z3c.form.form.applyChanges()).
+
+Because plone.dexterity's DexterityContent defines a __getattr__ that falls
+back to a field's default instead of raising an AttributeError, for a newly
+created object, accessing an attribute that doesn't exist yet will result in
+the fields default value.
+
+This will lead z3c.form to comparing the field's default value (prefilled in
+the form's widget) with the field's default value (returned by Dexterity's
+fallback when accessing a non-existent attribute). Because of that the field's
+value is never considered "changed", and therefore won't be written to the
+object.
+
+On the surface things appear to have worked though, because Dexterity's
+fallback also will dynamically return the default on display / programmatic
+read access.
+
+2) - AnnotationStorage
+
+Given:
+
+- Field in a behavior using AnnotationStorage
+- Field default that is equal to field's missing_value
+
+Steps to reproduce:
+
+- Add a new object using the z3c.form add form, leaving the field at its
+  prefilled default value (Add & immediately save)
+- Change the field's default or defaultFactory in the code
+
+=> The field's value will not have been persisted.
+
+In this case, the value isn't being persisted because there is a similar
+fallback in AnnotationsFactoryImpl: Instead of raising an AttributeError, it
+will fall back to returning the field's missing_value
+(see plone.behavior.annotation.AnnotationsFactoryImpl.__getattr__).
+
+This will result in z3c.form.form.applyChanges() comparing the default value
+for a field against the field's missing_value - if they happen to be the same,
+the field's value will never be persisted.
+
+Approach to fixing the issues
+-----------------------------
+
+We attempt to fix the z3c.form related issues where default values won't be
+persisted by patching z3c.form.util.changedField(). The idea is to patch it in
+a way so that it doesn't just rely on the DataManager to return a field's
+value (which would trigger the mentioned fallbacks), but instead uses the
+function below to really get to the persisted value for a field, taking the
+underlying storage into account. That way we can hopefully avoid any fallbacks
+that would fool the check.
+"""
+
+from Acquisition import aq_base
+from persistent.interfaces import IPersistent
+from plone.behavior.annotation import AnnotationsFactoryImpl
+from plone.dexterity.utils import iterSchemata
+from zope.schema import getFieldsInOrder
+from zope.schema._bootstrapinterfaces import IContextAwareDefaultFactory
+
+
+def get_persisted_value_for_field(context, field):
+    """Return the *real* stored value for a field, avoiding any fallbacks.
+
+    In particular, this circumvents the __getattr__ fallbacks in
+    DexterityContent and AnnotationsFactoryImpl that return the field's
+    default / missing_value.
+
+    Raises an AttributeError if there is no stored value for the field.
+    """
+    if not IPersistent.providedBy(context):
+        raise Exception(
+            "Attempt to get persisted field value for a non-persistent object")
+
+    # AQ unwrap object to avoid finding an attribute via acquisition
+    context = aq_base(context)
+    storage_impl = field.interface(context)
+
+    if isinstance(storage_impl, AnnotationsFactoryImpl):
+        # AnnotationStorage
+        name = field.__name__
+        if name not in storage_impl.__dict__['schema']:
+            raise AttributeError(name)
+
+        annotations = storage_impl.__dict__['annotations']
+        key_name = storage_impl.__dict__['prefix'] + name
+        try:
+            value = annotations[key_name]
+        except KeyError:
+            # Don't do the fallback to field.missing_value that
+            # AnnotationsFactoryImpl.__getattr__ does
+            raise AttributeError(name)
+        return value
+    else:
+        # Assume attribute storage
+        name = field.getName()
+        try:
+            # Two possible cases here: Field in base schema, or field in
+            # behavior with attribute storage. Either way, we look up the
+            # attribute in the objec's __dict__ in order to circumvent the
+            # fallback in DexterityContent.__getattr__
+            value = context.__dict__[name]
+        except KeyError:
+            raise AttributeError(name)
+        return value
+
+
+def get_persisted_values_for_obj(context):
+    values = {}
+    schemas = list(iterSchemata(context))
+    for schema in schemas:
+        fields = getFieldsInOrder(schema)
+        for name, field in fields:
+            try:
+                value = get_persisted_value_for_field(context, field)
+                values[name] = value
+            except AttributeError:
+                continue
+    return values
+
+
+def set_default_values(content, container, values):
+    """Set default values for all fields.
+
+    This is necessary for content created programmatically since dexterity
+    only sets default values in a view.
+
+    Parameters:
+    - content:   The object in creation. Might not be AQ wrapped yet
+    - container: The parent container the object will be added to
+    - values:    Mapping of *actual* values (not defaults) that will be or
+                 have been set on the object (not by us). I.e. kwargs to
+                 invokeFactory or createContentInContainer. Will be taken
+                 into consideration when determining whether defaults should
+                 apply or not.
+
+    """
+    marker = object()
+
+    def object_has_value_for_field(obj, field):
+        """Determine whether a value is persisted on `obj` for `field`.
+        """
+        try:
+            get_persisted_value_for_field(content, field)
+            return True
+        except AttributeError:
+            return False
+
+    def determine_default_value(field, container):
+        """Determine a field's default value during object creation.
+        """
+        # We deliberately ignore form level defaults here.
+
+        # zope.schema defaultFactory
+        #
+        # Based on zope.schema._boostrapfields.DefaultProperty. We don't use
+        # the class level 'default' attribute, which is a DefaultProperty,
+        # because we want to be able to distinguish "default of None" and
+        # "no default", at least for the defaultFactory. That's why it's
+        # necessary to check in the instance dict for a defaultFactory first,
+        # instead of letting the DefaultProperty implementation handle it.
+
+        default_factory = field.__dict__.get('defaultFactory')
+        if default_factory is not None:
+
+            if IContextAwareDefaultFactory.providedBy(default_factory):
+                # Access DefaultProperty descriptor to trigger validation
+                field.bind(container).default
+                return default_factory(container)
+            else:
+                # Access DefaultProperty descriptor to trigger validation
+                field.default
+                return default_factory()
+
+        field_default = field.__dict__.get('default')
+        if field_default is not None:
+            # Access DefaultProperty descriptor to trigger validation
+            field.default
+            return field_default
+
+        return marker
+
+    for schema in iterSchemata(content):
+        for name, field in getFieldsInOrder(schema):
+            default = determine_default_value(field, container)
+            if default is not marker:
+                if name in values:
+                    # Only set default if no *actual* value was supplied as
+                    # an argument to object construction
+                    continue
+
+                if object_has_value_for_field(content, field):
+                    # Only set default if a value hasn't been set on the
+                    # object yet
+                    continue
+
+                field.set(field.interface(content), default)

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,5 +1,6 @@
 from .create_mail_defaults import PatchCreateMailInContainer
 from .default_values import PatchDexterityContentGetattr
+from .default_values import PatchDXCreateContentInContainer
 from .default_values import PatchZ3CFormChangedField
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
@@ -18,6 +19,7 @@ PatchCMFEditonsHistoryHandlerTool()()
 PatchCopyContainerVerifyObjectPaste()()
 PatchCreateMailInContainer()()
 PatchDXContainerPastePermission()()
+PatchDXCreateContentInContainer()()
 PatchZ3CFormChangedField()()
 PatchLDAPUserFolderEncoding()()
 PatchNamedfileNamedDataConverter()()

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,5 +1,6 @@
 from .create_mail_defaults import PatchCreateMailInContainer
 from .default_values import PatchDexterityContentGetattr
+from .default_values import PatchZ3CFormChangedField
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
@@ -17,6 +18,7 @@ PatchCMFEditonsHistoryHandlerTool()()
 PatchCopyContainerVerifyObjectPaste()()
 PatchCreateMailInContainer()()
 PatchDXContainerPastePermission()()
+PatchZ3CFormChangedField()()
 PatchLDAPUserFolderEncoding()()
 PatchNamedfileNamedDataConverter()()
 PatchPlone43RC1Upgrade()()

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -2,6 +2,7 @@ from .create_mail_defaults import PatchCreateMailInContainer
 from .default_values import PatchDexterityContentGetattr
 from .default_values import PatchDXCreateContentInContainer
 from .default_values import PatchZ3CFormChangedField
+from .default_values import PatchInvokeFactory
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
@@ -21,6 +22,7 @@ PatchCreateMailInContainer()()
 PatchDXContainerPastePermission()()
 PatchDXCreateContentInContainer()()
 PatchZ3CFormChangedField()()
+PatchInvokeFactory()()
 PatchLDAPUserFolderEncoding()()
 PatchNamedfileNamedDataConverter()()
 PatchPlone43RC1Upgrade()()

--- a/opengever/base/tests/test_default_values.py
+++ b/opengever/base/tests/test_default_values.py
@@ -190,3 +190,104 @@ class TestDefaultValuePersistenceCreateContent(TestDVPersistenceBase):
 
         self.assert_value_persisted(
             field, initial_default=None, new_default=42)
+
+
+class TestDefaultValuePersistenceInvokeFactoryPortal(TestDVPersistenceBase):
+    """Dexterity's Container extends invokeFactory which it inherits from
+    PortalFolderBase.
+
+    Just to be sure our monkey patch affects both, we test both cases:
+    Calling invokeFactory on the Portal (this testcase), and calling it on
+    a DX Container (testcase below).
+    """
+
+    def add_object(self, browser):
+        portal = self.layer['portal']
+        obj = portal[portal.invokeFactory('Dummy', 'dummy')]
+        return obj
+
+    def test_base_schema(self):
+        field = IDummySchema['int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_base_schema_with_default_equal_missing_value(self):
+        field = IDummySchema['int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+    def test_attr_behavior(self):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_attr_behavior_with_default_equal_missing_value(self):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+    def test_ann_behavior(self):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_ann_behavior_with_default_equal_missing_value(self):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+
+class TestDefaultValuePersistenceInvokeFactoryDXContent(TestDVPersistenceBase):
+
+    def add_object(self, browser):
+        folder = self.portal[self.portal.invokeFactory('Dummy', 'dummyfolder')]
+        obj = folder[folder.invokeFactory('Dummy', 'dummy')]
+        return obj
+
+    def test_base_schema(self):
+        field = IDummySchema['int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_base_schema_with_default_equal_missing_value(self):
+        field = IDummySchema['int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+    def test_attr_behavior(self):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_attr_behavior_with_default_equal_missing_value(self):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+    def test_ann_behavior(self):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_ann_behavior_with_default_equal_missing_value(self):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)

--- a/opengever/base/tests/test_default_values.py
+++ b/opengever/base/tests/test_default_values.py
@@ -1,0 +1,145 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.base.default_values import get_persisted_value_for_field
+from opengever.testing import FunctionalTestCase
+from opengever.testing.patch import TempMonkeyPatch
+from opengever.testing.types import IDummyAnnotationStorageBehavior
+from opengever.testing.types import IDummyAttributeStorageBehavior
+from opengever.testing.types import IDummySchema
+import unittest
+
+
+class TestZ3CFormFilledInDefaults(FunctionalTestCase):
+
+    def add_object(self, browser):
+        browser.login().open()
+        factoriesmenu.add('Dummy')
+        browser.click_on('Save')
+        obj = browser.context
+        return obj
+
+    @unittest.skip(
+        """Fails because the persisted value is equal to missing value, and
+        therefore doesn't get used in the edit form, but gets replaced instead
+        with the default value""")
+    @browsing
+    def test_ann_behavior_with_default_equal_missing_value(self, browser):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+        assert field.missing_value is None
+
+        with TempMonkeyPatch(field, 'default', None):
+            obj = self.add_object(browser)
+            initial_value = field.get(field.interface(obj))
+
+            def mydefault():
+                return 42
+
+            with TempMonkeyPatch(field, 'defaultFactory', mydefault):
+                browser.visit(obj, view='@@edit')
+                form = browser.forms['form']
+                self.assertEqual(
+                    initial_value,
+                    int(form.find(field.title).value),
+                    'Value %r should have been prefilled' % initial_value)
+
+
+class TestDVPersistenceBase(FunctionalTestCase):
+    """Base class for testcases that default values are persisted on the
+    object in all relevant combinations of methods of creation
+    (createContentInContainer, invokeFactory, TTW via z3c.form add form) and
+    storage (base schema + attribute storage, behavior + attribute storage,
+    behavior + annotation storage).
+    """
+
+    def add_object(self, browser):
+        """Create an object using the creation method under test.
+        """
+        raise NotImplementedError
+
+    def assert_value_persisted(self, field, initial_default, new_default,
+                               browser=None):
+        """Create an object (by delegating to add_object() implemented by the
+        specific testcase) and assert that a field's default value will
+        actually be persisted on the object after creation.
+
+        We do this by
+        - first patching the field's defaultFactory to return a known value
+        - creating the object using that default
+        - modifiying the defaultFactory to return a different default
+        - checking that the field value on the object didn't also change
+        """
+        # We're using the defaultFactory here to be able to distinguish
+        # a default of `None` from "no default"
+        with TempMonkeyPatch(field, 'defaultFactory', lambda: initial_default):
+            obj = self.add_object(browser)
+            initial_value = field.get(field.interface(obj))
+
+            with TempMonkeyPatch(field, 'defaultFactory', lambda: new_default):
+                current_value = field.get(field.interface(obj))
+
+        self.assertEqual(
+            initial_value, current_value,
+            'Value %r should have been persisted, got %r instead' % (
+                initial_value, current_value))
+
+        # In addition to asserting initial_value == current_value, also check
+        # persistence using our own helper function which should raise an
+        # AttributeError if no value has been persisted.
+        persisted_value = get_persisted_value_for_field(obj, field)
+        self.assertEqual(persisted_value, current_value)
+
+
+class TestDefaultValuePersistenceZ3CForm(TestDVPersistenceBase):
+
+    def add_object(self, browser):
+        browser.login().open()
+        factoriesmenu.add('Dummy')
+        browser.click_on('Save')
+        obj = browser.context
+        return obj
+
+    @browsing
+    def test_base_schema(self, browser):
+        field = IDummySchema['int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42, browser=browser)
+
+    @browsing
+    def test_base_schema_with_default_equal_missing_value(self, browser):
+        field = IDummySchema['int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42, browser=browser)
+
+    @browsing
+    def test_attr_behavior(self, browser):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42, browser=browser)
+
+    @browsing
+    def test_attr_behavior_with_default_equal_missing_value(self, browser):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field,
+            initial_default=None, new_default=42, browser=browser)
+
+    @browsing
+    def test_ann_behavior(self, browser):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42, browser=browser)
+
+    @browsing
+    def test_ann_behavior_with_default_equal_missing_value(self, browser):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42, browser=browser)

--- a/opengever/base/tests/test_default_values.py
+++ b/opengever/base/tests/test_default_values.py
@@ -6,6 +6,7 @@ from opengever.testing.patch import TempMonkeyPatch
 from opengever.testing.types import IDummyAnnotationStorageBehavior
 from opengever.testing.types import IDummyAttributeStorageBehavior
 from opengever.testing.types import IDummySchema
+from plone.dexterity.utils import createContentInContainer
 import unittest
 
 
@@ -143,3 +144,49 @@ class TestDefaultValuePersistenceZ3CForm(TestDVPersistenceBase):
 
         self.assert_value_persisted(
             field, initial_default=None, new_default=42, browser=browser)
+
+
+class TestDefaultValuePersistenceCreateContent(TestDVPersistenceBase):
+
+    def add_object(self, browser):
+        obj = createContentInContainer(self.portal, 'Dummy')
+        return obj
+
+    def test_base_schema(self):
+        field = IDummySchema['int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_base_schema_with_default_equal_missing_value(self):
+        field = IDummySchema['int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+    def test_attr_behavior(self):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_attr_behavior_with_default_equal_missing_value(self):
+        field = IDummyAttributeStorageBehavior['attr_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)
+
+    def test_ann_behavior(self):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+
+        self.assert_value_persisted(
+            field, initial_default=11, new_default=42)
+
+    def test_ann_behavior_with_default_equal_missing_value(self):
+        field = IDummyAnnotationStorageBehavior['ann_behavior_int_field']
+        assert field.missing_value is None
+
+        self.assert_value_persisted(
+            field, initial_default=None, new_default=42)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -1,0 +1,791 @@
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testing import freeze
+from opengever.base.default_values import get_persisted_values_for_obj
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.testing import FunctionalTestCase
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.utils import createContentInContainer
+from plone.namedfile.file import NamedBlobFile
+import textwrap
+import transaction
+
+
+FROZEN_NOW = datetime.now()
+FROZEN_TODAY = FROZEN_NOW.date()
+
+DEFAULT_TITLE = u'My title'
+
+OMITTED_FORM_FIELDS = ['creators']
+
+REPOROOT_DEFAULTS = {
+    'title_de': DEFAULT_TITLE,
+}
+REPOROOT_FORM_DEFAULTS = {}
+REPOROOT_FORM_INITVALUES = {
+    'valid_from': None,
+    'valid_until': None,
+    'version': None,
+}
+
+
+REPOFOLDER_DEFAULTS = {
+    'creators': (),
+    'description': u'',
+    'public_trial': u'unchecked',
+    'public_trial_statement': '',
+    'reference_number_prefix': u'1',
+    'title_de': DEFAULT_TITLE,
+}
+REPOFOLDER_FORM_DEFAULTS = {
+    'archival_value': u'unchecked',
+    'classification': u'unprotected',
+    'custody_period': 30,
+    'privacy_layer': u'privacy_layer_no',
+    'retention_period': 5,
+}
+REPOFOLDER_FORM_INITVALUES = {
+    'addable_dossier_types': [],
+    'archival_value_annotation': None,
+    'date_of_cassation': None,
+    'date_of_submission': None,
+    'former_reference': None,
+    'location': None,
+    'referenced_activity': None,
+    'retention_period_annotation': None,
+    'valid_from': None,
+    'valid_until': None,
+}
+
+
+DOSSIER_DEFAULTS = {
+    'description': u'',
+    'keywords': (),
+    'public_trial': u'unchecked',
+    'public_trial_statement': u'',
+    'relatedDossier': [],
+    'start': FROZEN_TODAY,
+    'title': DEFAULT_TITLE,
+}
+DOSSIER_FORM_DEFAULTS = {
+    'archival_value': u'unchecked',
+    'classification': u'unprotected',
+    'custody_period': 30,
+    'privacy_layer': u'privacy_layer_no',
+    'responsible': TEST_USER_ID,
+    'retention_period': 5,
+}
+DOSSIER_FORM_INITVALUES = {
+    'archival_value_annotation': None,
+    'comments': None,
+    'container_location': None,
+    'container_type': None,
+    'date_of_cassation': None,
+    'date_of_submission': None,
+    'end': None,
+    'filing_prefix': None,
+    'number_of_containers': None,
+    'retention_period_annotation': None,
+}
+
+
+DOCUMENT_DEFAULTS = {
+    'creators': (),
+    'description': u'',
+    'digitally_available': False,
+    'document_date': FROZEN_TODAY,
+    'keywords': (),
+    'preserved_as_paper': True,
+    'public_trial': u'unchecked',
+    'public_trial_statement': '',
+    'relatedItems': [],
+    'title': DEFAULT_TITLE,
+}
+DOCUMENT_FORM_DEFAULTS = {
+    'classification': u'unprotected',
+    'privacy_layer': u'privacy_layer_no',
+}
+DOCUMENT_FORM_INITVALUES = {
+    'delivery_date': None,
+    'document_author': None,
+    'document_type': None,
+    'file': None,
+    'foreign_reference': None,
+    'receipt_date': None,
+}
+
+
+MAIL_DEFAULTS = {
+    'description': u'',
+    'digitally_available': True,
+    'document_author': u'from@example.org',
+    'document_date': date(2010, 1, 1),
+    'keywords': (),
+    'preserved_as_paper': True,
+    'public_trial': u'unchecked',
+    'public_trial_statement': '',
+    'receipt_date': FROZEN_TODAY,
+}
+MAIL_FORM_DEFAULTS = {
+    'classification': u'unprotected',
+    'privacy_layer': u'privacy_layer_no',
+}
+MAIL_FORM_INITVALUES = {
+    'delivery_date': None,
+    'document_type': None,
+    'foreign_reference': None,
+}
+
+
+TASK_DEFAULTS = {
+    'deadline': FROZEN_TODAY + timedelta(days=5),
+    'issuer': TEST_USER_ID,
+    'relatedItems': [],
+    'responsible': TEST_USER_ID,
+    'responsible_client': u'client1',
+    'title': u'My title',
+}
+TASK_FORM_DEFAULTS = {
+    'responsible_client': u'client1',
+}
+TASK_FORM_INITVALUES = {
+    'date_of_completion': None,
+    'effectiveCost': None,
+    'effectiveDuration': None,
+    'expectedCost': None,
+    'expectedDuration': None,
+    'expectedStartOfWork': None,
+    'task_type': u'information',
+    'text': None,
+}
+
+
+CONTACT_DEFAULTS = {
+    'description': u'',
+}
+CONTACT_FORM_DEFAULTS = {}
+CONTACT_FORM_INITVALUES = {
+    'academic_title': None,
+    'address1': None,
+    'address2': None,
+    'city': None,
+    'company': None,
+    'country': None,
+    'department': None,
+    'email': None,
+    'email2': None,
+    'firstname': u'John',
+    'function': None,
+    'lastname': u'John',
+    'phone_fax': None,
+    'phone_home': None,
+    'phone_mobile': None,
+    'phone_office': None,
+    'picture': None,
+    'salutation': None,
+    'url': None,
+    'zip_code': None,
+}
+
+
+COMMITTEE_DEFAULTS = {}
+COMMITTEE_FORM_DEFAULTS = {}
+COMMITTEE_FORM_INITVALUES = {
+    'agendaitem_list_template': None,
+    'excerpt_template': None,
+    'protocol_template': None,
+}
+
+
+class TestDefaultsBase(FunctionalTestCase):
+
+    type_defaults = None
+    form_defaults = None
+    form_initvalues = None
+
+    def setUp(self):
+        super(TestDefaultsBase, self).setUp()
+        self.portal = self.layer.get('portal')
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+        # Set 'de-ch' and 'en' as supported languages to have title field show
+        # up at all for ITranslatedTitle, but still have the UI in english
+        # (otherwise using ftw.testbrowser will be painful)
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.setDefaultLanguage('en')
+        lang_tool.supported_langs = ['de-ch', 'en']
+        transaction.commit()
+
+    def get_type_defaults(self):
+        return self.type_defaults
+
+    def get_z3c_form_defaults(self):
+        defaults = {}
+        defaults.update(self.type_defaults)
+        defaults.update(self.form_defaults)
+        defaults.update(self.form_initvalues)
+
+        for key in OMITTED_FORM_FIELDS:
+            defaults.pop(key, None)
+
+        return defaults
+
+
+class TestRepositoryRootDefaults(TestDefaultsBase):
+
+    type_defaults = REPOROOT_DEFAULTS
+    form_defaults = REPOROOT_FORM_DEFAULTS
+    form_initvalues = REPOROOT_FORM_INITVALUES
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            reporoot = createContentInContainer(
+                self.portal,
+                'opengever.repository.repositoryroot',
+                title_de=DEFAULT_TITLE)
+
+        persisted_values = get_persisted_values_for_obj(reporoot)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_portal(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.portal.invokeFactory(
+                'opengever.repository.repositoryroot',
+                'reporoot',
+                title_de=DEFAULT_TITLE)
+            reporoot = self.portal[new_id]
+
+        persisted_values = get_persisted_values_for_obj(reporoot)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        with freeze(FROZEN_NOW):
+            browser.login().open()
+            factoriesmenu.add(u'RepositoryRoot')
+            browser.fill({u'Title': DEFAULT_TITLE}).save()
+            reporoot = browser.context
+
+        persisted_values = get_persisted_values_for_obj(reporoot)
+        expected = self.get_z3c_form_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestRepositoryFolderDefaults(TestDefaultsBase):
+
+    type_defaults = REPOFOLDER_DEFAULTS
+    form_defaults = REPOFOLDER_FORM_DEFAULTS
+    form_initvalues = REPOFOLDER_FORM_INITVALUES
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            repofolder = createContentInContainer(
+                self.portal,
+                'opengever.repository.repositoryfolder',
+                title_de=DEFAULT_TITLE)
+
+        persisted_values = get_persisted_values_for_obj(repofolder)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_portal(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.portal.invokeFactory(
+                'opengever.repository.repositoryfolder',
+                'repofolder',
+                title_de=DEFAULT_TITLE)
+            repofolder = self.portal[new_id]
+
+        persisted_values = get_persisted_values_for_obj(repofolder)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        outer_repofolder = createContentInContainer(
+            self.portal,
+            'opengever.repository.repositoryfolder',
+            title_de=u'Outer RepoFolder',
+        )
+
+        with freeze(FROZEN_NOW):
+            new_id = outer_repofolder.invokeFactory(
+                'opengever.repository.repositoryfolder',
+                'repofolder',
+                title_de=DEFAULT_TITLE)
+            repofolder = outer_repofolder[new_id]
+
+        persisted_values = get_persisted_values_for_obj(repofolder)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        with freeze(FROZEN_NOW):
+            browser.login().open()
+            factoriesmenu.add(u'RepositoryFolder')
+            browser.fill({u'Title': DEFAULT_TITLE}).save()
+            repofolder = browser.context
+
+        persisted_values = get_persisted_values_for_obj(repofolder)
+        expected = self.get_z3c_form_defaults()
+
+        # XXX: Don't know why this happens
+        expected['public_trial_statement'] = None
+        expected['description'] = None
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestDossierDefaults(TestDefaultsBase):
+
+    type_defaults = DOSSIER_DEFAULTS
+    form_defaults = DOSSIER_FORM_DEFAULTS
+    form_initvalues = DOSSIER_FORM_INITVALUES
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            dossier = createContentInContainer(
+                self.portal,
+                'opengever.dossier.businesscasedossier',
+                title=DEFAULT_TITLE)
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_portal(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.portal.invokeFactory(
+                'opengever.dossier.businesscasedossier',
+                'dossier-1',
+                title=DEFAULT_TITLE)
+            dossier = self.portal[new_id]
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        outer_dossier = createContentInContainer(
+            self.portal,
+            'opengever.dossier.businesscasedossier',
+            title=u'Outer Dossier',
+        )
+
+        with freeze(FROZEN_NOW):
+            new_id = outer_dossier.invokeFactory(
+                'opengever.dossier.businesscasedossier',
+                'dossier-1',
+                title=DEFAULT_TITLE)
+            dossier = outer_dossier[new_id]
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        with freeze(FROZEN_NOW):
+            browser.login().open()
+            factoriesmenu.add(u'Business Case Dossier')
+            browser.fill({u'Title': DEFAULT_TITLE}).save()
+            dossier = browser.context
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_z3c_form_defaults()
+
+        # XXX: Don't know why this happens
+        expected['public_trial_statement'] = None
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestDocumentDefaults(TestDefaultsBase):
+
+    type_defaults = DOCUMENT_DEFAULTS
+    form_defaults = DOCUMENT_FORM_DEFAULTS
+    form_initvalues = DOCUMENT_FORM_INITVALUES
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            doc = createContentInContainer(
+                self.portal,
+                'opengever.document.document',
+                title=DEFAULT_TITLE)
+
+        persisted_values = get_persisted_values_for_obj(doc)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_portal(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.portal.invokeFactory(
+                'opengever.document.document',
+                'document-1',
+                title=DEFAULT_TITLE)
+            doc = self.portal[new_id]
+
+        persisted_values = get_persisted_values_for_obj(doc)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        outer_dossier = createContentInContainer(
+            self.portal,
+            'opengever.dossier.businesscasedossier',
+            title=u'Outer Dossier',
+        )
+
+        with freeze(FROZEN_NOW):
+            new_id = outer_dossier.invokeFactory(
+                'opengever.document.document',
+                'document-1',
+                title=DEFAULT_TITLE)
+            doc = outer_dossier[new_id]
+
+        persisted_values = get_persisted_values_for_obj(doc)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        # Need to create doc inside a dossier, otherwise document-redirector
+        # won't work
+        outer_dossier = createContentInContainer(
+            self.portal,
+            'opengever.dossier.businesscasedossier',
+            title=u'Outer Dossier',
+        )
+        transaction.commit()
+
+        with freeze(FROZEN_NOW):
+            browser.login().open(outer_dossier)
+            factoriesmenu.add(u'Document')
+            browser.fill({u'Title': DEFAULT_TITLE}).save()
+            doc = outer_dossier['document-1']
+
+        persisted_values = get_persisted_values_for_obj(doc)
+        expected = self.get_z3c_form_defaults()
+
+        # XXX: Don't know why this happens
+        expected['public_trial_statement'] = None
+        expected['description'] = None
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestMailDefaults(TestDefaultsBase):
+
+    type_defaults = MAIL_DEFAULTS
+    form_defaults = MAIL_FORM_DEFAULTS
+    form_initvalues = MAIL_FORM_INITVALUES
+
+    SAMPLE_MAIL = textwrap.dedent("""\
+        MIME-Version: 1.0
+        Content-Type: text/plain; charset="us-ascii"
+        Content-Transfer-Encoding: 7bit
+        To: to@example.org
+        From: from@example.org
+        Subject: Lorem Ipsum
+        Date: Thu, 01 Jan 2010 01:00:00 +0100
+        Message-Id: <1>
+
+        Lorem ipsum dolor sit amet.
+        """)
+
+    @property
+    def sample_msg(self):
+        message_value = NamedBlobFile(
+            data=TestMailDefaults.SAMPLE_MAIL,
+            contentType='message/rfc822',
+            filename=u'msg.eml')
+        return message_value
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            mail = createContentInContainer(
+                self.portal,
+                'ftw.mail.mail',
+                title=DEFAULT_TITLE,
+                message=self.sample_msg)
+
+        persisted_values = get_persisted_values_for_obj(mail)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_portal(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.portal.invokeFactory(
+                'ftw.mail.mail',
+                'mail',
+                title=DEFAULT_TITLE,
+                message=self.sample_msg)
+            mail = self.portal[new_id]
+
+        persisted_values = get_persisted_values_for_obj(mail)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        outer_dossier = createContentInContainer(
+            self.portal,
+            'opengever.dossier.businesscasedossier',
+            title=u'Outer Dossier',
+        )
+
+        with freeze(FROZEN_NOW):
+            new_id = outer_dossier.invokeFactory(
+                'ftw.mail.mail',
+                'document-1',
+                title=DEFAULT_TITLE,
+                message=self.sample_msg)
+            mail = outer_dossier[new_id]
+
+        persisted_values = get_persisted_values_for_obj(mail)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        with freeze(FROZEN_NOW):
+            # Mail is not addable via factories menu
+            browser.login().open(view='++add++ftw.mail.mail')
+            browser.fill({
+                u'Title': DEFAULT_TITLE,
+                u'form.widgets.message': (TestMailDefaults.SAMPLE_MAIL,
+                                          'msg.eml', 'message/rfc822')}).save()
+            mail = browser.context
+
+        persisted_values = get_persisted_values_for_obj(mail)
+        expected = self.get_z3c_form_defaults()
+
+        # XXX: Don't know why this happens
+        expected['public_trial_statement'] = None
+        expected['description'] = None
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestTaskDefaults(TestDefaultsBase):
+
+    type_defaults = TASK_DEFAULTS
+    form_defaults = TASK_FORM_DEFAULTS
+    form_initvalues = TASK_FORM_INITVALUES
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            task = createContentInContainer(
+                self.portal,
+                'opengever.task.task',
+                title=DEFAULT_TITLE,
+                issuer=TEST_USER_ID,
+                responsible=TEST_USER_ID,
+                responsible_client='client1')
+
+        persisted_values = get_persisted_values_for_obj(task)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_portal(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.portal.invokeFactory(
+                'opengever.task.task',
+                'task-1',
+                title=DEFAULT_TITLE,
+                issuer=TEST_USER_ID,
+                responsible=TEST_USER_ID,
+                responsible_client='client1')
+            task = self.portal[new_id]
+
+        persisted_values = get_persisted_values_for_obj(task)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        outer_dossier = createContentInContainer(
+            self.portal,
+            'opengever.dossier.businesscasedossier',
+            title=u'Outer Dossier',
+        )
+
+        with freeze(FROZEN_NOW):
+            new_id = outer_dossier.invokeFactory(
+                'opengever.task.task',
+                'task-1',
+                title=DEFAULT_TITLE,
+                issuer=TEST_USER_ID,
+                responsible=TEST_USER_ID,
+                responsible_client='client1')
+            task = outer_dossier[new_id]
+
+        persisted_values = get_persisted_values_for_obj(task)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        with freeze(FROZEN_NOW):
+            browser.login().open()
+            factoriesmenu.add(u'Task')
+            browser.fill({
+                u'Title': DEFAULT_TITLE,
+                u'Responsible': TEST_USER_ID,
+                u'Task Type': 'information'}).save()
+            task = self.portal['task-1']
+
+        persisted_values = get_persisted_values_for_obj(task)
+        expected = self.get_z3c_form_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestContactDefaults(TestDefaultsBase):
+
+    type_defaults = CONTACT_DEFAULTS
+    form_defaults = CONTACT_FORM_DEFAULTS
+    form_initvalues = CONTACT_FORM_INITVALUES
+
+    def setUp(self):
+        super(TestContactDefaults, self).setUp()
+        self.contactfolder = createContentInContainer(
+            self.portal,
+            'opengever.contact.contactfolder',
+            title=u'Contacts',
+        )
+        transaction.commit()
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            contact = createContentInContainer(
+                self.contactfolder,
+                'opengever.contact.contact')
+
+        persisted_values = get_persisted_values_for_obj(contact)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.contactfolder.invokeFactory(
+                'opengever.contact.contact',
+                'john-doe')
+            contact = self.contactfolder[new_id]
+
+        persisted_values = get_persisted_values_for_obj(contact)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        with freeze(FROZEN_NOW):
+            browser.login().open(self.contactfolder)
+            factoriesmenu.add(u'Contact')
+            browser.fill({
+                u'Firstname': u'John',
+                u'Lastname': u'John'}).save()
+            contact = browser.context
+
+        persisted_values = get_persisted_values_for_obj(contact)
+        expected = self.get_z3c_form_defaults()
+
+        # XXX: Don't know why this happens
+        expected['description'] = None
+
+        self.assertDictEqual(expected, persisted_values)
+
+
+class TestCommitteeDefaults(TestDefaultsBase):
+
+    type_defaults = COMMITTEE_DEFAULTS
+    form_defaults = COMMITTEE_FORM_DEFAULTS
+    form_initvalues = COMMITTEE_FORM_INITVALUES
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestCommitteeDefaults, self).setUp()
+        self.container = createContentInContainer(
+            self.portal,
+            'opengever.meeting.committeecontainer',
+            title=u'Meetings',
+        )
+        transaction.commit()
+
+    def test_create_content_in_container(self):
+        with freeze(FROZEN_NOW):
+            committee = createContentInContainer(
+                self.container,
+                'opengever.meeting.committee',
+                title=DEFAULT_TITLE)
+
+        persisted_values = get_persisted_values_for_obj(committee)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    def test_invoke_factory_on_dx_container(self):
+        with freeze(FROZEN_NOW):
+            new_id = self.container.invokeFactory(
+                'opengever.meeting.committee',
+                'committee-1',
+                title=DEFAULT_TITLE)
+            contact = self.container[new_id]
+
+        persisted_values = get_persisted_values_for_obj(contact)
+        expected = self.get_type_defaults()
+
+        self.assertDictEqual(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        repofolder = createContentInContainer(
+            self.portal,
+            'opengever.repository.repositoryfolder',
+            title='Repofolder')
+        transaction.commit()
+
+        with freeze(FROZEN_NOW):
+            browser.login().open(self.container)
+            factoriesmenu.add(u'Committee')
+            browser.fill({
+                u'Title': DEFAULT_TITLE,
+                u'Group': 'client1_users',
+                u'Linked repository folder ': repofolder})
+            browser.find('Continue').click()
+            browser.find('Save').click()
+            committee = browser.context
+
+        persisted_values = get_persisted_values_for_obj(committee)
+        expected = self.get_z3c_form_defaults()
+
+        linked_repo = persisted_values.pop('repository_folder')
+        self.assertEqual(linked_repo.to_object, repofolder)
+
+        self.assertDictEqual(expected, persisted_values)

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -158,6 +158,7 @@ class OpengeverFixture(PloneSandboxLayer):
             '  <include package="opengever.core.tests" file="tests.zcml" />'
             '  <include package="opengever.ogds.base" file="tests.zcml" />'
             '  <include package="opengever.base.tests" file="tests.zcml" />'
+            '  <include package="opengever.testing" file="tests.zcml" />'
             '  <include package="opengever.setup.tests" />'
 
             '</configure>',
@@ -234,6 +235,8 @@ class OpengeverFixture(PloneSandboxLayer):
         applyProfile(portal, 'plone.formwidget.contenttree:default')
         applyProfile(portal, 'ftw.contentmenu:default')
         applyProfile(portal, 'ftw.zipexport:default')
+
+        applyProfile(portal, 'opengever.testing:testing')
 
     def createMemberFolder(self, portal):
         # Create a Members folder.

--- a/opengever/document/behaviors/related_docs.py
+++ b/opengever/document/behaviors/related_docs.py
@@ -16,6 +16,7 @@ class IRelatedDocuments(form.Schema):
     relatedItems = RelationList(
         title=_(u'label_related_documents', default=u'Related Documents'),
         default=[],
+        missing_value=[],
         value_type=RelationChoice(
             title=u"Related",
             source=RepositoryPathSourceBinder(

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -252,7 +252,7 @@ class TestDocumentDefaultValues(FunctionalTestCase):
         self.assertEqual(today, document.document_date)
 
     @browsing
-    def test_preserverd_as_paper_default(self, browser):
+    def test_preserved_as_paper_default_false(self, browser):
         browser.login()
 
         # registry default of False
@@ -268,6 +268,10 @@ class TestDocumentDefaultValues(FunctionalTestCase):
              'File': ('DATA', 'file.txt', 'text/plain')}).save()
         document = self.dossier['document-1']
         self.assertFalse(document.preserved_as_paper)
+
+    @browsing
+    def test_preserved_as_paper_default_true(self, browser):
+        browser.login()
 
         # registry default of True
         api.portal.set_registry_record(

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -147,6 +147,7 @@ class IDossier(form.Schema):
     relatedDossier = RelationList(
         title=_(u'label_related_dossier', default=u'Related Dossier'),
         default=[],
+        missing_value=[],
         value_type=RelationChoice(
             title=u"Related",
             source=RepositoryPathSourceBinder(

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -91,6 +91,7 @@ class ISendDocumentSchema(Interface):
     documents = RelationList(
         title=_(u'label_documents', default=u'Documents'),
         default=[],
+        missing_value=[],
         value_type=RelationChoice(
             title=u"Documents",
             source=DossierPathSourceBinder(

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -63,6 +63,7 @@ class IResponse(Interface):
     relatedItems = RelationList(
         title=_(u'label_related_items', default=u'Related Items'),
         default=[],
+        missing_value=[],
         value_type=RelationChoice(
             title=u"Related",
             source=DossierPathSourceBinder(

--- a/opengever/testing/configure.zcml
+++ b/opengever/testing/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+      xmlns="http://namespaces.zope.org/zope"
+      xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:registerProfile
+      name="testing"
+      title="opengever.testing:testing"
+      description="testing profile"
+      directory="profiles/testing"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+</configure>

--- a/opengever/testing/patch.py
+++ b/opengever/testing/patch.py
@@ -1,0 +1,38 @@
+from copy import copy
+
+
+class TempMonkeyPatch(object):
+    """Context manager to temporarily monkey patch an object's attribute.
+
+    Only meant to be used in tests!
+
+    This context manager will back up the attribute's original value, patch
+    it to a new value, and upon leaving the context, restore the original
+    value.
+    """
+
+    def __init__(self, target_obj, target_attr, new_value):
+        self.target_obj = target_obj
+        self.target_attr = target_attr
+        self.new_value = new_value
+
+    def backup(self):
+        self.original_value = copy(getattr(self.target_obj, self.target_attr))
+
+    def patch(self):
+        setattr(self.target_obj, self.target_attr, self.new_value)
+
+    def restore(self):
+        setattr(self.target_obj, self.target_attr, self.original_value)
+
+    def __enter__(self):
+        """Back up the original value and batch the target object's attribute.
+        """
+        self.backup()
+        self.patch()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Restore the original value to the target object's attribute.
+        """
+        self.restore()

--- a/opengever/testing/profiles/testing/types.xml
+++ b/opengever/testing/profiles/testing/types.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+
+    <object name="Dummy" meta_type="Dexterity FTI" />
+
+</object>

--- a/opengever/testing/profiles/testing/types/Dummy.xml
+++ b/opengever/testing/profiles/testing/types/Dummy.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<object name="Dummy"
+   meta_type="Dexterity FTI"
+   i18n:domain="opengever.testing" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">Dummy</property>
+  <property name="description" i18n:translate=""></property>
+  <property name="icon_expr"></property>
+  <property name="factory">Dummy</property>
+  <property name="add_view_expr">string:${folder_url}/++add++Dummy</property>
+  <property name="global_allow">True</property>
+  <property name="filter_content_types">False</property>
+  <property name="allowed_content_types"/>
+  <property name="allow_discussion">False</property>
+
+  <!-- schema and class used for content items -->
+  <property name="schema">opengever.testing.types.IDummySchema</property>
+  <property name="klass">opengever.testing.types.Dummy</property>
+
+  <property name="behaviors">
+    <element value="opengever.testing.types.IDummyAnnotationStorageBehavior" />
+    <element value="opengever.testing.types.IDummyAttributeStorageBehavior" />
+  </property>
+
+</object>

--- a/opengever/testing/tests.zcml
+++ b/opengever/testing/tests.zcml
@@ -1,0 +1,21 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="opengever.testing">
+
+    <plone:behavior
+        title="Dummy Behavior (AttributeStorage)"
+        description=""
+        provides="opengever.testing.types.IDummyAttributeStorageBehavior"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
+    <plone:behavior
+        title="Dummy Behavior (AnnotationStorage)"
+        description=""
+        provides="opengever.testing.types.IDummyAnnotationStorageBehavior"
+        factory="plone.behavior.AnnotationStorage"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
+</configure>

--- a/opengever/testing/tests.zcml
+++ b/opengever/testing/tests.zcml
@@ -18,4 +18,13 @@
         for="plone.dexterity.interfaces.IDexterityContent"
         />
 
+  <plone:behavior
+      title="Dummy Behavior (with marker)"
+      description=""
+      provides="opengever.testing.types.IDummyWithMarkerSchema"
+      factory="plone.behavior.AnnotationStorage"
+      marker="opengever.testing.types.IDummyMarker"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
 </configure>

--- a/opengever/testing/types.py
+++ b/opengever/testing/types.py
@@ -1,0 +1,41 @@
+from plone.dexterity.content import Container
+from plone.directives import form
+from zope import schema
+from zope.interface import alsoProvides
+
+
+class IDummySchema(form.Schema):
+    """Dummy schema used for testing.
+    """
+
+    int_field = schema.Int(
+        title=u'Int Field',
+        required=False,
+        default=111,
+    )
+
+
+class IDummyAttributeStorageBehavior(form.Schema):
+
+    attr_behavior_int_field = schema.Int(
+        title=u'Behavior (AttributeStorage) Int Field',
+        required=False,
+        default=222,
+    )
+
+alsoProvides(IDummyAttributeStorageBehavior, form.IFormFieldProvider)
+
+
+class IDummyAnnotationStorageBehavior(form.Schema):
+
+    ann_behavior_int_field = schema.Int(
+        title=u'Behavior (AnnotationStorage) Int Field',
+        required=False,
+        default=333,
+    )
+
+alsoProvides(IDummyAnnotationStorageBehavior, form.IFormFieldProvider)
+
+
+class Dummy(Container):
+    """Dummy type used for testing"""

--- a/opengever/testing/types.py
+++ b/opengever/testing/types.py
@@ -2,6 +2,7 @@ from plone.dexterity.content import Container
 from plone.directives import form
 from zope import schema
 from zope.interface import alsoProvides
+from zope.interface import Interface
 
 
 class IDummySchema(form.Schema):
@@ -13,6 +14,19 @@ class IDummySchema(form.Schema):
         required=False,
         default=111,
     )
+
+
+class IDummyWithMarkerSchema(form.Schema):
+    """Dummy schema used for testing.
+    """
+
+    int_marker_field = schema.Int(
+        title=u'Behavior (with marker) Int Field',
+        required=False,
+        default=111,
+    )
+
+alsoProvides(IDummyWithMarkerSchema, form.IFormFieldProvider)
 
 
 class IDummyAttributeStorageBehavior(form.Schema):
@@ -39,3 +53,7 @@ alsoProvides(IDummyAnnotationStorageBehavior, form.IFormFieldProvider)
 
 class Dummy(Container):
     """Dummy type used for testing"""
+
+
+class IDummyMarker(Interface):
+    """Behavior marker interface"""


### PR DESCRIPTION
This addresses several issues described in #1778:

These changes make sure that
- default values are actually persisted when adding content **TTW with `z3c.form`**
- default values are set when using **`createContentInContainer`**
- default values are set when using **`invokeFactory`**

(Will add / clean up changelog once merged into `master`

@deiferni @phgross 