### PR TITLE
Contact view improvements 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Group related persons by active state in the organization detail view.
+  [phgross]
+
 - Sort participations alphabetically on participants title.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Sort participations alphabetically on participants title.
+  [phgross]
+
 - Change Person label to `Name Surname` instead of `Surname Name`.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Change Person label to `Name Surname` instead of `Surname Name`.
+  [phgross]
+
 - Implement SQLSchemaDumper and also dump schemas for common SQL types.
   [lgraf]
 

--- a/opengever/contact/browser/organization.py
+++ b/opengever/contact/browser/organization.py
@@ -28,10 +28,16 @@ class OrganizationView(BrowserView):
     def get_actor_link(self, archive):
         return Actor.lookup(archive.actor_id).get_link()
 
-    def get_org_roles(self):
+    def get_org_roles(self, active):
         query = OrgRole.query.filter_by(organization=self.context.model)
-        return query.join(Person).order_by(
-            Person.lastname, Person.firstname).all()
+        query = query.join(Person).filter(Person.is_active == active)
+        return query.order_by(Person.lastname, Person.firstname).all()
+
+    def get_active_org_roles(self):
+        return self.get_org_roles(active=True)
+
+    def get_inactive_org_roles(self):
+        return self.get_org_roles(active=False)
 
     def participations_fetch_url(self):
         return self.context.model.get_url('participations/list')

--- a/opengever/contact/browser/organization.py
+++ b/opengever/contact/browser/organization.py
@@ -31,7 +31,7 @@ class OrganizationView(BrowserView):
     def get_org_roles(self):
         query = OrgRole.query.filter_by(organization=self.context.model)
         return query.join(Person).order_by(
-            Person.firstname, Person.lastname).all()
+            Person.lastname, Person.firstname).all()
 
     def participations_fetch_url(self):
         return self.context.model.get_url('participations/list')

--- a/opengever/contact/browser/participations.py
+++ b/opengever/contact/browser/participations.py
@@ -79,4 +79,7 @@ class ParticpationTab(BrowserView, GeverTabMixin):
     def get_participations(self):
         """Returns all participations for the current context.
         """
-        return Participation.query.by_dossier(self.context).all()
+        participations = Participation.query.by_dossier(self.context).all()
+        return sorted(
+            participations,
+            key=lambda participation: participation.participant.get_title())

--- a/opengever/contact/browser/templates/organization.pt
+++ b/opengever/contact/browser/templates/organization.pt
@@ -86,8 +86,25 @@
       </table>
 
       <h3 i18n:translate="label_persons">Persons</h3>
-      <ul class="persons orgrole_listing">
-        <li tal:repeat="org_role view/get_org_roles">
+      <h4 i18n:translate="label_active">Active</h4>
+      <ul class="active_persons persons orgrole_listing">
+        <li tal:repeat="org_role view/get_active_org_roles">
+          <span class="name">
+            <a href="#"
+               tal:attributes="href org_role/person/get_url"
+               tal:content="org_role/person/fullname" />
+          </span>
+          <span class="function" tal:content="org_role/function" />
+          <span class="department" tal:content="org_role/department" />
+        </li>
+      </ul>
+
+      <h4 i18n:translate="label_inactive">Inactive</h4>
+      <ul class="inactive_persons persons orgrole_listing"
+          tal:define="org_roles view/get_inactive_org_roles"
+          tal:condition="org_roles">
+
+        <li tal:repeat="org_role org_roles">
           <span class="name">
             <a href="#"
                tal:attributes="href org_role/person/get_url"

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-09-14 15:13+0000\n"
+"POT-Creation-Date: 2016-10-04 11:25+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -162,6 +162,7 @@ msgstr "Titel"
 
 #. Default: "Active"
 #: ./opengever/contact/browser/byline.py:16
+#: ./opengever/contact/browser/templates/organization.pt:89
 msgid "label_active"
 msgstr "Aktiv"
 
