### PR TITLE
SchemaDumper: Include max_length for stringish field types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- SchemaDumper: Include max_length for Stringish field types.
+  [lgraf]
+
 - Add new functionality "Private Dossier, a private area for every user to
   create his private dossiers and store and edit private documents there.
   [phgross]

--- a/docs/schema-dumps/_opengever.contact.models.Address.json
+++ b/docs/schema-dumps/_opengever.contact.models.Address.json
@@ -18,35 +18,40 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "street",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "zip_code",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 16
                 },
                 {
                     "name": "city",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "country",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.contact.models.Address.json
+++ b/docs/schema-dumps/_opengever.contact.models.Address.json
@@ -7,7 +7,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -15,35 +15,35 @@
                 },
                 {
                     "name": "label",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "street",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "zip_code",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "city",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "country",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false

--- a/docs/schema-dumps/_opengever.contact.models.MailAddress.json
+++ b/docs/schema-dumps/_opengever.contact.models.MailAddress.json
@@ -18,14 +18,16 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "address",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.contact.models.MailAddress.json
+++ b/docs/schema-dumps/_opengever.contact.models.MailAddress.json
@@ -7,7 +7,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -15,14 +15,14 @@
                 },
                 {
                     "name": "label",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "address",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true

--- a/docs/schema-dumps/_opengever.contact.models.OrgRole.json
+++ b/docs/schema-dumps/_opengever.contact.models.OrgRole.json
@@ -18,21 +18,24 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "department",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "description",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.contact.models.OrgRole.json
+++ b/docs/schema-dumps/_opengever.contact.models.OrgRole.json
@@ -7,7 +7,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -15,21 +15,21 @@
                 },
                 {
                     "name": "function",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "department",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "description",
-                    "type": "UnicodeCoercingText",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false

--- a/docs/schema-dumps/_opengever.contact.models.Organization.json
+++ b/docs/schema-dumps/_opengever.contact.models.Organization.json
@@ -10,7 +10,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 }
             ]
         },
@@ -30,7 +31,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 20
                 },
                 {
                     "name": "is_active",
@@ -45,7 +47,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "former_contact_id",

--- a/docs/schema-dumps/_opengever.contact.models.Organization.json
+++ b/docs/schema-dumps/_opengever.contact.models.Organization.json
@@ -7,7 +7,7 @@
             "fields": [
                 {
                     "name": "name",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
@@ -19,7 +19,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -27,14 +27,14 @@
                 },
                 {
                     "name": "contact_type",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
                 },
                 {
                     "name": "is_active",
-                    "type": "Boolean",
+                    "type": "Bool",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -42,14 +42,14 @@
                 },
                 {
                     "name": "description",
-                    "type": "UnicodeCoercingText",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "former_contact_id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": false

--- a/docs/schema-dumps/_opengever.contact.models.Person.json
+++ b/docs/schema-dumps/_opengever.contact.models.Person.json
@@ -10,28 +10,32 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "academic_title",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "firstname",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 },
                 {
                     "name": "lastname",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 }
             ]
         },
