### PR TITLE
Add excel export functionality for documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Added excel export functionality to document listings
+  [Rotonen]
+
 - Add dossier resolving jobs:
 
   - Trigger archival_file conversion.

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -24,12 +24,10 @@ def readable_author(author):
 
     return Actor.lookup(author).get_label()
 
+
 def readable_date(date):
     """Helper method to return a localized date"""
-    if date:
-        return get_localized_time(date)
-    else:
-        return None
+    return get_localized_time(date) if date else None
 
 
 class StringTranslater(object):

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -31,10 +31,6 @@ def readable_date(date):
     else:
         return None
 
-def issuing_org_unit_label(org_unit):
-    """Helper method which returns the label of the issuing org_unit"""
-    return org_unit().label()
-
 
 class StringTranslater(object):
     """provide the translate method as helper method

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -98,11 +98,10 @@ class XLSReporter(object):
             cell.font = title_font
 
     def insert_value_rows(self, sheet):
-        for row, dossier in enumerate(self.results, 2):
+        for row, obj in enumerate(self.results, 2):
             for column, attr in enumerate(self.attributes, 1):
                 cell = sheet.cell(row=row, column=column)
-
-                value = getattr(dossier, attr.get('id'))
+                value = getattr(obj, attr.get('id'))
                 if attr.get('transform'):
                     value = attr.get('transform')(value)
                 if value == MissingValue:

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -9,6 +9,14 @@ from zope.i18n import translate
 DATE_NUMBER_FORMAT = 'DD.MM.YYYY'
 
 
+def value(input_string):
+    """Return unicode"""
+
+    if not isinstance(input_string, unicode):
+        input_string = input_string.decode('utf-8')
+    return input_string
+
+
 def readable_author(author):
     """Helper method which returns the author description,
     instead of the userid"""
@@ -19,6 +27,7 @@ def readable_author(author):
 def issuing_org_unit_label(org_unit):
     """Helper method which returns the label of the issuing org_unit"""
     return org_unit().label()
+
 
 class StringTranslater(object):
     """provide the translate method as helper method

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -2,6 +2,7 @@ from Missing import Value as MissingValue
 from opengever.ogds.base.actor import Actor
 from openpyxl import Workbook
 from openpyxl.styles import Font
+from plone.api.portal import get_localized_time
 from StringIO import StringIO
 from zope.i18n import translate
 
@@ -23,6 +24,12 @@ def readable_author(author):
 
     return Actor.lookup(author).get_label()
 
+def readable_date(date):
+    """Helper method to return a localized date"""
+    if date:
+        return get_localized_time(date)
+    else:
+        return None
 
 def issuing_org_unit_label(org_unit):
     """Helper method which returns the label of the issuing org_unit"""

--- a/opengever/document/browser/report.py
+++ b/opengever/document/browser/report.py
@@ -52,8 +52,6 @@ class DocumentReporter(grok.View):
         ]
 
     def get_selected_documents(self):
-
-        # get the given documents
         catalog = getToolByName(self.context, 'portal_catalog')
         documents = []
         for path in self.request.get('paths'):
@@ -63,7 +61,6 @@ class DocumentReporter(grok.View):
         return documents
 
     def render(self):
-
         if not self.request.get('paths'):
             msg = _(
                 u'error_no_items', default=u'You have not selected any Items')

