### PR TITLE
Fixed manual journal entry creation when users are selected as contacts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed manual journal entry creation when users are selected as contacts.
+  [phgross]
 
 
 4.12.0 (2016-11-03)

--- a/opengever/contact/models/contact.py
+++ b/opengever/contact/models/contact.py
@@ -51,6 +51,10 @@ class Contact(Base, SQLFormSupport):
     def id(self):
         return self.contact_id
 
+    @property
+    def is_adapted_user(self):
+        return False
+
     def has_archived_information(self):
         return any([self.archived_contacts,
                     self.archived_addresses,

--- a/opengever/contact/models/org_role.py
+++ b/opengever/contact/models/org_role.py
@@ -36,6 +36,10 @@ class OrgRole(Base):
         return self.org_role_id
 
     @property
+    def is_adapted_user(self):
+        return False
+
+    @property
     def addresses(self):
         return self.person.addresses + self.organization.addresses
 

--- a/opengever/contact/ogdsuser.py
+++ b/opengever/contact/ogdsuser.py
@@ -146,6 +146,10 @@ class OgdsUserToContactAdapter(BaseAdapter):
     def id(self):
         return self.ogds_user.userid
 
+    @property
+    def is_adapted_user(self):
+        return True
+
     def get_title(self, with_former_id=True):
         return self.ogds_user.label(with_principal=with_former_id)
 

--- a/opengever/journal/entry.py
+++ b/opengever/journal/entry.py
@@ -18,12 +18,13 @@ class ManualJournalEntry(object):
     Its used by the ManualJournalEntry form.
     """
 
-    def __init__(self, context, category, comment, contacts, documents):
+    def __init__(self, context, category, comment, contacts, users, documents):
         self.context = context
         self.request = getRequest()
         self.category = category
         self.comment = comment
         self.contacts = contacts
+        self.users = users
         self.documents = documents
 
     def save(self):
@@ -33,7 +34,8 @@ class ManualJournalEntry(object):
                      'title': self.get_title(),
                      'visible': True,
                      'documents': self.serialize_documents(),
-                     'contacts': self.serialize_contacts()}),
+                     'contacts': self.serialize_contacts(),
+                     'users': self.serialize_users()}),
                  'actor': api.user.get_current().getId(),
                  'comment': self.comment.encode('utf-8')}
 
@@ -61,6 +63,16 @@ class ManualJournalEntry(object):
             value.append(
                 PersistentDict({'id': item.get_contact_id(),
                                 'title': item.get_title()}))
+
+        return value
+
+    def serialize_users(self):
+        """Returns a persistent list of dicts for all users.
+        """
+        value = PersistentList()
+        for item in self.users:
+            value.append(
+                PersistentDict({'id': item.id, 'title': item.get_title()}))
 
         return value
 

--- a/opengever/journal/entry.py
+++ b/opengever/journal/entry.py
@@ -28,6 +28,7 @@ class ManualJournalEntry(object):
         self.documents = documents
 
     def save(self):
+        comment = self.comment.encode('utf-8') if self.comment else ''
         entry = {'obj': self.context,
                  'action': PersistentDict({
                      'type': MANUAL_JOURNAL_ENTRY,
@@ -37,7 +38,7 @@ class ManualJournalEntry(object):
                      'contacts': self.serialize_contacts(),
                      'users': self.serialize_users()}),
                  'actor': api.user.get_current().getId(),
-                 'comment': self.comment.encode('utf-8')}
+                 'comment': comment}
 
         notify(JournalEntryEvent(**entry))
 

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -58,13 +58,29 @@ class ManualJournalEntryAddForm(AddForm):
     fields['contacts'].widgetFactory = AutocompleteMultiFieldWidget
 
     def createAndAdd(self, data):
+        contacts, users = self.split_contacts_and_users(data.get('contacts'))
         entry = ManualJournalEntry(self.context,
                                    data.get('category'),
                                    data.get('comment'),
-                                   data.get('contacts'),
+                                   contacts,
+                                   users,
                                    data.get('related_documents'))
         entry.save()
         return entry
+
+    def split_contacts_and_users(self, items):
+        """Spliting up the contact list, in to a list of contact objects
+        and a list of adapted users.
+        """
+        contacts = []
+        users = []
+        for item in items:
+            if item.is_adapted_user:
+                users.append(item)
+            else:
+                contacts.append(item)
+
+        return contacts, users
 
     def nextURL(self):
         return '{}#journal'.format(self.context.absolute_url())

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -91,6 +91,7 @@ class JournalTab(BaseListingTab):
         """
         self.documents = item.get('action').get('documents', [])
         self.contacts = item.get('action').get('contacts', [])
+        self.users = item.get('action').get('users', [])
         return self.reference_template(self)
 
     def get_contactfolder_url(self):

--- a/opengever/journal/templates/journal_references.pt
+++ b/opengever/journal/templates/journal_references.pt
@@ -1,9 +1,14 @@
-<div class="contacts" tal:condition="view/contacts">
+<div class="contacts" tal:condition="python: view.contacts or view.users"
+     tal:define="portal_url context/@@plone_portal_state/portal_url">
   <p i18n:domain="opengever.journal" i18n:translate="label_contacts">Contacts</p>
   <ul>
     <li tal:repeat="contact view/contacts">
       <a href="#" tal:attributes="href string:${view/get_contactfolder_url}/contact-${contact/id}"
          tal:content="contact/title" />
+    </li>
+    <li tal:repeat="user view/users">
+      <a href="#" tal:attributes="href string:${portal_url}/@@user-details/${user/id}"
+         tal:content="user/title" />
     </li>
   </ul>
 </div>

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -117,3 +117,19 @@ class TestManualJournalEntry(FunctionalTestCase):
             ['http://nohost/plone/@@user-details/peter.mueller'],
             [link.get('href') for link in links])
         self.assertEquals([u'M\xfcller Peter (peter.mueller)'], links.text)
+
+    @browsing
+    def test_supports_adding_an_entry_without_a_comment(self, browser):
+        peter = create(Builder('person')
+                       .having(firstname=u'H\xfcgo', lastname='Boss'))
+
+        browser.login().open(self.dossier, view='add-journal-entry')
+        browser.fill({'Category': u'phone-call',
+                      'Contacts': [get_token(peter)]})
+        browser.css('#form-buttons-add').first.click()
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+
+        self.assertEquals('Manual entry: Phone call', row.dict().get('Title'))
+        self.assertEquals('', row.dict().get('Comments'))

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.contact.ogdsuser import OgdsUserToContactAdapter
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import get_contacts_vocabulary
 
@@ -91,3 +92,28 @@ class TestManualJournalEntry(FunctionalTestCase):
              'http://nohost/plone/opengever-contact-contactfolder/contact-2'],
             [link.get('href') for link in links])
         self.assertEquals([u'Boss H\xfcgo', 'Meier AG'], links.text)
