### PR TITLE
Readd prepoverlay.js

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Readd prepoverlay.js, was removed by mistake.
+  [phgross]
+
 - Purge reference number mapping when dossiers are pasted.
   [deiferni]
 

--- a/opengever/base/profiles/default/jsregistry.xml
+++ b/opengever/base/profiles/default/jsregistry.xml
@@ -39,8 +39,13 @@
                 insert-after="++resource++opengever.meeting/protocol.js" />
 
     <javascript cacheable="True" compression="safe" cookable="True" expression=""
+                enabled="True" id="++resource++opengever.base/prepoverlay.js" inline="False"
+                insert-after="++resource++opengever.meeting/datetimepicker.js"
+                />
+
+    <javascript cacheable="True" compression="safe" cookable="True" expression=""
                 enabled="True" id="++resource++opengever.base/qtip.js" inline="False"
-                insert-after="++resource++opengever.meeting/datetimepicker.js" />
+                insert-after="++resource++opengever.base/prepoverlay.js" />
 
     <javascript cacheable="True" compression="safe" cookable="True" expression=""
                 enabled="True" id="++resource++opengever.base/tooltip.js" inline="False"


### PR DESCRIPTION
The prepoverlay js was removed by mistake in the javsascript dependencies cleanup PR (see #2159).

@deiferni 

cc @bierik 