### PR TITLE
Add views and forms for dossier participations

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.10.1 (unreleased)
 -------------------
 
+- Added participation tab and forms (add, edit, remove) using the new
+  contact implementation.
+  [phgross]
+
 - Disable local tab on contactfolder when contact feature is enabled.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.1 (unreleased)
 -------------------
 
+- Disable local tab on contactfolder when contact feature is enabled.
+  [phgross]
+
 - Move bumblebee installation script to opengever.maintenance.
   [phgross]
 

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -32,6 +32,13 @@
       />
 
   <browser:page
+      name="tabbedview_view-participations"
+      for="*"
+      class=".participations.ParticpationTab"
+      permission="zope2.View"
+      />
+
+  <browser:page
       name="edit"
       for="opengever.contact.interfaces.IPerson"
       class=".person.EditPerson"

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -39,6 +39,27 @@
       />
 
   <browser:page
+      name="add-sql-participation"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      class=".participation_forms.ParticipationAddForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.contact.participation.IParticipationWrapper"
+      class=".participation_forms.ParticipationEditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <browser:page
+      name="remove"
+      for="opengever.contact.participation.IParticipationWrapper"
+      class=".participation_forms.ParticipationRemoveForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <browser:page
       name="edit"
       for="opengever.contact.interfaces.IPerson"
       class=".person.EditPerson"

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -69,6 +69,13 @@
       />
 
   <browser:page
+      name="add-participation"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      class=".participation_add_view.ParticipationAddView"
+      permission="cmf.AddPortalContent"
+      />
+
+  <browser:page
       name="mails"
       for="opengever.contact.interfaces.IPerson"
       class=".mail.MailAddressesView"

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -21,7 +21,7 @@
       name="tabbed_view"
       class=".tabbed.ContactFolderTabbedView"
       permission="zope2.View"
-      allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
   <browser:page

--- a/opengever/contact/browser/participation_add_view.py
+++ b/opengever/contact/browser/participation_add_view.py
@@ -1,0 +1,16 @@
+from opengever.contact import is_contact_feature_enabled
+from Products.Five.browser import BrowserView
+
+
+class ParticipationAddView(BrowserView):
+    """A simple redirector view which redirects to the corresponding add form,
+    depending on the is_contact_feature_enabled flag.
+
+    The view is called by dossiers `Add participation` factoriesmenu action.
+    """
+
+    def __call__(self):
+        if is_contact_feature_enabled():
+            return self.request.RESPONSE.redirect('add-sql-participation')
+
+        return self.request.response.redirect('add-plone-participation')

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -1,0 +1,92 @@
+from collective.elephantvocabulary import wrap_vocabulary
+from five import grok
+from opengever.base.model import create_session
+from opengever.base.oguid import Oguid
+from opengever.contact.models import Contact
+from opengever.contact.models import Participation
+from opengever.dossier import _
+from plone import api
+from plone.directives import form
+from plone.formwidget.autocomplete import AutocompleteFieldWidget
+from plone.z3cform import layout
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
+from z3c.form.interfaces import ActionExecutionError
+from zope import schema
+from zope.interface import Interface
+from zope.interface import Invalid
+import z3c.form
+
+
+class IParticipation(form.Schema):
+    """ Participation Form schema
+    """
+
+    contact = schema.Choice(
+        title=_(u'label_contact', default=u'Contact'),
+        description=_(u'help_contact', default=u''),
+        vocabulary=u'opengever.contact.ContactsVocabulary',
+        required=True,
+    )
+
+    roles = schema.List(
+        title=_(u'label_roles', default=u'Roles'),
+        value_type=schema.Choice(
+            source=wrap_vocabulary(
+                'opengever.dossier.participation_roles',
+                visible_terms_from_registry='opengever.dossier'
+                '.interfaces.IDossierParticipants.roles'),
+        ),
+        required=True,
+        missing_value=[],
+        default=[],
+    )
+
+
+class ParticipationAddForm(z3c.form.form.Form):
+    ignoreContext = True
+    label = _(u'label_add_participation', default=u'Add Participation')
+    fields = z3c.form.field.Fields(IParticipation).omit('participation_id')
+
+    fields['contact'].widgetFactory = AutocompleteFieldWidget
+    fields['roles'].widgetFactory = CheckBoxFieldWidget
+
+    @z3c.form.button.buttonAndHandler(_(u'button_add', default=u'Add'))
+    def handle_add(self, action):
+        data, errors = self.extractData()
+
+        contact = Contact.query.get(data.get('contact'))
+        oguid = Oguid.for_object(self.context)
+
+        if Participation.query.by_oguid_and_contact(oguid, contact).count():
+            raise ActionExecutionError(Invalid(
+                _(u'msg_participation_already_exists',
+                  u"There already exists a participation for this contact.")))
+
+        if not errors:
+            participation = Participation(contact=contact, dossier_oguid=oguid)
+            create_session().add(participation)
+            participation.add_roles(data.get('roles'))
+
+            msg = _(u'info_participation_create', u'Participation created')
+            api.portal.show_message(
+                message=msg, request=self.request, type='info')
+            return self.redirect_to_participants_tab()
+
+    @z3c.form.button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
+    def handle_cancel(self, action):
+        return self.redirect_to_participants_tab()
+
+    def redirect_to_participants_tab(self):
+        return self.request.RESPONSE.redirect(
+            '{}#participations'.format(self.context.absolute_url()))
+
+
+class ParticipationAddFormView(layout.FormWrapper, grok.View):
+    grok.context(Interface)
+    grok.name('add-contact-participation')
+    grok.require('cmf.AddPortalContent')
+    form = ParticipationAddForm
+
+    def __init__(self, *args, **kwargs):
+        layout.FormWrapper.__init__(self, *args, **kwargs)
+        grok.View.__init__(self, *args, **kwargs)

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -50,9 +50,9 @@ class ParticipationAddForm(ModelAddForm):
     fields['roles'].widgetFactory = CheckBoxFieldWidget
 
     def validate(self, data):
-        contact = Contact.query.get(data.get('contact'))
-        oguid = Oguid.for_object(self.context)
-        if Participation.query.by_oguid_and_contact(oguid, contact).count():
+        query = Participation.query.by_dossier(self.context).filter_by(
+            contact_id=data.get('contact'))
+        if query.count():
             raise ActionExecutionError(Invalid(
                 _(u'msg_participation_already_exists',
                   u"There already exists a participation for this contact.")))

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -90,7 +90,7 @@ class ParticipationAddForm(z3c.form.form.Form):
 
 class ParticipationAddFormView(layout.FormWrapper, grok.View):
     grok.context(Interface)
-    grok.name('add-contact-participation')
+    grok.name('add-sql-participation')
     grok.require('cmf.AddPortalContent')
     form = ParticipationAddForm
 

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -3,9 +3,9 @@ from collective.elephantvocabulary import wrap_vocabulary
 from opengever.base.browser.modelforms import ModelAddForm
 from opengever.base.browser.modelforms import ModelEditForm
 from opengever.base.oguid import Oguid
+from opengever.contact import _
 from opengever.contact.models import Contact
 from opengever.contact.models import Participation
-from opengever.dossier import _
 from plone import api
 from plone.directives import form
 from plone.formwidget.autocomplete import AutocompleteFieldWidget
@@ -24,7 +24,6 @@ class IParticipation(form.Schema):
 
     contact = schema.Choice(
         title=_(u'label_contact', default=u'Contact'),
-        description=_(u'help_contact', default=u''),
         vocabulary=u'opengever.contact.ContactsVocabulary',
         required=True,
     )

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -1,6 +1,7 @@
+from Acquisition import aq_parent
 from collective.elephantvocabulary import wrap_vocabulary
-from five import grok
-from opengever.base.model import create_session
+from opengever.base.browser.modelforms import ModelAddForm
+from opengever.base.browser.modelforms import ModelEditForm
 from opengever.base.oguid import Oguid
 from opengever.contact.models import Contact
 from opengever.contact.models import Participation
@@ -8,14 +9,11 @@ from opengever.dossier import _
 from plone import api
 from plone.directives import form
 from plone.formwidget.autocomplete import AutocompleteFieldWidget
-from plone.z3cform import layout
+from z3c.form import button
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.interfaces import ActionExecutionError
-from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import IDataConverter
-from zExceptions import Unauthorized
 from zope import schema
-from zope.interface import Interface
 from zope.interface import Invalid
 import z3c.form
 
@@ -23,11 +21,6 @@ import z3c.form
 class IParticipation(form.Schema):
     """ Participation Form schema
     """
-
-    participation_id = schema.TextLine(
-        title=u'participation_id',
-        required=False
-    )
 
     contact = schema.Choice(
         title=_(u'label_contact', default=u'Contact'),
@@ -49,77 +42,47 @@ class IParticipation(form.Schema):
     )
 
 
-class ParticipationAddForm(z3c.form.form.Form):
-    ignoreContext = True
+class ParticipationAddForm(ModelAddForm):
     label = _(u'label_add_participation', default=u'Add Participation')
-    fields = z3c.form.field.Fields(IParticipation).omit('participation_id')
+    fields = z3c.form.field.Fields(IParticipation)
+    model_class = Participation
 
     fields['contact'].widgetFactory = AutocompleteFieldWidget
     fields['roles'].widgetFactory = CheckBoxFieldWidget
 
-    @z3c.form.button.buttonAndHandler(_(u'button_add', default=u'Add'))
-    def handle_add(self, action):
-        data, errors = self.extractData()
-
+    def validate(self, data):
         contact = Contact.query.get(data.get('contact'))
         oguid = Oguid.for_object(self.context)
-
         if Participation.query.by_oguid_and_contact(oguid, contact).count():
             raise ActionExecutionError(Invalid(
                 _(u'msg_participation_already_exists',
                   u"There already exists a participation for this contact.")))
 
-        if not errors:
-            participation = Participation(contact=contact, dossier_oguid=oguid)
-            create_session().add(participation)
-            participation.add_roles(data.get('roles'))
+    def create(self, data):
+        self.validate(data)
+        participation = self.model_class(
+            contact=Contact.query.get(data.get('contact')),
+            dossier_oguid=Oguid.for_object(self.context))
+        participation.add_roles(data.get('roles'))
+        return participation
 
-            msg = _(u'info_participation_create', u'Participation created')
-            api.portal.show_message(
-                message=msg, request=self.request, type='info')
-            return self.redirect_to_participants_tab()
-
-    @z3c.form.button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
-    def handle_cancel(self, action):
-        return self.redirect_to_participants_tab()
-
-    def redirect_to_participants_tab(self):
-        return self.request.RESPONSE.redirect(
-            '{}#participations'.format(self.context.absolute_url()))
+    def nextURL(self):
+        return '{}#participations'.format(self.context.absolute_url())
 
 
-class ParticipationAddFormView(layout.FormWrapper, grok.View):
-    grok.context(Interface)
-    grok.name('add-sql-participation')
-    grok.require('cmf.AddPortalContent')
-    form = ParticipationAddForm
-
-    def __init__(self, *args, **kwargs):
-        layout.FormWrapper.__init__(self, *args, **kwargs)
-        grok.View.__init__(self, *args, **kwargs)
-
-
-class ParticipationEditForm(z3c.form.form.EditForm):
-    ignoreContext = True
+class ParticipationEditForm(ModelEditForm):
     fields = z3c.form.field.Fields(IParticipation).omit('contact')
-    participation = None
-
-    fields['participation_id'].mode = HIDDEN_MODE
     fields['roles'].widgetFactory = CheckBoxFieldWidget
