### PR TITLE
Show statusmessage and redirect back to document when calling a checkin

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 4.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Show statusmessage and redirect back to document when calling a checkin
+  view without selecting documents.
+  [phgross]
 
 
 4.11.0 (2016-10-19)

--- a/opengever/document/checkout/checkin.py
+++ b/opengever/document/checkout/checkin.py
@@ -198,7 +198,8 @@ class CheckinDocuments(layout.FormWrapper, grok.View):
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 
-            return get_containing_document_tab_url(self.context)
+            return self.request.RESPONSE.redirect(
+                get_containing_document_tab_url(self.context))
 
 
 class CheckinDocumentWithoutComment(BrowserView):
@@ -226,7 +227,15 @@ class CheckinDocumentsWithoutComment(CheckinDocumentWithoutComment):
 
     """
     def checkin(self):
-        self.checkin_controller.checkin_documents(self.request.get('paths'))
+        try:
+            self.checkin_controller.checkin_documents(self.request.get('paths'))
+        except NoItemsSelected:
+            msg = _(u'You have not selected any documents')
+            IStatusMessage(self.request).addStatusMessage(
+                msg, type='error')
+
+            return self.request.RESPONSE.redirect(
+                get_containing_document_tab_url(self.context))
 
     def redirect(self):
         return self.request.RESPONSE.redirect(

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
 from opengever.base.interfaces import IRedirector
@@ -375,6 +376,29 @@ class TestCheckinViews(FunctionalTestCase):
         history = repository_tool.getHistory(document2)
         last_entry = repository_tool.retrieve(document2, len(history)-1)
         self.assertEquals(None, last_entry.comment)
+
+    @browsing
+    def test_multi_checkin_shows_message_when_no_documents_are_selected(self, browser):
+        browser.login().open(
+            self.dossier,
+            data={'paths': [],
+                  'checkin_without_comment:method': 1,
+                  '_authenticator': createToken()})
+
+        self.assertEquals(['You have not selected any documents'],
+                          error_messages())
+        self.assertEquals('http://nohost/plone/dossier-1#documents', browser.url)
+
+        browser.login().open(
+            self.dossier,
+            data={'paths': [],
+                  'checkin_documents:method': 1,
+                  '_authenticator': createToken()})
+        browser.click_on('Checkin')
+
+        self.assertEquals(['You have not selected any documents'],
+                          error_messages())
+        self.assertEquals('http://nohost/plone/dossier-1#documents', browser.url)
 
 
 # TODO: rewrite this test-case to express intent


### PR DESCRIPTION
view without selection documents.

Fixes #2252.

@deiferni 
