### PR TITLE
[bumblebee] Fix bumblebee fallback image on document overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.1 (unreleased)
 -------------------
 
+- Fix bumblebee fallback image on document overview
+  [Kevin Bieri]
+
 - Sort related persons and organizations alphabetically in contact detail views.
   [phgross]
 

--- a/opengever/document/browser/overview_templates/overview.pt
+++ b/opengever/document/browser/overview_templates/overview.pt
@@ -14,7 +14,7 @@
             </table>
         </div>
         <div tal:condition="view/show_preview" class="documentPreview">
-            <img class="showroom-item"
+            <img class="showroom-item bumblebee-thumbnail"
                  tal:attributes="data-showroom-target view/get_overlay_url;
                                  data-showroom-title string:${context/title};
                                  src view/get_preview_image_url;


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2115

To make the `scanForBrokenImages` function working the target
element must have the `bumblebee-thumbnail` class.

![screen shot 2016-08-26 at 15 00 58](https://cloud.githubusercontent.com/assets/1637820/18006046/fd6e157e-6b9d-11e6-8c88-c70ac28725e0.png)
