### PR TITLE
Let bumblebee take precedence over pdfconverter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Let bumblebee take precedence over pdfconverter.
+  Don't consider pdfconverter being available when bumblebee feature is enabled.
+  [deiferni]
+
 - Add participation model for contacts.
   [deiferni]
 

--- a/opengever/base/pdfconverter.py
+++ b/opengever/base/pdfconverter.py
@@ -1,0 +1,14 @@
+import pkg_resources
+from opengever.bumblebee import is_bumblebee_feature_enabled
+
+
+try:
+    pkg_resources.get_distribution('opengever.pdfconverter')
+except pkg_resources.DistributionNotFound:
+    PDFCONVERTER_AVAILABLE = False
+else:
+    PDFCONVERTER_AVAILABLE = True
+
+
+def is_pdfconverter_enabled():
+    return PDFCONVERTER_AVAILABLE and not is_bumblebee_feature_enabled()

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -4,6 +4,7 @@ from ftw import bumblebee
 from opengever.base import _ as ogbmf
 from opengever.base.browser import edit_public_trial
 from opengever.base.browser.helper import get_css_class
+from opengever.base.pdfconverter import is_pdfconverter_enabled
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document import _
 from opengever.document.browser.download import DownloadConfirmationHelper
@@ -24,10 +25,8 @@ from zope.component import queryMultiAdapter
 try:
     from opengever.pdfconverter.behaviors.preview import IPreviewMarker
     from opengever.pdfconverter.behaviors.preview import IPreview
-
-    PDFCONVERTER_AVAILABLE = True
 except ImportError:
-    PDFCONVERTER_AVAILABLE = False
+    pass
 
 
 class BaseRow(object):
@@ -207,7 +206,7 @@ class Overview(DisplayForm, GeverTabMixin):
 
     def is_preview_supported(self):
         # XXX TODO: should be persistent called two times
-        if PDFCONVERTER_AVAILABLE:
+        if is_pdfconverter_enabled():
             return IPreviewMarker.providedBy(self.context)
         return False
 

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from five import grok
 from ftw.table.interfaces import ITableSource
 from ftw.table.interfaces import ITableSourceConfig
+from opengever.base.pdfconverter import is_pdfconverter_enabled
 from opengever.base.protect import unprotected_write
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee import is_bumblebeeable
@@ -22,14 +23,6 @@ from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
-import pkg_resources
-
-try:
-    pkg_resources.get_distribution('opengever.pdfconverter')
-except pkg_resources.DistributionNotFound:
-    PDFCONVERTER_AVAILABLE = False
-else:
-    PDFCONVERTER_AVAILABLE = True
 
 
 def translate_link(url, label, css_class=None):
@@ -298,7 +291,7 @@ class VersionsTab(BaseListingTab):
          'column_title': _(u'label_download_copy', default=u'Download copy'),
          },
 
-        # Dropped if PDFCONVERTER_AVAILABLE == False
+        # Dropped if pdfconverter is not enabled
         {'column': 'pdf_preview_link',
          'column_title': ' ',
          },
@@ -307,6 +300,7 @@ class VersionsTab(BaseListingTab):
          'column_title': _(u'label_revert', default=u'Revert'),
          },
 
