### PR TITLE
[showroom] Fix document overview on searchpage

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.10.1 (unreleased)
 -------------------
 
+- [showroom] Fix document overview on searchpage
+  [Kevin Bieri]
+
 - Set and persist Dexterity default values:
   This is a massive overhaul that fixes the behavior around
   DX default and missing values. See PR #2118 for details.

--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -340,11 +340,9 @@
                           </dd>
                         </div>
                         <div class="searchImage" tal:condition="item/is_bumblebeeable">
-                          <img class="showroom-item bumblebeeSearchPreview"
+                          <img class="showroom-reference bumblebeeSearchPreview"
                                tal:attributes="src item/get_preview_image_url;
-                                               data-showroom-id item/UID;
-                                               data-showroom-target item/get_overlay_url;
-                                               data-showroom-title item/get_overlay_title;" />
+                                               data-showroom-target-item item/UID;" />
                         </div>
                       </div>
                       <div class="visualClear"><!-- --></div>

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -5,6 +5,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
 from plone import api
 from zope.component import getMultiAdapter
+from plone.uuid.interfaces import IUUID
 
 
 class TestOpengeverSearch(FunctionalTestCase):
@@ -47,7 +48,7 @@ class TestBumblebeePreview(FunctionalTestCase):
 
     @browsing
     def test_thumbnails_are_linked_to_bumblebee_overlay(self, browser):
-        create(Builder('document')
+        document = create(Builder('document')
                .titled(u'Foo Document')
                .with_dummy_content())
 
@@ -55,8 +56,8 @@ class TestBumblebeePreview(FunctionalTestCase):
         browser.fill({'Search Site': 'Foo Document'}).submit()
 
         self.assertEqual(
-            'http://nohost/plone/document-1/@@bumblebee-overlay-listing',
-            browser.css('.bumblebeeSearchPreview').first.get('data-showroom-target'))
+            IUUID(document),
+            browser.css('.bumblebeeSearchPreview').first.get('data-showroom-target-item'))
 
     @browsing
     def test_all_links_including_documents_are_linked_to_absolute_url(self, browser):


### PR DESCRIPTION
Multiple showroom items get initialized for the same document.
So use a showroom reference for the preview image.