### PR TITLE
Add country field to contact addresses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Add country field to contact addresses.
+  [deiferni]
+
 - Add POC officeatwork integration endpoints to GEVER.
   [deiferni]
 

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -32,6 +32,8 @@
                   <br />
                   <span tal:content="address/zip_code" />
                   <span tal:content="address/city" />
+                  <br />
+                  <span tal:content="address/country" />
                 </dd>
               </tal:repeat>
             </dl>
@@ -133,6 +135,8 @@
                       <br />
                       <span tal:content="archived_address/zip_code" />
                       <span tal:content="archived_address/city" />
+                      <br />
+                      <span tal:content="archived_address/country" />
                     </dd>
                   </tal:repeat>
                 </dl>

--- a/opengever/contact/browser/templates/person.pt
+++ b/opengever/contact/browser/templates/person.pt
@@ -42,6 +42,8 @@
                   <br />
                   <span tal:content="address/zip_code" />
                   <span tal:content="address/city" />
+                  <br />
+                  <span tal:content="address/country" />
                 </dd>
               </tal:repeat>
             </dl>
@@ -152,6 +154,8 @@
                       <br />
                       <span tal:content="archived_address/zip_code" />
                       <span tal:content="archived_address/city" />
+                      <br />
+                      <span tal:content="archived_address/country" />
                     </dd>
                   </tal:repeat>
                 </dl>

--- a/opengever/contact/models/address.py
+++ b/opengever/contact/models/address.py
@@ -20,3 +20,4 @@ class Address(Base):
     street = Column(String(CONTENT_TITLE_LENGTH))
     zip_code = Column(String(ZIP_CODE_LENGTH))
     city = Column(String(CONTENT_TITLE_LENGTH))
+    country = Column(String(CONTENT_TITLE_LENGTH))

--- a/opengever/contact/models/archivedaddress.py
+++ b/opengever/contact/models/archivedaddress.py
@@ -21,3 +21,4 @@ class ArchivedAddress(ArchiveMixin, Base):
     street = Column(String(CONTENT_TITLE_LENGTH))
     zip_code = Column(String(ZIP_CODE_LENGTH))
     city = Column(String(CONTENT_TITLE_LENGTH))
+    country = Column(String(CONTENT_TITLE_LENGTH))

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -42,7 +42,8 @@ class TestOrganizationView(FunctionalTestCase):
         create(Builder('address')
                .for_contact(organization)
                .labeled('Hauptsitz')
-               .having(street=u'Dammweg 9', zip_code=u'3013', city=u'Bern'))
+               .having(street=u'Dammweg 9', zip_code=u'3013', city=u'Bern',
+                       country=u'Schweiz'))
         create(Builder('address')
                .for_contact(organization)
                .labeled('Standort Romandie')
@@ -53,7 +54,7 @@ class TestOrganizationView(FunctionalTestCase):
 
         self.assertEquals([u'Hauptsitz', u'Standort Romandie'],
                           browser.css('.address dt').text)
-        self.assertEquals([u'Dammweg 9\n3013 Bern',
+        self.assertEquals([u'Dammweg 9\n3013 Bern\nSchweiz',
                            u'S\xfcdweststrasse 24\n1700 Fribourg'],
                           browser.css('.address dd').text)
 
@@ -65,13 +66,13 @@ class TestOrganizationView(FunctionalTestCase):
                .for_contact(organization)
                .labeled('Hauptsitz')
                .having(street=u'Engehaldenstrasse 42', zip_code=u'3012',
-                       city=u'Bern'))
+                       city=u'Bern', country=u'Schweiz'))
 
         browser.login().open(organization.get_url())
 
         self.assertEquals([u'Hauptsitz'],
                           browser.css('#contactHistory .address dt').text)