@@ -187,30 +188,30 @@ msgid "label_addresses"
 msgstr "Adressen"
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:122
-#: ./opengever/contact/browser/templates/person.pt:141
+#: ./opengever/contact/browser/templates/organization.pt:141
+#: ./opengever/contact/browser/templates/person.pt:144
 msgid "label_archived_addresses"
 msgstr "Archivierte Adressen"
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:143
-#: ./opengever/contact/browser/templates/person.pt:162
+#: ./opengever/contact/browser/templates/organization.pt:164
+#: ./opengever/contact/browser/templates/person.pt:167
 msgid "label_archived_mail"
 msgstr "Archivierte Mail Adressen"
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:104
+#: ./opengever/contact/browser/templates/organization.pt:123
 msgid "label_archived_organizations"
 msgstr "Archivierte Informationen"
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:114
+#: ./opengever/contact/browser/templates/person.pt:117
 msgid "label_archived_persons"
 msgstr "Archivierte persönliche Informationen"
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:162
-#: ./opengever/contact/browser/templates/person.pt:181
+#: ./opengever/contact/browser/templates/organization.pt:183
+#: ./opengever/contact/browser/templates/person.pt:186
 msgid "label_archived_phone_numbers"
 msgstr "Archivierte Telefonnummern"
 
@@ -264,7 +265,7 @@ msgstr "Beteiligung von ${title} bearbeiten"
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:103
-#: ./opengever/contact/contactfolder.py:117
+#: ./opengever/contact/contactfolder.py:108
 msgid "label_email"
 msgstr "E-Mail 1"
 
@@ -276,14 +277,19 @@ msgstr "E-Mail 2"
 #. Default: "Firstname"
 #: ./opengever/contact/browser/person.py:102
 #: ./opengever/contact/contact.py:82
-#: ./opengever/contact/contactfolder.py:112
+#: ./opengever/contact/contactfolder.py:103
 msgid "label_firstname"
 msgstr "Vorname"
+
+#. Default: "Inactive"
+#: ./opengever/contact/browser/templates/organization.pt:101
+msgid "label_inactive"
+msgstr "Inaktiv"
 
 #. Default: "Lastname"
 #: ./opengever/contact/browser/person.py:107
 #: ./opengever/contact/contact.py:75
-#: ./opengever/contact/contactfolder.py:107
+#: ./opengever/contact/contactfolder.py:98
 msgid "label_lastname"
 msgstr "Nachname"
 
@@ -298,8 +304,8 @@ msgid "label_local"
 msgstr "Lokal"
 
 #. Default: "Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:42
-#: ./opengever/contact/browser/templates/person.pt:52
+#: ./opengever/contact/browser/templates/organization.pt:44
+#: ./opengever/contact/browser/templates/person.pt:54
 msgid "label_mail"
 msgstr "Mail Addressen"
 
@@ -316,12 +322,12 @@ msgstr "Keine Beteiligungen"
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:96
+#: ./opengever/contact/browser/templates/person.pt:98
 msgid "label_organizations"
 msgstr "Organisationen"
 
 #. Default: "Participation of ${contact_title}"
-#: ./opengever/contact/models/participation.py:92
+#: ./opengever/contact/models/participation.py:101
 msgid "label_participation_of"
 msgstr "Beteiligung von ${contact_title}"
 
@@ -332,7 +338,7 @@ msgstr "Persönliche Informationen:"
 
 #. Default: "Persons"
 #: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:86
+#: ./opengever/contact/browser/templates/organization.pt:88
 msgid "label_persons"
 msgstr "Personen"
 
@@ -352,14 +358,14 @@ msgid "label_phone_mobile"
 msgstr "Telefon Mobile"
 
 #. Default: "Phone numbers"
-#: ./opengever/contact/browser/templates/organization.pt:57
-#: ./opengever/contact/browser/templates/person.pt:67
+#: ./opengever/contact/browser/templates/organization.pt:59
+#: ./opengever/contact/browser/templates/person.pt:69
 msgid "label_phone_numbers"
 msgstr "Telefonnummern"
 
 #. Default: "Phone office"
 #: ./opengever/contact/contact.py:120
-#: ./opengever/contact/contactfolder.py:122
+#: ./opengever/contact/contactfolder.py:113
 msgid "label_phone_office"
 msgstr "Telefon Arbeit"
 
@@ -401,8 +407,8 @@ msgid "label_url"
 msgstr "URL"
 
 #. Default: "URLs"
-#: ./opengever/contact/browser/templates/organization.pt:71
-#: ./opengever/contact/browser/templates/person.pt:81
+#: ./opengever/contact/browser/templates/organization.pt:73
+#: ./opengever/contact/browser/templates/person.pt:83
 msgid "label_urls"
 msgstr "URLs"
 

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-14 15:13+0000\n"
+"POT-Creation-Date: 2016-10-04 11:25+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-contact/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "Add Person"
 #: ./opengever/contact/browser/person.py:123
