### PR TITLE
Add manual journal entry form

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Add new form to add a manual journal entry.
+  [phgross]
+
 - Add new column former contact id to the contact listings.
   [phgross]
 

--- a/opengever/contact/browser/mail.py
+++ b/opengever/contact/browser/mail.py
@@ -17,25 +17,25 @@ class IMailAddressesActions(Interface):
 
     def list():
         """Returns json list of all mailaddresses for the current context (contact).
-        'plone/person-3/mails/list'
+        'plone/contact-3/mails/list'
         """
 
     def update():
         """Updates the mailaddress attributes, with the one given by
         the request parameter.
         The view expect that its called by traversing over the mailaddress:
-        `plone/person-3/mails/14/update` for example.
+        `plone/contact-3/mails/14/update` for example.
         """
 
     def delete():
         """Remove the given mailaddress.
         The view expect that its called by traversing over the mailaddress:
-        `plone/person-3/mails/14/delete` for example.
+        `plone/contact-3/mails/14/delete` for example.
         """
 
     def add():
         """Add a new mail to the database
-        'plone/person-3/mails/add'
+        'plone/contact-3/mails/add'
         """
 
 

--- a/opengever/contact/contactfolder.py
+++ b/opengever/contact/contactfolder.py
@@ -4,10 +4,7 @@ from opengever.base.browser.translated_title import TranslatedTitleAddForm
 from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.contact import _
 from opengever.contact.interfaces import IContactFolder
-from opengever.contact.models import Organization
-from opengever.contact.models import Person
-from opengever.contact.wrapper import PersonWrapper
-from opengever.contact.wrapper import OrganizationWrapper
+from opengever.contact.models import Contact
 from opengever.tabbedview import BaseCatalogListingTab
 from opengever.tabbedview.helper import email_helper
 from plone.dexterity.content import Container
@@ -37,17 +34,11 @@ class ContactFolder(Container, TranslatedTitleMixin):
         if obj is not default:
             return obj
 
-        if id_.startswith('person-'):
-            person_id = int(id_.split('-')[-1])
-            person = Person.query.get(person_id)
-            if person:
-                return PersonWrapper.wrap(self, person)
-
-        if id_.startswith('organization-'):
-            organization_id = int(id_.split('-')[-1])
-            organization = Organization.query.get(organization_id)
-            if organization:
-                return OrganizationWrapper.wrap(self, organization)
+        if id_.startswith('contact-'):
+            contact_id = int(id_.split('-')[-1])
+            contact = Contact.query.get(contact_id)
+            if contact:
+                return contact.get_wrapper(self)
 
         if default is _marker:
             raise KeyError(id_)

--- a/opengever/contact/models/contact.py
+++ b/opengever/contact/models/contact.py
@@ -57,3 +57,6 @@ class Contact(Base, SQLFormSupport):
                     self.archived_mail_addresses,
                     self.archived_phonenumbers,
                     self.archived_urls])
+
+    def get_contact_id(self):
+        return self.contact_id

--- a/opengever/contact/models/org_role.py
+++ b/opengever/contact/models/org_role.py
@@ -48,3 +48,8 @@ class OrgRole(Base):
 
     def get_css_class(self):
         return self.person.get_css_class()
+
+    def get_contact_id(self):
+        """Returns the id of the person that is represented by the Orgrole.
+        """
+        return self.person.contact_id

--- a/opengever/contact/models/organization.py
+++ b/opengever/contact/models/organization.py
@@ -7,6 +7,7 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
+from opengever.contact.wrapper import OrganizationWrapper
 
 
 class OrganizationQuery(BaseQuery):
@@ -28,7 +29,10 @@ class Organization(Contact):
 
     @property
     def wrapper_id(self):
-        return 'organization-{}'.format(self.organization_id)
+        return 'contact-{}'.format(self.organization_id)
+
+    def get_wrapper(self, context):
+        return OrganizationWrapper.wrap(context, self)
 
     def get_url(self, view='view'):
         return '{}/{}/{}'.format(

--- a/opengever/contact/models/person.py
+++ b/opengever/contact/models/person.py
@@ -1,14 +1,15 @@
 from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.contact.models.contact import Contact
 from opengever.contact.utils import get_contactfolder_url
+from opengever.contact.wrapper import PersonWrapper
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
+from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
-from opengever.ogds.models.query import BaseQuery
 
 
 class PersonQuery(BaseQuery):
@@ -37,7 +38,10 @@ class Person(Contact):
 
     @property
     def wrapper_id(self):
-        return 'person-{}'.format(self.person_id)
+        return 'contact-{}'.format(self.person_id)
+
+    def get_wrapper(self, context):
+        return PersonWrapper.wrap(context, self)
 
     def get_url(self, view='view'):
         return '{}/{}/{}'.format(

--- a/opengever/contact/tests/test_mail_addresses_view.py
+++ b/opengever/contact/tests/test_mail_addresses_view.py
@@ -29,7 +29,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'label': 'Private', 'mailaddress': 'max.muster@example.com'},
-            view='person-1/mails/add')
+            view='contact-1/mails/add')
 
         mailaddress = MailAddress.query.first()
 
@@ -48,7 +48,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'mailaddress': 'max.muster@example.com'},
-            view='person-1/mails/add')
+            view='contact-1/mails/add')
 
         self.assertEquals(0, self.session.query(MailAddress).count())
 
@@ -62,7 +62,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'label': 'Private'},
-            view='person-1/mails/add')
+            view='contact-1/mails/add')
 
         self.assertEquals(0, self.session.query(MailAddress).count())
 
