### PR TITLE
Fix/update script for bumblebee activation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix/update script for bumblebee activation.
+  Add feature to calculate bumblebee checksums for archived documents.
+  [deiferni]
+
 - Fix showroom CSS loading order
   [Kevin Bieri]
 

--- a/opengever/base/archeologist.py
+++ b/opengever/base/archeologist.py
@@ -3,14 +3,15 @@ from Products.CMFEditions.utilities import dereference
 
 
 class Archeologist(object):
-    """Dig out an archived version of an object.
+    """Dig up a mutable, archived version of an object.
+    Warning: Returned object may be incomplete!
 
     Parameters:
     obj - the current plone object for which you want to access the archived
           object
     version_data - a VersionData instance as returned by `portal_repository`
 
-    The layers of abstraction that are involded (in order of appearance):
+    The layers of abstraction that are involved (in order of appearance):
 
     CopyModifyMergeRepositoryTool - `portal_repository`:
     Stores versions in `portal_archivist`. Data is associated with an object
@@ -42,7 +43,7 @@ class Archeologist(object):
         """Return a reference to the archived object.
 
         Bypass all the copies made by the different layers of abstraction and
-        dig out a reference to the archived object.
+        dig up a reference to the archived object.
 
         Warning: objects returned by excavate may be incomplete and may
         not contain all their attributes/references. Use at your own risk.

--- a/opengever/base/archeologist.py
+++ b/opengever/base/archeologist.py
@@ -1,0 +1,66 @@
+from plone import api
+from Products.CMFEditions.utilities import dereference
+
+
+class Archeologist(object):
+    """Dig out an archived version of an object.
+
+    Parameters:
+    obj - the current plone object for which you want to access the archived
+          object
+    version_data - a VersionData instance as returned by `portal_repository`
+
+    The layers of abstraction that are involded (in order of appearance):
+
+    CopyModifyMergeRepositoryTool - `portal_repository`:
+    Stores versions in `portal_archivist`. Data is associated with an object
+    based on a `history_id` (provided by `portal_historyidhandler`) and a
+    `selector` for the version (an auto-incremented version_id).
+
+    ArchivistTool - `portal_archivist`:
+    Stores versions in `portal_historiesstorage` based on the `history_id`
+    and `selector` provided by `portal_repository`.
+
+    ZVCStorageTool - `portal_historiesstorage`:
+    Stores versions in a ZopeRepository, based on a different history_id and
+    selector. Maintains a mapping between these two different sets of
+    identifiers.
+
+    ZopeRepository:
+    Actually stores data in ZopeVersionHistory (contains the history for each
+    versioned object) and ZopeVersion (contains the archived version of an
+    object).
+
+    """
+    def __init__(self, obj, version_data):
+        self.obj, self.history_id = dereference(obj)
+        self.selector = version_data.version_id
+        self.version_data = version_data
+        self.storage = api.portal.get_tool('portal_historiesstorage')
+
+    def excavate(self):
+        """Return a reference to the archived object.
+
+        Bypass all the copies made by the different layers of abstraction and
+        dig out a reference to the archived object.
+
+        Warning: objects returned by excavate may be incomplete and may
+        not contain all their attributes/references. Use at your own risk.
+
+        """
+        # the following comment and code is based on ZVCStorageTool.purge:
+        #
+        # digging into ZVC internals:
+        # Get a reference to the version stored in the ZVC history storage
+        #
+        # ZVCs ``getVersionOfResource`` is quite more complex. But as we
+        # do not use labeling and branches it is not a problem to get the
+        # version in the following simple way.
+        zvc_repo = self.storage._getZVCRepo()
+        zvc_histid, zvc_selector = self.storage._getZVCAccessInfo(
+            self.history_id, self.selector, countPurged=True)
+
+        zvc_history = zvc_repo.getVersionHistory(zvc_histid)
+        version = zvc_history.getVersionById(zvc_selector)
+        archived_obj = version._data._object.object
+        return archived_obj

--- a/opengever/base/tests/test_archeologist.py
+++ b/opengever/base/tests/test_archeologist.py
@@ -1,0 +1,43 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
+from opengever.base.archeologist import Archeologist
+from opengever.testing import FunctionalTestCase
+from opengever.testing.helpers import create_document_version
+from plone import api
+from zope.annotation.interfaces import IAnnotations
+import transaction
+
+
+TEST_ANNOTATION_KEY = 'test_archeologist'
+
+
+class TestArcheologist(FunctionalTestCase):
+
+    def test_archeologist_returns_modifyable_persistent_reference(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document')
+                          .within(dossier)
+                          .attach_file_containing(
+                              bumblebee_asset('example.docx').bytes(),
+                              u'example.docx'))
+        create_document_version(document, version_id=1)
+        create_document_version(document, version_id=2)
+
+        repository = api.portal.get_tool('portal_repository')
+
+        archived_obj = Archeologist(
+            document, repository.retrieve(document, selector=1)).excavate()
+        annotations = IAnnotations(archived_obj)
+        self.assertNotIn(TEST_ANNOTATION_KEY, annotations)
+        annotations[TEST_ANNOTATION_KEY] = 'can touch this!'
+        archived_obj.some_attr = 'can touch this!'
+
+        transaction.commit()
+
+        archived_obj = Archeologist(
+            document, repository.retrieve(document, selector=1)).excavate()
+        annotations = IAnnotations(archived_obj)
+        self.assertIn(TEST_ANNOTATION_KEY, annotations)
+        self.assertEqual('can touch this!', annotations[TEST_ANNOTATION_KEY])
+        self.assertEqual('can touch this!', archived_obj.some_attr)

--- a/scripts/bumblebee_installation.py
+++ b/scripts/bumblebee_installation.py
@@ -48,13 +48,16 @@ root_logger.addHandler(handler)
 
 LOG = logging.getLogger('bumblebee-installation')
 
+
 parser = OptionParser()
 
-parser.add_option("-m", "--mode", dest="mode",
+parser.add_option("-m", "--mode", dest="mode", type="choice",
                   help="REQUIRED: Specify the upgrade-mode.",
+                  choices=['reindex', 'store'],
                   metavar="reindex|store")
 
 parser.add_option("-r", "--reset-timestamp", dest="reset", default=False,
+                  action="store_true",
                   help="If set to true, all objects will be reindexed again. "
                        "Otherwise it wont update already stored objects if "
                        "you restart the script",

--- a/scripts/bumblebee_installation.py
+++ b/scripts/bumblebee_installation.py
@@ -5,26 +5,26 @@ To reindex the objects run:
 
     bin/instance run ./scripts/bumblebee_installation.py -m reindex
 
-To calculate checksums for objects archived in  portal_repository run:
+To calculate checksums for objects archived in portal_repository run:
 
     bin/instance run ./scripts/bumblebee_installation.py -m history
 
 To store the objects run:
 
-    bin/instance run ./scripts/bumblebee_installation.py -m reindex
+    bin/instance run ./scripts/bumblebee_installation.py -m store
 
-If you have to specify the path to your plone insance
-then you can use following parameter:
+If you have to specify the path to your plone instance you can use following
+parameter:
 
     -p <path/to/plonesite>
 
-Per default the timestamp wont be resetted. That means, already stored
-objects wont be stored again.
+By default the timestamp won't be reset. That means, already stored objects
+won't be stored again.
 
-If you want to reset the timestamp and store all objects again then you can
-define this with the following parameter:
+If you want to reset the timestamp and store all objects again you can
+specify this with the following parameter:
 
-    -r True
+    -r
 
 For help-information type in the following:
 
@@ -90,7 +90,7 @@ def main(app, argv=sys.argv[1:]):
         parser.print_help()
         parser.error(
             'Please specify the "mode" with "bin/instance run <yourscript> -m '
-            'reindex | store"\n'
+            'reindex | history | store"\n'
             )
 
     if options.plone_path:

--- a/scripts/bumblebee_installation.py
+++ b/scripts/bumblebee_installation.py
@@ -34,6 +34,7 @@ from optparse import OptionParser
 from zope.component import getUtility
 import logging
 import sys
+import transaction
 
 # Set global logger to info - this is necessary for the log-outbut with
 # bin/instance run.
@@ -89,7 +90,8 @@ def main(app, argv=sys.argv[1:]):
 
     if mode == 'reindex':
         LOG.info("Start indexing objects...")
-        return converter.reindex()
+        converter.reindex()
+        return transaction.commit()
 
     elif mode == 'store':
         LOG.info("Start storing objects...")


### PR DESCRIPTION
Fix existing reindex script to actually commit the changes (Follow-up of https://github.com/4teamwork/opengever.core/pull/1980).

Add feature to calculate bumblebee checksums for archived documents:

Adds an `Archeologist` which can excavate old archived versions of objects. It returns a direct reference to the archived object by bypassing all the other layers of abstraction. For more details please see `Archeologist`'s docstring.

The script was also tested manually by:
- creating a random amount of versions for ~1000 documents on our dev-server
- generating checksums for these versions
- validating that checksums were present for all versions