@@ -51,7 +55,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 20
                 },
                 {
                     "name": "is_active",
@@ -66,7 +71,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "former_contact_id",

--- a/docs/schema-dumps/_opengever.contact.models.Person.json
+++ b/docs/schema-dumps/_opengever.contact.models.Person.json
@@ -7,28 +7,28 @@
             "fields": [
                 {
                     "name": "salutation",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "academic_title",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "firstname",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
                 },
                 {
                     "name": "lastname",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
@@ -40,7 +40,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -48,14 +48,14 @@
                 },
                 {
                     "name": "contact_type",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
                 },
                 {
                     "name": "is_active",
-                    "type": "Boolean",
+                    "type": "Bool",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -63,14 +63,14 @@
                 },
                 {
                     "name": "description",
-                    "type": "UnicodeCoercingText",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "former_contact_id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": false

--- a/docs/schema-dumps/_opengever.contact.models.PhoneNumber.json
+++ b/docs/schema-dumps/_opengever.contact.models.PhoneNumber.json
@@ -7,7 +7,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -15,14 +15,14 @@
                 },
                 {
                     "name": "label",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "phone_number",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true

--- a/docs/schema-dumps/_opengever.contact.models.PhoneNumber.json
+++ b/docs/schema-dumps/_opengever.contact.models.PhoneNumber.json
@@ -18,14 +18,16 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "phone_number",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.contact.models.URL.json
+++ b/docs/schema-dumps/_opengever.contact.models.URL.json
@@ -18,14 +18,16 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "url",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.contact.models.URL.json
+++ b/docs/schema-dumps/_opengever.contact.models.URL.json
@@ -7,7 +7,7 @@
             "fields": [
                 {
                     "name": "id",
-                    "type": "Integer",
+                    "type": "Int",
                     "title": null,
                     "desc": null,
                     "required": true,
@@ -15,14 +15,14 @@
                 },
                 {
                     "name": "label",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "url",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true

--- a/docs/schema-dumps/_opengever.ogds.models.group.Group.json
+++ b/docs/schema-dumps/_opengever.ogds.models.group.Group.json
@@ -7,14 +7,14 @@
             "fields": [
                 {
                     "name": "groupid",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
                 },
                 {
                     "name": "active",
-                    "type": "Boolean",
+                    "type": "Bool",
                     "title": null,
                     "desc": null,
                     "required": false,
@@ -22,7 +22,7 @@
                 },
                 {
                     "name": "title",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false

--- a/docs/schema-dumps/_opengever.ogds.models.group.Group.json
+++ b/docs/schema-dumps/_opengever.ogds.models.group.Group.json
@@ -10,7 +10,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 },
                 {
                     "name": "active",
@@ -25,7 +26,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 50
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.json
@@ -10,7 +10,8 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 },
                 {
                     "name": "active",
@@ -25,140 +26,160 @@
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "lastname",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "directorate",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "directorate_abbr",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 50
                 },
                 {
                     "name": "department",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "department_abbr",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 50
                 },
                 {
                     "name": "email",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "email2",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "url",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 100
                 },
                 {
                     "name": "phone_office",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 30
                 },
                 {
                     "name": "phone_fax",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 30
                 },
                 {
                     "name": "phone_mobile",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 30
                 },
                 {
                     "name": "salutation",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 30
                 },
                 {
                     "name": "description",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "address1",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 100
                 },
                 {
                     "name": "address2",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 100
                 },
                 {
                     "name": "zip_code",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 10
                 },
                 {
                     "name": "city",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 100
                 },
                 {
                     "name": "country",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 20
                 },
                 {
                     "name": "import_stamp",
                     "type": "Text",
                     "title": null,
                     "desc": null,
-                    "required": false
+                    "required": false,
+                    "max_length": 26
                 }
             ]
         }

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.json
@@ -7,14 +7,14 @@
             "fields": [
                 {
                     "name": "userid",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": true
                 },
                 {
                     "name": "active",
-                    "type": "Boolean",
+                    "type": "Bool",
                     "title": null,
                     "desc": null,
                     "required": false,
@@ -22,140 +22,140 @@
                 },
                 {
                     "name": "firstname",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "lastname",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "directorate",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "directorate_abbr",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "department",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "department_abbr",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "email",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "email2",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "url",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "phone_office",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "phone_fax",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "phone_mobile",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "salutation",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "description",
-                    "type": "UnicodeCoercingText",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "address1",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "address2",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "zip_code",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "city",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "country",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false
                 },
                 {
                     "name": "import_stamp",
-                    "type": "String",
+                    "type": "Text",
                     "title": null,
                     "desc": null,
                     "required": false

--- a/docs/schema-dumps/ftw.mail.mail.json
+++ b/docs/schema-dumps/ftw.mail.mail.json
@@ -67,6 +67,7 @@
                     "title": "Bearbeitungsinformation",
                     "desc": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "required": false,
+                    "max_length": null,
                     "default": ""
                 }
             ],
@@ -87,7 +88,8 @@
                     "type": "Text",
                     "title": "Beschreibung",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "keywords",
@@ -101,7 +103,8 @@
                     "type": "TextLine",
                     "title": "Fremdzeichen",
                     "desc": "Referenz auf das entsprechende Dossier des Absenders",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "document_date",
@@ -147,7 +150,8 @@
                     "type": "TextLine",
                     "title": "Autor",
                     "desc": "Nachname Vorname oder ein Benutzerk\u00fcrzel (wird automatisch nach Nachname Vorname aufgel\u00f6st).",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "digitally_available",
@@ -224,7 +228,8 @@
                     "type": "TextLine",
                     "title": "Titel",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 }
             ],
             "fieldsets": {
@@ -242,6 +247,7 @@
                     "title": "\u00c4nderungsnotiz",
                     "desc": "Geben Sie einen Kommentar ein, der die von Ihnen gemachten \u00c4nderungen beschreibt.",
                     "required": false,
+                    "max_length": null,
                     "omitted": {
                         "z3c.form.interfaces.IAddForm": true,
                         "z3c.form.interfaces.IEditForm": true,

--- a/docs/schema-dumps/opengever.contact.contact.json
+++ b/docs/schema-dumps/opengever.contact.contact.json
@@ -10,63 +10,72 @@
                     "type": "TextLine",
                     "title": "Anrede",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "academic_title",
                     "type": "TextLine",
                     "title": "Titel",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "lastname",
                     "type": "TextLine",
                     "title": "Nachname",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 },
                 {
                     "name": "firstname",
                     "type": "TextLine",
                     "title": "Vorname",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": 255
                 },
                 {
                     "name": "company",
                     "type": "TextLine",
                     "title": "Firma",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "department",
                     "type": "TextLine",
                     "title": "Abteilung",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "function",
                     "type": "TextLine",
                     "title": "Funktion",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "email",
                     "type": "TextLine",
                     "title": "E-Mail 1",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "email2",
                     "type": "TextLine",
                     "title": "E-Mail 2",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": 255
                 },
                 {
                     "name": "url",
@@ -80,28 +89,32 @@
                     "type": "TextLine",
                     "title": "Telefon Arbeit",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "phone_fax",
                     "type": "TextLine",
                     "title": "Fax Arbeit",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "phone_mobile",
                     "type": "TextLine",
                     "title": "Telefon Mobile",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "phone_home",
                     "type": "TextLine",
                     "title": "Telefon Privat",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "picture",
@@ -115,42 +128,48 @@
                     "type": "Text",
                     "title": "Beschreibung",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "address1",
                     "type": "TextLine",
                     "title": "Adresse (Strasse / Nr.)",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "address2",
                     "type": "TextLine",
                     "title": "Adresszusatz",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "zip_code",
                     "type": "TextLine",
                     "title": "PLZ",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "city",
                     "type": "TextLine",
                     "title": "Ort",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "country",
                     "type": "TextLine",
                     "title": "Land",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 }
             ],
             "fieldsets": {

--- a/docs/schema-dumps/opengever.document.document.json
+++ b/docs/schema-dumps/opengever.document.document.json
@@ -10,7 +10,8 @@
                     "type": "TextLine",
                     "title": "Titel",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "file",
@@ -90,6 +91,7 @@
                     "title": "Bearbeitungsinformation",
                     "desc": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "required": false,
+                    "max_length": null,
                     "default": ""
                 }
             ],
@@ -129,6 +131,7 @@
                     "title": "\u00c4nderungsnotiz",
                     "desc": "Geben Sie einen Kommentar ein, der die von Ihnen gemachten \u00c4nderungen beschreibt.",
                     "required": false,
+                    "max_length": null,
                     "omitted": {
                         "z3c.form.interfaces.IAddForm": true,
                         "z3c.form.interfaces.IEditForm": true,
@@ -150,7 +153,8 @@
                     "type": "Text",
                     "title": "Beschreibung",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "keywords",
@@ -164,7 +168,8 @@
                     "type": "TextLine",
                     "title": "Fremdzeichen",
                     "desc": "Referenz auf das entsprechende Dossier des Absenders",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "document_date",
@@ -210,7 +215,8 @@
                     "type": "TextLine",
                     "title": "Autor",
                     "desc": "Nachname Vorname oder ein Benutzerk\u00fcrzel (wird automatisch nach Nachname Vorname aufgel\u00f6st).",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "digitally_available",

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.json
@@ -14,14 +14,16 @@
                     "type": "TextLine",
                     "title": "Titel",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": null
                 },
                 {
                     "name": "description",
                     "type": "Text",
                     "title": "Beschreibung",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 }
             ],
             "fieldsets": {
@@ -61,7 +63,8 @@
                     "type": "Text",
                     "title": "Kommentar",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "responsible",
@@ -91,6 +94,7 @@
                     "title": "Tempor\u00e4res fr\u00fcheres Aktenzeichen",
                     "desc": "",
                     "required": false,
+                    "max_length": null,
                     "omitted": {
                         "zope.interface.Interface": true
                     }
@@ -119,7 +123,8 @@
                     "type": "TextLine",
                     "title": "Beh\u00e4ltnis-Standort",
                     "desc": "Standortangabe des Beh\u00e4lters, in dem ein Dossier in Papierform abgelegt ist",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "relatedDossier",
@@ -135,6 +140,7 @@
                     "title": "Fr\u00fcheres Aktenzeichen",
                     "desc": "",
                     "required": false,
+                    "max_length": null,
                     "modes": {
                         "zope.interface.Interface": "display"
                     }
@@ -144,7 +150,8 @@
                     "type": "TextLine",
                     "title": "Aktenzeichen",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 }
             ],
             "fieldsets": {
@@ -214,6 +221,7 @@
                     "title": "Bearbeitungsinformation",
                     "desc": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "required": false,
+                    "max_length": null,
                     "default": ""
                 }
             ],
