### PR TITLE
Disallow moving/copying dossiers to a branch node.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,14 @@ Changelog
 4.11.0 (unreleased)
 -------------------
 
+- Show warning message when adding a repositoryfolder to a leafnode
+  which already contains dossiers.
+  [phgross]
+
+- Check allowedContentTypes before pasting objects from clipboard
+  to avoid pasting dossier into branch nodes.
+  [phgross]
+
 - Use ftw.tabbedview 3.5.4 to fix issue with duplicate history-entries.
   The user no longer has to press the browser-back button twice on
   tabbed-views.

--- a/opengever/base/browser/paste.py
+++ b/opengever/base/browser/paste.py
@@ -32,12 +32,26 @@ class PasteClipboardView(grok.View):
                                     request=self.request, type='error')
             return self.redirect()
 
+        if not self.is_pasting_objects_allowed(objs):
+            msg = _(u"msg_pasting_not_allowed",
+                    default=u"Can't paste items, it's not allowed to add "
+                    "objects of this type.")
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+            return self.redirect()
+
         self.activate_request_layer()
         self.copy_objects(objs)
         msg = _(u"msg_successfuly_pasted",
                 default=u"Objects from clipboard successfully pasted.")
         api.portal.show_message(message=msg, request=self.request, type='info')
         return self.redirect()
+
+    def is_pasting_objects_allowed(self, objs):
+        allowed_content_types = [
+            fti.id for fti in self.context.allowedContentTypes()]
+
+        return all(obj.portal_type in allowed_content_types for obj in objs)
 
     def activate_request_layer(self):
         alsoProvides(self.request, ICopyPasteRequestLayer)

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-05 13:07+0000\n"
+"POT-Creation-Date: 2016-10-18 14:56+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -26,7 +26,7 @@ msgstr "(INAKTIV)"
 msgid "Copy Items"
 msgstr "Kopieren"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:36
+#: ./opengever/base/browser/templates/gever-macros.pt:38
 msgid "No content"
 msgstr "Keine Inhalte"
 
@@ -137,7 +137,7 @@ msgid "help_retention_period"
 msgstr "Zeitraum zwischen dem jüngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses für die Geschäftstätigkeit der Verwaltungseinheit nicht mehr benötigt wird"
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:199
+#: ./opengever/base/adapters.py:209
 msgid "label_already_removed"
 msgstr "-- Bereits gelöscht --"
 
@@ -197,7 +197,7 @@ msgid "label_dateofsubmission"
 msgstr "Anbietezeitpunkt"
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:117
+#: ./opengever/base/browser/templates/gever-macros.pt:120
 msgid "label_default_error_message"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -252,14 +252,14 @@ msgid "label_search"
 msgstr "Suche"
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:116
+#: ./opengever/base/browser/templates/gever-macros.pt:119
 msgid "label_severity_error"
 msgstr "Fehler"
 
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py:24
 #: ./opengever/base/browser/translated_title.py:36
-#: ./opengever/base/widgets.py:77
+#: ./opengever/base/widgets.py:78
 msgid "label_title"
 msgstr "Titel"
 
@@ -304,9 +304,14 @@ msgid "msg_empty_clipboard"
 msgstr "Es können keine Objekte eingefügt werden, die Zwischenablage ist leer."
 
 #. Default: "No items available"
-#: ./opengever/base/widgets.py:49
+#: ./opengever/base/widgets.py:50
 msgid "msg_no_items_available"
 msgstr "Es sind keine Elemente verfügbar."
+
+#. Default: "Can't paste items, it's not allowed to add objects of this type."
+#: ./opengever/base/browser/paste.py:36
+msgid "msg_pasting_not_allowed"
+msgstr "Es ist nicht erlaubt Objekte dieses Typs einzufügen."
 
 #. Default: "Selected objects successfully copied."
 #: ./opengever/base/browser/copy_items.py:36