@@ -165,6 +164,7 @@ msgstr "Titre"
 
 #. Default: "Active"
 #: ./opengever/contact/browser/byline.py:16
+#: ./opengever/contact/browser/templates/organization.pt:89
 msgid "label_active"
 msgstr "Actif"
 
@@ -190,30 +190,30 @@ msgid "label_addresses"
 msgstr ""
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:122
-#: ./opengever/contact/browser/templates/person.pt:141
+#: ./opengever/contact/browser/templates/organization.pt:141
+#: ./opengever/contact/browser/templates/person.pt:144
 msgid "label_archived_addresses"
 msgstr ""
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:143
-#: ./opengever/contact/browser/templates/person.pt:162
+#: ./opengever/contact/browser/templates/organization.pt:164
+#: ./opengever/contact/browser/templates/person.pt:167
 msgid "label_archived_mail"
 msgstr ""
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:104
+#: ./opengever/contact/browser/templates/organization.pt:123
 msgid "label_archived_organizations"
 msgstr ""
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:114
+#: ./opengever/contact/browser/templates/person.pt:117
 msgid "label_archived_persons"
 msgstr ""
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:162
-#: ./opengever/contact/browser/templates/person.pt:181
+#: ./opengever/contact/browser/templates/organization.pt:183
+#: ./opengever/contact/browser/templates/person.pt:186
 msgid "label_archived_phone_numbers"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgstr ""
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:103
-#: ./opengever/contact/contactfolder.py:117
+#: ./opengever/contact/contactfolder.py:108
 msgid "label_email"
 msgstr "Email 1"
 
@@ -278,14 +278,19 @@ msgstr "Email 2"
 #. Default: "Firstname"
 #: ./opengever/contact/browser/person.py:102
 #: ./opengever/contact/contact.py:82
-#: ./opengever/contact/contactfolder.py:112
+#: ./opengever/contact/contactfolder.py:103
 msgid "label_firstname"
 msgstr "Prénom"
+
+#. Default: "Inactive"
+#: ./opengever/contact/browser/templates/organization.pt:101
+msgid "label_inactive"
+msgstr ""
 
 #. Default: "Lastname"
 #: ./opengever/contact/browser/person.py:107
 #: ./opengever/contact/contact.py:75
-#: ./opengever/contact/contactfolder.py:107
+#: ./opengever/contact/contactfolder.py:98
 msgid "label_lastname"
 msgstr "Nom"
 
@@ -300,8 +305,8 @@ msgid "label_local"
 msgstr "Local"
 
 #. Default: "Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:42
-#: ./opengever/contact/browser/templates/person.pt:52
+#: ./opengever/contact/browser/templates/organization.pt:44
+#: ./opengever/contact/browser/templates/person.pt:54
 msgid "label_mail"
 msgstr ""
 
@@ -318,12 +323,12 @@ msgstr ""
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:96
+#: ./opengever/contact/browser/templates/person.pt:98
 msgid "label_organizations"
 msgstr ""
 
 #. Default: "Participation of ${contact_title}"
-#: ./opengever/contact/models/participation.py:92
+#: ./opengever/contact/models/participation.py:101
 msgid "label_participation_of"
 msgstr ""
 
@@ -334,7 +339,7 @@ msgstr ""
 
 #. Default: "Persons"
 #: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:86
+#: ./opengever/contact/browser/templates/organization.pt:88
 msgid "label_persons"
 msgstr ""
 
@@ -354,14 +359,14 @@ msgid "label_phone_mobile"
 msgstr "Téléphone mobile"
 
 #. Default: "Phone numbers"
-#: ./opengever/contact/browser/templates/organization.pt:57
-#: ./opengever/contact/browser/templates/person.pt:67
+#: ./opengever/contact/browser/templates/organization.pt:59
+#: ./opengever/contact/browser/templates/person.pt:69
 msgid "label_phone_numbers"
 msgstr ""
 
 #. Default: "Phone office"
 #: ./opengever/contact/contact.py:120
-#: ./opengever/contact/contactfolder.py:122
+#: ./opengever/contact/contactfolder.py:113
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 
@@ -403,8 +408,8 @@ msgid "label_url"
 msgstr "Adresse URL"
 
 #. Default: "URLs"
-#: ./opengever/contact/browser/templates/organization.pt:71
-#: ./opengever/contact/browser/templates/person.pt:81
+#: ./opengever/contact/browser/templates/organization.pt:73
+#: ./opengever/contact/browser/templates/person.pt:83
 msgid "label_urls"
 msgstr ""
 
