### PR TITLE
Add new functionality "Private Dossier"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Add new functionality "Private Dossier, a private area for every user to
+  create his private dossiers and store and edit private documents there.
+  [phgross]
+
 - Group related persons by active state in the organization detail view.
   [phgross]
 

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -26,84 +26,87 @@
            tal:attributes="class string:boxGroup boxGroup${box_id};
                            style string:width:${css_width}%">
         <div tal:repeat="box boxes" class="box" tal:attributes="id string:${box/id}Box">
-          <h2 i18n:translate="" tal:content="box/label|box/id"></h2>
+          <tal:condition tal:condition="python: box.get('available', True)">
 
-          <tal:box tal:condition="python: not hasattr(box.get('content'), '__iter__')">
-            <tal:item  tal:condition="box/content">
-              <span tal:content="box/content" />
-            </tal:item>
-            <tal:item tal:condition="not: box/content">
-              <span i18n:translate="" >No content</span>
-            </tal:item>
-          </tal:box>
+            <h2 i18n:translate="" tal:content="box/label|box/id"></h2>
 
-          <tal:box tal:condition="python: hasattr(box.get('content'), '__iter__')">
-            <tal:items define="items box/content">
-              <ul tal:condition="items">
-                <li tal:repeat="item items">
+            <tal:box tal:condition="python: not hasattr(box.get('content'), '__iter__')">
+              <tal:item  tal:condition="box/content">
+                <span tal:content="box/content" />
+              </tal:item>
+              <tal:item tal:condition="not: box/content">
+                <span i18n:translate="" >No content</span>
+              </tal:item>
+            </tal:box>
 
-                  <tal:comment replace="nothing">
-                    Item is a widget:
-                  </tal:comment>
-                  <tal:brain tal:condition="python: view.get_type(item) == 'widget'">
-                    <tal:cond tal:condition="item/label">
-                      <span tal:content="structure item/label" />
-                      <span>: </span>
-                      <span tal:content="structure item/render" />
-                    </tal:cond>
-                    <tal:cond tal:condition="not: item/label">
-                      <span tal:content="structure item/render" />
-                    </tal:cond>
-                  </tal:brain>
+            <tal:box tal:condition="python: hasattr(box.get('content'), '__iter__')">
+              <tal:items define="items box/content">
+                <ul tal:condition="items">
+                  <li tal:repeat="item items">
 
-                  <tal:comment replace="nothing">
-                    Item is a brain:
-                  </tal:comment>
-                  <tal:brain tal:condition="python: view.get_type(item) == 'brain'">
-                    <a href="" tal:attributes="href item/getURL|nothing;
-                                               title item/alt|nothing;
-                                               class python:view.get_item_css_classes(item)" tal:omit-tag="not: item/getURL|nothing"
-                       tal:content="item/Title">
-                    </a>
-                  </tal:brain>
+                    <tal:comment replace="nothing">
+                      Item is a widget:
+                    </tal:comment>
+                    <tal:brain tal:condition="python: view.get_type(item) == 'widget'">
+                      <tal:cond tal:condition="item/label">
+                        <span tal:content="structure item/label" />
+                        <span>: </span>
+                        <span tal:content="structure item/render" />
+                      </tal:cond>
+                      <tal:cond tal:condition="not: item/label">
+                        <span tal:content="structure item/render" />
+                      </tal:cond>
+                    </tal:brain>
 
-                  <tal:comment replace="nothing">
-                    Item is a contentlistingobject:
-                  </tal:comment>
-                  <tal:contentlisting tal:condition="python: view.get_type(item) == 'contentlistingobject'">
-                    <a tal:replace="structure item/render_link" />
-                  </tal:contentlisting>
+                    <tal:comment replace="nothing">
+                      Item is a brain:
+                    </tal:comment>
+                    <tal:brain tal:condition="python: view.get_type(item) == 'brain'">
+                      <a href="" tal:attributes="href item/getURL|nothing;
+                                                 title item/alt|nothing;
+                                                 class python:view.get_item_css_classes(item)" tal:omit-tag="not: item/getURL|nothing"
+                         tal:content="item/Title">
+                      </a>
+                    </tal:brain>
 
-                  <tal:comment replace="nothing">
-                    Item is a dict (Documents and participants):
-                  </tal:comment>
-                  <tal:dict tal:condition="python: view.get_type(item) == 'dict'">
-                    <a href=""
-                       tal:attributes="href item/getURL|nothing;
-                                       title item/alt|nothing;
-                                       class python:'rollover-breadcrumb %s' % (item.get('css_class'))"
-                       tal:omit-tag="not: item/getURL|nothing">
-                    <span tal:content="item/Title" /></a>
-                  </tal:dict>
+                    <tal:comment replace="nothing">
+                      Item is a contentlistingobject:
+                    </tal:comment>
+                    <tal:contentlisting tal:condition="python: view.get_type(item) == 'contentlistingobject'">
+                      <a tal:replace="structure item/render_link" />
+                    </tal:contentlisting>
+
+                    <tal:comment replace="nothing">
+                      Item is a dict (Documents and participants):
+                    </tal:comment>
+                    <tal:dict tal:condition="python: view.get_type(item) == 'dict'">
+                      <a href=""
+                         tal:attributes="href item/getURL|nothing;
+                                         title item/alt|nothing;
+                                         class python:'rollover-breadcrumb %s' % (item.get('css_class'))"
+                         tal:omit-tag="not: item/getURL|nothing">
+                      <span tal:content="item/Title" /></a>
+                    </tal:dict>
 
 
-                  <tal:comment replace="nothing">
-                    SQLAlchemy Objects (Tasks from GlobalIndex):
-                  </tal:comment>
-                  <tal:sql tal:condition="python: view.get_type(item) == 'globalindex_task'">
-                    <div tal:replace="structure python:view.render_globalindex_task(item)" />
-                  </tal:sql>
-                </li>
+                    <tal:comment replace="nothing">
+                      SQLAlchemy Objects (Tasks from GlobalIndex):
+                    </tal:comment>
+                    <tal:sql tal:condition="python: view.get_type(item) == 'globalindex_task'">
+                      <div tal:replace="structure python:view.render_globalindex_task(item)" />
+                    </tal:sql>
+                  </li>
 
-                <li class="moreLink" tal:condition="exists: box/href">
-                  <a tal:attributes="href string:#${box/href}"
-                     i18n:translate="">
-                  show all</a>
-                </li>
-              </ul>
-              <span tal:condition="not: items" i18n:translate="">No content</span>
-            </tal:items>
-          </tal:box>
+                  <li class="moreLink" tal:condition="exists: box/href">
+                    <a tal:attributes="href string:#${box/href}"
+                       i18n:translate="">
+                    show all</a>
+                  </li>
+                </ul>
+                <span tal:condition="not: items" i18n:translate="">No content</span>
+              </tal:items>
+            </tal:box>
+          </tal:condition>
 
         </div>
       </div>

--- a/opengever/base/profiles/default/propertiestool.xml
+++ b/opengever/base/profiles/default/propertiestool.xml
@@ -35,6 +35,7 @@
             <element value="opengever.task.task"/>
             <element value="opengever.tasktemplates.tasktemplate"/>
             <element value="opengever.tasktemplates.tasktemplatefolder"/>
+            <element value="opengever.private.root"/>
         </property>
     </object>
 
@@ -42,4 +43,3 @@
         <property name="icon_visibility" type="string">enabled</property>
     </object>
 </object>
-

--- a/opengever/base/tests/test_pasting_allowed.py
+++ b/opengever/base/tests/test_pasting_allowed.py
@@ -49,12 +49,20 @@ class TestPastingAllowed(FunctionalTestCase):
         self.assertSequenceEqual(
             ['Export as Zip', 'Properties', 'save attachments'], actions)
 
-    def test_pasting_not_allowed_if_disallowed_subobject_type(self):
+    @browsing
+    def test_pasting_not_allowed_if_disallowed_subobject_type(self, browser):
         repofolder = create(Builder('repository'))
-        dossier = create(Builder('dossier')
-                         .within(repofolder))
-        document = create(Builder('document')
-                          .within(dossier))
+        dossier = create(Builder('dossier').within(repofolder))
+        document = create(Builder('document').within(dossier))
+
+        browser.login().open(
+            dossier,
+            view='copy_items',
+            data={'paths:list': ['/'.join(document.getPhysicalPath())]})
+
+        browser.open(repofolder, view='is_pasting_allowed')
+        self.assertFalse(browser.contents)
+
     @browsing
     def test_pasting_public_content_into_private_container_is_disallowed(self, browser):
         repo = create(Builder('repository'))
@@ -86,10 +94,5 @@ class TestPastingAllowed(FunctionalTestCase):
             view='copy_items',
             data={'paths:list': ['/'.join(document.getPhysicalPath())]})
 
-        dossier.manage_copyObjects(document.id)
-        pasting_allowed_view = repofolder.restrictedTraverse(
-            'is_pasting_allowed')
-        allowed = pasting_allowed_view()
-        self.assertFalse(allowed)
         browser.open(dossier_2, view='is_pasting_allowed')
         self.assertTrue(browser.contents)

