### PR TITLE
Add latest participation listing on contact detail views

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- List participating dossiers on organization detail view.
+  [phgross]
+
 - [showroom] Support ftw.showroom 1.2.2 version
   [Kevin Bieri]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
-- List participating dossiers on organization detail view.
+- List participating dossiers on organization and person detail view.
   [phgross]
 
 - [showroom] Support ftw.showroom 1.2.2 version

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -32,6 +32,14 @@
       />
 
   <browser:page
+      name="participations"
+      for="opengever.contact.interfaces.IContact"
+      class=".participations.ParticipationsView"
+      permission="zope2.View"
+      allowed_attributes="list"
+      />
+
+  <browser:page
       name="tabbedview_view-participations"
       for="*"
       class=".participations.ParticpationTab"

--- a/opengever/contact/browser/organization.py
+++ b/opengever/contact/browser/organization.py
@@ -30,3 +30,6 @@ class OrganizationView(BrowserView):
         query = OrgRole.query.filter_by(organization=self.context.model)
         return query.join(Person).order_by(
             Person.firstname, Person.lastname).all()
+
+    def participations_fetch_url(self):
+        return self.context.model.get_url('participations/list')

--- a/opengever/contact/browser/organization.py
+++ b/opengever/contact/browser/organization.py
@@ -15,6 +15,8 @@ class OrganizationView(BrowserView):
     implements(IBrowserView, IPublishTraverse)
 
     template = ViewPageTemplateFile('templates/organization.pt')
+    latest_participations = ViewPageTemplateFile(
+        'templates/latest_participations.pt')
 
     def __init__(self, context, request):
         super(OrganizationView, self).__init__(context, request)
@@ -33,3 +35,6 @@ class OrganizationView(BrowserView):
 
     def participations_fetch_url(self):
         return self.context.model.get_url('participations/list')
+
+    def latest_participations_template(self):
+        return self.latest_participations()

--- a/opengever/contact/browser/participations.py
+++ b/opengever/contact/browser/participations.py
@@ -1,7 +1,45 @@
+from ftw.tabbedview.interfaces import ITabbedView
+from opengever.base.response import JSONResponse
 from opengever.contact.models import Participation
 from opengever.tabbedview import GeverTabMixin
+from plone import api
 from Products.Five.browser import BrowserView
+from sqlalchemy import desc
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+
+
+class ParticipationsView(BrowserView):
+    """An endpoint to fetch all participations for the current contact.
+    """
+
+    def get_slice_size(self):
+        return api.portal.get_registry_record(
+            'batch_size', interface=ITabbedView)
+
+    def list(self):
+        """Returns a json dict with the following structure.
+
+        `participations`: a list of json representation of the current
+        contexts participations. It sliced to the default tabbedview batch
+        size depending on the `show_all` request_flag.
+        `has_more`: a boolean value if the list is sliced.
+        """
+
+        data = {}
+        query = Participation.query.filter_by(contact=self.context.model)
+        query = query.order_by(desc(Participation.participation_id))
+        total = query.count()
+
+        if self.request.get('show_all') != 'true':
+            query = query.limit(self.get_slice_size())
+
+        data['participations'] = self._serialize(query)
+        data['has_more'] = total > len(data['participations'])
+        return JSONResponse(self.request).data(**data).dump()
+
+    def _serialize(self, participations):
+        return [participation.get_json_representation()
+                for participation in participations]
 
 
 class ParticpationTab(BrowserView, GeverTabMixin):

--- a/opengever/contact/browser/participations.py
+++ b/opengever/contact/browser/participations.py
@@ -1,10 +1,12 @@
 from ftw.tabbedview.interfaces import ITabbedView
 from opengever.base.response import JSONResponse
+from opengever.contact import _
 from opengever.contact.models import Participation
 from opengever.tabbedview import GeverTabMixin
 from plone import api
 from Products.Five.browser import BrowserView
 from sqlalchemy import desc
