### PR TITLE
Fix showroom CSS loading order

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.0 (unreleased)
 -------------------
 
+- Fix showroom CSS loading order
+  [Kevin Bieri]
+
 - Fix UnicodeDecodeError in contentlisting render_link method.
   [phgross]
 

--- a/opengever/bumblebee/profiles/default/cssregistry.xml
+++ b/opengever/bumblebee/profiles/default/cssregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+
+    <stylesheet
+        id="++resource++ftw.showroom/style.css"
+        insert-before="++theme++plonetheme.teamraum/css/gever/gever.css" />
+
+</object>

--- a/opengever/bumblebee/upgrades/20160818143144_fix_showroom_css_order/cssregistry.xml
+++ b/opengever/bumblebee/upgrades/20160818143144_fix_showroom_css_order/cssregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+
+    <stylesheet
+        id="++resource++ftw.showroom/style.css"
+        insert-before="++theme++plonetheme.teamraum/css/gever/gever.css" />
+
+</object>

--- a/opengever/bumblebee/upgrades/20160818143144_fix_showroom_css_order/upgrade.py
+++ b/opengever/bumblebee/upgrades/20160818143144_fix_showroom_css_order/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixShowroomCSSOrder(UpgradeStep):
+    """Fix showroom css order.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
In some cases the ftw.showroom styling gets loaded after the GEVER styles. This causes the showroom styles defined in GEVER not to apply.
The upgrade step moves the showroom styles before the GEVER styles.