-        self.assertEquals([u'Engehaldenstrasse 42\n3012 Bern'],
+        self.assertEquals([u'Engehaldenstrasse 42\n3012 Bern\nSchweiz'],
                           browser.css('#contactHistory .address dd').text)
 
     @browsing

--- a/opengever/contact/tests/test_person_view.py
+++ b/opengever/contact/tests/test_person_view.py
@@ -81,7 +81,8 @@ class TestPersonView(FunctionalTestCase):
         create(Builder('address')
                .for_contact(peter)
                .labeled('Arbeit')
-               .having(street=u'Dammweg 9', zip_code=u'3013', city=u'Bern'))
+               .having(street=u'Dammweg 9', zip_code=u'3013', city=u'Bern',
+                       country=u'Schweiz'))
         create(Builder('address')
                .for_contact(peter)
                .labeled('Privat')
@@ -92,7 +93,7 @@ class TestPersonView(FunctionalTestCase):
 
         self.assertEquals([u'Arbeit', u'Privat'],
                           browser.css('.address dt').text)
-        self.assertEquals([u'Dammweg 9\n3013 Bern',
+        self.assertEquals([u'Dammweg 9\n3013 Bern\nSchweiz',
                            u'S\xfcdweststrasse 24\n6315 Ober\xe4geri'],
                           browser.css('.address dd').text)
 
@@ -105,13 +106,13 @@ class TestPersonView(FunctionalTestCase):
                .for_contact(peter)
                .labeled('Wochenendhaus')
                .having(street=u'Waldstrasse 1', zip_code=u'1234',
-                       city=u'Hintertupfigen'))
+                       city=u'Hintertupfigen', country=u'Deutschland'))
 
         browser.login().open(self.contactfolder, view=peter.wrapper_id)
 
         self.assertEquals([u'Wochenendhaus'],
                           browser.css('#contactHistory .address dt').text)
-        self.assertEquals([u'Waldstrasse 1\n1234 Hintertupfigen'],
+        self.assertEquals([u'Waldstrasse 1\n1234 Hintertupfigen\nDeutschland'],
                           browser.css('#contactHistory .address dd').text)
 
     @browsing

--- a/opengever/contact/upgrades/20160921094244_add_country_field_to_addresses/upgrade.py
+++ b/opengever/contact/upgrades/20160921094244_add_country_field_to_addresses/upgrade.py
@@ -1,0 +1,12 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+
+
+class AddCountryFieldToAddresses(SchemaMigration):
+    """Add country field to addresses.
+    """
+
+    def migrate(self):
+        self.op.add_column('addresses', Column('country', String(255)))
+        self.op.add_column('archived_addresses', Column('country', String(255)))

--- a/opengever/examplecontent/contacts.py
+++ b/opengever/examplecontent/contacts.py
@@ -20,6 +20,7 @@ ADDRESS_LABELS = ['Arbeit', 'Privat', None]
 PHONENUMBER_LABELS = ['Arbeit', 'Privat', 'Mobile']
 ORG_ROLE_FUNCTIONS = [
     None, 'Verwalter', 'Vorsitz', 'Putzfachmann', 'Beratung', 'Angestellter']
+COUNTRIES = [u'Schweiz', u'Deutschland', u'\xd6sterreich', u'Belgien']
 
 
 class ExampleContactCreator(object):
@@ -122,6 +123,7 @@ class ExampleContactCreator(object):
                           street=item['street'],
                           zip_code=item['zip_code'],
                           city=item['city'],
+                          country=random.choice(COUNTRIES),
                           contact=contact)
         self.db_session.add(address)
 
@@ -136,6 +138,7 @@ class ExampleContactCreator(object):
                 street=item['street'],
                 zip_code=item['zip_code'],
                 city=item['city'],
+                country=random.choice(COUNTRIES),
                 contact=contact)
             self.db_session.add(archived_address)
 


### PR DESCRIPTION
This PR adds an additional field `country` to `Address` and `ArchivedAddress` entities. Such a field is required for addresses outside Switzerland.

Closes #2165.