### PR TITLE
Don't fire `save_reference_number_prefix()` handler twice:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Don't fire save_reference_number_prefix() handler twice. IObjectAddedEvent
+  inherits from IObjectMovedEvent, so registering it on IObjectMovedEvent
+  is enough.
+  [lgraf]
+
 - Enable task-templates for meeting-dossiers.
   [deiferni]
 

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -55,7 +55,8 @@ def set_former_reference_after_moving(obj, event):
     obj.reindexObject(idxs=['reference'])
 
 
-@grok.subscribe(IDossierMarker, IObjectAddedEvent)
+# Update reference number when adding / moving content
+# (IObjectAddedEvent inherits from IObjectMovedEvent)
 @grok.subscribe(IDossierMarker, IObjectMovedEvent)
 def save_reference_number_prefix(obj, event):
     if IObjectRemovedEvent.providedBy(event):


### PR DESCRIPTION
[`IObjectAddedEvent` inherits from `IObjectMovedEvent`](https://github.com/zopefoundation/zope.lifecycleevent/blob/ac722331f18076ecdb2a49fa847915539a1cc1fb/src/zope/lifecycleevent/interfaces.py#L128), so registering it on IObjectMovedEvent is enough.

Fixes #2197 

@deiferni 