@@ -76,7 +76,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'label': 'Private', 'mailaddress': 'bademail'},
-            view='person-1/mails/add')
+            view='contact-1/mails/add')
 
         self.assertEquals(0, self.session.query(MailAddress).count())
 
@@ -89,7 +89,7 @@ class TestMailAddressesView(FunctionalTestCase):
     def test_add_mailaddress_without_address_and_label(self, browser):
         browser.login().visit(
             self.contactfolder,
-            view='person-1/mails/add')
+            view='contact-1/mails/add')
 
         self.assertEquals(0, self.session.query(MailAddress).count())
 
@@ -112,13 +112,13 @@ class TestMailAddressesView(FunctionalTestCase):
                    label=u'Business',
                    address=u"max.muster@foo.com"))
 
-        browser.login().visit(self.contactfolder, view='person-1/mails/list')
+        browser.login().visit(self.contactfolder, view='contact-1/mails/list')
 
         self.assertEqual(2, len(browser.json.get('mailaddresses')))
 
     @browsing
     def test_list_no_mailaddresses(self, browser):
-        browser.login().visit(self.contactfolder, view='person-1/mails/list')
+        browser.login().visit(self.contactfolder, view='contact-1/mails/list')
 
         self.assertEqual(0, len(browser.json.get('mailaddresses')))
 
@@ -128,7 +128,7 @@ class TestMailAddressesView(FunctionalTestCase):
 
         self.assertEqual(1, self.session.query(MailAddress).count())
 
-        browser.login().visit(self.contactfolder, view='person-1/mails/1/delete')
+        browser.login().visit(self.contactfolder, view='contact-1/mails/1/delete')
 
         self.assertDictContainsSubset({
             'message': 'Mailaddress successfully deleted',
@@ -150,7 +150,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'label': 'Business', 'mailaddress': 'james.bond@example.com'},
-            view='person-1/mails/1/update')
+            view='contact-1/mails/1/update')
 
         mailaddress = MailAddress.query.first()
 
@@ -173,7 +173,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'label': 'Business'},
-            view='person-1/mails/1/update')
+            view='contact-1/mails/1/update')
 
         mailaddress = MailAddress.query.first()
 
@@ -191,7 +191,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(
             self.contactfolder,
             {'mailaddress': 'james.bond@example.com'},
-            view='person-1/mails/1/update')
+            view='contact-1/mails/1/update')
 
         mailaddress = MailAddress.query.first()
 
@@ -200,24 +200,24 @@ class TestMailAddressesView(FunctionalTestCase):
 
     @browsing
     def test_call_api_function_if_available(self, browser):
-        browser.login().visit(self.contactfolder, view='person-1/mails/list')
+        browser.login().visit(self.contactfolder, view='contact-1/mails/list')
 
         self.assertEqual(['mailaddresses'], browser.json.keys())
 
     @browsing
     def test_raise_not_found_if_not_an_api_function_and_not_a_number(self, browser):
         with self.assertRaises(NotFound):
-            browser.login().visit(self.contactfolder, view='person-1/mails/bad_name')
+            browser.login().visit(self.contactfolder, view='contact-1/mails/bad_name')
 
     @browsing
     def test_raise_not_found_if_mail_address_id_is_already_set_on_view(self, browser):
         with self.assertRaises(NotFound):
-            browser.login().visit(self.contactfolder, view='person-1/mails/10/100')
+            browser.login().visit(self.contactfolder, view='contact-1/mails/10/100')
 
     @browsing
     def test_raise_not_found_if_no_mailaddress_with_the_given_id_exists(self, browser):
         with self.assertRaises(NotFound):
-            browser.login().visit(self.contactfolder, view='person-1/mails/10')
+            browser.login().visit(self.contactfolder, view='contact-1/mails/10')
 
     @browsing
     def test_raise_not_found_if_mailaddress_is_not_linked_to_the_given_context(self, browser):
@@ -231,7 +231,7 @@ class TestMailAddressesView(FunctionalTestCase):
         with self.assertRaises(NotFound):
             browser.login().visit(
                 self.contactfolder,
-                view='person-1/mails/{}'.format(email.mailaddress_id))
+                view='contact-1/mails/{}'.format(email.mailaddress_id))
 
     @browsing
     def test_returns_view_if_mailaddress_found_on_given_context(self, browser):
@@ -242,8 +242,8 @@ class TestMailAddressesView(FunctionalTestCase):
 
         browser.login().visit(
             self.contactfolder,
-            view='person-1/mails/{}'.format(email.mailaddress_id))
+            view='contact-1/mails/{}'.format(email.mailaddress_id))
 
         self.assertEqual(
-            '{}/person-1/mails/1'.format(self.contactfolder.absolute_url()),
+            '{}/contact-1/mails/1'.format(self.contactfolder.absolute_url()),
             browser.url)

--- a/opengever/contact/tests/test_organization.py
+++ b/opengever/contact/tests/test_organization.py
@@ -12,8 +12,8 @@ class TestOrganization(FunctionalTestCase):
         org2 = create(Builder('organization').named(u'4teamwork AG'))
 
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/organization-1/view',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-1/view',
             org1.get_url())
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/organization-2/edit',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-2/edit',
             org2.get_url(view='edit'))

--- a/opengever/contact/tests/test_organization_listing.py
+++ b/opengever/contact/tests/test_organization_listing.py
@@ -52,7 +52,7 @@ class TestOrganizationListing(FunctionalTestCase):
             self.contactfolder, view='tabbedview_view-organizations')
 
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/organization-1/view',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-1/view',
             browser.find(u'Meier AG').get('href'))
 
     @browsing

