### PR TITLE
Enable sql-participation for ogds-users in dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Enable sql-participation for ogds-users in dossiers.
+  [deiferni]
+
 - Display former_contact_id in the contact selection field and make it searchable.
   [phgross]
 

--- a/opengever/contact/models/__init__.py
+++ b/opengever/contact/models/__init__.py
@@ -11,6 +11,7 @@ from opengever.contact.models.mailaddress import MailAddress  # noqa
 from opengever.contact.models.org_role import OrgRole  # noqa
 from opengever.contact.models.organization import Organization  # noqa
 from opengever.contact.models.participation import ContactParticipation  # noqa
+from opengever.contact.models.participation import OgdsUserParticipation  # noqa
 from opengever.contact.models.participation import OrgRoleParticipation  # noqa
 from opengever.contact.models.participation import Participation  # noqa
 from opengever.contact.models.participation_role import ParticipationRole  # noqa

--- a/opengever/contact/ogdsuser.py
+++ b/opengever/contact/ogdsuser.py
@@ -1,0 +1,29 @@
+from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.base.browser.userdetails import UserDetails
+
+
+class OgdsUserAdapter(object):
+    """Adapter that represents ogds users as sql-contacts."""
+
+    class QueryAdapter(object):
+        """Adapter for query calls."""
+
+        def get(self, userid):
+            return OgdsUserAdapter(ogds_service().find_user(userid))
+    query = QueryAdapter()
+
+    def __init__(self, ogds_user):
+        self.ogds_user = ogds_user
+
+    @property
+    def id(self):
+        return self.ogds_user.userid
+
+    def get_title(self):
+        return self.ogds_user.label()
+
+    def get_url(self):
+        return UserDetails.url_for(self.id)
+
+    def get_css_class(self):
+        return 'contenttype-person'

--- a/opengever/contact/ogdsuser.py
+++ b/opengever/contact/ogdsuser.py
@@ -15,11 +15,24 @@ class OgdsUserAdapter(object):
     def __init__(self, ogds_user):
         self.ogds_user = ogds_user
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.id == other.id
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, self.__class__):
+            return not self.__eq__(other)
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.id)
+
     @property
     def id(self):
         return self.ogds_user.userid
 
-    def get_title(self):
+    def get_title(self, with_former_id=None):
         return self.ogds_user.label()
 
     def get_url(self):

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -10,111 +10,13 @@ from opengever.contact.interfaces import IContactSettings
 from opengever.contact.models.participation import Participation
 from opengever.core.testing import toggle_feature
 from opengever.testing import FunctionalTestCase
-from opengever.testing import MEMORY_DB_LAYER
 from opengever.testing.helpers import get_contacts_vocabulary
 from plone import api
 from zExceptions import Unauthorized
-import unittest2
 
 
 def get_token(obj):
     return get_contacts_vocabulary().getTerm(obj).token
-
-
-class TestContactParticipation(unittest2.TestCase):
-
-    layer = MEMORY_DB_LAYER
-
-    def setUp(self):
-        super(TestContactParticipation, self).setUp()
-        self.contact = create(Builder('person').having(
-            firstname=u'peter', lastname=u'hans'))
-
-    def test_adding(self):
-        create(Builder('contact_participation')
-               .having(contact=self.contact, dossier_oguid=Oguid('foo', 1234)))
-
-    def test_participation_can_have_multiple_roles(self):
-        participation = create(Builder('contact_participation').having(
-            contact=self.contact,
-            dossier_oguid=Oguid('foo', 1234)))
-        role1 = create(Builder('participation_role').having(
-            participation=participation,
-            role=u'Sch\xf6ff'))
-        role2 = create(Builder('participation_role').having(
-            participation=participation,
-            role=u'Hanswutscht'))
-
-        self.assertEquals([role1, role2], participation.roles)
-
-    def test_update_roles_removes_existing_no_longer_used_roles(self):
-        participation = create(Builder('contact_participation').having(
-            contact=self.contact,
-            dossier_oguid=Oguid('foo', 1234)))
-        create(Builder('participation_role').having(
-            participation=participation,
-            role=u'final-drawing'))
-        create(Builder('participation_role').having(
-            participation=participation,
-            role=u'regard'))
-
-        participation.update_roles(['regard'])
-        self.assertEquals(['regard'],
-                          [role.role for role in participation.roles])
-
-    def test_update_roles_add_new_roles(self):
-        contact = create(Builder('person').having(
-            firstname=u'peter', lastname=u'hans'))
-        participation = create(Builder('contact_participation').having(
-            contact=contact,
-            dossier_oguid=Oguid('foo', 1234)))
-        create(Builder('participation_role').having(
-            participation=participation,
-            role=u'final-drawing'))
-        create(Builder('participation_role').having(
-            participation=participation,
-            role=u'regard'))
-
-        participation.update_roles(['regard', 'participation'])
-
-        self.assertEquals(['regard', 'participation'],
-                          [role.role for role in participation.roles])
-
-
-class TestOrgRoleParticipation(unittest2.TestCase):
-
-    layer = MEMORY_DB_LAYER
-
-    def test_adding(self):
-        person = create(Builder('person').having(
-            firstname=u'peter', lastname=u'hans'))
-        organization = create(Builder('organization').named('ACME'))
-        orgrole = create(Builder('org_role').having(
-            person=person, organization=organization, function=u'cheffe'))
-
-        create(Builder('org_role_participation').having(
-            org_role=orgrole,
-            dossier_oguid=Oguid('foo', 1234)))
-
-    def test_participation_can_have_multiple_roles(self):
-        person = create(Builder('person').having(
-            firstname=u'peter', lastname=u'hans'))
-        organization = create(Builder('organization').named('ACME'))
-        orgrole = create(Builder('org_role').having(
-            person=person, organization=organization, function=u'cheffe'))
-
-        participation = create(Builder('org_role_participation').having(
-            org_role=orgrole,
-            dossier_oguid=Oguid('foo', 1234)))
-
-        role1 = create(Builder('participation_role').having(
-            participation=participation,
-            role=u'Sch\xf6ff'))
-        role2 = create(Builder('participation_role').having(
-            participation=participation,
-            role=u'Hanswutscht'))
-
-        self.assertEquals([role1, role2], participation.roles)
 
 
 class TestDossierParticipation(FunctionalTestCase):

