### PR TITLE
Bump lxml to version 3.3.1.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Bump lxml to 3.3.1 and get rid of lxml import warnings and openpyxl user warnings.
+  [deiferni]
+
 - Change document linking to document overview, instead of the
   bumblebee overlay.
   [phgross]

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -2,9 +2,11 @@ from Missing import Value as MissingValue
 from opengever.ogds.base.actor import Actor
 from openpyxl import Workbook
 from openpyxl.styles import Font
-from openpyxl.styles import Style
 from StringIO import StringIO
 from zope.i18n import translate
+
+
+DATE_NUMBER_FORMAT = 'DD.MM.YYYY'
 
 
 def readable_author(author):
@@ -28,12 +30,6 @@ class StringTranslater(object):
         if value:
             return translate(value, domain=self.domain, context=self.request)
         return None
-
-
-def get_date_style(format='DD.MM.YYYY'):
-    """ Set up a date format style to use in the spreadsheet and return it."""
-
-    return Style(number_format=format)
 
 
 class XLSReporter(object):
@@ -94,5 +90,5 @@ class XLSReporter(object):
 
                 cell.value = value
 
-                if attr.get('style'):
-                    cell.style = attr.get('style')
+                if 'number_format' in attr:
+                    cell.number_format = attr.get('number_format')

--- a/opengever/base/tests/test_reporter.py
+++ b/opengever/base/tests/test_reporter.py
@@ -5,7 +5,7 @@ from ftw.builder import create
 from ftw.testing import MockTestCase
 from Missing import Value as MissingValue
 from opengever.base import _
-from opengever.base.reporter import get_date_style
+from opengever.base.reporter import DATE_NUMBER_FORMAT
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
@@ -45,7 +45,7 @@ class TestReporter(MockTestCase):
             {'id': 'Title', 'title': _('label_title', default='Title')},
             {'id': 'missing', 'missing': 'Missing', },
             {'id': 'start', 'title': _('label_start', default='Start'),
-             'style': get_date_style()},
+             'number_format': DATE_NUMBER_FORMAT},
             {'id': 'responsible',
              'title': _('label_responsible', default='Responsible'),
              'transform': readable_author},

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -1,6 +1,6 @@
 from five import grok
 from opengever.base.behaviors.utils import set_attachment_content_disposition
-from opengever.base.reporter import get_date_style
+from opengever.base.reporter import DATE_NUMBER_FORMAT
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater, XLSReporter
 from opengever.dossier import _
@@ -34,10 +34,10 @@ class DossierReporter(grok.View):
              'transform': to_unicode},
             {'id': 'start',
              'title': _(u'label_start', default=u'Opening Date'),
-             'style': get_date_style()},
+             'number_format': DATE_NUMBER_FORMAT},
             {'id': 'end',
              'title': _(u'label_end', default=u'Closing Date'),
-             'style': get_date_style()},
+             'number_format': DATE_NUMBER_FORMAT},
             {'id': 'responsible',
              'title': _(u'label_responsible', default='Responsible'),
              'transform': readable_author},

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from five import grok
 from opengever.base.behaviors.utils import set_attachment_content_disposition
-from opengever.base.reporter import get_date_style
+from opengever.base.reporter import DATE_NUMBER_FORMAT
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
@@ -62,9 +62,9 @@ class TaskReporter(grok.View):
              'transform': StringTranslater(
                  self.context.REQUEST, 'plone').translate},
             {'id': 'deadline', 'title': _('label_deadline'),
-             'style': get_date_style()},
+             'number_format': DATE_NUMBER_FORMAT},
             {'id': 'completed', 'title': _('label_completed'),
-             'style': get_date_style()},
+             'number_format': DATE_NUMBER_FORMAT},
             {'id': 'containing_dossier', 'title': _('label_dossier_title')},
             {'id': 'issuer', 'title': _('label_issuer'),
              'transform': readable_author},

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -1,10 +1,14 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from lxml.cssselect import css_to_xpath
+from lxml.cssselect import LxmlTranslator
 from lxml.etree import fromstring
 from lxml.etree import tostring
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
+
+
+def css_to_xpath(css):
+    return LxmlTranslator().css_to_xpath(css)
 
 
 class TestTaskLinkGeneration(FunctionalTestCase):

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -1,14 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from lxml.cssselect import LxmlTranslator
 from lxml.etree import fromstring
 from lxml.etree import tostring
 from opengever.testing import FunctionalTestCase
+from opengever.testing.helpers import css_to_xpath
 from plone.app.testing import TEST_USER_ID
-
-
-def css_to_xpath(css):
-    return LxmlTranslator().css_to_xpath(css)
 
 
 class TestTaskLinkGeneration(FunctionalTestCase):

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -93,7 +93,7 @@ class TestTriggeringTaskTemplate(FunctionalTestCase):
 
         self.assertEquals(
             ['Mitbericht FD'],
-            browser.css('#formfield-form-widgets-tasktemplates input:checked').getparents().text)
+            browser.css('#formfield-form-widgets-tasktemplates input[checked]').getparents().text)
 
     @browsing
     def test_creates_main_task_assigned_to_current_user(self, browser):

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from lxml.cssselect import LxmlTranslator
 from opengever.base.date_time import as_utc
 from plone import api
 from Products.CMFCore.utils import getToolByName
@@ -70,3 +71,7 @@ def create_document_version(doc, version_id, data=None):
     vdata = data or 'VERSION {} DATA'.format(version_id)
     doc.file.data = vdata
     repo_tool.save(obj=doc, comment="This is Version %s" % version_id)
+
+
+def css_to_xpath(css):
+    return LxmlTranslator().css_to_xpath(css)


### PR DESCRIPTION
This is required by openpyxl and gets rid of warnings while boot the instances.

Closes https://github.com/4teamwork/opengever.core/issues/1753.