### PR TITLE
Improve bumblebee integration in search results page.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,13 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Improve bumblebee integration in the search results page:
+
+  - Change document link to document overview.
+  - Display document tooltip on document links.
+
+  [phgross]
+
 - Deactivate 'Authentication' capability for LDAP plugin during setup for
   production deployments.
   In production, auth will always be performed by CAS portal.

--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -297,18 +297,8 @@
                     <tal:results repeat="item batch">
                       <div class="search-item-wrapper">
                         <div class="searchItem">
-                          <dt tal:attributes="class item/ContentTypeClass">
-                            <img tal:replace="structure item/getIcon" />
-                              <a href="#"
-                                 tal:define="item_url item/getURL;
-                                             item_type item/portal_type"
-                                 tal:attributes="href python:item_type in use_view_action and (item_url + '/view') or item_url;
-                                                 class item/get_css_classes;
-                                                 title item/Title;
-                                                 data-showroom-id item/UID;
-                                                 data-showroom-target item/get_overlay_url;
-                                                 data-showroom-title item/get_overlay_title;"
-                                 tal:content="item/CroppedTitle" />
+                          <dt>
+                            <a tal:replace="structure item/render_link" />
                           </dt>
                           <dd>
                             <div class="main_dossier">
@@ -350,9 +340,11 @@
                           </dd>
                         </div>
                         <div class="searchImage" tal:condition="item/is_bumblebeeable">
-                          <img class="showroom-reference bumblebeeSearchPreview"
-                                 tal:attributes="src item/get_preview_image_url;
-                                                 data-showroom-target-item item/UID;" />
+                          <img class="showroom-item bumblebeeSearchPreview"
+                               tal:attributes="src item/get_preview_image_url;
+                                               data-showroom-id item/UID;
+                                               data-showroom-target item/get_overlay_url;
+                                               data-showroom-title item/get_overlay_title;" />
                         </div>
                       </div>
                       <div class="visualClear"><!-- --></div>

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -77,10 +77,7 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
     def get_css_classes(self):
         """Return the css classes for this item."""
 
-        classes = ["state-{}".format(self.review_state())]
-        if self.is_bumblebeeable():
-            classes.append("showroom-item")
-        return " ".join(classes)
+        return "state-{}".format(self.review_state())
 
     def get_overlay_url(self):
         """Return the url to fetch the bumblebee overlay."""
@@ -122,4 +119,4 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         structure = '<a href="{url}" alt="{title}" class="{css_class}">{title}</a>'
         return structure.format(
             url=self.getURL(), title=self.Title(),
-            css_class=self.get_css_classes())
+            css_class=self.ContentTypeClass())

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -7,6 +7,7 @@ from opengever.document.document import Document
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.mail.mail import OGMail
 from plone.app.contentlisting.catalog import CatalogContentListingObject
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 
 
@@ -17,6 +18,7 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
     Description methods.
     """
 
+    simple_link_template = ViewPageTemplateFile('templates/simple_link.pt')
     documentish_types = ['opengever.document.document', 'ftw.mail.mail']
 
     @property
@@ -116,7 +118,8 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         if self.is_documentish:
             return DocumentLinkWidget(self).render()
 
-        structure = '<a href="{url}" alt="{title}" class="{css_class}">{title}</a>'
-        return structure.format(
-            url=self.getURL(), title=self.Title(),
-            css_class=self.ContentTypeClass())
+        return self._render_simplelink()
+
+    def _render_simplelink(self):
+        self.context = self
+        return self.simple_link_template(self, self.request)

--- a/opengever/base/templates/simple_link.pt
+++ b/opengever/base/templates/simple_link.pt
@@ -1,0 +1,4 @@
+<a  href="#" tal:content="context/Title"
+    tal:attributes="href context/getURL;
+                    class context/ContentTypeClass;
+                    alt context/Title" />

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -178,7 +178,7 @@ class TestBrainContentListingRenderLink(FunctionalTestCase):
         dossier = create(Builder('dossier').titled(u'Dossier A'))
 
         self.assertEquals(
-            '<a href="http://nohost/plone/dossier-1" alt="Dossier A" class="contenttype-opengever-dossier-businesscasedossier">Dossier A</a>',
+            '<a href="http://nohost/plone/dossier-1" alt="Dossier A" class="contenttype-opengever-dossier-businesscasedossier">Dossier A</a>\n',
             IContentListingObject(obj2brain(dossier)).render_link())
 
 

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -178,7 +178,7 @@ class TestBrainContentListingRenderLink(FunctionalTestCase):
         dossier = create(Builder('dossier').titled(u'Dossier A'))
 
         self.assertEquals(
-            '<a href="http://nohost/plone/dossier-1" alt="Dossier A" class="state-dossier-state-active">Dossier A</a>',
+            '<a href="http://nohost/plone/dossier-1" alt="Dossier A" class="contenttype-opengever-dossier-businesscasedossier">Dossier A</a>',
             IContentListingObject(obj2brain(dossier)).render_link())
 
 
@@ -226,10 +226,6 @@ class TestOpengeverContentListingWithEnabledBumblebee(FunctionalTestCase):
         listing = IContentListingObject(obj2brain(dossier))
 
         self.assertFalse(listing.is_bumblebeeable())
-
-    def test_get_css_classes_extended_with_showroom_item_class(self):
-        self.assertEqual('state-document-state-draft showroom-item',
-                         self.obj.get_css_classes())
 
     def test_get_preview_image_url(self):
         self.assertIsNotNone(self.obj.get_preview_image_url())


### PR DESCRIPTION

<img width="1184" alt="bildschirmfoto 2016-08-10 um 09 09 11" src="https://cloud.githubusercontent.com/assets/485755/17544999/dcbd9c52-5eda-11e6-978b-aa7df01814e9.png">

- Change document link to document overview.
- Display document tooltip on document links.

Closes #2074 

---

I've tried to move the document thumbnail to the left side of the searchresult listing, but the result was not satisfying, the listing looked very restless (unruhig). Therefore I propose to let the thumbnail on the right side of the listing and wait for feedbacks and reactions from the SaaS Trial:
![bildschirmfoto 2016-08-10 um 08 57 36](https://cloud.githubusercontent.com/assets/485755/17544953/93f8fb60-5eda-11e6-8315-d0f35a529d95.png)
 
@lukasgraf please have a look
