### PR TITLE
Prepare forms for TOCs

### DIFF
--- a/opengever/base/browser/modelforms.py
+++ b/opengever/base/browser/modelforms.py
@@ -1,6 +1,6 @@
+from opengever.base import _
 from opengever.base.model import create_session
 from opengever.base.utils import disable_edit_bar
-from opengever.base import _
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from z3c.form import button
@@ -61,14 +61,14 @@ class ModelAddForm(AutoExtensibleForm, AddForm):
         return self.context.absolute_url()
 
 
-class ModelEditForm(EditForm):
+class ModelEditForm(AutoExtensibleForm, EditForm):
     """Base edit-form for stand-alone model objects.
     """
 
     ignoreContext = True
     has_model_breadcrumbs = True
+    schema = None
 
-    fields = None
     field_prefix = 'form.widgets.'
 
     def __init__(self, context, request, model):

--- a/opengever/base/model.py
+++ b/opengever/base/model.py
@@ -76,7 +76,7 @@ class SQLFormSupport(object):
         return True
 
     def get_edit_url(self, context):
-        return self.get_url(view='edit')
+        return self.get_url(context, view='edit')
 
     def get_edit_values(self, fieldnames):
         values = {}

--- a/opengever/contact/models/contact.py
+++ b/opengever/contact/models/contact.py
@@ -47,6 +47,9 @@ class Contact(Base, SQLFormSupport):
     __mapper_args__ = {'polymorphic_on': contact_type,
                        'with_polymorphic': '*'}
 
+    def get_edit_url(self, context):
+        return self.get_url(view='edit')
+
     @property
     def id(self):
         return self.contact_id

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -89,7 +89,7 @@ class Participation(Base, SQLFormSupport):
     def wrapper_id(self):
         return 'participation-{}'.format(self.participation_id)
 
-    def get_url(self, view=u''):
+    def get_url(self, context, view=u''):
         elements = [self.dossier_oguid.resolve_object().absolute_url(),
                     self.wrapper_id]
         if view:

--- a/opengever/contact/participation.py
+++ b/opengever/contact/participation.py
@@ -10,3 +10,6 @@ class IParticipationWrapper(Interface):
 class ParticipationWrapper(SQLWrapperBase):
 
     implements(IParticipationWrapper)
+
+    def absolute_url(self):
+        return self.model.get_url(self.parent)

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -115,4 +115,11 @@
       allowed_attributes="available"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IPeriodWrapper"
+      name="edit"
+      class=".periods.EditPeriod"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -110,7 +110,7 @@ class DownloadProtocolJson(DownloadGeneratedProtocol):
         return self.get_protocol_json(pretty=True)
 
 
-class EditProtocol(AutoExtensibleForm, ModelEditForm):
+class EditProtocol(ModelEditForm):
 
     has_model_breadcrumbs = True
     ignoreContext = True

--- a/opengever/meeting/browser/memberships.py
+++ b/opengever/meeting/browser/memberships.py
@@ -72,9 +72,7 @@ class EditMembership(ModelEditForm):
 
     label = _('label_edit_membership', default=u'Edit Membership')
 
-    fields = field.Fields(IMembershipModel)
-    fields['date_to'].widgetFactory[INPUT_MODE] = DatePickerFieldWidget
-    fields['date_from'].widgetFactory[INPUT_MODE] = DatePickerFieldWidget
+    schema = IMembershipModel
 
     def __init__(self, context, request):
         super(EditMembership, self).__init__(context, request, context.model)

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -1,15 +1,18 @@
 from datetime import date
 from five import grok
+from ftw.datepicker.widget import DatePickerFieldWidget
+from opengever.base.browser.modelforms import ModelAddForm
+from opengever.base.browser.modelforms import ModelEditForm
 from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.meeting import _
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.committee import ICommittee
-from opengever.base.browser.modelforms import ModelAddForm
-from opengever.base.browser.modelforms import ModelEditForm
 from opengever.meeting.model import Period
 from plone.directives import form
+from plone.directives import form
 from plone.z3cform.layout import FormWrapper
+from z3c.form import field
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.interfaces import IDataConverter
@@ -24,11 +27,13 @@ class IPeriodModel(form.Schema):
         max_length=256,
         required=True)
 
+    form.widget(date_from=DatePickerFieldWidget)
     date_from = schema.Date(
         description=_('label_date_from', default='Start date'),
         required=True,
     )
 
+    form.widget(date_to=DatePickerFieldWidget)
     date_to = schema.Date(
         description=_('label_date_to', default='End date'),
         required=True,
@@ -185,3 +190,12 @@ class AddNewPeriodStepView(FormWrapper, grok.View):
 
     def available(self):
         return is_meeting_feature_enabled()
+
+
+class EditPeriod(ModelEditForm):
+
+    fields = field.Fields(IPeriodModel)
+
+
+    def __init__(self, context, request):
+        super(EditPeriod, self).__init__(context, request, context.model)

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from datetime import date
 from five import grok
 from ftw.datepicker.widget import DatePickerFieldWidget
@@ -10,9 +12,7 @@ from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.committee import ICommittee
 from opengever.meeting.model import Period
 from plone.directives import form
-from plone.directives import form
 from plone.z3cform.layout import FormWrapper
-from z3c.form import field
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.interfaces import IDataConverter
@@ -194,8 +194,13 @@ class AddNewPeriodStepView(FormWrapper, grok.View):
 
 class EditPeriod(ModelEditForm):
 
-    fields = field.Fields(IPeriodModel)
+    label = _('label_edit_period', default=u'Edit Period')
 
+    schema = IPeriodModel
 
     def __init__(self, context, request):
         super(EditPeriod, self).__init__(context, request, context.model)
+
+    def nextURL(self):
+        return "{}#periods".format(
+            aq_parent(aq_inner(self.context)).absolute_url())

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -62,6 +62,13 @@ class ICommittee(form.Schema):
         required=False,
     )
 
