### PR TITLE
Always enable bumblebee for development by default.

### DIFF
--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -12,4 +12,8 @@
       <value key="create_doc_properties">True</value>
     </records>
 
+    <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings">
+      <value key="is_feature_enabled">True</value>
+    </records>
+
 </registry>


### PR DESCRIPTION
Most of our customers will enable bumblebee, so we should, too while developing.