### PR TITLE
Deactivate 'Authentication' capability for LDAP plugin during setup for production deployments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Deactivate 'Authentication' capability for LDAP plugin during setup for
+  production deployments.
+  In production, auth will always be performed by CAS portal.
+  [lgraf]
+
 - Document Tooltip:
 
   - Add label to the thumbnail link.

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -9,6 +9,7 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
 from Products.CMFPlone.factory import addPloneSite
 from Products.CMFPlone.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
 from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from sqlalchemy import MetaData
 from zope.component import getAdapter
@@ -111,6 +112,11 @@ class GeverDeployment(object):
         plugins.movePluginsUp(IPropertiesPlugin, ('ldap',))
         plugins.movePluginsUp(IPropertiesPlugin, ('ldap',))
         plugins.movePluginsUp(IPropertiesPlugin, ('ldap',))
+
+        if not self.is_development_setup:
+            # Deactivate 'Authentication' capability for LDAP plugin
+            # In production, auth will always be performed by CAS portal
+            plugins.deactivatePlugin(IAuthenticationPlugin, 'ldap')
 
     def sync_ogds(self):
         if not self.has_ogds_sync:


### PR DESCRIPTION
In production, authentication will always be performed by CAS portal, and it should not be possible to authenticate against LDAP with Plone directly (e.g. via `/login_form`).

This is necessary so we can enforce the requirement for the second factor in 2FA via the CAS Portal.

⚠️  **Note** ⚠️ 
This means that it will be impossible to authenticate via LDAP *without the CAS Portal* for any deployment that isn't a local development setup (extending from `development.cfg`). *Every* GEVER deployment needs a CAS Portal from now on.

@phgross   