### PR TITLE
Remove ftw.casauth from development-packages

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -12,8 +12,6 @@ development-packages =
 # https://github.com/4teamwork/opengever.ogds.models/pull/41
   opengever.ogds.models
   ftw.showroom
-# https://github.com/4teamwork/ftw.casauth/pull/8
-  ftw.casauth
 # https://github.com/4teamwork/ooxml_docprops/pull/5
   ooxml-docprops
 


### PR DESCRIPTION
It's been [released](https://pypi.python.org/pypi/ftw.casauth) and [pinned](https://github.com/4teamwork/kgs/commit/7f4cfeda804a50709a45a7ac0943720dbcdd4d39) as 1.1.0.

@deiferni 