### PR TITLE
LDAPSearch utility: Also consider _extra_user_filter for user_filter expression.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.11.1 (unreleased)
 -------------------
 
+- LDAPSearch utility: Also respect _extra_user_filter property during OGDS sync.
+  [lgraf]
+
 - Make period start/end date required.
   [deiferni]
 

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -251,9 +251,9 @@ class LDAPSearch(grok.Adapter):
             search_filter = '(objectClass=%s)' % user_object_classes[0]
 
         custom_filter = self.get_user_filter()
-        if custom_filter not in [None, '']:
+        if custom_filter:
             custom_filter = self._apply_schema_map_to_filter(custom_filter)
-            search_filter = self._combine_filters(custom_filter, search_filter)
+        search_filter = self._combine_filters(custom_filter, search_filter)
 
         mapped_results = []
         results = self.search(base_dn=self.context.users_base,
@@ -283,8 +283,7 @@ class LDAPSearch(grok.Adapter):
         search_filter = '(|%s)' % possible_classes
 
         custom_filter = self.get_group_filter()
-        if custom_filter not in [None, '']:
-            search_filter = self._combine_filters(custom_filter, search_filter)
+        search_filter = self._combine_filters(custom_filter, search_filter)
 
         results = self.search(base_dn=self.context.groups_base,
                               filter=search_filter)
@@ -441,9 +440,17 @@ class LDAPSearch(grok.Adapter):
 
     def _combine_filters(self, filter_a, filter_b):
         """Combine two LDAP filter expressions with a boolean AND.
+
+        If one of the filters is the empty string, simply return the other one.
         """
-        combined_filter = '(& %s %s)' % (filter_a, filter_b)
-        return combined_filter
+        if filter_a == '':
+            return filter_b
+        elif filter_b == '':
+            return filter_a
+        else:
+            # Both filters are non-empty, need to combine them
+            combined_filter = '(& %s %s)' % (filter_a, filter_b)
+            return combined_filter
 
     def _get_object_classes(self):
         """Returns a list of tuples containing primary and alternative names

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -415,10 +415,17 @@ class LDAPSearch(grok.Adapter):
 
     def get_user_filter(self):
         """Get the user filter expression defined for the adapted
-        LDAPUserFolder from the custom property `user_filter`.
+        LDAPUserFolder by combining the GEVER custom property `user_filter`
+        and the LDAPUserFolder's `_extra_user_filter`.
         """
         uf = self.context
-        return uf.getProperty('user_filter')
+
+        # TODO: Do we still need a custom property for this?
+        user_filter = uf.getProperty('user_filter')
+
+        extra_user_filter = uf.getProperty('_extra_user_filter')
+        user_filter = self._combine_filters(user_filter, extra_user_filter)
+        return user_filter
 
     def get_group_filter(self):
         """Get the group filter expression defined for the adapted

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -145,6 +145,9 @@ class OGDSUpdater(grok.Adapter):
             uid_attr = self._get_uid_attr(ldap_userfolder)
 
             ldap_util = ILDAPSearch(ldap_userfolder)
+            logger.info(u'Users base: %s' % ldap_userfolder.users_base)
+            logger.info(u'User filter: %s' % ldap_util.get_user_filter())
+
             ldap_users = ldap_util.get_users()
 
             for ldap_user in ldap_users:
@@ -226,6 +229,9 @@ class OGDSUpdater(grok.Adapter):
             ldap_userfolder = plugin._getLDAPUserFolder()
 
             ldap_util = ILDAPSearch(ldap_userfolder)
+            logger.info(u'Groups base: %s' % ldap_userfolder.groups_base)
+            logger.info(u'Group filter: %r' % ldap_util.get_group_filter())
+
             ldap_groups = ldap_util.get_groups()
 
             for ldap_group in ldap_groups:
@@ -327,7 +333,7 @@ class OGDSUpdater(grok.Adapter):
                         except MultipleResultsFound:
                             # Duplicate user - skip (see above).
                             logger.warn(
-                                u"Skipping duplicate user '{}'!".format(userid))
+                                u"  Skipping duplicate user '{}'!".format(userid))
                             continue
 
                         contained_users.append(user)

--- a/opengever/ogds/base/tests/ldaphelpers.py
+++ b/opengever/ogds/base/tests/ldaphelpers.py
@@ -19,6 +19,8 @@ class FakeLDAPUserFolder(object):
     def __init__(self):
         self.users = []
         self.groups = []
+        self.users_base = ''
+        self.groups_base = ''
 
     def getSchemaDict(self):
         return (
@@ -69,6 +71,12 @@ class FakeLDAPSearchUtility(object):
 
     def __init__(self, userfolder):
         self.userfolder = userfolder
+
+    def get_user_filter(self):
+        return ''
+
+    def get_group_filter(self):
+        return ''
 
     def get_users(self):
         return self.userfolder.users


### PR DESCRIPTION
This makes sure that the official `_extra_user_filter` property is also respected during OGDS sync, in addition to our custom `user_filter` property.

@phgross @deiferni