### PR TITLE
Fixed showroom identifier of preview thumbnails in search template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Fixed showroom identifier of preview thumbnails in search template.
+  [phgross]
+
 - Add specific byline for persons and organizations.
   [phgross]
 

--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -342,7 +342,7 @@
                         <div class="searchImage" tal:condition="item/is_bumblebeeable">
                           <img class="showroom-reference bumblebeeSearchPreview"
                                tal:attributes="src item/get_preview_image_url;
-                                               data-showroom-target-item item/UID;" />
+                                               data-showroom-id string:showroom-id-${item/UID};" />
                         </div>
                       </div>
                       <div class="visualClear"><!-- --></div>

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -56,8 +56,8 @@ class TestBumblebeePreview(FunctionalTestCase):
         browser.fill({'Search Site': 'Foo Document'}).submit()
 
         self.assertEqual(
-            IUUID(document),
-            browser.css('.bumblebeeSearchPreview').first.get('data-showroom-target-item'))
+            'showroom-id-{}'.format(IUUID(document)),
+            browser.css('.bumblebeeSearchPreview').first.get('data-showroom-id'))
 
     @browsing
     def test_all_links_including_documents_are_linked_to_absolute_url(self, browser):


### PR DESCRIPTION
The thumbnail uses now the hidden-link for the showroom reference, therefore we have to use the same identifieres, when rendering the thumbnail.

Fixes #2138 

@deiferni @lukasgraf 