### PR TITLE
Update API documentation

### DIFF
--- a/docs/api/basics.rst
+++ b/docs/api/basics.rst
@@ -90,6 +90,7 @@ Wenn eine Response einen Body hat, ist dies immer ein JSON-Dokument:
       "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23",
       "@type": "opengever.dossier.businesscasedossier",
       "title": "Titel des Objekts",
+      "review_state": "dossier-state-active",
        "...": "..."
    }
 
@@ -115,6 +116,17 @@ Key           Bedeutung               Beschreibung
                                 wissen, welche Felder mit welchen Datentypen
                                 in einer Antwort zu erwarten sind.
 ============= ================= ===============================================
+
+Zusätzlich zu den oben aufgeführten JSON-LD Attributen gibt es für Objekttypen,
+welche einen Workflow haben, ein allgemeines Property ``review_state``, welches
+den aktuellen Workflow-State enthält:
+
+================= ================= ===============================================
+Key               Bedeutung               Beschreibung
+================= ================= ===============================================
+``review_state``  Workflow-Status   Falls das Objekt einen Workflow hat, enthält
+                                    dieses Property den aktuellen Worflow-Status.
+================= ================= ===============================================
 
 
 ------

--- a/docs/api/basics.rst
+++ b/docs/api/basics.rst
@@ -117,6 +117,7 @@ Key           Bedeutung               Beschreibung
                                 in einer Antwort zu erwarten sind.
 ============= ================= ===============================================
 
+
 Zusätzlich zu den oben aufgeführten JSON-LD Attributen gibt es für Objekttypen,
 welche einen Workflow haben, ein allgemeines Property ``review_state``, welches
 den aktuellen Workflow-State enthält:
@@ -124,9 +125,11 @@ den aktuellen Workflow-State enthält:
 ================= ================= ===============================================
 Key               Bedeutung               Beschreibung
 ================= ================= ===============================================
-``review_state``  Workflow-Status   Falls das Objekt einen Workflow hat, enthält
-                                    dieses Property den aktuellen Worflow-Status.
+``review_state``  Workflow-State    Falls das Objekt einen Workflow hat, enthält
+                                    dieses Property den aktuellen Worflow-State.
 ================= ================= ===============================================
+
+Siehe :ref:`Workflow <workflow>` für Details bezüglich Workflows.
 
 
 ------

--- a/docs/api/batching.rst
+++ b/docs/api/batching.rst
@@ -1,0 +1,98 @@
+Paginierung
+===========
+
+Paginierung (auch *Batching* gennannt) bezeichnet das Aufteilen von Resultaten
+auf mehrere "Seiten", um den Server nicht unnötig zu belasten und die Grösse
+von Responses kontrollierbar zu halten.
+
+Repräsentationen von Collection-artigen Resourcen werden in der API paginiert
+wennd die Anzahl Resultate die Batch-Grösse (standardmässig 25) überschreitet.
+
+.. code:: json
+
+    {
+      "@id": "http://example.org/dossier/search",
+      "batching": {
+        "@id": "http://example.org/dossier/search?b_size=10&b_start=20",
+        "first": "http://example.org/dossier/search?b_size=10&b_start=0",
+        "last": "http://example.org/dossier/search?b_size=10&b_start=170",
+        "prev": "http://example.org/dossier/search?b_size=10&b_start=10",
+        "next": "http://example.org/dossier/search?b_size=10&b_start=30"
+      },
+      "items": [
+        "..."
+      ],
+      "items_total": 175,
+    }
+
+Die Batch-Grösse kann pro Request über den Query-String Parameter ``b_size``
+gesteuert werden.
+
+Wenn Resultate über mehrere Seiten verteilt werden mussten, sind im Top-Level
+Property ``batching`` Hypermedia-Links zur Navigation der Batches enthalten.
+
+Falls hingegen alle Resultate auf einer Seite Platz haben, wird das Top-Level
+Property ``batching`` weggelassen.
+
+
+Top-level Properties
+--------------------
+
+================ ===========================================================
+Property         Description
+================ ===========================================================
+``@id``          Kanonische basis-URL für die entsprechende Resource, ohne
+                 irgendwelche Batching-Parameter
+``items``        Batch mit den Resultaten der aktuellen Seite
+``items_total``  Anzahl Resultate insgesamt
+``batching``     Hypermedia-Links zur Navigation der Batches
+================ ===========================================================
+
+
+Batching links
+--------------
+
+Falls die Resultate über mehrere Seiten verteilt werden mussten, enthält der
+Response-Body auf der obersten Ebene ein Property ``batching``, welches
+Links zur Navigation der Batches enthält. Diese Links können von einem Client
+verwendet werden, um die Seiten einer paginierten Resultatliste zu
+navigieren:
+
+================ ===========================================================
+Attribute        Description
+================ ===========================================================
+``@id``          Link zur aktuellen Seite
+``first``        Link zur ersten Seite
+``prev``         Link zur vorherigen Seite (*falls vorhanden*)
+``next``         Link zur nächsten Seite (*falls vorhanden*)
+``last``         Link zur letzten Seite
+================ ===========================================================
+
+
+
+Parameter
+---------
+
+Die Paginierung kann mittels zwei Query-String Parametern kontrolliert werden.
+Um eine bestimmte Seite zu addressieren, kann der Parameter ``b_start``
+verwendet werden. Mit dem Parameter ``b_size`` kann gesteuert werden, wieviele
+Resultate eine Seite (maximal) enthalten soll.
+
+================ ===========================================================
+Parameter        Beschreibung
+================ ===========================================================
+``b_size``       Anzahl Resultate pro Seite (default ist 25)
+``b_start``      Erstes Resultat ab welchem die Batch-Seite beginnen soll
+================ ===========================================================
+
+
+Komplettes Beispiel einer paginierten Response:
+
+.. sourcecode:: http
+
+    GET /dossier/@search?b_size=5&sort_on=path HTTP/1.1
+    Accept: application/json
+
+
+.. literalinclude:: examples/batching.json
+   :language: http

