### PR TITLE
Bumblebee overlay and tooltip improvments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Link dossier title in bumblebee overlay.
+  [phgross]
+
 - Add new tabs `Persons` and `Organizations` to the contactfolder tabbedview.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
-- Link breadcrumbs in document tooltip.
+- Document Tooltip:
+
+  - Add label to the thumbnail link.
+  - Link breadcrumbs in document tooltip.
+
   [phgross]
 
 - Link dossier title in bumblebee overlay.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 
   - Add label to the thumbnail link.
   - Link breadcrumbs in document tooltip.
+  - Improve tooltip position.
 
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Link breadcrumbs in document tooltip.
+  [phgross]
+
 - Link dossier title in bumblebee overlay.
   [phgross]
 

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -6,9 +6,10 @@
     position: {
       target: "mouse", // Set tooltip position relative to the current mouse location
       viewport: $(window), // The tooltip must not leave the window
+      at: "bottom right",
+      my: "center left",
       adjust: {
         mouse: false, // Do not track the mouse
-        method: "shift", // Set the x,y coordinates when the tooltip should leave the viewport
         x: 20, // Slighly shift the location in x direction
         y: 20 // Slighly shift the location in y direction
       },

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -20,7 +20,9 @@
       </tr>
       <tr tal:define="dossier view/overlay/get_containing_dossier" tal:condition="nocall: dossier">
         <td class="title" i18n:translate="">Dossier:</td>
-        <td class="value" tal:attributes="href dossier/absolute_url" tal:content="dossier/Title"></td>
+        <td class="value">
+          <a tal:attributes="href dossier/absolute_url" tal:content="dossier/Title" />
+        </td>
       </tr>
       <tr>
         <td class="title" i18n:translate="">Reference number:</td>

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -159,6 +159,19 @@ class TestBumblebeeOverlayDocument(FunctionalTestCase):
         self.assertEqual(document.absolute_url(), title.get("href"))
 
     @browsing
+    def test_dossier_title_is_linked_to_the_dossier(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier A'))
+        document = create(Builder('document')
+                          .titled(u"Anfrage Meier")
+                          .within(dossier))
+
+        browser.login().visit(document, view="bumblebee-overlay-document")
+
+        dossier_link = browser.css('.metadata .value a')[1]
+        self.assertEqual('Dossier A', dossier_link.text)
+        self.assertEqual(dossier.absolute_url(), dossier_link.get('href'))
+
+    @browsing
     def test_actions_with_file(self, browser):
         dossier = create(Builder('dossier'))
         document = create(Builder('document')

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-07-29 08:44+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -378,6 +378,11 @@ msgstr "Nein"
 msgid "label_ok"
 msgstr "OK"
 
+#. Default: "Open document preview"
+#: ./opengever/document/widgets/tooltip.pt:42
+msgid "label_open_document_preview"
+msgstr "Dokumentvorschau öffnen"
+
 #. Default: "PDF Preview"
 #: ./opengever/document/browser/templates/file.pt:23
 msgid "label_pdf_preview"
@@ -483,4 +488,3 @@ msgstr "Mit Kommentar"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Ohne Kommentar"
-

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-07-29 08:44+0000\n"
 "PO-Revision-Date: 2013-07-09 10:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -369,6 +369,11 @@ msgstr "Non"
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:40
 msgid "label_ok"
 msgstr "Ok"
+
+#. Default: "Open document preview"
+#: ./opengever/document/widgets/tooltip.pt:42
+msgid "label_open_document_preview"
+msgstr ""
 
 #. Default: "PDF Preview"
 #: ./opengever/document/browser/templates/file.pt:23

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-07-29 08:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -371,6 +371,11 @@ msgstr ""
 
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:40
 msgid "label_ok"
+msgstr ""
+
+#. Default: "Open document preview"
+#: ./opengever/document/widgets/tooltip.pt:42
+msgid "label_open_document_preview"
 msgstr ""
 
 #. Default: "PDF Preview"

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -155,3 +155,7 @@ class TestDocumentLinkWidgetWithActivatedBumblebee(FunctionalTestCase):
             self.assertEquals(
                 thumbnail_url,
                 browser.css('.preview img').first.get('src'))
+
+            self.assertEquals(
+                ['Open document preview'],
+                browser.css('.preview span').text)

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -20,7 +20,7 @@ class TestDocumentTooltip(FunctionalTestCase):
         pdfconverter.PDFCONVERTER_AVAILABLE = self.converter_avaialable
 
     @browsing
-    def test_tooltip_contains_breadcrumb(self, browser):
+    def test_tooltip_contains_linked_breadcrumb(self, browser):
         root = create(Builder('repository_root').titled(u'Ordnungssystem'))
         repo = create(Builder('repository')
                       .within(root)
@@ -37,6 +37,10 @@ class TestDocumentTooltip(FunctionalTestCase):
         self.assertEquals(
             ['Ordnungssystem', '1. Ablage 1', 'Hans Meier', 'Anfrage Meier'],
             browser.css('.tooltip-breadcrumb li').text)
+
+        self.assertEquals(
+            [obj.absolute_url() for obj in [root, repo, dossier, document]],
+            [link.get('href') for link in browser.css('.tooltip-breadcrumb li a')])
 
     @browsing
     def test_tooltip_actions(self, browser):

--- a/opengever/document/widgets/tooltip.pt
+++ b/opengever/document/widgets/tooltip.pt
@@ -1,6 +1,8 @@
 <div class='tooltip-header' tal:content="context/title" />
 <ul class='tooltip-breadcrumb' tal:define="breadcrumbs view/document/get_breadcrumbs">
-  <li tal:repeat="breadcrumb breadcrumbs" tal:content="breadcrumb/Title" />
+  <li tal:repeat="breadcrumb breadcrumbs">
+    <a tal:content="breadcrumb/Title" tal:attributes="href breadcrumb/absolute_url" />
+  </li>
 </ul>
 
 <div class='tooltip-content'>

--- a/opengever/document/widgets/tooltip.pt
+++ b/opengever/document/widgets/tooltip.pt
@@ -39,6 +39,7 @@
        tal:attributes="data-showroom-id string:showroom-id-${view/document/uuid}">
       <img tal:attributes="src view/document/get_preview_image_url; alt context/title"
            width="200" class="file-preview" />
+      <span i18n:domain="opengever.document" i18n:translate="label_open_document_preview">Open document preview</span>
     </a>
   </div>
 


### PR DESCRIPTION
- Link dossier title in bumblebee overlay, closes #2072 
- Link breadcrumbs in document tooltip, closes #2069  
- Add label below the thumbnail link, closes #2068
- Improve tooltip position (closes #2071 ):
  The tooltip is now always positioned on the vertical center of the mouse, usually on the right side. If    there is not enough space, its positioned on the left side of the mouse.

Overlay:
<img width="1200" alt="bildschirmfoto 2016-07-29 um 11 04 55" src="https://cloud.githubusercontent.com/assets/485755/17243310/4f351ee4-557c-11e6-9175-b6491edf45b2.png">

Tooltip:
![bildschirmfoto 2016-07-29 um 11 00 21](https://cloud.githubusercontent.com/assets/485755/17243287/2a917cb8-557c-11e6-8cb7-f66312fd14e5.png)
![bildschirmfoto 2016-07-29 um 11 00 10](https://cloud.githubusercontent.com/assets/485755/17243286/2a8e4a20-557c-11e6-88de-b7243a20ef34.png)

@lukasgraf 
