### PR TITLE
Also set missing values if no default can be found

### DIFF
--- a/opengever/base/default_values.py
+++ b/opengever/base/default_values.py
@@ -156,6 +156,16 @@ def get_persisted_values_for_obj(context):
     return values
 
 
+def object_has_value_for_field(obj, field):
+    """Determine whether a value is persisted on `obj` for `field`.
+    """
+    try:
+        get_persisted_value_for_field(obj, field)
+        return True
+    except AttributeError:
+        return False
+
+
 def set_default_values(content, container, values):
     """Set default values for all fields.
 
@@ -173,15 +183,6 @@ def set_default_values(content, container, values):
 
     """
     marker = object()
-
-    def object_has_value_for_field(obj, field):
-        """Determine whether a value is persisted on `obj` for `field`.
-        """
-        try:
-            get_persisted_value_for_field(content, field)
-            return True
-        except AttributeError:
-            return False
 
     def determine_default_value(field, container):
         """Determine a field's default value during object creation.

--- a/opengever/base/default_values.py
+++ b/opengever/base/default_values.py
@@ -228,18 +228,18 @@ def set_default_values(content, container, values):
 
     for schema in iterSchemata(content):
         for name, field in getFieldsInOrder(schema):
+            if name in values:
+                # Only set default if no *actual* value was supplied as
+                # an argument to object construction
+                continue
+
+            if object_has_value_for_field(content, field):
+                # Only set default if a value hasn't been set on the
+                # object yet
+                continue
+
             default = determine_default_value(field, container)
             if default is not marker:
-                if name in values:
-                    # Only set default if no *actual* value was supplied as
-                    # an argument to object construction
-                    continue
-
-                if object_has_value_for_field(content, field):
-                    # Only set default if a value hasn't been set on the
-                    # object yet
-                    continue
-
                 if not is_aq_wrapped(content):
                     # Content isn't AQ wrapped - temporarily wrap it
                     content = content.__of__(container)

--- a/opengever/base/default_values.py
+++ b/opengever/base/default_values.py
@@ -156,6 +156,14 @@ def get_persisted_values_for_obj(context):
     return values
 
 
+def is_aq_wrapped(obj):
+    try:
+        obj.aq_base
+        return True
+    except AttributeError:
+        return False
+
+
 def object_has_value_for_field(obj, field):
     """Determine whether a value is persisted on `obj` for `field`.
     """
@@ -231,5 +239,9 @@ def set_default_values(content, container, values):
                     # Only set default if a value hasn't been set on the
                     # object yet
                     continue
+
+                if not is_aq_wrapped(content):
+                    # Content isn't AQ wrapped - temporarily wrap it
+                    content = content.__of__(container)
 
                 field.set(field.interface(content), default)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -21,7 +21,11 @@ FROZEN_TODAY = FROZEN_NOW.date()
 DEFAULT_TITLE = u'My title'
 DEFAULT_CLIENT = u'client1'
 
-OMITTED_FORM_FIELDS = ['creators']
+OMITTED_FORM_FIELDS = [
+    'creators', 'predecessor', 'preview', 'archival_file', 'thumbnail',
+    'former_reference_number', 'reference_number',
+    'temporary_former_reference_number'
+]
 
 REPOROOT_REQUIREDS = {
     'title_de': DEFAULT_TITLE,
@@ -93,8 +97,12 @@ DOSSIER_MISSING_VALUES = {
     'date_of_submission': None,
     'end': None,
     'filing_prefix': None,
+    'former_reference_number': None,
     'number_of_containers': None,
+    'reference_number': None,
+    'responsible': None,
     'retention_period_annotation': None,
+    'temporary_former_reference_number': None,
 }
 
 
@@ -116,12 +124,15 @@ DOCUMENT_DEFAULTS = {
 }
 DOCUMENT_FORM_DEFAULTS = {}
 DOCUMENT_MISSING_VALUES = {
+    'archival_file': None,
     'delivery_date': None,
     'document_author': None,
     'document_type': None,
     'file': None,
     'foreign_reference': None,
+    'preview': None,
     'receipt_date': None,
+    'thumbnail': None,
 }
 
 
@@ -141,9 +152,12 @@ MAIL_DEFAULTS = {
 }
 MAIL_FORM_DEFAULTS = {}
 MAIL_MISSING_VALUES = {
+    'archival_file': None,
     'delivery_date': None,
     'document_type': None,
     'foreign_reference': None,
+    'preview': None,
+    'thumbnail': None
 }
 
 
@@ -169,6 +183,7 @@ TASK_MISSING_VALUES = {
     'expectedCost': None,
     'expectedDuration': None,
     'expectedStartOfWork': None,
+    'predecessor': None,
     'text': None,
 }
 
@@ -210,6 +225,8 @@ class TestDefaultsBase(FunctionalTestCase):
     form_defaults = None
     missing_values = None
 
+    maxDiff = None
+
     def setUp(self):
         super(TestDefaultsBase, self).setUp()
         self.portal = self.layer.get('portal')
@@ -225,6 +242,7 @@ class TestDefaultsBase(FunctionalTestCase):
 
     def get_type_defaults(self):
         defaults = {}
+        defaults.update(self.missing_values)
         defaults.update(self.type_defaults)
         defaults.update(self.requireds)
         return defaults
@@ -308,6 +326,9 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(repofolder)
         expected = self.get_type_defaults()
 
+        # XXX: Don't know why this happens
+        expected['addable_dossier_types'] = None
+
         self.assertDictEqual(expected, persisted_values)
 
     def test_invoke_factory(self):
@@ -321,6 +342,9 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(repofolder)
         expected = self.get_type_defaults()
+
+        # XXX: Don't know why this happens
+        expected['addable_dossier_types'] = None
 
         self.assertDictEqual(expected, persisted_values)
 


### PR DESCRIPTION
This changes content creation so that in addition to setting default values, we also set missing values for fields that don't have a default.

This should simply result in **all fields** being set to a value

- provided value
- default value
- missing value

when creating objects with any method:

- through the web 
- `createContentInContainer`
- `invokeFactory`
- `plone.api.content.create`
- `plone.restapi`
- `ftw.builder`
- `transmogrify.dexterity`.

@phgross 