--- a/opengever/contact/tests/test_person.py
+++ b/opengever/contact/tests/test_person.py
@@ -17,10 +17,10 @@ class TestPerson(FunctionalTestCase):
                         .having(firstname=u'Sandra', lastname=u'Meier'))
 
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/person-1/view',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-1/view',
             peter.get_url())
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/person-2/edit',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-2/edit',
             sandra.get_url(view='edit'))
 
     @browsing

--- a/opengever/contact/tests/test_person_listing.py
+++ b/opengever/contact/tests/test_person_listing.py
@@ -75,11 +75,11 @@ class TestPersonListing(FunctionalTestCase):
             self.contactfolder, view='tabbedview_view-persons')
 
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/person-1/view',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-1/view',
             browser.find('Peter').get('href'))
 
         self.assertEquals(
-            'http://nohost/plone/opengever-contact-contactfolder/person-1/view',
+            'http://nohost/plone/opengever-contact-contactfolder/contact-1/view',
             browser.find(u'M\xfcller').get('href'))
 
     @browsing

--- a/opengever/journal/configure.zcml
+++ b/opengever/journal/configure.zcml
@@ -5,6 +5,7 @@
     xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:vdex="http://namespaces.zope.org/vdex"
     i18n_domain="opengever.journal">
 
     <!-- Grok the package to initialise schema interfaces and content classes -->
@@ -12,6 +13,8 @@
 
     <!-- register translations -->
     <i18n:registerTranslations directory="locales" />
+
+    <vdex:vocabulary directory="vdexvocabs" />
 
     <!-- Register an extension profile to make the product installable -->
     <genericsetup:registerProfile
@@ -44,6 +47,13 @@
         permission="zope2.View"
         class=".browser.JournalHistory"
         template="templates/journalhistory.pt"
+        />
+
+    <browser:page
+        name="add-journal-entry"
+        for="ftw.journal.interfaces.IJournalizable"
+        class=".form.ManualJournalEntryAddForm"
+        permission="cmf.ModifyPortalContent"
         />
 
 </configure>

--- a/opengever/journal/entry.py
+++ b/opengever/journal/entry.py
@@ -1,0 +1,80 @@
+from ftw.journal.events.events import JournalEntryEvent
+from opengever.base.oguid import Oguid
+from opengever.journal import _
+from persistent.dict import PersistentDict
+from persistent.list import PersistentList
+from plone import api
+from zope.component import getUtility
+from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+from zope.schema.interfaces import IVocabularyFactory
+
+
+MANUAL_JOURNAL_ENTRY = 'manually-journal-entry'
+
+
+class ManualJournalEntry(object):
+    """Object to create and add a journal entry to a context.
+    Its used by the ManualJournalEntry form.
+    """
+
+    def __init__(self, context, category, comment, contacts, documents):
+        self.context = context
+        self.request = getRequest()
+        self.category = category
+        self.comment = comment
+        self.contacts = contacts
+        self.documents = documents
+
+    def save(self):
+        entry = {'obj': self.context,
+                 'action': PersistentDict({
+                     'type': MANUAL_JOURNAL_ENTRY,
+                     'title': self.get_title(),
+                     'visible': True,
+                     'documents': self.serialize_documents(),
+                     'contacts': self.serialize_contacts()}),
+                 'actor': api.user.get_current().getId(),
+                 'comment': self.comment.encode('utf-8')}
+
+        notify(JournalEntryEvent(**entry))
+
+    def serialize_documents(self):
+        """Returns a persistent list of dicts with the following data for for
+        all documents:
+
+        id: oguid
+        title: document title
+        """
+        value = PersistentList()
+        for doc in self.documents:
+            value.append(PersistentDict(
+                {'id': Oguid.for_object(doc).id, 'title': doc.title}))
+
+        return value
+
+    def serialize_contacts(self):
+        """Returns a persistent list of dicts for all contacts.
+        """
+        value = PersistentList()
+        for item in self.contacts:
+            value.append(
+                PersistentDict({'id': item.get_contact_id(),
+                                'title': item.get_title()}))
+
+        return value
+
+    def get_title(self):
+        msg = _(u'label_manual_journal_entry',
+                default=u'Manual entry: ${category}',
+                mapping={'category': self.get_category_title()})
+
+        return translate(msg, context=getRequest())
+
+    def get_category_title(self):
+        voca_factory = getUtility(
+            IVocabularyFactory,
+            name='opengever.journal.manual_entry_categories')
+
+        return voca_factory(self.context).getTerm(self.category).title

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -1,0 +1,70 @@
+from opengever.base.source import RepositoryPathSourceBinder
+from opengever.journal import _
+from opengever.journal.entry import ManualJournalEntry
+from plone.directives import form
+from plone.formwidget.autocomplete import AutocompleteMultiFieldWidget
+from z3c.form.field import Fields
+from z3c.form.form import AddForm
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
+from zope import schema
+
+
+class IManualJournalEntry(form.Schema):
+
+    category = schema.Choice(
+        title=_(u'label_category', default=u'Category'),
+        vocabulary='opengever.journal.manual_entry_categories',
+        required=True,
+    )
+
+    comment = schema.Text(
+        title=_(u'label_comment', default=u'Comment'),
+        required=False,
+    )
+
+    contacts = schema.List(
+        title=_(u'label_contacts', default=u'Contacts'),
+        value_type=schema.Choice(
+            vocabulary=u'opengever.contact.ContactsVocabulary'),
+        required=False,
+    )
+
+    related_documents = RelationList(
+        title=_(u'label_related_documents', default=u'Related Documents'),
+        default=[],
+        missing_value=[],
+        value_type=RelationChoice(
+            title=u"Related",
+            source=RepositoryPathSourceBinder(
+                portal_type=("opengever.document.document", "ftw.mail.mail"),
+                navigation_tree_query={
+                    'object_provides':
+                    ['opengever.repository.repositoryroot.IRepositoryRoot',
+                     'opengever.repository.repositoryfolder.IRepositoryFolderSchema',
+                     'opengever.dossier.behaviors.dossier.IDossierMarker',
+                     'opengever.document.document.IDocumentSchema',
+                     'ftw.mail.mail.IMail', ]
+                }),
+            ),
+        required=False,
+    )
+
+
+class ManualJournalEntryAddForm(AddForm):
+    label = _(u'label_add_journal_entry', default=u'Add journal entry')
+    fields = Fields(IManualJournalEntry)
+
+    fields['contacts'].widgetFactory = AutocompleteMultiFieldWidget
+
+    def createAndAdd(self, data):
+        entry = ManualJournalEntry(self.context,
+                                   data.get('category'),
+                                   data.get('comment'),
+                                   data.get('contacts'),
+                                   data.get('related_documents'))
+        entry.save()
+        return entry
+
+    def nextURL(self):
+        return '{}#journal'.format(self.context.absolute_url())

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-09-19 14:00+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -20,19 +20,41 @@ msgid "heading_journal"
 msgstr "Journal"
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:68
+#: ./opengever/journal/tab.py:74
 msgid "label_actor"
 msgstr "Geändert von"
