### PR TITLE
Keep proposal physical_path in sync when moving dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix a bug where a proposal would "disappear" when moving its parent dossier.
+  [deiferni]
+
 - Conditionally display iframe for bumblebee document preview
   [Kevin Bieri]
 

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -9,10 +9,12 @@ from opengever.meeting.command import UpdateExcerptInDossierCommand
 from opengever.meeting.model import GeneratedExcerpt
 from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
+from opengever.meeting.proposal import IProposal
 from zope.component import getUtility
 from zope.component.interfaces import ComponentLookupError
 from zope.intid.interfaces import IIntIds
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.lifecycleevent.interfaces import IObjectMovedEvent
 
 
 @grok.subscribe(IDocumentSchema, IObjectWillBeRemovedEvent)
@@ -56,3 +58,12 @@ def _sync_excerpt(document):
         return
 
     UpdateExcerptInDossierCommand(proposal).execute()
+
+
+@grok.subscribe(IProposal, IObjectMovedEvent)
+def sync_moved_proposal(obj, event):
+    # make sure obj wasn't just created or deleted
+    if not event.oldParent or not event.newParent:
+        return
+
+    obj.sync_model()

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -313,7 +313,7 @@ class SubmittedProposal(ProposalBase):
             id=cls.generate_submitted_proposal_id(proposal),
             container=container)
 
-        submitted_proposal.sync_model(proposal)
+        submitted_proposal.sync_model(proposal_model=proposal)
         return submitted_proposal
 
     @classmethod
@@ -327,7 +327,9 @@ class SubmittedProposal(ProposalBase):
     def load_proposal(self, oguid):
         return ProposalModel.query.get_by_oguid(oguid)
 
-    def sync_model(self, proposal_model):
+    def sync_model(self, proposal_model=None):
+        proposal_model = proposal_model or self.load_model()
+
         proposal_model.submitted_oguid = Oguid.for_object(self)
         proposal_model.submitted_physical_path = self.get_physical_path()
         proposal_model.submitted_admin_unit_id = get_current_admin_unit().id()
@@ -460,6 +462,18 @@ class Proposal(ProposalBase):
             committee = str(committee.committee_id)
             values['committee'] = committee
         return values
+
+    def sync_model(self, proposal_model=None):
+        proposal_model = proposal_model or self.load_model()
+
+        reference_number = IReferenceNumber(
+            self.get_containing_dossier().get_main_dossier()).get_number()
+        repository_folder_title = self.get_repository_folder_title(
+            proposal_model.language)
+
+        proposal_model.physical_path = self.get_physical_path()
+        proposal_model.dossier_reference_number = reference_number
+        proposal_model.repository_folder_title = repository_folder_title
 
     def is_submit_additional_documents_allowed(self):
         return self.load_model().is_submit_additional_documents_allowed()

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -286,6 +286,30 @@ class TestProposal(FunctionalTestCase):
         submitted_mail = submitted_proposal.get_documents()[0]
         self.assertSubmittedDocumentCreated(proposal, mail, submitted_mail)
 
+    def test_proposal_paths_remain_in_sync_when_dossier_is_moved(self):
+        committee = create(Builder('committee').titled('My committee'))
+        mail = create(Builder('mail')
+                      .within(self.dossier)
+                      .with_dummy_message())
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model())
+                          .relate_to(mail))
+        new_repo_folder = create(Builder('repository')
+                                 .within(self.repo)
+                                 .titled(u'New'))
+
+        moved_dossier = api.content.move(
+            source=self.dossier, target=new_repo_folder)
+        moved_proposal = moved_dossier['proposal-1']
+        model = moved_proposal.load_model()
+        self.assertEqual(
+            'opengever-repository-repositoryroot/new/dossier-1/proposal-1',
+            model.physical_path)
+        self.assertEqual(u'New', model.repository_folder_title)
+        self.assertEqual(u'Client1 2', model.dossier_reference_number)
+
     @browsing
     def test_proposal_submission_works_correctly(self, browser):
         committee = create(Builder('committee').titled('My committee'))


### PR DESCRIPTION
This PR fixes an issue when moving a dossier with proposals. The proposals will no longer disappear from the dossiers proposals tab after the move.

Fixes  #2081.