### PR TITLE
Add department field to org-role.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,10 +1,12 @@
 
-
 Changelog
 =========
 
 4.11.0 (unreleased)
 -------------------
+
+- Add department field to org-role.
+  [deiferni]
 
 - Make mailaddress, url and phone_number required.
   [phgross]

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -94,6 +94,7 @@
                tal:content="org_role/person/fullname" />
           </span>
           <span class="function" tal:content="org_role/function" />
+          <span class="department" tal:content="org_role/department" />
         </li>
       </ul>
 

--- a/opengever/contact/browser/templates/person.pt
+++ b/opengever/contact/browser/templates/person.pt
@@ -104,6 +104,7 @@
                tal:content="org_role/organization/name" />
           </span>
           <span class="function" tal:content="org_role/function" />
+          <span class="department" tal:content="org_role/department" />
         </li>
       </ul>
 

--- a/opengever/contact/docprops.py
+++ b/opengever/contact/docprops.py
@@ -91,5 +91,7 @@ class OrgRoleDocPropertyProvider(PrefixableDocPropertyProvider):
                            self.org_role.function)
         self._add_property(properties, 'orgrole', 'description',
                            self.org_role.function)
+        self._add_property(properties, 'orgrole', 'department',
+                           self.org_role.department)
 
         return properties

--- a/opengever/contact/models/org_role.py
+++ b/opengever/contact/models/org_role.py
@@ -25,6 +25,7 @@ class OrgRole(Base):
     person = relationship("Person", back_populates="organizations")
 
     function = Column(String(CONTENT_TITLE_LENGTH))
+    department = Column(String(CONTENT_TITLE_LENGTH))
     description = Column(UnicodeCoercingText)
 
     participations = relationship("OrgRoleParticipation",
@@ -39,8 +40,10 @@ class OrgRole(Base):
             self.person.get_title(with_former_id=with_former_id),
             self.organization.get_title())
 
-        if self.function:
-            title = u'{} ({})'.format(title, self.function)
+        if self.function or self.department:
+            suffix = u' - '.join(filter(
+                lambda each: each, [self.function, self.department]))
+            title = u'{} ({})'.format(title, suffix)
 
         return title
 

--- a/opengever/contact/tests/test_docprops.py
+++ b/opengever/contact/tests/test_docprops.py
@@ -68,11 +68,13 @@ class TestContactDocPropertyProvider(FunctionalTestCase):
                           .having(organization=organization,
                                   person=peter,
                                   function=u'M\xe4dchen f\xfcr alles',
-                                  description='blub'))
+                                  description=u'blub',
+                                  department=u'Informatik'))
         provider = org_role.get_doc_property_provider(prefix='recipient')
         expected_orgrole_properties = {
             'ogg.recipient.orgrole.function': u'M\xe4dchen f\xfcr alles',
             'ogg.recipient.orgrole.description': 'blub',
+            'ogg.recipient.orgrole.department': 'Informatik',
             'ogg.recipient.contact.title': u'M\xfcller Peter',
             'ogg.recipient.contact.description': 'blablabla',
             'ogg.recipient.person.salutation': 'Herr',

--- a/opengever/contact/tests/test_org_role.py
+++ b/opengever/contact/tests/test_org_role.py
@@ -37,7 +37,7 @@ class TestOrganizationalRole(unittest2.TestCase):
         self.assertEquals([peter, hugo],
                           [role.person for role in meier_ag.persons])
 
-    def test_organization_title_is_person_organization_and_fuction_in_parentheses(self):
+    def test_organization_title_is_person_organization_and_suffix_in_parentheses(self):
         peter = create(Builder('person')
                        .having(firstname=u'Peter',
                                lastname=u'M\xfcller',
@@ -53,10 +53,23 @@ class TestOrganizationalRole(unittest2.TestCase):
                                                   organization=teamwork,
                                                   function='Developer'))
 
+        role3 = create(Builder('org_role').having(person=peter,
+                                                  organization=teamwork,
+                                                  function='Developer',
+                                                  department='IT'))
+
+        role4 = create(Builder('org_role').having(person=peter,
+                                                  organization=teamwork,
+                                                  department='IT'))
+
         self.assertEquals(
             u'Peter M\xfcller - Meier AG', role1.get_title())
         self.assertEquals(
             u'Peter M\xfcller - 4teamwork AG (Developer)', role2.get_title())
+        self.assertEquals(
+            u'Peter M\xfcller - 4teamwork AG (Developer - IT)', role3.get_title())
+        self.assertEquals(
+            u'Peter M\xfcller - 4teamwork AG (IT)', role4.get_title())
 
         self.assertEquals(
             u'Peter M\xfcller [123456] - Meier AG',

--- a/opengever/contact/tests/test_org_role.py
+++ b/opengever/contact/tests/test_org_role.py
@@ -37,7 +37,7 @@ class TestOrganizationalRole(unittest2.TestCase):
         self.assertEquals([peter, hugo],
                           [role.person for role in meier_ag.persons])
 
-    def test_organization_title_is_person_organization_and_fuction_in_braclets(self):
+    def test_organization_title_is_person_organization_and_fuction_in_parentheses(self):
         peter = create(Builder('person')
                        .having(firstname=u'Peter',
                                lastname=u'M\xfcller',

--- a/opengever/contact/upgrades/20160928163510_add_department_column_to_orgrole/upgrade.py
+++ b/opengever/contact/upgrades/20160928163510_add_department_column_to_orgrole/upgrade.py
@@ -1,0 +1,12 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+
+
+class AddDepartmentColumnToOrgrole(SchemaMigration):
+    """Add department column to orgrole.
+    """
+
+    def migrate(self):
+        self.op.add_column('org_roles',
+                           Column('department', String(255)))

--- a/opengever/examplecontent/contacts.py
+++ b/opengever/examplecontent/contacts.py
@@ -21,6 +21,15 @@ PHONENUMBER_LABELS = ['Arbeit', 'Privat', 'Mobile']
 ORG_ROLE_FUNCTIONS = [
     None, 'Verwalter', 'Vorsitz', 'Putzfachmann', 'Beratung', 'Angestellter']
 COUNTRIES = [u'Schweiz', u'Deutschland', u'\xd6sterreich', u'Belgien']
+DEPARTMENTS = [
+    None,
+    u'ausw\xe4rtige Angelegenheiten',
+    u'des Innern',
+    u'Justiz- und Polizeidepartement',
+    u'Finanzdepartement',
+    u'Wirtschaft, Bildung und Forschung',
+    u'Umwelt, Verkehr, Energie und Kommunikation'
+]
 
 
 class ExampleContactCreator(object):
@@ -102,7 +111,8 @@ class ExampleContactCreator(object):
             for entry in self.random_range:
                 org_role = OrgRole(person=person,
                                    function=random.choice(ORG_ROLE_FUNCTIONS),
-                                   organization=random.choice(organizations))
+                                   organization=random.choice(organizations),
+                                   department=random.choice(DEPARTMENTS))
                 self.db_session.add(org_role)
 
     def add_archived_persons(self, person, items):


### PR DESCRIPTION
This PR adds a department column/field (TextLine) to orgroles.

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/468.

Closes #2188.