### PR TITLE
Make committee-period dates required.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.1 (unreleased)
 -------------------
 
+- Make period start/end date required.
+  [deiferni]
+
 - Add a tab to list all periods of a committee.
   [deiferni]
 

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -99,9 +99,18 @@ class MeetingExampleContentCreator(object):
         self.create_proposals()
 
     def create_periods(self):
-        create(Builder('period').having(committee=self.committee_law_model))
-        create(Builder('period').having(committee=self.committee_accounting_model))
-        create(Builder('period').having(committee=self.committee_assembly_model))
+        create(Builder('period').having(
+            date_from=date(2016, 1, 1),
+            date_to=date(2016, 12, 31),
+            committee=self.committee_law_model))
+        create(Builder('period').having(
+            date_from=date(2016, 1, 1),
+            date_to=date(2016, 12, 31),
+            committee=self.committee_accounting_model))
+        create(Builder('period').having(
+            date_from=date(2016, 1, 1),
+            date_to=date(2016, 12, 31),
+            committee=self.committee_assembly_model))
 
     def create_members_and_memberships(self):
         peter = create(Builder('member')

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -26,12 +26,12 @@ class IPeriodModel(form.Schema):
 
     date_from = schema.Date(
         description=_('label_date_from', default='Start date'),
-        required=False,
+        required=True,
     )
 
     date_to = schema.Date(
         description=_('label_date_to', default='End date'),
-        required=False,
+        required=True,
     )
 
 

--- a/opengever/meeting/model/period.py
+++ b/opengever/meeting/model/period.py
@@ -38,8 +38,8 @@ class Period(Base):
     workflow_state = Column(String(WORKFLOW_STATE_LENGTH), nullable=False,
                             default=workflow.default_state.name)
     title = Column(String(256), nullable=False)
-    date_from = Column(Date)
-    date_to = Column(Date)
+    date_from = Column(Date, nullable=False)
+    date_to = Column(Date, nullable=False)
     decision_sequence_number = Column(Integer, nullable=False, default=0)
     meeting_sequence_number = Column(Integer, nullable=False, default=0)
 
@@ -47,24 +47,18 @@ class Period(Base):
         return '<Period {}>'.format(repr(self.title))
 
     def get_title(self):
-        if self.date_from or self.date_to:
-            return u'{} ({} - {})'.format(
-                self.title, self.get_date_from(), self.get_date_to())
-        return self.title
+        return u'{} ({} - {})'.format(
+            self.title, self.get_date_from(), self.get_date_to())
 
     def get_date_from(self):
         """Return a localized date."""
 
-        if self.date_from:
-            return api.portal.get_localized_time(datetime=self.date_from)
-        return ''
+        return api.portal.get_localized_time(datetime=self.date_from)
 
     def get_date_to(self):
         """Return a localized date."""
 
-        if self.date_to:
-            return api.portal.get_localized_time(datetime=self.date_to)
-        return ''
+        return api.portal.get_localized_time(datetime=self.date_to)
 
     def execute_transition(self, name):
         self.workflow.execute_transition(self, self, name)

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -17,8 +17,10 @@ class TestCommitteeOverview(FunctionalTestCase):
     def test_shows_current_period_box(self, browser):
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
-        self.assertEqual(unicode(date.today().year),
-                         browser.css('#periodBox li').first.text)
+        this_year = date.today().year
+        self.assertEqual(
+            u'{year} (Jan 01, {year} - Dec 31, {year})'.format(year=this_year),
+            browser.css('#periodBox li').first.text)
 
     @browsing
     def test_membership_box_shows_only_active_members(self, browser):

--- a/opengever/meeting/tests/test_period_query.py
+++ b/opengever/meeting/tests/test_period_query.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.meeting.model import Period
@@ -13,26 +14,37 @@ class TestPeriodQuery(TestCase):
         super(TestPeriodQuery, self).setUp()
 
         self.committee = create(Builder('committee_model'))
-        self.period = create(Builder('period').having(committee=self.committee))
+        self.period = create(
+            Builder('period').having(committee=self.committee,
+                                     date_from=date(2010, 1, 1),
+                                     date_to=date(2010, 12, 31)))
 
     def test_active_returns_only_active(self):
         create(Builder('period').having(workflow_state='closed',
-                                        committee=self.committee))
+                                        committee=self.committee,
+                                        date_from=date(2010, 1, 1),
+                                        date_to=date(2010, 12, 31)))
 
         self.assertEqual([self.period], Period.query.active().all())
 
     def test_by_committee_returns_periods_for_committee_in_all_states(self):
         committee_2 = create(Builder('committee_model').having(int_id=123))
-        create(Builder('period').having(committee=committee_2))
+        create(Builder('period').having(committee=committee_2,
+                                        date_from=date(2010, 1, 1),
+                                        date_to=date(2010, 12, 31)))
 
         period = create(Builder('period').having(workflow_state='closed',
-                                                 committee=self.committee))
+                                                 committee=self.committee,
+                                                 date_from=date(2010, 1, 1),
+                                                 date_to=date(2010, 12, 31)))
 
         self.assertEqual([self.period, period],
                          Period.query.by_committee(self.committee).all())
 
     def test_get_current(self):
         create(Builder('period').having(workflow_state='closed',
-                                        committee=self.committee))
+                                        committee=self.committee,
+                                        date_from=date(2010, 1, 1),
+                                        date_to=date(2010, 12, 31)))
 
         self.assertEqual(self.period, Period.query.get_current(self.committee))

