### PR TITLE
Add a column for the issuing org_unit to the task report .xlsx exports

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.12.1 (unreleased)
 -------------------
 
+- Added an issuing org_unit column to excel exports of tasks
+  [Rotonen]
+
 - Provide alphabetical table of contents for all agenda items of a period
   per committee.
   [deiferni]

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -16,6 +16,10 @@ def readable_author(author):
     return Actor.lookup(author).get_label()
 
 
+def issuing_org_unit_label(org_unit):
+    """Helper method which returns the label of the issuing org_unit"""
+    return org_unit().label()
+
 class StringTranslater(object):
     """provide the translate method as helper method
     for the given domain and request"""

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from five import grok
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.reporter import DATE_NUMBER_FORMAT
+from opengever.base.reporter import issuing_org_unit_label
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
@@ -68,6 +69,9 @@ class TaskReporter(grok.View):
             {'id': 'containing_dossier', 'title': _('label_dossier_title')},
             {'id': 'issuer', 'title': _('label_issuer'),
              'transform': readable_author},
+            {'id': 'get_issuing_org_unit',
+             'title': _('label_issuing_org_unit'),
+             'transform': issuing_org_unit_label},
             {'id': 'responsible', 'title': _('label_responsible'),
              'transform': readable_author},
             {'id': 'task_type', 'title': _('label_task_type'),

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -1,23 +1,22 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-11-09 10:25+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: German <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-globalindex/de/>\n"
-"Language: de\n"
+"Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: de\n"
+"X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/globalindex/browser/report.py:92
+#: ./opengever/globalindex/browser/report.py:96
 msgid "Could not generate the report"
 msgstr "Aufgaben Export konnte nicht erstellt werden."
 
@@ -27,56 +26,61 @@ msgid "Export selection"
 msgstr "Auswahl exportieren"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/globalindex/browser/report.py:49
+#: ./opengever/globalindex/browser/report.py:50
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:23
+#: ./opengever/globalindex/browser/report.py:24
 msgid "forwarding_task_type"
 msgstr "Weiterleitung"
 
-#: ./opengever/globalindex/browser/report.py:75
+#: ./opengever/globalindex/browser/report.py:79
 msgid "label_admin_unit_id"
 msgstr "Verwaltungseinheit"
 
-#: ./opengever/globalindex/browser/report.py:66
+#: ./opengever/globalindex/browser/report.py:67
 msgid "label_completed"
 msgstr "Erledigt am"
 
-#: ./opengever/globalindex/browser/report.py:64
+#: ./opengever/globalindex/browser/report.py:65
 msgid "label_deadline"
 msgstr "Frist"
 
-#: ./opengever/globalindex/browser/report.py:68
+#: ./opengever/globalindex/browser/report.py:69
 msgid "label_dossier_title"
 msgstr "Dossier Titel"
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py:70
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
-#: ./opengever/globalindex/browser/report.py:71
+#: ./opengever/globalindex/browser/report.py:73
+msgid "label_issuing_org_unit"
+msgstr "Auftraggeber Mandant"
+
+#: ./opengever/globalindex/browser/report.py:75
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
-#: ./opengever/globalindex/browser/report.py:76
+#: ./opengever/globalindex/browser/report.py:80
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
-#: ./opengever/globalindex/browser/report.py:60
+#: ./opengever/globalindex/browser/report.py:61
 msgid "label_task_title"
 msgstr "Aufgabentitel"
 
-#: ./opengever/globalindex/browser/report.py:73
+#: ./opengever/globalindex/browser/report.py:77
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:84
+#: ./opengever/globalindex/browser/report.py:88
 msgid "label_tasks"
 msgstr "Tasks"
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py:62
 msgid "review_state"
 msgstr "Status"
+

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -1,23 +1,22 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-11-09 10:25+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-globalindex/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/globalindex/browser/report.py:92
+#: ./opengever/globalindex/browser/report.py:96
 msgid "Could not generate the report"
 msgstr "Impossible de générer l'export de tâches"
 
@@ -27,56 +26,61 @@ msgid "Export selection"
 msgstr "Exporter choix"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/globalindex/browser/report.py:49
+#: ./opengever/globalindex/browser/report.py:50
 msgid "error_no_items"
 msgstr "Aucun élément sélectionné"
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:23
+#: ./opengever/globalindex/browser/report.py:24
 msgid "forwarding_task_type"
 msgstr "Transmission"
 
-#: ./opengever/globalindex/browser/report.py:75
+#: ./opengever/globalindex/browser/report.py:79
 msgid "label_admin_unit_id"
 msgstr "Unité administrative"
 
-#: ./opengever/globalindex/browser/report.py:66
+#: ./opengever/globalindex/browser/report.py:67
 msgid "label_completed"
 msgstr "Accompli le"
 
-#: ./opengever/globalindex/browser/report.py:64
+#: ./opengever/globalindex/browser/report.py:65
 msgid "label_deadline"
 msgstr "Délai"
 
-#: ./opengever/globalindex/browser/report.py:68
+#: ./opengever/globalindex/browser/report.py:69
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py:70
 msgid "label_issuer"
 msgstr "Mandataire"
 
-#: ./opengever/globalindex/browser/report.py:71
+#: ./opengever/globalindex/browser/report.py:73
+msgid "label_issuing_org_unit"
+msgstr ""
+
+#: ./opengever/globalindex/browser/report.py:75
 msgid "label_responsible"
 msgstr "Mandataire"
 
-#: ./opengever/globalindex/browser/report.py:76
+#: ./opengever/globalindex/browser/report.py:80
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
-#: ./opengever/globalindex/browser/report.py:60
+#: ./opengever/globalindex/browser/report.py:61
 msgid "label_task_title"
 msgstr "Titre de tâche"
 
-#: ./opengever/globalindex/browser/report.py:73
+#: ./opengever/globalindex/browser/report.py:77
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:84
+#: ./opengever/globalindex/browser/report.py:88
 msgid "label_tasks"
 msgstr "Mandats"
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py:62
 msgid "review_state"
 msgstr "Etat"
+

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2016-11-09 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.globalindex\n"
 
-#: ./opengever/globalindex/browser/report.py:92
+#: ./opengever/globalindex/browser/report.py:96
 msgid "Could not generate the report"
 msgstr ""
 
@@ -27,57 +27,61 @@ msgid "Export selection"
 msgstr ""
 
 #. Default: "You have not selected any Items"
-#: ./opengever/globalindex/browser/report.py:49
+#: ./opengever/globalindex/browser/report.py:50
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:23
+#: ./opengever/globalindex/browser/report.py:24
 msgid "forwarding_task_type"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:75
+#: ./opengever/globalindex/browser/report.py:79
 msgid "label_admin_unit_id"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:66
+#: ./opengever/globalindex/browser/report.py:67
 msgid "label_completed"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:64
+#: ./opengever/globalindex/browser/report.py:65
 msgid "label_deadline"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:68
+#: ./opengever/globalindex/browser/report.py:69
 msgid "label_dossier_title"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py:70
 msgid "label_issuer"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:71
+#: ./opengever/globalindex/browser/report.py:73
+msgid "label_issuing_org_unit"
+msgstr ""
+
+#: ./opengever/globalindex/browser/report.py:75
 msgid "label_responsible"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:76
+#: ./opengever/globalindex/browser/report.py:80
 msgid "label_sequence_number"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:60
+#: ./opengever/globalindex/browser/report.py:61
 msgid "label_task_title"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:73
+#: ./opengever/globalindex/browser/report.py:77
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:84
+#: ./opengever/globalindex/browser/report.py:88
 msgid "label_tasks"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py:62
 msgid "review_state"
 msgstr ""
 

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -35,6 +35,7 @@ class TestTaskReporter(FunctionalTestCase):
              None,
              None,
              u'Test User (test_user_1_)',
+             u'Client1',
              u'Test User (test_user_1_)',
              u'To comment',
              u'client1',


### PR DESCRIPTION
* Add a transform to the reporter to get the org_unit label
* Add the column to the excel export functionality
* Amend the tests
* Amend the locales
  * Only the German locale is filled 
* Add a changelog entry

Fixes #2210