+
+    def __init__(self, context, request):
+        super(ParticipationEditForm, self).__init__(
+            context, request, context.model)
 
     @property
     def label(self):
         return _(u'label_edit_participation',
                  default=u'Edit Participation of ${title}',
-                 mapping={'title': self.get_participation().contact.get_title()})
-
-    def get_participation(self):
-        participation_id = self.request.get('participation_id')
-        if not participation_id:
-            data, errors = self.widgets.extract()
-            participation_id = data.get('participation_id')
-
-        return Participation.query.get(participation_id)
+                 mapping={'title': self.model.contact.get_title()})
 
     def updateWidgets(self):
         super(ParticipationEditForm, self).updateWidgets()
@@ -129,115 +92,53 @@ class ParticipationEditForm(z3c.form.form.EditForm):
 
         widget = self.widgets['roles']
         widget.value = IDataConverter(widget).toWidgetValue(
-            [role.role for role in self.get_participation().roles])
-
-        widget = self.widgets['participation_id']
-        widget.value = IDataConverter(widget).toWidgetValue(
-            self.request.get('participation_id'))
+            [role.role for role in self.model.roles])
 
         self.widgets.update()
 
-    @z3c.form.button.buttonAndHandler(_(u'Save'), name='save')
-    def handleApply(self, action):
-        data, errors = self.extractData()
+    def applyChanges(self, data):
+        self.model.update_roles(data.get('roles'))
 
-        oguid = Oguid.for_object(self.context)
-        participation = Participation.query.get(data.get('participation_id'))
-        if participation.dossier_oguid != oguid:
-            raise Unauthorized
+    def nextURL(self):
+        """Returns the url to the dossiers participation tab."""
 
-        if not errors:
-            participation.update_roles(data.get('roles'))
-
-            msg = _(u'info_participation_updated', u'Participation updated')
-            api.portal.show_message(
-                message=msg, request=self.request, type='info')
-
-            return self.redirect_to_participants_tab()
-
-    @z3c.form.button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
-    def handle_cancel(self, action):
-        return self.redirect_to_participants_tab()
-
-    def redirect_to_participants_tab(self):
-        return self.request.RESPONSE.redirect(
-            '{}#participations'.format(self.context.absolute_url()))
-
-
-class ParticipationEditFormView(layout.FormWrapper, grok.View):
-    grok.context(Interface)
-    grok.name('edit-contact-participation')
-    grok.require('cmf.AddPortalContent')
-    form = ParticipationEditForm
-
-    def __init__(self, *args, **kwargs):
-        layout.FormWrapper.__init__(self, *args, **kwargs)
-        grok.View.__init__(self, *args, **kwargs)
+        return '{}#participations'.format(
+            aq_parent(self.context).absolute_url())
 
 
 class ParticipationRemoveForm(z3c.form.form.Form):
-    ignoreContext = True
-    fields = z3c.form.field.Fields(IParticipation).select('participation_id')
-    participation = None
 
-    fields['participation_id'].mode = HIDDEN_MODE
+    def __init__(self, context, request):
+        super(ParticipationRemoveForm, self).__init__(context, request)
+        self.model = context.model
 
     @property
     def label(self):
         return _(u'label_remove_participation',
                  default=u'Remove Participation of ${title}',
-                 mapping={'title': self.get_participation().contact.get_title()})
+                 mapping={'title': self.model.contact.get_title()})
 
-    def get_participation(self):
-        participation_id = self.request.get('participation_id')
-        if not participation_id:
-            data, errors = self.widgets.extract()
-            participation_id = data.get('participation_id')
-
-        return Participation.query.get(participation_id)
-
-    def updateWidgets(self):
-        super(ParticipationRemoveForm, self).updateWidgets()
-        if self.request.method != 'GET':
+    @button.buttonAndHandler(_(u'Remove'), name='remove')
+    def handleRemove(self, action):
+        data, errors = self.extractData()
+        if errors:
             return
 
-        widget = self.widgets['participation_id']
-        widget.value = IDataConverter(widget).toWidgetValue(
-            self.request.get('participation_id'))
-        self.widgets.update()
+        self.model.delete()
 
-    @z3c.form.button.buttonAndHandler(_(u'Remove'), name='remove')
-    def handleApply(self, action):
-        data, errors = self.extractData()
+        api.portal.show_message(
+            _(u'info_participation_removed', u'Participation removed'),
+            api.portal.get().REQUEST)
 
-        oguid = Oguid.for_object(self.context)
-        participation = Participation.query.get(data.get('participation_id'))
-        if participation.dossier_oguid != oguid:
-            raise Unauthorized
+        return self.request.RESPONSE.redirect(self.nextURL())
 
-        if not errors:
-            participation.delete()
-            msg = _(u'info_participation_removed', u'Participation removed')
-            api.portal.show_message(
-                message=msg, request=self.request, type='info')
+    @button.buttonAndHandler(
+        _(u'label_cancel', default=u'Cancel'), name='cancel')
+    def cancel(self, action):
+        return self.request.RESPONSE.redirect(self.nextURL())
 
-            return self.redirect_to_participants_tab()
+    def nextURL(self):
+        """Returns the url to the dossiers participation tab."""
 
-    @z3c.form.button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
-    def handle_cancel(self, action):
-        return self.redirect_to_participants_tab()
-
-    def redirect_to_participants_tab(self):
-        return self.request.RESPONSE.redirect(
-            '{}#participations'.format(self.context.absolute_url()))
-
-
-class ParticipationRemoveFormView(layout.FormWrapper, grok.View):
-    grok.context(Interface)
-    grok.name('remove-contact-participation')
-    grok.require('cmf.AddPortalContent')
-    form = ParticipationRemoveForm
-
-    def __init__(self, *args, **kwargs):
-        layout.FormWrapper.__init__(self, *args, **kwargs)
-        grok.View.__init__(self, *args, **kwargs)
+        return '{}#participations'.format(
+            aq_parent(self.context).absolute_url())

--- a/opengever/contact/browser/participations.py
+++ b/opengever/contact/browser/participations.py
@@ -1,0 +1,21 @@
+from opengever.base.oguid import Oguid
+from opengever.contact.models import Participation
+from opengever.tabbedview import GeverTabMixin
+from Products.Five.browser import BrowserView
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+
+
+class ParticpationTab(BrowserView, GeverTabMixin):
+
+    show_searchform = False
+
+    template = ViewPageTemplateFile('templates/participations.pt')
+
+    def __call__(self):
+        return self.template()
+
+    def get_participations(self):
+        """Returns all participations for the current context.
+        """
+        oguid = Oguid.for_object(self.context)
+        return Participation.query.by_oguid(oguid).all()

--- a/opengever/contact/browser/participations.py
+++ b/opengever/contact/browser/participations.py
@@ -1,4 +1,3 @@
-from opengever.base.oguid import Oguid
 from opengever.contact.models import Participation
 from opengever.tabbedview import GeverTabMixin
 from Products.Five.browser import BrowserView
@@ -17,5 +16,4 @@ class ParticpationTab(BrowserView, GeverTabMixin):
     def get_participations(self):
         """Returns all participations for the current context.
         """
-        oguid = Oguid.for_object(self.context)
-        return Participation.query.by_oguid(oguid).all()
+        return Participation.query.by_dossier(self.context).all()

--- a/opengever/contact/browser/tabbed.py
+++ b/opengever/contact/browser/tabbed.py
@@ -6,21 +6,8 @@ from opengever.contact import is_contact_feature_enabled
 class ContactFolderTabbedView(TabbedView):
 
     def get_tabs(self):
-        tabs = [
-            {'id': 'local',
-             'title': _(u'label_local', default=u'Local'),
-             'icon': None,
-             'url': '#',
-             'class': None},
-            {'id': 'users',
-             'title': _(u'label_users', default=u'Users'),
-             'icon': None,
-             'url': '#',
-             'class': None},
-        ]
-
         if is_contact_feature_enabled():