--- a/opengever/base/upgrades/20160923115614_exclude_private_root_from_navigation/propertiestool.xml
+++ b/opengever/base/upgrades/20160923115614_exclude_private_root_from_navigation/propertiestool.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+  <object name="navtree_properties" meta_type="Plone Property Sheet">
+    <property name="metaTypesNotToList" type="lines" purge="False">
+      <element value="opengever.private.root"/>
+    </property>
+  </object>
+
+</object>

--- a/opengever/base/upgrades/20160923115614_exclude_private_root_from_navigation/upgrade.py
+++ b/opengever/base/upgrades/20160923115614_exclude_private_root_from_navigation/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ExcludePrivateRootFromNavigation(UpgradeStep):
+    """Exclude private root from navigation.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -240,6 +240,7 @@ class OpengeverFixture(PloneSandboxLayer):
         applyProfile(portal, 'opengever.activity:default')
         applyProfile(portal, 'opengever.bumblebee:default')
         applyProfile(portal, 'opengever.officeatwork:default')
+        applyProfile(portal, 'opengever.private:default')
         applyProfile(portal, 'ftw.datepicker:default')
         applyProfile(portal, 'plone.formwidget.autocomplete:default')
         applyProfile(portal, 'plone.formwidget.contenttree:default')

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -14,6 +14,7 @@ from opengever.meeting.interfaces import IMeetingSettings
 from opengever.officeatwork.interfaces import IOfficeatworkSettings
 from opengever.ogds.base.setup import create_sql_tables
 from opengever.ogds.models import BASE
+from opengever.private import enable_opengever_private
 from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
@@ -451,6 +452,22 @@ class BumblebeeLayer(PloneSandboxLayer):
 
 
 OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER = BumblebeeLayer()
+
+
+class PrivateFolderLayer(PloneSandboxLayer):
+
+    def setUpPloneSite(self, portal):
+        enable_opengever_private()
+
+    def tearDownPloneSite(self, portal):
+        mtool = api.portal.get_tool('portal_membership')
+        if mtool.getMemberareaCreationFlag():
+            mtool.setMemberareaCreationFlag()
+
+    defaultBases = (OPENGEVER_FUNCTIONAL_TESTING,)
+
+
+OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER = PrivateFolderLayer()
 
 
 class OfficeatworkLayer(PloneSandboxLayer):

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -193,7 +193,6 @@ class OpengeverFixture(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         self.installOpengeverProfiles(portal)
-        self.createMemberFolder(portal)
         self.setupLanguageTool(portal)
         deactivate_activity_center()
         deactivate_bumblebee_feature()

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -309,6 +309,9 @@ class DefaultConstrainTypeDecider(grok.MultiAdapter):
             'opengever.dossier.businesscasedossier': 2,
             'opengever.dossier.projectdossier': 1,
             },
+        'opengever.private.dossier': {
+            'opengever.private.dossier': 2
+        },
         'opengever.dossier.projectdossier': {
             'opengever.dossier.projectdossier': 1,
             'opengever.dossier.businesscasedossier': 1,

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -9,6 +9,7 @@ from opengever.contact.participation import ParticipationWrapper
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
 from opengever.dossier.interfaces import IConstrainTypeDecider
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.meeting import is_meeting_feature_enabled
@@ -297,6 +298,9 @@ class DossierContainer(Container):
 
     def get_sequence_number(self):
         return getUtility(ISequenceNumber).get_number(self)
+
+    def has_participation_support(self):
+        return IParticipationAwareMarker.providedBy(self)
 
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -43,7 +43,8 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
                 dict(id='newest_tasks', content=self.tasks(),
                      href='tasks', label=_("Newest tasks")),
                 dict(id='participants', content=self.sharing(),
-                     href='participants', label=_("Participants")),
+                     href='participants', label=_("Participants"),
+                     available=self.context.has_participation_support()),
                 dict(id='references', content=self.linked_dossiers(),
                      label=_('label_linked_dossiers',
                              default='Linked Dossiers')),
@@ -78,6 +79,9 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
             ['opengever.document.document', 'ftw.mail.mail', ])[:10])
 
     def sharing(self):
+        if not self.context.has_participation_support():
+            return []
+
         # get the participants
         phandler = IParticipationAware(self.context)
         results = list(phandler.get_participations())

--- a/opengever/dossier/menu.py
+++ b/opengever/dossier/menu.py
@@ -8,11 +8,14 @@ from zope.interface import Interface
 class DossierPostFactoryMenu(FilteredPostFactoryMenu):
     grok.adapts(IDossierMarker, Interface)
 
+    dossier_types = [u'opengever.dossier.businesscasedossier',
+                     u'opengever.private.dossier']
+
     def __init__(self, context, request):
         super(DossierPostFactoryMenu, self).__init__(context, request)
 
     def rename(self, factory):
-        if factory.get('id') == u'opengever.dossier.businesscasedossier':
+        if factory.get('id') in self.dossier_types:
             factory['title'] = _(u'Subdossier')
 
         return factory

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -103,6 +103,10 @@ class TestDossierContainer(FunctionalTestCase):
         self.assertEquals(2, subdossier.get_sequence_number())
         self.assertEquals(3, dossier_2.get_sequence_number())
 
+    def test_support_participations(self):
+        dossier = create(Builder("dossier"))
+        self.assertTrue(dossier.has_participation_support())
+
 
 class TestDossierChecks(FunctionalTestCase):
 

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -7,6 +7,7 @@ from ftw.builder import create
 from ftw.builder import session
 from opengever.base.model import create_session
 from opengever.examplecontent.contacts import ExampleContactCreator
+from opengever.private import enable_opengever_private
 from opengever.setup.hooks import block_context_portlets
 from opengever.testing import builders  # keep!
 from plone import api
@@ -208,3 +209,4 @@ def municipality_content_profile_installed(site):
     creator.create()
 
     block_portlets_for_meetings(site)
+    enable_opengever_private()

--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -28,6 +28,7 @@
     <dependency>profile-opengever.activity:default</dependency>
     <dependency>profile-opengever.bumblebee:default</dependency>
     <dependency>profile-opengever.officeatwork:default</dependency>
+    <dependency>profile-opengever.private:default</dependency>
     <dependency>profile-ftw.datepicker:default</dependency>
     <dependency>profile-ftw.contentmenu:default</dependency>
     <dependency>profile-ftw.zipexport:default</dependency>

--- a/opengever/policy/base/profiles/default/types/Plone_Site.xml
+++ b/opengever/policy/base/profiles/default/types/Plone_Site.xml
@@ -8,5 +8,6 @@
   <element value="opengever.inbox.inbox"/>
   <element value="opengever.inbox.container"/>
   <element value="opengever.meeting.committeecontainer"/>
+  <element value="opengever.private.root"/>
  </property>
 </object>

--- a/opengever/policy/base/upgrades/20160923114424_install_opengever_private/metadata.xml
+++ b/opengever/policy/base/upgrades/20160923114424_install_opengever_private/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+  <dependencies>
+    <dependency>profile-opengever.private:default</dependency>
+  </dependencies>
+</metadata>

--- a/opengever/policy/base/upgrades/20160923114424_install_opengever_private/types/Plone_Site.xml
+++ b/opengever/policy/base/upgrades/20160923114424_install_opengever_private/types/Plone_Site.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+  <property name="allowed_content_types" purge="False">
+    <element value="opengever.private.root"/>
+  </property>
+</object>

--- a/opengever/policy/base/upgrades/20160923114424_install_opengever_private/upgrade.py
+++ b/opengever/policy/base/upgrades/20160923114424_install_opengever_private/upgrade.py
@@ -22,3 +22,5 @@ class InstallOpengeverPrivate(UpgradeStep):
 
         if private_root.id != MEMBERSFOLDER_ID:
             api.content.rename(obj=private_root, new_id=MEMBERSFOLDER_ID)
+
+        block_context_portlets(api.portal.get(), MEMBERSFOLDER_ID)

--- a/opengever/policy/base/upgrades/20160923114424_install_opengever_private/upgrade.py
+++ b/opengever/policy/base/upgrades/20160923114424_install_opengever_private/upgrade.py
@@ -1,0 +1,24 @@
+from ftw.upgrade import UpgradeStep
+from opengever.setup.hooks import block_context_portlets
+from plone import api
+
+MEMBERSFOLDER_ID = 'private'
+
+
+class InstallOpengeverPrivate(UpgradeStep):
+    """Install opengever private.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        if not api.portal.get().get(MEMBERSFOLDER_ID):
+            self.create_private_root()
+
+    def create_private_root(self):
+        private_root = api.content.create(
+            type='opengever.private.root',
+            title='Private',
+            container=api.portal.get())
+
+        if private_root.id != MEMBERSFOLDER_ID:
+            api.content.rename(obj=private_root, new_id=MEMBERSFOLDER_ID)

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -116,3 +116,8 @@ setup.maximum_mail_size.post_ask_question = opengever.policytemplates.hooks:post
 
 setup.preserved_as_paper.question = "Preserved as paper" default
 setup.preserved_as_paper.post_ask_question = opengever.policytemplates.hooks:post_preserved_as_paper
+
+setup.enable_private_folder.question = Enable private folder feature
+setup.enable_private_folder.required = True
+setup.enable_private_folder.default = False
+setup.enable_private_folder.post_ask_hook = mrbob.hooks:to_boolean

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/hooks.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/hooks.py.bob
@@ -1,4 +1,7 @@
 from opengever.setup.hooks import assign_default_navigation_portlet
