### PR TITLE
Add active/inactive flag for contacts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Add specific byline for persons and organizations.
+  [phgross]
+
 - Add active flag for contacts, including a separate
   column and an active statefilter on contactlistings.
   [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Add active flag for contacts, including a separate
+  column and an active statefilter on contactlistings.
+  [phgross]
+
 - Add participations for OrgRoles.
   Update model and particpation-forms to work with both, Contacts and OrgRoles.
   [deiferni]

--- a/opengever/contact/browser/byline.py
+++ b/opengever/contact/browser/byline.py
@@ -1,0 +1,24 @@
+from opengever.base.viewlets.byline import BylineBase
+from opengever.contact import _
+from Products.CMFPlone import PloneMessageFactory as PMF
+
+
+class ContactByline(BylineBase):
+
+    def get_items(self):
+        return [
+            {'class': 'sequenceNumber',
+             'label': _('label_sequence_number', default='Sequence Number'),
+             'content': self.context.model.contact_id,
+             'replace': False},
+
+            {'class': 'active',
+             'label': _('label_active', default='Active'),
+             'content': self.active_label(),
+             'replace': False}
+        ]
+
+    def active_label(self):
+        if self.context.model.is_active:
+            return PMF('Yes')
+        return PMF('No')

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -31,6 +31,14 @@
       permission="zope2.View"
       />
 
+  <browser:viewlet
+      name="plone.belowcontenttitle.documentbyline"
+      for="opengever.contact.interfaces.IContact"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+      class=".byline.ContactByline"
+      permission="zope2.View"
+      />
+
   <browser:page
       name="participations"
       for="opengever.contact.interfaces.IContact"

--- a/opengever/contact/browser/layout.py
+++ b/opengever/contact/browser/layout.py
@@ -1,7 +1,22 @@
 from opengever.base.browser.layout import GeverLayoutPolicy
 
 
-class PersonLayoutPolicy(GeverLayoutPolicy):
+class ContactLayoutPolicy(GeverLayoutPolicy):
+
+    def bodyClass(self, template, view):
+        """Add additional state_class to the body classes.
+        """
+        body_class = super(ContactLayoutPolicy, self).bodyClass(template, view)
+        return ' '.join((body_class, self.get_state_class()))
+
+    def get_state_class(self):
+        if self.context.model.is_active:
+            return 'state-active'
+        else:
+            return 'state-inactive'
+
+
+class PersonLayoutPolicy(ContactLayoutPolicy):
 
     def bodyClass(self, template, view):
         """Replace the portaltype class if the current context is the
@@ -12,7 +27,7 @@ class PersonLayoutPolicy(GeverLayoutPolicy):
                                   'portaltype-opengever-contact-person')
 
 
-class OrganizationLayoutPolicy(GeverLayoutPolicy):
+class OrganizationLayoutPolicy(ContactLayoutPolicy):
 
     def bodyClass(self, template, view):
         """Replace the portaltype class if the current context is the
@@ -20,6 +35,5 @@ class OrganizationLayoutPolicy(GeverLayoutPolicy):
 
         body_class = super(OrganizationLayoutPolicy, self).bodyClass(
             template, view)
-
         return body_class.replace('portaltype-opengever-contact-contactfolder',
                                   'portaltype-opengever-contact-organization')

--- a/opengever/contact/browser/organization_listing.py
+++ b/opengever/contact/browser/organization_listing.py
@@ -6,6 +6,7 @@ from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Organization
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import SqlTableSource
+from opengever.tabbedview.helper import boolean_helper
 from opengever.tabbedview.helper import linked_sql_object
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
@@ -27,6 +28,10 @@ class OrganizationListingTab(BaseListingTab):
             {'column': 'name',
              'column_title': _(u'column_name', default=u'Name'),
              'transform': linked_sql_object},
+
+            {'column': 'is_active',
+             'column_title': _(u'column_active', default=u'Active'),
+             'transform': boolean_helper}
         )
 
     def get_base_query(self):

--- a/opengever/contact/browser/organization_listing.py
+++ b/opengever/contact/browser/organization_listing.py
@@ -2,10 +2,14 @@ from five import grok
 from ftw.table.interfaces import ITableSource
 from ftw.table.interfaces import ITableSourceConfig
 from opengever.contact import _
+from opengever.contact.browser.person_listing import ActiveOnlyFilter
 from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Organization