+        # Dropped if bumblebee is not enabled
         {'column': 'preview',
          'column_title': _(u'label_preview', default=u'Preview'),
          'transform': linked_version_preview
@@ -320,7 +314,7 @@ class VersionsTab(BaseListingTab):
         if not is_bumblebee_feature_enabled() or not is_bumblebeeable(self.context):
             self._columns = self.remove_column('preview')
 
-        if not PDFCONVERTER_AVAILABLE:
+        if not is_pdfconverter_enabled():
             self._columns = self.remove_column('pdf_preview_link')
 
         return self._columns

--- a/opengever/document/tests/test_document_link_widget.py
+++ b/opengever/document/tests/test_document_link_widget.py
@@ -2,8 +2,8 @@ from ftw import bumblebee
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.base import pdfconverter
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.document.widgets import document_link
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.testing import FunctionalTestCase
 
@@ -12,11 +12,11 @@ class TestDocumentLinkWidget(FunctionalTestCase):
 
     def setUp(self):
         super(TestDocumentLinkWidget, self).setUp()
-        self.converter_avaialable = document_link.PDFCONVERTER_AVAILABLE
+        self.converter_avaialable = pdfconverter.PDFCONVERTER_AVAILABLE
 
     def tearDown(self):
         super(TestDocumentLinkWidget, self).tearDown()
-        document_link.PDFCONVERTER_AVAILABLE = self.converter_avaialable
+        pdfconverter.PDFCONVERTER_AVAILABLE = self.converter_avaialable
 
     @browsing
     def test_link_contains_mimetype_icon_clas(self, browser):
@@ -61,7 +61,7 @@ class TestDocumentLinkWidget(FunctionalTestCase):
 
     @browsing
     def test_tooltip_actions(self, browser):
-        document_link.PDFCONVERTER_AVAILABLE = True
+        pdfconverter.PDFCONVERTER_AVAILABLE = True
         document = create(Builder('document').with_dummy_content())
 
         browser.open_html(DocumentLinkWidget(document).render())
@@ -103,7 +103,7 @@ class TestDocumentLinkWidget(FunctionalTestCase):
 
     @browsing
     def test_preview_link_is_only_available_for_documents(self, browser):
-        document_link.PDFCONVERTER_AVAILABLE = True
+        pdfconverter.PDFCONVERTER_AVAILABLE = True
         document = create(Builder('document').with_dummy_content())
         mail = create(Builder('mail'))
 
@@ -117,11 +117,11 @@ class TestDocumentLinkWidget(FunctionalTestCase):
     def test_preview_link_is_only_available_when_pdfconverter_is_active(self, browser):
         document = create(Builder('document').with_dummy_content())
 
-        document_link.PDFCONVERTER_AVAILABLE = True
+        pdfconverter.PDFCONVERTER_AVAILABLE = True
         browser.open_html(DocumentLinkWidget(document).render())
         self.assertIn('PDF Preview', browser.css('.tooltip-links a').text)
 
-        document_link.PDFCONVERTER_AVAILABLE = False
+        pdfconverter.PDFCONVERTER_AVAILABLE = False
         browser.open_html(DocumentLinkWidget(document).render())
         self.assertNotIn('PDF Preview', browser.css('.tooltip-links a').text)
 

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.base import pdfconverter
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import create_document_version
@@ -125,13 +126,11 @@ class TestVersionsTabWithPDFConverter(TestVersionsTab):
 
     def setUp(self):
         super(TestVersionsTabWithPDFConverter, self).setUp()
-        import opengever.document
-        opengever.document.browser.versions_tab.PDFCONVERTER_AVAILABLE = True
+        pdfconverter.PDFCONVERTER_AVAILABLE = True
 
     def tearDown(self):
         super(TestVersionsTabWithPDFConverter, self).tearDown()
-        import opengever.document
-        opengever.document.browser.versions_tab.PDFCONVERTER_AVAILABLE = False
+        pdfconverter.PDFCONVERTER_AVAILABLE = False
 
     @browsing
     def test_download_pdf_link_is_properly_constructed(self, browser):

--- a/opengever/document/widgets/document_link.py
+++ b/opengever/document/widgets/document_link.py
@@ -1,17 +1,9 @@
+from opengever.base.pdfconverter import is_pdfconverter_enabled
 from opengever.document.browser.download import DownloadConfirmationHelper
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.protect.utils import addTokenToUrl
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.globalrequest import getRequest
-import pkg_resources
-
-
-try:
-    pkg_resources.get_distribution('opengever.pdfconverter')
-except pkg_resources.DistributionNotFound:
-    PDFCONVERTER_AVAILABLE = False
-else:
-    PDFCONVERTER_AVAILABLE = True
 
 
 class DocumentLinkWidget(object):
@@ -39,7 +31,7 @@ class DocumentLinkWidget(object):
         return self.document.Title().decode('utf-8')
 
     def preview_link_available(self):
-        return self.document.is_document and PDFCONVERTER_AVAILABLE
+        return self.document.is_document and is_pdfconverter_enabled()
 
     def edit_metadata_link_available(self):
         return not self.document.is_trashed

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -15,15 +15,6 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-import pkg_resources
-
-
-try:
-    pkg_resources.get_distribution('opengever.pdfconverter')
-except pkg_resources.DistributionNotFound:
-    PDFCONVERTER_AVAILABLE = False
-else:
-    PDFCONVERTER_AVAILABLE = True
 
 
 def org_unit_title_helper(item, value):

--- a/sources.cfg
+++ b/sources.cfg
@@ -11,6 +11,8 @@ development-packages =
 # https://github.com/4teamwork/ftw.bumblebee/pull/96
   ftw.bumblebee
   plonetheme.teamraum
+# https://github.com/4teamwork/opengever.pdfconverter/pull/15
+  opengever.pdfconverter
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
When both bumblebee and pdfconverter are installed, bumblebee should take precdence.

Depends on https://github.com/4teamwork/opengever.pdfconverter/pull/15.

Closes #2020.