@@ -447,3 +452,4 @@ msgstr "Résultat(s): ${amount}"
 #: ./opengever/contact/contact.py:44
 msgid "telefon"
 msgstr "Téléphone"
+

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-14 15:13+0000\n"
+"POT-Creation-Date: 2016-10-04 11:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -165,6 +165,7 @@ msgstr ""
 
 #. Default: "Active"
 #: ./opengever/contact/browser/byline.py:16
+#: ./opengever/contact/browser/templates/organization.pt:89
 msgid "label_active"
 msgstr ""
 
@@ -190,30 +191,30 @@ msgid "label_addresses"
 msgstr ""
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:122
-#: ./opengever/contact/browser/templates/person.pt:141
+#: ./opengever/contact/browser/templates/organization.pt:141
+#: ./opengever/contact/browser/templates/person.pt:144
 msgid "label_archived_addresses"
 msgstr ""
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:143
-#: ./opengever/contact/browser/templates/person.pt:162
+#: ./opengever/contact/browser/templates/organization.pt:164
+#: ./opengever/contact/browser/templates/person.pt:167
 msgid "label_archived_mail"
 msgstr ""
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:104
+#: ./opengever/contact/browser/templates/organization.pt:123
 msgid "label_archived_organizations"
 msgstr ""
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:114
+#: ./opengever/contact/browser/templates/person.pt:117
 msgid "label_archived_persons"
 msgstr ""
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:162
-#: ./opengever/contact/browser/templates/person.pt:181
+#: ./opengever/contact/browser/templates/organization.pt:183
+#: ./opengever/contact/browser/templates/person.pt:186
 msgid "label_archived_phone_numbers"
 msgstr ""
 
@@ -266,7 +267,7 @@ msgstr ""
 
 #. Default: "email"
 #: ./opengever/contact/contact.py:103
-#: ./opengever/contact/contactfolder.py:117
+#: ./opengever/contact/contactfolder.py:108
 msgid "label_email"
 msgstr ""
 
@@ -278,14 +279,19 @@ msgstr ""
 #. Default: "Firstname"
 #: ./opengever/contact/browser/person.py:102
 #: ./opengever/contact/contact.py:82
-#: ./opengever/contact/contactfolder.py:112
+#: ./opengever/contact/contactfolder.py:103
 msgid "label_firstname"
+msgstr ""
+
+#. Default: "Inactive"
+#: ./opengever/contact/browser/templates/organization.pt:101
+msgid "label_inactive"
 msgstr ""
 
 #. Default: "Lastname"
 #: ./opengever/contact/browser/person.py:107
 #: ./opengever/contact/contact.py:75
-#: ./opengever/contact/contactfolder.py:107
+#: ./opengever/contact/contactfolder.py:98
 msgid "label_lastname"
 msgstr ""
 
@@ -300,8 +306,8 @@ msgid "label_local"
 msgstr ""
 
 #. Default: "Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:42
-#: ./opengever/contact/browser/templates/person.pt:52
+#: ./opengever/contact/browser/templates/organization.pt:44
+#: ./opengever/contact/browser/templates/person.pt:54
 msgid "label_mail"
 msgstr ""
 
@@ -318,12 +324,12 @@ msgstr ""
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:96
+#: ./opengever/contact/browser/templates/person.pt:98
 msgid "label_organizations"
 msgstr ""
 
 #. Default: "Participation of ${contact_title}"
-#: ./opengever/contact/models/participation.py:92
+#: ./opengever/contact/models/participation.py:101
 msgid "label_participation_of"
 msgstr ""
 
@@ -334,7 +340,7 @@ msgstr ""
 
 #. Default: "Persons"
 #: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:86
+#: ./opengever/contact/browser/templates/organization.pt:88
 msgid "label_persons"
 msgstr ""
 
@@ -354,14 +360,14 @@ msgid "label_phone_mobile"
 msgstr ""
 
 #. Default: "Phone numbers"
-#: ./opengever/contact/browser/templates/organization.pt:57
-#: ./opengever/contact/browser/templates/person.pt:67
+#: ./opengever/contact/browser/templates/organization.pt:59
+#: ./opengever/contact/browser/templates/person.pt:69
 msgid "label_phone_numbers"
 msgstr ""
 
 #. Default: "Phone office"
 #: ./opengever/contact/contact.py:120
-#: ./opengever/contact/contactfolder.py:122
+#: ./opengever/contact/contactfolder.py:113
 msgid "label_phone_office"
 msgstr ""
 