@@ -314,7 +319,7 @@ msgid "msg_successfuly_copied"
 msgstr "Die selektieren Objekte wurden kopiert."
 
 #. Default: "Objects from clipboard successfully pasted."
-#: ./opengever/base/browser/paste.py:37
+#: ./opengever/base/browser/paste.py:45
 msgid "msg_successfuly_pasted"
 msgstr "Die Objekte der Zwischenablage wurden eingefügt."
 
@@ -363,7 +368,7 @@ msgstr "Haben Sie nicht gefunden, wonach Sie gesucht haben? Die ${advanced_searc
 msgid "search_results_advanced_link"
 msgstr "erweiterte Suche"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:99
+#: ./opengever/base/browser/templates/gever-macros.pt:101
 msgid "show all"
 msgstr "Alle anzeigen"
 
@@ -382,4 +387,3 @@ msgstr "Nicht geprüft"
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr "Nicht klassifiziert"
-

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-05 13:07+0000\n"
+"POT-Creation-Date: 2016-10-18 14:56+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -27,7 +27,7 @@ msgstr "(INACTIF)"
 msgid "Copy Items"
 msgstr "Copier"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:36
+#: ./opengever/base/browser/templates/gever-macros.pt:38
 msgid "No content"
 msgstr "Pas de contenu"
 
@@ -136,7 +136,7 @@ msgid "help_retention_period"
 msgstr "Durée entre la date du document plus récent contenu dans un dossier et la date à partir de laquelle le document n'est plus requis pour les activités administratives"
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:199
+#: ./opengever/base/adapters.py:209
 msgid "label_already_removed"
 msgstr "-- Déjà annulé --"
 
@@ -196,7 +196,7 @@ msgid "label_dateofsubmission"
 msgstr "Date de proposition (des documents)"
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:117
+#: ./opengever/base/browser/templates/gever-macros.pt:120
 msgid "label_default_error_message"
 msgstr "Une erreur est survenue"
 
@@ -251,14 +251,14 @@ msgid "label_search"
 msgstr "Recherche"
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:116
+#: ./opengever/base/browser/templates/gever-macros.pt:119
 msgid "label_severity_error"
 msgstr "Erreur"
 
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py:24
 #: ./opengever/base/browser/translated_title.py:36
-#: ./opengever/base/widgets.py:77
+#: ./opengever/base/widgets.py:78
 msgid "label_title"
 msgstr "Titre"
 
@@ -303,8 +303,13 @@ msgid "msg_empty_clipboard"
 msgstr "Aucun objet ne peut être ajouté, le presse-papier est vide."
 
 #. Default: "No items available"
-#: ./opengever/base/widgets.py:49
+#: ./opengever/base/widgets.py:50
 msgid "msg_no_items_available"
+msgstr ""
+
+#. Default: "Can't paste items, it's not allowed to add objects of this type."
+#: ./opengever/base/browser/paste.py:36
+msgid "msg_pasting_not_allowed"
 msgstr ""
 
 #. Default: "Selected objects successfully copied."
@@ -313,7 +318,7 @@ msgid "msg_successfuly_copied"
 msgstr "Les objets sélectionnés ont été copiés."
 
 #. Default: "Objects from clipboard successfully pasted."
-#: ./opengever/base/browser/paste.py:37
+#: ./opengever/base/browser/paste.py:45
 msgid "msg_successfuly_pasted"
 msgstr "Les objets du presse-papiers ont été ajoutés."
 
@@ -362,7 +367,7 @@ msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search}
 msgid "search_results_advanced_link"
 msgstr "Recherche avancée"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:99
+#: ./opengever/base/browser/templates/gever-macros.pt:101
 msgid "show all"
 msgstr "Tout afficher"
 

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-05 13:07+0000\n"
+"POT-Creation-Date: 2016-10-18 14:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 msgid "Copy Items"
 msgstr ""
 