+{{% if setup.enable_private_folder %}}
+from opengever.private import enable_opengever_private
+{{% endif %}}
 {{% if setup.enable_meeting_feature %}}
 from opengever.setup.hooks import block_context_portlets
 {{% endif %}}
@@ -10,4 +13,7 @@ def default_content_installed(site):
     assign_default_navigation_portlet(site, 'kontakte')
 {{% if setup.enable_meeting_feature %}}
     block_context_portlets(site, 'sitzungen')
+{{% endif %}}
+{{% if setup.enable_private_folder %}}
+    enable_opengever_private()
 {{% endif %}}

--- a/opengever/private/__init__.py
+++ b/opengever/private/__init__.py
@@ -1,0 +1,4 @@
+from zope.i18nmessageid import MessageFactory
+
+
+_ = MessageFactory('opengever.private')

--- a/opengever/private/__init__.py
+++ b/opengever/private/__init__.py
@@ -1,4 +1,5 @@
 from zope.i18nmessageid import MessageFactory
 
-
 _ = MessageFactory('opengever.private')
+
+MEMBERSFOLDER_ID = 'private'

--- a/opengever/private/__init__.py
+++ b/opengever/private/__init__.py
@@ -1,5 +1,12 @@
+from plone import api
 from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('opengever.private')
 
 MEMBERSFOLDER_ID = 'private'
+
+
+def enable_opengever_private():
+    mtool = api.portal.get_tool('portal_membership')
+    if not mtool.getMemberareaCreationFlag():
+        mtool.setMemberareaCreationFlag()

--- a/opengever/private/browser/configure.zcml
+++ b/opengever/private/browser/configure.zcml
@@ -1,0 +1,14 @@
+<configure
+      xmlns="http://namespaces.zope.org/zope"
+      xmlns:browser="http://namespaces.zope.org/browser"
+      i18n_domain="opengever.dossier">
+
+  <browser:page
+      for="opengever.private.folder.IPrivateFolder"
+      name="tabbed_view"
+      class=".tabbed.PrivateFolderTabbedView"
+      permission="zope2.View"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
+      />
+
+</configure>

--- a/opengever/private/browser/configure.zcml
+++ b/opengever/private/browser/configure.zcml
@@ -11,4 +11,12 @@
       allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
+  <browser:page
+      for="opengever.private.dossier.IPrivateDossier"
+      name="tabbed_view"
+      class=".tabbed.PrivateDossierTabbedView"
+      permission="zope2.View"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
+      />
+
 </configure>

--- a/opengever/private/browser/forms.py
+++ b/opengever/private/browser/forms.py
@@ -1,0 +1,6 @@
+from five import grok
+from opengever.dossier.behaviors.dossier import AddForm
+
+
+class PrivateDossierAddForm(AddForm):
+    grok.name('opengever.private.dossier')

--- a/opengever/private/browser/tabbed.py
+++ b/opengever/private/browser/tabbed.py
@@ -24,6 +24,8 @@ class PrivateFolderDossiers(Dossiers):
 
     filterlist_available = False
 
+    enabled_actions = ['pdf_dossierlisting', 'export_dossiers']
+
 
 class PrivateDossierTabbedView(DossierTabbedView):
     """Overwrite the DossierTabbedview to hide the task, proposal,

--- a/opengever/private/browser/tabbed.py
+++ b/opengever/private/browser/tabbed.py
@@ -1,0 +1,24 @@
+from five import grok
+from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.private import _
+from opengever.private.folder import IPrivateFolder
+from opengever.tabbedview.browser.tabs import Dossiers
+
+
+class PrivateFolderTabbedView(TabbedView):
+
+    dossier_tab = {
+        'id': 'dossiers',
+        'title': _(u'label_dossiers', default=u'Dossiers'),
+        'icon': None,
+        'url': '#',
+        'class': None}
+
+    def get_tabs(self):
+        return [self.dossier_tab]
+
+
+class PrivateFolderDossiers(Dossiers):
+    grok.context(IPrivateFolder)
+
+    filterlist_available = False

--- a/opengever/private/browser/tabbed.py
+++ b/opengever/private/browser/tabbed.py
@@ -1,5 +1,6 @@
 from five import grok
 from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.dossier.browser.tabbed import DossierTabbedView
 from opengever.private import _
 from opengever.private.folder import IPrivateFolder
 from opengever.tabbedview.browser.tabs import Dossiers
@@ -22,3 +23,16 @@ class PrivateFolderDossiers(Dossiers):
     grok.context(IPrivateFolder)
 
     filterlist_available = False
+
+
+class PrivateDossierTabbedView(DossierTabbedView):
+    """Overwrite the DossierTabbedview to hide the task, proposal,
+    participation and info tab.
+    """
+
+    def get_tabs(self):
+        return [self.overview_tab,
+                self.subdossiers_tab,
+                self.documents_tab,
+                self.trash_tab,
+                self.journal_tab]

--- a/opengever/private/browser/tabbed.py
+++ b/opengever/private/browser/tabbed.py
@@ -22,8 +22,6 @@ class PrivateFolderTabbedView(TabbedView):
 class PrivateFolderDossiers(Dossiers):
     grok.context(IPrivateFolder)
 
-    filterlist_available = False
-
     enabled_actions = ['pdf_dossierlisting', 'export_dossiers']
 
 

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -35,4 +35,9 @@
       title="opengever.private: Add private folder"
       />
 
+  <permission
+      id="opengever.private.AddPrivateDossier"
+      title="opengever.private: Add private dossier"
+      />
+
 </configure>

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -15,4 +15,11 @@
 
   <include package=".upgrades" />
 
+
+  <!-- permissions -->
+  <permission
+      id="opengever.private.AddPrivateRoot"
+      title="opengever.private: Add private root"
+      />
+
 </configure>

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -18,12 +18,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <profilehook:hook
+      profile="opengever.private:default"
+      handler=".hooks.configure_members_area"
+      />
+
   <include package=".upgrades" />
   <include package=".browser" />
 
-
-  <!-- adpaters -->
-  <adapter factory=".folder.PrivateFolderNameFromTitle" />
 
   <!-- permissions -->
   <permission

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -19,6 +19,7 @@
       />
 
   <include package=".upgrades" />
+  <include package=".browser" />
 
 
   <!-- adpaters -->

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -2,8 +2,13 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
+    xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.private">
+
+  <i18n:registerTranslations directory="locales" />
+
+  <grok:grok package="." />
 
   <genericsetup:registerProfile
       name="default"
@@ -16,10 +21,18 @@
   <include package=".upgrades" />
 
 
+  <!-- adpaters -->
+  <adapter factory=".folder.PrivateFolderNameFromTitle" />
+
   <!-- permissions -->
   <permission
       id="opengever.private.AddPrivateRoot"
       title="opengever.private: Add private root"
+      />
+
+  <permission
+      id="opengever.private.AddPrivateFolder"
+      title="opengever.private: Add private folder"
       />
 
 </configure>

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:profilehook="http://namespaces.zope.org/profilehook"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="opengever.private">
+
+  <genericsetup:registerProfile
+      name="default"
+      title="opengever.private"
+      description="Contains the private obj types(PrivateRoot, PrivateFolder, PrivateDossier) and corresponding workflows."
+      directory="profiles/default"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <include package=".upgrades" />
+
+</configure>

--- a/opengever/private/dossier.py
+++ b/opengever/private/dossier.py
@@ -1,5 +1,6 @@
 from opengever.dossier.base import DossierContainer
 from opengever.dossier.businesscase import IBusinessCaseDossier
+from opengever.private.interfaces import IPrivateContainer
 
 
 class IPrivateDossier(IBusinessCaseDossier, IPrivateContainer):

--- a/opengever/private/dossier.py
+++ b/opengever/private/dossier.py
@@ -1,0 +1,13 @@
+from opengever.dossier.base import DossierContainer
+from opengever.dossier.businesscase import IBusinessCaseDossier
+
+
+class IPrivateDossier(IBusinessCaseDossier, IPrivateContainer):
+    """PrivateDossier marker interface.
+    """
+
+
+class PrivateDossier(DossierContainer):
+    """A specific dossier type, only addable to a PrivateFolder in the
+    private Area and only visible for the Owner and Managers.
+    """

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -1,0 +1,44 @@
+from opengever.ogds.base.actor import Actor
+from opengever.private import _
+from opengever.repository.repositoryfolder import IRepositoryFolderSchema
+from plone.app.content.interfaces import INameFromTitle
+from plone.dexterity.content import Container
+from zope import schema
+from zope.component import adapts
+from zope.interface import implements
+
+
+class IPrivateFolder(IRepositoryFolderSchema, IPrivateContainer):
+    """Private folder marker and schema interface.
+    """
+
+    userid = schema.TextLine(
+        title=_(u'label_userid', default=u'User ID'),
+        required=True,
+    )
+
+
+class PrivateFolder(Container):
+    """A private folder, container for all PrivateDossiers.
+
+    Created automatically by the portal_membership tool for every user on
+    the first login.
+    """
+
+    def Title(self):
+        return Actor.lookup(self.userid).get_label(self)
+
+
+class PrivateFolderNameFromTitle(object):
+    """An INameFromTitle adapter to make sure that the userid is used as id.
+    """
+
+    implements(INameFromTitle)
+    adapts(IPrivateFolder)
+
+    def __init__(self, context):
+        self.context = context
+
+    @property
+    def title(self):
+        return self.context.userid

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -1,7 +1,11 @@
 from opengever.ogds.base.actor import Actor
 from opengever.private.interfaces import IPrivateContainer
 from opengever.repository.repositoryfolder import IRepositoryFolderSchema
+from plone import api
 from plone.dexterity.content import Container
+
+PRIVATE_FOLDER_DEFAULT_ROLES = [
+    'Owner', 'Reader', 'Contributor', 'Editor', 'Reviewer', 'Publisher']
 
 
 class IPrivateFolder(IRepositoryFolderSchema, IPrivateContainer):
@@ -18,3 +22,12 @@ class PrivateFolder(Container):
 
     def Title(self):
         return Actor.lookup(self.id).get_label(self)
+
+    def notifyMemberAreaCreated(self):
+        """Add additional local_roles to the members folder.
+
+        This method is called by the MembershipTool after MembersFolder
+        creation.
+        """
+        api.user.grant_roles(username=self.id, obj=self,
+                             roles=PRIVATE_FOLDER_DEFAULT_ROLES)

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -1,4 +1,5 @@
 from opengever.ogds.base.actor import Actor
+from opengever.private.interfaces import IPrivateContainer
 from opengever.repository.repositoryfolder import IRepositoryFolderSchema
 from plone.dexterity.content import Container
 

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -1,21 +1,11 @@
 from opengever.ogds.base.actor import Actor
-from opengever.private import _
 from opengever.repository.repositoryfolder import IRepositoryFolderSchema
-from plone.app.content.interfaces import INameFromTitle
 from plone.dexterity.content import Container
-from zope import schema
-from zope.component import adapts
-from zope.interface import implements
 
 
 class IPrivateFolder(IRepositoryFolderSchema, IPrivateContainer):
     """Private folder marker and schema interface.
     """
-
-    userid = schema.TextLine(
-        title=_(u'label_userid', default=u'User ID'),
-        required=True,
-    )
 
 
 class PrivateFolder(Container):
@@ -26,19 +16,4 @@ class PrivateFolder(Container):
     """
 
     def Title(self):