+    toc_template = RelationChoice(
+        title=_('label_toc_template',
+                default=u'Table of contents template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
     repository_folder = RelationChoice(
         title=_(u'Linked repository folder'),
         description=_(
@@ -202,6 +209,12 @@ class Committee(ModelContainer):
             return self.agendaitem_list_template.to_object
 
         return self.get_committee_container().get_agendaitem_list_template()
+
+    def get_toc_template(self):
+        if self.toc_template:
+            return self.toc_template.to_object
+
+        return self.get_committee_container().get_toc_template()
 
     def get_repository_folder(self):
         return self.repository_folder.to_object

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -7,10 +7,12 @@ from opengever.meeting.committeeroles import CommitteeRoles
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.model import Committee as CommitteeModel
 from opengever.meeting.model import Meeting
+from opengever.meeting.model import Period
 from opengever.meeting.service import meeting_service
 from opengever.meeting.sources import repository_folder_source
 from opengever.meeting.sources import sablon_template_source
 from opengever.meeting.wrapper import MeetingWrapper
+from opengever.meeting.wrapper import PeriodWrapper
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.directives import form
@@ -132,6 +134,12 @@ class Committee(ModelContainer):
             meeting = Meeting.query.get(meeting_id)
             if meeting:
                 return MeetingWrapper.wrap(self, meeting)
+
+        elif id_.startswith('period'):
+            period_id = int(id_.split('-')[-1])
+            period = Period.query.get(period_id)
+            if period:
+                return PeriodWrapper.wrap(self, period)
 
         if default is _marker:
             raise KeyError(id_)

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -34,6 +34,13 @@ class ICommitteeContainer(form.Schema):
         required=False,
     )
 
+    toc_template = RelationChoice(
+        title=_('label_toc_template',
+                default=u'Table of contents template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
 
 class CommitteeContainerAddForm(TranslatedTitleAddForm):
     grok.name('opengever.meeting.committeecontainer')
@@ -79,5 +86,11 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
     def get_agendaitem_list_template(self):
         if self.agendaitem_list_template:
             return self.agendaitem_list_template.to_object
+
+        return None
+
+    def get_toc_template(self):
+        if self.toc_template:
+            return self.toc_template.to_object
 
         return None

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -24,5 +24,9 @@ class IMembershipWrapper(ISQLObjectWrapper):
     """Marker interface for membership object wrappers."""
 
 
+class IPeriodWrapper(ISQLObjectWrapper):
+    """Marker interface for period object wrappers."""
+
+
 class IMeetingDossier(form.Schema):
     """Marker interface for MeetingDossier"""

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-01 08:51+0000\n"
+"POT-Creation-Date: 2016-11-03 14:44+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,12 +48,12 @@ msgstr "Mitgliedschaft hinzufügen"
 msgid "Add committee"
 msgstr "Gremium hinzufügen"
 
-#: ./opengever/meeting/browser/periods.py:40
+#: ./opengever/meeting/browser/periods.py:45
 msgid "Add new period"
 msgstr "Neue Periode hinzufügen"
 
 #: ./opengever/meeting/browser/committeeforms.py:33
-#: ./opengever/meeting/browser/periods.py:125
+#: ./opengever/meeting/browser/periods.py:130
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
@@ -82,7 +82,7 @@ msgstr "Sind Sie sicher das Sie dieses Traktandum beschliessen möchten?"
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr "Die Mitgliedschaft kann nicht erstellt werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis ${date_to} überschneidet."
 
-#: ./opengever/meeting/browser/memberships.py:89
+#: ./opengever/meeting/browser/memberships.py:87
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis zum ${date_to} überschneidet."
 
@@ -94,11 +94,11 @@ msgstr "Traktanden auswählen"
 msgid "Close all proposals"
 msgstr "Alle Anträge werden abgeschlossen"
 
-#: ./opengever/meeting/browser/periods.py:59
+#: ./opengever/meeting/browser/periods.py:64
 msgid "Close currently active period"
 msgstr "Aktuelle Periode abschliessen"
 
-#: ./opengever/meeting/browser/periods.py:39
+#: ./opengever/meeting/browser/periods.py:44
 msgid "Close period"
 msgstr "Periode abschliessen"
 
@@ -150,7 +150,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:53
+#: ./opengever/meeting/committee.py:55
 #: ./opengever/meeting/committeecontainer.py:25
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
@@ -207,7 +207,7 @@ msgstr "Antrag einfügen"
 msgid "Include publish in"
 msgstr "Veröffentlichung in einfügen"
 
-#: ./opengever/meeting/committee.py:66
+#: ./opengever/meeting/committee.py:75
 msgid "Linked repository folder"
 msgstr "Ablageposition"
 
@@ -287,7 +287,7 @@ msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:47
+#: ./opengever/meeting/committee.py:49
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Protocol template"
 msgstr "Vorlage Protokoll"
@@ -357,7 +357,7 @@ msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
 #. Default: "Active"
 #: ./opengever/meeting/model/committee.py:30
-#: ./opengever/meeting/model/period.py:20
+#: ./opengever/meeting/model/period.py:21
 msgid "active"
 msgstr "Aktiv"
 
@@ -414,7 +414,7 @@ msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:80
+#: ./opengever/meeting/browser/periods.py:85
 msgid "button_close_period"
 msgstr "Periode abschliessen"
 
@@ -447,13 +447,13 @@ msgid "close_meeting"
 msgstr "Abschliessen"
 
 #. Default: "Close period"
-#: ./opengever/meeting/model/period.py:28
+#: ./opengever/meeting/model/period.py:29
 msgid "close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/period.py:21
+#: ./opengever/meeting/model/period.py:22
 msgid "closed"
 msgstr "geschlossen"
 
@@ -469,13 +469,13 @@ msgstr "Datum"
 
 #. Default: "Date from"
 #: ./opengever/meeting/tabs/membershiplisting.py:29
-#: ./opengever/meeting/tabs/periodlisting.py:31
+#: ./opengever/meeting/tabs/periodlisting.py:32
 msgid "column_date_from"
 msgstr "Von"
 
 #. Default: "Date to"
 #: ./opengever/meeting/tabs/membershiplisting.py:33
-#: ./opengever/meeting/tabs/periodlisting.py:36
+#: ./opengever/meeting/tabs/periodlisting.py:37
 msgid "column_date_to"
 msgstr "Bis"
 
@@ -528,7 +528,7 @@ msgstr "Status"
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/periodlisting.py:27
+#: ./opengever/meeting/tabs/periodlisting.py:28
 msgid "column_title"
 msgstr "Titel"
 
@@ -555,7 +555,7 @@ msgid "decided"
 msgstr "Beschlossen"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:95
+#: ./opengever/meeting/committee.py:104
 msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
@@ -628,7 +628,7 @@ msgid "label_agendaitem_list"
 msgstr "Traktandenliste"
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:59
+#: ./opengever/meeting/committee.py:61
 #: ./opengever/meeting/committeecontainer.py:31
 msgid "label_agendaitem_list_template"
 msgstr "Vorlage Traktandenliste"
@@ -697,14 +697,14 @@ msgstr "Aktuelle Periode"
 
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:21
-#: ./opengever/meeting/browser/periods.py:28
+#: ./opengever/meeting/browser/periods.py:32
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "Von"
 
 #. Default: "End date"
 #: ./opengever/meeting/browser/memberships.py:26
-#: ./opengever/meeting/browser/periods.py:33
+#: ./opengever/meeting/browser/periods.py:38
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Bis"
@@ -778,6 +778,7 @@ msgstr "Traktandenliste herunterladen"
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
+#: ./opengever/meeting/tabs/periodlisting.py:49
 msgid "label_edit"
 msgstr "Bearbeiten"
 
@@ -795,6 +796,11 @@ msgstr "Abbrechen"
 #: ./opengever/meeting/browser/memberships.py:73
 msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
+
+#. Default: "Edit Period"
+#: ./opengever/meeting/browser/periods.py:197
+msgid "label_edit_period"
+msgstr "Bearbeiten"
 
 #. Default: "Save"
 #: ./opengever/meeting/browser/meetings/meeting.py:360
@@ -830,7 +836,7 @@ msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:94
+#: ./opengever/meeting/committee.py:103
 msgid "label_group"
 msgstr "Gruppe"
 
@@ -868,7 +874,7 @@ msgid "label_linked_meeting"
 msgstr "Sitzung"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:67
+#: ./opengever/meeting/committee.py:76
 msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
@@ -1020,6 +1026,12 @@ msgstr "Start"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "Table of contents template"
+#: ./opengever/meeting/committee.py:68
+#: ./opengever/meeting/committeecontainer.py:38
+msgid "label_toc_template"
+msgstr "Vorlage Inhaltsverzeichnis"
+
 #. Default: "Transition ${transition} executed"
 #: ./opengever/meeting/browser/meetings/transitions.py:25
 msgid "label_transition_executed"
@@ -1109,7 +1121,7 @@ msgid "msg_meeting_successfully_closed"
 msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollauszüge wurden generiert und an die Urprungsdossiers zurückgespielt."
 
 #. Default: "The membership was deleted successfully"
-#: ./opengever/meeting/browser/memberships.py:108
+#: ./opengever/meeting/browser/memberships.py:106
 msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-01 08:51+0000\n"
+"POT-Creation-Date: 2016-11-03 14:44+0000\n"
 "PO-Revision-Date: 2016-08-10 05:19+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -50,12 +50,12 @@ msgstr "Ajouter l'affiliation"
 msgid "Add committee"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:40
+#: ./opengever/meeting/browser/periods.py:45
 msgid "Add new period"
 msgstr ""
 
 #: ./opengever/meeting/browser/committeeforms.py:33
-#: ./opengever/meeting/browser/periods.py:125
+#: ./opengever/meeting/browser/periods.py:130
 msgid "Add period"
 msgstr ""
 
@@ -84,7 +84,7 @@ msgstr ""
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr "Impossible d'ajouter une affiliation, elle se chevauche avec une affiliation existante du ${date_from} jusqu'au ${date_to}"
 
-#: ./opengever/meeting/browser/memberships.py:89
+#: ./opengever/meeting/browser/memberships.py:87
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr ""
 
@@ -96,11 +96,11 @@ msgstr ""
 msgid "Close all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:59
+#: ./opengever/meeting/browser/periods.py:64
 msgid "Close currently active period"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:39
+#: ./opengever/meeting/browser/periods.py:44
 msgid "Close period"
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:53
+#: ./opengever/meeting/committee.py:55
 #: ./opengever/meeting/committeecontainer.py:25
 msgid "Excerpt template"
 msgstr ""
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:66
+#: ./opengever/meeting/committee.py:75
 msgid "Linked repository folder"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
-#: ./opengever/meeting/committee.py:47
+#: ./opengever/meeting/committee.py:49
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Protocol template"
 msgstr ""
@@ -359,7 +359,7 @@ msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
 #. Default: "Active"
 #: ./opengever/meeting/model/committee.py:30
-#: ./opengever/meeting/model/period.py:20
+#: ./opengever/meeting/model/period.py:21
 msgid "active"
 msgstr ""
 
@@ -416,7 +416,7 @@ msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:80
+#: ./opengever/meeting/browser/periods.py:85
 msgid "button_close_period"
 msgstr ""
 
@@ -449,13 +449,13 @@ msgid "close_meeting"
 msgstr ""
 
 #. Default: "Close period"
-#: ./opengever/meeting/model/period.py:28
+#: ./opengever/meeting/model/period.py:29
 msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/period.py:21
+#: ./opengever/meeting/model/period.py:22
 msgid "closed"
 msgstr "Fermé"
 
@@ -471,13 +471,13 @@ msgstr "Date"
 
 #. Default: "Date from"
 #: ./opengever/meeting/tabs/membershiplisting.py:29
-#: ./opengever/meeting/tabs/periodlisting.py:31
+#: ./opengever/meeting/tabs/periodlisting.py:32
 msgid "column_date_from"
 msgstr "De"
 
 #. Default: "Date to"
 #: ./opengever/meeting/tabs/membershiplisting.py:33
-#: ./opengever/meeting/tabs/periodlisting.py:36
+#: ./opengever/meeting/tabs/periodlisting.py:37
 msgid "column_date_to"
 msgstr "Jusqu'à"
 
@@ -530,7 +530,7 @@ msgstr "Etat"
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/periodlisting.py:27
+#: ./opengever/meeting/tabs/periodlisting.py:28
 msgid "column_title"
 msgstr "Titre"
 
@@ -557,7 +557,7 @@ msgid "decided"
 msgstr "Décidé"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:95
+#: ./opengever/meeting/committee.py:104
 msgid "description_group"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgid "label_agendaitem_list"
 msgstr ""
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:59
+#: ./opengever/meeting/committee.py:61
 #: ./opengever/meeting/committeecontainer.py:31
 msgid "label_agendaitem_list_template"
 msgstr ""
@@ -699,14 +699,14 @@ msgstr ""
 
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:21
-#: ./opengever/meeting/browser/periods.py:28
+#: ./opengever/meeting/browser/periods.py:32
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "De"
 
 #. Default: "End date"
 #: ./opengever/meeting/browser/memberships.py:26
-#: ./opengever/meeting/browser/periods.py:33
+#: ./opengever/meeting/browser/periods.py:38
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Jusqu'à"
@@ -780,6 +780,7 @@ msgstr ""
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
+#: ./opengever/meeting/tabs/periodlisting.py:49
 msgid "label_edit"
 msgstr ""
 
@@ -796,6 +797,11 @@ msgstr ""
 #. Default: "Edit Membership"
 #: ./opengever/meeting/browser/memberships.py:73
 msgid "label_edit_membership"
+msgstr ""
+
+#. Default: "Edit Period"
+#: ./opengever/meeting/browser/periods.py:197
+msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
@@ -832,7 +838,7 @@ msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:94
+#: ./opengever/meeting/committee.py:103
 msgid "label_group"
 msgstr ""
 
@@ -870,7 +876,7 @@ msgid "label_linked_meeting"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:67
+#: ./opengever/meeting/committee.py:76
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -1022,6 +1028,12 @@ msgstr "Début"
 msgid "label_title"
 msgstr "Titre"
 
+#. Default: "Table of contents template"
+#: ./opengever/meeting/committee.py:68
+#: ./opengever/meeting/committeecontainer.py:38
+msgid "label_toc_template"
+msgstr ""
+
 #. Default: "Transition ${transition} executed"
 #: ./opengever/meeting/browser/meetings/transitions.py:25
 msgid "label_transition_executed"
@@ -1111,7 +1123,7 @@ msgid "msg_meeting_successfully_closed"
 msgstr ""
 
 #. Default: "The membership was deleted successfully"
-#: ./opengever/meeting/browser/memberships.py:108
+#: ./opengever/meeting/browser/memberships.py:106
 msgid "msg_membership_deleted"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-01 08:51+0000\n"
+"POT-Creation-Date: 2016-11-03 14:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,12 +47,12 @@ msgstr ""
 msgid "Add committee"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:40
+#: ./opengever/meeting/browser/periods.py:45
 msgid "Add new period"
 msgstr ""
 
 #: ./opengever/meeting/browser/committeeforms.py:33
-#: ./opengever/meeting/browser/periods.py:125
+#: ./opengever/meeting/browser/periods.py:130
 msgid "Add period"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr ""
 
-#: ./opengever/meeting/browser/memberships.py:89
+#: ./opengever/meeting/browser/memberships.py:87
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}"
 msgstr ""
 
@@ -93,11 +93,11 @@ msgstr ""
 msgid "Close all proposals"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:59
+#: ./opengever/meeting/browser/periods.py:64
 msgid "Close currently active period"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:39
+#: ./opengever/meeting/browser/periods.py:44
 msgid "Close period"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:53
+#: ./opengever/meeting/committee.py:55
 #: ./opengever/meeting/committeecontainer.py:25
 msgid "Excerpt template"
 msgstr ""
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Include publish in"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:66
+#: ./opengever/meeting/committee.py:75
 msgid "Linked repository folder"
 msgstr ""
 
@@ -286,7 +286,7 @@ msgstr ""
 msgid "Protocol for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:47
+#: ./opengever/meeting/committee.py:49
 #: ./opengever/meeting/committeecontainer.py:19
 msgid "Protocol template"
 msgstr ""
@@ -356,7 +356,7 @@ msgstr ""
 
 #. Default: "Active"
 #: ./opengever/meeting/model/committee.py:30
-#: ./opengever/meeting/model/period.py:20
+#: ./opengever/meeting/model/period.py:21
 msgid "active"
 msgstr ""
 
@@ -413,7 +413,7 @@ msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:80
+#: ./opengever/meeting/browser/periods.py:85
 msgid "button_close_period"
 msgstr ""
 
@@ -446,13 +446,13 @@ msgid "close_meeting"
 msgstr ""
 
 #. Default: "Close period"
-#: ./opengever/meeting/model/period.py:28
+#: ./opengever/meeting/model/period.py:29
 msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
 #: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/period.py:21
+#: ./opengever/meeting/model/period.py:22
 msgid "closed"
 msgstr ""
 
@@ -468,13 +468,13 @@ msgstr ""
 
 #. Default: "Date from"
 #: ./opengever/meeting/tabs/membershiplisting.py:29
-#: ./opengever/meeting/tabs/periodlisting.py:31
+#: ./opengever/meeting/tabs/periodlisting.py:32
 msgid "column_date_from"
 msgstr ""
 
 #. Default: "Date to"
 #: ./opengever/meeting/tabs/membershiplisting.py:33
-#: ./opengever/meeting/tabs/periodlisting.py:36
+#: ./opengever/meeting/tabs/periodlisting.py:37
 msgid "column_date_to"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/meeting/tabs/committeelisting.py:24
 #: ./opengever/meeting/tabs/meetinglisting.py:46
-#: ./opengever/meeting/tabs/periodlisting.py:27
+#: ./opengever/meeting/tabs/periodlisting.py:28
 msgid "column_title"
 msgstr ""
 
@@ -554,7 +554,7 @@ msgid "decided"
 msgstr ""
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:95
+#: ./opengever/meeting/committee.py:104
 msgid "description_group"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgid "label_agendaitem_list"
 msgstr ""
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:59
+#: ./opengever/meeting/committee.py:61
 #: ./opengever/meeting/committeecontainer.py:31
 msgid "label_agendaitem_list_template"
 msgstr ""
@@ -696,14 +696,14 @@ msgstr ""
 
 #. Default: "Start date"
 #: ./opengever/meeting/browser/memberships.py:21
-#: ./opengever/meeting/browser/periods.py:28
+#: ./opengever/meeting/browser/periods.py:32
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr ""
 
 #. Default: "End date"
 #: ./opengever/meeting/browser/memberships.py:26
-#: ./opengever/meeting/browser/periods.py:33
+#: ./opengever/meeting/browser/periods.py:38
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr ""
@@ -777,6 +777,7 @@ msgstr ""
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
+#: ./opengever/meeting/tabs/periodlisting.py:49
 msgid "label_edit"
 msgstr ""
 
@@ -793,6 +794,11 @@ msgstr ""
 #. Default: "Edit Membership"
 #: ./opengever/meeting/browser/memberships.py:73
 msgid "label_edit_membership"
+msgstr ""
+
+#. Default: "Edit Period"
+#: ./opengever/meeting/browser/periods.py:197
+msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
@@ -829,7 +835,7 @@ msgid "label_firstname"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:94
+#: ./opengever/meeting/committee.py:103
 msgid "label_group"
 msgstr ""
 
@@ -867,7 +873,7 @@ msgid "label_linked_meeting"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:67
+#: ./opengever/meeting/committee.py:76
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -1019,6 +1025,12 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "Table of contents template"
+#: ./opengever/meeting/committee.py:68
+#: ./opengever/meeting/committeecontainer.py:38
+msgid "label_toc_template"
+msgstr ""
+
 #. Default: "Transition ${transition} executed"
 #: ./opengever/meeting/browser/meetings/transitions.py:25
 msgid "label_transition_executed"
@@ -1108,7 +1120,7 @@ msgid "msg_meeting_successfully_closed"
 msgstr ""
 
 #. Default: "The membership was deleted successfully"
-#: ./opengever/meeting/browser/memberships.py:108
+#: ./opengever/meeting/browser/memberships.py:106
 msgid "msg_membership_deleted"
 msgstr ""
 

--- a/opengever/meeting/model/membership.py
+++ b/opengever/meeting/model/membership.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from datetime import time
 from opengever.base.model import Base
+from opengever.base.model import SQLFormSupport
 from plone import api
 from sqlalchemy import Column
 from sqlalchemy import Date
@@ -12,12 +13,12 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 
 
-class Membership(Base):
+class Membership(Base, SQLFormSupport):
     """Associate members with their commmission for a certain timespan.
 
     """
     __tablename__ = 'memberships'
-    __mapper_args__= {'order_by': 'date_from'}
+    __mapper_args__ = {'order_by': 'date_from'}
     __table_args__ = (UniqueConstraint('committee_id',
                                        'member_id',
                                        'date_from',
@@ -42,9 +43,6 @@ class Membership(Base):
             self.date_from,
             self.date_to)
 
-    def is_editable(self):
-        return True
-
     def is_removable(self):
         return True
 
@@ -64,25 +62,14 @@ class Membership(Base):
     def title(self):
         return self.member.fullname
 
-    def get_edit_values(self, fieldnames):
-        values = {}
-        for fieldname in fieldnames:
-            value = getattr(self, fieldname, None)
-            if value:
-                values[fieldname] = value
-
-        return values
-
-    def update_model(self, data):
-        for key, value in data.items():
-            setattr(self, key, value)
-
-    def get_url(self, context):
-        return "{}/membership-{}".format(context.absolute_url(),
-                                         self.membership_id)
-
-    def get_edit_url(self, context):
-        return '/'.join((self.get_url(context), 'edit'))
+    def get_url(self, context, view=None):
+        parts = [
+            context.absolute_url(),
+            'membership-{}'.format(self.membership_id),
+        ]
+        if view:
+            parts.append(view)
+        return '/'.join(parts)
 
     def get_remove_url(self, context):
-        return '/'.join((self.get_url(context), 'remove'))
+        return self.get_url(context, view='remove')

--- a/opengever/meeting/model/period.py
+++ b/opengever/meeting/model/period.py
@@ -46,9 +46,19 @@ class Period(Base):
     def __repr__(self):
         return '<Period {}>'.format(repr(self.title))
 
+    def is_editable(self):
+        return True
+
+    def is_removable(self):
+        return False
+
     def get_title(self):
         return u'{} ({} - {})'.format(
             self.title, self.get_date_from(), self.get_date_to())
+
+    def get_url(self, context, view=None):
+        # XXX move to sqlformsupport
+        return "{}/period-{}".format(context.absolute_url(), self.period_id)
 
     def get_date_from(self):
         """Return a localized date."""

--- a/opengever/meeting/model/period.py
+++ b/opengever/meeting/model/period.py
@@ -1,4 +1,5 @@
 from opengever.base.model import Base
+from opengever.base.model import SQLFormSupport
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.workflow import State
@@ -14,7 +15,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 
 
-class Period(Base):
+class Period(Base, SQLFormSupport):
 
     STATE_ACTIVE = State('active', is_default=True,
                          title=_('active', default='Active'))
@@ -46,8 +47,9 @@ class Period(Base):
     def __repr__(self):
         return '<Period {}>'.format(repr(self.title))
 
-    def is_editable(self):
-        return True
+    @property
+    def wrapper_id(self):
+        return 'period-{}'.format(self.period_id)
 
     def is_removable(self):
         return False
@@ -57,8 +59,11 @@ class Period(Base):
             self.title, self.get_date_from(), self.get_date_to())
 
     def get_url(self, context, view=None):
-        # XXX move to sqlformsupport
-        return "{}/period-{}".format(context.absolute_url(), self.period_id)
+        elements = [context.absolute_url(), self.wrapper_id]
+        if view:
+            elements.append(view)
+
+        return '/'.join(elements)
 
     def get_date_from(self):
         """Return a localized date."""
@@ -75,19 +80,6 @@ class Period(Base):
 
     def can_execute_transition(self, name):
         return self.workflow.can_execute_transition(self, name)
-
-    def get_edit_values(self, fieldnames):
-        values = {}
-        for fieldname in fieldnames:
-            value = getattr(self, fieldname, None)
-            if value:
-                values[fieldname] = value
-
-        return values
-
-    def update_model(self, data):
-        for key, value in data.items():
-            setattr(self, key, value)
 
     def get_next_decision_sequence_number(self):
         self.decision_sequence_number += 1

--- a/opengever/meeting/tabs/periodlisting.py
+++ b/opengever/meeting/tabs/periodlisting.py
@@ -29,12 +29,12 @@ class PeriodListingTab(BaseListingTab):
              },
 
             {'column': 'date_from',
-             'column_title': _(u'column_date_from', default=u'From'),
+             'column_title': _(u'column_date_from', default=u'Date from'),
              'transform': lambda item, value: item.get_date_from(),
              },
 
             {'column': 'date_to',
-             'column_title': _(u'column_date_to', default=u'To'),
+             'column_title': _(u'column_date_to', default=u'Date to'),
              'transform': lambda item, value: item.get_date_to(),
              },
             {'column': '',

--- a/opengever/meeting/tabs/periodlisting.py
+++ b/opengever/meeting/tabs/periodlisting.py
@@ -5,6 +5,7 @@ from opengever.meeting import _
 from opengever.meeting.model import Period
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import SqlTableSource
+from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -36,7 +37,17 @@ class PeriodListingTab(BaseListingTab):
              'column_title': _(u'column_date_to', default=u'To'),
              'transform': lambda item, value: item.get_date_to(),
              },
+            {'column': '',
+             'transform': self.get_edit_link,
+             },
             )
+
+    def get_edit_link(self, item, value):
+        url = item.get_edit_url(self.context)
+
+        return '<a  href="{0}" title="{1}" class="edit_period">{1}</a>'.format(
+                url, translate(_('label_edit', default=u'Edit'),
+                               context=self.request))
 
     def get_base_query(self):
         return Period.query.by_committee(self.context.load_model())

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -24,7 +24,9 @@ class TestCommittee(FunctionalTestCase):
         self.repository_folder = create(Builder('repository')
                                         .within(self.repo_root)
                                         .titled('Repo'))
-        self.container = create(Builder('committee_container'))
+        self.template = create(Builder('sablontemplate'))
+        self.container = create(Builder('committee_container')
+                                .having(toc_template=self.template))
 
     def test_committee_can_be_added(self):
         committee = create(Builder('committee').within(self.container))
@@ -33,6 +35,17 @@ class TestCommittee(FunctionalTestCase):
         model = committee.load_model()
         self.assertIsNotNone(model)
         self.assertEqual(Oguid.for_object(committee), model.oguid)
+
+    def test_get_toc_template_returns_committee_template_if_available(self):
+        committee = create(
+            Builder('committee')
+            .having(toc_template=self.template)
+            .within(self.container))
+        self.assertEqual(self.template, committee.get_toc_template())
+
+    def test_get_toc_template_falls_back_to_container(self):
+        committee = create(Builder('committee').within(self.container))
+        self.assertEqual(self.template, committee.get_toc_template())
 
     @browsing
     def test_committee_repository_is_validated(self, browser):
@@ -75,6 +88,7 @@ class TestCommittee(FunctionalTestCase):
             {'Title': u'A c\xf6mmittee',
              'Protocol template': sablon_template,
              'Excerpt template': sablon_template,
+             'Table of contents template': sablon_template,
              'Linked repository folder': self.repository_folder,
              self.group_field_name: 'client1_users'})
         browser.css('#form-buttons-save').first.click()

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -22,8 +22,9 @@ class TestCommitteeContainer(FunctionalTestCase):
         browser.login().open(view='++add++opengever.meeting.committeecontainer')
         browser.fill({'Title (German)': u'Sitzungen',
                       'Title (French)': u's\xe9ance',
-                      'Protocol template':self.template,
-                      'Excerpt template': self.template})
+                      'Protocol template': self.template,
+                      'Excerpt template': self.template,
+                      'Table of contents template': self.template})
 
         browser.find('Save').click()
 
