### PR TITLE
Copy participations whenever a dossier is copied.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.1 (unreleased)
 -------------------
 
+- Copy participations whenever a dossier is copied.
+  [deiferni]
+
 - Add participations box implementation to dossier overview for the new
   contact implementation.
   [phgross]

--- a/opengever/base/oguid.py
+++ b/opengever/base/oguid.py
@@ -17,12 +17,20 @@ class Oguid(object):
     SEPARATOR = ':'
 
     @classmethod
-    def for_object(cls, context):
-        """Create the Oguid of a Plone content object."""
+    def for_object(cls, context, register=False):
+        """Create the Oguid of a Plone content object.
 
-        int_id = getUtility(IIntIds).queryId(context)
+        Optionally also register the object if on intid could be retrieved.
+        This helps generating oguids for objects that are created in the same
+        request and might not have an intid assigned yet.
+
+        """
+        intids = getUtility(IIntIds)
+        int_id = intids.queryId(context)
         if not int_id:
-            return None
+            if not register:
+                return None
+            int_id = intids.register(context)
         return cls(get_current_admin_unit().id(), int_id)
 
     @classmethod

--- a/opengever/base/tests/test_oguid.py
+++ b/opengever/base/tests/test_oguid.py
@@ -55,3 +55,14 @@ class TestOguidFunctional(FunctionalTestCase):
         self.assertEqual(
             'http://example.com/@@resolve_oguid?oguid=foo:1234',
             oguid.get_url())
+
+    def test_oguid_register_registers_intid(self):
+        repo = create(Builder('repository'))
+        dossier = create(Builder('dossier').within(repo))
+
+        copied_dossier = dossier._getCopy(repo)
+        self.assertIsNone(Oguid.for_object(copied_dossier))
+
+        oguid = Oguid.for_object(copied_dossier, register=True)
+        self.assertIsNotNone(oguid)
+        self.assertEqual(oguid, Oguid.for_object(copied_dossier))

--- a/opengever/contact/handlers.py
+++ b/opengever/contact/handlers.py
@@ -1,0 +1,19 @@
+from five import grok
+from opengever.base.model import create_session
+from opengever.contact.models import Participation
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from zope.lifecycleevent.interfaces import IObjectCopiedEvent
+
+
+@grok.subscribe(IDossierMarker, IObjectCopiedEvent)
+def copy_participations(copied_dossier, event):
+    """Make sure that participations are copied as well when copying a dossier.
+    """
+
+    participations = Participation.query.by_dossier(event.original).all()
+    if not participations:
+        return
+
+    session = create_session()
+    for participation in participations:
+        session.add(participation.copy_to_dossier(copied_dossier))

--- a/opengever/contact/tests/test_participation_unit.py
+++ b/opengever/contact/tests/test_participation_unit.py
@@ -18,6 +18,22 @@ class TestContactParticipation(unittest2.TestCase):
         create(Builder('contact_participation')
                .having(contact=self.contact, dossier_oguid=Oguid('foo', 1234)))
 
+    def test_copy_participation(self):
+        participation = create(Builder('contact_participation').having(
+            contact=self.contact,
+            dossier_oguid=Oguid('foo', 1234)))
+        role = create(Builder('participation_role').having(
+            participation=participation,
+            role=u'Sch\xf6ff'))
+
+        copied_participation = participation.copy()
+        self.assertEqual(self.contact, copied_participation.contact)
+        self.assertEqual('foo', copied_participation.dossier_admin_unit_id)
+        self.assertEqual(1234, copied_participation.dossier_int_id)
+        self.assertEqual(1, len(copied_participation.roles))
+        copied_role = copied_participation.roles[0]
+        self.assertEqual(u'Sch\xf6ff', copied_role.role)
+
     def test_participation_can_have_multiple_roles(self):
         participation = create(Builder('contact_participation').having(
             contact=self.contact,
@@ -75,6 +91,18 @@ class TestOgdsUserParticipation(unittest2.TestCase):
             ogds_user=peter,
             dossier_oguid=Oguid('foo', 1234)))
 
+    def test_copy_participation(self):
+        peter = create(Builder('ogds_user').id('peter').as_contact_adapter())
+        participation = create(Builder('ogds_user_participation').having(
+            ogds_user=peter,
+            dossier_oguid=Oguid('foo', 1234)))
+
+        copied_participation = participation.copy()
+        self.assertEqual(peter, copied_participation.ogds_user)
+        self.assertEqual('foo', copied_participation.dossier_admin_unit_id)
+        self.assertEqual(1234, copied_participation.dossier_int_id)
+        self.assertEqual(0, len(copied_participation.roles))
+
 
 class TestOrgRoleParticipation(unittest2.TestCase):
 
@@ -110,3 +138,19 @@ class TestOrgRoleParticipation(unittest2.TestCase):
             role=u'Hanswutscht'))
 
         self.assertEquals([role1, role2], participation.roles)
+
+    def test_copy_participation(self):
+        person = create(Builder('person').having(
+            firstname=u'peter', lastname=u'hans'))
+        organization = create(Builder('organization').named('ACME'))
+        orgrole = create(Builder('org_role').having(
+            person=person, organization=organization, function=u'cheffe'))
+        participation = create(Builder('org_role_participation').having(
+            org_role=orgrole,
+            dossier_oguid=Oguid('foo', 1234)))
+
+        copied_participation = participation.copy()
+        self.assertEqual(orgrole, copied_participation.org_role)
+        self.assertEqual('foo', copied_participation.dossier_admin_unit_id)
+        self.assertEqual(1234, copied_participation.dossier_int_id)
+        self.assertEqual(0, len(copied_participation.roles))


### PR DESCRIPTION
This PR fixes an issue and ensures that participations are copied as well whenever a dossier is copied. 

Closes #2251.