+
+#. Default: "Add journal entry"
+#: ./opengever/journal/form.py:55
+#: ./opengever/journal/templates/journal_selection.pt:2
+msgid "label_add_journal_entry"
+msgstr "Journaleintrag hinzufügen"
 
 #. Default: "Attachments deleted: ${filenames}"
 #: ./opengever/journal/handlers.py:318
 msgid "label_attachments_deleted"
 msgstr "Attachments gelöscht: ${filenames}"
 
+#. Default: "Category"
+#: ./opengever/journal/form.py:16
+msgid "label_category"
+msgstr "Kategorie"
+
+#. Default: "Comment"
+#: ./opengever/journal/form.py:22
+msgid "label_comment"
+msgstr "Kommentar"
+
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:72
+#: ./opengever/journal/tab.py:78
 msgid "label_comments"
 msgstr "Kommentare"
+
+#. Default: "Contacts"
+#: ./opengever/journal/form.py:27
+#: ./opengever/journal/templates/journal_references.pt:2
+msgid "label_contacts"
+msgstr "Kontakte"
 
 #. Default: "DocProperties updated."
 #: ./opengever/journal/handlers.py:308
@@ -119,6 +141,11 @@ msgstr "Dokumentversand per E-Mail: ${subject}"
 msgid "label_document_sent_comment"
 msgstr "Anhänge: ${documents} | Empfänger: ${receiver} | Nachricht: ${message}"
 
+#. Default: "Documents"
+#: ./opengever/journal/templates/journal_references.pt:12
+msgid "label_documents"
+msgstr "Dokumente"
+
 #. Default: "Dossier added: ${title}"
 #: ./opengever/journal/handlers.py:210
 msgid "label_dossier_added"
@@ -164,6 +191,11 @@ msgstr "Lokale Rollen modifiziert."
 msgid "label_local_roles_modified_at"
 msgstr "Lokale Rollen von ${repository} modifziert."
 
+#. Default: "Manual entry: ${category}"
+#: ./opengever/journal/entry.py:75
+msgid "label_manual_journal_entry"
+msgstr "Manueller Eintrag: ${category}"
+
 #. Default: "Object cut: ${title}"
 #: ./opengever/journal/handlers.py:734
 msgid "label_object_cut"
@@ -194,6 +226,16 @@ msgstr "PDF heruntergeladen"
 msgid "label_prefix_unlocked"
 msgstr "Aktenzeichen ${prefix} in ${repository} wurde freigegeben."
 
+#. Default: "References"
+#: ./opengever/journal/tab.py:82
+msgid "label_references"
+msgstr "Referenzen"
+
+#. Default: "Related Documents"
+#: ./opengever/journal/form.py:34
+msgid "label_related_documents"
+msgstr "Dokumentverweise"
+
 #. Default: "Object restore: ${title}"
 #: ./opengever/journal/handlers.py:611
 msgid "label_restore"
@@ -210,12 +252,12 @@ msgid "label_task_modified"
 msgstr "Aufgabe modifiziert: ${title}"
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:60
+#: ./opengever/journal/tab.py:66
 msgid "label_time"
 msgstr "Zeitpunkt"
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:64
+#: ./opengever/journal/tab.py:70
 msgid "label_title"
 msgstr "Titel"
 
@@ -230,7 +272,6 @@ msgid "summary_journal"
 msgstr "Journal"
 
 #. Default: "${amount} matches."
-#: ./opengever/journal/no_selection_amount.pt:3
+#: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
 msgstr "${amount} Treffer."
-

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-09-19 14:00+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-journal/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "Journal"
 #: ./opengever/journal/templates/journalhistory.pt:15
@@ -23,19 +22,41 @@ msgid "heading_journal"
 msgstr "Historique"
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:68
+#: ./opengever/journal/tab.py:74
 msgid "label_actor"
 msgstr "Modifier le"
