### PR TITLE
Setup: Keep track of reference number to path mappings per repository root

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Setup: Keep track of reference number to path mappings *per repository root*.
+  [lgraf]
+
 - Enable sql-participation for ogds-users in dossiers.
   [deiferni]
 

--- a/opengever/setup/sections/reference.py
+++ b/opengever/setup/sections/reference.py
@@ -67,21 +67,27 @@ class PathFromReferenceNumberSection(object):
             refnum = item['reference_number']
             refnum = self.get_reference_number(refnum)
 
+            # We need to keep track of refnums -> paths PER repository
+            repo_root_id = item['_repo_root_id']
+            if repo_root_id not in self.refnum_mapping:
+                self.refnum_mapping[repo_root_id] = {}
+
             if len(refnum.split('.')) == 1:
                 # Top level repository folder
-                repo_root_id = item['_repo_root_id']
                 path = "/%s/%s" % (repo_root_id,
                                    self.normalize(item, max_length=MAX_LENGTH))
-                self.refnum_mapping[refnum] = path
+                self.refnum_mapping[repo_root_id][refnum] = path
             else:
                 parent_refnum = refnum[:refnum.rfind('.')]
-                if not parent_refnum in self.refnum_mapping:
-                    raise Exception("Parent position for %s does not exist!" %
-                                    refnum)
+                if parent_refnum not in self.refnum_mapping[repo_root_id]:
+                    raise Exception(
+                        "(%s) Parent position for %s does not "
+                        "exist!" % (repo_root_id, refnum))
 
-                path = "%s/%s" % (self.refnum_mapping[parent_refnum],
-                                  self.normalize(item, max_length=MAX_LENGTH))
-                self.refnum_mapping[refnum] = path
+                parent_path = self.refnum_mapping[repo_root_id][parent_refnum]
+                path = "%s/%s" % (
+                    parent_path, self.normalize(item, max_length=MAX_LENGTH))
+                self.refnum_mapping[repo_root_id][refnum] = path
 
             item['_path'] = path
 


### PR DESCRIPTION
When using `opengever.setup` to set up **two or more** repositories, the reference number to path mapping wasn't kept separate for the different repositories.

This lead to items in the XLSX that were missing a parent slipping by. Normally these would be caught and an exception raised:

```
Exception: Parent position for 11.4.1 does not exist!
```

However, Items may arrive in the Transmogrifier pipeline in arbitrary order. So in the case that an invalid repository XLSX contained an item with no parent, it's supposed parent's reference number might have been found in the mapping that was shared over the entire pipeline, because the reference number was already present from a different repository.

**Solution**: Keep track of reference numbers -> paths **per repository root** by keeping a separate mapping for each repo root.

Also see: https://basecamp.com/2768704/projects/12786285/todos/273842470

@phgross @deiferni 
/cc @buchi 
