### PR TITLE
Use correct dossier byline for meeting dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Use correct dossier byline for meeting dossiers.
+  [deiferni]
+
 - Added excel export functionality to document listings
   [Rotonen]
 

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -21,18 +21,20 @@ class TestDossierByline(TestBylineBase):
         self.intids = getUtility(IIntIds)
 
         create_ogds_user('hugo.boss')
-
-        self.dossier = create(Builder('dossier')
-               .in_state('dossier-state-active')
-               .having(reference_number_prefix='5',
-                       responsible='hugo.boss',
-                       start=date(2013, 11, 6),
-                       end=date(2013, 11, 7)))
+        self.dossier = self.create_dossier()
 
         registry = getUtility(IRegistry)
         mail_settings = registry.forInterface(IMailSettings)
         mail_settings.mail_domain = u'opengever.4teamwork.ch'
         transaction.commit()
+
+    def create_dossier(self):
+        return create(Builder('dossier')
+                      .in_state('dossier-state-active')
+                      .having(reference_number_prefix='5',
+                              responsible='hugo.boss',
+                              start=date(2013, 11, 6),
+                              end=date(2013, 11, 7)))
 
     @browsing
     def test_dossier_byline_responsible_display(self, browser):

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -1,5 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:i18n="http://namespaces.zope.org/i18n"
@@ -24,5 +25,12 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
     <include package=".upgrades" />
+
+    <browser:viewlet
+        name="plone.belowcontenttitle.documentbyline"
+        for="opengever.meeting.interfaces.IMeetingDossier"
+        manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+        class="opengever.dossier.viewlets.byline.BusinessCaseByline"
+        permission="zope2.View" />
 
 </configure>

--- a/opengever/meeting/tests/test_meeting_dossier_byline.py
+++ b/opengever/meeting/tests/test_meeting_dossier_byline.py
@@ -1,0 +1,15 @@
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.dossier.tests.test_dossier_byline import TestDossierByline
+
+
+class TestMeetingDossierByline(TestDossierByline):
+
+    def create_dossier(self):
+        return create(Builder('meeting_dossier')
+                      .in_state('dossier-state-active')
+                      .having(reference_number_prefix='5',
+                              responsible='hugo.boss',
+                              start=date(2013, 11, 6),
+                              end=date(2013, 11, 7)))


### PR DESCRIPTION
A meeting-dossier should re-use the byline of a businesscase-dossier.

Fixes #1910.