-#: ./opengever/base/browser/templates/gever-macros.pt:36
+#: ./opengever/base/browser/templates/gever-macros.pt:38
 msgid "No content"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid "help_retention_period"
 msgstr ""
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:199
+#: ./opengever/base/adapters.py:209
 msgid "label_already_removed"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgid "label_dateofsubmission"
 msgstr ""
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:117
+#: ./opengever/base/browser/templates/gever-macros.pt:120
 msgid "label_default_error_message"
 msgstr ""
 
@@ -249,14 +249,14 @@ msgid "label_search"
 msgstr ""
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:116
+#: ./opengever/base/browser/templates/gever-macros.pt:119
 msgid "label_severity_error"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py:24
 #: ./opengever/base/browser/translated_title.py:36
-#: ./opengever/base/widgets.py:77
+#: ./opengever/base/widgets.py:78
 msgid "label_title"
 msgstr ""
 
@@ -300,8 +300,13 @@ msgid "msg_empty_clipboard"
 msgstr ""
 
 #. Default: "No items available"
-#: ./opengever/base/widgets.py:49
+#: ./opengever/base/widgets.py:50
 msgid "msg_no_items_available"
+msgstr ""
+
+#. Default: "Can't paste items, it's not allowed to add objects of this type."
+#: ./opengever/base/browser/paste.py:36
+msgid "msg_pasting_not_allowed"
 msgstr ""
 
 #. Default: "Selected objects successfully copied."
@@ -310,7 +315,7 @@ msgid "msg_successfuly_copied"
 msgstr ""
 
 #. Default: "Objects from clipboard successfully pasted."
-#: ./opengever/base/browser/paste.py:37
+#: ./opengever/base/browser/paste.py:45
 msgid "msg_successfuly_pasted"
 msgstr ""
 
@@ -359,7 +364,7 @@ msgstr ""
 msgid "search_results_advanced_link"
 msgstr ""
 
-#: ./opengever/base/browser/templates/gever-macros.pt:99
+#: ./opengever/base/browser/templates/gever-macros.pt:101
 msgid "show all"
 msgstr ""
 

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -159,3 +159,21 @@ class TestCopyPaste(FunctionalTestCase):
                           'Dossier modified: dossier-1',
                           u'Document added: Testdokum\xe4nt',
                           'Dossier added: dossier-1'], titles)
+
+    @browsing
+    def test_pasting_dossiers_into_a_branch_node_redirects_back_and_shows_statusmessage(self, browser):
+        branch_node = create(Builder('repository'))
+        leaf_node = create(Builder('repository').within(branch_node))
+        dossier = create(Builder('dossier').within(leaf_node))
+
+        browser.login().open(
+            leaf_node, view="copy_items",
+            data={'paths:list': ['/'.join(dossier.getPhysicalPath())]})
+
+        browser.login().open(branch_node)
+        browser.click_on('Paste')
+
+        self.assertEqual(
+            ["Can't paste items, it's not allowed to add objects of this type."],
+            error_messages())
+        self.assertEqual(branch_node.absolute_url(), browser.url)

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -17,11 +17,13 @@ from plone.dexterity.interfaces import IDexterityFTI
 from plone.directives import form, dexterity
 from plone.z3cform.textlines.textlines import TextLinesFieldWidget
 from z3c.relationfield.schema import RelationChoice, RelationList
+from zExceptions import Unauthorized
 from zope import schema
 from zope.component import getUtility
 from zope.interface import Interface, alsoProvides
 from zope.interface import invariant, Invalid
 import logging
+
 
 LOG = logging.getLogger('opengever.dossier')
 
@@ -198,6 +200,13 @@ alsoProvides(IDossier, IFormFieldProvider)
 # TODO: temporary default value (autocompletewidget)
 class AddForm(dexterity.AddForm):
     grok.name('opengever.dossier.businesscasedossier')