-        return Actor.lookup(self.userid).get_label(self)
-
-
-class PrivateFolderNameFromTitle(object):
-    """An INameFromTitle adapter to make sure that the userid is used as id.
-    """
-
-    implements(INameFromTitle)
-    adapts(IPrivateFolder)
-
-    def __init__(self, context):
-        self.context = context
-
-    @property
-    def title(self):
-        return self.context.userid
+        return Actor.lookup(self.id).get_label(self)

--- a/opengever/private/hooks.py
+++ b/opengever/private/hooks.py
@@ -1,0 +1,11 @@
+from opengever.private import MEMBERSFOLDER_ID
+from plone import api
+
+
+def configure_members_area(site):
+    """Configure and enable Plone's MemberAreaCreation.
+    """
+    mtool = api.portal.get_tool('portal_membership')
+    mtool.setMembersFolderById(MEMBERSFOLDER_ID)
+    mtool.setMemberAreaType('opengever.private.folder')
+    mtool.setMemberareaCreationFlag()

--- a/opengever/private/hooks.py
+++ b/opengever/private/hooks.py
@@ -8,4 +8,3 @@ def configure_members_area(site):
     mtool = api.portal.get_tool('portal_membership')
     mtool.setMembersFolderById(MEMBERSFOLDER_ID)
     mtool.setMemberAreaType('opengever.private.folder')
-    mtool.setMemberareaCreationFlag()

--- a/opengever/private/interfaces.py
+++ b/opengever/private/interfaces.py
@@ -1,0 +1,7 @@
+from zope.interface import Interface
+
+
+class IPrivateContainer(Interface):
+    """Marker interface for private containers, only accessible
+    by the corresponding user.
+    """

--- a/opengever/private/locales/de/LC_MESSAGES/opengever.private.po
+++ b/opengever/private/locales/de/LC_MESSAGES/opengever.private.po
@@ -1,0 +1,36 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2016-09-23 14:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#: ./opengever/private/profiles/default/actions.xml
+msgid "My repository"
+msgstr "Meine Ablage"
+
+#: ./opengever/private/profiles/default/types/opengever.private.dossier.xml
+msgid "Private Dossier"
+msgstr "Persönliches Dossier"
+
+#: ./opengever/private/profiles/default/types/opengever.private.root.xml
+msgid "Private Root"
+msgstr "Persönliches Verzeichnis"
+
+#: ./opengever/private/profiles/default/types/opengever.private.folder.xml
+msgid "Private folder"
+msgstr "Persönlicher Ordner"
+
+#. Default: "Dossiers"
+#: ./opengever/private/browser/tabbed.py:13
+msgid "label_dossiers"
+msgstr "Dossiers"

--- a/opengever/private/locales/fr/LC_MESSAGES/opengever.private.po
+++ b/opengever/private/locales/fr/LC_MESSAGES/opengever.private.po
@@ -1,0 +1,37 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2016-09-23 14:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#: ./opengever/private/profiles/default/actions.xml
+msgid "My repository"
+msgstr ""
+
+#: ./opengever/private/profiles/default/types/opengever.private.dossier.xml
+msgid "Private Dossier"
+msgstr ""
+
+#: ./opengever/private/profiles/default/types/opengever.private.root.xml
+msgid "Private Root"
+msgstr ""
+
+#: ./opengever/private/profiles/default/types/opengever.private.folder.xml
+msgid "Private folder"
+msgstr ""
+
+#. Default: "Dossiers"
+#: ./opengever/private/browser/tabbed.py:13
+msgid "label_dossiers"
+msgstr ""
+

--- a/opengever/private/locales/opengever.private.pot
+++ b/opengever/private/locales/opengever.private.pot
@@ -1,0 +1,40 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2016-09-23 14:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: opengever.private\n"
+
+#: ./opengever/private/profiles/default/actions.xml
+msgid "My repository"
+msgstr ""
+
+#: ./opengever/private/profiles/default/types/opengever.private.dossier.xml
+msgid "Private Dossier"
+msgstr ""
+
+#: ./opengever/private/profiles/default/types/opengever.private.root.xml
+msgid "Private Root"
+msgstr ""
+
+#: ./opengever/private/profiles/default/types/opengever.private.folder.xml
+msgid "Private folder"
+msgstr ""
+
+#. Default: "Dossiers"
+#: ./opengever/private/browser/tabbed.py:13
+msgid "label_dossiers"
+msgstr ""
+

--- a/opengever/private/profiles/default/actions.xml
+++ b/opengever/private/profiles/default/actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <object name="portal_tabs" meta_type="CMF Action Category">
+    <object name="my_repository" meta_type="CMF Action" i18n:domain="opengever.private">
+      <property name="title" i18n:translate="">My repository</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${portal/portal_membership/getHomeUrl}</property>
+      <property name="link_target"></property>
+      <property name="icon_expr"></property>
+      <property name="available_expr">portal/portal_membership/getHomeFolder</property>
+      <property name="permissions">
+        <element value="View"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+
+</object>

--- a/opengever/private/profiles/default/rolemap.xml
+++ b/opengever/private/profiles/default/rolemap.xml
@@ -5,5 +5,9 @@
     <permission name="opengever.private: Add private root" acquire="True">
       <role name="Manager"/>
     </permission>
+
+    <permission name="opengever.private: Add private folder" acquire="True">
+      <role name="Manager"/>
+    </permission>
   </permissions>
 </rolemap>

--- a/opengever/private/profiles/default/rolemap.xml
+++ b/opengever/private/profiles/default/rolemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<rolemap>
+  <permissions>
+    <permission name="opengever.private: Add private root" acquire="True">
+      <role name="Manager"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/private/profiles/default/types.xml
+++ b/opengever/private/profiles/default/types.xml
@@ -1,4 +1,5 @@
 <object name="portal_types">
     <object name="opengever.private.root" meta_type="Dexterity FTI" />
     <object name="opengever.private.folder" meta_type="Dexterity FTI" />
+    <object name="opengever.private.dossier" meta_type="Dexterity FTI" />
 </object>

--- a/opengever/private/profiles/default/types.xml
+++ b/opengever/private/profiles/default/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types">
+    <object name="opengever.private.root" meta_type="Dexterity FTI" />
+</object>

--- a/opengever/private/profiles/default/types.xml
+++ b/opengever/private/profiles/default/types.xml
@@ -1,3 +1,4 @@
 <object name="portal_types">
     <object name="opengever.private.root" meta_type="Dexterity FTI" />
+    <object name="opengever.private.folder" meta_type="Dexterity FTI" />
 </object>

