### PR TITLE
Show pdf icon for preview link in document versions tab.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Show pdf icon for preview link in document versions tab.
+  [deiferni]
+
 - Bump lxml to 3.3.1 and get rid of lxml import warnings and openpyxl user warnings.
   [deiferni]
 

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -200,12 +200,10 @@ def linked_version_preview(item, value):
 
     return """
     <div>
-        <a class="showroom-item"
+        <a class="showroom-item function-preview-pdf"
            href="{%(url)s}"
            data-showroom-target="%(showroom_url)s"
-           data-showroom-title="%(showroom_title)s">
-        %(title)s
-        </a>
+           data-showroom-title="%(showroom_title)s">%(title)s</a>
     </div>
     """ % data
 


### PR DESCRIPTION
Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/445.

Remove newlines in generated markup to avoid additional whitespace before
title.

![screen shot 2016-07-19 at 12 04 43](https://cloud.githubusercontent.com/assets/736583/16949207/b1de2060-4db9-11e6-84ad-26c5dd395508.png)


Closes https://github.com/4teamwork/opengever.core/issues/2022.