+
+#. Default: "Add journal entry"
+#: ./opengever/journal/form.py:55
+#: ./opengever/journal/templates/journal_selection.pt:2
+msgid "label_add_journal_entry"
+msgstr ""
 
 #. Default: "Attachments deleted: ${filenames}"
 #: ./opengever/journal/handlers.py:318
 msgid "label_attachments_deleted"
 msgstr "Fichiers attachés effacés: ${filenames}"
 
+#. Default: "Category"
+#: ./opengever/journal/form.py:16
+msgid "label_category"
+msgstr ""
+
+#. Default: "Comment"
+#: ./opengever/journal/form.py:22
+msgid "label_comment"
+msgstr ""
+
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:72
+#: ./opengever/journal/tab.py:78
 msgid "label_comments"
 msgstr "Commentaire"
+
+#. Default: "Contacts"
+#: ./opengever/journal/form.py:27
+#: ./opengever/journal/templates/journal_references.pt:2
+msgid "label_contacts"
+msgstr ""
 
 #. Default: "DocProperties updated."
 #: ./opengever/journal/handlers.py:308
@@ -122,6 +143,11 @@ msgstr "Envoi de document par Email: ${subject}"
 msgid "label_document_sent_comment"
 msgstr "Annexes:  ${documents} | Récepteur ${receiver} | Message ${message}"
 
+#. Default: "Documents"
+#: ./opengever/journal/templates/journal_references.pt:12
+msgid "label_documents"
+msgstr ""
+
 #. Default: "Dossier added: ${title}"
 #: ./opengever/journal/handlers.py:210
 msgid "label_dossier_added"
@@ -167,6 +193,11 @@ msgstr "Rôles à l'intérne modifiés"
 msgid "label_local_roles_modified_at"
 msgstr "Rôles à l'intérne pour ${repository} modifiés"
 
+#. Default: "Manual entry: ${category}"
+#: ./opengever/journal/entry.py:75
+msgid "label_manual_journal_entry"
+msgstr ""
+
 #. Default: "Object cut: ${title}"
 #: ./opengever/journal/handlers.py:734
 msgid "label_object_cut"
@@ -197,6 +228,16 @@ msgstr "Télécharger le PDF"
 msgid "label_prefix_unlocked"
 msgstr "Référence ${prefix} dans ${repository} a été débloqué."
 
+#. Default: "References"
+#: ./opengever/journal/tab.py:82
+msgid "label_references"
+msgstr ""
+
+#. Default: "Related Documents"
+#: ./opengever/journal/form.py:34
+msgid "label_related_documents"
+msgstr ""
+
 #. Default: "Object restore: ${title}"
 #: ./opengever/journal/handlers.py:611
 msgid "label_restore"
@@ -213,12 +254,12 @@ msgid "label_task_modified"
 msgstr "Tâche modifiée : ${title}"
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:60
+#: ./opengever/journal/tab.py:66
 msgid "label_time"
 msgstr "Date"
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:64
+#: ./opengever/journal/tab.py:70
 msgid "label_title"
 msgstr "Titre"
 
@@ -233,6 +274,7 @@ msgid "summary_journal"
 msgstr "Historique"
 
 #. Default: "${amount} matches."
-#: ./opengever/journal/no_selection_amount.pt:3
+#: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
 msgstr "Résultat(s) : ${amount}"
+

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-09-19 14:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,8 +23,14 @@ msgid "heading_journal"
 msgstr ""
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:68
+#: ./opengever/journal/tab.py:74
 msgid "label_actor"
+msgstr ""
+
+#. Default: "Add journal entry"
+#: ./opengever/journal/form.py:55
+#: ./opengever/journal/templates/journal_selection.pt:2
+msgid "label_add_journal_entry"
 msgstr ""
 
 #. Default: "Attachments deleted: ${filenames}"
@@ -32,9 +38,25 @@ msgstr ""
 msgid "label_attachments_deleted"
 msgstr ""
 
+#. Default: "Category"
+#: ./opengever/journal/form.py:16
+msgid "label_category"
+msgstr ""
+
+#. Default: "Comment"
+#: ./opengever/journal/form.py:22
+msgid "label_comment"
+msgstr ""
+
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:72
+#: ./opengever/journal/tab.py:78
 msgid "label_comments"
+msgstr ""
+
+#. Default: "Contacts"
+#: ./opengever/journal/form.py:27
+#: ./opengever/journal/templates/journal_references.pt:2
+msgid "label_contacts"
 msgstr ""
 
 #. Default: "DocProperties updated."
@@ -122,6 +144,11 @@ msgstr ""
 msgid "label_document_sent_comment"
 msgstr ""
 
+#. Default: "Documents"
+#: ./opengever/journal/templates/journal_references.pt:12
+msgid "label_documents"
+msgstr ""
+
 #. Default: "Dossier added: ${title}"
 #: ./opengever/journal/handlers.py:210
 msgid "label_dossier_added"
@@ -167,6 +194,11 @@ msgstr ""
 msgid "label_local_roles_modified_at"
 msgstr ""
 
+#. Default: "Manual entry: ${category}"
+#: ./opengever/journal/entry.py:75
+msgid "label_manual_journal_entry"
+msgstr ""
+
 #. Default: "Object cut: ${title}"
 #: ./opengever/journal/handlers.py:734
 msgid "label_object_cut"
@@ -197,6 +229,16 @@ msgstr ""
 msgid "label_prefix_unlocked"
 msgstr ""
 
+#. Default: "References"
+#: ./opengever/journal/tab.py:82
+msgid "label_references"
+msgstr ""
+
+#. Default: "Related Documents"
+#: ./opengever/journal/form.py:34
+msgid "label_related_documents"
+msgstr ""
+
 #. Default: "Object restore: ${title}"
 #: ./opengever/journal/handlers.py:611
 msgid "label_restore"