--- a/opengever/document/browser/report.py
+++ b/opengever/document/browser/report.py
@@ -1,0 +1,96 @@
+from five import grok
+from opengever.base.behaviors.utils import set_attachment_content_disposition
+from opengever.base.reporter import readable_author
+from opengever.base.reporter import readable_date
+from opengever.base.reporter import StringTranslater
+from opengever.base.reporter import XLSReporter
+from opengever.document import _
+from Products.CMFCore.utils import getToolByName
+from Products.statusmessages.interfaces import IStatusMessage
+from zope.interface import Interface
+
+
+class DocumentReporter(grok.View):
+    """View that generates an excel spreadsheet with the XLSReporter,
+    listing the selected documents (paths in request)
+    and their important attributes.
+    """
+
+    grok.context(Interface)
+    grok.name('document_report')
+    grok.require('zope2.View')
+
+    def get_document_attributes(self):
+        return [
+            {'id': 'reference',
+             'title': _(u'label_document_reference_number')},
+            {'id': 'sequence_number',
+             'title': _(u'label_document_sequence_number')},
+            {'id': 'Title',
+             'title': _(u'label_title')},
+            {'id': 'document_author',
+             'title': _(u'label_author'),
+             'transform': readable_author},
+            {'id': 'document_date',
+             'title': _(u'label_document_date'),
+             'transform': readable_date},
+            {'id': 'receipt_date',
+             'title': _(u'label_document_receipt_date'),
+             'transform': readable_date},
+            {'id': 'delivery_date',
+             'title': _(u'label_document_delivery_date'),
+             'transform': readable_date},
+            {'id': 'checked_out',
+             'title': _(u'label_document_checked_out_by'),
+             'transform': readable_author},
+            {'id': 'public_trial',
+             'title': _(u'label_public_trial'),
+             'transform': StringTranslater(
+                 self.request, 'opengever.base').translate},
+            {'id': 'containing_dossier',
+             'title': _(u'label_dossier_title')},
+        ]
+
+    def get_selected_documents(self):
+
+        # get the given documents
+        catalog = getToolByName(self.context, 'portal_catalog')
+        documents = []
+        for path in self.request.get('paths'):
+            documents.append(
+                catalog(path={'query': path, 'depth': 0})[0]
+                )
+        return documents
+
+    def render(self):
+
+        if not self.request.get('paths'):
+            msg = _(
+                u'error_no_items', default=u'You have not selected any Items')
+            IStatusMessage(self.request).addStatusMessage(msg, type='error')
+            return_temp = self.request.get(
+                'orig_template', self.context.absolute_url())
+
+            return self.request.RESPONSE.redirect(return_temp)
+
+        documents = self.get_selected_documents()
+
+        # generate the xls data with the XLSReporter
+        reporter = XLSReporter(
+            self.request, self.get_document_attributes(), documents)
+
+        data = reporter()
+        if not data:
+            msg = _(u'Could not generate the report')
+            IStatusMessage(self.request).addStatusMessage(
+                msg, type='error')
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+        response = self.request.RESPONSE
+
+        response.setHeader(
+            'Content-Type',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        set_attachment_content_disposition(self.request, "document_report.xlsx")
+
+        return data

--- a/opengever/document/browser/select_all.pt
+++ b/opengever/document/browser/select_all.pt
@@ -1,0 +1,19 @@
+<div>
+  <div id="above_visibles">
+    <div class="hidden_items">
+      <tal:repeat tal:repeat="item options/above">
+        <input type="hidden" tal:attributes="value item/document_id"
+               value="" name="document_ids:list">
+      </tal:repeat>
+    </div>
+  </div>
+
+  <div id="beneath_visibles">
+    <div class="hidden_items">
+      <tal:repeat tal:repeat="item options/beneath">
+        <input type="hidden" tal:attributes="value item/document_id"
+               value="" name="document_ids:list">
+      </tal:repeat>
+    </div>
+  </div>
+</div>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-10-24 09:02+0000\n"
+"POT-Creation-Date: 2016-11-14 11:29+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -72,6 +72,10 @@ msgstr "Es ist nicht erlaubt, das Dokument ${title} auszuchecken."
 msgid "Could not check out object: ${title}, it is not a document"
 msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
 
+#: ./opengever/document/browser/report.py:96
+msgid "Could not generate the report"
+msgstr "Report konnte nicht generiert werden"
+
 #: ./opengever/document/profiles/default/actions.xml
 msgid "Create Task"
 msgstr "Aufgabe erstellen"
@@ -87,6 +91,11 @@ msgstr "Dokument"
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:22
 msgid "Don't show this message again."
 msgstr "Diese Meldung nicht mehr anzeigen."
+
+#: ./opengever/document/profiles/default/actions.xml
+#: ./opengever/document/upgrades/20161111090446_add_document_export_actions/actions.xml
+msgid "Export selection"
+msgstr "Auswahl exportieren"
 
 #: ./opengever/document/browser/templates/logout_overlay.pt:19
 msgid "Logout"
@@ -169,17 +178,22 @@ msgid "description_download_confirmation"
 msgstr "Sie sind dabei, eine Kopie des Dokuments ${filename} herunterzuladen."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:187
+#: ./opengever/document/behaviors/metadata.py:182
 msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:96
+#: ./opengever/document/document.py:99
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
 
+#. Default: "You have not selected any Items"
+#: ./opengever/document/browser/report.py:80
+msgid "error_no_items"
+msgstr "Sie haben keine Objekte ausgewählt."
+
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:73
+#: ./opengever/document/document.py:76
 msgid "error_title_or_file_required"
 msgstr "Ein Titel oder eine Datei muss angegeben werden."
 
@@ -191,7 +205,7 @@ msgstr "Archiv Datei"
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:39
 #: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:49
+#: ./opengever/document/document.py:52
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -239,7 +253,7 @@ msgid "help_document_date"
 msgstr "Datum des Dokuments"
 
 #. Default: ""
-#: ./opengever/document/document.py:66
+#: ./opengever/document/document.py:69
 msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
@@ -285,6 +299,7 @@ msgstr "Status Archivdatei"
 
 #. Default: "Author"
 #: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/browser/report.py:46
 msgid "label_author"
 msgstr "Autor"
 
@@ -349,15 +364,40 @@ msgstr "Beschreibung"
 msgid "label_digitally_available"
 msgstr "Digital verfügbar"
 
+#: ./opengever/document/browser/report.py:55
+msgid "label_document_checked_out_by"
+msgstr "In Bearbeitung"
+
 #. Default: "Document Date"
 #: ./opengever/document/behaviors/metadata.py:82
+#: ./opengever/document/browser/report.py:49
 msgid "label_document_date"
 msgstr "Dokumentdatum"
+
+#: ./opengever/document/browser/report.py:53
+msgid "label_document_delivery_date"
+msgstr "Eingangsdatum"
+
+#: ./opengever/document/browser/report.py:51
+msgid "label_document_receipt_date"
+msgstr "Ausgangsdatum"
+
+#: ./opengever/document/browser/report.py:37
+msgid "label_document_reference_number"
+msgstr "Referenznummer"
+
+#: ./opengever/document/browser/report.py:40
+msgid "label_document_sequence_number"
+msgstr "Laufnummer"
 
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py:105
 msgid "label_document_type"
 msgstr "Dokumenttyp"
+
+#: ./opengever/document/browser/report.py:61
+msgid "label_dossier_title"
+msgstr "Dossier Titel"
 
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:25
 msgid "label_download"
@@ -371,8 +411,8 @@ msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:153
-#: ./opengever/document/document.py:65
+#: ./opengever/document/browser/overview.py:146
+#: ./opengever/document/document.py:68
 msgid "label_file"
 msgstr "Datei"
 
@@ -416,6 +456,10 @@ msgstr "In Papierform aufbewahrt"
 msgid "label_preview"
 msgstr "Vorschau"
 
+#: ./opengever/document/browser/report.py:58
+msgid "label_public_trial"
+msgstr "Öffentlichkeitsstatus"
+
 #. Default: "Date of receipt"
 #: ./opengever/document/behaviors/metadata.py:91
 msgid "label_receipt_date"
@@ -457,7 +501,8 @@ msgid "label_thumbnail"
 msgstr "Kurzbild"
 
 #. Default: "Title"
-#: ./opengever/document/document.py:59
+#: ./opengever/document/browser/report.py:43
+#: ./opengever/document/document.py:62
 msgid "label_title"
 msgstr "Titel"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-24 09:02+0000\n"
+"POT-Creation-Date: 2016-11-14 11:29+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -72,6 +72,10 @@ msgstr "Checkout de ${title} n'a pas abouti"
 msgid "Could not check out object: ${title}, it is not a document"
 msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti"
 
+#: ./opengever/document/browser/report.py:96
+msgid "Could not generate the report"
+msgstr ""
+
 #: ./opengever/document/profiles/default/actions.xml
 msgid "Create Task"
 msgstr "Créer une tâche"
@@ -87,6 +91,11 @@ msgstr "Document"
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:22
 msgid "Don't show this message again."
 msgstr "Ne plus afficher ce message."
+
+#: ./opengever/document/profiles/default/actions.xml
+#: ./opengever/document/upgrades/20161111090446_add_document_export_actions/actions.xml
+msgid "Export selection"
+msgstr ""
 
 #: ./opengever/document/browser/templates/logout_overlay.pt:19
 msgid "Logout"
@@ -168,17 +177,22 @@ msgid "description_download_confirmation"
 msgstr "Vous étes en train de télécharger une copie du document ${filename}."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:187
+#: ./opengever/document/behaviors/metadata.py:182
 msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:96
+#: ./opengever/document/document.py:99
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
 
+#. Default: "You have not selected any Items"
+#: ./opengever/document/browser/report.py:80
+msgid "error_no_items"
+msgstr ""
+
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:73
+#: ./opengever/document/document.py:76
 msgid "error_title_or_file_required"
 msgstr "Un titre ou un fichier est requis."
 
@@ -190,7 +204,7 @@ msgstr ""
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:39
 #: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:49
+#: ./opengever/document/document.py:52
 msgid "fieldset_common"
 msgstr "En général"
 
@@ -236,7 +250,7 @@ msgstr "Date, à laquelle le document a été envoyé par écrit"
 msgid "help_document_date"
 msgstr "Date de création du document"
 
-#: ./opengever/document/document.py:66
+#: ./opengever/document/document.py:69
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
@@ -279,6 +293,7 @@ msgstr ""
 
 #. Default: "Author"
 #: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/browser/report.py:46
 msgid "label_author"
 msgstr "Auteur"
 
@@ -343,15 +358,40 @@ msgstr "Description"
 msgid "label_digitally_available"
 msgstr "Disponble sous forme numérique"
 
+#: ./opengever/document/browser/report.py:55
+msgid "label_document_checked_out_by"
+msgstr ""
+
 #. Default: "Document Date"
 #: ./opengever/document/behaviors/metadata.py:82
+#: ./opengever/document/browser/report.py:49
 msgid "label_document_date"
 msgstr "Date du document"
+
+#: ./opengever/document/browser/report.py:53
+msgid "label_document_delivery_date"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:51
+msgid "label_document_receipt_date"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:37
+msgid "label_document_reference_number"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:40
+msgid "label_document_sequence_number"
+msgstr ""
 
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py:105
 msgid "label_document_type"
 msgstr "Type de document"
+
+#: ./opengever/document/browser/report.py:61
+msgid "label_dossier_title"
+msgstr ""
 
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:25
 msgid "label_download"
@@ -365,8 +405,8 @@ msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:153
-#: ./opengever/document/document.py:65
+#: ./opengever/document/browser/overview.py:146
+#: ./opengever/document/document.py:68
 msgid "label_file"
 msgstr "Fichier"
 
@@ -410,6 +450,10 @@ msgstr "Conserver sous forme papier"
 msgid "label_preview"
 msgstr "Aperçu"
 
+#: ./opengever/document/browser/report.py:58
+msgid "label_public_trial"
+msgstr ""
+
 #. Default: "Date of receipt"
 #: ./opengever/document/behaviors/metadata.py:91
 msgid "label_receipt_date"
@@ -451,7 +495,8 @@ msgid "label_thumbnail"
 msgstr "Vignette"
 
 #. Default: "Title"
-#: ./opengever/document/document.py:59
+#: ./opengever/document/browser/report.py:43
+#: ./opengever/document/document.py:62
 msgid "label_title"
 msgstr "Titre"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-24 09:02+0000\n"
+"POT-Creation-Date: 2016-11-14 11:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,6 +73,10 @@ msgstr ""
 msgid "Could not check out object: ${title}, it is not a document"
 msgstr ""
 
+#: ./opengever/document/browser/report.py:96
+msgid "Could not generate the report"
+msgstr ""
+
 #: ./opengever/document/profiles/default/actions.xml
 msgid "Create Task"
 msgstr ""
@@ -87,6 +91,11 @@ msgstr ""
 
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:22
 msgid "Don't show this message again."
+msgstr ""
+
+#: ./opengever/document/profiles/default/actions.xml
+#: ./opengever/document/upgrades/20161111090446_add_document_export_actions/actions.xml
+msgid "Export selection"
 msgstr ""
 
 #: ./opengever/document/browser/templates/logout_overlay.pt:19
@@ -169,17 +178,22 @@ msgid "description_download_confirmation"
 msgstr ""
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:187
+#: ./opengever/document/behaviors/metadata.py:182
 msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:96
+#: ./opengever/document/document.py:99
 msgid "error_mail_upload"
 msgstr ""
 
+#. Default: "You have not selected any Items"
+#: ./opengever/document/browser/report.py:80
+msgid "error_no_items"
+msgstr ""
+
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:73
+#: ./opengever/document/document.py:76
 msgid "error_title_or_file_required"
 msgstr ""
 
@@ -191,7 +205,7 @@ msgstr ""
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:39
 #: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:49
+#: ./opengever/document/document.py:52
 msgid "fieldset_common"
 msgstr ""
 
@@ -237,7 +251,7 @@ msgstr ""
 msgid "help_document_date"
 msgstr ""
 
-#: ./opengever/document/document.py:66
+#: ./opengever/document/document.py:69
 msgid "help_file"
 msgstr ""
 
@@ -280,6 +294,7 @@ msgstr ""
 
 #. Default: "Author"
 #: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/browser/report.py:46
 msgid "label_author"
 msgstr ""
 
@@ -344,14 +359,39 @@ msgstr ""
 msgid "label_digitally_available"
 msgstr ""
 
+#: ./opengever/document/browser/report.py:55
+msgid "label_document_checked_out_by"
+msgstr ""
+
 #. Default: "Document Date"
 #: ./opengever/document/behaviors/metadata.py:82
+#: ./opengever/document/browser/report.py:49
 msgid "label_document_date"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:53
+msgid "label_document_delivery_date"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:51
+msgid "label_document_receipt_date"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:37
+msgid "label_document_reference_number"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:40
+msgid "label_document_sequence_number"
 msgstr ""
 
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py:105
 msgid "label_document_type"
+msgstr ""
+
+#: ./opengever/document/browser/report.py:61
+msgid "label_dossier_title"
 msgstr ""
 
 #: ./opengever/document/browser/download_templates/downloadconfirmation.pt:25
@@ -366,8 +406,8 @@ msgid "label_download_copy"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:153
-#: ./opengever/document/document.py:65
+#: ./opengever/document/browser/overview.py:146
+#: ./opengever/document/document.py:68
 msgid "label_file"
 msgstr ""
 
@@ -411,6 +451,10 @@ msgstr ""
 msgid "label_preview"
 msgstr ""
 
+#: ./opengever/document/browser/report.py:58
+msgid "label_public_trial"
+msgstr ""
+
 #. Default: "Date of receipt"
 #: ./opengever/document/behaviors/metadata.py:91
 msgid "label_receipt_date"
@@ -452,7 +496,8 @@ msgid "label_thumbnail"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/document/document.py:59
+#: ./opengever/document/browser/report.py:43
+#: ./opengever/document/document.py:62
 msgid "label_title"
 msgstr ""
 

--- a/opengever/document/profiles/default/actions.xml
+++ b/opengever/document/profiles/default/actions.xml
@@ -88,6 +88,17 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="export_documents" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Export selection</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:@@document_report:method</property>
+          <property name="icon_expr"></property>
+      <property name="available_expr"></property>
+      <property name="permissions">
+        <element value="View"/>
+          </property>
+      <property name="visible">True</property>
+    </object>
 
   </object>
   <object name="object_checkin_menu" meta_type="CMF Action Category">

--- a/opengever/document/tests/test_reporter.py
+++ b/opengever/document/tests/test_reporter.py
@@ -1,0 +1,70 @@
+from dateutil.parser import parse as parse_date
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.ogds.base.actor import Actor
+from opengever.testing import create_ogds_user
+from opengever.testing import FunctionalTestCase
+from openpyxl import load_workbook
+from plone.api.portal import get_localized_time
+from plone.app.testing import TEST_USER_ID
+from tempfile import NamedTemporaryFile
+
+
+class TestDocumentReporter(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDocumentReporter, self).setUp()
+        create_ogds_user('max.mustermann',
+                         firstname='Max',
+                         lastname='Mustermann')
+        self.document_date = parse_date('2020-02-01').date()
+        self.receipt_date = parse_date('2020-02-02').date()
+        self.delivery_date = parse_date('2020-02-03').date()
+        self.dossier = create(Builder('dossier').titled(u'Dossier A'))
+        self.document = create(
+            Builder('document')
+            .within(self.dossier)
+            .having(
+                document_author='max.mustermann',
+                document_date=self.document_date,
+                receipt_date=self.receipt_date,
+                delivery_date=self.delivery_date,
+                )
+            .checked_out()
+            )
+
+    @browsing
+    def test_empty_document_report(self, browser):
+        browser.login().open(view='document_report',
+                             data={'paths:list': []})
+
+        self.assertEquals('Error You have not selected any Items',
+                          browser.css('.portalMessage.error').text[0])
+
+    @browsing
+    def test_document_report(self, browser):
+        browser.login().open(view='document_report',
+                             data={'paths:list': [
+                                   '/'.join(self.document.getPhysicalPath()),
+                                   ]})
+
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(browser.contents)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+
+        self.assertSequenceEqual(
+            [
+             u'Client1 / 1 / 1',
+             1L,
+             u'Testdokum\xe4nt',
+             u'Mustermann Max',
+             get_localized_time(self.document_date),
+             get_localized_time(self.receipt_date),
+             get_localized_time(self.delivery_date),
+             Actor.lookup(TEST_USER_ID).get_label(),
+             u'unchecked',
+             u'Dossier A',
+             ],
+            [cell.value for cell in workbook.active.rows[1]])

--- a/opengever/document/tests/test_reporter.py
+++ b/opengever/document/tests/test_reporter.py
@@ -1,4 +1,4 @@
-from dateutil.parser import parse as parse_date
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -18,9 +18,9 @@ class TestDocumentReporter(FunctionalTestCase):
         create_ogds_user('max.mustermann',
                          firstname='Max',
                          lastname='Mustermann')
-        self.document_date = parse_date('2020-02-01').date()
-        self.receipt_date = parse_date('2020-02-02').date()
-        self.delivery_date = parse_date('2020-02-03').date()
+        self.document_date = date(2020, 02, 01)
+        self.receipt_date = date(2020, 02, 02)
+        self.delivery_date = date(2020, 02, 03)
         self.dossier = create(Builder('dossier').titled(u'Dossier A'))
         self.document = create(
             Builder('document')

--- a/opengever/document/upgrades/20161111090446_add_document_export_actions/actions.xml
+++ b/opengever/document/upgrades/20161111090446_add_document_export_actions/actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  i18n:domain="opengever.dossier">
+  <object name="folder_buttons" meta_type="CMF Action Category">
+
+    <object name="export_documents" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Export selection</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:@@document_report:method</property>
+      <property name="icon_expr"></property>
+      <property name="available_expr"></property>
+      <property name="permissions">
+        <element value="View"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+</object>

--- a/opengever/document/upgrades/20161111090446_add_document_export_actions/upgrade.py
+++ b/opengever/document/upgrades/20161111090446_add_document_export_actions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDocumentExportActions(UpgradeStep):
+    """Add document export actions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -39,7 +39,7 @@ class DossierReporter(grok.View):
              'transform': StringTranslater(self.request, 'plone').translate},
             {'id': 'reference',
              'title': _(u'label_reference_number',
-                       default=u'Reference Number')},
+                        default=u'Reference Number')},
         ]
 
     def get_selected_dossiers(self):

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -3,18 +3,11 @@ from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.reporter import DATE_NUMBER_FORMAT
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater, XLSReporter
+from opengever.base.reporter import value
 from opengever.dossier import _
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.interface import Interface
-
-
-def to_unicode(title):
-    """Return unicode"""
-
-    if not isinstance(title, unicode):
-        title = title.decode('utf-8')
-    return title
 
 
 class DossierReporter(grok.View):
@@ -31,7 +24,7 @@ class DossierReporter(grok.View):
         return [
             {'id': 'Title',
              'title': _('label_title', default=u'Title'),
-             'transform': to_unicode},
+             'transform': value},
             {'id': 'start',
              'title': _(u'label_start', default=u'Opening Date'),
              'number_format': DATE_NUMBER_FORMAT},

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -594,7 +594,7 @@ class TestTemplateDossierListings(FunctionalTestCase):
 
         self.assertEqual(
             ['Copy Items', 'Checkin with comment', 'Checkin without comment',
-             'trashed', 'Export as Zip'],
+             'Export selection', 'trashed', 'Export as Zip'],
             browser.css('.actionMenuContent li').text)
 
     @browsing
@@ -615,7 +615,7 @@ class TestTemplateDossierListings(FunctionalTestCase):
 
         self.assertEqual(
             ['Copy Items', 'Checkin with comment', 'Checkin without comment',
-             'trashed', 'Export as Zip'],
+             'Export selection', 'trashed', 'Export as Zip'],
             browser.css('.actionMenuContent li').text)
 
     @browsing

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from five import grok
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.reporter import DATE_NUMBER_FORMAT
-from opengever.base.reporter import issuing_org_unit_label
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
@@ -69,9 +68,8 @@ class TaskReporter(grok.View):
             {'id': 'containing_dossier', 'title': _('label_dossier_title')},
             {'id': 'issuer', 'title': _('label_issuer'),
              'transform': readable_author},
-            {'id': 'get_issuing_org_unit',
-             'title': _('label_issuing_org_unit'),
-             'transform': issuing_org_unit_label},
+            {'id': 'issuing_org_unit_label',
+             'title': _('label_issuing_org_unit')},
             {'id': 'responsible', 'title': _('label_responsible'),
              'transform': readable_author},
             {'id': 'task_type', 'title': _('label_task_type'),

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -129,6 +129,10 @@ class Task(Base):
     def is_successor(self):
         return bool(self.predecessor)
 
+    @property
+    def issuing_org_unit_label(self):
+        return self.get_issuing_org_unit().label()
+
     def get_admin_unit(self):
         return ogds_service().fetch_admin_unit(self.admin_unit_id)
 

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -197,6 +197,7 @@ class MyDocuments(Documents):
 
     enabled_actions = [
         'zip_selected',
+        'export_documents',
     ]
     major_actions = []
 

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -184,6 +184,7 @@ class MyDocumentsProxy(DocumentsProxy):
     grok.context(Interface)
 
     listview = "tabbedview_view-mydocuments"
+    select_all_template = "document_view-select_all"
     galleryview = "tabbedview_view-mydocuments-gallery"
 
 

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -157,6 +157,7 @@ class Documents(BaseCatalogListingTab):
         'move_items',
         'copy_items',
         'zip_selected',
+        'export_documents',
         ]
 
     major_actions = [

--- a/opengever/task/browser/related_documents.py
+++ b/opengever/task/browser/related_documents.py
@@ -236,6 +236,7 @@ class RelatedDocuments(Documents):
         'move_items',
         'copy_items',
         'zip_selected',
+        'export_documents',
         ]
 
     sort_on = 'sortable_title'


### PR DESCRIPTION
* Added an export_documents action to portal_actions folder_buttons
* Added the action to relevant views
* Cleaned up the XLSX report generation code where appropriate
* Fixed the MyDocumentsProxy select_all view
  * Was not implemented
  * The javascript from ftw.tabbedview expects a listing of all documents (export despite pagination)
  * Was listing the full site contents without implementing the view
* Localized
* Amended existing tests
* Added a test for the document XLSX export
* Added a changelog entry

Fixes #2209