@@ -32,6 +33,19 @@ class TestCommitteeContainer(FunctionalTestCase):
 
         browser.find('DE').click()
         self.assertEquals(u'Sitzungen', browser.css('h1').first.text)
+
+    def test_get_toc_template(self):
+        toc_template = create(
+            Builder('sablontemplate')
+            .attach_file_containing("blabla", name=u'toc.docx'))
+
+        container = create(
+            Builder('committee_container').having(
+                protocol_template=self.template,
+                excerpt_template=self.template,
+                toc_template=toc_template))
+
+        self.assertEqual(toc_template, container.get_toc_template())
 
 
 class TestCommitteesTab(FunctionalTestCase):

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -23,6 +23,14 @@ class TestMemberships(FunctionalTestCase):
         self.member = create(Builder('member'))
         self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
 
+    def test_get_url(self):
+        membership = create(Builder('membership').having(
+            committee=self.committee.load_model(), member=self.member))
+
+        self.assertEqual(
+            'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/membership-1',
+            membership.get_url(self.committee))
+
     @browsing
     def test_membership_can_be_added(self, browser):
         self.assertEqual(0, len(self.committee.get_memberships()))

--- a/opengever/meeting/tests/test_periods.py
+++ b/opengever/meeting/tests/test_periods.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.model import Period
 from opengever.testing import FunctionalTestCase
 
 
