### PR TITLE
Consequently use builders to create contact sql objects in tests.

### DIFF
--- a/opengever/contact/tests/test_org_role.py
+++ b/opengever/contact/tests/test_org_role.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.contact.models import Organization
 from opengever.contact.models import OrgRole
 from opengever.contact.models import Person
@@ -10,16 +12,28 @@ class TestOrganizationalRole(unittest2.TestCase):
     layer = MEMORY_DB_LAYER
 
     def test_organization_person_relation(self):
-        school = Organization(name='4teamwork AG')
-        meier_ag = Organization(name='Meier AG')
+        school = create(Builder('organization').named(u'4teamwork AG'))
+        meier_ag = create(Builder('organization').named(u'Meier AG'))
 
-        peter = Person(firstname=u'Peter', lastname=u'M\xfcller')
-        hugo = Person(firstname=u'Hugo', lastname=u'Boss')
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        hugo = create(Builder('person')
+                      .having(firstname=u'Hugo', lastname=u'Boss'))
 
-        role1 = OrgRole(person=peter, organization=meier_ag,
-                         function='Developer')
-        role2 = OrgRole(person=hugo, organization=meier_ag, function='CTO')
-        role3 = OrgRole(person=peter, organization=school, function='Member')
+        role1 = create(Builder('org_role')
+                       .having(person=peter,
+                               organization=meier_ag,
+                               function='Developer'))
+
+        role2 = create(Builder('org_role')
+                       .having(person=hugo,
+                               organization=meier_ag,
+                               function='CTO'))
+
+        role3 = create(Builder('org_role')
+                       .having(person=peter,
+                               organization=school,
+                               function='Member'))
 
         self.assertEquals([role1, role3], peter.organizations)
         self.assertEquals([role2], hugo.organizations)

--- a/opengever/contact/tests/test_organization.py
+++ b/opengever/contact/tests/test_organization.py
@@ -1,6 +1,6 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.contact.models import Contact
-from opengever.contact.models import Organization
-from opengever.contact.models import URL
 from opengever.testing import MEMORY_DB_LAYER
 import unittest2
 
@@ -10,16 +10,23 @@ class TestOrganization(unittest2.TestCase):
     layer = MEMORY_DB_LAYER
 
     def test_is_contact(self):
-        organization = Organization(name='4teamwork AG')
+        organization = create(Builder('organization').named(u'4teamwork AG'))
 
         self.assertTrue(isinstance(organization, Contact))
         self.assertEquals('organization', organization.contact_type)
 
     def test_organization_can_have_multiple_urls(self):
-        organization = Organization(name='4teamwork AG')
+        organization = create(Builder('organization').named(u'4teamwork AG'))
 
