### PR TITLE
Improve performance of person listing, using eager loading strategy.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Improve performance of person listing, using eager loading strategy.
+  [phgross]
+
 - Add department field to org-role.
   [deiferni]
 

--- a/opengever/contact/browser/person_listing.py
+++ b/opengever/contact/browser/person_listing.py
@@ -12,6 +12,7 @@ from opengever.tabbedview.filters import Filter
 from opengever.tabbedview.filters import FilterList
 from opengever.tabbedview.helper import boolean_helper
 from opengever.tabbedview.helper import linked_sql_object
+from sqlalchemy.orm import joinedload
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -66,7 +67,7 @@ class PersonListingTab(BaseListingTab):
         return ', '.join(links)
 
     def get_base_query(self):
-        return Person.query
+        return Person.query.options(joinedload('organizations'))
 
 
 class PersonTableSource(SqlTableSource):


### PR DESCRIPTION
With #2113 an  `organizations` column was added to the person listing.

To avoid fetching the organization data with a separate SQL-query per person, we eager load the Organization data in the base query.

@deiferni 