--- a/opengever/contact/tests/test_participation_unit.py
+++ b/opengever/contact/tests/test_participation_unit.py
@@ -71,11 +71,9 @@ class TestOgdsUserParticipation(unittest2.TestCase):
     layer = MEMORY_DB_LAYER
 
     def test_adding(self):
-        adapted_peter = OgdsUserAdapter(
-            create(Builder('ogds_user').id('peter')))
-
+        peter = create(Builder('ogds_user').id('peter').as_contact_adapter())
         create(Builder('ogds_user_participation').having(
-            ogds_user=adapted_peter,
+            ogds_user=peter,
             dossier_oguid=Oguid('foo', 1234)))
 
 

--- a/opengever/contact/tests/test_participation_unit.py
+++ b/opengever/contact/tests/test_participation_unit.py
@@ -1,0 +1,101 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.oguid import Oguid
+from opengever.testing import MEMORY_DB_LAYER
+import unittest2
+
+
+class TestContactParticipation(unittest2.TestCase):
+
+    layer = MEMORY_DB_LAYER
+
+    def setUp(self):
+        super(TestContactParticipation, self).setUp()
+        self.contact = create(Builder('person').having(
+            firstname=u'peter', lastname=u'hans'))
+
+    def test_adding(self):
+        create(Builder('contact_participation')
+               .having(contact=self.contact, dossier_oguid=Oguid('foo', 1234)))
+
+    def test_participation_can_have_multiple_roles(self):
+        participation = create(Builder('contact_participation').having(
+            contact=self.contact,
+            dossier_oguid=Oguid('foo', 1234)))
+        role1 = create(Builder('participation_role').having(
+            participation=participation,
+            role=u'Sch\xf6ff'))
+        role2 = create(Builder('participation_role').having(
+            participation=participation,
+            role=u'Hanswutscht'))
+
+        self.assertEquals([role1, role2], participation.roles)
+
+    def test_update_roles_removes_existing_no_longer_used_roles(self):
+        participation = create(Builder('contact_participation').having(
+            contact=self.contact,
+            dossier_oguid=Oguid('foo', 1234)))
+        create(Builder('participation_role').having(
+            participation=participation,
+            role=u'final-drawing'))
+        create(Builder('participation_role').having(
+            participation=participation,
+            role=u'regard'))
+
+        participation.update_roles(['regard'])
+        self.assertEquals(['regard'],
+                          [role.role for role in participation.roles])
+
+    def test_update_roles_add_new_roles(self):
+        contact = create(Builder('person').having(
+            firstname=u'peter', lastname=u'hans'))
+        participation = create(Builder('contact_participation').having(
+            contact=contact,
+            dossier_oguid=Oguid('foo', 1234)))
+        create(Builder('participation_role').having(
+            participation=participation,
+            role=u'final-drawing'))
+        create(Builder('participation_role').having(
+            participation=participation,
+            role=u'regard'))
+
+        participation.update_roles(['regard', 'participation'])
+
+        self.assertEquals(['regard', 'participation'],
+                          [role.role for role in participation.roles])
+
+
+class TestOrgRoleParticipation(unittest2.TestCase):
+
+    layer = MEMORY_DB_LAYER
+
+    def test_adding(self):
+        person = create(Builder('person').having(
+            firstname=u'peter', lastname=u'hans'))
+        organization = create(Builder('organization').named('ACME'))
+        orgrole = create(Builder('org_role').having(
+            person=person, organization=organization, function=u'cheffe'))
+
+        create(Builder('org_role_participation').having(
+            org_role=orgrole,
+            dossier_oguid=Oguid('foo', 1234)))
+
+    def test_participation_can_have_multiple_roles(self):
+        person = create(Builder('person').having(
+            firstname=u'peter', lastname=u'hans'))
+        organization = create(Builder('organization').named('ACME'))
+        orgrole = create(Builder('org_role').having(
+            person=person, organization=organization, function=u'cheffe'))
+
+        participation = create(Builder('org_role_participation').having(
+            org_role=orgrole,
+            dossier_oguid=Oguid('foo', 1234)))
+
+        role1 = create(Builder('participation_role').having(
+            participation=participation,
+            role=u'Sch\xf6ff'))
+        role2 = create(Builder('participation_role').having(
+            participation=participation,
+            role=u'Hanswutscht'))
+
+        self.assertEquals([role1, role2], participation.roles)