@@ -213,12 +255,12 @@ msgid "label_task_modified"
 msgstr ""
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:60
+#: ./opengever/journal/tab.py:66
 msgid "label_time"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:64
+#: ./opengever/journal/tab.py:70
 msgid "label_title"
 msgstr ""
 
@@ -233,7 +275,7 @@ msgid "summary_journal"
 msgstr ""
 
 #. Default: "${amount} matches."
-#: ./opengever/journal/no_selection_amount.pt:3
+#: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
 msgstr ""
 

--- a/opengever/journal/no_selection_amount.pt
+++ b/opengever/journal/no_selection_amount.pt
@@ -1,4 +1,0 @@
-<div i18n:domain="opengever.journal"
-     i18n:translate="tab_matches">
-    <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
-</div>

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -7,6 +7,7 @@ from ftw.journal.interfaces import IJournalizable
 from ftw.journal.interfaces import IWorkflowHistoryJournalizable
 from ftw.table import helper
 from ftw.table.interfaces import ITableSourceConfig, ITableSource
+from opengever.contact.utils import get_contactfolder_url
 from opengever.journal import _
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import GeverTableSource
@@ -39,6 +40,8 @@ class JournalTab(BaseListingTab):
 
     implements(IJournalSourceConfig)
 
+    reference_template = ViewPageTemplateFile('templates/journal_references.pt')
+
     grok.name('tabbedview_view-journal')
     grok.require('zope2.View')
     grok.context(IJournalizable)
@@ -55,23 +58,39 @@ class JournalTab(BaseListingTab):
     major_actions = []
     selection = ViewPageTemplateFile("no_selection_amount.pt")
 
-    columns = (
-        {'column': 'time',
-         'column_title': _(u'label_time', default=u'Time'),
-         'transform': helper.readable_date_time},
+    @property
+    def columns(self):
+        return (
+            {'column': 'time',
+             'column_title': _(u'label_time', default=u'Time'),
+             'transform': helper.readable_date_time},
 
-        {'column': 'title',
-         'column_title': _(u'label_title', 'Title'),
-         'transform': title_helper},
+            {'column': 'title',
+             'column_title': _(u'label_title', 'Title'),
+             'transform': title_helper},
 
-        {'column': 'actor',
-         'column_title': _(u'label_actor', default=u'Changed by'),
-         'transform': linked_ogds_author},
+            {'column': 'actor',
+             'column_title': _(u'label_actor', default=u'Changed by'),
+             'transform': linked_ogds_author},
 
-        {'column': 'comments',
-         'column_title': _(u'label_comments', default=u'Comments'),
-         'transform': tooltip_helper},
+            {'column': 'comments',
+             'column_title': _(u'label_comments', default=u'Comments'),
+             'transform': tooltip_helper},
+
+            {'column': 'references',
+             'column_title': _(u'label_references', default=u'References'),
+             'transform': self.journal_references},
         )
+
+    def journal_references(self, item, value):
+        """
+        """
+        self.documents = item.get('action').get('documents', [])
+        self.contacts = item.get('action').get('contacts', [])
+        return self.reference_template(self)
+
+    def get_contactfolder_url(self):
+        return get_contactfolder_url()
 
     def get_base_query(self):
         return None

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -113,7 +113,7 @@ class JournalTableSource(GeverTableSource):
 
         def _search_method(item):
             # title
-            if text.lower() in title_helper(item, '').lower():
+            if text.lower() in title_helper(item, u'').lower().encode('utf-8'):
                 return True
 
             # actor

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -12,6 +12,7 @@ from opengever.journal import _
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import GeverTableSource
 from opengever.tabbedview.helper import linked_ogds_author
+from plone import api
 from zope.annotation.interfaces import IAnnotations
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.globalrequest import getRequest
@@ -56,7 +57,7 @@ class JournalTab(BaseListingTab):
     show_selects = False
     enabled_actions = []
     major_actions = []
-    selection = ViewPageTemplateFile("no_selection_amount.pt")
+    selection = ViewPageTemplateFile("templates/journal_selection.pt")
 
     @property
     def columns(self):
@@ -94,6 +95,11 @@ class JournalTab(BaseListingTab):
 
     def get_base_query(self):
         return None
+
+    def manual_entry_allowed(self):
+        return api.user.has_permission('Modify portal content',
+                                       user=api.user.get_current(),
+                                       obj=self.context)
 
 
 class JournalTableSource(GeverTableSource):

--- a/opengever/journal/templates/journal_references.pt
+++ b/opengever/journal/templates/journal_references.pt
@@ -1,0 +1,20 @@
+<div class="contacts" tal:condition="view/contacts">
+  <p i18n:domain="opengever.journal" i18n:translate="label_contacts">Contacts</p>
+  <ul>
+    <li tal:repeat="contact view/contacts">
+      <a href="#" tal:attributes="href string:${view/get_contactfolder_url}/contact-${contact/id}"
+         tal:content="contact/title" />
+    </li>
+  </ul>
+</div>
+
+<div class="documents" tal:condition="view/documents">
+  <p i18n:domain="opengever.journal" i18n:translate="label_documents">Documents</p>
+  <ul class="documents">
+    <li tal:repeat="document view/documents">
+      <a href="#"
+         tal:attributes="href string: ${context/absolute_url}/@@resolve_oguid?oguid=${document/id}"
+         tal:content="document/title" />
+    </li>
+  </ul>
+</div>

--- a/opengever/journal/templates/journal_selection.pt
+++ b/opengever/journal/templates/journal_selection.pt
@@ -1,0 +1,10 @@
+<div class="actions" tal:condition="view/manual_entry_allowed">
+  <a class="add_journal_entry" href="add-journal-entry"
+     i18n:domain="opengever.journal" i18n:translate="label_add_journal_entry">
+    Add journal entry
+  </a>
+</div>
+
+<div i18n:domain="opengever.journal" i18n:translate="tab_matches">
+  <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
+</div>

--- a/opengever/journal/tests/test_journal_tab.py
+++ b/opengever/journal/tests/test_journal_tab.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.testing import FunctionalTestCase
+
+
+class TestJournalTab(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestJournalTab, self).setUp()
+
+    @browsing
+    def test_list_all_journal_entries(self, browser):
+        with freeze(datetime(2016, 8, 12)):
+            self.dossier = create(Builder('dossier'))
+            self.document = create(Builder('document')
+                                   .titled(u'Anfrage M\xfcller')
+                                   .within(self.dossier))
+
+            browser.login().open(self.dossier, view=u'tabbedview_view-journal')
+
+            expected = [['Time', 'Title', 'Changed by', 'Comments'],
+                        ['12.08.2016 01:00',
+                         'Dossier modified: dossier-1',
+                         'Test User (test_user_1_)', ''],
+                        ['12.08.2016 01:00',
+                         u'Document added: Anfrage M\xfcller',
+                         'Test User (test_user_1_)', ''],
+                        ['12.08.2016 01:00',
+                         'Dossier added: dossier-1',
+                         'Test User (test_user_1_)', '']]
+
+            self.assertEquals(expected, browser.css('.listing').first.lists())
+
+    @browsing
+    def test_listing_supports_filtering_on_title(self, browser):
+        with freeze(datetime(2016, 8, 12)):
+            self.dossier = create(Builder('dossier'))
+            self.document = create(Builder('document')
+                                   .titled(u'Anfrage M\xfcller')
+                                   .within(self.dossier))
+            browser.login().open(self.dossier, view=u'tabbedview_view-journal',
+                                 data={'searchable_text': u'M\xfcl'})
+
+            expected = [['Time', 'Title', 'Changed by', 'Comments'],
+                        ['12.08.2016 01:00',
+                         u'Document added: Anfrage M\xfcller',
+                         'Test User (test_user_1_)', '']]
+            self.assertEquals(expected, browser.css('.listing').first.lists())

--- a/opengever/journal/tests/test_journal_tab.py
+++ b/opengever/journal/tests/test_journal_tab.py
@@ -51,3 +51,16 @@ class TestJournalTab(FunctionalTestCase):
                  u'Document added: Anfrage M\xfcller',
                  'Test User (test_user_1_)', '', '']]
             self.assertEquals(expected, browser.css('.listing').first.lists())