-        info = URL(contact=organization, url=u'http://www.4teamwork.ch')
-        gever = URL(contact=organization, url=u'http://www.onegovgever.ch')
+        info = create(Builder('url')
+                      .for_contact(organization)
+                      .labeled(u'Info')
+                      .having(url=u'http://www.4teamwork.ch'))
+
+        gever = create(Builder('url')
+                       .for_contact(organization)
+                       .labeled(u'Info')
+                       .having(url=u'http://www.onegovgever.ch'))
 
         self.assertEquals([info, gever], organization.urls)
         self.assertEquals([u'http://www.4teamwork.ch',

--- a/opengever/contact/tests/test_person_unit.py
+++ b/opengever/contact/tests/test_person_unit.py
@@ -1,8 +1,6 @@
-from opengever.contact.models import Address
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.contact.models import Contact
-from opengever.contact.models import MailAddress
-from opengever.contact.models import Person
-from opengever.contact.models import PhoneNumber
 from opengever.testing import MEMORY_DB_LAYER
 import unittest2
 
@@ -11,58 +9,83 @@ class TestPerson(unittest2.TestCase):
 
     layer = MEMORY_DB_LAYER
 
+    def setUp(self):
+        super(TestPerson, self).setUp()
+        self.session = self.layer.session
+
     def test_adding(self):
-        Person(firstname=u'Peter',
-               lastname='M\xc3\xbcller'.decode('utf-8'))
+        person = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
     def test_is_contact(self):
-        person = Person(firstname=u'Peter',
-                        lastname='M\xc3\xbcller'.decode('utf-8'))
+        person = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
         self.assertTrue(isinstance(person, Contact))
         self.assertEquals('person', person.contact_type)
 
     def test_person_can_have_multiple_addresses(self):
-        peter = Person(firstname=u'Peter',
-                       lastname='M\xc3\xbcller'.decode('utf-8'))
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
-        address1 = Address(contact=peter, label=u'Work',
-                           street=u'Dammweg 9', zip_code=u'3013', city=u'Bern')
-        address2 = Address(contact=peter, label=u'Home',
-                           street=u'Musterstrasse 283', zip_code=u'1700',
-                           city=u'Fribourg')
+        address1 = create(Builder('address')
+                          .for_contact(peter)
+                          .labeled(u'Work')
+                          .having(street=u'Dammweg 9', zip_code=u'3013',
+                                  city=u'Bern'))
+
+        address2 = create(Builder('address')
+                          .for_contact(peter)
+                          .labeled(u'Home')
+                          .having(street=u'Musterstrasse 283',
+                                  zip_code=u'1700',
+                                  city=u'Fribourg'))
 
         self.assertEquals([address1, address2], peter.addresses)
 
     def test_person_can_have_multiple_mail_addresses(self):
-        peter = Person(firstname=u'Peter',
-                       lastname='M\xc3\xbcller'.decode('utf-8'))
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
-        home = MailAddress(contact=peter, label=u'Work',
-                           address=u'peter@example.com')
-        work = MailAddress(contact=peter, label=u'Home',
-                           address=u'm.peter@example.com')
+        home = create(Builder('mailaddress')
+                      .for_contact(peter)
+                      .labeled(u'Home')
+                      .having(address=u'peter@example.com'))
+
+        work = create(Builder('mailaddress')
+                      .for_contact(peter)
+                      .labeled(u'Work')
+                      .having(address=u'm.peter@example.com'))
 
         self.assertEquals([home, work], peter.mail_addresses)
         self.assertEquals([u'peter@example.com', u'm.peter@example.com'],
                           [mail.address for mail in peter.mail_addresses])
 
     def test_person_can_have_multiple_phonenumbers(self):
-        peter = Person(firstname=u'Peter',
-                       lastname='M\xc3\xbcller'.decode('utf-8'))
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
-        home = PhoneNumber(contact=peter, label=u'Work',
-                           phone_number=u'+41791234566')
-        work = PhoneNumber(contact=peter, phone_number=u'0315110000')
+        home = create(Builder('phonenumber')
+                      .for_contact(peter)
+                      .labeled(u'Home')
+                      .having(phone_number=u'+41791234566'))
+
+        work = create(Builder('phonenumber')
+                      .for_contact(peter)
+                      .labeled(u'Work')
+                      .having(phone_number=u'0315110000'))
 
         self.assertEquals([home, work], peter.phonenumbers)
         self.assertEquals([u'+41791234566', u'0315110000'],
                           [phone.phone_number for phone in peter.phonenumbers])
 
     def test_fullname_is_firstname_and_lastname_separated_with_a_space(self):
-        peter = Person(firstname=u'Peter', lastname=u'M\xfcller')
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+
         self.assertEquals(u'Peter M\xfcller', peter.fullname)
 
     def test_title_is_fullname(self):
-        peter = Person(firstname=u'Peter', lastname=u'M\xfcller')
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
         self.assertEquals(u'Peter M\xfcller', peter.get_title())

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -10,6 +10,7 @@ from opengever.contact.models import Organization
 from opengever.contact.models import OrgRole
 from opengever.contact.models import Person
 from opengever.contact.models import PhoneNumber
+from opengever.contact.models import URL
 from opengever.globalindex.model.task import Task
 from opengever.locking.model import Lock
 from opengever.meeting.committee import ICommittee
@@ -375,6 +376,14 @@ class MailAddressBuilder(ContactAttributesBuilder):
     id_argument_name = 'mailaddress_id'
 
 builder_registry.register('mailaddress', MailAddressBuilder)
+
+
+class URLBuilder(ContactAttributesBuilder):
+
+    mapped_class = URL
+    id_argument_name = 'url_id'
+
+builder_registry.register('url', URLBuilder)
 
 
 class OrganizationBuilder(SqlObjectBuilder):


### PR DESCRIPTION
Fixes #2013.

@deiferni 