--- a/opengever/private/profiles/default/types/opengever.private.dossier.xml
+++ b/opengever/private/profiles/default/types/opengever.private.dossier.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<object name="opengever.private.dossier" meta_type="Dexterity FTI"
+        i18n:domain="opengever.private" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">Private Dossier</property>
+  <property name="description" i18n:translate=""></property>
+  <property name="icon_expr"></property>
+  <property name="allow_discussion">False</property>
+  <property name="global_allow">True</property>
+  <property name="filter_content_types">True</property>
+  <property name="allowed_content_types">
+    <element value="opengever.private.dossier" />
+    <element value="opengever.document.document" />
+    <element value="ftw.mail.mail"/>
+  </property>
+
+  <!-- schema interface -->
+  <property name="schema">opengever.private.dossier.IPrivateDossier</property>
+
+  <!-- class used for content items -->
+  <property name="klass">opengever.private.dossier.PrivateDossier</property>
+
+  <!-- add permission -->
+  <property name="add_permission">opengever.private.AddPrivateDossier</property>
+
+  <!-- enabled behaviors -->
+  <property name="behaviors">
+    <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+    <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+    <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+    <element value="opengever.dossier.behaviors.dossier.IDossier" />
+    <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
+    <element value="opengever.trash.trash.ITrashable" />
+    <element value="opengever.dossier.behaviors.dossiernamefromtitle.IDossierNameFromTitle" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.sharing.behaviors.IDossier" />
+    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    <element value="opengever.mail.behaviors.ISendableDocsContainer" />
+  </property>
+
+  <!-- View information -->
+  <property name="immediate_view">tabbed_view</property>
+  <property name="default_view">tabbed_view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="view"/>
+    <element value="tabbed_view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)" to="(selected layout)"/>
+  <alias from="edit" to="@@edit"/>
+  <alias from="sharing" to="@@sharing"/>
+  <alias from="view" to="@@view"/>
+
+  <!-- Actions -->
+  <action action_id="view"
+          visible="False"
+          title="View"
+          category="object"
+          url_expr="string:${object_url}"
+          condition_expr="">
+    <permission value="View"/>
+  </action>
+
+  <action action_id="edit"
+          visible="True"
+          title="Edit"
+          category="object"
+          url_expr="string:${object_url}/edit"
+          condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True">
+    <permission value="Modify portal content"/>
+  </action>
+
+  <action action_id="document_with_template"
+          visible="True"
+          title="document_with_template"
+          category="folder_factories"
+          url_expr="string:${object_url}/document_with_template"
+          icon_expr=""
+          condition_expr=""
+          i18n:domain="opengever.dossier">
+    <permission value="Add portal content"/>
+  </action>
+
+  <action action_id="document_from_officeatwork"
+          visible="True"
+          title="document_from_officeatwork"
+          category="folder_factories"
+          url_expr="string:${object_url}/document_from_officeatwork"
+          icon_expr=""
+          condition_expr="object/@@is_officeatwork_feature_enabled"
+          i18n:domain="opengever.dossier">
+    <permission value="Add portal content"/>
+  </action>
+
+</object>

--- a/opengever/private/profiles/default/types/opengever.private.folder.xml
+++ b/opengever/private/profiles/default/types/opengever.private.folder.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<object name="opengever.private.folder" meta_type="Dexterity FTI"
+        i18n:domain="opengever.private" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Private folder</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types" purge="False">
+        <element value="opengever.private.dossier" />
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">opengever.private.folder.IPrivateFolder</property>
+
+    <!-- class used for content items -->
+    <property name="klass">opengever.private.folder.PrivateFolder</property>
+
+    <!-- add permission -->
+    <property name="add_permission">opengever.private.AddPrivateFolder</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="opengever.base.behaviors.creator.ICreator" />
+        <element value="opengever.sharing.behaviors.IDossier" />
+        <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
+        <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    </property>
+
+    <!-- View information -->
+    <property name="immediate_view">tabbed_view</property>
+    <property name="default_view">tabbed_view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="tabbed_view" />
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(selected layout)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="@@view"/>
+
+    <!-- Actions -->
+    <action title="View" action_id="view" category="object"
+            condition_expr=""
+            url_expr="string:${object_url}" visible="False">
+      <permission value="View"/>
+    </action>
+
+    <action title="Edit" action_id="edit" category="object"
+            condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+            url_expr="string:${object_url}/edit" visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/opengever/private/profiles/default/types/opengever.private.root.xml
+++ b/opengever/private/profiles/default/types/opengever.private.root.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<object name="opengever.private.root" meta_type="Dexterity FTI"
+        i18n:domain="opengever.private" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Private Root</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="opengever.private.folder" />
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">opengever.private.root.IPrivateRoot</property>
+
+    <!-- class used for content items -->
+    <property name="klass">opengever.private.root.PrivateRoot</property>
+
+    <!-- add permission -->
+    <property name="add_permission">opengever.private.AddPrivateRoot</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
+        <element value="opengever.sharing.behaviors.IDossier" />
+        <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+        <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+        <element value="opengever.base.behaviors.translated_title.ITranslatedTitle" />
+    </property>
+
+    <!-- View information -->
+    <property name="immediate_view">tabbed_view</property>
+    <property name="default_view">tabbed_view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+      <element value="tabbed_view" />
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(selected layout)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="@@view"/>
+
+    <!-- Actions -->
+    <action title="View" action_id="view" category="object" condition_expr=""
+            url_expr="string:${object_url}" visible="False">
+      <permission value="View"/>
+    </action>
+
+    <action title="Edit" action_id="edit" category="object"
+            condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+            url_expr="string:${object_url}/edit" visible="True">
+      <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/opengever/private/profiles/default/workflows.xml
+++ b/opengever/private/profiles/default/workflows.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <object name="portal_workflow" meta_type="Plone Workflow Tool">
 
+    <object name="opengever_private_root_workflow" meta_type="Workflow"/>
     <object name="opengever_private_folder_workflow" meta_type="Workflow"/>
     <object name="opengever_private_dossier_workflow" meta_type="Workflow"/>
 
@@ -13,6 +14,12 @@
     <bindings>
         <type type_id="opengever.private.folder">
             <bound-workflow workflow_id="opengever_private_folder_workflow"/>
+        </type>
+    </bindings>
+
+    <bindings>
+        <type type_id="opengever.private.root">
+            <bound-workflow workflow_id="opengever_private_root_workflow"/>
         </type>
     </bindings>
 

--- a/opengever/private/profiles/default/workflows.xml
+++ b/opengever/private/profiles/default/workflows.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+    <object name="opengever_private_folder_workflow" meta_type="Workflow"/>
+    <object name="opengever_private_dossier_workflow" meta_type="Workflow"/>
+
+    <bindings>
+        <type type_id="opengever.private.dossier">
+            <bound-workflow workflow_id="opengever_private_dossier_workflow"/>
+        </type>
+    </bindings>
+
+    <bindings>
+        <type type_id="opengever.private.folder">
+            <bound-workflow workflow_id="opengever_private_folder_workflow"/>
+        </type>
+    </bindings>
+
+</object>

--- a/opengever/private/profiles/default/workflows/opengever_private_dossier_workflow/definition.xml
+++ b/opengever/private/profiles/default/workflows/opengever_private_dossier_workflow/definition.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0"?>
+<dc-workflow workflow_id="opengever_private_dossier_workflow" title="Dossier Workflow" description="" state_variable="review_state" initial_state="dossier-state-active" manager_bypass="False">
+ <permission>Access contents information</permission>
+ <permission>Add portal content</permission>
+ <permission>Copy or Move</permission>
+ <permission>Delete objects</permission>
+ <permission>List folder contents</permission>
+ <permission>Manage properties</permission>
+ <permission>Modify portal content</permission>
+ <permission>Remove GEVER content</permission>
+ <permission>Review portal content</permission>
+ <permission>View</permission>
+ <permission>ftw.mail: Add Inbound Mail</permission>
+ <permission>ftw.mail: Add Mail</permission>
+ <permission>opengever.document: Add document</permission>
+ <permission>opengever.document: Cancel</permission>
+ <permission>opengever.document: Checkin</permission>
+ <permission>opengever.document: Checkout</permission>
+ <permission>opengever.document: Force Checkin</permission>
+ <permission>opengever.dossier: Add businesscasedossier</permission>
+ <permission>opengever.meeting: Add Proposal</permission>
+ <permission>opengever.task: Add task</permission>
+ <permission>opengever.trash: Trash content</permission>
+ <permission>opengever.trash: Untrash content</permission>
+ <state state_id="dossier-state-active" title="dossier-state-active">
+  <exit-transition transition_id="dossier-transition-deactivate"/>
+  <exit-transition transition_id="dossier-transition-resolve"/>
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Copy or Move" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="List folder contents" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Manage properties" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Remove GEVER content" acquired="True">
+  </permission-map>
+  <permission-map name="Review portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="ftw.mail: Add Mail" acquired="True">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.document: Add document" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.document: Cancel" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.document: Checkin" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.document: Checkout" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.document: Force Checkin" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.meeting: Add Proposal" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.task: Add task" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.trash: Trash content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.trash: Untrash content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+ </state>
+ <state state_id="dossier-state-inactive" title="dossier-state-inactive">
+  <exit-transition transition_id="dossier-transition-activate"/>
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+  </permission-map>
+  <permission-map name="Copy or Move" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="List folder contents" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Manage properties" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+  </permission-map>
+  <permission-map name="Remove GEVER content" acquired="False">
+  </permission-map>
+  <permission-map name="Review portal content" acquired="True">
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
+  </permission-map>
+  <permission-map name="ftw.mail: Add Mail" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Add document" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Cancel" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Checkin" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Checkout" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Force Checkin" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.meeting: Add Proposal" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.task: Add task" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.trash: Trash content" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.trash: Untrash content" acquired="False">
+  </permission-map>
+ </state>
+ <state state_id="dossier-state-resolved" title="dossier-state-resolved">
+  <exit-transition transition_id="dossier-transition-reactivate"/>
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+  </permission-map>
+  <permission-map name="Copy or Move" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="List folder contents" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Manage properties" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+  </permission-map>
+  <permission-map name="Remove GEVER content" acquired="False">
+  </permission-map>
+  <permission-map name="Review portal content" acquired="True">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
+  </permission-map>
+  <permission-map name="ftw.mail: Add Mail" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Add document" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Cancel" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Checkin" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Checkout" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.document: Force Checkin" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.meeting: Add Proposal" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.task: Add task" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.trash: Trash content" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.trash: Untrash content" acquired="False">
+  </permission-map>
+ </state>
+ <transition transition_id="dossier-transition-activate" title="Owner activates dossier" new_state="dossier-state-active" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/transition-activate" category="workflow" icon="">dossier-transition-activate</action>
+  <guard>
+  </guard>
+ </transition>
+ <transition transition_id="dossier-transition-deactivate" title="Owner deactivates dossier" new_state="dossier-state-inactive" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/transition-deactivate" category="workflow" icon="">dossier-transition-deactivate</action>
+  <guard>
+  </guard>
+ </transition>
+ <transition transition_id="dossier-transition-reactivate" title="Owner reactivates dossier" new_state="dossier-state-active" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/transition-reactivate" category="workflow" icon="">dossier-transition-reactivate</action>
+  <guard>
+  </guard>
+ </transition>
+ <transition transition_id="dossier-transition-resolve" title="Owner resolves dossier" new_state="dossier-state-resolved" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/transition-resolve" category="workflow" icon="">dossier-transition-resolve</action>
+  <guard>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </transition>
+ <worklist worklist_id="reviewer_queue" title="">
+  <description>Reviewer tasks</description>
+  <action url="%(portal_url)s/search?review_state=pending" category="global" icon="">Pending (%(count)d)</action>
+  <guard>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+  <match name="review_state" values="pending"/>
+ </worklist>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+  <description>The last transition</description>
+  <default>
+
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+  <description>The ID of the user who performed the last transition</description>
+  <default>
+
+   <expression>user/getId</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+  <description>Comments about the last transition</description>
+  <default>
+
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+  <description>Provides access to workflow history</description>
+  <default>
+
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard>
+   <guard-permission>View</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+  <description>Time of the last transition</description>
+  <default>
+
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+</dc-workflow>

