### PR TITLE
Restructure default value tests

### DIFF
--- a/opengever/api/tests/test_content_creation.py
+++ b/opengever/api/tests/test_content_creation.py
@@ -8,7 +8,6 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
 import transaction
-import unittest
 
 
 class TestContentCreation(FunctionalTestCase):
@@ -40,30 +39,6 @@ class TestContentCreation(FunctionalTestCase):
         lang_tool.supported_langs = ['fr-ch', 'de-ch']
         transaction.commit()
 
-    @unittest.skip("""This test fails because of a broken default value
-    lookup for the `privacy_layer` and `classification` fields after patching
-    DexterityContent.__getattr__:
-
-    Before the patch, the respective field wasn't even found because
-    DexterityContent.__getattr__ looked for it in *marker interfaces* instead
-    of schema interfaces. Because the field was never found, __getattr__ did
-    raise an AttributeError in the end, and triggered Acquisition. Using
-    acquisition, the attribute was looked up on parents (dossiers, repofolders)
-    which *did* have a value set, and that's why this ever worked at all.
-
-    With the patch, DexterityContent.__getattr__ now correctly takes schema
-    interfaces for behaviors into consideration when looking for the field.
-    The field is therefore found. But the `privacy_layer` and `classification`
-    fields currently do not have a Field.default(Factory) yet, but still use
-    z3c.form default value adapters. The way zope.schema's DefaultProperty is
-    implemented though, it always returns a value, `None` if no default is
-    set. This doesn't validate, and leads to errors during content creation if
-    those fields are omitted.
-
-    Once the default value adapters for those (and possibly other) fields
-    have been rewritten as defaultFactories, it should be possible to re-enable
-    this test without any changes.
-    """)
     def test_dossier_creation(self):
         payload = {
             u'@type': u'opengever.dossier.businesscasedossier',
@@ -82,8 +57,6 @@ class TestContentCreation(FunctionalTestCase):
         dossier = self.repofolder.restrictedTraverse('dossier-2')
         self.assertEqual(u'Sanierung B\xe4rengraben 2016', dossier.title)
 
-    @unittest.skip("""This test is failing for the same reason as
-    test_dossier_creation above""")
     def test_document_creation(self):
         payload = {
             u'@type': u'opengever.document.document',

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -251,7 +251,7 @@ class TestRepositoryRootDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_portal(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.portal.invokeFactory(
                 'opengever.repository.repositoryroot',
@@ -296,32 +296,13 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_portal(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.portal.invokeFactory(
                 'opengever.repository.repositoryfolder',
                 'repofolder',
                 title_de=DEFAULT_TITLE)
             repofolder = self.portal[new_id]
-
-        persisted_values = get_persisted_values_for_obj(repofolder)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    def test_invoke_factory_on_dx_container(self):
-        outer_repofolder = createContentInContainer(
-            self.portal,
-            'opengever.repository.repositoryfolder',
-            title_de=u'Outer RepoFolder',
-        )
-
-        with freeze(FROZEN_NOW):
-            new_id = outer_repofolder.invokeFactory(
-                'opengever.repository.repositoryfolder',
-                'repofolder',
-                title_de=DEFAULT_TITLE)
-            repofolder = outer_repofolder[new_id]
 
         persisted_values = get_persisted_values_for_obj(repofolder)
         expected = self.get_type_defaults()
@@ -364,32 +345,13 @@ class TestDossierDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_portal(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.portal.invokeFactory(
                 'opengever.dossier.businesscasedossier',
                 'dossier-1',
                 title=DEFAULT_TITLE)
             dossier = self.portal[new_id]
-
-        persisted_values = get_persisted_values_for_obj(dossier)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    def test_invoke_factory_on_dx_container(self):
-        outer_dossier = createContentInContainer(
-            self.portal,
-            'opengever.dossier.businesscasedossier',
-            title=u'Outer Dossier',
-        )
-
-        with freeze(FROZEN_NOW):
-            new_id = outer_dossier.invokeFactory(
-                'opengever.dossier.businesscasedossier',
-                'dossier-1',
-                title=DEFAULT_TITLE)
-            dossier = outer_dossier[new_id]
 
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_type_defaults()
@@ -431,32 +393,13 @@ class TestDocumentDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_portal(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.portal.invokeFactory(
                 'opengever.document.document',
                 'document-1',
                 title=DEFAULT_TITLE)
             doc = self.portal[new_id]
-
-        persisted_values = get_persisted_values_for_obj(doc)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    def test_invoke_factory_on_dx_container(self):
-        outer_dossier = createContentInContainer(
-            self.portal,
-            'opengever.dossier.businesscasedossier',
-            title=u'Outer Dossier',
-        )
-
-        with freeze(FROZEN_NOW):
-            new_id = outer_dossier.invokeFactory(
-                'opengever.document.document',
-                'document-1',
-                title=DEFAULT_TITLE)
-            doc = outer_dossier[new_id]
 
         persisted_values = get_persisted_values_for_obj(doc)
         expected = self.get_type_defaults()
@@ -530,7 +473,7 @@ class TestMailDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_portal(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.portal.invokeFactory(
                 'ftw.mail.mail',
@@ -538,26 +481,6 @@ class TestMailDefaults(TestDefaultsBase):
                 title=DEFAULT_TITLE,
                 message=self.sample_msg)
             mail = self.portal[new_id]
-
-        persisted_values = get_persisted_values_for_obj(mail)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    def test_invoke_factory_on_dx_container(self):
-        outer_dossier = createContentInContainer(
-            self.portal,
-            'opengever.dossier.businesscasedossier',
-            title=u'Outer Dossier',
-        )
-
-        with freeze(FROZEN_NOW):
-            new_id = outer_dossier.invokeFactory(
-                'ftw.mail.mail',
-                'document-1',
-                title=DEFAULT_TITLE,
-                message=self.sample_msg)
-            mail = outer_dossier[new_id]
 
         persisted_values = get_persisted_values_for_obj(mail)
         expected = self.get_type_defaults()
@@ -606,7 +529,7 @@ class TestTaskDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_portal(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.portal.invokeFactory(
                 'opengever.task.task',
@@ -616,28 +539,6 @@ class TestTaskDefaults(TestDefaultsBase):
                 responsible=TEST_USER_ID,
                 responsible_client='client1')
             task = self.portal[new_id]
-
-        persisted_values = get_persisted_values_for_obj(task)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    def test_invoke_factory_on_dx_container(self):
-        outer_dossier = createContentInContainer(
-            self.portal,
-            'opengever.dossier.businesscasedossier',
-            title=u'Outer Dossier',
-        )
-
-        with freeze(FROZEN_NOW):
-            new_id = outer_dossier.invokeFactory(
-                'opengever.task.task',
-                'task-1',
-                title=DEFAULT_TITLE,
-                issuer=TEST_USER_ID,
-                responsible=TEST_USER_ID,
-                responsible_client='client1')
-            task = outer_dossier[new_id]
 
         persisted_values = get_persisted_values_for_obj(task)
         expected = self.get_type_defaults()
@@ -687,7 +588,7 @@ class TestContactDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_dx_container(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.contactfolder.invokeFactory(
                 'opengever.contact.contact',
@@ -747,7 +648,7 @@ class TestCommitteeDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
-    def test_invoke_factory_on_dx_container(self):
+    def test_invoke_factory(self):
         with freeze(FROZEN_NOW):
             new_id = self.container.invokeFactory(
                 'opengever.meeting.committee',

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -5,7 +5,6 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testing import freeze
 from opengever.base.default_values import get_persisted_values_for_obj
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import setRoles
@@ -201,16 +200,6 @@ CONTACT_MISSING_VALUES = {
     'salutation': None,
     'url': None,
     'zip_code': None,
-}
-
-
-COMMITTEE_REQUIREDS = {}
-COMMITTEE_DEFAULTS = {}
-COMMITTEE_FORM_DEFAULTS = {}
-COMMITTEE_MISSING_VALUES = {
-    'agendaitem_list_template': None,
-    'excerpt_template': None,
-    'protocol_template': None,
 }
 
 
@@ -657,76 +646,5 @@ class TestContactDefaults(TestDefaultsBase):
 
         # XXX: Don't know why this happens
         expected['description'] = None
-
-        self.assertDictEqual(expected, persisted_values)
-
-
-class TestCommitteeDefaults(TestDefaultsBase):
-
-    requireds = COMMITTEE_REQUIREDS
-    type_defaults = COMMITTEE_DEFAULTS
-    form_defaults = COMMITTEE_FORM_DEFAULTS
-    missing_values = COMMITTEE_MISSING_VALUES
-
-    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
-
-    def setUp(self):
-        super(TestCommitteeDefaults, self).setUp()
-        self.container = createContentInContainer(
-            self.portal,
-            'opengever.meeting.committeecontainer',
-            title=u'Meetings',
-        )
-        transaction.commit()
-
-    def test_create_content_in_container(self):
-        with freeze(FROZEN_NOW):
-            committee = createContentInContainer(
-                self.container,
-                'opengever.meeting.committee',
-                title=DEFAULT_TITLE)
-
-        persisted_values = get_persisted_values_for_obj(committee)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    def test_invoke_factory(self):
-        with freeze(FROZEN_NOW):
-            new_id = self.container.invokeFactory(
-                'opengever.meeting.committee',
-                'committee-1',
-                title=DEFAULT_TITLE)
-            contact = self.container[new_id]
-
-        persisted_values = get_persisted_values_for_obj(contact)
-        expected = self.get_type_defaults()
-
-        self.assertDictEqual(expected, persisted_values)
-
-    @browsing
-    def test_z3c_add_form(self, browser):
-        repofolder = createContentInContainer(
-            self.portal,
-            'opengever.repository.repositoryfolder',
-            title='Repofolder')
-        transaction.commit()
-
-        with freeze(FROZEN_NOW):
-            browser.login().open(self.container)
-            factoriesmenu.add(u'Committee')
-            browser.fill({
-                u'Title': DEFAULT_TITLE,
-                u'Group': 'client1_users',
-                u'Linked repository folder ': repofolder})
-            browser.find('Continue').click()
-            browser.find('Save').click()
-            committee = browser.context
-
-        persisted_values = get_persisted_values_for_obj(committee)
-        expected = self.get_z3c_form_defaults()
-
-        linked_repo = persisted_values.pop('repository_folder')
-        self.assertEqual(linked_repo.to_object, repofolder)
 
         self.assertDictEqual(expected, persisted_values)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -27,7 +27,7 @@ REPOROOT_DEFAULTS = {
     'title_de': DEFAULT_TITLE,
 }
 REPOROOT_FORM_DEFAULTS = {}
-REPOROOT_FORM_INITVALUES = {
+REPOROOT_MISSING_VALUES = {
     'valid_from': None,
     'valid_until': None,
     'version': None,
@@ -48,7 +48,7 @@ REPOFOLDER_DEFAULTS = {
     'title_de': DEFAULT_TITLE,
 }
 REPOFOLDER_FORM_DEFAULTS = {}
-REPOFOLDER_FORM_INITVALUES = {
+REPOFOLDER_MISSING_VALUES = {
     'addable_dossier_types': [],
     'archival_value_annotation': None,
     'date_of_cassation': None,
@@ -79,7 +79,7 @@ DOSSIER_DEFAULTS = {
 DOSSIER_FORM_DEFAULTS = {
     'responsible': TEST_USER_ID,
 }
-DOSSIER_FORM_INITVALUES = {
+DOSSIER_MISSING_VALUES = {
     'archival_value_annotation': None,
     'comments': None,
     'container_location': None,
@@ -108,7 +108,7 @@ DOCUMENT_DEFAULTS = {
     'title': DEFAULT_TITLE,
 }
 DOCUMENT_FORM_DEFAULTS = {}
-DOCUMENT_FORM_INITVALUES = {
+DOCUMENT_MISSING_VALUES = {
     'delivery_date': None,
     'document_author': None,
     'document_type': None,
@@ -132,7 +132,7 @@ MAIL_DEFAULTS = {
     'receipt_date': FROZEN_TODAY,
 }
 MAIL_FORM_DEFAULTS = {}
-MAIL_FORM_INITVALUES = {
+MAIL_MISSING_VALUES = {
     'delivery_date': None,
     'document_type': None,
     'foreign_reference': None,
@@ -150,7 +150,7 @@ TASK_DEFAULTS = {
 TASK_FORM_DEFAULTS = {
     'responsible_client': u'client1',
 }
-TASK_FORM_INITVALUES = {
+TASK_MISSING_VALUES = {
     'date_of_completion': None,
     'effectiveCost': None,
     'effectiveDuration': None,
@@ -166,7 +166,7 @@ CONTACT_DEFAULTS = {
     'description': u'',
 }
 CONTACT_FORM_DEFAULTS = {}
-CONTACT_FORM_INITVALUES = {
+CONTACT_MISSING_VALUES = {
     'academic_title': None,
     'address1': None,
     'address2': None,
@@ -192,7 +192,7 @@ CONTACT_FORM_INITVALUES = {
 
 COMMITTEE_DEFAULTS = {}
 COMMITTEE_FORM_DEFAULTS = {}
-COMMITTEE_FORM_INITVALUES = {
+COMMITTEE_MISSING_VALUES = {
     'agendaitem_list_template': None,
     'excerpt_template': None,
     'protocol_template': None,
@@ -203,7 +203,7 @@ class TestDefaultsBase(FunctionalTestCase):
 
     type_defaults = None
     form_defaults = None
-    form_initvalues = None
+    missing_values = None
 
     def setUp(self):
         super(TestDefaultsBase, self).setUp()
@@ -225,7 +225,7 @@ class TestDefaultsBase(FunctionalTestCase):
         defaults = {}
         defaults.update(self.type_defaults)
         defaults.update(self.form_defaults)
-        defaults.update(self.form_initvalues)
+        defaults.update(self.missing_values)
 
         for key in OMITTED_FORM_FIELDS:
             defaults.pop(key, None)
@@ -237,7 +237,7 @@ class TestRepositoryRootDefaults(TestDefaultsBase):
 
     type_defaults = REPOROOT_DEFAULTS
     form_defaults = REPOROOT_FORM_DEFAULTS
-    form_initvalues = REPOROOT_FORM_INITVALUES
+    missing_values = REPOROOT_MISSING_VALUES
 
     def test_create_content_in_container(self):
         with freeze(FROZEN_NOW):
@@ -282,7 +282,7 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
 
     type_defaults = REPOFOLDER_DEFAULTS
     form_defaults = REPOFOLDER_FORM_DEFAULTS
-    form_initvalues = REPOFOLDER_FORM_INITVALUES
+    missing_values = REPOFOLDER_MISSING_VALUES
 
     def test_create_content_in_container(self):
         with freeze(FROZEN_NOW):
@@ -331,7 +331,7 @@ class TestDossierDefaults(TestDefaultsBase):
 
     type_defaults = DOSSIER_DEFAULTS
     form_defaults = DOSSIER_FORM_DEFAULTS
-    form_initvalues = DOSSIER_FORM_INITVALUES
+    missing_values = DOSSIER_MISSING_VALUES
 
     def test_create_content_in_container(self):
         with freeze(FROZEN_NOW):
@@ -379,7 +379,7 @@ class TestDocumentDefaults(TestDefaultsBase):
 
     type_defaults = DOCUMENT_DEFAULTS
     form_defaults = DOCUMENT_FORM_DEFAULTS
-    form_initvalues = DOCUMENT_FORM_INITVALUES
+    missing_values = DOCUMENT_MISSING_VALUES
 
     def test_create_content_in_container(self):
         with freeze(FROZEN_NOW):
@@ -437,7 +437,7 @@ class TestMailDefaults(TestDefaultsBase):
 
     type_defaults = MAIL_DEFAULTS
     form_defaults = MAIL_FORM_DEFAULTS
-    form_initvalues = MAIL_FORM_INITVALUES
+    missing_values = MAIL_MISSING_VALUES
 
     SAMPLE_MAIL = textwrap.dedent("""\
         MIME-Version: 1.0
@@ -512,7 +512,7 @@ class TestTaskDefaults(TestDefaultsBase):
 
     type_defaults = TASK_DEFAULTS
     form_defaults = TASK_FORM_DEFAULTS
-    form_initvalues = TASK_FORM_INITVALUES
+    missing_values = TASK_MISSING_VALUES
 
     def test_create_content_in_container(self):
         with freeze(FROZEN_NOW):
@@ -566,7 +566,7 @@ class TestContactDefaults(TestDefaultsBase):
 
     type_defaults = CONTACT_DEFAULTS
     form_defaults = CONTACT_FORM_DEFAULTS
-    form_initvalues = CONTACT_FORM_INITVALUES
+    missing_values = CONTACT_MISSING_VALUES
 
     def setUp(self):
         super(TestContactDefaults, self).setUp()
@@ -623,7 +623,7 @@ class TestCommitteeDefaults(TestDefaultsBase):
 
     type_defaults = COMMITTEE_DEFAULTS
     form_defaults = COMMITTEE_FORM_DEFAULTS
-    form_initvalues = COMMITTEE_FORM_INITVALUES
+    missing_values = COMMITTEE_MISSING_VALUES
 
     layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
 


### PR DESCRIPTION
This is a series of restructurings ad cleanups for the default value tests. These will eventually be needed in order to implement setting missing values.

@phgross  