### PR TITLE
Display download_copy link also for mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Display download_copy link in the tooltip also on mails.
+  [phgross]
+
 - Make tabbedview filter on sqltables listings case insensitive.
   [phgross]
 

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -119,14 +119,18 @@ class TestDocumentTooltip(FunctionalTestCase):
                          browser.css('.file-actions a').text)
 
     @browsing
-    def test_download_link_is_only_available_for_documents(self, browser):
+    def test_download_link_is_available_for_documents_and_mails_when_file_exists(self, browser):
         document = create(Builder('document').with_dummy_content())
-        mail = create(Builder('mail'))
+        document_without_file = create(Builder('document'))
+        mail = create(Builder('mail').with_dummy_message())
 
         browser.login().open(document, view='tooltip')
         self.assertIn('Download copy', browser.css('.file-actions a').text)
 
-        browser.open(mail, view='tooltip')
+        browser.login().open(mail, view='tooltip')
+        self.assertIn('Download copy', browser.css('.file-actions a').text)
+
+        browser.login().open(document_without_file, view='tooltip')
         self.assertNotIn('Download copy', browser.css('.file-actions a').text)
 
 

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -27,7 +27,7 @@ class TooltipView(BrowserView):
         return addTokenToUrl('{}/editing_document'.format(self.get_url()))
 
     def download_link_available(self):
-        return self.document.is_document
+        return self.document.digitally_available
 
     def download_link(self):
         dc_helper = DownloadConfirmationHelper()


### PR DESCRIPTION
Change the condition if the download_copy is shown in the tooltip, to the digitally_available flag. So the link is shown for documents and mails as long as they contain a file.

Closed #2045 

@lukasgraf 