### PR TITLE
Whitelist @login, @logout and @login-renew API endpoints for anonymous access on site root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Whitelist @login, @logout and @login-renew REST API endpoints for anonymous
+  access on Plone site root.
+
 - Patch transmogrify.dexterity's schema updater so it correctly sets default
   values, using our own `determine_default_value` function to determine the
   default, and `get_persisted_value_for_field` to avoid any __getattr__

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -136,6 +136,6 @@ def disallow_anonymous_views_on_site_root(event):
             ISiteRoot.providedBy(aq_parent(context))
 
         if is_site_root or is_tabbed_view_on_site_root:
-            endpoint_name = event.request['PUBLISHED'].__name__
+            endpoint_name = event.request.steps[-1]
             if endpoint_name not in ALLOWED_ENDPOINTS:
                 raise Unauthorized

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -25,6 +25,9 @@ from ZPublisher.interfaces import IPubAfterTraversal
 
 
 ALLOWED_ENDPOINTS = set([
+    '@login',
+    '@logout',
+    '@login-renew',
     'customlogo',
     'favicon',
     'list-open-dossiers-json',


### PR DESCRIPTION
These endpoints are protected with `zope.Public` and need to be accessed anonymously.

Additionally, `request.steps[-1]` needs to be used to access the endpoint name so it gets translated from the internal service ID (`POST_application_json_@endpoint`) to just `@endpoint` ([see `plone.rest`](https://github.com/plone/plone.rest/blob/f711777060cdad4b1fa247af59cf8b4997218916/src/plone/rest/negotiation.py#L45)). 