@@ -403,8 +409,8 @@ msgid "label_url"
 msgstr ""
 
 #. Default: "URLs"
-#: ./opengever/contact/browser/templates/organization.pt:71
-#: ./opengever/contact/browser/templates/person.pt:81
+#: ./opengever/contact/browser/templates/organization.pt:73
+#: ./opengever/contact/browser/templates/person.pt:83
 msgid "label_urls"
 msgstr ""
 

--- a/opengever/contact/models/person.py
+++ b/opengever/contact/models/person.py
@@ -38,7 +38,7 @@ class Person(Contact):
 
     @property
     def fullname(self):
-        return u'{} {}'.format(self.firstname, self.lastname)
+        return u'{} {}'.format(self.lastname, self.firstname)
 
     @property
     def wrapper_id(self):

--- a/opengever/contact/tests/test_org_role.py
+++ b/opengever/contact/tests/test_org_role.py
@@ -63,14 +63,14 @@ class TestOrganizationalRole(unittest2.TestCase):
                                                   department='IT'))
 
         self.assertEquals(
-            u'Peter M\xfcller - Meier AG', role1.get_title())
+            u'M\xfcller Peter - Meier AG', role1.get_title())
         self.assertEquals(
-            u'Peter M\xfcller - 4teamwork AG (Developer)', role2.get_title())
+            u'M\xfcller Peter - 4teamwork AG (Developer)', role2.get_title())
         self.assertEquals(
-            u'Peter M\xfcller - 4teamwork AG (Developer - IT)', role3.get_title())
+            u'M\xfcller Peter - 4teamwork AG (Developer - IT)', role3.get_title())
         self.assertEquals(
-            u'Peter M\xfcller - 4teamwork AG (IT)', role4.get_title())
+            u'M\xfcller Peter - 4teamwork AG (IT)', role4.get_title())
 
         self.assertEquals(
-            u'Peter M\xfcller [123456] - Meier AG',
+            u'M\xfcller Peter [123456] - Meier AG',
             role1.get_title(with_former_id=True))

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -183,6 +183,28 @@ class TestOrganizationView(FunctionalTestCase):
             browser.css('.persons .function').text)
 
     @browsing
+    def test_group_related_persons_by_active_state(self, browser):
+        org1 = create(Builder('organization').named(u'4teamwork AG'))
+
+        create(Builder('person')
+               .having(firstname=u'Peter', lastname=u'M\xfcller')
+               .in_orgs([(org1, 'CEO')]))
+        create(Builder('person')
+               .having(firstname=u'Sandra', lastname=u'Muster',
+                       is_active=False)
+               .in_orgs([(org1, u'Stellvertretende F\xfchrung')]))
+        create(Builder('person')
+               .having(firstname=u'Sandra', lastname=u'Meier')
+               .in_orgs([(org1, u'CFO')]))
+
+        browser.login().open(org1.get_url())
+
+        self.assertEquals(['Meier Sandra', u'M\xfcller Peter'],
+                          browser.css('.active_persons .name').text)
+        self.assertEquals(['Muster Sandra'],
+                          browser.css('.inactive_persons .name').text)
+
+    @browsing
     def test_shows_linked_urls_prefixed_with_label(self, browser):
         organization = create(Builder('organization').named(u'4teamwork'))
 

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -176,10 +176,10 @@ class TestOrganizationView(FunctionalTestCase):
         browser.login().open(org1.get_url())
 
         self.assertEquals(
-            [u'M\xfcller Peter', 'Meier Sandra', 'Muster Sandra'],
+            ['Meier Sandra', 'Muster Sandra', u'M\xfcller Peter'],
             browser.css('.persons .name').text)
         self.assertEquals(
-            [u'CEO', u'CFO', u'Stellvertretende F\xfchrung'],
+            [u'CFO', u'Stellvertretende F\xfchrung', u'CEO'],
             browser.css('.persons .function').text)
 
     @browsing

