### PR TITLE
Add missing local role definition for examplecontent committee container.

### DIFF
--- a/opengever/examplecontent/profiles/init/local_role_configuration/01_local_roles.json
+++ b/opengever/examplecontent/profiles/init/local_role_configuration/01_local_roles.json
@@ -38,5 +38,15 @@
                 "Reader"
             ]
         }
+    },
+    {
+        "_path": "sitzungen",
+        "_ac_local_roles": {
+            "og_demo-ftw_users": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ]
+        }
     }
 ]


### PR DESCRIPTION
Fixes #1904.

*IMO Changelog entry not necessary*
