### PR TITLE
Patch transmogrify.dexterity's schema updater to set correct default values

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Patch transmogrify.dexterity's schema updater so it correctly sets default
+  values, using our own `determine_default_value` function to determine the
+  default, and `get_persisted_value_for_field` to avoid any __getattr__
+  fallbacks.
+  [lgraf]
+
 - Fixed permission declaration for the documents tooltip view.
   [phgross]
 

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -4,6 +4,7 @@ from .default_values import PatchDexterityContentGetattr
 from .default_values import PatchDexterityDefaultAddForm
 from .default_values import PatchDXCreateContentInContainer
 from .default_values import PatchInvokeFactory
+from .default_values import PatchTransmogrifyDXSchemaUpdater
 from .default_values import PatchZ3CFormChangedField
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
@@ -31,6 +32,7 @@ PatchLDAPUserFolderEncoding()()
 PatchNamedfileNamedDataConverter()()
 PatchPlone43RC1Upgrade()()
 PatchResourceRegistriesURLRegex()()
+PatchTransmogrifyDXSchemaUpdater()()
 PatchWebDAVLockTimeout()()
 PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()

--- a/sources.cfg
+++ b/sources.cfg
@@ -12,6 +12,8 @@ development-packages =
 # https://github.com/4teamwork/opengever.ogds.models/pull/41
   opengever.ogds.models
   ftw.showroom
+#https://github.com/collective/transmogrify.dexterity/pull/25
+  transmogrify.dexterity
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Patch transmogrify.dexterity's schema updater so it correctly sets default values, using our own `determine_default_value` function to determine the default, and `get_persisted_value_for_field` to avoid any `__getattr__` fallbacks.

This fixes, among other things, an `AttributeError` for `privacy_layer` on repositoryfolders for a freshly created GEVER instance.

@phgross 