+
+    def render(self):
+        fti = getUtility(IDexterityFTI, name=self.portal_type)
+        if fti not in self.context.allowedContentTypes():
+            raise Unauthorized
+
+        return super(AddForm, self).render()
 
     def update(self):
         """Adds a default value for `responsible` to the request so the

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -7,6 +7,7 @@ from opengever.mail.behaviors import ISendableDocsContainer
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
 from Products.CMFCore.utils import getToolByName
+from zExceptions import Unauthorized
 
 
 class TestDossier(FunctionalTestCase):
@@ -104,6 +105,15 @@ class TestDossier(FunctionalTestCase):
 
         self.assertNotIn(self.portal_type,
                          [fti.id for fti in sub.allowedContentTypes()])
+
+    @browsing
+    def test_visiting_dossier_add_form_on_branch_node_raise_unauthorized(self, browser):
+        branch_node = create(Builder('repository'))
+        create(Builder('repository').within(branch_node))
+
+        with self.assertRaises(Unauthorized):
+            browser.login().open(
+                branch_node, view='++add++{}'.format(self.portal_type))
 
     def get_factory_menu_items(self, obj):
         menu = FactoriesMenu(obj)

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-10-18 15:37+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -53,22 +53,22 @@ msgstr "Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf glei
 #. Default: "Common"
 #: ./opengever/repository/behaviors/referenceprefix.py:33
 #: ./opengever/repository/behaviors/responsibleorg.py:12
-#: ./opengever/repository/repositoryfolder.py:28
+#: ./opengever/repository/repositoryfolder.py:30
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:78
+#: ./opengever/repository/repositoryfolder.py:80
 msgid "help_addable_dossier_types"
 msgstr "Wählen Sie die Spezialdossiers aus, die in dieser Ordnungsposition erlaubt sind."
 
 #. Default: "A short summary of the content."
-#: ./opengever/repository/repositoryfolder.py:41
+#: ./opengever/repository/repositoryfolder.py:43
 msgid "help_description"
 msgstr "Eine kurze Beschreibung des Inhalts."
 
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:76
+#: ./opengever/repository/repositoryfolder.py:78
 msgid "label_addable_dossier_types"
 msgstr "Erlaubte Spezialdossiers"
 
@@ -83,17 +83,17 @@ msgid "label_delete_repository"
 msgstr "Ordnungsposition löschen"
 
 #. Default: "Description"
-#: ./opengever/repository/repositoryfolder.py:40
+#: ./opengever/repository/repositoryfolder.py:42
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:70
+#: ./opengever/repository/repositoryfolder.py:72
 msgid "label_former_reference"
 msgstr "Früheres Zeichen"
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:58
+#: ./opengever/repository/repositoryfolder.py:60
 msgid "label_location"
 msgstr "Standort"
 
@@ -103,7 +103,7 @@ msgid "label_reference_number_prefix"
 msgstr "Präfix des Aktenzeichens"
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:63
+#: ./opengever/repository/repositoryfolder.py:65
 msgid "label_referenced_activity"
 msgstr "Leistung"
 
@@ -113,13 +113,13 @@ msgid "label_successfully_deleted"
 msgstr "Die Ordnungsposition wurde erfolgreich gelöscht."
 
 #. Default: "Valid from"
-#: ./opengever/repository/repositoryfolder.py:48
+#: ./opengever/repository/repositoryfolder.py:50
 #: ./opengever/repository/repositoryroot.py:20
 msgid "label_valid_from"
 msgstr "Gültig ab"
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:53
+#: ./opengever/repository/repositoryfolder.py:55
 #: ./opengever/repository/repositoryroot.py:25
 msgid "label_valid_until"
 msgstr "Gültig bis"
@@ -143,6 +143,11 @@ msgstr "Status"
 #: ./opengever/repository/browser/deletion_templates/deletion.pt:26
 msgid "msg_delete_confirmation"
 msgstr "Möchten Sie die aktuelle Ordnungsposition wirklich löschen?"
+
+#. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
+#: ./opengever/repository/repositoryfolder.py:194
+msgid "msg_leafnode_warning"
+msgstr "Sie fügen eine Ordnungsposition einem Blattknoten hinzu, der bereits Dossiers enthält. Dies ist nur vorübergehend erlaubt und darin enthaltene Dossiers müssen anschliessend wieder in einen Blattknoten verschoben werden."
 
 #. Default: "Name"
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt:24
@@ -188,4 +193,3 @@ msgstr "Aufgaben"
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt:25
 msgid "unlock"
 msgstr "Freigeben"
-

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-10-18 15:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,22 +49,22 @@ msgstr "A ce niveau du classement ce numéro de référence existe déjà."
 #. Default: "Common"
 #: ./opengever/repository/behaviors/referenceprefix.py:33
 #: ./opengever/repository/behaviors/responsibleorg.py:12
-#: ./opengever/repository/repositoryfolder.py:28
+#: ./opengever/repository/repositoryfolder.py:30
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:78
+#: ./opengever/repository/repositoryfolder.py:80
 msgid "help_addable_dossier_types"
 msgstr "Sélectionnez les types de dossiers à ajouter pour cette position du classeur"
 
 #. Default: "A short summary of the content."
-#: ./opengever/repository/repositoryfolder.py:41
+#: ./opengever/repository/repositoryfolder.py:43
 msgid "help_description"
 msgstr "Brève description du contenu."
 
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:76
+#: ./opengever/repository/repositoryfolder.py:78
 msgid "label_addable_dossier_types"
 msgstr "Types de dossiers à ajouter"
 
@@ -79,17 +79,17 @@ msgid "label_delete_repository"
 msgstr "Effacer le numéro de la position"
 
 #. Default: "Description"
-#: ./opengever/repository/repositoryfolder.py:40
+#: ./opengever/repository/repositoryfolder.py:42
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:70
+#: ./opengever/repository/repositoryfolder.py:72
 msgid "label_former_reference"
 msgstr "Ancien numéro de référence"
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:58
+#: ./opengever/repository/repositoryfolder.py:60
 msgid "label_location"
 msgstr "Site"
 
@@ -99,7 +99,7 @@ msgid "label_reference_number_prefix"
 msgstr "Préfixe référence"
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:63
+#: ./opengever/repository/repositoryfolder.py:65
 msgid "label_referenced_activity"
 msgstr "Performance"
 
@@ -109,13 +109,13 @@ msgid "label_successfully_deleted"
 msgstr "Le numéro de la position a été effacé avec succès."
 
 #. Default: "Valid from"
-#: ./opengever/repository/repositoryfolder.py:48
+#: ./opengever/repository/repositoryfolder.py:50
 #: ./opengever/repository/repositoryroot.py:20
 msgid "label_valid_from"
 msgstr "Valable de :"
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:53
+#: ./opengever/repository/repositoryfolder.py:55
 #: ./opengever/repository/repositoryroot.py:25
 msgid "label_valid_until"
 msgstr "Valable jusqu'à :"
@@ -139,6 +139,11 @@ msgstr "Etat"
 #: ./opengever/repository/browser/deletion_templates/deletion.pt:26
 msgid "msg_delete_confirmation"
 msgstr "Voulez-vous vraiment effacer le numéro de la position actuel?"
+
+#. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
+#: ./opengever/repository/repositoryfolder.py:194
+msgid "msg_leafnode_warning"
+msgstr ""
 
 #. Default: "Name"
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt:24

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-10-18 15:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,22 +52,22 @@ msgstr ""
 #. Default: "Common"
 #: ./opengever/repository/behaviors/referenceprefix.py:33
 #: ./opengever/repository/behaviors/responsibleorg.py:12
-#: ./opengever/repository/repositoryfolder.py:28
+#: ./opengever/repository/repositoryfolder.py:30
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:78
+#: ./opengever/repository/repositoryfolder.py:80
 msgid "help_addable_dossier_types"
 msgstr ""
 
 #. Default: "A short summary of the content."
-#: ./opengever/repository/repositoryfolder.py:41
+#: ./opengever/repository/repositoryfolder.py:43
 msgid "help_description"
 msgstr ""
 
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:76
+#: ./opengever/repository/repositoryfolder.py:78
 msgid "label_addable_dossier_types"
 msgstr ""
 
@@ -82,17 +82,17 @@ msgid "label_delete_repository"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/repository/repositoryfolder.py:40
+#: ./opengever/repository/repositoryfolder.py:42
 msgid "label_description"
 msgstr ""
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:70
+#: ./opengever/repository/repositoryfolder.py:72
 msgid "label_former_reference"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:58
+#: ./opengever/repository/repositoryfolder.py:60
 msgid "label_location"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgid "label_reference_number_prefix"
 msgstr ""
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:63
+#: ./opengever/repository/repositoryfolder.py:65
 msgid "label_referenced_activity"
 msgstr ""
 
@@ -112,13 +112,13 @@ msgid "label_successfully_deleted"
 msgstr ""
 
 #. Default: "Valid from"
-#: ./opengever/repository/repositoryfolder.py:48
+#: ./opengever/repository/repositoryfolder.py:50
 #: ./opengever/repository/repositoryroot.py:20
 msgid "label_valid_from"
 msgstr ""
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:53
+#: ./opengever/repository/repositoryfolder.py:55
 #: ./opengever/repository/repositoryroot.py:25
 msgid "label_valid_until"
 msgstr ""
@@ -141,6 +141,11 @@ msgstr ""
 #. Default: "Do you really want to delete the current repository?"
 #: ./opengever/repository/browser/deletion_templates/deletion.pt:26
 msgid "msg_delete_confirmation"
+msgstr ""
+
+#. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
+#: ./opengever/repository/repositoryfolder.py:194
+msgid "msg_leafnode_warning"
 msgstr ""
 
 #. Default: "Name"

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -5,9 +5,11 @@ from opengever.base.behaviors.utils import hide_fields_from_behavior
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
 from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.base.interfaces import IReferenceNumber
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.repository import _
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.interfaces import IRepositoryFolderRecords
+from plone import api
 from plone.app.content.interfaces import INameFromTitle
 from plone.dexterity import content
 from plone.directives import form
@@ -186,6 +188,25 @@ class RepositoryFolder(content.Container):
 
 class AddForm(TranslatedTitleAddForm):
     grok.name('opengever.repository.repositoryfolder')
+
+    def render(self):
+        if self.contains_dossiers():
+            msg = _('msg_leafnode_warning',
+                    default=u'You are adding a repositoryfolder to a leafnode '
+                    'which already contains dossiers. This is only '
+                    'temporarily allowed and all dossiers must be moved into '
+                    'a new leafnode afterwards.')
+
+            api.portal.show_message(
+                msg, request=self.request, type='warning')
+
+        return super(AddForm, self).render()
+
+    def contains_dossiers(self):
+        dossiers = api.content.find(context=self.context,
+                                    depth=1,
+                                    object_provides=IDossierMarker)
+        return bool(dossiers)
 
     def updateFields(self):
         super(AddForm, self).updateFields()


### PR DESCRIPTION
Check allowedContentTypes before pasting objects from clipboard. To avoid pasting dossier in to branch_nodes.

Besides the repository add form shows now a warning message when adding a repositoryfolder to a leafnode, which already contains dossiers.
![bildschirmfoto 2016-10-18 um 12 26 39](https://cloud.githubusercontent.com/assets/485755/19476734/1d64212c-953b-11e6-8102-f03261b7bd5a.png)

@deiferni 