### PR TITLE
 Display contacts URLs in the person and organization detail views.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.1 (unreleased)
 -------------------
 
+- Display contacts URLs in the person and organization detail views.
+  [phgross]
+
 - Fix bumblebee fallback image on document overview
   [Kevin Bieri]
 

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -66,6 +66,20 @@
           </td>
         </tr>
 
+        <tr>
+          <th i18n:translate="label_urls">URLs</th>
+          <td>
+            <dl class="url">
+              <tal:repeat tal:repeat="url organization/urls">
+                <dt tal:content="url/label" />
+                <dd>
+                  <span tal:content="url/url" />
+                </dd>
+              </tal:repeat>
+            </dl>
+          </td>
+        </tr>
+
       </table>
 
       <h3 i18n:translate="label_persons">Persons</h3>

--- a/opengever/contact/browser/templates/person.pt
+++ b/opengever/contact/browser/templates/person.pt
@@ -76,6 +76,20 @@
           </td>
         </tr>
 
+        <tr>
+          <th i18n:translate="label_urls">URLs</th>
+          <td>
+            <dl class="url">
+              <tal:repeat tal:repeat="url person/urls">
+                <dt tal:content="url/label" />
+                <dd>
+                  <span tal:content="url/url" />
+                </dd>
+              </tal:repeat>
+            </dl>
+          </td>
+        </tr>
+
       </table>
 
       <h3 i18n:translate="label_organizations">Organizations</h3>

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -184,6 +184,26 @@ class TestOrganizationView(FunctionalTestCase):
             browser.css('.persons .function').text)
 
     @browsing
+    def test_shows_urls_prefixed_with_label(self, browser):
+        organization = create(Builder('organization').named(u'4teamwork'))
+
+        create(Builder('url')
+               .for_contact(organization)
+               .labeled('Blog')
+               .having(url=u'peters-blog.example.com'))
+        create(Builder('url')
+               .for_contact(organization)
+               .labeled('Homepage')
+               .having(url=u'peters-homepage.example.com'))
+
+        browser.login().open(self.contactfolder, view=organization.wrapper_id)
+
+        self.assertEquals([u'Blog', u'Homepage'], browser.css('.url dt').text)
+        self.assertEquals(
+            [u'peters-blog.example.com', u'peters-homepage.example.com'],
+            browser.css('.url dd').text)
+
+    @browsing
     def test_related_persons_are_linked_to_person_view(self, browser):
         org1 = create(Builder('organization').named(u'4teamwork AG'))
         peter = create(Builder('person')

--- a/opengever/contact/tests/test_person_view.py
+++ b/opengever/contact/tests/test_person_view.py
@@ -202,6 +202,27 @@ class TestPersonView(FunctionalTestCase):
                           browser.css('#contactHistory .mail dd').text)
 
     @browsing
+    def test_shows_urls_prefixed_with_label(self, browser):
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+
+        create(Builder('url')
+               .for_contact(peter)
+               .labeled('Blog')
+               .having(url=u'peters-blog.example.com'))
+        create(Builder('url')
+               .for_contact(peter)
+               .labeled('Homepage')
+               .having(url=u'peters-homepage.example.com'))
+
+        browser.login().open(self.contactfolder, view=peter.wrapper_id)
+
+        self.assertEquals([u'Blog', u'Homepage'], browser.css('.url dt').text)
+        self.assertEquals(
+            [u'peters-blog.example.com', u'peters-homepage.example.com'],
+            browser.css('.url dd').text)
+
+    @browsing
     def test_list_all_of_the_users_organizations_alphabetically(self, browser):
         org1 = create(Builder('organization').named(u'Jaeger & Heike GmbH'))
         create(Builder('organization').named(u'Schuhmacher Peter AG'))


### PR DESCRIPTION
![bildschirmfoto 2016-08-26 um 17 43 16](https://cloud.githubusercontent.com/assets/485755/18011253/9f3e05ec-6bb4-11e6-8a24-73d227846c95.png)

Styling adjustment in plonetheme.teamraum: https://github.com/4teamwork/plonetheme.teamraum/pull/458

@lukasgraf or @deiferni 