### PR TITLE
Fix public_trial being hidden on document views after visiting a dossier

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.12.1 (unreleased)
 -------------------
 
+- Fix public_trial being hidden on document views after visiting a dossier.
+  [Rotonen]
+
 - Update collective quickupload to 1.9.0 to prevent construction of partial files.
   [deiferni]
 

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -624,3 +624,24 @@ class TestPublicTrial(FunctionalTestCase):
         # check if object got indexed
         self.assertEquals('private',
                           index_data_for(self.document).get('public_trial'))
+
+    @browsing
+    def test_public_trial_is_displayed(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier A'))
+        document = create(Builder('document').within(dossier))
+
+        browser.login().open(document, view='view')
+
+        self.assertTrue(
+            browser.css('#form-widgets-IClassification-public_trial'))
+
+    @browsing
+    def test_public_trial_is_displayed_after_visiting_a_dossier(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier A'))
+        document = create(Builder('document').within(dossier))
+
+        browser.login().open(dossier, view='view')
+        browser.open(document, view='view')
+
+        self.assertTrue(
+            browser.css('#form-widgets-IClassification-public_trial'))

--- a/opengever/dossier/browser/default_view.py
+++ b/opengever/dossier/browser/default_view.py
@@ -10,7 +10,7 @@ class DossierDefaultView(OGDefaultView):
 
     @property
     def omitted_fields(self):
-        fields = super(DossierDefaultView, self).omitted_fields
-        fields.extend(['IClassification.public_trial',
-                       'IClassification.public_trial_statement'])
+        fields = ['IClassification.public_trial',
+                  'IClassification.public_trial_statement']
+        fields.extend(super(DossierDefaultView, self).omitted_fields)
         return fields


### PR DESCRIPTION
* Changelog entry
* Test cases
* Modify self instead of the ancestor in dossier field exclusions for views

Fixes #2208