### PR TITLE
Display former_contact_id in the contact selection field and make it searchable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Display former_contact_id in the contact selection field and make it searchable.
+  [phgross]
+
 - Add country field to contact addresses.
   [deiferni]
 

--- a/opengever/contact/models/org_role.py
+++ b/opengever/contact/models/org_role.py
@@ -33,9 +33,9 @@ class OrgRole(Base):
     def id(self):
         return self.org_role_id
 
-    def get_title(self):
+    def get_title(self, with_former_id=False):
         title = u'{} - {}'.format(
-            self.person.get_title(),
+            self.person.get_title(with_former_id=with_former_id),
             self.organization.get_title())
 
         if self.function:

--- a/opengever/contact/models/organization.py
+++ b/opengever/contact/models/organization.py
@@ -38,7 +38,10 @@ class Organization(Contact):
         return '{}/{}/{}'.format(
             get_contactfolder_url(), self.wrapper_id, view)
 
-    def get_title(self):
+    def get_title(self, with_former_id=False):
+        if with_former_id and self.former_contact_id:
+            return u'{} [{}]'.format(self.name, self.former_contact_id)
+
         return self.name
 
     def get_css_class(self):

--- a/opengever/contact/models/person.py
+++ b/opengever/contact/models/person.py
@@ -47,7 +47,10 @@ class Person(Contact):
         return '{}/{}/{}'.format(
             get_contactfolder_url(), self.wrapper_id, view)
 
-    def get_title(self):
+    def get_title(self, with_former_id=False):
+        if with_former_id and self.former_contact_id:
+            return u'{} [{}]'.format(self.fullname, self.former_contact_id)
+
         return self.fullname
 
     def get_css_class(self):

--- a/opengever/contact/models/query.py
+++ b/opengever/contact/models/query.py
@@ -23,7 +23,7 @@ class ContactQuery(BaseQuery):
         return extend_query_with_textfilter(
             query,
             [Person.firstname, Person.lastname, Organization.name,
-             OrgRole.function],
+             OrgRole.function, Contact.former_contact_id],
             text_filters,
         )
 

--- a/opengever/contact/tests/test_org_role.py
+++ b/opengever/contact/tests/test_org_role.py
@@ -1,8 +1,5 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.contact.models import Organization
-from opengever.contact.models import OrgRole
-from opengever.contact.models import Person
 from opengever.testing import MEMORY_DB_LAYER
 import unittest2
 
@@ -39,3 +36,28 @@ class TestOrganizationalRole(unittest2.TestCase):
         self.assertEquals([role2], hugo.organizations)
         self.assertEquals([peter, hugo],
                           [role.person for role in meier_ag.persons])
+
+    def test_organization_title_is_person_organization_and_fuction_in_braclets(self):
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter',
+                               lastname=u'M\xfcller',
+                               former_contact_id=123456))
+
+        teamwork = create(Builder('organization').named(u'4teamwork AG'))
+        meier = create(Builder('organization').named(u'Meier AG'))
+
+        role1 = create(Builder('org_role').having(person=peter,
+                                                  organization=meier))
+
+        role2 = create(Builder('org_role').having(person=peter,
+                                                  organization=teamwork,
+                                                  function='Developer'))
+
+        self.assertEquals(
+            u'Peter M\xfcller - Meier AG', role1.get_title())
+        self.assertEquals(
+            u'Peter M\xfcller - 4teamwork AG (Developer)', role2.get_title())
+
+        self.assertEquals(
+            u'Peter M\xfcller [123456] - Meier AG',
+            role1.get_title(with_former_id=True))

--- a/opengever/contact/tests/test_organization_unit.py
+++ b/opengever/contact/tests/test_organization_unit.py
@@ -89,3 +89,18 @@ class TestOrganization(unittest2.TestCase):
         self.assertEquals([u'http://www.4teamwork.ch',
                            u'http://www.onegovgever.ch'],
                           [url.url for url in organization.urls])
+
+    def test_title_is_name(self):
+        organization = create(Builder('organization').named(u'4teamwork AG'))
+        self.assertEquals(u'4teamwork AG', organization.get_title())
+
+    def test_title_is_extended_with_former_id_in_brackets_when_flag_is_set(self):
+        teamwork = create(Builder('organization').named(u'4teamwork AG'))
+        meier = create(Builder('organization')
+                       .having(former_contact_id=123456)
+                       .named(u'Meier AG'))
+
+        self.assertEquals(u'4teamwork AG',
+                          teamwork.get_title(with_former_id=True))
+        self.assertEquals(u'Meier AG [123456]',
+                          meier.get_title(with_former_id=True))

--- a/opengever/contact/tests/test_person_unit.py
+++ b/opengever/contact/tests/test_person_unit.py
@@ -14,7 +14,7 @@ class TestPerson(unittest2.TestCase):
         self.session = self.layer.session
 
     def test_adding(self):
