### PR TITLE
Fix sticky heading

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix sticky heading in order to a refactoring of the baseclass.
+  [elioschmutz]
+
 - Fix FileOrPaperValidator in case where the file gets removed in the edit form.
   [phgross]
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -449,9 +449,9 @@
     global.autosize($('body.template-edit.portaltype-opengever-meeting-submittedproposal textarea'));
 
     $(global.document).on("notify", function() {
-      var notifyContainer = new global.StickyHeading({ selector: "#columns", clone: false, fix: false });
-      notifyContainer.onSticky(function() { $(".notifyjs-corner").addClass("sticky"); });
-      notifyContainer.onNoSticky(function() { $(".notifyjs-corner").removeClass("sticky"); });
+      var notifyContainer = global.Pin("#columns", null, { pin: false });
+      notifyContainer.onPin(function() { $(".notifyjs-corner").addClass("sticky"); });
+      notifyContainer.onRelease(function() { $(".notifyjs-corner").removeClass("sticky"); });
     });
   });
 


### PR DESCRIPTION
Dieser PR fix den Sticky-Heading.

Durch ein Refactoring wurde der Klassennamen geändert. Für mehr infos #2051 

closes #2051 