### PR TITLE
Display parse errors in livesearch.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Display a hint in livesearch results view when the query could
+  not be processed.
+  [deiferni]
+
 - Make transition required for the addresponse view.
   [deiferni]
 

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -107,8 +107,8 @@ label_no_results_found = _(
     default='No matching results found.')
 label_has_parse_errors = _(
     'label_has_parse_errors',
-    default='There were errors parsing your query, please note that boolen '
-            'expressions like AND, NOT and OR are not allowed in quick '
+    default='There were errors parsing your query, please note that boolean '
+            'expressions like AND, NOT and OR are only allowed in advanced '
             'search.')
 label_advanced_search = _(
     'label_advanced_search',

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -99,11 +99,23 @@ RESPONSE.setHeader('Content-Type', 'text/xml;charset=%s' % site_encoding)
 # replace named entities with their numbered counterparts, in the xml the named ones are not correct
 #   &darr;      --> &#8595;
 #   &hellip;    --> &#8230;
-legend_livesearch = _('legend_livesearch', default='LiveSearch &#8595;')
-label_no_results_found = _('label_no_results_found', default='No matching results found.')
-label_has_parse_errors = _('label_has_parse_errors', default='There were errors parsing your query, please note that boolen expressions like AND, NOT and OR are not allowed in quick search.')
-label_advanced_search = _('label_advanced_search', default='Advanced Search&#8230;')
-label_show_all = _('label_show_all', default='Show all items')
+legend_livesearch = _(
+    'legend_livesearch',
+    default='LiveSearch &#8595;')
+label_no_results_found = _(
+    'label_no_results_found',
+    default='No matching results found.')
+label_has_parse_errors = _(
+    'label_has_parse_errors',
+    default='There were errors parsing your query, please note that boolen '
+            'expressions like AND, NOT and OR are not allowed in quick '
+            'search.')
+label_advanced_search = _(
+    'label_advanced_search',
+    default='Advanced Search&#8230;')
+label_show_all = _(
+    'label_show_all',
+    default='Show all items')
 
 ts = getToolByName(context, 'translation_service')
 

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -11,8 +11,10 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.browser.navtree import getNavigationRoot
 from Products.CMFPlone.utils import safe_unicode
-from Products.PythonScripts.standard import url_quote_plus
 from Products.PythonScripts.standard import html_quote
+from Products.PythonScripts.standard import url_quote_plus
+from Products.ZCTextIndex.ParseTree import ParseError
+
 
 ploneUtils = getToolByName(context, 'plone_utils')
 portal_url = getToolByName(context, 'portal_url')()
@@ -81,7 +83,12 @@ else:
     params['path'] = path
 
 # search limit+1 results to know if limit is exceeded
-results = catalog(**params)
+has_parse_errors = False
+try:
+    results = catalog(**params)
+except ParseError:
+    results = []
+    has_parse_errors = True
 
 searchterm_query = '?searchterm=%s' % url_quote_plus(q)
 
@@ -94,6 +101,7 @@ RESPONSE.setHeader('Content-Type', 'text/xml;charset=%s' % site_encoding)
 #   &hellip;    --> &#8230;
 legend_livesearch = _('legend_livesearch', default='LiveSearch &#8595;')
 label_no_results_found = _('label_no_results_found', default='No matching results found.')
+label_has_parse_errors = _('label_has_parse_errors', default='There were errors parsing your query, please note that boolen expressions like AND, NOT and OR are not allowed in quick search.')
 label_advanced_search = _('label_advanced_search', default='Advanced Search&#8230;')
 label_show_all = _('label_show_all', default='Show all items')
 
@@ -110,7 +118,12 @@ if not results:
     write('''<fieldset class="livesearchContainer">''')
     write('''<legend id="livesearchLegend">%s</legend>''' % ts.translate(legend_livesearch, context=REQUEST))
     write('''<div class="LSIEFix">''')
-    write('''<div id="LSNothingFound">%s</div>''' % ts.translate(label_no_results_found, context=REQUEST))
+    if has_parse_errors:
+        write('''<div id="LSParseErrors"><div class="label_error">%s</div>%s</div>''' %
+              (ts.translate(_('Error'), context=REQUEST),
+               ts.translate(label_has_parse_errors, context=REQUEST)))
+    else:
+        write('''<div id="LSNothingFound">%s</div>''' % ts.translate(label_no_results_found, context=REQUEST))
     write('''<div class="LSRow">''')
     write('<a href="%s" style="font-weight:normal">%s</a>' %
          (portal_url + '/advanced_search?SearchableText=%s' % searchurlparameter,

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -310,5 +310,5 @@ msgid "transition-add-document"
 msgstr "Dokument hinzugefügt"
 
 msgid "label_has_parse_errors"
-msgstr "Fehler bei der Verarbeitung Ihrer Suchanfrage. Bitte beachten Sie, dass Ausdrücke wie AND, NOT und OR in der Schnellsuche nicht erlaubt sind."
+msgstr "Fehler bei der Verarbeitung Ihrer Suchanfrage. Bitte beachten Sie, dass Ausdrücke wie AND, NOT und OR nur in der erweiterten Suche erlaubt sind."
 

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -309,3 +309,6 @@ msgstr "Aktivieren"
 msgid "transition-add-document"
 msgstr "Dokument hinzugefügt"
 
+msgid "label_has_parse_errors"
+msgstr "Fehler bei der Verarbeitung Ihrer Suchanfrage. Bitte beachten Sie, dass Ausdrücke wie AND, NOT und OR in der Schnellsuche nicht erlaubt sind."
+

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -317,3 +317,6 @@ msgstr ""
 
 msgid "Close current period"
 msgstr ""
+
+msgid "label_has_parse_errors"
+msgstr ""


### PR DESCRIPTION
Display a hint in livesearch results view when the query could not be processed.

Styles are added in https://github.com/4teamwork/plonetheme.teamraum/pull/441.

![screen shot 2016-07-07 at 10 34 18](https://cloud.githubusercontent.com/assets/736583/16647205/647078ee-442e-11e6-8e7f-057346d712b1.png)

Fixes #649.