-        person = create(Builder('person')
+        create(Builder('person')
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
     def test_is_contact(self):
@@ -114,3 +114,16 @@ class TestPerson(unittest2.TestCase):
         peter = create(Builder('person')
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
         self.assertEquals(u'Peter M\xfcller', peter.get_title())
+
+    def test_title_is_extended_with_former_id_in_brackets_when_flag_is_set(self):
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+        james = create(Builder('person')
+                       .having(firstname=u'James',
+                               lastname=u'M\xfcller',
+                               former_contact_id=123456))
+
+        self.assertEquals(u'Peter M\xfcller',
+                          peter.get_title(with_former_id=True))
+        self.assertEquals(u'James M\xfcller [123456]',
+                          james.get_title(with_former_id=True))

--- a/opengever/contact/tests/test_vocabularies.py
+++ b/opengever/contact/tests/test_vocabularies.py
@@ -12,7 +12,8 @@ class TestContactsVocabulary(FunctionalTestCase):
 
         self.peter_a = create(Builder('person')
                               .having(firstname=u'Peter',
-                                      lastname=u'M\xfcller'))
+                                      lastname=u'M\xfcller',
+                                      former_contact_id=1111))
         self.peter_b = create(Builder('person')
                               .having(firstname=u'Peter',
                                       lastname=u'Fl\xfcckiger'))
@@ -21,7 +22,8 @@ class TestContactsVocabulary(FunctionalTestCase):
                                       lastname=u'Meier')
                               .having(is_active=False))
         self.meier_ag = create(Builder('organization')
-                               .named(u'Meier AG'))
+                               .named(u'Meier AG')
+                               .having(former_contact_id=2222))
         self.teamwork_ag = create(Builder('organization')
                                   .named(u'4teamwork AG'))
         self.school = create(Builder('organization')
@@ -43,11 +45,11 @@ class TestContactsVocabulary(FunctionalTestCase):
         vocabulary = voca_factory(self.portal)
 
         self.assertTerms(
-            [(self.peter_a, u'Peter M\xfcller'),
-             (self.role1, u'Peter M\xfcller - Meier AG (Developer)'),
-             (self.role2, u'Peter M\xfcller - 4teamwork AG (Scheffe)'),
+            [(self.peter_a, u'Peter M\xfcller [1111]'),
+             (self.role1, u'Peter M\xfcller [1111] - Meier AG (Developer)'),
+             (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)'),
              (self.peter_b, u'Peter Fl\xfcckiger'),
-             (self.meier_ag, u'Meier AG'),
+             (self.meier_ag, u'Meier AG [2222]'),
              (self.teamwork_ag, u'4teamwork AG')],
             vocabulary.search('*'))
 
@@ -57,13 +59,13 @@ class TestContactsVocabulary(FunctionalTestCase):
         vocabulary = voca_factory(self.portal)
 
         self.assertTerms(
-            [(self.meier_ag, 'Meier AG')],
+            [(self.meier_ag, 'Meier AG [2222]')],
             vocabulary.search('Meier'))
 
         self.assertTerms(
-            [(self.peter_a, u'Peter M\xfcller'),
-             (self.role1, u'Peter M\xfcller - Meier AG (Developer)'),
-             (self.role2, u'Peter M\xfcller - 4teamwork AG (Scheffe)'),
+            [(self.peter_a, u'Peter M\xfcller [1111]'),
+             (self.role1, u'Peter M\xfcller [1111] - Meier AG (Developer)'),
+             (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)'),
              (self.peter_b, u'Peter Fl\xfcckiger')],
             vocabulary.search('Peter'))
 
@@ -74,3 +76,12 @@ class TestContactsVocabulary(FunctionalTestCase):
         self.assertTerms(
             [(self.peter_b, u'Peter Fl\xfcckiger')],
             vocabulary.search('Pe Fl'))
+
+        self.assertTerms(
+            [(self.peter_a, u'Peter M\xfcller [1111]'),
+             (self.role1, u'Peter M\xfcller [1111] - Meier AG (Developer)'),
+             (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)')],
+            vocabulary.search('1111'))
+
+        self.assertTerms(
+            [(self.meier_ag, u'Meier AG [2222]')], vocabulary.search('2222'))

--- a/opengever/contact/vocabularies.py
+++ b/opengever/contact/vocabularies.py
@@ -31,7 +31,7 @@ class ContactsVocabulary(object):
         term_type = self.by_class[value.__class__]
         return SimpleTerm(value=value,
                           token='{}:{}'.format(term_type, value.id),
-                          title=value.get_title())
+                          title=value.get_title(with_former_id=True))
 
     def getTermByToken(self, token):
         if not token:


### PR DESCRIPTION
![bildschirmfoto 2016-09-21 um 09 17 59](https://cloud.githubusercontent.com/assets/485755/18701796/d79cf392-7fde-11e6-9e2d-5e7126bebbf0.png)


See basecamp discussions 
 - https://basecamp.com/2768704/projects/12330648/todos/273237333 and 
 - https://basecamp.com/2768704/projects/12330648/todos/266608587.


Needs https://github.com/4teamwork/opengever.ogds.models/pull/42