-            tabs += [
+            tabs = [
                 {'id': 'persons',
                  'title': _(u'label_persons', default=u'Persons'),
                  'icon': None,
@@ -31,5 +18,21 @@ class ContactFolderTabbedView(TabbedView):
                  'icon': None,
                  'url': '#',
                  'class': None}]
+
+        else:
+            tabs = [
+                {'id': 'local',
+                 'title': _(u'label_local', default=u'Local'),
+                 'icon': None,
+                 'url': '#',
+                 'class': None},
+            ]
+
+        tabs += [
+            {'id': 'users',
+             'title': _(u'label_users', default=u'Users'),
+             'icon': None,
+             'url': '#',
+             'class': None}]
 
         return tabs

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -71,11 +71,11 @@
       <h3 i18n:translate="label_persons">Persons</h3>
       <ul class="persons orgrole_listing">
         <li tal:repeat="org_role organization/persons">
-          <p>
-            <a href="#" class="name"
+          <span class="name">
+            <a href="#"
                tal:attributes="href org_role/person/get_url"
                tal:content="org_role/person/fullname" />
-          </p>
+          </span>
           <span class="function" tal:content="org_role/function" />
         </li>
       </ul>

--- a/opengever/contact/browser/templates/participations.pt
+++ b/opengever/contact/browser/templates/participations.pt
@@ -1,4 +1,4 @@
-<ul id="participation_listing">
+<ul id="participation_listing" i18n:domain="opengever.contact">
   <li tal:repeat="participation view/get_participations">
     <div class="contact">
       <a href="#"

--- a/opengever/contact/browser/templates/participations.pt
+++ b/opengever/contact/browser/templates/participations.pt
@@ -14,14 +14,14 @@
     <ul class="actions">
       <li>
         <a class="edit-action"
-           tal:attributes="href string:${context/absolute_url}/edit-contact-participation?participation_id=${participation/participation_id}"
+           tal:attributes="href string:${context/absolute_url}/${participation/wrapper_id}/edit"
            i18n:translate="button_edit">
           Edit
         </a>
       </li>
       <li>
       <a class="remove-action"
-         tal:attributes="href string:${context/absolute_url}/remove-contact-participation?participation_id=${participation/participation_id}"
+         tal:attributes="href string:${context/absolute_url}/${participation/wrapper_id}/remove"
          i18n:translate="button_remove">
         Remove
       </a>

--- a/opengever/contact/browser/templates/participations.pt
+++ b/opengever/contact/browser/templates/participations.pt
@@ -21,7 +21,7 @@
       </li>
       <li>
       <a class="remove-action"
-         tal:attributes="href string:${context/absolute_url}/remove_participation?participation_id=${participation/participation_id}"
+         tal:attributes="href string:${context/absolute_url}/remove-contact-participation?participation_id=${participation/participation_id}"
          i18n:translate="button_remove">
         Remove
       </a>

--- a/opengever/contact/browser/templates/participations.pt
+++ b/opengever/contact/browser/templates/participations.pt
@@ -8,7 +8,7 @@
     </div>
     <ul class="roles">
       <li tal:repeat="role participation/roles">
-        <span tal:content="role/role" />
+        <span tal:content="role/get_label" />
       </li>
     </ul>
     <ul class="actions">

--- a/opengever/contact/browser/templates/participations.pt
+++ b/opengever/contact/browser/templates/participations.pt
@@ -1,0 +1,31 @@
+<ul id="participation_listing">
+  <li tal:repeat="participation view/get_participations">
+    <div class="contact">
+      <a href="#"
+         tal:attributes="href participation/contact/get_url;
+                         class participation/contact/get_css_class"
+         tal:content="participation/contact/get_title" />
+    </div>
+    <ul class="roles">
+      <li tal:repeat="role participation/roles">
+        <span tal:content="role/role" />
+      </li>
+    </ul>
+    <ul class="actions">
+      <li>
+        <a class="edit-action"
+           tal:attributes="href string:${context/absolute_url}/edit-contact-participation?participation_id=${participation/participation_id}"
+           i18n:translate="button_edit">
+          Edit
+        </a>
+      </li>
+      <li>
+      <a class="remove-action"
+         tal:attributes="href string:${context/absolute_url}/remove_participation?participation_id=${participation/participation_id}"
+         i18n:translate="button_remove">
+        Remove
+      </a>
+      </li>
+    </ul>
+  </li>
+</ul>

--- a/opengever/contact/browser/templates/person.pt
+++ b/opengever/contact/browser/templates/person.pt
@@ -81,11 +81,11 @@
       <h3 i18n:translate="label_organizations">Organizations</h3>
       <ul class="organizations orgrole_listing">
         <li tal:repeat="org_role person/organizations">
-          <p>
-            <a href="#" class="name"
+          <span class="name">
+            <a href="#"
                tal:attributes="href org_role/organization/get_url"
                tal:content="org_role/organization/name" />
-          </p>
+          </span>
           <span class="function" tal:content="org_role/function" />
         </li>
       </ul>

--- a/opengever/contact/configure.zcml
+++ b/opengever/contact/configure.zcml
@@ -31,4 +31,9 @@
       handler=".hooks.installed"
       />
 
+  <utility
+      factory=".vocabularies.ContactsVocabularyFactory"
+      name="opengever.contact.ContactsVocabulary"
+      />
+
 </configure>

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-08-16 13:12+0000\n"
+"POT-Creation-Date: 2016-08-24 16:03+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -52,10 +52,24 @@ msgstr "E-Mail-Adressen"
 msgid "Label"
 msgstr "Label"
 
+#: ./opengever/contact/browser/participation_forms.py:120
+msgid "Remove"
+msgstr "Löschen"
+
 #. Default: "Address"
 #: ./opengever/contact/contact.py:54
 msgid "address"
 msgstr "Adresse"
+
+#. Default: "Edit"
+#: ./opengever/contact/browser/templates/participations.pt:16
+msgid "button_edit"
+msgstr "Bearbeiten"
+
+#. Default: "Remove"
+#: ./opengever/contact/browser/templates/participations.pt:23
+msgid "button_remove"
+msgstr "Löschen"
 
 #. Default: "Academic title"
 #: ./opengever/contact/browser/person_listing.py:30
@@ -112,6 +126,11 @@ msgstr "Bitte geben Sie ein Labe sowie eine E-Mail-Adresse ein."
 msgid "info_mailaddress_created"
 msgstr "Die E-Mail-Adresse wurde erstellt."
 
+#. Default: "Participation removed"
+#: ./opengever/contact/browser/participation_forms.py:129
+msgid "info_participation_removed"
+msgstr "Beteiligung gelöscht"
+
 #. Default: "Internet"
 #: ./opengever/contact/contact.py:35
 msgid "internet"
@@ -123,6 +142,11 @@ msgstr "Internet"
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr "Titel"
+
+#. Default: "Add Participation"
+#: ./opengever/contact/browser/participation_forms.py:45
+msgid "label_add_participation"
+msgstr "Beteiligung hinzufügen"
 
 #. Default: "Address 1"
 #: ./opengever/contact/contact.py:150
@@ -169,6 +193,7 @@ msgid "label_archived_phone_numbers"
 msgstr "Archivierte Telefonnummern"
 
 #. Default: "Cancel"
+#: ./opengever/contact/browser/participation_forms.py:135
 #: ./opengever/contact/browser/templates/person_edit.pt:28
 msgid "label_cancel"
 msgstr "Abbrechen"
@@ -182,6 +207,11 @@ msgstr "Ort"
 #: ./opengever/contact/contact.py:88
 msgid "label_company"
 msgstr "Firma"
+
+#. Default: "Contact"
+#: ./opengever/contact/browser/participation_forms.py:26
+msgid "label_contact"
+msgstr "Kontakt"
 
 #. Default: "Country"
 #: ./opengever/contact/contact.py:170
@@ -203,6 +233,11 @@ msgstr "Abteilung"
 #: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr "Beschreibung"
+
+#. Default: "Edit Participation of ${title}"
+#: ./opengever/contact/browser/participation_forms.py:82
+msgid "label_edit_participation"
+msgstr "Beteiligung von ${title} bearbeiten"
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:103
@@ -230,7 +265,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Local"
-#: ./opengever/contact/browser/tabbed.py:11
+#: ./opengever/contact/browser/tabbed.py:25
 msgid "label_local"
 msgstr "Lokal"
 
@@ -247,10 +282,15 @@ msgid "label_name"
 msgstr "Name"
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/tabbed.py:30
+#: ./opengever/contact/browser/tabbed.py:17
 #: ./opengever/contact/browser/templates/person.pt:81
 msgid "label_organizations"
 msgstr "Organisationen"
+
+#. Default: "Participation of ${contact_title}"
+#: ./opengever/contact/models/participation.py:56
+msgid "label_participation_of"
+msgstr "Beteiligung von ${contact_title}"
 
 #. Default: "Personal information:"
 #: ./opengever/contact/browser/templates/person.pt:19
@@ -258,7 +298,7 @@ msgid "label_personal_information"
 msgstr "Persönliche Informationen:"
 
 #. Default: "Persons"
-#: ./opengever/contact/browser/tabbed.py:25
+#: ./opengever/contact/browser/tabbed.py:12
 #: ./opengever/contact/browser/templates/organization.pt:71
 msgid "label_persons"
 msgstr "Personen"
@@ -295,6 +335,16 @@ msgstr "Telefon Arbeit"
 msgid "label_picture"
 msgstr "Bild"
 
+#. Default: "Remove Participation of ${title}"
+#: ./opengever/contact/browser/participation_forms.py:116
+msgid "label_remove_participation"
+msgstr "Beteiligung von ${title} löschen"
+
+#. Default: "Roles"
+#: ./opengever/contact/browser/participation_forms.py:32
+msgid "label_roles"
+msgstr "Rollen"
+
 #. Default: "Salutation"
 #: ./opengever/contact/browser/person.py:77
 #: ./opengever/contact/browser/templates/person.pt:26
@@ -308,7 +358,7 @@ msgid "label_url"
 msgstr "URL"
 
 #. Default: "Users"
-#: ./opengever/contact/browser/tabbed.py:16
+#: ./opengever/contact/browser/tabbed.py:33
 msgid "label_users"
 msgstr "Benutzer"
 
@@ -327,6 +377,11 @@ msgstr "Funktion"
 msgid "mail_address_deleted"
 msgstr "Die E-Mail-Adresse wurde gelöscht."
 
+#. Default: "There already exists a participation for this contact."
+#: ./opengever/contact/browser/participation_forms.py:57
+msgid "msg_participation_already_exists"
+msgstr "Für diesen Kontakt existiert bereits eine Beteiligung."
+
 #. Default: "Personal Stuff"
 #: ./opengever/contact/contact.py:20
 msgid "personal"
@@ -341,4 +396,3 @@ msgstr "${amount} Treffer."
 #: ./opengever/contact/contact.py:44
 msgid "telefon"
 msgstr "Telefon"
-

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-08-16 13:12+0000\n"
+"POT-Creation-Date: 2016-08-24 16:03+0000\n"
 "PO-Revision-Date: 2016-08-10 04:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
@@ -54,10 +54,24 @@ msgstr "Adresses e-mail"
 msgid "Label"
 msgstr "Libellé"
 
+#: ./opengever/contact/browser/participation_forms.py:120
+msgid "Remove"
+msgstr ""
+
 #. Default: "Address"
 #: ./opengever/contact/contact.py:54
 msgid "address"
 msgstr "Adresse"
+
+#. Default: "Edit"
+#: ./opengever/contact/browser/templates/participations.pt:16
+msgid "button_edit"
+msgstr ""
+
+#. Default: "Remove"
+#: ./opengever/contact/browser/templates/participations.pt:23
+msgid "button_remove"
+msgstr ""
 
 #. Default: "Academic title"
 #: ./opengever/contact/browser/person_listing.py:30
@@ -114,6 +128,11 @@ msgstr ""
 msgid "info_mailaddress_created"
 msgstr ""
 
+#. Default: "Participation removed"
+#: ./opengever/contact/browser/participation_forms.py:129
+msgid "info_participation_removed"
+msgstr ""
+
 #. Default: "Internet"
 #: ./opengever/contact/contact.py:35
 msgid "internet"
@@ -125,6 +144,11 @@ msgstr "Site internet"
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr "Titre"
+
+#. Default: "Add Participation"
+#: ./opengever/contact/browser/participation_forms.py:45
+msgid "label_add_participation"
+msgstr ""
 
 #. Default: "Address 1"
 #: ./opengever/contact/contact.py:150
@@ -171,6 +195,7 @@ msgid "label_archived_phone_numbers"
 msgstr ""
 
 #. Default: "Cancel"
+#: ./opengever/contact/browser/participation_forms.py:135
 #: ./opengever/contact/browser/templates/person_edit.pt:28
 msgid "label_cancel"
 msgstr ""
@@ -184,6 +209,11 @@ msgstr "Localité"
 #: ./opengever/contact/contact.py:88
 msgid "label_company"
 msgstr "Entreprise"
+
+#. Default: "Contact"
+#: ./opengever/contact/browser/participation_forms.py:26
+msgid "label_contact"
+msgstr ""
 
 #. Default: "Country"
 #: ./opengever/contact/contact.py:170
@@ -205,6 +235,11 @@ msgstr "Service"
 #: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr "Description"
+
+#. Default: "Edit Participation of ${title}"
+#: ./opengever/contact/browser/participation_forms.py:82
+msgid "label_edit_participation"
+msgstr ""
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:103
@@ -232,7 +267,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Local"
-#: ./opengever/contact/browser/tabbed.py:11
+#: ./opengever/contact/browser/tabbed.py:25
 msgid "label_local"
 msgstr "Local"
 
@@ -249,9 +284,14 @@ msgid "label_name"
 msgstr ""
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/tabbed.py:30
+#: ./opengever/contact/browser/tabbed.py:17
 #: ./opengever/contact/browser/templates/person.pt:81
 msgid "label_organizations"
+msgstr ""
+
+#. Default: "Participation of ${contact_title}"
+#: ./opengever/contact/models/participation.py:56
+msgid "label_participation_of"
 msgstr ""
 
 #. Default: "Personal information:"
@@ -260,7 +300,7 @@ msgid "label_personal_information"
 msgstr ""
 
 #. Default: "Persons"
-#: ./opengever/contact/browser/tabbed.py:25
+#: ./opengever/contact/browser/tabbed.py:12
 #: ./opengever/contact/browser/templates/organization.pt:71
 msgid "label_persons"
 msgstr ""
@@ -297,6 +337,16 @@ msgstr "Téléphone professionnel"
 msgid "label_picture"
 msgstr "Image"
 
+#. Default: "Remove Participation of ${title}"
+#: ./opengever/contact/browser/participation_forms.py:116
+msgid "label_remove_participation"
+msgstr ""
+
+#. Default: "Roles"
+#: ./opengever/contact/browser/participation_forms.py:32
+msgid "label_roles"
+msgstr ""
+
 #. Default: "Salutation"
 #: ./opengever/contact/browser/person.py:77
 #: ./opengever/contact/browser/templates/person.pt:26
@@ -310,7 +360,7 @@ msgid "label_url"
 msgstr "Adresse URL"
 
 #. Default: "Users"
-#: ./opengever/contact/browser/tabbed.py:16
+#: ./opengever/contact/browser/tabbed.py:33
 msgid "label_users"
 msgstr "Utilisateurs"
 
@@ -327,6 +377,11 @@ msgstr "Fonction"
 #. Default: "Mailaddress successfully deleted"
 #: ./opengever/contact/browser/mail.py:122
 msgid "mail_address_deleted"
+msgstr ""
+
+#. Default: "There already exists a participation for this contact."
+#: ./opengever/contact/browser/participation_forms.py:57
+msgid "msg_participation_already_exists"
 msgstr ""
 
 #. Default: "Personal Stuff"

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-08-16 13:12+0000\n"
+"POT-Creation-Date: 2016-08-24 16:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,9 +55,23 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
+#: ./opengever/contact/browser/participation_forms.py:120
+msgid "Remove"
+msgstr ""
+
 #. Default: "Address"
 #: ./opengever/contact/contact.py:54
 msgid "address"
+msgstr ""
+
+#. Default: "Edit"
+#: ./opengever/contact/browser/templates/participations.pt:16
+msgid "button_edit"
+msgstr ""
+
+#. Default: "Remove"
+#: ./opengever/contact/browser/templates/participations.pt:23
+msgid "button_remove"
 msgstr ""
 
 #. Default: "Academic title"
@@ -115,6 +129,11 @@ msgstr ""
 msgid "info_mailaddress_created"
 msgstr ""
 
+#. Default: "Participation removed"
+#: ./opengever/contact/browser/participation_forms.py:129
+msgid "info_participation_removed"
+msgstr ""
+
 #. Default: "Internet"
 #: ./opengever/contact/contact.py:35
 msgid "internet"
@@ -125,6 +144,11 @@ msgstr ""
 #: ./opengever/contact/browser/templates/person.pt:30
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
+msgstr ""
+
+#. Default: "Add Participation"
+#: ./opengever/contact/browser/participation_forms.py:45
+msgid "label_add_participation"
 msgstr ""
 
 #. Default: "Address 1"
@@ -172,6 +196,7 @@ msgid "label_archived_phone_numbers"
 msgstr ""
 
 #. Default: "Cancel"
+#: ./opengever/contact/browser/participation_forms.py:135
 #: ./opengever/contact/browser/templates/person_edit.pt:28
 msgid "label_cancel"
 msgstr ""
@@ -184,6 +209,11 @@ msgstr ""
 #. Default: "Company"
 #: ./opengever/contact/contact.py:88
 msgid "label_company"
+msgstr ""
+
+#. Default: "Contact"
+#: ./opengever/contact/browser/participation_forms.py:26
+msgid "label_contact"
 msgstr ""
 
 #. Default: "Country"
@@ -205,6 +235,11 @@ msgstr ""
 #: ./opengever/contact/browser/person.py:97
 #: ./opengever/contact/contact.py:145
 msgid "label_description"
+msgstr ""
+
+#. Default: "Edit Participation of ${title}"
+#: ./opengever/contact/browser/participation_forms.py:82
+msgid "label_edit_participation"
 msgstr ""
 
 #. Default: "email"
@@ -233,7 +268,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Local"
-#: ./opengever/contact/browser/tabbed.py:11
+#: ./opengever/contact/browser/tabbed.py:25
 msgid "label_local"
 msgstr ""
 
@@ -250,9 +285,14 @@ msgid "label_name"
 msgstr ""
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/tabbed.py:30
+#: ./opengever/contact/browser/tabbed.py:17
 #: ./opengever/contact/browser/templates/person.pt:81
 msgid "label_organizations"
+msgstr ""
+
+#. Default: "Participation of ${contact_title}"
+#: ./opengever/contact/models/participation.py:56
+msgid "label_participation_of"
 msgstr ""
 
 #. Default: "Personal information:"
@@ -261,7 +301,7 @@ msgid "label_personal_information"
 msgstr ""
 
 #. Default: "Persons"
-#: ./opengever/contact/browser/tabbed.py:25
+#: ./opengever/contact/browser/tabbed.py:12
 #: ./opengever/contact/browser/templates/organization.pt:71
 msgid "label_persons"
 msgstr ""
@@ -298,6 +338,16 @@ msgstr ""
 msgid "label_picture"
 msgstr ""
 
+#. Default: "Remove Participation of ${title}"
+#: ./opengever/contact/browser/participation_forms.py:116
+msgid "label_remove_participation"
+msgstr ""
+
+#. Default: "Roles"
+#: ./opengever/contact/browser/participation_forms.py:32
+msgid "label_roles"
+msgstr ""
+
 #. Default: "Salutation"
 #: ./opengever/contact/browser/person.py:77
 #: ./opengever/contact/browser/templates/person.pt:26
@@ -311,7 +361,7 @@ msgid "label_url"
 msgstr ""
 
 #. Default: "Users"
-#: ./opengever/contact/browser/tabbed.py:16
+#: ./opengever/contact/browser/tabbed.py:33
 msgid "label_users"
 msgstr ""
 
@@ -328,6 +378,11 @@ msgstr ""
 #. Default: "Mailaddress successfully deleted"
 #: ./opengever/contact/browser/mail.py:122
 msgid "mail_address_deleted"
+msgstr ""
+
+#. Default: "There already exists a participation for this contact."
+#: ./opengever/contact/browser/participation_forms.py:57
+msgid "msg_participation_already_exists"
 msgstr ""
 
 #. Default: "Personal Stuff"

--- a/opengever/contact/models/organization.py
+++ b/opengever/contact/models/organization.py
@@ -30,3 +30,6 @@ class Organization(Contact):
 
     def get_title(self):
         return self.name
+
+    def get_css_class(self):
+        return 'contenttype-organization'

--- a/opengever/contact/models/organization.py
+++ b/opengever/contact/models/organization.py
@@ -28,5 +28,5 @@ class Organization(Contact):
         return '{}/{}/{}'.format(
             get_contactfolder_url(), self.wrapper_id, view)
 
-    def get_title(self, view='view'):
+    def get_title(self):
         return self.name

--- a/opengever/contact/models/organization.py
+++ b/opengever/contact/models/organization.py
@@ -1,11 +1,17 @@
 from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.contact.models.contact import Contact
 from opengever.contact.utils import get_contactfolder_url
+from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
+
+
+class OrganizationQuery(BaseQuery):
+
+    searchable_fields = ['name']
 
 
 class Organization(Contact):
@@ -33,3 +39,6 @@ class Organization(Contact):
 
     def get_css_class(self):
         return 'contenttype-organization'
+
+
+Organization.query_cls = OrganizationQuery

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -17,12 +17,8 @@ from sqlalchemy.schema import Sequence
 
 class ParticipationQuery(BaseQuery):
 
-    def by_oguid(self, oguid):
-        return self.filter(Participation.dossier_oguid == oguid)
-
-    def by_oguid_and_contact(self, oguid, contact):
-        return self.by_oguid(oguid=oguid).filter(
-            Participation.contact == contact)
+    def by_dossier(self, dossier):
+        return self.filter_by(dossier_oguid=Oguid.for_object(dossier))
 
 
 class Participation(Base, SQLFormSupport):

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -70,4 +70,12 @@ class Participation(Base):
 
         self.roles = new_roles
 
+    def delete(self):
+        session = create_session()
+        for role in self.roles:
+            session.delete(role)
+
+        session.delete(self)
+
+
 Participation.query_cls = ParticipationQuery

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -1,6 +1,9 @@
 from opengever.base.model import Base
+from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
+from opengever.contact.models.participation_role import ParticipationRole
 from opengever.ogds.models import UNIT_ID_LENGTH
+from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
@@ -8,6 +11,16 @@ from sqlalchemy import String
 from sqlalchemy.orm import composite
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
+
+
+class ParticipationQuery(BaseQuery):
+
+    def by_oguid(self, oguid):
+        return self.filter(Participation.dossier_oguid == oguid)
+
+    def by_oguid_and_contact(self, oguid, contact):
+        return self.by_oguid(oguid=oguid).filter(
+            Participation.contact == contact)
 
 
 class Participation(Base):
@@ -27,3 +40,11 @@ class Participation(Base):
 
     def resolve_dossier(self):
         return self.dossier_oguid.resolve_object()
+
+    def add_roles(self, roles):
+        for role_title in roles:
+            role = ParticipationRole(participation=self, role=role_title)
+            create_session().add(role)
+
+
+Participation.query_cls = ParticipationQuery

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -41,10 +41,33 @@ class Participation(Base):
     def resolve_dossier(self):
         return self.dossier_oguid.resolve_object()
 
-    def add_roles(self, roles):
-        for role_title in roles:
-            role = ParticipationRole(participation=self, role=role_title)
+    def add_roles(self, role_names):
+        for name in role_names:
+            role = ParticipationRole(participation=self, role=name)
             create_session().add(role)
 
+    def update_roles(self, role_names):
+        """Update the ParticipationRoles of the Participation:
+         - Removes existing roles wich are not part of the given `role_names`
+         - Keep existing roles wich are part of the given `role_names`
+         - Add new roles from `role_names`
+        """
+
+        session = create_session()
+        new_roles = []
+
+        for existing_role in self.roles:
+            if existing_role.role not in role_names:
+                session.delete(existing_role)
+            else:
+                new_roles.append(existing_role)
+                role_names.remove(existing_role.role)
+
+        for name in role_names:
+            role = ParticipationRole(role=name)
+            create_session().add(role)
+            new_roles.append(role)
+
+        self.roles = new_roles
 
 Participation.query_cls = ParticipationQuery

--- a/opengever/contact/models/participation_role.py
+++ b/opengever/contact/models/participation_role.py
@@ -1,11 +1,13 @@
 from opengever.base.model import Base
 from opengever.base.model import CONTENT_TITLE_LENGTH
+from plone import api
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
+from zope.schema.vocabulary import getVocabularyRegistry
 
 
 class ParticipationRole(Base):
@@ -24,3 +26,16 @@ class ParticipationRole(Base):
 
     def __repr__(self):
         return u'<ParticipationRole {} >'.format(self.role)
+
+    def get_label(self):
+        vocabulary_registry = getVocabularyRegistry()
+        vocab = vocabulary_registry.get(
+            api.portal.get(),
+            'opengever.dossier.participation_roles')
+
+        try:
+            term = vocab.getTerm(self.role)
+        except LookupError:
+            return self.role
+        else:
+            return term.title

--- a/opengever/contact/models/participation_role.py
+++ b/opengever/contact/models/participation_role.py
@@ -21,3 +21,6 @@ class ParticipationRole(Base):
                               nullable=False)
     participation = relationship('Participation', back_populates='roles')
     role = Column(String(CONTENT_TITLE_LENGTH), nullable=False)
