### PR TITLE
Make tabbedview filter on sqltables listings case insensitive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Make tabbedview filter on sqltables listings case insensitive.
+  [phgross]
+
 - Fix security-issue to cross-delete and update agendaitems.
   [elioschmutz]
 

--- a/opengever/ogds/base/events.py
+++ b/opengever/ogds/base/events.py
@@ -20,6 +20,11 @@ def setup_isolation_level_on_connect(dbapi_connection, connection_record):
     dbapi_connection.isolation_level = None
 
 
+def make_like_case_sensitive(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute('PRAGMA case_sensitive_like = ON')
+
+
 def ping_connection(dbapi_connection, connection_record, connection_proxy):
     # Invalidate stale database connections checked out from the pool
     # Helps us deal with "MySQL has gone away" error
@@ -52,6 +57,7 @@ def setup_engine_options(event):
 
     elif engine.name == 'sqlite':
         listen(engine, 'connect', setup_isolation_level_on_connect)
+        listen(engine, 'connect', make_like_case_sensitive)
 
     elif engine.name == 'mysql':
         listen(Pool, 'checkout', ping_connection)

--- a/opengever/tabbedview/sqlsource.py
+++ b/opengever/tabbedview/sqlsource.py
@@ -80,7 +80,7 @@ class SqlTableSource(GeverTableSource):
                 query.session
 
                 query = query.filter(or_(
-                    *[cast(field, String).like(term)
+                    *[cast(field, String).ilike(term)
                       for field in self.searchable_columns]))
 
         return query

--- a/opengever/tabbedview/tests/test_sqlsource.py
+++ b/opengever/tabbedview/tests/test_sqlsource.py
@@ -52,6 +52,16 @@ class TestTextFilter(FunctionalTestCase):
                           [row.get('Title') for row in table.dicts()])
 
     @browsing
+    def test_filtering_is_case_insensitive(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks',
+            data={'searchable_text': u'closed'})
+
+        table = browser.css('.listing').first
+        self.assertEquals(['Closed Task B'],
+                          [row.get('Title') for row in table.dicts()])
+
+    @browsing
     def test_filtering_on_integer_columns(self, browser):
         browser.login().open(
             self.dossier, view='tabbedview_view-tasks',


### PR DESCRIPTION
The filterbox should be an easy and fast possibility to limit the entries of a listing, therefore it should work case insensitive.

Note: the filterbox on catalog listings already works case insensitive.

 --- 
Additionally in enable case_sensitive_like on sql lite connections.
This makes sure that all like queries in tests are case sensitive. So our test DB (SQLLite) works in the same manner than our production DBs (Oracle/PostgreSQL).

@lukasgraf