--- a/opengever/contact/tests/test_organization_view.py
+++ b/opengever/contact/tests/test_organization_view.py
@@ -176,7 +176,7 @@ class TestOrganizationView(FunctionalTestCase):
         browser.login().open(org1.get_url())
 
         self.assertEquals(
-            [u'Peter M\xfcller', 'Sandra Meier', 'Sandra Muster'],
+            [u'M\xfcller Peter', 'Meier Sandra', 'Muster Sandra'],
             browser.css('.persons .name').text)
         self.assertEquals(
             [u'CEO', u'CFO', u'Stellvertretende F\xfchrung'],

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -72,10 +72,10 @@ class TestParticipationWrapper(FunctionalTestCase):
             self.dossier.absolute_url()))
 
         self.assertEqual(
-            [u'Edit Participation of Hans M\xfcller'],
+            [u'Edit Participation of M\xfcller Hans'],
             browser.css('h1').text)
         self.assertEqual(
-            [u'You are here: Client1 / dossier-1 / Participation of Hans M\xfcller'],
+            [u'You are here: Client1 / dossier-1 / Participation of M\xfcller Hans'],
             browser.css('#portal-breadcrumbs').text)
 
     @browsing
@@ -414,7 +414,7 @@ class TestEditForm(FunctionalTestCase):
                              view=u'tabbedview_view-participations')
         browser.click_on('Edit')
 
-        self.assertEquals([u'Edit Participation of Peter M\xfcller'],
+        self.assertEquals([u'Edit Participation of M\xfcller Peter'],
                           browser.css('h1').text)
 
     @browsing
@@ -446,7 +446,7 @@ class TestEditForm(FunctionalTestCase):
                              view=u'tabbedview_view-participations')
         browser.click_on('Edit')
 
-        self.assertEquals([u'Edit Participation of Peter M\xfcller - Meier AG (cheffe)'],
+        self.assertEquals([u'Edit Participation of M\xfcller Peter - Meier AG (cheffe)'],
                           browser.css('h1').text)
 
     @browsing
@@ -543,7 +543,7 @@ class TestRemoveForm(FunctionalTestCase):
                              view=u'tabbedview_view-participations')
         browser.click_on('Remove')
 
-        self.assertEquals([u'Remove Participation of Peter M\xfcller'],
+        self.assertEquals([u'Remove Participation of M\xfcller Peter'],
                           browser.css('h1').text)
 
     @browsing

--- a/opengever/contact/tests/test_participation_tab.py
+++ b/opengever/contact/tests/test_participation_tab.py
@@ -22,20 +22,20 @@ class ParticipationTab(FunctionalTestCase):
                                 .as_contact_adapter())
 
         create(Builder('contact_participation')
-               .for_contact(self.hans)
-               .for_dossier(self.dossier)
-               .with_roles(['regard', 'final-drawing']))
-        create(Builder('contact_participation')
                .for_contact(self.peter_ag)
                .for_dossier(self.dossier)
                .with_roles(['participation']))
+        create(Builder('contact_participation')
+               .for_contact(self.hans)
+               .for_dossier(self.dossier)
+               .with_roles(['regard', 'final-drawing']))
         create(Builder('ogds_user_participation')
                .for_dossier(self.dossier)
                .for_ogds_user(self.ogds_user)
                .with_roles(['participation']))
 
     @browsing
-    def test_list_all_participating_contacts_and_link_them_to_detail_view(self, browser):
+    def test_list_all_participating_contacts_alphabetically_and_link_to_detail_view(self, browser):
         browser.login().open(self.dossier,
                              view=u'tabbedview_view-participations')
 
@@ -100,5 +100,5 @@ class ParticipationTab(FunctionalTestCase):
         edit_link = browser.css('#participation_listing > li .edit-action').first
 
         self.assertEquals('Edit', edit_link.text)
-        self.assertEquals('http://nohost/plone/dossier-1/participation-1/edit',
+        self.assertEquals('http://nohost/plone/dossier-1/participation-2/edit',
                           edit_link.get('href'))

--- a/opengever/contact/tests/test_participation_tab.py
+++ b/opengever/contact/tests/test_participation_tab.py
@@ -40,7 +40,7 @@ class ParticipationTab(FunctionalTestCase):
                              view=u'tabbedview_view-participations')
 
         self.assertEquals(
-            [u'Hans M\xfcller', 'Peter AG', 'Peter Hans (peter)'],
+            [u'M\xfcller Hans', 'Peter AG', 'Peter Hans (peter)'],
             browser.css('#participation_listing .contact').text)
 
         links = browser.css('#participation_listing .contact a')
@@ -65,7 +65,7 @@ class ParticipationTab(FunctionalTestCase):
         browser.login().open(self.dossier,
                              view=u'tabbedview_view-participations')
         self.assertEquals(
-            [u'Hans M\xfcller', 'Peter AG', 'Peter Hans (peter)'],
+            [u'M\xfcller Hans', 'Peter AG', 'Peter Hans (peter)'],
             browser.css('#participation_listing .contact').text)
 
     @browsing