+
+    @browsing
+    def test_adding_a_entry_with_a_user_as_contact(self, browser):
+        peter = create(Builder('ogds_user').having(userid=u'peter.mueller',
+                                                   firstname=u'Peter',
+                                                   lastname=u'M\xfcller'))
+
+        browser.login().open(self.dossier, view='add-journal-entry')
+        browser.fill({
+            'Category': u'phone-call',
+            'Comment': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier',
+            'Contacts': [get_token(OgdsUserToContactAdapter(peter))]})
+        browser.css('#form-buttons-add').first.click()
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+        links = row.css('.contacts a')
+
+        self.assertEquals(u'Contacts M\xfcller Peter (peter.mueller)',
+                          row.dict().get('References'))
+
+        self.assertEquals(
+            ['http://nohost/plone/@@user-details/peter.mueller'],
+            [link.get('href') for link in links])
+        self.assertEquals([u'M\xfcller Peter (peter.mueller)'], links.text)


### PR DESCRIPTION
As discussed I've added a separate list `users` to the PersistentDict, so that references to users are handled separately.

In the journal tab all references (contacts and users) are listed together under the same title, equal than in the form.
<img width="879" alt="bildschirmfoto 2016-11-07 um 17 51 31" src="https://cloud.githubusercontent.com/assets/485755/20091066/10bbc84c-a591-11e6-9446-ef936820100d.png">

Besides the fix for the users references this PR also fix adding entries without a comment.

@deiferni 