+from zope.i18n import translate
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 
 
@@ -23,6 +25,7 @@ class ParticipationsView(BrowserView):
         contexts participations. It sliced to the default tabbedview batch
         size depending on the `show_all` request_flag.
         `has_more`: a boolean value if the list is sliced.
+        `show_all_label`: label for the show all link.
         """
 
         data = {}
@@ -35,7 +38,14 @@ class ParticipationsView(BrowserView):
 
         data['participations'] = self._serialize(query)
         data['has_more'] = total > len(data['participations'])
+        data['show_all_label'] = self.get_show_all_label(total)
         return JSONResponse(self.request).data(**data).dump()
+
+    def get_show_all_label(self, total):
+        msg = _(u'label_show_all',
+                default=u'Show all ${total} participations',
+                mapping={'total': total})
+        return translate(msg, context=self.request)
 
     def _serialize(self, participations):
         return [participation.get_json_representation()

--- a/opengever/contact/browser/person.py
+++ b/opengever/contact/browser/person.py
@@ -53,10 +53,13 @@ class PersonView(BrowserView):
     implements(IBrowserView, IPublishTraverse)
 
     template = ViewPageTemplateFile('templates/person.pt')
+    latest_participations = ViewPageTemplateFile(
+        'templates/latest_participations.pt')
 
     def __init__(self, context, request):
         super(PersonView, self).__init__(context, request)
         self.model = self.context.model
+        self.request = request
 
     def __call__(self):
         return self.template()
@@ -77,6 +80,9 @@ class PersonView(BrowserView):
     def get_org_roles(self):
         query = OrgRole.query.filter_by(person=self.context.model)
         return query.join(Organization).order_by(Organization.name).all()
+
+    def latest_participations_template(self):
+        return self.latest_participations()
 
 
 class IPersonModel(form.Schema):

--- a/opengever/contact/browser/person.py
+++ b/opengever/contact/browser/person.py
@@ -61,6 +61,9 @@ class PersonView(BrowserView):
     def __call__(self):
         return self.template()
 
+    def participations_fetch_url(self):
+        return self.context.model.get_url('participations/list')
+
     def prepare_model_tabs(self, viewlet):
         if not self.model.is_editable():
             return tuple()

--- a/opengever/contact/browser/resources/contact.js
+++ b/opengever/contact/browser/resources/contact.js
@@ -1,6 +1,38 @@
 (function(global, $) {
 
   "use strict";
+  function ParticipatedDossierController(options) {
+    global.Controller.call(this,
+                           $("#latest_participations_template").html(),
+                           $("#latest_participation_listing"), options);
+
+    this._show_all = false;
+
+    this.fetch = function() {
+      var url = $('#latest_participation_listing').data('fetch-url');
+      return $.get(url, {'show_all': this._show_all});
+    };
+
+    this.render = function(data) {
+      return this.template({ participations: data.participations,
+                             has_more: data.has_more });
+    }
+
+    this.show_all = function(data) {
+      this._show_all = true;
+      this.update();
+    }
+
+    this.events = [
+      {
+        method: "click",
+        target: "#participation_show_all",
+        callback: this.show_all
+      }
+    ];
+
+    this.init();
+  }
 
   function ContactController(options) {
 
@@ -124,6 +156,10 @@
   }
 
   $(function() {
+
+    if ($('body.portaltype-opengever-contact-organization').length){
+      var participatedDossierController = new ParticipatedDossierController();
+    }
 
     if ($(".portaltype-opengever-contact-person.template-edit").length) {
       var contactController = new ContactController();

--- a/opengever/contact/browser/resources/contact.js
+++ b/opengever/contact/browser/resources/contact.js
@@ -15,7 +15,8 @@
 
     this.render = function(data) {
       return this.template({ participations: data.participations,
-                             has_more: data.has_more });
+                             has_more: data.has_more,
+                             show_all_label: data.show_all_label});
     }
 
     this.show_all = function(data) {

--- a/opengever/contact/browser/resources/contact.js
+++ b/opengever/contact/browser/resources/contact.js
@@ -157,7 +157,8 @@
 
   $(function() {
 
-    if ($('body.portaltype-opengever-contact-organization').length){
+    if ($('body.portaltype-opengever-contact-organization').length ||
+        $('body.portaltype-opengever-contact-person').length){
       var participatedDossierController = new ParticipatedDossierController();
     }
 

--- a/opengever/contact/browser/templates/latest_participations.pt
+++ b/opengever/contact/browser/templates/latest_participations.pt
@@ -8,11 +8,6 @@
     <img tal:attributes="src string:${portal_url}/spinner.gif" class="spinner"/>
 
     <script id="latest_participations_template" type="text/x-handlebars-template">
-      {{#if has_more}}
-      <a href="" id="participation_show_all">
-        {{show_all_label}}
-      </a>
-      {{/if}}
       {{#each participations}}
       <li>
         <span class="name">
@@ -27,6 +22,13 @@
         </ul>
       </li>
       {{/each}}
+      {{#if has_more}}
+      <li class="show_all_link">
+        <a href="" id="participation_show_all">
+          {{show_all_label}}
+        </a>
+      </li>
+      {{/if}}
     </script>
   </ul>
 </tal:define>

--- a/opengever/contact/browser/templates/latest_participations.pt
+++ b/opengever/contact/browser/templates/latest_participations.pt
@@ -9,7 +9,9 @@
 
     <script id="latest_participations_template" type="text/x-handlebars-template">
       {{#if has_more}}
-      <a href="" id="participation_show_all" i18n:translate="label_show_all">Show all</a>
+      <a href="" id="participation_show_all">
+        {{show_all_label}}
+      </a>
       {{/if}}
       {{#each participations}}
       <li>

--- a/opengever/contact/browser/templates/latest_participations.pt
+++ b/opengever/contact/browser/templates/latest_participations.pt
@@ -1,0 +1,30 @@
+<tal:define i18n:domain="opengever.contact"
+            tal:define="portal_url context/@@plone_portal_state/portal_url">
+
+  <h3 i18n:translate="label_latest_participations">Latest participations</h3>
+  <ul class="person dossier_listing" id="latest_participation_listing"
+    tal:attributes="data-fetch-url view/participations_fetch_url">
+
+    <img tal:attributes="src string:${portal_url}/spinner.gif" class="spinner"/>
+
+    <script id="latest_participations_template" type="text/x-handlebars-template">
+      {{#if has_more}}
+      <a href="" id="participation_show_all" i18n:translate="label_show_all">Show all</a>
+      {{/if}}
+      {{#each participations}}
+      <li>
+        <span class="name">
+          <a class="dossier" href="{{url}}">{{title}}</a>
+        </span>
+        <ul class="roles function" >
+          {{#each roles}}
+          <li>
+            <span>{{label}}</span>
+          </li>
+          {{/each}}
+        </ul>
+      </li>
+      {{/each}}
+    </script>
+  </ul>
+</tal:define>

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -94,33 +94,7 @@
         </li>
       </ul>
 
-      <h3 i18n:translate="label_latest_participations">Latest participations</h3>
-      <ul class="person dossier_listing" id="latest_participation_listing"
-          tal:attributes="data-fetch-url view/participations_fetch_url">
-
-        <img tal:attributes="src string:${portal_url}/spinner.gif" class="spinner"/>
-
-        <script id="latest_participations_template" type="text/x-handlebars-template">
-          {{#if has_more}}
-          <a href="" id="participation_show_all" i18n:translate="label_show_all">Show all</a>
-          {{/if}}
-          {{#each participations}}
-          <li>
-            <span class="name">
-              <a class="dossier" href="{{url}}">{{title}}</a>
-            </span>
-            <ul class="roles function" >
-              {{#each roles}}
-              <li>
-                <span>{{label}}</span>
-              </li>
-              {{/each}}
-            </ul>
-          </li>
-          {{/each}}
-        </script>
-      </ul>
-
+      <div tal:replace="structure view/latest_participations_template" />
 
       <div class="collapsible" id="contactHistory">
         <div class="collapsible-header">

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -94,6 +94,34 @@
         </li>
       </ul>
 
+      <h3 i18n:translate="label_latest_participations">Latest participations</h3>
+      <ul class="person dossier_listing" id="latest_participation_listing"
+          tal:attributes="data-fetch-url view/participations_fetch_url">
+
+        <img tal:attributes="src string:${portal_url}/spinner.gif" class="spinner"/>
+
+        <script id="latest_participations_template" type="text/x-handlebars-template">
+          {{#if has_more}}
+          <a href="" id="participation_show_all" i18n:translate="label_show_all">Show all</a>
+          {{/if}}
+          {{#each participations}}
+          <li>
+            <span class="name">
+              <a class="dossier" href="{{url}}">{{title}}</a>
+            </span>
+            <ul class="roles function" >
+              {{#each roles}}
+              <li>
+                <span>{{label}}</span>
+              </li>
+              {{/each}}
+            </ul>
+          </li>
+          {{/each}}
+        </script>
+      </ul>
+
+
       <div class="collapsible" id="contactHistory">
         <div class="collapsible-header">
           <button class="button fa fa-plus"></button>

--- a/opengever/contact/browser/templates/person.pt
+++ b/opengever/contact/browser/templates/person.pt
@@ -104,6 +104,33 @@
         </li>
       </ul>
 
+      <h3 i18n:translate="label_latest_participations">Latest participations</h3>
+      <ul class="person dossier_listing" id="latest_participation_listing"
+          tal:attributes="data-fetch-url view/participations_fetch_url">
+
+        <img tal:attributes="src string:${portal_url}/spinner.gif" class="spinner"/>
+
+        <script id="latest_participations_template" type="text/x-handlebars-template">
+          {{#if has_more}}
+          <a href="" id="participation_show_all" i18n:translate="label_show_all">Show all</a>
+          {{/if}}
+          {{#each participations}}
+          <li>
+            <span class="name">
+              <a class="dossier" href="{{url}}">{{title}}</a>
+            </span>
+            <ul class="roles function" >
+              {{#each roles}}
+              <li>
+                <span>{{label}}</span>
+              </li>
+              {{/each}}
+            </ul>
+          </li>
+          {{/each}}
+        </script>
+      </ul>
+
       <div class="collapsible" id="contactHistory">
         <div class="collapsible-header">
           <button class="button fa fa-plus"></button>

--- a/opengever/contact/browser/templates/person.pt
+++ b/opengever/contact/browser/templates/person.pt
@@ -104,32 +104,7 @@
         </li>
       </ul>
 
-      <h3 i18n:translate="label_latest_participations">Latest participations</h3>
-      <ul class="person dossier_listing" id="latest_participation_listing"
-          tal:attributes="data-fetch-url view/participations_fetch_url">
-
-        <img tal:attributes="src string:${portal_url}/spinner.gif" class="spinner"/>
-
-        <script id="latest_participations_template" type="text/x-handlebars-template">
-          {{#if has_more}}
-          <a href="" id="participation_show_all" i18n:translate="label_show_all">Show all</a>
-          {{/if}}
-          {{#each participations}}
-          <li>
-            <span class="name">
-              <a class="dossier" href="{{url}}">{{title}}</a>
-            </span>
-            <ul class="roles function" >
-              {{#each roles}}
-              <li>
-                <span>{{label}}</span>
-              </li>
-              {{/each}}
-            </ul>
-          </li>
-          {{/each}}
-        </script>
-      </ul>
+      <div tal:replace="structure view/latest_participations_template" />
 
       <div class="collapsible" id="contactHistory">
         <div class="collapsible-header">

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-08-29 06:43+0000\n"
+"POT-Creation-Date: 2016-08-30 12:13+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Add Person"
-#: ./opengever/contact/browser/person.py:114
+#: ./opengever/contact/browser/person.py:123
 msgid "Add Person"
 msgstr "Person hinzufügen"
 
@@ -142,7 +142,7 @@ msgid "internet"
 msgstr "Internet"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person.py:88
+#: ./opengever/contact/browser/person.py:97
 #: ./opengever/contact/browser/templates/person.pt:30
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
@@ -170,30 +170,30 @@ msgid "label_addresses"
 msgstr "Adressen"
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:104
-#: ./opengever/contact/browser/templates/person.pt:123
+#: ./opengever/contact/browser/templates/organization.pt:120
+#: ./opengever/contact/browser/templates/person.pt:139
 msgid "label_archived_addresses"
 msgstr "Archivierte Adressen"
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:125
-#: ./opengever/contact/browser/templates/person.pt:144
+#: ./opengever/contact/browser/templates/organization.pt:141
+#: ./opengever/contact/browser/templates/person.pt:160
 msgid "label_archived_mail"
 msgstr "Archivierte Mail Adressen"
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:86
+#: ./opengever/contact/browser/templates/organization.pt:102
 msgid "label_archived_organizations"
 msgstr "Archivierte Informationen"
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:96
+#: ./opengever/contact/browser/templates/person.pt:112
 msgid "label_archived_persons"
 msgstr "Archivierte persönliche Informationen"
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:143
-#: ./opengever/contact/browser/templates/person.pt:162
+#: ./opengever/contact/browser/templates/organization.pt:159
+#: ./opengever/contact/browser/templates/person.pt:178
 msgid "label_archived_phone_numbers"
 msgstr "Archivierte Telefonnummern"
 
@@ -234,7 +234,7 @@ msgid "label_department"
 msgstr "Abteilung"
 
 #. Default: "Description"
-#: ./opengever/contact/browser/person.py:103
+#: ./opengever/contact/browser/person.py:112
 #: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr "Beschreibung"
@@ -256,18 +256,23 @@ msgid "label_email2"
 msgstr "E-Mail 2"
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person.py:93
+#: ./opengever/contact/browser/person.py:102
 #: ./opengever/contact/contact.py:82
 #: ./opengever/contact/contactfolder.py:112
 msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person.py:98
+#: ./opengever/contact/browser/person.py:107
 #: ./opengever/contact/contact.py:75
 #: ./opengever/contact/contactfolder.py:107
 msgid "label_lastname"
 msgstr "Nachname"
+
+#. Default: "Latest participations"
+#: ./opengever/contact/browser/templates/latest_participations.pt:4
+msgid "label_latest_participations"
+msgstr "Letzte Beteiligungen"
 
 #. Default: "Local"
 #: ./opengever/contact/browser/tabbed.py:25
@@ -293,7 +298,7 @@ msgstr "Keine Beteiligungen"
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:81
+#: ./opengever/contact/browser/templates/person.pt:95
 msgid "label_organizations"
 msgstr "Organisationen"
 
@@ -309,7 +314,7 @@ msgstr "Persönliche Informationen:"
 
 #. Default: "Persons"
 #: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:71
+#: ./opengever/contact/browser/templates/organization.pt:85
 msgid "label_persons"
 msgstr "Personen"
 
@@ -356,16 +361,27 @@ msgid "label_roles"
 msgstr "Rollen"
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person.py:83
+#: ./opengever/contact/browser/person.py:92
 #: ./opengever/contact/browser/templates/person.pt:26
 #: ./opengever/contact/contact.py:64
 msgid "label_salutation"
 msgstr "Anrede"
 
+#. Default: "Show all ${total} participations"
+#: ./opengever/contact/browser/participations.py:45
+msgid "label_show_all"
+msgstr "Alle ${total} Beteiligungen anzeigen"
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py:115
 msgid "label_url"
 msgstr "URL"
+
+#. Default: "URLs"
+#: ./opengever/contact/browser/templates/organization.pt:70
+#: ./opengever/contact/browser/templates/person.pt:80
+msgid "label_urls"
+msgstr "URLs"
 
 #. Default: "Users"
 #: ./opengever/contact/browser/tabbed.py:33

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-08-29 06:43+0000\n"
+"POT-Creation-Date: 2016-08-30 12:13+0000\n"
 "PO-Revision-Date: 2016-08-10 04:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "Add Person"
-#: ./opengever/contact/browser/person.py:114
+#: ./opengever/contact/browser/person.py:123
 msgid "Add Person"
 msgstr "Ajouter une personne"
 
@@ -144,7 +144,7 @@ msgid "internet"
 msgstr "Site internet"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person.py:88
+#: ./opengever/contact/browser/person.py:97
 #: ./opengever/contact/browser/templates/person.pt:30
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
@@ -172,30 +172,30 @@ msgid "label_addresses"
 msgstr ""
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:104
-#: ./opengever/contact/browser/templates/person.pt:123
+#: ./opengever/contact/browser/templates/organization.pt:120
+#: ./opengever/contact/browser/templates/person.pt:139
 msgid "label_archived_addresses"
 msgstr ""
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:125
-#: ./opengever/contact/browser/templates/person.pt:144
+#: ./opengever/contact/browser/templates/organization.pt:141
+#: ./opengever/contact/browser/templates/person.pt:160
 msgid "label_archived_mail"
 msgstr ""
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:86
+#: ./opengever/contact/browser/templates/organization.pt:102
 msgid "label_archived_organizations"
 msgstr ""
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:96
+#: ./opengever/contact/browser/templates/person.pt:112
 msgid "label_archived_persons"
 msgstr ""
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:143
-#: ./opengever/contact/browser/templates/person.pt:162
+#: ./opengever/contact/browser/templates/organization.pt:159
+#: ./opengever/contact/browser/templates/person.pt:178
 msgid "label_archived_phone_numbers"
 msgstr ""
 
@@ -236,7 +236,7 @@ msgid "label_department"
 msgstr "Service"
 
 #. Default: "Description"
-#: ./opengever/contact/browser/person.py:103
+#: ./opengever/contact/browser/person.py:112
 #: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr "Description"
@@ -258,18 +258,23 @@ msgid "label_email2"
 msgstr "Email 2"
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person.py:93
+#: ./opengever/contact/browser/person.py:102
 #: ./opengever/contact/contact.py:82
 #: ./opengever/contact/contactfolder.py:112
 msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person.py:98
+#: ./opengever/contact/browser/person.py:107
 #: ./opengever/contact/contact.py:75
 #: ./opengever/contact/contactfolder.py:107
 msgid "label_lastname"
 msgstr "Nom"
+
+#. Default: "Latest participations"
+#: ./opengever/contact/browser/templates/latest_participations.pt:4
+msgid "label_latest_participations"
+msgstr ""
 
 #. Default: "Local"
 #: ./opengever/contact/browser/tabbed.py:25
@@ -295,7 +300,7 @@ msgstr ""
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:81
+#: ./opengever/contact/browser/templates/person.pt:95
 msgid "label_organizations"
 msgstr ""
 
@@ -311,7 +316,7 @@ msgstr ""
 
 #. Default: "Persons"
 #: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:71
+#: ./opengever/contact/browser/templates/organization.pt:85
 msgid "label_persons"
 msgstr ""
 
@@ -358,16 +363,27 @@ msgid "label_roles"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person.py:83
+#: ./opengever/contact/browser/person.py:92
 #: ./opengever/contact/browser/templates/person.pt:26
 #: ./opengever/contact/contact.py:64
 msgid "label_salutation"
 msgstr "Titre"
 
+#. Default: "Show all ${total} participations"
+#: ./opengever/contact/browser/participations.py:45
+msgid "label_show_all"
+msgstr ""
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py:115
 msgid "label_url"
 msgstr "Adresse URL"
+
+#. Default: "URLs"
+#: ./opengever/contact/browser/templates/organization.pt:70
+#: ./opengever/contact/browser/templates/person.pt:80
+msgid "label_urls"
+msgstr ""
 
 #. Default: "Users"
 #: ./opengever/contact/browser/tabbed.py:33

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-08-29 06:43+0000\n"
+"POT-Creation-Date: 2016-08-30 12:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.contact\n"
 
 #. Default: "Add Person"
-#: ./opengever/contact/browser/person.py:114
+#: ./opengever/contact/browser/person.py:123
 msgid "Add Person"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgid "internet"
 msgstr ""
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person.py:88
+#: ./opengever/contact/browser/person.py:97
 #: ./opengever/contact/browser/templates/person.pt:30
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
@@ -173,30 +173,30 @@ msgid "label_addresses"
 msgstr ""
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:104
-#: ./opengever/contact/browser/templates/person.pt:123
+#: ./opengever/contact/browser/templates/organization.pt:120
+#: ./opengever/contact/browser/templates/person.pt:139
 msgid "label_archived_addresses"
 msgstr ""
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:125
-#: ./opengever/contact/browser/templates/person.pt:144
+#: ./opengever/contact/browser/templates/organization.pt:141
+#: ./opengever/contact/browser/templates/person.pt:160
 msgid "label_archived_mail"
 msgstr ""
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:86
+#: ./opengever/contact/browser/templates/organization.pt:102
 msgid "label_archived_organizations"
 msgstr ""
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:96
+#: ./opengever/contact/browser/templates/person.pt:112
 msgid "label_archived_persons"
 msgstr ""
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:143
-#: ./opengever/contact/browser/templates/person.pt:162
+#: ./opengever/contact/browser/templates/organization.pt:159
+#: ./opengever/contact/browser/templates/person.pt:178
 msgid "label_archived_phone_numbers"
 msgstr ""
 
@@ -237,7 +237,7 @@ msgid "label_department"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/contact/browser/person.py:103
+#: ./opengever/contact/browser/person.py:112
 #: ./opengever/contact/contact.py:145
 msgid "label_description"
 msgstr ""
@@ -259,17 +259,22 @@ msgid "label_email2"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person.py:93
+#: ./opengever/contact/browser/person.py:102
 #: ./opengever/contact/contact.py:82
 #: ./opengever/contact/contactfolder.py:112
 msgid "label_firstname"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person.py:98
+#: ./opengever/contact/browser/person.py:107
 #: ./opengever/contact/contact.py:75
 #: ./opengever/contact/contactfolder.py:107
 msgid "label_lastname"
+msgstr ""
+
+#. Default: "Latest participations"
+#: ./opengever/contact/browser/templates/latest_participations.pt:4
+msgid "label_latest_participations"
 msgstr ""
 
 #. Default: "Local"
@@ -296,7 +301,7 @@ msgstr ""
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:81
+#: ./opengever/contact/browser/templates/person.pt:95
 msgid "label_organizations"
 msgstr ""
 
@@ -312,7 +317,7 @@ msgstr ""
 
 #. Default: "Persons"
 #: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:71
+#: ./opengever/contact/browser/templates/organization.pt:85
 msgid "label_persons"
 msgstr ""
 
@@ -359,15 +364,26 @@ msgid "label_roles"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person.py:83
+#: ./opengever/contact/browser/person.py:92
 #: ./opengever/contact/browser/templates/person.pt:26
 #: ./opengever/contact/contact.py:64
 msgid "label_salutation"
 msgstr ""
 
+#. Default: "Show all ${total} participations"
+#: ./opengever/contact/browser/participations.py:45
+msgid "label_show_all"
+msgstr ""
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py:115
 msgid "label_url"
+msgstr ""
+
+#. Default: "URLs"
+#: ./opengever/contact/browser/templates/organization.pt:70
+#: ./opengever/contact/browser/templates/person.pt:80
+msgid "label_urls"
 msgstr ""
 
 #. Default: "Users"

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -56,6 +56,12 @@ class Participation(Base, SQLFormSupport):
     def resolve_dossier(self):
         return self.dossier_oguid.resolve_object()
 
+    def get_json_representation(self):
+        dossier = self.resolve_dossier()
+        return {'title': dossier.title,
+                'url': dossier.absolute_url(),
+                'roles': [{'label': role.get_label()} for role in self.roles]}
+
     def add_roles(self, role_names):
         for name in role_names:
             role = ParticipationRole(participation=self, role=name)

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -152,13 +152,12 @@ class TestParticipationsEndPoint(FunctionalTestCase):
         browser.login().open(self.meierag.get_url('participations/list'))
 
         self.assertEqual(
-            [{u'url': u'http://nohost/plone/dossier-3',
-              u'roles': [{u'label': u'Participation'}],
-              u'title': u'Dossier C'},
-             {u'url': u'http://nohost/plone/dossier-2',
-              u'roles': [{u'label': u'Regard'},
-                         {u'label': u'Final drawing'}],
-              u'title': u'Dossier B'}],
+            [{u'roles': [{u'label': u'Participation'}],
+              u'title': u'Dossier C',
+              u'url': u'http://nohost/plone/dossier-3'},
+             {u'roles': [{u'label': u'Participation'}],
+              u'title': u'Dossier B',
+              u'url': u'http://nohost/plone/dossier-2'}],
             browser.json.get('participations'))
 
     @browsing
@@ -168,7 +167,8 @@ class TestParticipationsEndPoint(FunctionalTestCase):
         self.assertEqual(browser.json.get('has_more'), True)
         self.assertEqual(
             [u'Dossier C', u'Dossier B'],
-            [participation for participation in browser.json.get('participations')])
+            [participation.get('title') for participation
+             in browser.json.get('participations')])
 
     @browsing
     def test_returns_all_participations_when_request_flag_is_set(self, browser):
@@ -177,7 +177,8 @@ class TestParticipationsEndPoint(FunctionalTestCase):
 
         self.assertEqual(
             [u'Dossier C', u'Dossier B', u'Dossier A'],
-            [participation for participation in browser.json.get('participations')])
+            [participation.get('title') for participation
+             in browser.json.get('participations')])
 
 
 class TestAddParticipationAction(FunctionalTestCase):

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -171,6 +171,13 @@ class TestParticipationsEndPoint(FunctionalTestCase):
              in browser.json.get('participations')])
 
     @browsing
+    def test_show_all_link(self, browser):
+        browser.login().open(self.meierag.get_url('participations/list'))
+
+        self.assertEqual(u'Show all 3 participations',
+                         browser.json.get('show_all_label'))
+
+    @browsing
     def test_returns_all_participations_when_request_flag_is_set(self, browser):
         browser.login().open(self.meierag.get_url('participations/list'),
                              {'show_all': 'true'})


### PR DESCRIPTION
Closes #2108 

![bildschirmfoto 2016-08-30 um 14 07 21](https://cloud.githubusercontent.com/assets/485755/18088675/358812c2-6ebc-11e6-8a16-a2f4f3e79e45.png)

To avoid performance issues, by fetching all dossiers over the IntId utility, the listing is implemented asynchronous and limited to 50 items. Listing all participations ist possible with a "show all" link.

@deiferni 