--- a/opengever/private/profiles/default/workflows/opengever_private_folder_workflow/definition.xml
+++ b/opengever/private/profiles/default/workflows/opengever_private_folder_workflow/definition.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<dc-workflow workflow_id="opengever_private_folder_workflow" title="Private Folder Workflow" description="" state_variable="review_state" initial_state="folder-state-active" manager_bypass="False">
+ <permission>Access contents information</permission>
+ <permission>Add portal content</permission>
+ <permission>Change portal events</permission>
+ <permission>Copy or Move</permission>
+ <permission>List folder contents</permission>
+ <permission>Modify portal content</permission>
+ <permission>View</permission>
+ <permission>opengever.dossier: Add businesscasedossier</permission>
+ <permission>opengever.private: Add private dossier</permission>
+ <permission>opengever.repository: Add repositoryfolder</permission>
+ <permission>Delete objects</permission>
+ <state state_id="folder-state-active" title="repositoryfolder-state-active">
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Change portal events" acquired="False">
+  </permission-map>
+  <permission-map name="Copy or Move" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="List folder contents" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+   <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+  </permission-map>
+  <permission-map name="opengever.private: Add private dossier" acquired="False">
+    <permission-role>Manager</permission-role>
+    <permission-role>Owner</permission-role>
+  </permission-map>
+  <permission-map name="opengever.repository: Add repositoryfolder" acquired="False">
+  </permission-map>
+ </state>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+  <description>Previous transition</description>
+  <default>
+
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+  <description>The ID of the user who performed the previous transition</description>
+  <default>
+
+   <expression>user/getUserName</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+  <description>Comment about the last transition</description>
+  <default>
+
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+  <description>Provides access to workflow history</description>
+  <default>
+
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard>
+   <guard-permission>Request review</guard-permission>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+  <description>When the previous transition was performed</description>
+  <default>
+
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+</dc-workflow>

--- a/opengever/private/profiles/default/workflows/opengever_private_root_workflow/definition.xml
+++ b/opengever/private/profiles/default/workflows/opengever_private_root_workflow/definition.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<dc-workflow workflow_id="opengever_private_root_workflow" title="PrivateRoot Workflow" description="" state_variable="review_state" initial_state="repositoryroot-state-active" manager_bypass="False">
+ <permission>Access contents information</permission>
+ <permission>Add portal content</permission>
+ <permission>Change portal events</permission>
+ <permission>Copy or Move</permission>
+ <permission>List folder contents</permission>
+ <permission>Modify portal content</permission>
+ <permission>Sharing page: Delegate Contributor role</permission>
+ <permission>Sharing page: Delegate Editor role</permission>
+ <permission>Sharing page: Delegate Reader role</permission>
+ <permission>Sharing page: Delegate Reviewer role</permission>
+ <permission>Sharing page: Delegate roles</permission>
+ <permission>View</permission>
+ <permission>opengever.repository: Add repositoryfolder</permission>
+ <state state_id="repositoryroot-state-active" title="privateroot-state-active">
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Change portal events" acquired="False">
+  </permission-map>
+  <permission-map name="Copy or Move" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="List folder contents" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Sharing page: Delegate Editor role" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Sharing page: Delegate Reader role" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="Sharing page: Delegate roles" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+  <permission-map name="opengever.repository: Add repositoryfolder" acquired="False">
+   <permission-role>Manager</permission-role>
+  </permission-map>
+ </state>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+  <description>Previous transition</description>
+  <default>
+
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+  <description>The ID of the user who performed the previous transition</description>
+  <default>
+
+   <expression>user/getUserName</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+  <description>Comment about the last transition</description>
+  <default>
+
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+  <description>Provides access to workflow history</description>
+  <default>
+
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard>
+   <guard-permission>Request review</guard-permission>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+  <description>When the previous transition was performed</description>
+  <default>
+
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+</dc-workflow>

--- a/opengever/private/reference.py
+++ b/opengever/private/reference.py
@@ -15,7 +15,7 @@ class PrivateFolderReferenceNumber(BasicReferenceNumber):
     ref_type = 'repository'
 
     def get_local_number(self):
-        return self.context.userid
+        return self.context.getId()
 
     def get_repository_number(self):
         numbers = self.get_parent_numbers()

--- a/opengever/private/reference.py
+++ b/opengever/private/reference.py
@@ -1,0 +1,22 @@
+from five import grok
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.reference import BasicReferenceNumber
+from opengever.private.folder import IPrivateFolder
+
+
+class PrivateFolderReferenceNumber(BasicReferenceNumber):
+    """Reference number adapter for private folder. It uses the userid
+    as local number part.
+    """
+
+    grok.provides(IReferenceNumber)
+    grok.context(IPrivateFolder)
+
+    ref_type = 'repository'
+
+    def get_local_number(self):
+        return self.context.userid
+
+    def get_repository_number(self):
+        numbers = self.get_parent_numbers()
+        return self.get_active_formatter().repository_number(numbers)

--- a/opengever/private/root.py
+++ b/opengever/private/root.py
@@ -1,0 +1,15 @@
+from opengever.base.behaviors.translated_title import TranslatedTitleMixin
+from plone.dexterity.content import Container
+from plone.directives import form
+
+
+class IPrivateRoot(form.Schema):
+    """PrivateRoot marker interface.
+    """
+
+
+class PrivateRoot(Container, TranslatedTitleMixin):
+    """A private root, the container for all the PrivateFolders.
+    """
+
+    Title = TranslatedTitleMixin.Title

--- a/opengever/private/tests/__init__.py
+++ b/opengever/private/tests/__init__.py
@@ -1,0 +1,14 @@
+from plone import api
+from plone.app.testing import TEST_USER_ID
+import transaction
+
+
+def create_members_folder(private_root):
+    mtool = api.portal.get_tool('portal_membership')
+    mtool.setMembersFolderById(private_root.id)
+    mtool.setMemberAreaType('opengever.private.folder')
+
+    mtool.createMemberArea()
+    transaction.commit()
+
+    return private_root.get(TEST_USER_ID)

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -59,3 +59,22 @@ class TestPrivateDossier(FunctionalTestCase):
                           IReferenceNumber(dossier1).get_number())
         self.assertEquals('Client1 test_user_1_ / 2',
                           IReferenceNumber(dossier2).get_number())
+
+
+class TestPrivateDossierTabbedView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPrivateDossierTabbedView, self).setUp()
+        self.root = create(Builder('private_root'))
+        self.folder = create(Builder('private_folder')
+                             .having(userid=TEST_USER_ID)
+                             .within(self.root))
+
+    @browsing
+    def test_task_proposal_participations_and_info_tab_are_hidden(self, browser):
+        dossier = create(Builder('private_dossier').within(self.folder))
+        browser.login().open(dossier)
+
+        self.assertEquals(
+            ['Overview', 'Subdossiers', 'Documents', 'Trash', 'Journal'],
+            browser.css('.formTab').text)

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -72,6 +72,24 @@ class TestPrivateDossier(FunctionalTestCase):
         self.assertEquals('Client1 test_user_1_ / 2',
                           IReferenceNumber(dossier2).get_number())
 