+
+    @browsing
+    def test_add_journal_entry_link_is_only_shown_when_dosier_can_be_modified(self, browser):
+        dossier_a = create(Builder('dossier'))
+        dossier_b = create(Builder('dossier')
+                           .in_state('dossier-state-resolved'))
+
+        browser.login().open(dossier_a, view=u'tabbedview_view-journal')
+        self.assertEquals(['Add journal entry'],
+                          browser.css('.add_journal_entry').text)
+
+        browser.login().open(dossier_b, view=u'tabbedview_view-journal')
+        self.assertEquals([], browser.css('.add_journal_entry'))

--- a/opengever/journal/tests/test_journal_tab.py
+++ b/opengever/journal/tests/test_journal_tab.py
@@ -21,16 +21,17 @@ class TestJournalTab(FunctionalTestCase):
 
             browser.login().open(self.dossier, view=u'tabbedview_view-journal')
 
-            expected = [['Time', 'Title', 'Changed by', 'Comments'],
-                        ['12.08.2016 01:00',
-                         'Dossier modified: dossier-1',
-                         'Test User (test_user_1_)', ''],
-                        ['12.08.2016 01:00',
-                         u'Document added: Anfrage M\xfcller',
-                         'Test User (test_user_1_)', ''],
-                        ['12.08.2016 01:00',
-                         'Dossier added: dossier-1',
-                         'Test User (test_user_1_)', '']]
+            expected = [
+                ['Time', 'Title', 'Changed by', 'Comments', 'References'],
+                ['12.08.2016 01:00',
+                 'Dossier modified: dossier-1',
+                 'Test User (test_user_1_)', '', ''],
+                ['12.08.2016 01:00',
+                 u'Document added: Anfrage M\xfcller',
+                 'Test User (test_user_1_)', '', ''],
+                ['12.08.2016 01:00',
+                 'Dossier added: dossier-1',
+                 'Test User (test_user_1_)', '', '']]
 
             self.assertEquals(expected, browser.css('.listing').first.lists())
 
@@ -44,8 +45,9 @@ class TestJournalTab(FunctionalTestCase):
             browser.login().open(self.dossier, view=u'tabbedview_view-journal',
                                  data={'searchable_text': u'M\xfcl'})
 