--- a/opengever/contact/tests/test_participation_unit.py
+++ b/opengever/contact/tests/test_participation_unit.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.oguid import Oguid
+from opengever.contact.ogdsuser import OgdsUserAdapter
 from opengever.testing import MEMORY_DB_LAYER
 import unittest2
 
@@ -63,6 +64,19 @@ class TestContactParticipation(unittest2.TestCase):
 
         self.assertEquals(['regard', 'participation'],
                           [role.role for role in participation.roles])
+
+
+class TestOgdsUserParticipation(unittest2.TestCase):
+
+    layer = MEMORY_DB_LAYER
+
+    def test_adding(self):
+        adapted_peter = OgdsUserAdapter(
+            create(Builder('ogds_user').id('peter')))
+
+        create(Builder('ogds_user_participation').having(
+            ogds_user=adapted_peter,
+            dossier_oguid=Oguid('foo', 1234)))
 
 
 class TestOrgRoleParticipation(unittest2.TestCase):

--- a/opengever/contact/tests/test_vocabularies.py
+++ b/opengever/contact/tests/test_vocabularies.py
@@ -1,5 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.contact.ogdsuser import OgdsUserAdapter
+from opengever.ogds.base.utils import ogds_service
 from opengever.testing import FunctionalTestCase
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
@@ -38,6 +40,7 @@ class TestContactsVocabulary(FunctionalTestCase):
                             .having(person=self.peter_a,
                                     organization=self.teamwork_ag,
                                     function='Scheffe'))
+        self.ogds_user = OgdsUserAdapter(ogds_service().all_users()[0])
 
     def test_contains_only_active_organizations_and_persons_and_org_roles(self):
         voca_factory = getUtility(IVocabularyFactory,
@@ -50,7 +53,8 @@ class TestContactsVocabulary(FunctionalTestCase):
              (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)'),
              (self.peter_b, u'Peter Fl\xfcckiger'),
              (self.meier_ag, u'Meier AG [2222]'),
-             (self.teamwork_ag, u'4teamwork AG')],
+             (self.teamwork_ag, u'4teamwork AG'),
+             (self.ogds_user, u'Test User (test_user_1_)')],
             vocabulary.search('*'))
 
     def test_supports_fuzzy_search(self):

--- a/opengever/contact/upgrades/20160921154421_add_ogds_user_participation/upgrade.py
+++ b/opengever/contact/upgrades/20160921154421_add_ogds_user_participation/upgrade.py
@@ -1,0 +1,11 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+
+
+class AddOgdsUserParticipation(SchemaMigration):
+    """Add ogds-user participation."""
+
+    def migrate(self):
+        self.op.add_column('participations',
+                           Column('ogds_userid', String(255)))

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -13,6 +13,7 @@ from opengever.contact.models import ArchivedPhoneNumber
 from opengever.contact.models import ArchivedURL
 from opengever.contact.models import ContactParticipation
 from opengever.contact.models import MailAddress
+from opengever.contact.models import OgdsUserParticipation
 from opengever.contact.models import Organization
 from opengever.contact.models import OrgRole
 from opengever.contact.models import OrgRoleParticipation
@@ -513,12 +514,22 @@ class OrgRoleParticipationBuilder(BaseParticipationBuilder):
 
     mapped_class = OrgRoleParticipation
 
-
     def for_org_role(self, org_role):
         self.arguments['org_role'] = org_role
         return self
 
 builder_registry.register('org_role_participation', OrgRoleParticipationBuilder)
+
+
+class OgdsUserParticipationBuilder(BaseParticipationBuilder):
+
+    mapped_class = OgdsUserParticipation
+
+    def for_ogds_user(self, adapted_ogds_user):
+        self.arguments['ogds_user'] = adapted_ogds_user
+        return self
+
+builder_registry.register('ogds_user_participation', OgdsUserParticipationBuilder)
 
 
 class ParticipationRoleBuilder(SqlObjectBuilder):


### PR DESCRIPTION
This PR enables SQL-participation of users from ogds in dossiers.

Depends on https://github.com/4teamwork/opengever.core/pull/2174.

Currently the ogds is abstracted by a service, we must respect this decision and not add direct relationships to the ogds tables. This may change in the near future though. For now this PR introduces an adapter (the design-pattern, not the plone-thing) for the ogds user that adapts it to `Contact`s interface.

Closes #2164.