### PR TITLE
Fix setting of default values for quickuploaded documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.12.1 (unreleased)
 -------------------
 
+- Fix setting of default values for quickuploaded documents.
+  [lgraf]
+
 - Fix public_trial being hidden on document views after visiting a dossier.
   [Rotonen]
 

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -4,15 +4,10 @@ from os.path import join
 from os.path import splitext
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
-from plone.dexterity.utils import iterSchemata
-from plone.rfc822.interfaces import IPrimaryField
 from plone.rfc822.interfaces import IPrimaryFieldInfo
-from z3c.form.interfaces import IValue
-from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.lifecycleevent import ObjectCreatedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
-from zope.schema import getFieldsInOrder
 
 
 class CreateDocumentCommand(object):
@@ -43,7 +38,6 @@ class CreateDocumentCommand(object):
         # Temporarily acquisition wrap content to make adaptation work
         content = content.__of__(self.context)
         self.set_primary_field_value(content)
-        self.set_default_values(content, self.context)
         self.notify_created(content)
 
         # Remove temporary acquisition wrapper
@@ -76,35 +70,6 @@ class CreateDocumentCommand(object):
         value = field._type(data=self.data, filename=self.filename,
                             contentType=self.content_type)
         field.set(field.interface(obj), value)
-
-    def set_default_values(self, content, container):
-        """Set default values for all fields.
-
-        This is necessary for content created programmatically since dexterity
-        only sets default values in a view.
-
-        """
-        for schema in iterSchemata(content):
-            for name, field in getFieldsInOrder(schema):
-                if name in self.skip_defaults_fields:
-                    continue
-                if IPrimaryField.providedBy(field):
-                    continue
-                else:
-                    default = queryMultiAdapter(
-                        (container, container.REQUEST, None, field, None),
-                        IValue, name='default')
-                    if default is not None:
-                        default = default.get()
-                    if default is None:
-                        default = getattr(field, 'default', None)
-                    if default is None:
-                        try:
-                            default = field.missing_value
-                        except AttributeError:
-                            pass
-                    value = default
-                    field.set(field.interface(content), value)
 
 
 class CreateEmailCommand(CreateDocumentCommand):

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -27,7 +27,7 @@ class CreateDocumentCommand(object):
         self.context = context
         self.data = data
         self.filename = filename
-        self.title = title or filename
+        self.title = title
         self.content_type = content_type
         self.additional_args = kwargs
 

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -81,6 +81,12 @@ class CreateEmailCommand(CreateDocumentCommand):
     """
     portal_type = 'ftw.mail.mail'
 
+    def notify_created(self, content):
+        """Make sure filename is updated from subject upon creation.
+        """
+        content._update_title_from_message_subject()
+        notify(ObjectCreatedEvent(content))
+
     def is_msg_upload(self):
         root, ext = splitext(self.filename)
         return ext.lower() == '.msg'

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -77,9 +77,11 @@ class OGQuickUploadCapableFileFactory(grok.Adapter):
                  data, portal_type):
 
         if self.is_email_upload(filename):
-            command = CreateEmailCommand(self.context, filename, data)
+            command = CreateEmailCommand(
+                self.context, filename, data, description=description)
         else:
-            command = CreateDocumentCommand(self.context, filename, data)
+            command = CreateDocumentCommand(
+                self.context, filename, data, description=description)
 
         obj = command.execute()
 

--- a/opengever/base/tests/test_classification.py
+++ b/opengever/base/tests/test_classification.py
@@ -51,6 +51,22 @@ class TestClassificationDefault(FunctionalTestCase):
         self.assertEqual(u'confidential', value)
 
     @browsing
+    def test_classification_acquires_default_with_quickupload(self, browser):
+        browser.login().open(self.repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
+        browser.fill(
+            {'Title': 'My Dossier', 'Classification': 'confidential'}).save()
+        dossier = browser.context
+        transaction.commit()
+
+        document = create(Builder('quickuploaded_document')
+                          .within(dossier)
+                          .with_data('text'))
+
+        value = self.get_classification(document)
+        self.assertEqual(u'confidential', value)
+
+    @browsing
     def test_intermediate_folder_doesnt_break_default_aq(self, browser):
         # An intermediate folderish object that doesn't have the respective
         # field shouldn't break acquisition of the default

--- a/opengever/testing/builders/qickupload.py
+++ b/opengever/testing/builders/qickupload.py
@@ -19,7 +19,7 @@ class QuickuploadMailBuilder(PloneObjectBuilder):
 
         result = factory(filename=self.filename,
                          title='',  # ignored by adapter
-                         description='',  # ignored by adapter
+                         description=None,
                          content_type='message/rfc822',
                          data=self.data,
                          portal_type='ftw.mail.mail')
@@ -52,7 +52,7 @@ class QuickuploadDocumentBuilder(PloneObjectBuilder):
 
         result = factory(filename=self.filename,
                          title='',  # ignored by adapter
-                         description='',  # ignored by adapter
+                         description=None,
                          content_type=self.content_type,
                          data=self.data,
                          portal_type='opengever.document.document')


### PR DESCRIPTION
When uploading documents with quickupload, default values were previously set incorrectly, because the `CreateDocumentCommand` attempted to set the default values itself (improperly, as it turns out).

Setting of default values is now handled by centralized patches in `opengever.base`, so this should be dropped. Fixes #2268

@phgross @deiferni 