### PR TITLE
Remove transmogrify.dexterity from development-packages

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -12,8 +12,6 @@ development-packages =
 # https://github.com/4teamwork/opengever.ogds.models/pull/41
   opengever.ogds.models
   ftw.showroom
-# https://github.com/collective/transmogrify.dexterity/pull/25
-  transmogrify.dexterity
 # https://github.com/4teamwork/ftw.casauth/pull/8
   ftw.casauth
 


### PR DESCRIPTION
It's been [released](https://pypi.python.org/pypi/transmogrify.dexterity) and [pinned](https://github.com/4teamwork/kgs/commit/c6a3ceb601557dc73a792b4f9009e36ca6a5839a) as 1.6.3.

@deiferni 