### PR TITLE
Purge reference number mapping when dossiers are pasted.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Purge reference number mapping when dossiers are pasted.
+  [deiferni]
+
 - Fix extracting attachments for mails in inboxes.
   [deiferni]
 

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -32,6 +32,16 @@ class ReferenceNumberPrefixAdpater(grok.Adapter):
     def __init__(self, context):
         self.context = context
 
+    def purge_mappings(self):
+        """Purge all child/prefix-mappings for context.
+
+        This is potentially dangerous and should only be used carefully!
+        """
+
+        annotations = unprotected_write(IAnnotations(self.context))
+        annotations.pop(REPOSITORY_FOLDER_KEY, None)
+        annotations.pop(DOSSIER_KEY, None)
+
     def get_reference_mapping(self, obj=None):
         type_key = self.get_type_key(obj)
         annotations = unprotected_write(IAnnotations(self.context))

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -10,7 +10,7 @@ from plone import api
 from Products.CMFCore.utils import getToolByName
 from zope.component import getAdapter
 from zope.lifecycleevent import IObjectRemovedEvent
-from zope.lifecycleevent.interfaces import IObjectAddedEvent
+from zope.lifecycleevent.interfaces import IObjectCopiedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectMovedEvent
 
@@ -116,3 +116,13 @@ def reindex_containing_dossier(dossier, event):
                         if brain.portal_type in ['opengever.task.task',
                             'opengever.inbox.forwarding']:
                             sync_task(brain.getObject(), event)
+
+
+@grok.subscribe(IDossierMarker, IObjectCopiedEvent)
+def purge_reference_number_mappings(copied_dossier, event):
+    """Reset the reference number mapping when copying (or actually pasting)
+    dossiers.
+    """
+
+    prefix_adapter = IReferenceNumberPrefix(copied_dossier)
+    prefix_adapter.purge_mappings()

--- a/opengever/dossier/tests/test_copy_dossier.py
+++ b/opengever/dossier/tests/test_copy_dossier.py
@@ -1,0 +1,43 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.interfaces import IReferenceNumberPrefix
+from opengever.testing import FunctionalTestCase
+from plone import api
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+
+
+class TestCopyDossiers(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCopyDossiers, self).setUp()
+        self.request = self.layer['request']
+
+        self.root = create(Builder('repository_root'))
+        self.source_repo = create(Builder('repository').within(self.root))
+        self.target_repo = create(Builder('repository').within(self.root))
+
+    def test_copying_dossier_purges_child_reference_number_mappings(self):
+        dossier = create(Builder('dossier').within(self.source_repo))
+        subdossier_1 = create(Builder('dossier').within(dossier))
+        subdossier_2 = create(Builder('dossier').within(dossier))
+
+        dossier_copy = api.content.copy(
+            source=dossier, target=self.target_repo)
+
+        # there are two copied subdossiers
+        self.assertEqual(2, len(dossier_copy.listFolderContents()))
+        subdossier1_copy = dossier_copy.listFolderContents()[0]
+
+        # copied dossier contains mappings for copied subdossiers starting at
+        # 1, the mapping was purged on copy
+        ref = IReferenceNumberPrefix(dossier_copy)
+        ref.get_child_mapping(subdossier1_copy)
+        self.assertItemsEqual(
+            [u'1', u'2'], ref.get_child_mapping(subdossier1_copy).keys())
+
+        # there are no more entries for the previous subdossiers
+        intids = getUtility(IIntIds)
+        prefixed_intids = ref.get_prefix_mapping(subdossier1_copy).keys()
+        self.assertNotIn(intids.getId(subdossier_1), prefixed_intids)
+        self.assertNotIn(intids.getId(subdossier_2), prefixed_intids)


### PR DESCRIPTION
When copy-pasting an existing dossier with sub-dossiers, the sub-dossiers's reference numbers are not assigned correctly. This PR fixes that issue by reseting the reference-number mapping when copying (or more exactly when pasting) a dossier.

Fixes #2092.