@@ -37,11 +38,29 @@ class TestPeriod(FunctionalTestCase):
         browser.login().open(self.committee, view='tabbedview_view-periods')
         listing_table = browser.css('.listing').first
         self.assertEqual(
-            [{'From': 'Jan 01, 2016', 'Title': '2016', 'To': 'Dec 31, 2016'},
-             {'To': 'Dec 31, 2011', 'From': 'Jan 01, 2011', 'Title': '2011'},
-             {'To': 'Dec 31, 2010', 'From': 'Jan 01, 2010', 'Title': '2010'},
+            [{'Date from': 'Jan 01, 2016',
+              'Title': '2016',
+              'Date to': 'Dec 31, 2016',
+              '': 'Edit'},
+             {'Date to': 'Dec 31, 2011',
+              'Date from': 'Jan 01, 2011',
+              'Title': '2011',
+              '': 'Edit'},
+             {'Date to': 'Dec 31, 2010',
+              'Date from': 'Jan 01, 2010',
+              'Title': '2010',
+              '': 'Edit'},
              ],
             listing_table.dicts())
+
+    @browsing
+    def test_edit_period(self, browser):
+        browser.login().open(self.committee, view='tabbedview_view-periods')
+        browser.find('Edit').click()
+        browser.fill({'Start date': 'January 20, 2016'}).submit()
+
+        self.assertEqual(['Changes saved'], info_messages())
+        self.assertEqual(date(2016, 1, 20), Period.query.one().date_from)
 
     @browsing
     def test_close_and_create_new_period(self, browser):

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -32,7 +32,7 @@ class TestTOC(FunctionalTestCase):
             dossier_reference_number='1.1.4 / 1',
             int_id=1))
         proposal1_2 = create(Builder('proposal_model').having(
-            title=u'5 D\xfcnge',
+            title=u'\xdchhh',
             repository_folder_title='Business',
             dossier_reference_number='1.1.4 / 2',
             int_id=2))