+from opengever.tabbedview import _ as tmf
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import SqlTableSource
+from opengever.tabbedview.filters import Filter
+from opengever.tabbedview.filters import FilterList
 from opengever.tabbedview.helper import boolean_helper
 from opengever.tabbedview.helper import linked_sql_object
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -51,6 +55,13 @@ class Organizations(OrganizationListingTab):
 
     selection = ViewPageTemplateFile("templates/no_selection.pt")
     sort_on = 'name'
+
+    show_selects = False
+    filterlist_name = 'organization_state_filter'
+    filterlist_available = True
+    filterlist = FilterList(
+        Filter('filter_all', tmf('all')),
+        ActiveOnlyFilter('filter_active', tmf('Active'), default=True))
 
     enabled_actions = []
     major_actions = []

--- a/opengever/contact/browser/person_listing.py
+++ b/opengever/contact/browser/person_listing.py
@@ -6,6 +6,7 @@ from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Person
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import SqlTableSource
+from opengever.tabbedview.helper import boolean_helper
 from opengever.tabbedview.helper import linked_sql_object
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
@@ -38,6 +39,10 @@ class PersonListingTab(BaseListingTab):
             {'column': 'lastname',
              'column_title': _(u'column_lastname', default=u'Lastname'),
              'transform': linked_sql_object},