+
+    def __repr__(self):
+        return u'<ParticipationRole {} >'.format(self.role)

--- a/opengever/contact/models/person.py
+++ b/opengever/contact/models/person.py
@@ -39,3 +39,6 @@ class Person(Contact):
 
     def get_title(self):
         return self.fullname
+
+    def get_css_class(self):
+        return 'contenttype-person'

--- a/opengever/contact/models/person.py
+++ b/opengever/contact/models/person.py
@@ -8,6 +8,12 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
+from opengever.ogds.models.query import BaseQuery
+
+
+class PersonQuery(BaseQuery):
+
+    searchable_fields = ['firstname', 'lastname']
 
 
 class Person(Contact):
@@ -42,3 +48,6 @@ class Person(Contact):
 
     def get_css_class(self):
         return 'contenttype-person'
+
+
+Person.query_cls = PersonQuery

--- a/opengever/contact/participation.py
+++ b/opengever/contact/participation.py
@@ -1,0 +1,12 @@
+from opengever.base.wrapper import SQLWrapperBase
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class IParticipationWrapper(Interface):
+    """Marker interface for participation object wrappers."""
+
+
+class ParticipationWrapper(SQLWrapperBase):
+
+    implements(IParticipationWrapper)

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -197,4 +197,4 @@ class TestOrganizationView(FunctionalTestCase):
 
         self.assertEquals(
             peter.get_url(),
-            browser.css('.persons a.name').first.get('href'))
+            browser.css('.persons .name > a').first.get('href'))

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -183,6 +183,15 @@ class TestEditForm(FunctionalTestCase):
             [role.role for role in Participation.query.first().roles])
 
     @browsing
