### PR TITLE
Fix wrong pin position when trix content has been changed

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Fix wrong pin position when trix content has been changed.
+  [Kevin Bieri]
+
 - [showroom] Support ftw.showroom 1.2.2 version
   [Kevin Bieri]
 

--- a/opengever/meeting/browser/resources/protocol.js
+++ b/opengever/meeting/browser/resources/protocol.js
@@ -136,7 +136,7 @@
 
     var headings = global.Pin("#opengever_meeting_protocol .protocol_title", "trix-toolbar");
     var labels = global.Pin("#opengever_meeting_protocol .agenda_items label", null, { pin: false });
-    var navigation = global.Pin(".protocol-navigation", null, { pin: false });
+    global.Pin(".protocol-navigation", null, { pin: false });
 
     headings.onRelease(function() {
       scrollspy.reset();
@@ -148,6 +148,11 @@
 
     labels.onPin(function(item) {
       scrollspy.select($("#" + item.element.attr("for") + "-anchor"));
+    });
+
+    $(document).on("trix-change", function() {
+      headings.refresh();
+      labels.refresh();
     });
 
   }


### PR DESCRIPTION
When the trix content grows, the pin item position is not
going to be updated. So trigger a refresh on `trix-change`