### PR TITLE
Register OGDefaultView for all contenttypes, to hide the form helpers in tasks detail view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Register OGDefaultView for all contenttypes, to hide the form
+  helpers in tasks detailview.
+  [phgross]
 
 
 4.13.0 (2016-11-14)

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -22,7 +22,15 @@
 
     <browser:page
         name="view"
-        for="plone.dexterity.interfaces.IDexterityContent"
+        for="plone.dexterity.interfaces.IDexterityItem"
+        class=".default_view.OGDefaultView"
+        permission="zope2.View"
+        layer="opengever.base.interfaces.IOpengeverBaseLayer"
+        />
+
+    <browser:page
+        name="view"
+        for="plone.dexterity.interfaces.IDexterityContainer"
         class=".default_view.OGDefaultView"
         permission="zope2.View"
         layer="opengever.base.interfaces.IOpengeverBaseLayer"

--- a/opengever/base/tests/test_default_view.py
+++ b/opengever/base/tests/test_default_view.py
@@ -1,0 +1,14 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestOGDefaultView(FunctionalTestCase):
+
+    @browsing
+    def tests_default_view_does_not_show_help_messages(self, browser):
+        task = create(Builder('task'))
+        browser.login().open(task, view='view')
+
+        self.assertEquals([], browser.css('.formHelp'))


### PR DESCRIPTION
Because plone.app.dexterity also register a view for `IDexterityItem` and `IDexterityContent` our `OGDefaultView` has to be registered for both detailed interface `IDexterityItem` and `IDexterityContent` instead of using the base inteface `IDexterityContent` (see https://github.com/plone/plone.app.dexterity/blob/master/plone/app/dexterity/browser/configure.zcml#L7-L22.

Fixes #2214 

@deiferni 