### PR TITLE
Implement (basic) SQLSchemaDumper and also dump schemas for common SQL types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Implement SQLSchemaDumper and also dump schemas for common SQL types.
+  [lgraf]
+
 - Improve performance of person listing, using eager loading strategy.
   [phgross]
 

--- a/docs/schema-dumps/_opengever.contact.models.Address.json
+++ b/docs/schema-dumps/_opengever.contact.models.Address.json
@@ -1,0 +1,54 @@
+{
+    "portal_type": "_opengever.contact.models.Address",
+    "title": "Address",
+    "schemas": [
+        {
+            "name": "Address",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(adresses_id_seq)"
+                },
+                {
+                    "name": "label",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "street",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "zip_code",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "city",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "country",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.contact.models.MailAddress.json
+++ b/docs/schema-dumps/_opengever.contact.models.MailAddress.json
@@ -1,0 +1,33 @@
+{
+    "portal_type": "_opengever.contact.models.MailAddress",
+    "title": "MailAddress",
+    "schemas": [
+        {
+            "name": "MailAddress",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(mail_adresses_id_seq)"
+                },
+                {
+                    "name": "label",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "address",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.contact.models.OrgRole.json
+++ b/docs/schema-dumps/_opengever.contact.models.OrgRole.json
@@ -1,0 +1,40 @@
+{
+    "portal_type": "_opengever.contact.models.OrgRole",
+    "title": "OrgRole",
+    "schemas": [
+        {
+            "name": "OrgRole",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(org_roles_id_seq)"
+                },
+                {
+                    "name": "function",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "department",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "description",
+                    "type": "UnicodeCoercingText",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.contact.models.Organization.json
+++ b/docs/schema-dumps/_opengever.contact.models.Organization.json
@@ -1,0 +1,60 @@
+{
+    "portal_type": "_opengever.contact.models.Organization",
+    "title": "Organization",
+    "schemas": [
+        {
+            "name": "Organization",
+            "fields": [
+                {
+                    "name": "name",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                }
+            ]
+        },
+        {
+            "name": "Contact",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(contacts_id_seq)"
+                },
+                {
+                    "name": "contact_type",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                },
+                {
+                    "name": "is_active",
+                    "type": "Boolean",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": true
+                },
+                {
+                    "name": "description",
+                    "type": "UnicodeCoercingText",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "former_contact_id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.contact.models.Person.json
+++ b/docs/schema-dumps/_opengever.contact.models.Person.json
@@ -1,0 +1,81 @@
+{
+    "portal_type": "_opengever.contact.models.Person",
+    "title": "Person",
+    "schemas": [
+        {
+            "name": "Person",
+            "fields": [
+                {
+                    "name": "salutation",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "academic_title",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "firstname",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                },
+                {
+                    "name": "lastname",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                }
+            ]
+        },
+        {
+            "name": "Contact",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(contacts_id_seq)"
+                },
+                {
+                    "name": "contact_type",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                },
+                {
+                    "name": "is_active",
+                    "type": "Boolean",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": true
+                },
+                {
+                    "name": "description",
+                    "type": "UnicodeCoercingText",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "former_contact_id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.contact.models.PhoneNumber.json
+++ b/docs/schema-dumps/_opengever.contact.models.PhoneNumber.json
@@ -1,0 +1,33 @@
+{
+    "portal_type": "_opengever.contact.models.PhoneNumber",
+    "title": "PhoneNumber",
+    "schemas": [
+        {
+            "name": "PhoneNumber",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(phonenumber_id_seq)"
+                },
+                {
+                    "name": "label",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "phone_number",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.contact.models.URL.json
+++ b/docs/schema-dumps/_opengever.contact.models.URL.json
@@ -1,0 +1,33 @@
+{
+    "portal_type": "_opengever.contact.models.URL",
+    "title": "URL",
+    "schemas": [
+        {
+            "name": "URL",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "Integer",
+                    "title": null,
+                    "desc": null,
+                    "required": true,
+                    "default": "Sequence(urls_id_seq)"
+                },
+                {
+                    "name": "label",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "url",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.ogds.models.group.Group.json
+++ b/docs/schema-dumps/_opengever.ogds.models.group.Group.json
@@ -1,0 +1,33 @@
+{
+    "portal_type": "_opengever.ogds.models.group.Group",
+    "title": "Group",
+    "schemas": [
+        {
+            "name": "Group",
+            "fields": [
+                {
+                    "name": "groupid",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                },
+                {
+                    "name": "active",
+                    "type": "Boolean",
+                    "title": null,
+                    "desc": null,
+                    "required": false,
+                    "default": true
+                },
+                {
+                    "name": "title",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.json
@@ -1,0 +1,166 @@
+{
+    "portal_type": "_opengever.ogds.models.user.User",
+    "title": "User",
+    "schemas": [
+        {
+            "name": "User",
+            "fields": [
+                {
+                    "name": "userid",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": true
+                },
+                {
+                    "name": "active",
+                    "type": "Boolean",
+                    "title": null,
+                    "desc": null,
+                    "required": false,
+                    "default": true
+                },
+                {
+                    "name": "firstname",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "lastname",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "directorate",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "directorate_abbr",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "department",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "department_abbr",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "email",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "email2",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "url",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "phone_office",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "phone_fax",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "phone_mobile",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "salutation",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "description",
+                    "type": "UnicodeCoercingText",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "address1",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "address2",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "zip_code",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "city",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "country",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                },
+                {
+                    "name": "import_stamp",
+                    "type": "String",
+                    "title": null,
+                    "desc": null,
+                    "required": false
+                }
+            ]
+        }
+    ]
+}

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.json
@@ -88,7 +88,7 @@
                 {
                     "name": "temporary_former_reference_number",
                     "type": "TextLine",
-                    "title": "Temporary former reference number",
+                    "title": "Tempor\u00e4res fr\u00fcheres Aktenzeichen",
                     "desc": "",
                     "required": false,
                     "omitted": {

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -11,6 +11,17 @@ GEVER_TYPES = [
     'opengever.repository.repositoryroot',
 ]
 
+GEVER_SQL_TYPES = [
+    '_opengever.contact.models.Address',
+    '_opengever.contact.models.MailAddress',
+    '_opengever.contact.models.OrgRole',
+    '_opengever.contact.models.Organization',
+    '_opengever.contact.models.Person',
+    '_opengever.contact.models.PhoneNumber',
+    '_opengever.contact.models.URL',
+    '_opengever.ogds.models.user.User',
+    '_opengever.ogds.models.group.Group',
+]
 
 VOCAB_OVERRIDES = {
     'opengever.dossier.behaviors.dossier.IDossier': {

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -139,9 +139,15 @@ class SQLTypeDumper(object):
             mapper_args = getattr(main_klass, '__mapper_args__', {})
 
             if bases and 'polymorphic_identity' not in mapper_args:
-                raise Exception(
+                raise NotImplementedError(
                     "Unexpected inheritance for %r: Mapped base classes, but "
                     "no polymorphic_identity found!" % main_klass)
+
+            for base_class in bases:
+                if list(filter(_is_mapped_class, base_class.__bases__)) != []:
+                    raise NotImplementedError(
+                        "More than one level of inheritance currently not"
+                        "supported when dumping SQL schemas.")
 
             for cls in [main_klass] + bases:
                 schema = schema_dumper.dump(cls)


### PR DESCRIPTION
This adds a minimal `SQLSchemaDumper` in order to also dump schemas for our SQL types.

The implementation currently is as minimal as possible, and well need to be built on later, but it already covers **listing available fields** (columns), and whether they're **required** (not nullable) or not.

The primary need for this is to validate SQL query results used for data migration against the structure we expect them to have.

@phgross @deiferni 