### PR TITLE
Fix UnicodeDecodeError in contentlisting render_link method.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix UnicodeDecodeError in contentlisting render_link method.
+  [phgross]
+
 - Fix a bug where a proposal would "disappear" when moving its parent dossier.
   [deiferni]
 

--- a/opengever/base/templates/simple_link.pt
+++ b/opengever/base/templates/simple_link.pt
@@ -1,4 +1,4 @@
 <a  href="#" tal:content="context/Title"
     tal:attributes="href context/getURL;
                     class context/ContentTypeClass;
-                    alt context/Title" />
+                    alt python: context.Title().decode('utf-8')" />

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -175,10 +175,10 @@ class TestBrainContentListingRenderLink(FunctionalTestCase):
             IContentListingObject(obj2brain(mail)).render_link())
 
     def test_uses_simple_renderer_for_dossiers(self):
-        dossier = create(Builder('dossier').titled(u'Dossier A'))
+        dossier = create(Builder('dossier').titled(u'D\xf6ssier A'))
 
         self.assertEquals(
-            '<a href="http://nohost/plone/dossier-1" alt="Dossier A" class="contenttype-opengever-dossier-businesscasedossier">Dossier A</a>\n',
+            u'<a href="http://nohost/plone/dossier-1" alt="D\xf6ssier A" class="contenttype-opengever-dossier-businesscasedossier">D\xf6ssier A</a>\n',
             IContentListingObject(obj2brain(dossier)).render_link())
 
 


### PR DESCRIPTION
This happens when the title of a object contains non-ascii characters.

Closes #2089.

@deiferni 