+    def test_allow_one_level_of_subdossiers(self):
+        dossier = create(Builder('private_dossier')
+                         .within(self.folder)
+                         .having(responsible=TEST_USER_ID))
+        subdossier = create(Builder('private_dossier')
+                            .within(dossier)
+                            .having(responsible=TEST_USER_ID))
+
+        self.assertSequenceEqual(
+            ['opengever.document.document',
+             'ftw.mail.mail',
+             'opengever.private.dossier'],
+            [fti.id for fti in dossier.allowedContentTypes()])
+
+        self.assertSequenceEqual(
+            ['opengever.document.document', 'ftw.mail.mail'],
+            [fti.id for fti in subdossier.allowedContentTypes()])
+
 
 class TestPrivateDossierTabbedView(FunctionalTestCase):
 

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -5,6 +5,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from zope.component import getUtility
@@ -17,9 +18,7 @@ class TestPrivateDossier(FunctionalTestCase):
     def setUp(self):
         super(TestPrivateDossier, self).setUp()
         self.root = create(Builder('private_root'))
-        self.folder = create(Builder('private_folder')
-                             .having(userid=TEST_USER_ID)
-                             .within(self.root))
+        self.folder = create_members_folder(self.root)
 
     @browsing
     def test_is_addable_to_a_private_folder(self, browser):
@@ -51,10 +50,10 @@ class TestPrivateDossier(FunctionalTestCase):
     def test_uses_the_same_reference_number_schema_as_regular_dossiers(self):
         dossier1 = create(Builder('private_dossier')
                           .within(self.folder)
-                          .having(userid=TEST_USER_ID))
+                          .having(responsible=TEST_USER_ID))
         dossier2 = create(Builder('private_dossier')
                           .within(self.folder)
-                          .having(userid=TEST_USER_ID))
+                          .having(responsible=TEST_USER_ID))
 
         self.assertEquals('Client1 test_user_1_ / 1',
                           IReferenceNumber(dossier1).get_number())

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -5,6 +5,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -90,6 +90,12 @@ class TestPrivateDossier(FunctionalTestCase):
             ['opengever.document.document', 'ftw.mail.mail'],
             [fti.id for fti in subdossier.allowedContentTypes()])
 
+    def test_does_not_support_participations(self):
+        dossier = create(Builder('private_dossier')
+                         .within(self.folder)
+                         .having(responsible=TEST_USER_ID))
+        self.assertFalse(dossier.has_participation_support())
+
 
 class TestPrivateDossierTabbedView(FunctionalTestCase):
 
@@ -108,6 +114,16 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
         self.assertEquals(
             ['Overview', 'Subdossiers', 'Documents', 'Trash', 'Journal'],
             browser.css('.formTab').text)
+
+    @browsing
+    def test_participation_box_is_not_shown_on_overview(self, browser):
+        dossier = create(Builder('private_dossier').within(self.folder))
+        browser.login().open(dossier, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            ['Dossier structure', 'Newest tasks', 'Linked Dossiers',
+             'Newest documents', 'Description'],
+            browser.css('.box h2').text)
 
 
 class TestPrivateDossierWorkflow(FunctionalTestCase):

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import FunctionalTestCase
@@ -78,3 +79,32 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
         self.assertEquals(
             ['Overview', 'Subdossiers', 'Documents', 'Trash', 'Journal'],
             browser.css('.formTab').text)
+
+
+class TestPrivateDossierWorkflow(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPrivateDossierWorkflow, self).setUp()
+        self.root = create(Builder('private_root'))
+        self.folder = create(Builder('private_folder')
+                             .having(userid=TEST_USER_ID)
+                             .within(self.root))
+        self.dossier = create(Builder('private_dossier').within(self.folder))
+
+    @browsing
+    def test_tasks_and_propsoals_are_not_addable(self, browser):
+        browser.login().open(self.dossier)
+
+        self.assertEquals(
+            ['Document', 'document_with_template', 'Subdossier'],
+            factoriesmenu.addable_types())
+
+    @browsing
+    def test_adding_subdossiers_is_allowed(self, browser):
+        browser.login().open(self.dossier)
+        factoriesmenu.add('Subdossier')
+        browser.fill({'Title': u'Sub 1',
+                      'Responsible': TEST_USER_ID})
+        browser.click_on('Save')
+
+        self.assertEquals(['Item created'], info_messages())

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -5,6 +5,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
@@ -29,6 +30,16 @@ class TestPrivateDossier(FunctionalTestCase):
         browser.click_on('Save')
 
         self.assertEquals([u'My Personal Stuff'], browser.css('h1').text)