@@ -76,18 +76,6 @@ class TestTOC(FunctionalTestCase):
 
     def test_toc(self):
         expected = [{
-            'group_title': u'5',
-            'contents': [
-                {
-                    'title': u'5 D\xfcnge',
-                    'dossier_reference_number': '1.1.4 / 2',
-                    'repository_folder_title': 'Business',
-                    'meeting_date': u'Jan 01, 2010',
-                    'decision_number': 3,
-                    'has_proposal': True,
-                    'meeting_start_page_number': 33,
-                }]
-            }, {
             'group_title': u'A',
             'contents': [
                 {
@@ -109,8 +97,7 @@ class TestTOC(FunctionalTestCase):
                 'decision_number': 2,
                 'has_proposal': True,
                 'meeting_start_page_number': 33,
-
-            }, {
+                }, {
                 'title': u'Proposal 3',
                 'dossier_reference_number': '2.1.4 / 1',
                 'repository_folder_title': 'Stuff',
@@ -118,6 +105,18 @@ class TestTOC(FunctionalTestCase):
                 'decision_number': 4,
                 'has_proposal': True,
                 'meeting_start_page_number': 129,
-            }]
+                }]
+            }, {
+            'group_title': u'\xdc',
+            'contents': [
+                {
+                    'title': u'\xdchhh',
+                    'dossier_reference_number': '1.1.4 / 2',
+                    'repository_folder_title': 'Business',
+                    'meeting_date': u'Jan 01, 2010',
+                    'decision_number': 3,
+                    'has_proposal': True,
+                    'meeting_start_page_number': 33,
+                }]
         }]
         self.assertEqual(expected, AlphabeticalToc(self.period).get_json())

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -1,0 +1,111 @@
+from datetime import date
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.toc.alphabetical import AlphabeticalToc
+from opengever.testing import FunctionalTestCase
+import pytz
+
+
+class TestTOC(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestTOC, self).setUp()
+
+        self.committee = create(Builder('committee_model'))
+        self.meeting1 = create(Builder('meeting').having(
+            committee=self.committee,
+            start=pytz.UTC.localize(datetime(2010, 1, 1, 10, 30)),
+            protocol_start_page_number=33))
+        self.meeting2 = create(Builder('meeting').having(
+            committee=self.committee,
+            start=pytz.UTC.localize(datetime(2010, 12, 31, 18, 30)),
+            protocol_start_page_number=129))
+
+        proposal1_1 = create(Builder('proposal_model').having(
+            title=u'Proposal 1',
+            repository_folder_title='Business',
+            dossier_reference_number='1.1.4 / 1',
+            int_id=1))
+        proposal1_2 = create(Builder('proposal_model').having(
+            title=u'5 Dinge',
+            repository_folder_title='Business',
+            dossier_reference_number='1.1.4 / 2',
+            int_id=2))
+
+        proposal2_1 = create(Builder('proposal_model').having(
+            title=u'Proposal 3',
+            repository_folder_title='Stuff',
+            dossier_reference_number='2.1.4 / 1',
+            int_id=3))
+        proposal2_2 = create(Builder('proposal_model').having(
+            title=u'Anything goes',
+            repository_folder_title='Other Stuff',
+            dossier_reference_number='3.1.4 / 77',
+            int_id=4))
+
+        create(Builder('agenda_item').having(
+            meeting=self.meeting1,
+            proposal=proposal1_1,
+            decision_number=2,
+            ))
+        create(Builder('agenda_item').having(
+            meeting=self.meeting1,
+            proposal=proposal1_2,
+            decision_number=3,
+            ))
+        create(Builder('agenda_item').having(
+            meeting=self.meeting2,
+            proposal=proposal2_1,
+            decision_number=4,
+            ))
+        create(Builder('agenda_item').having(
+            meeting=self.meeting2,
+            proposal=proposal2_2,
+            decision_number=5,
+            ))
+
+        self.period = create(Builder('period').having(
+            date_from=date(2010, 1, 1),
+            date_to=date(2010, 12, 31),
+            committee=self.committee))
+
+    def test_toc(self):
+        expected = [{
+            'title': u'5 Dinge',
+            'dossier_reference_number': '1.1.4 / 2',
+            'repository_folder_title': 'Business',
+            'meeting_date': u'Jan 01, 2010',
+            'decision_number': 3,
+            'has_proposal': True,
+            'meeting_start_page_number': 33,
+        }, {
+            'title': u'Anything goes',
+            'dossier_reference_number': '3.1.4 / 77',
+            'repository_folder_title': 'Other Stuff',
+            'meeting_date': u'Dec 31, 2010',
+            'decision_number': 5,
+            'has_proposal': True,
+            'meeting_start_page_number': 129,
+        }, {
+            'title': u'Proposal 1',
+            'dossier_reference_number': u'1.1.4 / 1',
+            'repository_folder_title': u'Business',
+            'meeting_date': 'Jan 01, 2010',
+            'decision_number': 2,
+            'has_proposal': True,
+            'meeting_start_page_number': 33,
+
+        }, {
+            'title': u'Proposal 3',
+            'dossier_reference_number': '2.1.4 / 1',
+            'repository_folder_title': 'Stuff',
+            'meeting_date': u'Dec 31, 2010',
+            'decision_number': 4,
+            'has_proposal': True,
+            'meeting_start_page_number': 129,
+        }]
+        self.assertEqual(expected, AlphabeticalToc(self.period).get_json())

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -11,6 +11,7 @@ import pytz
 class TestTOC(FunctionalTestCase):
 
     layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+    maxDiff = None
 
     def setUp(self):
         super(TestTOC, self).setUp()