@@ -83,7 +83,7 @@ class ParticipationTab(FunctionalTestCase):
 
         row1, row2, row3 = browser.css('#participation_listing > li')
 
-        self.assertEquals([u'Hans M\xfcller'], row1.css('.contact').text)
+        self.assertEquals([u'M\xfcller Hans'], row1.css('.contact').text)
         self.assertEquals(['Regard', 'Final drawing'], row1.css('.roles li').text)
 
         self.assertEquals([u'Peter AG'], row2.css('.contact').text)

--- a/opengever/contact/tests/test_person_unit.py
+++ b/opengever/contact/tests/test_person_unit.py
@@ -104,16 +104,16 @@ class TestPerson(unittest2.TestCase):
                            u'http://www.onegovgever.ch'],
                           [url.url for url in peter.urls])
 
-    def test_fullname_is_firstname_and_lastname_separated_with_a_space(self):
+    def test_fullname_is_lastname_and_firstname_separated_with_a_space(self):
         peter = create(Builder('person')
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
-        self.assertEquals(u'Peter M\xfcller', peter.fullname)
+        self.assertEquals(u'M\xfcller Peter', peter.fullname)
 
     def test_title_is_fullname(self):
         peter = create(Builder('person')
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
-        self.assertEquals(u'Peter M\xfcller', peter.get_title())
+        self.assertEquals(u'M\xfcller Peter', peter.get_title())
 
     def test_title_is_extended_with_former_id_in_brackets_when_flag_is_set(self):
         peter = create(Builder('person')
@@ -123,7 +123,7 @@ class TestPerson(unittest2.TestCase):
                                lastname=u'M\xfcller',
                                former_contact_id=123456))
 
-        self.assertEquals(u'Peter M\xfcller',
+        self.assertEquals(u'M\xfcller Peter',
                           peter.get_title(with_former_id=True))
-        self.assertEquals(u'James M\xfcller [123456]',
+        self.assertEquals(u'M\xfcller James [123456]',
                           james.get_title(with_former_id=True))

--- a/opengever/contact/tests/test_person_view.py
+++ b/opengever/contact/tests/test_person_view.py
@@ -19,10 +19,10 @@ class TestPersonView(FunctionalTestCase):
                         .having(firstname=u'Sandra', lastname=u'Fl\xfcckiger'))
 
         browser.login().open(self.contactfolder, view=peter.wrapper_id)
-        self.assertEquals([u'Peter M\xfcller'], browser.css('h1').text)
+        self.assertEquals([u'M\xfcller Peter'], browser.css('h1').text)
 
         browser.login().open(self.contactfolder, view=sandra.wrapper_id)
-        self.assertEquals([u'Sandra Fl\xfcckiger'], browser.css('h1').text)
+        self.assertEquals([u'Fl\xfcckiger Sandra'], browser.css('h1').text)
 
     @browsing
     def test_shows_fullname_as_title(self, browser):
@@ -30,7 +30,7 @@ class TestPersonView(FunctionalTestCase):
                        .having(firstname=u'Peter', lastname=u'M\xfcller'))
 
         browser.login().open(self.contactfolder, view=peter.wrapper_id)
-        self.assertEquals([u'Peter M\xfcller'], browser.css('h1').text)
+        self.assertEquals([u'M\xfcller Peter'], browser.css('h1').text)
 
     @browsing
     def test_shows_personal_information_as_vertical_table(self, browser):
@@ -43,7 +43,7 @@ class TestPersonView(FunctionalTestCase):
         browser.login().open(self.contactfolder, view=peter.wrapper_id)
         table = browser.css('.contact_details').first
 
-        [['Name', u'Peter M\xfcller'],
+        [['Name', u'M\xfcller Peter'],
          ['Salutation', 'Herr'],
          ['Academic title', 'Dr. rer. nat.'],
          ['Addresses'],
@@ -68,7 +68,7 @@ class TestPersonView(FunctionalTestCase):
         browser.login().open(self.contactfolder, view=peter.wrapper_id)
         table = browser.css('#contactHistory .contact_details').first
 
-        [['Name', u'Peter Hanssen'],
+        [['Name', u'Hanssen Peter'],
          ['Salutation', 'Herr'],
          ['Academic title', 'Magister']]
         table.dicts()

--- a/opengever/contact/tests/test_vocabularies.py
+++ b/opengever/contact/tests/test_vocabularies.py
@@ -48,10 +48,10 @@ class TestContactsVocabulary(FunctionalTestCase):
         vocabulary = voca_factory(self.portal)
 
         self.assertTerms(
-            [(self.peter_a, u'Peter M\xfcller [1111]'),
-             (self.role1, u'Peter M\xfcller [1111] - Meier AG (Developer)'),
-             (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)'),
-             (self.peter_b, u'Peter Fl\xfcckiger'),
+            [(self.peter_a, u'M\xfcller Peter [1111]'),
+             (self.role1, u'M\xfcller Peter [1111] - Meier AG (Developer)'),
+             (self.role2, u'M\xfcller Peter [1111] - 4teamwork AG (Scheffe)'),
+             (self.peter_b, u'Fl\xfcckiger Peter'),
              (self.meier_ag, u'Meier AG [2222]'),
              (self.teamwork_ag, u'4teamwork AG'),
              (self.ogds_user, u'Test User (test_user_1_)')],
@@ -67,24 +67,24 @@ class TestContactsVocabulary(FunctionalTestCase):
             vocabulary.search('Meier'))
 
         self.assertTerms(
-            [(self.peter_a, u'Peter M\xfcller [1111]'),
-             (self.role1, u'Peter M\xfcller [1111] - Meier AG (Developer)'),
-             (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)'),
-             (self.peter_b, u'Peter Fl\xfcckiger')],
+            [(self.peter_a, u'M\xfcller Peter [1111]'),
+             (self.role1, u'M\xfcller Peter [1111] - Meier AG (Developer)'),
+             (self.role2, u'M\xfcller Peter [1111] - 4teamwork AG (Scheffe)'),
+             (self.peter_b, u'Fl\xfcckiger Peter')],
             vocabulary.search('Peter'))
 
         self.assertTerms(
-            [(self.peter_b, u'Peter Fl\xfcckiger')],
+            [(self.peter_b, u'Fl\xfcckiger Peter')],
             vocabulary.search('Peter Fl'))
 
         self.assertTerms(
-            [(self.peter_b, u'Peter Fl\xfcckiger')],
+            [(self.peter_b, u'Fl\xfcckiger Peter')],
             vocabulary.search('Pe Fl'))
 
         self.assertTerms(
-            [(self.peter_a, u'Peter M\xfcller [1111]'),
-             (self.role1, u'Peter M\xfcller [1111] - Meier AG (Developer)'),
-             (self.role2, u'Peter M\xfcller [1111] - 4teamwork AG (Scheffe)')],
+            [(self.peter_a, u'M\xfcller Peter [1111]'),
+             (self.role1, u'M\xfcller Peter [1111] - Meier AG (Developer)'),
+             (self.role2, u'M\xfcller Peter [1111] - 4teamwork AG (Scheffe)')],
             vocabulary.search('1111'))
 
         self.assertTerms(

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -231,7 +231,7 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
         self.assertEquals(u'test-docx.docx', document.file.filename)
 
         expected_person_properties = {
-            'ogg.recipient.contact.title': u'Peter M\xfcller',
+            'ogg.recipient.contact.title': u'M\xfcller Peter',
             'ogg.recipient.person.firstname': 'Peter',
             'ogg.recipient.person.lastname': u'M\xfcller',
         }

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -83,11 +83,11 @@ class TestManualJournalEntry(FunctionalTestCase):
         row = browser.css('.listing').first.rows[1]
         links = row.css('.contacts a')
 
-        self.assertEquals(u'Contacts H\xfcgo Boss Meier AG',
+        self.assertEquals(u'Contacts Boss H\xfcgo Meier AG',
                           row.dict().get('References'))
 
         self.assertEquals(
             ['http://nohost/plone/opengever-contact-contactfolder/contact-1',
              'http://nohost/plone/opengever-contact-contactfolder/contact-2'],
             [link.get('href') for link in links])
-        self.assertEquals([u'H\xfcgo Boss', 'Meier AG'], links.text)
+        self.assertEquals([u'Boss H\xfcgo', 'Meier AG'], links.text)


### PR DESCRIPTION
- Change Person label to `Name Surname`: According to the user label, also the person label should use the format `Name Surname` as every where else in GEVER. Closes #2190.
- Sort participations alphabetically on participant's title, closes #2189.
- Sort persons alphabetically on lastname, firstname in the organization detail view.
- Group related persons by active state in the organization detail view closes #2191 