@@ -249,7 +257,8 @@
                     "type": "Text",
                     "title": "Kommentar zur Aufbewahrungsdauer",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "archival_value",
@@ -271,7 +280,8 @@
                     "type": "Text",
                     "title": "Kommentar zur Archivw\u00fcrdigkeit",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "custody_period",

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.json
@@ -10,7 +10,8 @@
                     "type": "Text",
                     "title": "Beschreibung",
                     "desc": "Eine kurze Beschreibung des Inhalts.",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "valid_from",
@@ -31,21 +32,24 @@
                     "type": "TextLine",
                     "title": "Standort",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "referenced_activity",
                     "type": "TextLine",
                     "title": "Leistung",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "former_reference",
                     "type": "TextLine",
                     "title": "Fr\u00fcheres Zeichen",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "addable_dossier_types",
@@ -114,6 +118,7 @@
                     "title": "Bearbeitungsinformation",
                     "desc": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "required": false,
+                    "max_length": null,
                     "default": ""
                 }
             ],
@@ -134,14 +139,16 @@
                     "type": "TextLine",
                     "title": "Titel (deutsch)",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": null
                 },
                 {
                     "name": "title_fr",
                     "type": "TextLine",
                     "title": "Titel (franz\u00f6sisch)",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": null
                 }
             ]
         },