@@ -31,7 +32,7 @@ class TestTOC(FunctionalTestCase):
             dossier_reference_number='1.1.4 / 1',
             int_id=1))
         proposal1_2 = create(Builder('proposal_model').having(
-            title=u'5 Dinge',
+            title=u'5 D\xfcnge',
             repository_folder_title='Business',
             dossier_reference_number='1.1.4 / 2',
             int_id=2))
@@ -75,37 +76,48 @@ class TestTOC(FunctionalTestCase):
 
     def test_toc(self):
         expected = [{
-            'title': u'5 Dinge',
-            'dossier_reference_number': '1.1.4 / 2',
-            'repository_folder_title': 'Business',
-            'meeting_date': u'Jan 01, 2010',
-            'decision_number': 3,
-            'has_proposal': True,
-            'meeting_start_page_number': 33,
-        }, {
-            'title': u'Anything goes',
-            'dossier_reference_number': '3.1.4 / 77',
-            'repository_folder_title': 'Other Stuff',
-            'meeting_date': u'Dec 31, 2010',
-            'decision_number': 5,
-            'has_proposal': True,
-            'meeting_start_page_number': 129,
-        }, {
-            'title': u'Proposal 1',
-            'dossier_reference_number': u'1.1.4 / 1',
-            'repository_folder_title': u'Business',
-            'meeting_date': 'Jan 01, 2010',
-            'decision_number': 2,
-            'has_proposal': True,
-            'meeting_start_page_number': 33,
+            'group_title': u'5',
+            'contents': [
+                {
+                    'title': u'5 D\xfcnge',
+                    'dossier_reference_number': '1.1.4 / 2',
+                    'repository_folder_title': 'Business',
+                    'meeting_date': u'Jan 01, 2010',
+                    'decision_number': 3,
+                    'has_proposal': True,
+                    'meeting_start_page_number': 33,
+                }]
+            }, {
+            'group_title': u'A',
+            'contents': [
+                {
+                    'title': u'Anything goes',
+                    'dossier_reference_number': '3.1.4 / 77',
+                    'repository_folder_title': 'Other Stuff',
+                    'meeting_date': u'Dec 31, 2010',
+                    'decision_number': 5,
+                    'has_proposal': True,
+                    'meeting_start_page_number': 129,
+                }]
+            }, {
+            'group_title': u'P',
+            'contents': [{
+                'title': u'Proposal 1',
+                'dossier_reference_number': u'1.1.4 / 1',
+                'repository_folder_title': u'Business',
+                'meeting_date': 'Jan 01, 2010',
+                'decision_number': 2,
+                'has_proposal': True,
+                'meeting_start_page_number': 33,
 
-        }, {
-            'title': u'Proposal 3',
-            'dossier_reference_number': '2.1.4 / 1',
-            'repository_folder_title': 'Stuff',
-            'meeting_date': u'Dec 31, 2010',
-            'decision_number': 4,
-            'has_proposal': True,
-            'meeting_start_page_number': 129,
+            }, {
+                'title': u'Proposal 3',
+                'dossier_reference_number': '2.1.4 / 1',
+                'repository_folder_title': 'Stuff',
+                'meeting_date': u'Dec 31, 2010',
+                'decision_number': 4,
+                'has_proposal': True,
+                'meeting_start_page_number': 129,
+            }]
         }]
         self.assertEqual(expected, AlphabeticalToc(self.period).get_json())

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -1,6 +1,11 @@
+from itertools import groupby
 from opengever.meeting.model import AgendaItem