+    def test_label_contains_participation_contact_title(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+        browser.click_on('Edit')
+
+        self.assertEquals([u'Edit Participation of Peter M\xfcller'],
+                          browser.css('h1').text)
+
+    @browsing
     def test_cancel_redirects_to_participations_tab(self, browser):
         browser.login().open(self.dossier,
                              view=u'tabbedview_view-participations')

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -200,3 +200,52 @@ class TestEditForm(FunctionalTestCase):
         browser.click_on('Cancel')
         self.assertEquals(
             'http://nohost/plone/dossier-1#participations', browser.url)
+
+
+class TestRemoveForm(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRemoveForm, self).setUp()
+        self.contactfolder = create(Builder('contactfolder'))
+        self.dossier = create(Builder('dossier'))
+        self.peter = create(Builder('person')
+                            .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        self.meier_ag = create(Builder('organization').named(u'Meier AG'))
+        self.participation = create(Builder('participation')
+                                    .for_dossier(self.dossier)
+                                    .for_contact(self.peter))
+        create(Builder('participation_role').having(
+            participation=self.participation, role=u'regard'))
+        create(Builder('participation_role').having(
+            participation=self.participation, role=u'final-drawing'))
+
+    @browsing
+    def test_remove_particpation_role(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+        browser.click_on('Remove')
+
+        browser.click_on('Remove')
+        self.assertEquals(['Participation removed'], info_messages())
+        self.assertEquals(
+            'http://nohost/plone/dossier-1#participations', browser.url)
+        self.assertEquals(0, Participation.query.count())
+
+    @browsing
+    def test_label_contains_participation_contact_title(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+        browser.click_on('Remove')
+
+        self.assertEquals([u'Remove Participation of Peter M\xfcller'],
+                          browser.css('h1').text)
+
+    @browsing
+    def test_cancel_redirects_to_participations_tab(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+        browser.click_on('Remove')
+
+        browser.click_on('Cancel')
+        self.assertEquals(
+            'http://nohost/plone/dossier-1#participations', browser.url)

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -1,8 +1,12 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
 from opengever.base.oguid import Oguid
+from opengever.contact.models.participation import Participation
 from opengever.testing import FunctionalTestCase
 from opengever.testing import MEMORY_DB_LAYER
+from zExceptions import Unauthorized
 import unittest2
 
 
@@ -13,9 +17,8 @@ class TestParticipation(unittest2.TestCase):
     def test_adding(self):
         contact = create(Builder('person').having(
             firstname=u'peter', lastname=u'hans'))
-        participation = create(Builder('participation').having(
-            contact=contact,
-            dossier_oguid=Oguid('foo', 1234)))
+        create(Builder('participation')
+               .having(contact=contact, dossier_oguid=Oguid('foo', 1234)))
 
     def test_participation_can_have_multiple_roles(self):
         contact = create(Builder('person').having(
@@ -44,3 +47,64 @@ class TestDossierParticipation(FunctionalTestCase):
             dossier_oguid=Oguid.for_object(dossier)))
 
         self.assertEqual(dossier, participation.resolve_dossier())
+
+
+class TestAddForm(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestAddForm, self).setUp()
+        self.dossier = create(Builder('dossier'))
+        self.peter = create(Builder('person')
+                            .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        self.meier_ag = create(Builder('organization').named(u'Meier AG'))
+
+    @browsing
+    def test_raises_unathorized_when_user_is_not_allowed_to_add_content(self, browser):
+        self.grant('Reader')
+        with self.assertRaises(Unauthorized):
+            browser.login().open(self.dossier,
+                                 view='add-contact-participation')
+
+    @browsing
+    def test_add_participation_for_person(self, browser):
+        browser.login().open(self.dossier, view='add-contact-participation')
+        browser.fill({'Contact': str(self.peter.contact_id),
+                      'Roles': ['Regard']})
+        browser.click_on('Add')
+
+        participation = Participation.query.first()
+        self.assertEquals(self.peter.person_id,
+                          participation.contact.person_id)
+        self.assertEquals(self.dossier, participation.resolve_dossier())
+        self.assertEquals(['regard'],
+                          [role.role for role in participation.roles])
+
+    @browsing
+    def test_add_participation_for_organization(self, browser):
+        browser.login().open(self.dossier, view='add-contact-participation')
+        browser.fill({'Contact': str(self.meier_ag.contact_id),
+                      'Roles': ['Final drawing', 'Regard']})
+        browser.click_on('Add')
+
+        participation = Participation.query.first()
+        self.assertEquals(self.meier_ag.organization_id,
+                          participation.contact.organization_id)
+        self.assertEquals(self.dossier, participation.resolve_dossier())
+        self.assertEquals([u'final-drawing', u'regard'],
+                          [role.role for role in participation.roles])
+
+    @browsing
+    def test_add_already_existing_participation_raise_validation_error(self, browser):
+        create(Builder('participation')
+               .having(contact=self.peter,
+                       dossier_oguid=Oguid.for_object(self.dossier)))
+
+        browser.login().open(self.dossier, view='add-contact-participation')
+        browser.fill({'Contact': str(self.peter.contact_id),
+                      'Roles': ['Final drawing', 'Regard']})
+        browser.click_on('Add')
+
+        self.assertEquals(['There were some errors.'], error_messages())
+        self.assertEquals(
+            ['There already exists a participation for this contact.'],
+            browser.css('div.error').text),

--- a/opengever/contact/tests/test_participation_tab.py
+++ b/opengever/contact/tests/test_participation_tab.py
@@ -1,0 +1,84 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class ParticipationTab(FunctionalTestCase):
+
+    def setUp(self):
+        super(ParticipationTab, self).setUp()
+        create(Builder('contactfolder'))
+        self.dossier = create(Builder('dossier'))
+        self.hans = create(Builder('person').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+        self.sandra = create(Builder('person').having(
+            firstname=u'sandra', lastname=u'Meier'))
+        self.peter_ag = create(Builder('organization')
+                               .having(name=u'Peter AG'))
+
+        create(Builder('participation')
+               .for_contact(self.hans)
+               .for_dossier(self.dossier)
+               .with_roles(['regard, final-drawing']))
+        create(Builder('participation')
+               .for_contact(self.peter_ag)
+               .for_dossier(self.dossier)
+               .with_roles(['participation']))
+
+    @browsing
+    def test_list_all_participating_contacts_and_link_them_to_detail_view(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+
+        self.assertEquals(
+            [u'Hans M\xfcller', 'Peter AG'],
+            browser.css('#participation_listing .contact').text)
+
+        links = browser.css('#participation_listing .contact a')
+        self.assertEquals(
+            [self.hans.get_url(), self.peter_ag.get_url()],
+            [link.get('href') for link in links])
+
+        self.assertEquals(
+            ['contenttype-person', 'contenttype-organization'],
+            [link.get('class') for link in links])
+
+    @browsing
+    def test_list_only_participations_of_the_current_dossier(self, browser):
+        dossier_2 = create(Builder('dossier'))
+        create(Builder('participation')
+               .for_contact(self.sandra)
+               .for_dossier(dossier_2)
+               .with_roles(['regard, final-drawing']))
+
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+        self.assertEquals(
+            [u'Hans M\xfcller', 'Peter AG'],
+            browser.css('#participation_listing .contact').text)
+
+    @browsing
+    def test_roles_of_each_participation_is_visible(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+
+        row1, row2 = browser.css('#participation_listing > li')
+
+        self.assertEquals([u'Hans M\xfcller'], row1.css('.contact').text)
+        self.assertEquals(['regard, final-drawing'], row1.css('.roles').text)
+
+        self.assertEquals([u'Peter AG'], row2.css('.contact').text)
+        self.assertEquals(['participation'], row2.css('.roles').text)
+
+    @browsing
+    def test_edit_action_is_available(self, browser):
+        browser.login().open(self.dossier,
+                             view=u'tabbedview_view-participations')
+
+        edit_link = browser.css('#participation_listing > li .edit-action').first
+
+        self.assertEquals(
+            'http://nohost/plone/dossier-1/edit-contact-participation?participation_id=1',
+            edit_link.get('href'))
+        self.assertEquals('Edit', edit_link.text)

--- a/opengever/contact/tests/test_participation_tab.py
+++ b/opengever/contact/tests/test_participation_tab.py
@@ -78,7 +78,6 @@ class ParticipationTab(FunctionalTestCase):
 
         edit_link = browser.css('#participation_listing > li .edit-action').first
 
-        self.assertEquals(
-            'http://nohost/plone/dossier-1/edit-contact-participation?participation_id=1',
-            edit_link.get('href'))
         self.assertEquals('Edit', edit_link.text)
+        self.assertEquals('http://nohost/plone/dossier-1/participation-1/edit',
+                          edit_link.get('href'))

--- a/opengever/contact/tests/test_participation_tab.py
+++ b/opengever/contact/tests/test_participation_tab.py
@@ -20,7 +20,7 @@ class ParticipationTab(FunctionalTestCase):
         create(Builder('participation')
                .for_contact(self.hans)
                .for_dossier(self.dossier)
-               .with_roles(['regard, final-drawing']))
+               .with_roles(['regard', 'final-drawing']))
         create(Builder('participation')
                .for_contact(self.peter_ag)
                .for_dossier(self.dossier)
@@ -59,17 +59,17 @@ class ParticipationTab(FunctionalTestCase):
             browser.css('#participation_listing .contact').text)
 
     @browsing
-    def test_roles_of_each_participation_is_visible(self, browser):
+    def test_roles_of_each_participation_is_visible_and_translated(self, browser):
         browser.login().open(self.dossier,
                              view=u'tabbedview_view-participations')
 
         row1, row2 = browser.css('#participation_listing > li')
 
         self.assertEquals([u'Hans M\xfcller'], row1.css('.contact').text)
-        self.assertEquals(['regard, final-drawing'], row1.css('.roles').text)
+        self.assertEquals(['Regard', 'Final drawing'], row1.css('.roles li').text)
 
         self.assertEquals([u'Peter AG'], row2.css('.contact').text)
-        self.assertEquals(['participation'], row2.css('.roles').text)
+        self.assertEquals(['Participation'], row2.css('.roles li').text)
 
     @browsing
     def test_edit_action_is_available(self, browser):

--- a/opengever/contact/tests/test_person_view.py
+++ b/opengever/contact/tests/test_person_view.py
@@ -233,4 +233,4 @@ class TestPersonView(FunctionalTestCase):
 
         self.assertEquals(
             org1.get_url(),
-            browser.css('.organizations a.name').first.get('href'))
+            browser.css('.organizations .name > a').first.get('href'))

--- a/opengever/contact/tests/test_tabbed.py
+++ b/opengever/contact/tests/test_tabbed.py
@@ -22,10 +22,10 @@ class TestContactFolderTabbedView(FunctionalTestCase):
             browser.css('.formTab').text)
 
     @browsing
-    def test_shows_person_and_organization_tab_when_contact_feature_is_enabled(self, browser):
+    def test_shows_person_organization_and_user_tab_when_contact_feature_is_enabled(self, browser):
         toggle_feature(IContactSettings, enabled=True)
         browser.login().open(self.contactfolder, view='tabbed_view')
 
         self.assertEquals(
-            ['Local', 'Users', 'Persons', 'Organizations'],
+            ['Persons', 'Organizations', 'Users'],
             browser.css('.formTab').text)

--- a/opengever/contact/tests/test_vocabularies.py
+++ b/opengever/contact/tests/test_vocabularies.py
@@ -24,18 +24,18 @@ class TestContactsVocabulary(FunctionalTestCase):
     def test_contains_all_organizations_and_persons(self):
         voca_factory = getUtility(IVocabularyFactory,
                                   name='opengever.contact.ContactsVocabulary')
+        vocabulary = voca_factory(self.portal)
 
         self.assertTerms(
             [(self.peter_a.contact_id, u'Peter M\xfcller'),
              (self.peter_b.contact_id, u'Peter Fl\xfcckiger'),
              (self.meier_ag.contact_id, u'Meier AG'),
              (self.teamwork_ag.contact_id, u'4teamwork AG')],
-            voca_factory(self.portal))
+            vocabulary.search('*'))
 
     def test_supports_fuzzy_search(self):
         voca_factory = getUtility(IVocabularyFactory,
                                   name='opengever.contact.ContactsVocabulary')
-
         vocabulary = voca_factory(self.portal)
 
         self.assertTerms(

--- a/opengever/contact/tests/test_vocabularies.py
+++ b/opengever/contact/tests/test_vocabularies.py
@@ -1,0 +1,56 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+
+class TestContactsVocabulary(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestContactsVocabulary, self).setUp()
+
+        self.peter_a = create(Builder('person')
+                              .having(firstname=u'Peter',
+                                      lastname=u'M\xfcller'))
+        self.peter_b = create(Builder('person')
+                              .having(firstname=u'Peter',
+                                      lastname=u'Fl\xfcckiger'))
+        self.meier_ag = create(Builder('organization')
+                               .named(u'Meier AG'))
+        self.teamwork_ag = create(Builder('organization')
+                                  .named(u'4teamwork AG'))
+
+    def test_contains_all_organizations_and_persons(self):
+        voca_factory = getUtility(IVocabularyFactory,
+                                  name='opengever.contact.ContactsVocabulary')
+
+        self.assertTerms(
+            [(self.peter_a.contact_id, u'Peter M\xfcller'),
+             (self.peter_b.contact_id, u'Peter Fl\xfcckiger'),
+             (self.meier_ag.contact_id, u'Meier AG'),
+             (self.teamwork_ag.contact_id, u'4teamwork AG')],
+            voca_factory(self.portal))
+
+    def test_supports_fuzzy_search(self):
+        voca_factory = getUtility(IVocabularyFactory,
+                                  name='opengever.contact.ContactsVocabulary')
+
+        vocabulary = voca_factory(self.portal)
+
+        self.assertTerms(
+            [(self.meier_ag.contact_id, 'Meier AG')],
+            vocabulary.search('Meier'))
+
+        self.assertTerms(
+            [(self.peter_a.contact_id, u'Peter M\xfcller'),
+             (self.peter_b.contact_id, u'Peter Fl\xfcckiger')],
+            vocabulary.search('Peter'))
+
+        self.assertTerms(
+            [(self.peter_b.contact_id, u'Peter Fl\xfcckiger')],
+            vocabulary.search('Peter Fl'))
+
+        self.assertTerms(
+            [(self.peter_b.contact_id, u'Peter Fl\xfcckiger')],
+            vocabulary.search('Pe Fl'))

--- a/opengever/contact/vocabularies.py
+++ b/opengever/contact/vocabularies.py
@@ -1,0 +1,46 @@
+from five import grok
+from opengever.contact.models import Contact
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+class SQLSimpleVocabulary(SimpleVocabulary):
+
+    def search(self, query_string):
+        """search method for `z3c.formwidget.autocomplete` support. Returns
+        all matching contacts.
+        """
+
+        if isinstance(query_string, str):
+            query_string = query_string.decode('utf8')
+        query = query_string.lower().split(' ')
+
+        for term in self:
+            if self._compare(query, term.title):
+                yield term
+
+    def _compare(self, query, value):
+        if not value:
+            return False
+
+        for word in query:
+            if len(word) > 0 and word not in value.lower():
+                return False
+        return True
+
+
+class ContactsAndUsersVocabularyFactory(grok.GlobalUtility):
+    """Vocabulary of contacts, users and the inbox of each client.
+    """
+
+    grok.provides(IVocabularyFactory)
+    grok.name('opengever.contact.ContactsVocabulary')
+
+    def __call__(self, context):
+        terms = []
+        for contact in Contact.query.all():
+            terms.append(SimpleTerm(
+                value=contact.contact_id, title=contact.get_title()))
+
+        return SQLSimpleVocabulary(terms)

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -174,7 +174,7 @@ class ParticipationAddForm(z3c.form.form.Form):
 
 class ParticipationAddFormView(layout.FormWrapper, grok.View):
     grok.context(IParticipationAwareMarker)
-    grok.name('add-participation')
+    grok.name('add-plone-participation')
     grok.require('cmf.AddPortalContent')
     form = ParticipationAddForm
 

--- a/opengever/dossier/browser/configure.zcml
+++ b/opengever/dossier/browser/configure.zcml
@@ -30,7 +30,7 @@
       name="tabbed_view"
       class=".tabbed.DossierTabbedView"
       permission="zope2.View"
-      allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
   <browser:page
@@ -38,7 +38,7 @@
       name="tabbed_view"
       class=".tabbed.TemplateDossierTabbedView"
       permission="zope2.View"
-      allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
 </configure>

--- a/opengever/dossier/browser/configure.zcml
+++ b/opengever/dossier/browser/configure.zcml
@@ -25,4 +25,20 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      name="tabbed_view"
+      class=".tabbed.DossierTabbedView"
+      permission="zope2.View"
+      allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+      />
+
+  <browser:page
+      for="opengever.dossier.templatedossier.ITemplateDossier"
+      name="tabbed_view"
+      class=".tabbed.TemplateDossierTabbedView"
+      permission="zope2.View"
+      allowed_attributes="listing select_all reorder setgridstate set_default_tab msg_unknownresponse"
+      />
+
 </configure>

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -1,4 +1,5 @@
 from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.contact import is_contact_feature_enabled
 from opengever.dossier import _
 from opengever.meeting import is_meeting_feature_enabled
 
@@ -22,13 +23,6 @@ class DossierTabbedView(TabbedView):
     tasks_tab = {
         'id': 'tasks',
         'title': _(u'label_tasks', default=u'Tasks'),
-        'icon': None,
-        'url': '#',
-        'class': None}
-
-    participants_tab = {
-        'id': 'participants',
-        'title': _(u'label_participants', default=u'Participants'),
         'icon': None,
         'url': '#',
         'class': None}
@@ -76,13 +70,30 @@ class DossierTabbedView(TabbedView):
 
         return None
 
+    @property
+    def participations_tab(self):
+        if is_contact_feature_enabled():
+            return {
+                'id': 'participations',
+                'title': _(u'label_participations', default=u'Participations'),
+                'icon': None,
+                'url': '#',
+                'class': None}
+
+        return {
+            'id': 'participants',
+            'title': _(u'label_participants', default=u'Participants'),
+            'icon': None,
+            'url': '#',
+            'class': None}
+
     def get_tabs(self):
         tabs = [self.overview_tab,
                 self.subdossiers_tab,
                 self.documents_tab,
                 self.tasks_tab,
                 self.proposals_tab,
-                self.participants_tab,
+                self.participations_tab,
                 self.trash_tab,
                 self.journal_tab,
                 self.info_tab]

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -1,0 +1,129 @@
+from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.dossier import _
+from opengever.meeting import is_meeting_feature_enabled
+
+
+class DossierTabbedView(TabbedView):
+
+    overview_tab = {
+        'id': 'overview',
+        'title': _(u'label_overview', default=u'Overview'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    documents_tab = {
+        'id': 'documents-proxy',
+        'title': _(u'label_documents', default=u'Documents'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    tasks_tab = {
+        'id': 'tasks',
+        'title': _(u'label_tasks', default=u'Tasks'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    participants_tab = {
+        'id': 'participants',
+        'title': _(u'label_participants', default=u'Participants'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    trash_tab = {
+        'id': 'trash',
+        'title': _(u'label_trash', default=u'Trash'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    journal_tab = {
+        'id': 'journal',
+        'title': _(u'label_journal', default=u'Journal'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    info_tab = {
+        'id': 'sharing',
+        'title': _(u'label_info', default=u'Info'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    @property
+    def subdossiers_tab(self):
+        if self.context.show_subdossier:
+            return {'id': 'subdossiers',
+                    'title': _(u'label_subdossiers', default=u'Subdossiers'),
+                    'icon': None,
+                    'url': '#',
+                    'class': None}
+
+        return None
+
+    @property
+    def proposals_tab(self):
+        if is_meeting_feature_enabled():
+            return {'id': 'proposals',
+                    'title': _(u'label_proposals', default=u'Proposals'),
+                    'icon': None,
+                    'url': '#',
+                    'class': None}
+
+        return None
+
+    def get_tabs(self):
+        tabs = [self.overview_tab,
+                self.subdossiers_tab,
+                self.documents_tab,
+                self.tasks_tab,
+                self.proposals_tab,
+                self.participants_tab,
+                self.trash_tab,
+                self.journal_tab,
+                self.info_tab]
+
+        # skip conditionally disabled tabs
+        return [tab for tab in tabs if tab]
+
+
+class TemplateDossierTabbedView(TabbedView):
+
+    template_tab = {
+        'id': 'documents-proxy',
+        'title': _(u'label_documents', default=u'Documents'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    tasktemplate_folders_tab = {
+        'id': 'tasktemplatefolders',
+        'title': _(u'label_tasktemplate_folders',
+                   default=u'Tasktemplate Folders'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    @property
+    def sablon_tab(self):
+        if is_meeting_feature_enabled():
+            return {'id': 'sablontemplates',
+                    'title': _(u'label_sablon_templates',
+                               default=u'Sablon Templates'),
+                    'icon': None,
+                    'url': '#',
+                    'class': None}
+
+    def get_tabs(self):
+        tabs = [
+            self.template_tab,
+            self.sablon_tab,
+            self.tasktemplate_folders_tab
+        ]
+
+        # skip conditionally disabled tabs
+        return [tab for tab in tabs if tab]

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-08-17 14:51+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: German <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-dossier/de/>\n"
-"Language: de\n"
+"Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: de\n"
+"X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/dossier/move_items.py:149
 msgid "${copied_items} Elements were moved successfully"
@@ -81,9 +80,7 @@ msgstr "Folgende Elemente konnten nicht verschoben werden: ${failed_objects}"
 
 #: ./opengever/dossier/move_items.py:161
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
-msgstr ""
-"Die folgenden Objekte konnten nicht kopiert werden: ${failed_objects}. Sie "
-"sind via WebDAV gesperrt."
+msgstr "Die folgenden Objekte konnten nicht kopiert werden: ${failed_objects}. Sie sind via WebDAV gesperrt."
 
 #: ./opengever/dossier/move_items.py:212
 msgid "It isn't allowed to add such items there"
@@ -119,7 +116,7 @@ msgstr "Es sind keine Vorlagen vorhanden."
 
 #: ./opengever/dossier/browser/overview.py:46
 msgid "Participants"
-msgstr "Beteiligte"
+msgstr "Beteiligungen"
 
 #. Default: "Project Dossier"
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
@@ -413,6 +410,11 @@ msgstr "Erstellt von"
 msgid "label_destination"
 msgstr "Zielposition / Zieldossier"
 
+#. Default: "Documents"
+#: ./opengever/dossier/browser/tabbed.py:18
+msgid "label_documents"
+msgstr "Dokumente"
+
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:48
 msgid "label_edit_after_creation"
@@ -451,6 +453,16 @@ msgstr "Ablagenummer"
 msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
+#. Default: "Info"
+#: ./opengever/dossier/browser/tabbed.py:46
+msgid "label_info"
+msgstr "Info"
+
+#. Default: "Journal"
+#: ./opengever/dossier/browser/tabbed.py:39
+msgid "label_journal"
+msgstr "Journal"
+
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:57
 msgid "label_keywords"
@@ -476,10 +488,30 @@ msgstr "Die Archivnummer wird erst beim Erstellen generiert."
 msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
+#. Default: "Overview"
+#: ./opengever/dossier/browser/tabbed.py:11
+msgid "label_overview"
+msgstr "Übersicht"
+
+#. Default: "Participants"
+#: ./opengever/dossier/browser/tabbed.py:81
+msgid "label_participants"
+msgstr "Beteiligungen"
+
 #. Default: "Participation"
 #: ./opengever/dossier/behaviors/participation.py:148
 msgid "label_participation"
 msgstr "Beteiligung"
+
+#. Default: "Participations"
+#: ./opengever/dossier/browser/tabbed.py:74
+msgid "label_participations"
+msgstr "Beteiligungen"
+
+#. Default: "Proposals"
+#: ./opengever/dossier/browser/tabbed.py:64
+msgid "label_proposals"
+msgstr "Anträge"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:176
@@ -510,6 +542,11 @@ msgstr "Status"
 msgid "label_roles"
 msgstr "Rollen"
 
+#. Default: "Sablon Templates"
+#: ./opengever/dossier/browser/tabbed.py:122
+msgid "label_sablon_templates"
+msgstr "Sablon Vorlagen"
+
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py:61
 msgid "label_sequence_number"
@@ -527,6 +564,21 @@ msgstr "Beginn"
 msgid "label_start_byline"
 msgstr "Beginn"
 
+#. Default: "Subdossiers"
+#: ./opengever/dossier/browser/tabbed.py:55
+msgid "label_subdossiers"
+msgstr "Subdossiers"
+
+#. Default: "Tasks"
+#: ./opengever/dossier/browser/tabbed.py:25
+msgid "label_tasks"
+msgstr "Aufgaben"
+
+#. Default: "Tasktemplate Folders"
+#: ./opengever/dossier/browser/tabbed.py:112
+msgid "label_tasktemplate_folders"
+msgstr "Standardabläufe"
+
 #. Default: "Template"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:21
 msgid "label_template"
@@ -538,6 +590,11 @@ msgstr "Vorlage"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:30
 msgid "label_title"
 msgstr "Titel"
+
+#. Default: "Trash"
+#: ./opengever/dossier/browser/tabbed.py:32
+msgid "label_trash"
+msgstr "Papierkorb"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-08-17 14:51+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-dossier/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/dossier/move_items.py:149
 msgid "${copied_items} Elements were moved successfully"
@@ -79,9 +78,7 @@ msgstr "Impossible de déplacer les éléments suivants: ${failed_objects}"
 
 #: ./opengever/dossier/move_items.py:161
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
-msgstr ""
-"Les objets suivants ne peuvent pas être copiés: ${failed_objects}. Ils sont "
-"verrouillés par WebDAV."
+msgstr "Les objets suivants ne peuvent pas être copiés: ${failed_objects}. Ils sont verrouillés par WebDAV."
 
 #: ./opengever/dossier/move_items.py:212
 msgid "It isn't allowed to add such items there"
@@ -409,6 +406,11 @@ msgstr "Créé par"
 msgid "label_destination"
 msgstr "Destination"
 
+#. Default: "Documents"
+#: ./opengever/dossier/browser/tabbed.py:18
+msgid "label_documents"
+msgstr "Documents"
+
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:48
 msgid "label_edit_after_creation"
@@ -447,6 +449,16 @@ msgstr "Numéro d'inventaire"
 msgid "label_former_reference_number"
 msgstr "Ancienne numéro référence"
 
+#. Default: "Info"
+#: ./opengever/dossier/browser/tabbed.py:46
+msgid "label_info"
+msgstr "Info"
+
+#. Default: "Journal"
+#: ./opengever/dossier/browser/tabbed.py:39
+msgid "label_journal"
+msgstr "Historique"
+
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:57
 msgid "label_keywords"
@@ -472,10 +484,30 @@ msgstr "Le numéro de classement est généré lors de la création du document.
 msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
+#. Default: "Overview"
+#: ./opengever/dossier/browser/tabbed.py:11
+msgid "label_overview"
+msgstr "Sommaire"
+
+#. Default: "Participants"
+#: ./opengever/dossier/browser/tabbed.py:81
+msgid "label_participants"
+msgstr "Participants"
+
 #. Default: "Participation"
 #: ./opengever/dossier/behaviors/participation.py:148
 msgid "label_participation"
 msgstr "Participation"
+
+#. Default: "Participations"
+#: ./opengever/dossier/browser/tabbed.py:74
+msgid "label_participations"
+msgstr "Participation"
+
+#. Default: "Proposals"
+#: ./opengever/dossier/browser/tabbed.py:64
+msgid "label_proposals"
+msgstr "Propositions"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:176
@@ -506,6 +538,11 @@ msgstr "Etat"
 msgid "label_roles"
 msgstr "Rôles"
 
+#. Default: "Sablon Templates"
+#: ./opengever/dossier/browser/tabbed.py:122
+msgid "label_sablon_templates"
+msgstr "Sablon Modèles"
+
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py:61
 msgid "label_sequence_number"
@@ -523,6 +560,21 @@ msgstr "Date début"
 msgid "label_start_byline"
 msgstr "De"
 
+#. Default: "Subdossiers"
+#: ./opengever/dossier/browser/tabbed.py:55
+msgid "label_subdossiers"
+msgstr "Sous-dossiers"
+
+#. Default: "Tasks"
+#: ./opengever/dossier/browser/tabbed.py:25
+msgid "label_tasks"
+msgstr "Tâches"
+
+#. Default: "Tasktemplate Folders"
+#: ./opengever/dossier/browser/tabbed.py:112
+msgid "label_tasktemplate_folders"
+msgstr "Déroulements standards"
+
 #. Default: "Template"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:21
 msgid "label_template"
@@ -534,6 +586,11 @@ msgstr "Modèle"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:30
 msgid "label_title"
 msgstr "Titre"
+
+#. Default: "Trash"
+#: ./opengever/dossier/browser/tabbed.py:32
+msgid "label_trash"
+msgstr "Corbeille"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-08-17 14:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -407,6 +407,11 @@ msgstr ""
 msgid "label_destination"
 msgstr ""
 
+#. Default: "Documents"
+#: ./opengever/dossier/browser/tabbed.py:18
+msgid "label_documents"
+msgstr ""
+
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:48
 msgid "label_edit_after_creation"
@@ -445,6 +450,16 @@ msgstr ""
 msgid "label_former_reference_number"
 msgstr ""
 
+#. Default: "Info"
+#: ./opengever/dossier/browser/tabbed.py:46
+msgid "label_info"
+msgstr ""
+
+#. Default: "Journal"
+#: ./opengever/dossier/browser/tabbed.py:39
+msgid "label_journal"
+msgstr ""
+
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:57
 msgid "label_keywords"
@@ -470,9 +485,29 @@ msgstr ""
 msgid "label_number_of_containers"
 msgstr ""
 
+#. Default: "Overview"
+#: ./opengever/dossier/browser/tabbed.py:11
+msgid "label_overview"
+msgstr ""
+
+#. Default: "Participants"
+#: ./opengever/dossier/browser/tabbed.py:81
+msgid "label_participants"
+msgstr ""
+
 #. Default: "Participation"
 #: ./opengever/dossier/behaviors/participation.py:148
 msgid "label_participation"
+msgstr ""
+
+#. Default: "Participations"
+#: ./opengever/dossier/browser/tabbed.py:74
+msgid "label_participations"
+msgstr ""
+
+#. Default: "Proposals"
+#: ./opengever/dossier/browser/tabbed.py:64
+msgid "label_proposals"
 msgstr ""
 
 #. Default: "Reference Number"
@@ -504,6 +539,11 @@ msgstr ""
 msgid "label_roles"
 msgstr ""
 
+#. Default: "Sablon Templates"
+#: ./opengever/dossier/browser/tabbed.py:122
+msgid "label_sablon_templates"
+msgstr ""
+
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py:61
 msgid "label_sequence_number"
@@ -521,6 +561,21 @@ msgstr ""
 msgid "label_start_byline"
 msgstr ""
 
+#. Default: "Subdossiers"
+#: ./opengever/dossier/browser/tabbed.py:55
+msgid "label_subdossiers"
+msgstr ""
+
+#. Default: "Tasks"
+#: ./opengever/dossier/browser/tabbed.py:25
+msgid "label_tasks"
+msgstr ""
+
+#. Default: "Tasktemplate Folders"
+#: ./opengever/dossier/browser/tabbed.py:112
+msgid "label_tasktemplate_folders"
+msgstr ""
+
 #. Default: "Template"
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:21
 msgid "label_template"
@@ -531,6 +586,11 @@ msgstr ""
 #: ./opengever/dossier/templatedossier/form.py:127
 #: ./opengever/dossier/templatedossier/form_templates/template_form.pt:30
 msgid "label_title"
+msgstr ""
+
+#. Default: "Trash"
+#: ./opengever/dossier/browser/tabbed.py:32
+msgid "label_trash"
 msgstr ""
 
 #. Default: "State"

--- a/opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -101,54 +101,6 @@
         <permission value="Add portal content"/>
     </action>
 
-
-    <!-- Tabbedview tabs-->
-    <action i18n:domain="opengever.dossier" title="Overview" action_id="overview" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Subdossiers" action_id="subdossiers" category="tabbedview-tabs"
-            condition_expr="object/show_subdossier" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Documents" action_id="documents-proxy" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Tasks" action_id="tasks" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Proposals" action_id="proposals" category="tabbedview-tabs"
-            condition_expr="object/@@is_meeting_feature_enabled" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Participants" action_id="participants" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Trash" action_id="trash-proxy" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Journal" action_id="journal" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-
-    <action i18n:domain="opengever.dossier" title="Sharing" action_id="sharing" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#"
-            visible="True">
-        <permission value="View"/>
-    </action>
-
     <action i18n:domain="opengever.dossier" title="Give Filing Number" action_id="filing_nr" category="object_buttons"
             condition_expr="python: object.portal_workflow.getInfoFor(object, 'review_state', None) == 'dossier-state-resolved' and getattr( object, 'filing_no', None) == None" url_expr="string:${object_url}/transition-archive" visible="True">
         <permission value="Modify portal content"/>

--- a/opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.projectdossier.xml
@@ -66,29 +66,4 @@
     <permission value="Modify portal content"/>
   </action>
 
-  <!-- Tabbedview tabs-->
-  <action title="Overview" action_id="overview" category="tabbedview-tabs"
-          condition_expr="" url_expr="string:#" visible="True">
-    <permission value="View"/>
-  </action>
-  <action title="Subdossiers" action_id="subdossiers" category="tabbedview-tabs"
-          condition_expr="" url_expr="string:#" visible="True">
-    <permission value="View"/>
-  </action>
-  <action title="Documents" action_id="documents-proxy" category="tabbedview-tabs"
-          condition_expr="" url_expr="string:#" visible="True">
-    <permission value="View"/>
-  </action>
-  <action title="Tasks" action_id="tasks" category="tabbedview-tabs"
-          condition_expr="" url_expr="string:#" visible="True">
-    <permission value="View"/>
-  </action>
-  <action title="Journal" action_id="journal" category="tabbedview-tabs"
-          condition_expr="" url_expr="string:#" visible="True">
-    <permission value="View"/>
-  </action>
-  <action title="Sharing" action_id="sharing" category="tabbedview-tabs"
-          condition_expr="" url_expr="string:#" visible="True">
-    <permission value="View"/>
-  </action>
 </object>

--- a/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
@@ -64,25 +64,4 @@
         <permission value="opengever.dossier: Add templatedossier"/>
     </action>
 
-    <!-- Tabbedview tabs-->
-    <action title="Templates" action_id="documents-proxy" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action title="Sablon Templates" action_id="sablontemplates" category="tabbedview-tabs"
-            condition_expr="object/@@is_meeting_feature_enabled" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action title="Tasktemplate Folders" action_id="tasktemplatefolders"
-            category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Trash" action_id="trash-proxy" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-    </action>
-
 </object>

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentmenu.menu import FactoriesMenu
+from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.mail.behaviors import ISendableDocsContainer
 from opengever.testing import FunctionalTestCase
@@ -43,17 +44,6 @@ class TestDossier(FunctionalTestCase):
                .in_state('dossier-state-resolved'))
         self.assertTrue(self.dossier.has_subdossiers())
 
-    def _get_active_tabbedview_tab_titles(self, obj):
-        types_tool = getToolByName(self.portal, 'portal_types')
-        actions = types_tool.listActionInfos(
-            object=obj, category='tabbedview-tabs')
-        tabs = [action['title'] for action in actions]
-        return tabs
-
-    def assert_tabbedview_tabs_for_obj(self, expected_tabs, obj):
-        self.assertEquals(expected_tabs,
-                          self._get_active_tabbedview_tab_titles(obj))
-
     def assert_searchable_text(self, expected, dossier):
         values = index_data_for(dossier).get('SearchableText')
         values.sort()
@@ -65,11 +55,13 @@ class TestDossier(FunctionalTestCase):
             ISendableDocsContainer.providedBy(self.dossier),
             'The dossier is not marked with the ISendableDocsContainer')
 
-    def test_tabbedview_tabs(self):
+    @browsing
+    def test_tabbedview_tabs(self, browser):
         expected_tabs = ['Overview', 'Subdossiers', 'Documents', 'Tasks',
-                         'Participants', 'Trash', 'Journal', 'Sharing', ]
+                         'Participants', 'Trash', 'Journal', 'Info']
 
-        self.assert_tabbedview_tabs_for_obj(expected_tabs, self.dossier)
+        browser.login().open(self.dossier, view='tabbed_view')
+        self.assertEquals(expected_tabs, browser.css('li.formTab').text)
 
     def test_use_the_dossier_workflow(self):
         wf_tool = getToolByName(self.portal, 'portal_workflow')

--- a/opengever/dossier/tests/test_tabbed.py
+++ b/opengever/dossier/tests/test_tabbed.py
@@ -1,0 +1,39 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.contact.interfaces import IContactSettings
+from opengever.testing import FunctionalTestCase
+from plone import api
+import transaction
+
+
+class TestParticipationTab(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestParticipationTab, self).setUp()
+        self.dossier = create(Builder('dossier'))
+
+    @browsing
+    def test_is_plone_object_implementation_when_contact_feature_is_disabled(self, browser):
+        api.portal.set_registry_record(
+            'is_feature_enabled', False, interface=IContactSettings)
+        transaction.commit()
+
+        browser.login().open(self.dossier, view='tabbed_view')
+        browser.click_on('Participants')
+
+        self.assertEqual('http://nohost/plone/dossier-1/tabbed_view#participants',
+                         browser.url)
+
+    @browsing
+    def test_is_sql_object_implementation_when_contact_feature_is_enabled(self, browser):
+        api.portal.set_registry_record(
+            'is_feature_enabled', True, interface=IContactSettings)
+        transaction.commit()
+
+        browser.login().open(self.dossier, view='tabbed_view')
+        browser.click_on('Participations')
+
+        self.assertEqual(
+            'http://nohost/plone/dossier-1/tabbed_view#participations',
+            browser.url)

--- a/opengever/dossier/upgrades/20160817080551_remove_tabbed_view_actions/upgrade.py
+++ b/opengever/dossier/upgrades/20160817080551_remove_tabbed_view_actions/upgrade.py
@@ -1,0 +1,47 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class RemoveTabbedViewActions(UpgradeStep):
+    """Remove tabbed view actions.
+    """
+
+    tabbeview_action_ids = [
+        'overview',
+        'subdossiers',
+        'documents-proxy',
+        'tasks',
+        'proposals',
+        'participants',
+        'trash-proxy',
+        'journal',
+        'sharing',
+        'tasktemplatefolders',
+        'sablontemplates'
+    ]
+
+    def __call__(self):
+        for fti in self.get_dossier_types():
+            self.remove_tabbedview_actions(fti)
+
+    def remove_tabbedview_actions(self, fti):
+        for action_id in self.tabbeview_action_ids:
+            self.actions_remove_type_action(fti.id, action_id)
+
+    def get_dossier_types(self):
+        ttool = api.portal.get_tool('portal_types')
+        for fti in ttool.listTypeInfo():
+            if self._is_dossier_fti(fti):
+                yield fti
+
+    def _is_dossier_fti(self, fti):
+        """Use the opengever.dossier.behaviors.dossier.IDossier behavior to
+        detect if the FTI is a dossier fti. That behavior is enabled for all
+        currently known dossiers.
+        """
+
+        behaviors = fti.getProperty('behaviors')
+        if not behaviors:
+            return False
+
+        return 'opengever.dossier.behaviors.dossier.IDossier' in behaviors

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -44,7 +44,7 @@
       name="tabbed_view"
       class=".tabbed.ModelProxyTabbedView"
       permission="zope2.View"
-      allowed_attributes="listing select_all reorder setgridstate set_default_tab"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
   <browser:page
@@ -52,7 +52,7 @@
       name="tabbed_view"
       class=".tabbed.ModelProxyTabbedView"
       permission="zope2.View"
-      allowed_attributes="listing select_all reorder setgridstate set_default_tab"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
   <browser:page
@@ -60,7 +60,7 @@
       name="tabbed_view"
       class=".tabbed.ModelProxyTabbedView"
       permission="zope2.View"
-      allowed_attributes="listing select_all reorder setgridstate set_default_tab"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
   <browser:page

--- a/opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.meetingdossier.xml
@@ -101,54 +101,6 @@
         <permission value="Add portal content"/>
     </action>
 
-
-    <!-- Tabbedview tabs-->
-    <action i18n:domain="opengever.dossier" title="Overview" action_id="overview" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Subdossiers" action_id="subdossiers" category="tabbedview-tabs"
-            condition_expr="object/show_subdossier" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Documents" action_id="documents-proxy" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Tasks" action_id="tasks" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Proposals" action_id="proposals" category="tabbedview-tabs"
-            condition_expr="object/@@is_meeting_feature_enabled" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Participants" action_id="participants" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Trash" action_id="trash-proxy" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-    </action>
-
-    <action i18n:domain="opengever.dossier" title="Journal" action_id="journal" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#" visible="True">
-        <permission value="View"/>
-    </action>
-
-
-    <action i18n:domain="opengever.dossier" title="Sharing" action_id="sharing" category="tabbedview-tabs"
-            condition_expr="" url_expr="string:#"
-            visible="True">
-        <permission value="View"/>
-    </action>
-
     <action i18n:domain="opengever.dossier" title="Give Filing Number" action_id="filing_nr" category="object_buttons"
             condition_expr="python: object.portal_workflow.getInfoFor(object, 'review_state', None) == 'dossier-state-resolved' and getattr( object, 'filing_no', None) == None" url_expr="string:${object_url}/transition-archive" visible="True">
         <permission value="Modify portal content"/>

--- a/opengever/meeting/tests/test_meeting_dossier.py
+++ b/opengever/meeting/tests/test_meeting_dossier.py
@@ -50,9 +50,11 @@ class TestMeetingDossier(TestDossier):
              'opengever.task.task'],
             [fti.id for fti in self.dossier.allowedContentTypes()])
 
-    def test_tabbedview_tabs(self):
+    @browsing
+    def test_tabbedview_tabs(self, browser):
         expected_tabs = ['Overview', 'Subdossiers', 'Documents', 'Tasks',
                          'Proposals', 'Participants', 'Trash', 'Journal',
-                         'Sharing', ]
+                         'Info']
 
-        self.assert_tabbedview_tabs_for_obj(expected_tabs, self.dossier)
+        browser.login().open(self.dossier, view='tabbed_view')
+        self.assertEquals(expected_tabs, browser.css('li.formTab').text)

--- a/opengever/tabbedview/browser/configure.zcml
+++ b/opengever/tabbedview/browser/configure.zcml
@@ -8,7 +8,7 @@
         name="personal_overview"
         class=".personal_overview.PersonalOverview"
         permission="zope2.View"
-        allowed_attributes="listing select_all user_is_allowed_to_view"
+        allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
         />
 
     <browser:resourceDirectory

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -483,6 +483,14 @@ class ParticipationBuilder(SqlObjectBuilder):
     mapped_class = Participation
     id_argument_name = 'participation_id'
 
+    def for_dossier(self, obj):
+        self.arguments['dossier_oguid'] = Oguid.for_object(obj)
+        return self
+
+    def for_contact(self, contact):
+        self.arguments['contact'] = contact
+        return self
+
 builder_registry.register('participation', ParticipationBuilder)
 
 

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -482,6 +482,7 @@ class ParticipationBuilder(SqlObjectBuilder):
 
     mapped_class = Participation
     id_argument_name = 'participation_id'
+    roles = []
 
     def for_dossier(self, obj):
         self.arguments['dossier_oguid'] = Oguid.for_object(obj)
@@ -490,6 +491,15 @@ class ParticipationBuilder(SqlObjectBuilder):
     def for_contact(self, contact):
         self.arguments['contact'] = contact
         return self
+
+    def with_roles(self, roles):
+        self.roles = roles
+        return self
+
+    def after_create(self, obj):
+        if self.roles:
+            obj.add_roles(self.roles)
+        return obj
 
 builder_registry.register('participation', ParticipationBuilder)
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,6 +9,8 @@ development-packages =
   plone.rest
   plonetheme.teamraum
   ftw.tabbedview
+# https://github.com/4teamwork/opengever.ogds.models/pull/41
+  opengever.ogds.models
 
 auto-checkout = ${buildout:development-packages}
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -8,6 +8,7 @@ development-packages =
   plone.restapi
   plone.rest
   plonetheme.teamraum
+  ftw.tabbedview
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Depend on https://github.com/4teamwork/opengever.ogds.models/pull/41

This PR adds views and forms for dossier participations using the new SQL contacts objects.

To make sure we can support both contacts implementation at once, the tab and the `add participation` action has to depend on the contact feature flag, which controls if the old Plone object implementation is active or the new SQL object implementation. Therefore I've reworked all dossier tabbedviews, to easily return the correct participation tab depending on the feature flag and register a redirect view which redirects to the correct Participation add form.

Participation Tab:
![bildschirmfoto 2016-08-18 um 14 47 16](https://cloud.githubusercontent.com/assets/485755/17778641/0aec4282-6565-11e6-8f72-3b210ee89378.png)
Add form
![bildschirmfoto 2016-08-18 um 14 47 32](https://cloud.githubusercontent.com/assets/485755/17778659/1a0f2ba8-6565-11e6-9ce1-af593cf46ecd.png)
Edit form
![bildschirmfoto 2016-08-18 um 14 49 15](https://cloud.githubusercontent.com/assets/485755/17778665/1ef16da2-6565-11e6-8895-256be8f0b9be.png)
Remove form
![bildschirmfoto 2016-08-18 um 14 49 37](https://cloud.githubusercontent.com/assets/485755/17778667/21b7ebb0-6565-11e6-9f7f-0eb327d9a083.png)

@deiferni 

Styling in a separate PR