### PR TITLE
Move showroom hidden-link outside the tooltip-trigger div.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix issue with wrong document-number: Move showroom hidden-link
+  outside the tooltip-trigger div.
+  [phgross]
+
 - Add an email-form for opengever contacts.
   [elioschmutz]
 

--- a/opengever/document/widgets/document_link.pt
+++ b/opengever/document/widgets/document_link.pt
@@ -1,5 +1,4 @@
 <div i18n:domain="opengever.document" class="linkWrapper tooltip-trigger"
-     tal:define="is_bumblebeeable context/is_bumblebeeable"
      tal:attributes="data-tooltip-url string:${view/get_url}/tooltip">
 
   <span tal:condition="context/is_removed" class='removed_document' />
@@ -7,10 +6,10 @@
   <a tal:content="view/get_title"
      tal:attributes="class view/get_css_class; href view/get_url;" />
 
-  <a href="#" class="hidden-link showroom-item"
-     tal:condition="is_bumblebeeable"
-     tal:attributes="data-showroom-target context/get_overlay_url;
-                     data-showroom-title context/get_overlay_title;
-                     data-showroom-id string:showroom-id-${context/uuid}" />
-
 </div>
+
+<a href="#" class="hidden-link showroom-item"
+   tal:condition="context/is_bumblebeeable"
+   tal:attributes="data-showroom-target context/get_overlay_url;
+                   data-showroom-title context/get_overlay_title;
+                   data-showroom-id string:showroom-id-${context/uuid}" />


### PR DESCRIPTION
Otherwise the hidden-link gets duplicated and this leads to a wrong document-number and a buggy scrolling between the different documents (fixes #2059).

@bierik 