+
+    @browsing
+    def test_responsible_is_current_user_by_default(self, browser):
+        browser.login().open(self.folder)
+        factoriesmenu.add('Private Dossier')
+        browser.fill({'Title': u'My Personal Stuff'})
+        browser.click_on('Save')
+
+        self.assertEquals(TEST_USER_ID,
+                          IDossier(self.folder.get('dossier-1')).responsible)
 
     def test_use_same_id_schema_as_regular_dossiers(self):
         dossier1 = create(Builder('private_dossier').titled(u'Zuz\xfcge'))

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -1,0 +1,61 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import ISequenceNumber
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+from zope.component import getUtility
+
+
+class TestPrivateDossier(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
+
+    def setUp(self):
+        super(TestPrivateDossier, self).setUp()
+        self.root = create(Builder('private_root'))
+        self.folder = create(Builder('private_folder')
+                             .having(userid=TEST_USER_ID)
+                             .within(self.root))
+
+    @browsing
+    def test_is_addable_to_a_private_folder(self, browser):
+        browser.login().open(self.folder)
+        factoriesmenu.add('Private Dossier')
+        browser.fill({'Title': u'My Personal Stuff',
+                      'Responsible': TEST_USER_ID})
+        browser.click_on('Save')
+
+        self.assertEquals([u'My Personal Stuff'], browser.css('h1').text)
+
+    def test_use_same_id_schema_as_regular_dossiers(self):
+        dossier1 = create(Builder('private_dossier').titled(u'Zuz\xfcge'))
+        dossier2 = create(Builder('private_dossier').titled(u'Abg\xe4nge'))
+
+        self.assertEquals('dossier-1', dossier1.getId())
+        self.assertEquals('dossier-2', dossier2.getId())
+
+    def test_uses_the_same_sequence_counter_as_regular_dossiers(self):
+        dossier1 = create(Builder('private_dossier'))
+        dossier2 = create(Builder('dossier'))
+        dossier3 = create(Builder('private_dossier'))
+
+        sequence_number = getUtility(ISequenceNumber)
+        self.assertEquals(1, sequence_number.get_number(dossier1))
+        self.assertEquals(2, sequence_number.get_number(dossier2))
+        self.assertEquals(3, sequence_number.get_number(dossier3))
+
+    def test_uses_the_same_reference_number_schema_as_regular_dossiers(self):
+        dossier1 = create(Builder('private_dossier')
+                          .within(self.folder)
+                          .having(userid=TEST_USER_ID))
+        dossier2 = create(Builder('private_dossier')
+                          .within(self.folder)
+                          .having(userid=TEST_USER_ID))
+
+        self.assertEquals('Client1 test_user_1_ / 1',
+                          IReferenceNumber(dossier1).get_number())
+        self.assertEquals('Client1 test_user_1_ / 2',
+                          IReferenceNumber(dossier2).get_number())

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from opengever.base.interfaces import IReferenceNumber
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from zExceptions import Unauthorized
@@ -38,3 +39,9 @@ class TestPrivateFolder(FunctionalTestCase):
     def test_title_is_corresponding_users_label(self):
         folder = create(Builder('private_folder').having(userid=TEST_USER_ID))
         self.assertEquals('Test User (test_user_1_)', folder.Title())
+
+    def test_uses_userid_as_reference_number_part(self):
+        folder = create(Builder('private_folder').having(userid=TEST_USER_ID))
+
+        self.assertEquals('Client1 test_user_1_',
+                          IReferenceNumber(folder).get_number())

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -93,3 +93,21 @@ class TestPrivateFolderWorkflow(FunctionalTestCase):
     def test_owner_can_add_private_dossiers(self, browser):
         browser.login().open(self.folder)
         self.assertIn('Private Dossier', factoriesmenu.addable_types())
+
+
+class TestMyRepositoryAction(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPrivateFolderWorkflow, self).setUp()
+        self.root = create(Builder('private_root'))
+        self.folder = create_members_folder(self.root)
+
+    @browsing
+    def is_show_when_private_folder_exists_and_redirects_to_homefolder(self, browser):
+        browser.debug().login()
+
+        self.assertIn('My Repository',
+                      browser.css('#portal-globalnav li').text)
+
+        browser.click_on('My Repository')
+        self.assertEquals(self.folder.absolute_url(), browser.url)

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -1,0 +1,40 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+from zExceptions import Unauthorized
+
+
+class TestPrivateFolder(FunctionalTestCase):
+
+    @browsing
+    def test_is_addable_on_private_root(self, browser):
+        self.grant('Manager')
+
+        root = create(Builder('private_root'))
+
+        browser.login().open(root)
+        factoriesmenu.add('Private folder')
+        browser.fill({'User ID': u'franz.mueller'})
+        browser.click_on('Save')
+
+        self.assertEquals([u'franz.mueller'], browser.css('h1').text)
+
+    @browsing
+    def test_is_only_addable_by_manager(self, browser):
+        root = create(Builder('private_root'))
+
+        with self.assertRaises(Unauthorized):
+            browser.login().open(root, view='++add++opengever.private.folder')
+            browser.fill({'User ID': TEST_USER_ID})
+            browser.click_on('Save')
+
+    def test_object_id_is_userid(self):
+        folder = create(Builder('private_folder').having(userid=TEST_USER_ID))
+        self.assertEquals(TEST_USER_ID, folder.getId())
+
+    def test_title_is_corresponding_users_label(self):
+        folder = create(Builder('private_folder').having(userid=TEST_USER_ID))
+        self.assertEquals('Test User (test_user_1_)', folder.Title())

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -5,6 +5,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testing import freeze
 from opengever.base.interfaces import IReferenceNumber
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
@@ -12,6 +13,8 @@ from zExceptions import Unauthorized
 
 
 class TestPrivateFolder(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 
     def setUp(self):
         super(TestPrivateFolder, self).setUp()
@@ -35,6 +38,8 @@ class TestPrivateFolder(FunctionalTestCase):
 
 
 class TestPrivateFolderTabbedView(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 
     def setUp(self):
         super(TestPrivateFolderTabbedView, self).setUp()
@@ -86,6 +91,8 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
 
 class TestPrivateFolderWorkflow(FunctionalTestCase):
 
+    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
+
     def setUp(self):
         super(TestPrivateFolderWorkflow, self).setUp()
         self.root = create(Builder('private_root'))
@@ -109,6 +116,8 @@ class TestPrivateFolderWorkflow(FunctionalTestCase):
 
 
 class TestMyRepositoryAction(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 
     def setUp(self):
         super(TestPrivateFolderWorkflow, self).setUp()

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -71,6 +71,19 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
             browser.css('.listing').first.lists())
 
 
+    @browsing
+    def test_copy_and_move_items_actions_are_disabled(self, browser):
+        create(Builder('private_dossier')
+               .within(self.folder)
+               .titled(u'Zuz\xfcge'))
+
+        browser.login().open(self.folder, view='tabbedview_view-dossiers')
+
+        self.assertEquals(
+            ['Export selection', 'Print selection (PDF)'],
+            browser.css('.actionMenuContent a').text)
+
+
 class TestPrivateFolderWorkflow(FunctionalTestCase):
 
     def setUp(self):

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -8,6 +8,7 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from zExceptions import Unauthorized
 
@@ -35,6 +36,12 @@ class TestPrivateFolder(FunctionalTestCase):
     def test_uses_userid_as_reference_number_part(self):
         self.assertEquals('Client1 test_user_1_',
                           IReferenceNumber(self.folder).get_number())
+
+    def test_adds_additonal_roles_after_creation(self):
+        self.assertEquals(
+            ['Publisher', 'Authenticated', 'Owner', 'Editor', 'Reader',
+             'Contributor', 'Reviewer'],
+            api.user.get_roles(username=TEST_USER_ID, obj=self.folder))
 
 
 class TestPrivateFolderTabbedView(FunctionalTestCase):

--- a/opengever/private/tests/test_root.py
+++ b/opengever/private/tests/test_root.py
@@ -1,0 +1,28 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.testing import FunctionalTestCase
+from zExceptions import Unauthorized
+
+
+class TestPrivateRoot(FunctionalTestCase):
+
+    @browsing
+    def test_is_addable_on_plone_site(self, browser):
+        self.grant('Manager')
+
+        browser.login().open()
+        factoriesmenu.add('Private Root')
+        browser.fill({'Title (German)': u'Meine Ablage',
+                      'Title (French)': u'Mon d\xe9p\xf4t'})
+        browser.click_on('Save')
+
+        self.assertEquals(['Meine Ablage'], browser.css('h1').text)
+
+    @browsing
+    def test_is_only_addable_by_manager(self, browser):
+        with self.assertRaises(Unauthorized):
+            browser.login().open(
+                self.portal, view='++add++opengever.private.root')
+            browser.fill({'Title (German)': u'Meine Ablage',
+                          'Title (French)': u'Mon d\xe9p\xf4t'})
+            browser.click_on('Save')

--- a/opengever/private/tests/test_root.py
+++ b/opengever/private/tests/test_root.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from opengever.testing import FunctionalTestCase
@@ -26,3 +28,10 @@ class TestPrivateRoot(FunctionalTestCase):
             browser.fill({'Title (German)': u'Meine Ablage',
                           'Title (French)': u'Mon d\xe9p\xf4t'})
             browser.click_on('Save')
+
+    @browsing
+    def test_is_excluded_from_the_navigation(self, browser):
+        create(Builder('private_root').titled(u'Meine Ablage'))
+        browser.login().open()
+        self.assertNotIn('meine-ablage',
+                         browser.css('#portal-globalnav li').text)

--- a/opengever/private/upgrades/configure.zcml
+++ b/opengever/private/upgrades/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    i18n_domain="opengever.private">
+
+  <include package="ftw.upgrade" file="meta.zcml" />
+
+  <upgrade-step:directory
+      profile="opengever.private:default"
+      directory="."
+      />
+
+  <!-- Do not add more upgrade steps here.
+       use ./bin/create-upgrade opengever.officeatwork "Upgrade description"
+       /-->
+
+</configure>

--- a/opengever/setup/hooks.py
+++ b/opengever/setup/hooks.py
@@ -1,3 +1,4 @@
+from opengever.private import MEMBERSFOLDER_ID
 from plone.app.portlets.portlets import navigation
 from plone.portlets.constants import CONTEXT_CATEGORY
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
@@ -18,6 +19,7 @@ def default_content_installed(site):
     assign_default_navigation_portlet(site, 'eingangskorb')
     assign_default_navigation_portlet(site, 'vorlagen')
     assign_default_navigation_portlet(site, 'kontakte')
+    block_context_portlets(site, MEMBERSFOLDER_ID)
 
 
 def set_global_roles(site):

--- a/opengever/setup/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/setup/profiles/default_content/content_creation/01_default_content.json
@@ -1,5 +1,11 @@
 [
     {
+        "_path": "private",
+        "_type": "opengever.private.root",
+        "title_de": "Meine Ablage",
+        "title_fr": "Mon depot"
+    },
+    {
         "_path": "eingangskorb",
         "_type": "opengever.inbox.inbox",
         "title_de": "Eingangskorb",

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -385,3 +385,10 @@ class TaskTemplateBuilder(DexterityBuilder):
 
 
 builder_registry.register('tasktemplate', TaskTemplateBuilder)
+
+
+class PrivateRootBuilder(DexterityBuilder):
+    portal_type = 'opengever.private.root'
+
+
+builder_registry.register('private_root', PrivateRootBuilder)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -399,3 +399,10 @@ class PrivateFolderBuilder(DexterityBuilder):
 
 
 builder_registry.register('private_folder', PrivateFolderBuilder)
+
+
+class PrivateDossierBuilder(DossierBuilder):
+    portal_type = 'opengever.private.dossier'
+
+
+builder_registry.register('private_dossier', PrivateDossierBuilder)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -392,3 +392,10 @@ class PrivateRootBuilder(DexterityBuilder):
 
 
 builder_registry.register('private_root', PrivateRootBuilder)
+
+
+class PrivateFolderBuilder(DexterityBuilder):
+    portal_type = 'opengever.private.folder'
+
+
+builder_registry.register('private_folder', PrivateFolderBuilder)

--- a/sources.cfg
+++ b/sources.cfg
@@ -14,6 +14,8 @@ development-packages =
   ftw.showroom
 # https://github.com/collective/transmogrify.dexterity/pull/25
   transmogrify.dexterity
+# https://github.com/4teamwork/ftw.casauth/pull/8
+  ftw.casauth
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Implementation as described in #2158 and https://docs.google.com/document/d/1nmicgpb2ae1ZU0xtMdJXQnYcje4h64X_mDj1vIX4uRM/edit. 

Technical details:
 - Adds a new sub directory `opengever.private`
 - Adds new types `opengever.private.root`, `opengever.private.folder` and `opengever.private.dossier`
 - Adds a `opengever.private.root` with the id `private` to the GEVER default content
 - Configure the PrivateRoot as MembersFolder and `opengever.private.folder` as HomeFolder Portaltype in the Membership tool. So the complete UserFolder creation on login is handled by Plone itself. We just add default dossier local roles to the owner after UserFolder creation.
 - Exclude PrivateRoots from navigation and add a `portal_tabs` action `Meine Ablage`, which links direct to users PrivateFolder.
 - Adds a configuration option to the policy templates
 - Activate feature  for the examplecontent profile

Styling: https://github.com/4teamwork/plonetheme.teamraum/pull/467

Not implemented yet: 
 - The possibility to really remove documents inside a PrivateDossier


@deiferni @lukasgraf 