### PR TITLE
Prevent copying proposals.

### DIFF
--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -1,15 +1,16 @@
-from Acquisition import aq_inner, aq_parent
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from five import grok
 from OFS.interfaces import IObjectWillBeMovedEvent
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberPrefix
-from opengever.dossier.behaviors.dossier import IDossierMarker, IDossier
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.resolve import DossierResolver
 from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from plone import api
 from Products.CMFCore.interfaces import IActionSucceededEvent
-from Products.CMFCore.utils import getToolByName
 from zope.component import getAdapter
 from zope.lifecycleevent import IObjectRemovedEvent
 from zope.lifecycleevent.interfaces import IObjectCopiedEvent
@@ -89,7 +90,7 @@ def reindex_contained_objects(dossier, event):
     show an outdated title in the ``subdossier`` column
     """
 
-    catalog = getToolByName(dossier, 'portal_catalog')
+    catalog = api.portal.get_tool('portal_catalog')
     parent = aq_parent(aq_inner(dossier))
     is_subdossier = IDossierMarker.providedBy(parent)
     if is_subdossier:

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -39,6 +39,7 @@ from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.event import notify
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
 from zope.i18nmessageid.message import Message
@@ -66,10 +67,10 @@ def propper_string(value):
 def journal_entry_factory(context, action, title,
                           visible=True, comment='', actor=None):
     portal_state = getMultiAdapter(
-        (context, context.REQUEST), name=u'plone_portal_state')
+        (context, getRequest()), name=u'plone_portal_state')
     if actor is None:
         actor = portal_state.member().getId()
-    comment = comment == '' and get_change_note(context.REQUEST, '') or comment
+    comment = comment == '' and get_change_note(getRequest(), '') or comment
     title = propper_string(title)
     action = propper_string(action)
     comment = propper_string(comment)
@@ -706,7 +707,7 @@ def object_moved(context, event):
         return
 
     # Skip automatically renamed objects during copy & paste process.
-    if ICopyPasteRequestLayer.providedBy(context.REQUEST):
+    if ICopyPasteRequestLayer.providedBy(getRequest()):
         return
 
     title = _(u'label_object_moved',
@@ -728,7 +729,7 @@ def object_will_be_moved(context, event):
         return
 
     # Skip automatically renamed objects during copy & paste process.
-    if ICopyPasteRequestLayer.providedBy(context.REQUEST):
+    if ICopyPasteRequestLayer.providedBy(getRequest()):
         return
 
     title = _(u'label_object_cut',

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -549,6 +549,17 @@ class TestProposal(FunctionalTestCase):
                 "reference to submitted document on {} should be removed".format(
                     record))
 
+    def test_copying_proposals_is_prevented(self):
+        committee = create(Builder('committee').titled('My committee'))
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .titled(u'My Proposal')
+                          .having(committee=committee.load_model()))
+
+        copied_dossier = api.content.copy(
+            source=self.dossier, target=self.repo_folder)
+        self.assertItemsEqual([], copied_dossier.getFolderContents())
+
     def test_is_submission_allowed(self):
         committee = create(Builder('committee').titled('My committee'))
         proposal = create(Builder('proposal')


### PR DESCRIPTION
Proposals should not be copied when copying a dossier.

There are many states where this does not make sense at the moment or the desired state after copying is unclear (e.g. already submitted or decided proposals.) Thus we prevent them from being copied for now.

Deleting the proposal right after it had been created had some consequences for the other event handlers, that's why i had to change from acquiring request/catalog to getting it through a global accessor.

Fixes #2282.