### PR TITLE
Fix extracting attachments for mails in inboxes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Fix extracting attachments for mails in inboxes.
+  [deiferni]
+
 - Fix bumblebee download view delivering wrong file for checked out documents.
   [deiferni]
 

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.base.browser.helper import get_css_class
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.inbox.inbox import IInbox
 from opengever.task.task import ITask
 from plone import api
 
@@ -33,6 +34,15 @@ class BaseDocumentMixin(object):
             return parent
         if ITask.providedBy(parent):
             return parent.get_containing_dossier()
+
+        return None
+
+    def get_parent_inbox(self):
+        """Return the document's parent inbox or None."""
+
+        parent = aq_parent(aq_inner(self))
+        if IInbox.providedBy(parent):
+            return parent
 
         return None
 

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -230,6 +230,18 @@ class TestDocument(FunctionalTestCase):
 
         self.assertEqual(dossier, document.get_parent_dossier())
 
+    def test_get_parent_inbox_returns_inbox_for_document_in_inbox(self):
+        inbox = create(Builder('inbox'))
+        document = create(Builder('document').within(inbox))
+
+        self.assertEqual(inbox, document.get_parent_inbox())
+
+    def test_get_parent_inbox_returns_none_for_document_in_dossier(self):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+
+        self.assertIsNone(document.get_parent_inbox())
+
 
 class TestDocumentDefaultValues(FunctionalTestCase):
 

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -139,12 +139,12 @@ class ExtractAttachments(grok.View):
                 self.extract_attachments(attachments, delete_action)
                 return self.request.RESPONSE.redirect(
                     "{}/#documents".format(
-                        self.context.get_parent_dossier().absolute_url()))
+                        self.context.get_extraction_parent().absolute_url()))
 
         return super(ExtractAttachments, self).__call__()
 
     def extract_attachments(self, positions, delete_action):
-        docs = self.context.extract_attachments_into_parent_dossier(positions)
+        docs = self.context.extract_attachments_into_parent(positions)
         for document in docs:
             msg = _(u'info_extracted_document',
                     default=u'Created document ${title}',


### PR DESCRIPTION
The mail did not return its parent correctly (None instead of the inbox)
thus creation failed.

Fixes #2235.