+
+            {'column': 'is_active',
+             'column_title': _(u'column_active', default=u'Active'),
+             'transform': boolean_helper},
 
             {'column': 'organizations',
              'column_title': _(u'column_organizations',

--- a/opengever/contact/browser/person_listing.py
+++ b/opengever/contact/browser/person_listing.py
@@ -4,11 +4,13 @@ from ftw.table.interfaces import ITableSourceConfig
 from opengever.contact import _
 from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Person
+from opengever.tabbedview import _ as tmf
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import SqlTableSource
+from opengever.tabbedview.filters import Filter
+from opengever.tabbedview.filters import FilterList
 from opengever.tabbedview.helper import boolean_helper
 from opengever.tabbedview.helper import linked_sql_object
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -69,12 +71,23 @@ class PersonTableSource(SqlTableSource):
     searchable_columns = [Person.firstname, Person.lastname]
 
 
+class ActiveOnlyFilter(Filter):
+    def update_query(self, query):
+        return query.filter_by(is_active=True)
+
+
 class Persons(PersonListingTab):
     grok.name('tabbedview_view-persons')
     grok.context(IContactFolder)
 
-    selection = ViewPageTemplateFile("templates/no_selection.pt")
     sort_on = 'lastname'
+
+    show_selects = False
+    filterlist_name = 'person_state_filter'
+    filterlist_available = True
+    filterlist = FilterList(
+        Filter('filter_all', tmf('all')),
+        ActiveOnlyFilter('filter_active', tmf('Active'), default=True))
 
     enabled_actions = []
     major_actions = []

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -72,32 +72,38 @@ msgid "button_remove"
 msgstr "Löschen"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person_listing.py:31
+#: ./opengever/contact/browser/person_listing.py:34
 msgid "column_academic_title"
 msgstr "Titel"
 
+#. Default: "Active"
+#: ./opengever/contact/browser/organization_listing.py:37
+#: ./opengever/contact/browser/person_listing.py:46
+msgid "column_active"
+msgstr "Aktiv"
+
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person_listing.py:35
+#: ./opengever/contact/browser/person_listing.py:38
 msgid "column_firstname"
 msgstr "Vorname"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person_listing.py:39
+#: ./opengever/contact/browser/person_listing.py:42
 msgid "column_lastname"
 msgstr "Nachname"
 
 #. Default: "Name"
-#: ./opengever/contact/browser/organization_listing.py:28
+#: ./opengever/contact/browser/organization_listing.py:33
 msgid "column_name"
 msgstr "Name"
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/person_listing.py:43
+#: ./opengever/contact/browser/person_listing.py:50
 msgid "column_organizations"
 msgstr "Organisationen"
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person_listing.py:28
+#: ./opengever/contact/browser/person_listing.py:31
 msgid "column_salutation"
 msgstr "Anrede"
 
@@ -147,6 +153,11 @@ msgstr "Internet"
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr "Titel"
+
+#. Default: "Active"
+#: ./opengever/contact/browser/byline.py:16
+msgid "label_active"
+msgstr "Aktiv"
 
 #. Default: "Add Participation"
 #: ./opengever/contact/browser/participation_forms.py:43
@@ -373,6 +384,11 @@ msgstr "Anrede"
 msgid "label_show_all"
 msgstr "Alle ${total} Beteiligungen anzeigen"
 
+#. Default: "Sequence Number"
+#: ./opengever/contact/browser/byline.py:11
+msgid "label_sequence_number"
+msgstr "Laufnummer"
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py:115
 msgid "label_url"
@@ -423,4 +439,3 @@ msgstr "${amount} Treffer."
 #: ./opengever/contact/contact.py:44
 msgid "telefon"
 msgstr "Telefon"
-

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -74,32 +74,38 @@ msgid "button_remove"
 msgstr ""
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person_listing.py:31
+#: ./opengever/contact/browser/person_listing.py:34
 msgid "column_academic_title"
 msgstr "Titre"
 
+#. Default: "Active"
+#: ./opengever/contact/browser/organization_listing.py:37
+#: ./opengever/contact/browser/person_listing.py:46
+msgid "column_active"
+msgstr ""
+
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person_listing.py:35
+#: ./opengever/contact/browser/person_listing.py:38
 msgid "column_firstname"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person_listing.py:39
+#: ./opengever/contact/browser/person_listing.py:42
 msgid "column_lastname"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/contact/browser/organization_listing.py:28
+#: ./opengever/contact/browser/organization_listing.py:33
 msgid "column_name"
 msgstr ""
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/person_listing.py:43
+#: ./opengever/contact/browser/person_listing.py:50
 msgid "column_organizations"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person_listing.py:28
+#: ./opengever/contact/browser/person_listing.py:31
 msgid "column_salutation"
 msgstr ""
 
@@ -149,6 +155,11 @@ msgstr "Site internet"
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
 msgstr "Titre"
+
+#. Default: "Active"
+#: ./opengever/contact/browser/byline.py:16
+msgid "label_active"
+msgstr "Actif"
 
 #. Default: "Add Participation"
 #: ./opengever/contact/browser/participation_forms.py:43
@@ -374,6 +385,11 @@ msgstr "Titre"
 msgid "label_show_all"
 msgstr ""
 
+#. Default: "Sequence Number"
+#: ./opengever/contact/browser/byline.py:11
+msgid "label_sequence_number"
+msgstr "Numéro courant"
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py:115
 msgid "label_url"
@@ -424,4 +440,3 @@ msgstr "Résultat(s): ${amount}"
 #: ./opengever/contact/contact.py:44
 msgid "telefon"
 msgstr "Téléphone"
-

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -75,32 +75,38 @@ msgid "button_remove"
 msgstr ""
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person_listing.py:31
+#: ./opengever/contact/browser/person_listing.py:34
 msgid "column_academic_title"
 msgstr ""
 
+#. Default: "Active"
+#: ./opengever/contact/browser/organization_listing.py:37
+#: ./opengever/contact/browser/person_listing.py:46
+msgid "column_active"
+msgstr ""
+
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person_listing.py:35
+#: ./opengever/contact/browser/person_listing.py:38
 msgid "column_firstname"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person_listing.py:39
+#: ./opengever/contact/browser/person_listing.py:42
 msgid "column_lastname"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/contact/browser/organization_listing.py:28
+#: ./opengever/contact/browser/organization_listing.py:33
 msgid "column_name"
 msgstr ""
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/person_listing.py:43
+#: ./opengever/contact/browser/person_listing.py:50
 msgid "column_organizations"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person_listing.py:28
+#: ./opengever/contact/browser/person_listing.py:31
 msgid "column_salutation"
 msgstr ""
 
@@ -149,6 +155,11 @@ msgstr ""
 #: ./opengever/contact/browser/templates/person.pt:30
 #: ./opengever/contact/contact.py:69
 msgid "label_academic_title"
+msgstr ""
+
+#. Default: "Active"
+#: ./opengever/contact/browser/byline.py:16
+msgid "label_active"
 msgstr ""
 
 #. Default: "Add Participation"
@@ -375,6 +386,11 @@ msgstr ""
 msgid "label_show_all"
 msgstr ""
 
+#. Default: "Sequence Number"
+#: ./opengever/contact/browser/byline.py:11
+msgid "label_sequence_number"
+msgstr ""
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py:115
 msgid "label_url"
@@ -425,4 +441,3 @@ msgstr ""
 #: ./opengever/contact/contact.py:44
 msgid "telefon"
 msgstr ""
-

--- a/opengever/contact/models/archivedcontact.py
+++ b/opengever/contact/models/archivedcontact.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
 from opengever.contact.models.archive import ArchiveMixin
 from opengever.ogds.models.types import UnicodeCoercingText
+from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -16,8 +17,10 @@ class ArchivedContact(ArchiveMixin, Base):
                                  Sequence('archived_contact_id_seq'),
                                  primary_key=True)
     contact = relationship("Contact", back_populates="archived_contacts")
+    archived_contact_type = Column(String(30), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+
     description = Column(UnicodeCoercingText)
 
-    archived_contact_type = Column(String(30), nullable=False)
     __mapper_args__ = {'polymorphic_on': archived_contact_type,
                        'with_polymorphic': '*'}

--- a/opengever/contact/models/contact.py
+++ b/opengever/contact/models/contact.py
@@ -2,6 +2,7 @@ from opengever.base.model import Base
 from opengever.base.model import SQLFormSupport
 from opengever.contact.models.participation import ContactParticipation
 from opengever.ogds.models.types import UnicodeCoercingText
+from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -20,6 +21,8 @@ class Contact(Base, SQLFormSupport):
     contact_id = Column('id', Integer, Sequence('contacts_id_seq'),
                         primary_key=True)
     contact_type = Column(String(20), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+
     description = Column(UnicodeCoercingText)
 
     addresses = relationship("Address", back_populates="contact")

--- a/opengever/contact/tests/test_byline.py
+++ b/opengever/contact/tests/test_byline.py
@@ -1,0 +1,57 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestContactByline(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestContactByline, self).setUp()
+        self.contactfolder = create(Builder('contactfolder'))
+
+    @browsing
+    def test_contains_contact_id_as_sequence_number(self, browser):
+        person = create(Builder('person')
+                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        organization = create(Builder('organization')
+                              .having(name=u'Meier AG'))
+
+        browser.login().open(self.contactfolder, view=person.wrapper_id)
+        self.assertEquals(
+            ['Sequence Number: 1'],
+            browser.css('#plone-document-byline .sequenceNumber').text)
+
+        browser.login().open(self.contactfolder, view=organization.wrapper_id)
+        self.assertEquals(
+            ['Sequence Number: 2'],
+            browser.css('#plone-document-byline .sequenceNumber').text)
+
+    @browsing
+    def test_is_active_value_is_yes_or_no(self, browser):
+        person1 = create(Builder('person')
+                         .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        person2 = create(Builder('person')
+                         .having(firstname=u'Peter', lastname=u'M\xfcller',
+                                 is_active=False))
+
+        organization1 = create(Builder('organization')
+                               .having(name=u'Meier AG'))
+        organization2 = create(Builder('organization')
+                               .having(name=u'Meier AG', is_active=False))
+
+        browser.login().open(self.contactfolder, view=person1.wrapper_id)
+        self.assertEquals(['Active: Yes'],
+                          browser.css('#plone-document-byline .active').text)
+
+        browser.login().open(self.contactfolder, view=person2.wrapper_id)
+        self.assertEquals(['Active: No'],
+                          browser.css('#plone-document-byline .active').text)
+
+        browser.login().open(self.contactfolder, view=organization1.wrapper_id)
+        self.assertEquals(['Active: Yes'],
+                          browser.css('#plone-document-byline .active').text)
+
+        browser.login().open(self.contactfolder, view=organization2.wrapper_id)
+        self.assertEquals(['Active: No'],
+                          browser.css('#plone-document-byline .active').text)

--- a/opengever/contact/tests/test_layout.py
+++ b/opengever/contact/tests/test_layout.py
@@ -1,0 +1,64 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestPersonLayout(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPersonLayout, self).setUp()
+        self.contactfolder = create(Builder('contactfolder'))
+
+    @browsing
+    def test_body_contains_person_type_class(self, browser):
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+
+        browser.login().open(self.contactfolder, view=peter.wrapper_id)
+        self.assertIn('portaltype-opengever-contact-person',
+                      browser.css('body').first.get('class'))
+
+    @browsing
+    def test_body_contains_state_class(self, browser):
+        active = create(Builder('person')
+                        .having(firstname=u'Peter', lastname=u'Meier'))
+        inactive = create(Builder('person')
+                          .having(firstname=u'Peter', lastname=u'Meier',
+                                  is_active=False))
+
+        browser.login().open(self.contactfolder, view=active.wrapper_id)
+        self.assertIn('state-active', browser.css('body').first.get('class'))
+
+        browser.login().open(self.contactfolder, view=inactive.wrapper_id)
+        self.assertIn('state-inactive', browser.css('body').first.get('class'))
+
+
+class TestOrganizationLayout(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestOrganizationLayout, self).setUp()
+        self.contactfolder = create(Builder('contactfolder'))
+
+    @browsing
+    def test_body_contains_person_type_class(self, browser):
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+
+        browser.login().open(self.contactfolder, view=peter.wrapper_id)
+        self.assertIn('portaltype-opengever-contact-person',
+                      browser.css('body').first.get('class'))
+
+    @browsing
+    def test_body_contains_state_class(self, browser):
+        active = create(Builder('person')
+                        .having(firstname=u'Peter', lastname=u'Meier'))
+        inactive = create(Builder('person')
+                          .having(firstname=u'Peter', lastname=u'Meier',
+                                  is_active=False))
+
+        browser.login().open(self.contactfolder, view=active.wrapper_id)
+        self.assertIn('state-active', browser.css('body').first.get('class'))
+
+        browser.login().open(self.contactfolder, view=inactive.wrapper_id)
+        self.assertIn('state-inactive', browser.css('body').first.get('class'))

--- a/opengever/contact/tests/test_organization_listing.py
+++ b/opengever/contact/tests/test_organization_listing.py
@@ -13,7 +13,9 @@ class TestOrganizationListing(FunctionalTestCase):
                                     .titled(u'Kontakte'))
 
         create(Builder('organization').named(u'Meier AG'))
-        create(Builder('organization').named(u'M\xfcller'))
+        create(Builder('organization')
+               .named(u'M\xfcller')
+               .having(is_active=False))
         create(Builder('organization').named(u'AAA Design'))
 
     @browsing
@@ -22,10 +24,10 @@ class TestOrganizationListing(FunctionalTestCase):
             self.contactfolder, view='tabbedview_view-organizations')
 
         self.assertEquals(
-            [[u'Name'],
-             [u'AAA Design'],
-             [u'Meier AG'],
-             [u'M\xfcller']],
+            [[u'Name', 'Active'],
+             [u'AAA Design', 'Yes'],
+             [u'Meier AG', 'Yes'],
+             [u'M\xfcller', 'No']],
             browser.css('.listing').first.lists())
 
     @browsing
@@ -45,6 +47,6 @@ class TestOrganizationListing(FunctionalTestCase):
             data={'searchable_text': 'Design'})
 
         self.assertEquals(
-            [[u'Name'],
-             [u'AAA Design']],
+            [[u'Name', 'Active'],
+             [u'AAA Design', 'Yes']],
             browser.css('.listing').first.lists())

--- a/opengever/contact/tests/test_organization_listing.py
+++ b/opengever/contact/tests/test_organization_listing.py
@@ -19,9 +19,21 @@ class TestOrganizationListing(FunctionalTestCase):
         create(Builder('organization').named(u'AAA Design'))
 
     @browsing
-    def test_lists_all_organizations_sorted_by_name(self, browser):
+    def test_lists_only_active_organizations_by_default(self, browser):
         browser.login().open(
             self.contactfolder, view='tabbedview_view-organizations')
+
+        self.assertEquals(
+            [[u'Name', 'Active'],
+             [u'AAA Design', 'Yes'],
+             [u'Meier AG', 'Yes']],
+            browser.css('.listing').first.lists())
+
+    @browsing
+    def test_includes_inactive_organizations_with_the_all_filter(self, browser):
+        browser.login().open(
+            self.contactfolder, view='tabbedview_view-organizations',
+            data={'organization_state_filter': 'filter_all'})
 
         self.assertEquals(
             [[u'Name', 'Active'],

--- a/opengever/contact/tests/test_organization_unit.py
+++ b/opengever/contact/tests/test_organization_unit.py
@@ -15,6 +15,11 @@ class TestOrganization(unittest2.TestCase):
         self.assertTrue(isinstance(organization, Contact))
         self.assertEquals('organization', organization.contact_type)
 
+    def test_is_active_by_default(self):
+        organization = create(Builder('organization').named(u'4teamwork AG'))
+
+        self.assertTrue(organization.is_active)
+
     def test_organization_can_have_multiple_addresses(self):
         organization = create(Builder('organization').named(u'4teamwork AG'))
 

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -23,14 +23,6 @@ class TestOrganizationView(FunctionalTestCase):
         self.assertEquals([u'4teamwork AG'], browser.css('h1').text)
 
     @browsing
-    def test_body_contains_person_type_class(self, browser):
-        organization = create(Builder('organization').named(u'4teamwork'))
-
-        browser.login().open(organization.get_url())
-        self.assertIn('portaltype-opengever-contact-organization',
-                      browser.css('body').first.get('class'))
-
-    @browsing
     def test_shows_archived_organizations(self, browser):
         organization = create(Builder('organization').named(u'4teamwork'))
         archived_organization = create(Builder('archived_organization').having(

--- a/opengever/contact/tests/test_person_listing.py
+++ b/opengever/contact/tests/test_person_listing.py
@@ -28,9 +28,22 @@ class TestPersonListing(FunctionalTestCase):
                                   lastname=u'Mustermann'))
 
     @browsing
-    def test_lists_all_persons(self, browser):
+    def test_lists_only_active_persons_by_default(self, browser):
         browser.login().open(
             self.contactfolder, view='tabbedview_view-persons')
+
+        self.assertEquals(
+            [['Salutation', 'Academic title', 'Firstname',
+              'Lastname', 'Active', 'Organizations'],
+             ['Frau', '', 'Sandra', 'Mustermann', 'Yes', ''],
+             ['Herr', 'Dr. rer. nat.', 'Peter', u'M\xfcller', 'Yes', '']],
+            browser.css('.listing').first.lists())
+
+    @browsing
+    def test_includes_inactive_persons_with_the_all_filter(self, browser):
+        browser.login().open(
+            self.contactfolder, view='tabbedview_view-persons',
+            data={'person_state_filter': 'filter_all'})
 
         self.assertEquals(
             [['Salutation', 'Academic title', 'Firstname',
@@ -43,7 +56,8 @@ class TestPersonListing(FunctionalTestCase):
     @browsing
     def test_sorts_on_lastname_by_default(self, browser):
         browser.login().open(
-            self.contactfolder, view='tabbedview_view-persons')
+            self.contactfolder, view='tabbedview_view-persons',
+            data={'person_state_filter': 'filter_all'})
 
         table = browser.css('.listing').first
         self.assertEquals(
@@ -85,7 +99,9 @@ class TestPersonListing(FunctionalTestCase):
             person=self.sandra, organization=self.org2))
 
         browser.login().open(
-            self.contactfolder, view='tabbedview_view-persons')
+            self.contactfolder,
+            view='tabbedview_view-persons',
+            data={'person_state_filter': 'filter_all'})
 
         row = browser.css('.listing').first.rows[1]
 
@@ -102,7 +118,8 @@ class TestPersonListing(FunctionalTestCase):
         browser.login().open(
             self.contactfolder,
             view='tabbedview_view-persons',
-            data={'searchable_text': 'sandra'})
+            data={'searchable_text': 'sandra',
+                  'person_state_filter': 'filter_all'})
 
         self.assertEquals(
             [['Salutation', 'Academic title', 'Firstname',
@@ -116,7 +133,8 @@ class TestPersonListing(FunctionalTestCase):
         browser.login().open(
             self.contactfolder,
             view='tabbedview_view-persons',
-            data={'searchable_text': 'Sandra Alb'})
+            data={'searchable_text': 'Sandra Alb',
+                  'person_state_filter': 'filter_all'})
 
         self.assertEquals(
             [['Salutation', 'Academic title', 'Firstname',

--- a/opengever/contact/tests/test_person_listing.py
+++ b/opengever/contact/tests/test_person_listing.py
@@ -20,7 +20,8 @@ class TestPersonListing(FunctionalTestCase):
         self.sandra = create(Builder('person')
                              .having(salutation='Frau',
                                      firstname=u'Sandra',
-                                     lastname=u'Albert'))
+                                     lastname=u'Albert',
+                                     is_active=False))
         self.max = create(Builder('person')
                           .having(salutation='Frau',
                                   firstname=u'Sandra',
@@ -33,10 +34,10 @@ class TestPersonListing(FunctionalTestCase):
 
         self.assertEquals(
             [['Salutation', 'Academic title', 'Firstname',
-              'Lastname', 'Organizations'],
-             ['Frau', '', 'Sandra', 'Albert', ''],
-             ['Frau', '', 'Sandra', 'Mustermann', ''],
-             ['Herr', 'Dr. rer. nat.', 'Peter', u'M\xfcller', '']],
+              'Lastname', 'Active', 'Organizations'],
+             ['Frau', '', 'Sandra', 'Albert', 'No', ''],
+             ['Frau', '', 'Sandra', 'Mustermann', 'Yes', ''],
+             ['Herr', 'Dr. rer. nat.', 'Peter', u'M\xfcller', 'Yes', '']],
             browser.css('.listing').first.lists())
 
     @browsing
@@ -72,7 +73,7 @@ class TestPersonListing(FunctionalTestCase):
             self.contactfolder, view='tabbedview_view-persons')
 
         row1 = browser.css('.listing').first.rows[1]
-        self.assertEquals('<b>Bold</b>', row1.css('td')[-2].text)
+        self.assertEquals('<b>Bold</b>', row1.css('td')[-3].text)
 
     @browsing
     def test_organizations_are_linked_and_sepearated_by_comma(self, browser):
@@ -89,7 +90,7 @@ class TestPersonListing(FunctionalTestCase):
         row = browser.css('.listing').first.rows[1]
 
         self.assertEquals(
-            ['Frau', '', 'Sandra', 'Albert', u'Meier AG, Sophie SA'],
+            ['Frau', '', 'Sandra', 'Albert', 'No', u'Meier AG, Sophie SA'],
             row.css('td').text)
         self.assertEquals(self.org1.get_url(),
                           row.find('Meier AG').get('href'))
@@ -105,9 +106,9 @@ class TestPersonListing(FunctionalTestCase):
 
         self.assertEquals(
             [['Salutation', 'Academic title', 'Firstname',
-              'Lastname', 'Organizations'],
-             ['Frau', '', 'Sandra', 'Albert', ''],
-             ['Frau', '', 'Sandra', 'Mustermann', '']],
+              'Lastname', 'Active', 'Organizations'],
+             ['Frau', '', 'Sandra', 'Albert', 'No', ''],
+             ['Frau', '', 'Sandra', 'Mustermann', 'Yes', '']],
             browser.css('.listing').first.lists())
 
     @browsing
@@ -119,6 +120,6 @@ class TestPersonListing(FunctionalTestCase):
 
         self.assertEquals(
             [['Salutation', 'Academic title', 'Firstname',
-              'Lastname', 'Organizations'],
-             ['Frau', '', 'Sandra', 'Albert', '']],
+              'Lastname', 'Active', 'Organizations'],
+             ['Frau', '', 'Sandra', 'Albert', 'No', '']],
             browser.css('.listing').first.lists())

--- a/opengever/contact/tests/test_person_unit.py
+++ b/opengever/contact/tests/test_person_unit.py
@@ -24,6 +24,12 @@ class TestPerson(unittest2.TestCase):
         self.assertTrue(isinstance(person, Contact))
         self.assertEquals('person', person.contact_type)
 
+    def test_is_active_by_default(self):
+        person = create(Builder('person')
+                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
+
+        self.assertTrue(person.is_active)
+
     def test_person_can_have_multiple_addresses(self):
         peter = create(Builder('person')
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))

--- a/opengever/contact/tests/test_person_view.py
+++ b/opengever/contact/tests/test_person_view.py
@@ -25,15 +25,6 @@ class TestPersonView(FunctionalTestCase):
         self.assertEquals([u'Sandra Fl\xfcckiger'], browser.css('h1').text)
 
     @browsing
-    def test_body_contains_person_type_class(self, browser):
-        peter = create(Builder('person')
-                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
-
-        browser.login().open(self.contactfolder, view=peter.wrapper_id)
-        self.assertIn('portaltype-opengever-contact-person',
-                      browser.css('body').first.get('class'))
-
-    @browsing
     def test_shows_fullname_as_title(self, browser):
         peter = create(Builder('person')
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))

--- a/opengever/contact/upgrades/20160831071153_add_is_active_column_to_contact/upgrade.py
+++ b/opengever/contact/upgrades/20160831071153_add_is_active_column_to_contact/upgrade.py
@@ -1,0 +1,34 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class AddIsActiveColumnToContact(SchemaMigration):
+    """Add is active column to contact.
+    """
+
+    def migrate(self):
+        for tablename in ['contacts', 'archived_contacts']:
+            self.add_column(tablename)
+            self.insert_default_value(tablename)
+            self.make_column_non_nullable(tablename)
+
+    def add_column(self, tablename):
+        self.op.add_column(
+            tablename,
+            Column('is_active', Boolean, default=True, nullable=True))
+
+    def insert_default_value(self, tablename):
+        contact_table = table(
+            tablename,
+            column("id"),
+            column("is_active"))
+
+        self.connection.execute(
+            contact_table.update().values(is_active=True))
+
+    def make_column_non_nullable(self, tablename):
+        self.op.alter_column(tablename, 'is_active',
+                             existing_type=Boolean, nullable=False)

--- a/opengever/tabbedview/base_tabs.py
+++ b/opengever/tabbedview/base_tabs.py
@@ -10,6 +10,7 @@ from opengever.tabbedview.browser.listing import ListingView
 from opengever.tabbedview.utils import get_translated_transitions
 from opengever.tabbedview.utils import get_translated_types
 from plone.registry.interfaces import IRegistry
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getUtility
 from zope.component import queryAdapter
 from zope.interface import implements
@@ -158,6 +159,8 @@ class BaseListingTab(grok.View, GeverTabMixin, ListingView):
     grok.context(Interface)
     grok.require('zope2.View')
 
+    selection = ViewPageTemplateFile("browser/selection_with_filters.pt")
+
     sort_on = 'modified'
     sort_reverse = False
     #lazy must be false otherwise there will be no correct batching
@@ -181,6 +184,8 @@ class BaseCatalogListingTab(grok.View, GeverTabMixin, CatalogListingView):
 
     grok.context(ITabbedView)
     grok.require('zope2.View')
+
+    selection = ViewPageTemplateFile("browser/selection_with_filters.pt")
 
     columns = ()
 

--- a/opengever/tabbedview/browser/selection_with_filters.pt
+++ b/opengever/tabbedview/browser/selection_with_filters.pt
@@ -1,8 +1,4 @@
-<div class="tabbedview_select"
-     tal:define="filterlist_name python: view.filterlist_name;
-                 filter_id python: view.request.get(filterlist_name)"
-     tal:attributes="id filterlist_name"
-     i18n:domain="ftw.tabbedview">
+<div class="tabbedview_select" i18n:domain="ftw.tabbedview">
 
     <tal:condition tal:condition="view/show_selects">
       <span i18n:translate="">Choose:</span>
@@ -14,20 +10,23 @@
       </span>
     </tal:condition>
 
-    <span tal:condition="view/filterlist_available"
-          tal:attributes="id filterlist_name" class="state_filters">
-      <span tal:condition="view/show_selects"> | </span>
+    <tal:condition tal:condition="view/filterlist_available">
+      <span tal:define="filterlist_name python: view.filterlist_name;
+                        filter_id python: view.request.get(filterlist_name)"
+            tal:attributes="id filterlist_name" class="state_filters">
+        <span tal:condition="view/show_selects"> | </span>
 
-      <span i18n:translate="" i18n:domain="opengever.tabbedview">State</span>
+        <span i18n:translate="" i18n:domain="opengever.tabbedview">State</span>
 
-      <a tal:repeat="filter python: view.filterlist.filters()"
-         tal:attributes="id filter/id;
-                         class python: filter.is_active(filter_id) and 'active'"
-         tal:content="filter/label"
-         href="javascript:void(0);"
-         i18n:domain="opengever.tabbedview">
-      </a>
+        <a tal:repeat="filter python: view.filterlist.filters()"
+           tal:attributes="id filter/id;
+                           class python: filter.is_active(filter_id) and 'active'"
+           tal:content="filter/label"
+           href="javascript:void(0);"
+           i18n:domain="opengever.tabbedview">
+        </a>
 
-    </span>
+      </span>
+    </tal:condition>
 
 </div>

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -180,7 +180,6 @@ class Documents(BaseCatalogListingTab):
 class Dossiers(BaseCatalogListingTab):
     grok.name('tabbedview_view-dossiers')
 
-    selection = ViewPageTemplateFile("selection_with_filters.pt")
     template = ViewPageTemplateFile("generic_with_filters.pt")
 
     filterlist_name = 'dossier_state_filter'
@@ -293,7 +292,6 @@ class Proposals(ProposalListingTab):
     sort_on = 'title'
     show_selects = False
 
-    selection = ViewPageTemplateFile("selection_with_filters.pt")
     template = ViewPageTemplateFile("generic_with_filters.pt")
 
     model = Proposal

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -55,7 +55,6 @@ class GlobalTaskListingTab(BaseListingTab):
     major_actions = []
 
     select_all_template = ViewPageTemplateFile('select_all_globaltasks.pt')
-    selection = ViewPageTemplateFile("selection_with_filters.pt")
 
     filterlist_name = 'task_state_filter'
     filterlist_available = True


### PR DESCRIPTION
PR contains:
 - Statefilter for contact listings
 - Separte column `Active` in the contact listings
 - A specific byline for organizations and persons
 - An icon addition on the watermark icon for inactive contacts.

Closes #1930 
The styles are in a separate PR  in `plonetheme.teamraum`: https://github.com/4teamwork/plonetheme.teamraum/pull/460

![bildschirmfoto 2016-09-01 um 11 09 07](https://cloud.githubusercontent.com/assets/485755/18161999/917a6cc8-7034-11e6-9cad-f103471b3c94.png)
![bildschirmfoto 2016-09-01 um 11 08 51](https://cloud.githubusercontent.com/assets/485755/18162000/917ee406-7034-11e6-9e8b-974856108f71.png)



@deiferni 