--- a/opengever/meeting/tests/test_periods.py
+++ b/opengever/meeting/tests/test_periods.py
@@ -31,14 +31,15 @@ class TestPeriod(FunctionalTestCase):
         create(Builder('period').having(
             title=u'2011',
             date_from=date(2011, 1, 1),
+            date_to=date(2011, 12, 31),
             committee=self.committee_model))
 
         browser.login().open(self.committee, view='tabbedview_view-periods')
         listing_table = browser.css('.listing').first
         self.assertEqual(
-            [{'To': '', 'From': 'Jan 01, 2011', 'Title': '2011'},
+            [{'From': 'Jan 01, 2016', 'Title': '2016', 'To': 'Dec 31, 2016'},
+             {'To': 'Dec 31, 2011', 'From': 'Jan 01, 2011', 'Title': '2011'},
              {'To': 'Dec 31, 2010', 'From': 'Jan 01, 2010', 'Title': '2010'},
-             {'To': '', 'From': '', 'Title': '2016'},
              ],
             listing_table.dicts())
 
@@ -70,23 +71,6 @@ class TestPeriod(FunctionalTestCase):
         self.assertEqual(u'New', new_period.title)
         self.assertEqual(date(2013, 1, 1), new_period.date_from)
         self.assertEqual(date(2013, 12, 31), new_period.date_to)
-
-    def test_period_title_without_date(self):
-        period = create(Builder('period').having(
-            title=u'Foo', committee=self.committee_model))
-        self.assertEqual(u'Foo', period.get_title())
-
-    def test_period_title_with_start_date(self):
-        period = create(Builder('period').having(
-            title=u'Foo', date_from=date(2010, 1, 1),
-            committee=self.committee_model))
-        self.assertEqual('Foo (Jan 01, 2010 - )', period.get_title())
-
-    def test_period_title_with_end_date(self):
-        period = create(Builder('period').having(
-            title=u'Foo', date_to=date(2010, 12, 31),
-            committee=self.committee_model))
-        self.assertEqual('Foo ( - Dec 31, 2010)', period.get_title())
 
     def test_period_title_with_start_and_end_date(self):
         period = create(Builder('period').having(

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -1,3 +1,4 @@
+from datetime import date
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -75,7 +76,9 @@ class TestUnitMeeting(TestCase):
         self.assertEqual(2, item_1.sort_order)
 
     def test_generate_decision_numbers(self):
-        create(Builder('period').having(committee=self.committee))
+        create(Builder('period').having(committee=self.committee,
+                                        date_from=date(2010, 1, 1),
+                                        date_to=date(2010, 12, 31)))
         item_1 = create(Builder('agenda_item')
                         .having(meeting=self.meeting))
         item_2 = create(Builder('agenda_item')
@@ -93,7 +96,9 @@ class TestUnitMeeting(TestCase):
         self.assertEqual(2, period.decision_sequence_number)
 
     def test_generate_meeting_number(self):
-        create(Builder('period').having(committee=self.committee))
+        create(Builder('period').having(committee=self.committee,
+                                        date_from=date(2010, 1, 1),
+                                        date_to=date(2010, 12, 31)))
 
         self.meeting.generate_meeting_number()
 

--- a/opengever/meeting/upgrades/20161101143905_make_period_dates_required/upgrade.py
+++ b/opengever/meeting/upgrades/20161101143905_make_period_dates_required/upgrade.py
@@ -1,0 +1,48 @@
+from datetime import date
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Date
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+class MakePeriodDatesRequired(SchemaMigration):
+    """Make period dates required.
+    """
+
+    periods_table = table(
+        'periods',
+        column('id'),
+        column('date_from'),
+        column('date_to'),
+    )
+
+    def migrate(self):
+        self.insert_default_period_start_end_date()
+        self.make_period_date_columns_non_nullable()
+
+    def insert_default_period_start_end_date(self):
+        today = date.today()
+        for period in self.connection.execute(
+                self.periods_table.select()).fetchall():
+
+            if period.date_from is None:
+                period_start = date(today.year, 1, 1)
+                self.update_period_record(period, date_from=period_start)
+
+            if period.date_to is None:
+                period_end = date(today.year, 12, 31)
+                self.update_period_record(period, date_to=period_end)
+
+    def update_period_record(self, period, **kwargs):
+        self.execute(
+            self.periods_table.update()
+            .values(**kwargs)
+            .where(self.periods_table.c.id == period.id))
+
+    def make_period_date_columns_non_nullable(self):
+        self.op.alter_column('periods', 'date_from',
+                             existing_type=Date,
+                             nullable=False)
+        self.op.alter_column('periods', 'date_to',
+                             existing_type=Date,
+                             nullable=False)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -356,7 +356,9 @@ class CommitteeBuilder(DexterityBuilder):
         db_session = self.session.session
 
         db_session.add(Period(committee=committee_model,
-                              title=unicode(today.year)))
+                              title=unicode(today.year),
+                              date_from=date(today.year, 1, 1),
+                              date_to=date(today.year, 12, 31)))
 
         if self.session.auto_commit:
             db_session.flush()


### PR DESCRIPTION
This PR makes start and end date of a Period required. This is required to be able to:

- select meetings based on start/end date to create a table of contents for a period
- make sure that no overlapping periods may exist (would add duplicates to aforementioned TOC)

The data-migration part of this upgrade step will set start/end of a period to span the whole current year. This should be a reasonable default but must be validated by the customer after migration.

Part of #1373.