### PR TITLE
Rewrite form defaults for IClassification and ILifeCycle fields to defaultFactories

### DIFF
--- a/opengever/base/acquisition.py
+++ b/opengever/base/acquisition.py
@@ -51,7 +51,7 @@ def acquire_field_value(field, container):
     return NO_VALUE_FOUND
 
 
-def set_default_with_acquisition(field, default=None):
+def acquired_default_factory(field, default=None):
     """Returns a factory that produces a default by trying to acquire the
     field value from it's ancestors, if possible.
 

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -12,7 +12,9 @@ from plone.memoize import ram
 from zope import schema
 from zope.i18n import translate
 from zope.interface import alsoProvides, Interface
+from zope.interface import provider
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
@@ -145,13 +147,15 @@ classification_vf = RestrictedVocabularyFactory(
     restricted=True)
 
 
-# XXX: Eventually rewrite this as a context aware defaultFactory
-form.default_value(field=IClassification['classification'])(
-    set_default_with_acquisition(
+@provider(IContextAwareDefaultFactory)
+def classification_default(context):
+    default_factory = set_default_with_acquisition(
         field=IClassification['classification'],
-        default=CLASSIFICATION_UNPROTECTED
-    )
-)
+        default=CLASSIFICATION_UNPROTECTED)
+    return default_factory(context)
+
+IClassification['classification'].defaultFactory = classification_default
+
 
 # PRIVACY_LAYER: Vocabulary and default value
 PRIVACY_LAYER_NO = u'privacy_layer_no'

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -173,13 +173,14 @@ privacy_layer_vf = RestrictedVocabularyFactory(
     restricted=True)
 
 
-# XXX: Eventually rewrite this as a context aware defaultFactory
-form.default_value(field=IClassification['privacy_layer'])(
-    set_default_with_acquisition(
+@provider(IContextAwareDefaultFactory)
+def privacy_layer_default(context):
+    default_factory = set_default_with_acquisition(
         field=IClassification['privacy_layer'],
-        default=PRIVACY_LAYER_NO
-    )
-)
+        default=PRIVACY_LAYER_NO)
+    return default_factory(context)
+
+IClassification['privacy_layer'].defaultFactory = privacy_layer_default
 
 
 class Classification(metadata.MetadataBase):

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -1,6 +1,6 @@
 from five import grok
 from opengever.base import _
-from opengever.base.acquisition import set_default_with_acquisition
+from opengever.base.acquisition import acquired_default_factory
 from opengever.base.restricted_vocab import propagate_vocab_restrictions
 from opengever.base.restricted_vocab import RestrictedVocabularyFactory
 from opengever.base.utils import language_cache_key
@@ -149,7 +149,7 @@ classification_vf = RestrictedVocabularyFactory(
 
 @provider(IContextAwareDefaultFactory)
 def classification_default(context):
-    default_factory = set_default_with_acquisition(
+    default_factory = acquired_default_factory(
         field=IClassification['classification'],
         default=CLASSIFICATION_UNPROTECTED)
     return default_factory(context)
@@ -175,7 +175,7 @@ privacy_layer_vf = RestrictedVocabularyFactory(
 
 @provider(IContextAwareDefaultFactory)
 def privacy_layer_default(context):
-    default_factory = set_default_with_acquisition(
+    default_factory = acquired_default_factory(
         field=IClassification['privacy_layer'],
         default=PRIVACY_LAYER_NO)
     return default_factory(context)

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -1,7 +1,7 @@
 from five import grok
 from ftw.datepicker.widget import DatePickerFieldWidget
 from opengever.base import _
-from opengever.base.acquisition import set_default_with_acquisition
+from opengever.base.acquisition import acquired_default_factory
 from opengever.base.interfaces import IBaseCustodyPeriods
 from opengever.base.interfaces import IRetentionPeriodRegister
 from opengever.base.restricted_vocab import propagate_vocab_restrictions
@@ -135,7 +135,7 @@ retention_period_vf = RestrictedVocabularyFactory(
 
 @provider(IContextAwareDefaultFactory)
 def retention_period_default(context):
-    default_factory = set_default_with_acquisition(
+    default_factory = acquired_default_factory(
         field=ILifeCycle['retention_period'],
         default=5)
     return default_factory(context)
@@ -168,7 +168,7 @@ custody_period_vf = RestrictedVocabularyFactory(
 
 @provider(IContextAwareDefaultFactory)
 def custody_period_default(context):
-    default_factory = set_default_with_acquisition(
+    default_factory = acquired_default_factory(
         field=ILifeCycle['custody_period'],
         default=30)
     return default_factory(context)
@@ -200,7 +200,7 @@ archival_value_vf = RestrictedVocabularyFactory(
 
 @provider(IContextAwareDefaultFactory)
 def archival_value_default(context):
-    default_factory = set_default_with_acquisition(
+    default_factory = acquired_default_factory(
         field=ILifeCycle['archival_value'],
         default=ARCHIVAL_VALUE_UNCHECKED)
     return default_factory(context)

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -166,14 +166,14 @@ custody_period_vf = RestrictedVocabularyFactory(
     restricted=True)
 
 
-# Default value
-# XXX: Eventually rewrite this as a context aware defaultFactory
-form.default_value(field=ILifeCycle['custody_period'])(
-    set_default_with_acquisition(
+@provider(IContextAwareDefaultFactory)
+def custody_period_default(context):
+    default_factory = set_default_with_acquisition(
         field=ILifeCycle['custody_period'],
-        default=30,
-    )
-)
+        default=30)
+    return default_factory(context)
+
+ILifeCycle['custody_period'].defaultFactory = custody_period_default
 
 
 # ARCHIVAL VALUE: Vocabulary and default value

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -198,10 +198,11 @@ archival_value_vf = RestrictedVocabularyFactory(
     restricted=True)
 
 
-# XXX: Eventually rewrite this as a context aware defaultFactory
-form.default_value(field=ILifeCycle['archival_value'])(
-    set_default_with_acquisition(
+@provider(IContextAwareDefaultFactory)
+def archival_value_default(context):
+    default_factory = set_default_with_acquisition(
         field=ILifeCycle['archival_value'],
-        default=ARCHIVAL_VALUE_UNCHECKED
-    )
-)
+        default=ARCHIVAL_VALUE_UNCHECKED)
+    return default_factory(context)
+
+ILifeCycle['archival_value'].defaultFactory = archival_value_default

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -13,7 +13,9 @@ from zope import schema
 from zope.component import getUtility
 from zope.interface import alsoProvides
 from zope.interface import Interface
+from zope.interface import provider
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.schema.interfaces import IContextAwareDefaultFactory
 
 
 class ILifeCycleMarker(Interface):
@@ -131,12 +133,14 @@ retention_period_vf = RestrictedVocabularyFactory(
     restricted=_is_retention_period_restricted)
 
 
-# Default value
-# XXX: Eventually rewrite this as a context aware defaultFactory
-form.default_value(field=ILifeCycle['retention_period'])(
-    set_default_with_acquisition(
+@provider(IContextAwareDefaultFactory)
+def retention_period_default(context):
+    default_factory = set_default_with_acquisition(
         field=ILifeCycle['retention_period'],
-        default=5))
+        default=5)
+    return default_factory(context)
+
+ILifeCycle['retention_period'].defaultFactory = retention_period_default
 
 
 # ---------- CUSTODY PERIOD -----------

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -35,6 +35,7 @@ REPOROOT_FORM_INITVALUES = {
 
 
 REPOFOLDER_DEFAULTS = {
+    'archival_value': u'unchecked',
     'classification': u'unprotected',
     'creators': (),
     'custody_period': 30,
@@ -46,9 +47,7 @@ REPOFOLDER_DEFAULTS = {
     'retention_period': 5,
     'title_de': DEFAULT_TITLE,
 }
-REPOFOLDER_FORM_DEFAULTS = {
-    'archival_value': u'unchecked',
-}
+REPOFOLDER_FORM_DEFAULTS = {}
 REPOFOLDER_FORM_INITVALUES = {
     'addable_dossier_types': [],
     'archival_value_annotation': None,
@@ -64,6 +63,7 @@ REPOFOLDER_FORM_INITVALUES = {
 
 
 DOSSIER_DEFAULTS = {
+    'archival_value': u'unchecked',
     'classification': u'unprotected',
     'custody_period': 30,
     'description': u'',
@@ -77,7 +77,6 @@ DOSSIER_DEFAULTS = {
     'title': DEFAULT_TITLE,
 }
 DOSSIER_FORM_DEFAULTS = {
-    'archival_value': u'unchecked',
     'responsible': TEST_USER_ID,
 }
 DOSSIER_FORM_INITVALUES = {

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -37,6 +37,7 @@ REPOROOT_FORM_INITVALUES = {
 REPOFOLDER_DEFAULTS = {
     'classification': u'unprotected',
     'creators': (),
+    'custody_period': 30,
     'description': u'',
     'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
@@ -47,7 +48,6 @@ REPOFOLDER_DEFAULTS = {
 }
 REPOFOLDER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
-    'custody_period': 30,
 }
 REPOFOLDER_FORM_INITVALUES = {
     'addable_dossier_types': [],
@@ -65,6 +65,7 @@ REPOFOLDER_FORM_INITVALUES = {
 
 DOSSIER_DEFAULTS = {
     'classification': u'unprotected',
+    'custody_period': 30,
     'description': u'',
     'keywords': (),
     'privacy_layer': u'privacy_layer_no',
@@ -77,7 +78,6 @@ DOSSIER_DEFAULTS = {
 }
 DOSSIER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
-    'custody_period': 30,
     'responsible': TEST_USER_ID,
 }
 DOSSIER_FORM_INITVALUES = {

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -42,12 +42,12 @@ REPOFOLDER_DEFAULTS = {
     'public_trial': u'unchecked',
     'public_trial_statement': '',
     'reference_number_prefix': u'1',
+    'retention_period': 5,
     'title_de': DEFAULT_TITLE,
 }
 REPOFOLDER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
     'custody_period': 30,
-    'retention_period': 5,
 }
 REPOFOLDER_FORM_INITVALUES = {
     'addable_dossier_types': [],
@@ -71,6 +71,7 @@ DOSSIER_DEFAULTS = {
     'public_trial': u'unchecked',
     'public_trial_statement': u'',
     'relatedDossier': [],
+    'retention_period': 5,
     'start': FROZEN_TODAY,
     'title': DEFAULT_TITLE,
 }
@@ -78,7 +79,6 @@ DOSSIER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
     'custody_period': 30,
     'responsible': TEST_USER_ID,
-    'retention_period': 5,
 }
 DOSSIER_FORM_INITVALUES = {
     'archival_value_annotation': None,

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -35,6 +35,7 @@ REPOROOT_FORM_INITVALUES = {
 
 
 REPOFOLDER_DEFAULTS = {
+    'classification': u'unprotected',
     'creators': (),
     'description': u'',
     'public_trial': u'unchecked',
@@ -44,7 +45,6 @@ REPOFOLDER_DEFAULTS = {
 }
 REPOFOLDER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
-    'classification': u'unprotected',
     'custody_period': 30,
     'privacy_layer': u'privacy_layer_no',
     'retention_period': 5,
@@ -64,6 +64,7 @@ REPOFOLDER_FORM_INITVALUES = {
 
 
 DOSSIER_DEFAULTS = {
+    'classification': u'unprotected',
     'description': u'',
     'keywords': (),
     'public_trial': u'unchecked',
@@ -74,7 +75,6 @@ DOSSIER_DEFAULTS = {
 }
 DOSSIER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
-    'classification': u'unprotected',
     'custody_period': 30,
     'privacy_layer': u'privacy_layer_no',
     'responsible': TEST_USER_ID,
@@ -95,6 +95,7 @@ DOSSIER_FORM_INITVALUES = {
 
 
 DOCUMENT_DEFAULTS = {
+    'classification': u'unprotected',
     'creators': (),
     'description': u'',
     'digitally_available': False,
@@ -107,7 +108,6 @@ DOCUMENT_DEFAULTS = {
     'title': DEFAULT_TITLE,
 }
 DOCUMENT_FORM_DEFAULTS = {
-    'classification': u'unprotected',
     'privacy_layer': u'privacy_layer_no',
 }
 DOCUMENT_FORM_INITVALUES = {
@@ -121,6 +121,7 @@ DOCUMENT_FORM_INITVALUES = {
 
 
 MAIL_DEFAULTS = {
+    'classification': u'unprotected',
     'description': u'',
     'digitally_available': True,
     'document_author': u'from@example.org',
@@ -132,7 +133,6 @@ MAIL_DEFAULTS = {
     'receipt_date': FROZEN_TODAY,
 }
 MAIL_FORM_DEFAULTS = {
-    'classification': u'unprotected',
     'privacy_layer': u'privacy_layer_no',
 }
 MAIL_FORM_INITVALUES = {

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -38,6 +38,7 @@ REPOFOLDER_DEFAULTS = {
     'classification': u'unprotected',
     'creators': (),
     'description': u'',
+    'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
     'public_trial_statement': '',
     'reference_number_prefix': u'1',
@@ -46,7 +47,6 @@ REPOFOLDER_DEFAULTS = {
 REPOFOLDER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
     'custody_period': 30,
-    'privacy_layer': u'privacy_layer_no',
     'retention_period': 5,
 }
 REPOFOLDER_FORM_INITVALUES = {
@@ -67,6 +67,7 @@ DOSSIER_DEFAULTS = {
     'classification': u'unprotected',
     'description': u'',
     'keywords': (),
+    'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
     'public_trial_statement': u'',
     'relatedDossier': [],
@@ -76,7 +77,6 @@ DOSSIER_DEFAULTS = {
 DOSSIER_FORM_DEFAULTS = {
     'archival_value': u'unchecked',
     'custody_period': 30,
-    'privacy_layer': u'privacy_layer_no',
     'responsible': TEST_USER_ID,
     'retention_period': 5,
 }
@@ -102,14 +102,13 @@ DOCUMENT_DEFAULTS = {
     'document_date': FROZEN_TODAY,
     'keywords': (),
     'preserved_as_paper': True,
+    'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
     'public_trial_statement': '',
     'relatedItems': [],
     'title': DEFAULT_TITLE,
 }
-DOCUMENT_FORM_DEFAULTS = {
-    'privacy_layer': u'privacy_layer_no',
-}
+DOCUMENT_FORM_DEFAULTS = {}
 DOCUMENT_FORM_INITVALUES = {
     'delivery_date': None,
     'document_author': None,
@@ -128,13 +127,12 @@ MAIL_DEFAULTS = {
     'document_date': date(2010, 1, 1),
     'keywords': (),
     'preserved_as_paper': True,
+    'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
     'public_trial_statement': '',
     'receipt_date': FROZEN_TODAY,
 }
-MAIL_FORM_DEFAULTS = {
-    'privacy_layer': u'privacy_layer_no',
-}
+MAIL_FORM_DEFAULTS = {}
 MAIL_FORM_INITVALUES = {
     'delivery_date': None,
     'document_type': None,


### PR DESCRIPTION
This rewrites the last remaining field defaults (that *shouldn't* be form defaults) as `defaultFactories`. Those are `IClassification` and `LifeCycle` fields that use fancy restricted vocabularies that had to undergo a major refactoring first (#2047).

@phgross 