### PR TITLE
Add upgradestep which reregisters the prepoverlay JS.

### DIFF
--- a/opengever/base/upgrades/20161018144110_re_register_prepoverlay_js/jsregistry.xml
+++ b/opengever/base/upgrades/20161018144110_re_register_prepoverlay_js/jsregistry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript cacheable="True" compression="safe" cookable="True" expression=""
+              enabled="True" id="++resource++opengever.base/prepoverlay.js" inline="False"
+              insert-after="++resource++opengever.meeting/datetimepicker.js"
+              />
+
+</object>

--- a/opengever/base/upgrades/20161018144110_re_register_prepoverlay_js/upgrade.py
+++ b/opengever/base/upgrades/20161018144110_re_register_prepoverlay_js/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReRegisterPrepoverlayJS(UpgradeStep):
+    """Reregister prepoverlay JS.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Follow up of #2241

I didn't realize that some deployments are created after the #2159 merge from source, so an upgradestep is necessary.

@deiferni 