### PR TITLE
Fix scrollspy auto scrolling.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix scrollspy auto scrolling.
+  [Kevin Bieri]
+
 - Display a hint in livesearch results view when the query could
   not be processed.
   [deiferni]

--- a/opengever/meeting/browser/resources/Scrollspy.js
+++ b/opengever/meeting/browser/resources/Scrollspy.js
@@ -14,7 +14,7 @@
 
     var beforeSelectCallback = $.noop;
 
-    var root = $(":root");
+    var root = $("html, body");
 
     function scrollTo(offset, callback) { root.animate({ scrollTop: offset + "px" }, 300, callback); }
 


### PR DESCRIPTION
The `:root` selector is not working for IE. It also behaves
strange on chrome with same version but on diffrent devices.