--- a/docs/api/docs_changelog.rst
+++ b/docs/api/docs_changelog.rst
@@ -8,6 +8,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2016-08-02
 ----------
 
+- Minimale Dokumentation für ``review_state`` (Workflow-Status) hinzugefügt
 - Kapitel "Paginierung" hinzugefügt
 - Kapitel "Serialisierung" hinzugefügt
 - Attribut ``member`` nach ``items`` umbenannt.

--- a/docs/api/docs_changelog.rst
+++ b/docs/api/docs_changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2016-08-02
+----------
+
+- Attribut ``member`` nach ``items`` umbenannt.
+
 2016-04-15
 ----------
 

--- a/docs/api/docs_changelog.rst
+++ b/docs/api/docs_changelog.rst
@@ -10,6 +10,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
 - Minimale Dokumentation für ``review_state`` (Workflow-Status) hinzugefügt
 - Kapitel "Paginierung" hinzugefügt
+- Kapitel "Workflow" hinzugefügt
 - Kapitel "Serialisierung" hinzugefügt
 - Attribut ``member`` nach ``items`` umbenannt.
 

--- a/docs/api/docs_changelog.rst
+++ b/docs/api/docs_changelog.rst
@@ -8,6 +8,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2016-08-02
 ----------
 
+- Kapitel "Paginierung" hinzugefügt
 - Kapitel "Serialisierung" hinzugefügt
 - Attribut ``member`` nach ``items`` umbenannt.
 

--- a/docs/api/docs_changelog.rst
+++ b/docs/api/docs_changelog.rst
@@ -8,6 +8,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2016-08-02
 ----------
 
+- Kapitel "Serialisierung" hinzugefügt
 - Attribut ``member`` nach ``items`` umbenannt.
 
 2016-04-15

--- a/docs/api/examples/batching.json
+++ b/docs/api/examples/batching.json
@@ -1,0 +1,45 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@id": "http://example.org/dossier/@search",
+  "batching": {
+    "@id": "http://example.org/dossier/@search?b_size=5&sort_on=path",
+    "first": "http://example.org/dossier/@search?b_size=5&sort_on=path&b_start=0",
+    "last": "http://example.org/dossier/@search?b_size=5&sort_on=path&b_start=5",
+    "next": "http://example.org/dossier/@search?b_size=5&sort_on=path&b_start=5"
+  },
+  "items": [
+    {
+      "@id": "http://example.org/plone/dossier",
+      "@type": "opengever.dossier.businesscasedossier",
+      "description": "",
+      "title": "Folder"
+    },
+    {
+      "@id": "http://example.org/dossier/doc-1",
+      "@type": "opengever.document.document",
+      "description": "",
+      "title": "Document 1"
+    },
+    {
+      "@id": "http://example.org/dossier/doc-2",
+      "@type": "opengever.document.document",
+      "description": "",
+      "title": "Document 2"
+    },
+    {
+      "@id": "http://example.org/dossier/doc-3",
+      "@type": "opengever.document.document",
+      "description": "",
+      "title": "Document 3"
+    },
+    {
+      "@id": "http://example.org/dossier/doc-4",
+      "@type": "opengever.document.document",
+      "description": "",
+      "title": "Document 4"
+    }
+  ],
+  "items_total": 8
+}