@@ -183,7 +190,8 @@
                     "type": "Text",
                     "title": "Kommentar zur Aufbewahrungsdauer",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "archival_value",
@@ -205,7 +213,8 @@
                     "type": "Text",
                     "title": "Kommentar zur Archivw\u00fcrdigkeit",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 },
                 {
                     "name": "custody_period",
@@ -257,6 +266,7 @@
                     "title": "Pr\u00e4fix des Aktenzeichens",
                     "desc": "",
                     "required": false,
+                    "max_length": null,
                     "default": "<H\u00f6chste auf dieser Ebene vergebene Nummer + 1>"
                 }
             ],

--- a/docs/schema-dumps/opengever.repository.repositoryroot.json
+++ b/docs/schema-dumps/opengever.repository.repositoryroot.json
@@ -24,7 +24,8 @@
                     "type": "TextLine",
                     "title": "Version",
                     "desc": "",
-                    "required": false
+                    "required": false,
+                    "max_length": null
                 }
             ]
         },
@@ -36,14 +37,16 @@
                     "type": "TextLine",
                     "title": "Titel (deutsch)",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": null
                 },
                 {
                     "name": "title_fr",
                     "type": "TextLine",
                     "title": "Titel (franz\u00f6sisch)",
                     "desc": "",
-                    "required": true
+                    "required": true,
+                    "max_length": null
                 }
             ]
         }

--- a/opengever/base/schemadump/field.py
+++ b/opengever/base/schemadump/field.py
@@ -183,6 +183,14 @@ class SQLFieldDumper(object):
     """Dumps a simple Python representation of a SQLAlchemy Column.
     """
 
+    # Mapping from SQLAlchemy column types to zope.schema field types
+    SQL_FIELD_TYPES = {
+        'Integer': 'Int',
+        'String': 'Text',
+        'UnicodeCoercingText': 'Text',
+        'Boolean': 'Bool',
+    }
+
     def __init__(self, klass):
         self.schema = klass
 
@@ -191,7 +199,7 @@ class SQLFieldDumper(object):
 
         field_dump = OrderedDict((
             ('name', column.name),
-            ('type', column.type.__class__.__name__),
+            ('type', self._map_field_type(column)),
             ('title', None),
             ('desc', None),
             ('required', not column.nullable),
@@ -224,3 +232,9 @@ class SQLFieldDumper(object):
             raise
 
         return field_dump
+
+    def _map_field_type(self, column):
+        col_type = column.type.__class__.__name__
+        if col_type not in self.SQL_FIELD_TYPES:
+            raise Exception('Unmapped SQL column type %r!' % col_type)
+        return self.SQL_FIELD_TYPES[col_type]

--- a/opengever/base/schemadump/field.py
+++ b/opengever/base/schemadump/field.py
@@ -22,6 +22,8 @@ log = setup_logging(__name__)
 
 NO_DEFAULT_MARKER = object()
 
+STRING_TYPES = ('Text', 'TextLine', 'ASCII', 'ASCIILine')
+
 
 class FieldDumper(object):
     """Dumps a simple Python representation of a zope.schema Field.
@@ -44,6 +46,9 @@ class FieldDumper(object):
             ('desc', field_desc),
             ('required', field.required),
         ))
+
+        if field_dump['type'] in STRING_TYPES:
+            field_dump['max_length'] = field.max_length
 
         # Determine the field's default value
         log.debug("      Determining default...")
@@ -204,6 +209,9 @@ class SQLFieldDumper(object):
             ('desc', None),
             ('required', not column.nullable),
         ))
+
+        if field_dump['type'] in STRING_TYPES:
+            field_dump['max_length'] = column.type.length
 
         # Determine the column's default value
         log.debug("      Determining default...")


### PR DESCRIPTION
Includes `max_length` in the field dumps for string-like fields.

Also maps `SQLAlchemy` column types to corresponding `zope.schema` field types.

@phgross @deiferni 