-            expected = [['Time', 'Title', 'Changed by', 'Comments'],
-                        ['12.08.2016 01:00',
-                         u'Document added: Anfrage M\xfcller',
-                         'Test User (test_user_1_)', '']]
+            expected = [
+                ['Time', 'Title', 'Changed by', 'Comments', 'References'],
+                ['12.08.2016 01:00',
+                 u'Document added: Anfrage M\xfcller',
+                 'Test User (test_user_1_)', '', '']]
             self.assertEquals(expected, browser.css('.listing').first.lists())

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.testing import FunctionalTestCase
+from opengever.testing.helpers import get_contacts_vocabulary
+
+
+def get_token(obj):
+    return get_contacts_vocabulary().getTerm(obj).token
+
+
+class TestManualJournalEntry(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestManualJournalEntry, self).setUp()
+        self.dossier = create(Builder('dossier'))
+        self.contactfolder = create(Builder('contactfolder'))
+
+    @browsing
+    def test_adds_entry_to_context_journal(self, browser):
+
+        with freeze(datetime(2016, 12, 9, 9, 40)):
+            browser.login().open(self.dossier, view='add-journal-entry')
+            browser.fill({
+                'Category': u'phone-call',
+                'Comment': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier'
+            })
+            browser.css('#form-buttons-add').first.click()
+
+        self.assertEquals('http://nohost/plone/dossier-1#journal', browser.url)
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        self.assertEquals(
+            {'Changed by': 'Test User (test_user_1_)',
+             'Title': 'Manual entry: Phone call',
+             'Comments': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier',
+             'References': u'',
+             'Time': '09.12.2016 09:40'},
+            browser.css('.listing').first.rows[1].dict())
+
+    @browsing
+    def test_selected_documents_are_listed_and_linked_in_the_references_column(self, browser):
+        doc1 = create(Builder('document')
+                      .titled(u'Testdokum\xe4nt A')
+                      .within(self.dossier))
+        doc2 = create(Builder('document')
+                      .titled(u'Testdokum\xe4nt B')
+                      .within(self.dossier))
+
+        browser.login().open(self.dossier, view='add-journal-entry')
+        browser.fill({
+            'Category': u'phone-call',
+            'Comment': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier',
+            'Related Documents': [doc1, doc2]})
+        browser.css('#form-buttons-add').first.click()
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+
+        self.assertEquals(u'Documents Testdokum\xe4nt A Testdokum\xe4nt B',
+                          row.dict().get('References'))
+
+        browser.click_on(u'Testdokum\xe4nt B')
+        self.assertEquals(doc2.absolute_url(), browser.url)
+
+    @browsing
+    def test_selected_contacts_are_listed_and_linked_in_the_references_column(self, browser):
+        peter = create(Builder('person')
+                       .having(firstname=u'H\xfcgo', lastname='Boss'))
+
+        meierag = create(Builder('organization').named(u'Meier AG'))
+
+        browser.login().open(self.dossier, view='add-journal-entry')
+        browser.fill({
+            'Category': u'phone-call',
+            'Comment': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier',
+            'Contacts': [get_token(peter), get_token(meierag)]})
+        browser.css('#form-buttons-add').first.click()
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+        links = row.css('.contacts a')
+
+        self.assertEquals(u'Contacts H\xfcgo Boss Meier AG',
+                          row.dict().get('References'))
+
+        self.assertEquals(
+            ['http://nohost/plone/opengever-contact-contactfolder/contact-1',
+             'http://nohost/plone/opengever-contact-contactfolder/contact-2'],
+            [link.get('href') for link in links])
+        self.assertEquals([u'H\xfcgo Boss', 'Meier AG'], links.text)

--- a/opengever/journal/vdexvocabs/manual_journal_entry_categories.vdex
+++ b/opengever/journal/vdexvocabs/manual_journal_entry_categories.vdex
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"
+      orderSignificant="false" language="en">
+    <vocabIdentifier>opengever.journal.manual_entry_categories</vocabIdentifier>
+
+    <term>
+        <termIdentifier>phone-call</termIdentifier>
+        <caption>
+            <langstring language="en">Phone call</langstring>
+            <langstring language="de-ch">Telefongespräch</langstring>
+            <langstring language="de">Telefongespräch</langstring>
+            <langstring language="fr">Conversation téléphonique</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>meeting</termIdentifier>
+        <caption>
+            <langstring language="en">Meeting</langstring>
+            <langstring language="de-ch">Sitzung</langstring>
+            <langstring language="de">Sitzung</langstring>
+            <langstring language="fr">Séances</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>information</termIdentifier>
+        <caption>
+            <langstring language="en">Information</langstring>
+            <langstring language="de-ch">Information</langstring>
+            <langstring language="de">Information</langstring>
+            <langstring language="fr">Information</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>other</termIdentifier>
+        <caption>
+            <langstring language="en">Other</langstring>
+            <langstring language="de-ch">Sonstiges</langstring>
+            <langstring language="de">Sonstiges</langstring>
+            <langstring language="fr">Divers</langstring>
+        </caption>
+    </term>
+</vdex>


### PR DESCRIPTION
![bildschirmfoto 2016-09-19 um 12 30 05](https://cloud.githubusercontent.com/assets/485755/18630142/d26772fa-7e6a-11e6-887e-b13d05245682.png)

![bildschirmfoto 2016-09-19 um 12 28 56](https://cloud.githubusercontent.com/assets/485755/18630141/d2640e62-7e6a-11e6-9193-55c5c9face04.png)

See [Todo](https://basecamp.com/2768704/projects/12330648/todos/271609550) for more details

Besides the new functionality to add a journal entry manually, this PR fixes #2144 and changes the wrapper id for contact objects, it uses now `contact-{id}` instead of `person-{id}` or `organization-{id}`.

The styling adjustments are in separate [PR in plonetheme.teamraum](https://github.com/4teamwork/plonetheme.teamraum/pull/464).

@deiferni @lukasgraf 