--- a/docs/api/examples/workflow_get.json
+++ b/docs/api/examples/workflow_get.json
@@ -1,0 +1,27 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "history": [
+    {
+      "action": null,
+      "actor": "john.doe",
+      "comments": "",
+      "review_state": "dossier-state-active",
+      "time": "2016-08-02T15:08:50+02:00"
+    },
+    {
+      "action": "dossier-transition-resolve",
+      "actor": "john.doe",
+      "comments": "",
+      "review_state": "dossier-state-resolved",
+      "time": "2016-08-02T15:08:54+02:00"
+    }
+  ],
+  "transitions": [
+    {
+      "@id": "http://example.org/dossier-15/@workflow/dossier-transition-reactivate",
+      "title": "dossier-transition-reactivate"
+    }
+  ]
+}

--- a/docs/api/examples/workflow_post.json
+++ b/docs/api/examples/workflow_post.json
@@ -1,0 +1,10 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "action": "dossier-transition-reactivate",
+  "actor": "john.doe",
+  "comments": "",
+  "review_state": "dossier-state-active",
+  "time": "2016-08-02T15:18:21+02:00"
+}

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,6 +11,7 @@ Inhalt:
    exploring.rst
    serialization.rst
    batching.rst
+   workflow.rst
    content_types.rst
    examples/index.rst
    docs_changelog.rst

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ Inhalt:
    operations.rst
    exploring.rst
    serialization.rst
+   batching.rst
    content_types.rst
    examples/index.rst
    docs_changelog.rst

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,6 +9,7 @@ Inhalt:
    basics.rst
    operations.rst
    exploring.rst
+   serialization.rst
    content_types.rst
    examples/index.rst
    docs_changelog.rst

--- a/docs/api/operations.rst
+++ b/docs/api/operations.rst
@@ -94,6 +94,7 @@ Unterobjekte enthält (direkte children des Objekts).
         "responsible": "john.doe",
         "retention_period": 5,
         "retention_period_annotation": null,
+        "review_state": "dossier-state-active",
         "start": "2016-01-08",
         "temporary_former_reference_number": null,
         "title": "Ein Geschäftsdossier"

--- a/docs/api/operations.rst
+++ b/docs/api/operations.rst
@@ -15,6 +15,8 @@ PATCH   /{path}      Aktualisiert einzelne Attribute eines Objekts
 ======= ============ ==========================================================
 
 
+.. _content-get:
+
 Inhalte lesen (GET)
 -------------------
 
@@ -109,6 +111,8 @@ Unterobjekte enthält (direkte children des Objekts).
     .. literalinclude:: examples/example_get.py
 
 
+.. _content-post:
+
 Inhalte erstellen (POST)
 ------------------------
 
@@ -159,6 +163,8 @@ finden.
 
     .. literalinclude:: examples/example_post.py
 
+
+.. _content-patch:
 
 Inhalte bearbeiten (PATCH)
 --------------------------

--- a/docs/api/operations.rst
+++ b/docs/api/operations.rst
@@ -22,7 +22,7 @@ Mit einem ``GET`` Request auf die URL eines Objekts können die Daten
 (Metadaten wie auch Primärdaten) eines Objekts ausgelesen werden.
 
 Im Fall eines Objekts das "folderish" ist (ein Container), gibt es ein
-spezielles Attribut ``member``, welches eine summarische Auflistung der
+spezielles Attribut ``items``, welches eine summarische Auflistung der
 Unterobjekte enthält (direkte children des Objekts).
 
 
@@ -64,7 +64,7 @@ Unterobjekte enthält (direkte children des Objekts).
         "filing_prefix": null,
         "former_reference_number": null,
         "keywords": [],