-from sqlalchemy.orm import joinedload
 from operator import itemgetter
+from sqlalchemy.orm import joinedload
+
+
+def _first_title_char(value):
+    return value['title'][:1].upper()
 
 
 class AlphabeticalToc(object):
@@ -12,10 +17,10 @@ class AlphabeticalToc(object):
         agenda_items = AgendaItem.query.options(
             joinedload('proposal'), joinedload('meeting'))
 
-        results = []
+        unordered_items = []
         for agenda_item in agenda_items:
             meeting = agenda_item.meeting
-            results.append({
+            unordered_items.append({
                 'title': agenda_item.get_title(),
                 'dossier_reference_number': agenda_item.get_dossier_reference_number(),
                 'repository_folder_title': agenda_item.get_repository_folder_title(),
@@ -24,6 +29,18 @@ class AlphabeticalToc(object):
                 'meeting_date': meeting.get_date(),
                 'meeting_start_page_number': meeting.protocol_start_page_number,
             })
+
+        # input items must be sorted since grouping depends on input order
         # currently sort on the client side since title can be either in the
         # agenda_items table or in the proposals table.
-        return sorted(results, key=itemgetter('title', 'decision_number'))
+        sorted_items = sorted(unordered_items,
+                              key=itemgetter('title', 'decision_number'))
+
+        results = []
+        for character, contents in groupby(sorted_items,
+                                           key=_first_title_char):
+            results.append({
+                'group_title': character,
+                'contents': list(contents)
+            })
+        return sorted(results, key=itemgetter('group_title'))

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -1,0 +1,29 @@
+from opengever.meeting.model import AgendaItem
+from sqlalchemy.orm import joinedload
+from operator import itemgetter
+
+
+class AlphabeticalToc(object):
+
+    def __init__(self, period):
+        self.period = period
+
+    def get_json(self):
+        agenda_items = AgendaItem.query.options(
+            joinedload('proposal'), joinedload('meeting'))
+
+        results = []
+        for agenda_item in agenda_items:
+            meeting = agenda_item.meeting
+            results.append({
+                'title': agenda_item.get_title(),
+                'dossier_reference_number': agenda_item.get_dossier_reference_number(),
+                'repository_folder_title': agenda_item.get_repository_folder_title(),
+                'decision_number': agenda_item.decision_number,
+                'has_proposal': agenda_item.has_proposal,
+                'meeting_date': meeting.get_date(),
+                'meeting_start_page_number': meeting.protocol_start_page_number,
+            })
+        # currently sort on the client side since title can be either in the
+        # agenda_items table or in the proposals table.
+        return sorted(results, key=itemgetter('title', 'decision_number'))

--- a/opengever/meeting/wrapper.py
+++ b/opengever/meeting/wrapper.py
@@ -3,6 +3,7 @@ from opengever.locking.interfaces import ISQLLockable
 from opengever.meeting.interfaces import IMeetingWrapper
 from opengever.meeting.interfaces import IMembershipWrapper
 from opengever.meeting.interfaces import IMemberWrapper
+from opengever.meeting.interfaces import IPeriodWrapper
 from opengever.meeting.model import Membership
 from zope.interface import implements
 
@@ -10,6 +11,16 @@ from zope.interface import implements
 class MeetingWrapper(SQLWrapperBase):
 
     implements(IMeetingWrapper, ISQLLockable)
+
+
+class PeriodWrapper(SQLWrapperBase):
+
+    implements(IPeriodWrapper)
+
+    default_view = 'edit'
+
+    def absolute_url(self):
+        return self.model.get_url(self.parent)
 
 
 class MemberWrapper(SQLWrapperBase):

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -344,6 +344,7 @@ class CommitteeBuilder(DexterityBuilder):
         self.arguments.pop('repository_folder', None)
         self.arguments.pop('excerpt_template', None)
         self.arguments.pop('protocol_template', None)
+        self.arguments.pop('toc_template', None)
 
         obj.create_model(self.arguments, self.container)
         self.create_default_period(obj)

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,6 +7,7 @@ development-packages =
   collective.js.timeago
   plone.restapi
   plone.rest
+  plonetheme.teamraum
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/477.

This PR prepares forms that are required to generate a TOC or to manage the period.

- Add a field for a toc template on commitee-container and committee
- Make Periods editable

It also contains an attempt to use the form/formsupport base-classes whenever possible.

*The CL entry for all these changes will follow in a later PR (in order to avoid splitting the CL entries too much)*

Part of #1373.