-        "member": [
+        "items": [
           {
             "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/document-259",
             "@type": "opengever.document.document",

--- a/docs/api/schemas/ftw.mail.mail.inc
+++ b/docs/api/schemas/ftw.mail.mail.inc
@@ -1,6 +1,6 @@
 .. py:class:: ftw.mail.mail
 
-    Inhaltstyp 'Mail'
+    Inhaltstyp 'E-Mail'
 
 
 
@@ -140,7 +140,7 @@
        :Datentyp: ``Bool``
        
        
-       :Beschreibung: Is the Document Digital Availabe
+       
        
 
 

--- a/docs/api/schemas/opengever.document.document.inc
+++ b/docs/api/schemas/opengever.document.document.inc
@@ -180,7 +180,7 @@
        :Datentyp: ``Bool``
        
        
-       :Beschreibung: Is the Document Digital Availabe
+       
        
 
 

--- a/docs/api/serialization.rst
+++ b/docs/api/serialization.rst
@@ -1,0 +1,136 @@
+Serialisierung
+==============
+
+In der REST API muss an verschiedenen Stellen Inhalt von und nach JSON
+serialisiert und deserialisiert werden.
+
+Grundsätzlich ist das Format für die Serialisierung (Lesen von der API)
+dasselbe wie für die Deserialisierung (Schreiben via API).
+
+Primitive Typen
+---------------
+
+Primitive Datentypen, welche eine entsprechende Repräsentation in JSON haben,
+wie z.B. Integers oder Strings, werden direkt zwischen Python und JSON
+übersetzt. Ein Python string aus GEVER wird also als JSON-String ausgegeben,
+und umkekehrt.
+
+Datum / Zeit
+--------------
+
+Da JSON keinen nativen Support für datetimes bietet, werden Python/Zope
+datetimes zu `ISO 8601 <https://de.wikipedia.org/wiki/ISO_8601>`_ Strings
+serialisiert.
+
+======================================= ======================================
+Python                                  JSON
+======================================= ======================================
+``time(19, 45, 55)``                    ``'19:45:55'``
+``date(2015, 11, 23)``                  ``'2015-11-23'``
+``datetime(2015, 11, 23, 19, 45, 55)``  ``'2015-11-23T19:45:55'``
+``DateTime('2015/11/23 19:45:55')``     ``'2015-11-23T19:45:55'``
+======================================= ======================================
+
+
+Dateien
+-------
+
+Download (Serialisierung)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Für den Download von Dateien wird ein File-Field zu einem Mapping serialisiert
+welches die wichtigsten Metadaten zur Datei (nicht zum Dokument), und einen
+Download-Link für das Herunterladen enthält:
+
+.. code:: json
+
+      {
+        "@id": "http://example.org/dossier/mydoc",
+        "@type": "opengever.document.document",
+        "title": "My document",
+        "...": "",
+        "file": {
+          "content-type": "application/pdf",
+          "download": "http://example.org/dossier/mydoc/@@download/file",
+          "filename": "file.pdf",
+          "size": 74429
+        }
+      }
+
+
+Die URL im ``download`` Property zeigt auf die reguläre Download-View von
+Plone. Dies bedeutet, dass der Client einen ``GET`` request auf diese URL
+durchführen kann, um die Datei herunterzuladen. Jedoch darf hier als
+``Accept`` Header nicht mehr ``application/json`` gesetzt werden (wie sonst
+für API-Requests üblich), sondern der MIME-Type der zu herunterladenden
+Datei (gemäss dem ``content-type`` Property).
+
+
+Upload (Deserialisierung)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Für Datei-Felder muss der Client die Datei und deren Metadaten als ein Mapping
+senden, ähnlich dem Mapping für den Download. Das Mapping muss die Daten der
+Datei base64 codiert im ``data`` Property enthalten, und weitere Metadaten in
+den übrigen Properties:
+
+- ``data`` - der Inhalt der Datei, base64 codiert
+- ``encoding`` - das Encoding das verwendet wurde, also ``base64``
+- ``content-type`` - der MIME-Type der Datei
+- ``filename`` - der Dateiname, inkl. Dateiendung
+
+.. code:: json
+
+      {
+        "@type": "opengever.document.document",
+        "title": "My file",
+        "...": "",
+        "file": {
+            "data": "TG9yZW0gSXBzdW0uCg==",
+            "encoding": "base64",
+            "filename": "lorem.txt",
+            "content-type": "text/plain"}
+      }
+
+
+Verweise
+--------
+
+Serialisierung
+^^^^^^^^^^^^^^
+
+Verweise werden zu einer summarischen Repräsentation des referenzierten
+Objekts serialisiert:
+
+.. code:: json
+
+    {
+      "...": "",
+      "relatedItems": [
+        {
+          "@id": "http://example.org/dossier/doc1",
+          "@type": "opengever.document.document",
+          "title": "Document 1",
+          "description": "Description"
+        }
+      ]
+    }
+
+Die Liste von Verweisen wird zu einer einfachen JSON-Liste serialisiert.
+
+Deserialisierung
+^^^^^^^^^^^^^^^^
+
+Um beim Erstellen oder Updaten von Objekten einen Verweis zu setzen, können
+verschiedene Methoden verwendet werden um das Verweisziel anzugeben. Es kann
+einer der hier aufgeführten Bezeichner verwendet werden, um das Verweisziel
+eindeutig zu identifizieren:
+
+======================================= ======================================
+Typ                                     Beispiel
+======================================= ======================================
+UID                                     ``'9b6a4eadb9074dde97d86171bb332ae9'``
+IntId                                   ``123456``
+Pfad                                    ``'/dossier/doc1'``
+URL                                     ``'http://example.org/dossier/doc1'``
+======================================= ======================================

--- a/docs/api/workflow.rst
+++ b/docs/api/workflow.rst
@@ -1,0 +1,76 @@
+.. _workflow:
+
+Workflow
+========
+
+In GEVER haben viele :ref:`Inhaltstypen <content-types>` einen assozierten Workflow (z.B.
+Ordnungspositionen, Dossiers, Aufgaben, ...).
+
+Der aktuelle **Workflow-State** eines Objekts ist der Einfachheit halber als
+``review_state`` direkt in der :ref:`GET <content-get>` Repreäsentation
+eines Objekts enthalten:
+
+.. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+       "@id": "https://example.org/dossier-15",
+       "@type": "opengever.dossier.businesscasedossier",
+       "...": "...",
+       "review_state": "dossier-state-active"
+    }
+
+
+Für die restlichen Aspekte des Workflows eines Objekts wird der ``@workflow``
+Endpoint verwendet:
+
+
+.. http:get:: /(path)/@workflow
+
+   Liefert die Workflow-Informationen zu dem durch `path` addressierten Objekt
+   zurück.
+
+   Die Workflow-Informationen enthalten die **Workflow-History** (und darin
+   enthalten, der aktuelle Workflow-State) und die für dieses Objekt möglichen
+   **Workflow-Transitionen**.
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /dossier-15/@workflow HTTP/1.1
+       Accept: application/json
+
+   **Beispiel-Response**:
+
+   .. literalinclude:: examples/workflow_get.json
+      :language: http
+
+   Dieses Dossier befindet sich zur Zeit im Status abgeschlossen (
+   ``dossier-state-resolved``, letzter Eintrag in der Workflow-History).
+
+   In diesem Beispiel ist die einzig von diesem Workflow-State ausgehende
+   Transition, das Dossier wiederzueröffnen
+   (``dossier-transition-reactivate``). Diese Transition kann ausgeführt
+   werden, indem ein ``POST`` Request auf die entsprechende URL durchgeführt
+   wird:
+
+.. http:post:: /(path)/@workflow/(transition)
+
+   Führt für das durch `path` addressierte Objekt die Workflow-Transition
+   `transition` durch.
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /dossier-15/@workflow/dossier-transition-reactivate HTTP/1.1
+       Accept: application/json
+
+   **Beispiel-Response**:
+
+   .. literalinclude:: examples/workflow_post.json
+      :language: http

--- a/docs/schema-dumps/ftw.mail.mail.json
+++ b/docs/schema-dumps/ftw.mail.mail.json
@@ -1,6 +1,6 @@
 {
     "portal_type": "ftw.mail.mail",
-    "title": "Mail",
+    "title": "E-Mail",
     "schemas": [
         {
             "name": "ftw.mail.mail.IMail",
@@ -153,7 +153,7 @@
                     "name": "digitally_available",
                     "type": "Bool",
                     "title": "Digital verf\u00fcgbar",
-                    "desc": "Is the Document Digital Availabe",
+                    "desc": "",
                     "required": false,
                     "modes": {
                         "zope.interface.Interface": "hidden"

--- a/docs/schema-dumps/opengever.document.document.json
+++ b/docs/schema-dumps/opengever.document.document.json
@@ -216,7 +216,7 @@
                     "name": "digitally_available",
                     "type": "Bool",
                     "title": "Digital verf\u00fcgbar",
-                    "desc": "Is the Document Digital Availabe",
+                    "desc": "",
                     "required": false,
                     "modes": {
                         "zope.interface.Interface": "hidden"


### PR DESCRIPTION
Updates the API docs to catch up with some recent changes / new features for `plone.restapi`:

- Update schema dumps.
- Add chapter 'Worfklow'
- Add minimal docs for ``review_state``
- Add chapter "Paginierung".
- Add chapter about serialization.
- Rename attribute ``member`` to ``items``.
