### PR TITLE
Implementiert Dossiertemplate

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add initial dossiertemplate type.
+  [elioschmutz]
+
 - Switch schema dumps to JSON schema.
   [lgraf]
 

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -10,6 +10,7 @@ from opengever.activity.interfaces import IActivitySettings
 from opengever.base import model
 from opengever.base.model import create_session
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
 from opengever.meeting.interfaces import IMeetingSettings
 from opengever.officeatwork.interfaces import IOfficeatworkSettings
 from opengever.ogds.base.setup import create_sql_tables
@@ -417,6 +418,20 @@ class ActivityLayer(PloneSandboxLayer):
 
 
 OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER = ActivityLayer()
+
+
+class DossierTemplateLayer(PloneSandboxLayer):
+
+    def setUpPloneSite(self, portal):
+        toggle_feature(IDossierTemplateSettings, enabled=True)
+
+    def tearDownPloneSite(self, portal):
+        toggle_feature(IDossierTemplateSettings, enabled=False)
+
+    defaultBases = (OPENGEVER_FUNCTIONAL_TESTING,)
+
+
+OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER = DossierTemplateLayer()
 
 
 class BumblebeeLayer(PloneSandboxLayer):

--- a/opengever/dossier/__init__.py
+++ b/opengever/dossier/__init__.py
@@ -1,3 +1,4 @@
 from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory("opengever.dossier")
+

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -10,6 +10,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.participation import IParticipationAwareMarker
+from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
 from opengever.dossier.interfaces import IConstrainTypeDecider
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.meeting import is_meeting_feature_enabled
@@ -338,6 +339,10 @@ class DefaultConstrainTypeDecider(grok.MultiAdapter):
         if factory_type in [u'opengever.meeting.proposal',
                             u'opengever.meeting.sablontemplate']:
             return is_meeting_feature_enabled()
+
+        if factory_type in [u'opengever.dossier.dossiertemplate']:
+            return is_dossier_template_feature_enabled()
+
         return True
 
     @property

--- a/opengever/dossier/behaviors.zcml
+++ b/opengever/dossier/behaviors.zcml
@@ -40,6 +40,15 @@
         for="opengever.dossier.behaviors.dossier.IDossierMarker"
         />
 
+    <!-- dossiertemplate name from title beahvior -->
+    <plone:behavior
+        title="dossiertemplate name from title"
+        description=""
+        provides=".dossiertemplate.behaviors.IDossierTemplateNameFromTitle"
+        factory=".dossiertemplate.behaviors.DossierTemplateNameFromTitle"
+        for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplate"
+        />
+
     <!-- Restricted dossier behavior -->
     <plone:behavior
         title="Restricted dossier"

--- a/opengever/dossier/dossiertemplate/__init__.py
+++ b/opengever/dossier/dossiertemplate/__init__.py
@@ -1,0 +1,8 @@
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate  # keep!
+from plone import api
+
+
+def is_dossier_template_feature_enabled():
+    return api.portal.get_registry_record(
+        'is_feature_enabled', interface=IDossierTemplateSettings)

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -1,0 +1,26 @@
+from opengever.dossier.behaviors.dossiernamefromtitle import DossierNameFromTitle
+from plone.app.content.interfaces import INameFromTitle
+from plone.directives import form
+from zope.interface import implements
+
+
+class IDossierTemplate(form.Schema):
+    """Behaviour interface for dossier template types.
+
+    Use this type of dossier to create a reusable template structures.
+    """
+
+
+class IDossierTemplateNameFromTitle(INameFromTitle):
+    """Behavior interface.
+    """
+
+
+class DossierTemplateNameFromTitle(DossierNameFromTitle):
+    """Choose IDs for a dossiertemplate in the following format:
+    'dossiertemplate-{sequence number}'
+    """
+
+    implements(IDossierTemplateNameFromTitle)
+
+    format = u'dossiertemplate-%i'

--- a/opengever/dossier/dossiertemplate/dossiertemplate.py
+++ b/opengever/dossier/dossiertemplate/dossiertemplate.py
@@ -1,0 +1,31 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from five import grok
+from opengever.dossier import _
+from opengever.dossier.dossiertemplate import IDossierTemplate
+from plone.dexterity.content import Container
+from plone.directives import dexterity
+
+
+class DossierTemplateAddForm(dexterity.AddForm):
+    grok.name('opengever.dossier.dossiertemplate')
+
+    @property
+    def label(self):
+        if IDossierTemplate.providedBy(self.context):
+            return _(u'Add Subdossier')
+        return super(DossierTemplateAddForm, self).label
+
+
+class DossierTemplateEditForm(dexterity.EditForm):
+    grok.context(IDossierTemplate)
+
+    @property
+    def label(self):
+        if IDossierTemplate.providedBy(aq_parent(aq_inner(self.context))):
+            return _(u'Edit Subdossier')
+        return super(DossierTemplateEditForm, self).label
+
+
+class DossierTemplate(Container):
+    """Base class for template dossiers."""

--- a/opengever/dossier/dossiertemplate/interfaces.py
+++ b/opengever/dossier/dossiertemplate/interfaces.py
@@ -1,0 +1,10 @@
+from zope import schema
+from zope.interface import Interface
+
+
+class IDossierTemplateSettings(Interface):
+
+    is_feature_enabled = schema.Bool(
+        title=u'Enable dossier template feature',
+        description=u'Whether dossier template feature is enabled or not.',
+        default=False)

--- a/opengever/dossier/dossiertemplate/menu.py
+++ b/opengever/dossier/dossiertemplate/menu.py
@@ -1,0 +1,17 @@
+from five import grok
+from opengever.base.menu import FilteredPostFactoryMenu
+from opengever.dossier import _
+from opengever.dossier.dossiertemplate import IDossierTemplate
+from zope.interface import Interface
+
+
+class DossierTemplatePostFactoryMenu(FilteredPostFactoryMenu):
+    grok.adapts(IDossierTemplate, Interface)
+
+    subdossier_types = [u'opengever.dossier.dossiertemplate']
+
+    def rename(self, factory):
+        if factory.get('id') in self.subdossier_types:
+            factory['title'] = _(u'Subdossier')
+
+        return factory

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-11-16 11:12+0000\n"
+"POT-Creation-Date: 2016-11-22 16:30+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -25,6 +25,7 @@ msgid "Add Business Case Dossier"
 msgstr "Geschäftsdossier hinzufügen"
 
 #: ./opengever/dossier/behaviors/dossier.py:232
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:19
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
@@ -37,7 +38,7 @@ msgstr "Geschäftsdossier"
 msgid "Can only move objects from open dossiers!"
 msgstr "Es können nur Objekte aus aktiven Dossiers verschoben werden!"
 
-#: ./opengever/dossier/browser/report.py:82
+#: ./opengever/dossier/browser/report.py:75
 msgid "Could not generate the report"
 msgstr "Report konnte nicht generiert werden."
 
@@ -57,11 +58,17 @@ msgstr "Dokument ${name} ist mit einer Aufgabe verbunden, bitte Aufgabe verschie
 msgid "Dossier structure"
 msgstr "Dossier-Struktur"
 
+#: ./opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
+#: ./opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.dossiertemplate.xml
+msgid "Dossier template"
+msgstr "Dossier Vorlage"
+
 #: ./opengever/dossier/resolve.py:89
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
 #: ./opengever/dossier/behaviors/dossier.py:254
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:33
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
@@ -131,6 +138,7 @@ msgstr "Dokument auswählen"
 msgid "Select recipient address"
 msgstr "Empfänger-Adresse auswählen"
 
+#: ./opengever/dossier/dossiertemplate/menu.py:15
 #: ./opengever/dossier/menu.py:19
 msgid "Subdossier"
 msgstr "Subdossier"
@@ -282,7 +290,7 @@ msgid "error_enddate"
 msgstr "Enddatum erforderlich"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/dossier/browser/report.py:66
+#: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
@@ -446,7 +454,7 @@ msgstr "E-Mail"
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
 #: ./opengever/dossier/behaviors/dossier.py:79
-#: ./opengever/dossier/browser/report.py:39
+#: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr "Ende"
 
@@ -553,7 +561,7 @@ msgstr "Empfänger"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:179
-#: ./opengever/dossier/browser/report.py:48
+#: ./opengever/dossier/browser/report.py:41
 #: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
@@ -566,12 +574,12 @@ msgstr "Verwandte Dossiers"
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:90
 #: ./opengever/dossier/browser/participants.py:169
-#: ./opengever/dossier/browser/report.py:42
+#: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:45
+#: ./opengever/dossier/browser/report.py:38
 msgid "label_review_state"
 msgstr "Status"
 
@@ -592,7 +600,7 @@ msgstr "Laufnummer"
 
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py:71
-#: ./opengever/dossier/browser/report.py:36
+#: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr "Beginn"
 
@@ -623,7 +631,7 @@ msgid "label_template"
 msgstr "Vorlage"
 
 #. Default: "Title"
-#: ./opengever/dossier/browser/report.py:33
+#: ./opengever/dossier/browser/report.py:26
 #: ./opengever/dossier/templatedossier/form.py:65
 msgid "label_title"
 msgstr "Titel"
@@ -713,3 +721,4 @@ msgstr "Dossier Journal ${today}"
 #: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
+

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-16 11:12+0000\n"
+"POT-Creation-Date: 2016-11-22 16:30+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -24,6 +24,7 @@ msgid "Add Business Case Dossier"
 msgstr "Insérer un dossier d'affaire"
 
 #: ./opengever/dossier/behaviors/dossier.py:232
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:19
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
 
@@ -35,7 +36,7 @@ msgstr "Dossier"
 msgid "Can only move objects from open dossiers!"
 msgstr "Seuls les objets de dossiers actifs peuvent être déplacés!"
 
-#: ./opengever/dossier/browser/report.py:82
+#: ./opengever/dossier/browser/report.py:75
 msgid "Could not generate the report"
 msgstr "Impossible de générer l'affichage"
 
@@ -55,11 +56,17 @@ msgstr "Document ${name} est lié avec une tâche, déplacer la tâche, svp."
 msgid "Dossier structure"
 msgstr "Structure du dossier"
 
+#: ./opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
+#: ./opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.dossiertemplate.xml
+msgid "Dossier template"
+msgstr ""
+
 #: ./opengever/dossier/resolve.py:89
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès"
 
 #: ./opengever/dossier/behaviors/dossier.py:254
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:33
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
@@ -128,6 +135,7 @@ msgstr ""
 msgid "Select recipient address"
 msgstr ""
 
+#: ./opengever/dossier/dossiertemplate/menu.py:15
 #: ./opengever/dossier/menu.py:19
 msgid "Subdossier"
 msgstr "Sous-dossier"
@@ -278,7 +286,7 @@ msgid "error_enddate"
 msgstr "Date de clôture obligatoire"
 
 #. Default: "You have not selected any Items"
-#: ./opengever/dossier/browser/report.py:66
+#: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun objet."
 
@@ -442,7 +450,7 @@ msgstr "Email"
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
 #: ./opengever/dossier/behaviors/dossier.py:79
-#: ./opengever/dossier/browser/report.py:39
+#: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr "Date de fin :"
 
@@ -549,7 +557,7 @@ msgstr ""
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:179
-#: ./opengever/dossier/browser/report.py:48
+#: ./opengever/dossier/browser/report.py:41
 #: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr "Numéro de référence"
@@ -562,12 +570,12 @@ msgstr "Dossiers liés"
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:90
 #: ./opengever/dossier/browser/participants.py:169
-#: ./opengever/dossier/browser/report.py:42
+#: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:45
+#: ./opengever/dossier/browser/report.py:38
 msgid "label_review_state"
 msgstr "Etat"
 
@@ -588,7 +596,7 @@ msgstr "Numéro courant"
 
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py:71
-#: ./opengever/dossier/browser/report.py:36
+#: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr "Date début"
 
@@ -619,7 +627,7 @@ msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/dossier/browser/report.py:33
+#: ./opengever/dossier/browser/report.py:26
 #: ./opengever/dossier/templatedossier/form.py:65
 msgid "label_title"
 msgstr "Titre"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-16 11:12+0000\n"
+"POT-Creation-Date: 2016-11-22 16:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,6 +25,7 @@ msgid "Add Business Case Dossier"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:232
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:19
 msgid "Add Subdossier"
 msgstr ""
 
@@ -36,7 +37,7 @@ msgstr ""
 msgid "Can only move objects from open dossiers!"
 msgstr ""
 
-#: ./opengever/dossier/browser/report.py:82
+#: ./opengever/dossier/browser/report.py:75
 msgid "Could not generate the report"
 msgstr ""
 
@@ -56,11 +57,17 @@ msgstr ""
 msgid "Dossier structure"
 msgstr ""
 
+#: ./opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
+#: ./opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.dossiertemplate.xml
+msgid "Dossier template"
+msgstr ""
+
 #: ./opengever/dossier/resolve.py:89
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:254
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:33
 msgid "Edit Subdossier"
 msgstr ""
 
@@ -129,6 +136,7 @@ msgstr ""
 msgid "Select recipient address"
 msgstr ""
 
+#: ./opengever/dossier/dossiertemplate/menu.py:15
 #: ./opengever/dossier/menu.py:19
 msgid "Subdossier"
 msgstr ""
@@ -279,7 +287,7 @@ msgid "error_enddate"
 msgstr ""
 
 #. Default: "You have not selected any Items"
-#: ./opengever/dossier/browser/report.py:66
+#: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
 msgstr ""
 
@@ -443,7 +451,7 @@ msgstr ""
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
 #: ./opengever/dossier/behaviors/dossier.py:79
-#: ./opengever/dossier/browser/report.py:39
+#: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr ""
 
@@ -550,7 +558,7 @@ msgstr ""
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:179
-#: ./opengever/dossier/browser/report.py:48
+#: ./opengever/dossier/browser/report.py:41
 #: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr ""
@@ -563,12 +571,12 @@ msgstr ""
 #. Default: "Responsible"
 #: ./opengever/dossier/behaviors/dossier.py:90
 #: ./opengever/dossier/browser/participants.py:169
-#: ./opengever/dossier/browser/report.py:42
+#: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:45
+#: ./opengever/dossier/browser/report.py:38
 msgid "label_review_state"
 msgstr ""
 
@@ -589,7 +597,7 @@ msgstr ""
 
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py:71
-#: ./opengever/dossier/browser/report.py:36
+#: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr ""
 
@@ -620,7 +628,7 @@ msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/dossier/browser/report.py:33
+#: ./opengever/dossier/browser/report.py:26
 #: ./opengever/dossier/templatedossier/form.py:65
 msgid "label_title"
 msgstr ""

--- a/opengever/dossier/permissions.zcml
+++ b/opengever/dossier/permissions.zcml
@@ -7,7 +7,7 @@
         id="opengever.dossier.AddBusinessCaseDossier"
         title="opengever.dossier: Add businesscasedossier"
         />
-        
+
     <permission
         id="opengever.dossier.AddProjectDossier"
         title="opengever.dossier: Add projectdossier"
@@ -17,5 +17,10 @@
         id="opengever.dossier.AddTemplateDossier"
         title="opengever.dossier: Add templatedossier"
         />
-   
+
+    <permission
+        id="opengever.dossier.AddDossierTemplate"
+        title="opengever.dossier: Add dossiertemplate"
+        />
+
 </configure>

--- a/opengever/dossier/profiles/default/registry.xml
+++ b/opengever/dossier/profiles/default/registry.xml
@@ -3,4 +3,5 @@
   <records interface="opengever.dossier.interfaces.IDossierParticipants" />
   <records interface="opengever.dossier.interfaces.ITemplateDossierProperties" />
   <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+  <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" />
 </registry>

--- a/opengever/dossier/profiles/default/rolemap.xml
+++ b/opengever/dossier/profiles/default/rolemap.xml
@@ -20,5 +20,10 @@
       <role name="Contributor"/>
       <role name="Administrator"/>
     </permission>
+    <permission name="opengever.dossier: Add dossiertemplate" acquire="True">
+      <role name="Manager"/>
+      <role name="Contributor"/>
+      <role name="Administrator"/>
+    </permission>
   </permissions>
 </rolemap>

--- a/opengever/dossier/profiles/default/types.xml
+++ b/opengever/dossier/profiles/default/types.xml
@@ -2,5 +2,6 @@
     <object name="opengever.dossier.projectdossier" meta_type="Dexterity FTI" />
     <object name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" />
     <object name="opengever.dossier.templatedossier" meta_type="Dexterity FTI" />
+    <object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI" />
     <!--object name="opengever.base.subjectdossier" meta_type="Dexterity FTI" /-->
 </object>

--- a/opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI"
+        i18n:domain="opengever.dossier" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Dossier template</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="opengever.dossier.dossiertemplate" />
+        <element value="opengever.document.document" />
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">opengever.dossier.dossiertemplate.IDossierTemplate</property>
+
+    <!-- class used for content items -->
+    <property name="klass">opengever.dossier.dossiertemplate.dossiertemplate.DossierTemplate</property>
+
+    <!-- add permission -->
+    <property name="add_permission">opengever.dossier.AddDossierTemplate</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+        <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+        <element value="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateNameFromTitle" />
+        <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+        <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    </property>
+
+    <!-- View information -->
+    <property name="immediate_view">view</property>
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(selected layout)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="view" to="@@view"/>
+
+    <!-- Actions -->
+    <action action_id="view"
+            visible="False"
+            title="View"
+            category="object"
+            url_expr="string:${object_url}"
+            condition_expr="">
+        <permission value="View"/>
+    </action>
+
+    <action action_id="edit"
+            visible="True"
+            title="Edit"
+            category="object"
+            url_expr="string:${object_url}/edit"
+            condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.templatedossier.xml
@@ -14,6 +14,7 @@
         <element value="opengever.tasktemplates.tasktemplatefolder" />
         <element value="opengever.dossier.templatedossier" />
         <element value="opengever.meeting.sablontemplate" />
+        <element value="opengever.dossier.dossiertemplate" />
     </property>
 
     <!-- schema interface -->

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -1,0 +1,130 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.dossiertemplate import IDossierTemplate
+from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
+from opengever.testing import FunctionalTestCase
+from plone import api
+
+
+class TestIsDossierTemplateFeatureEnabled(FunctionalTestCase):
+
+    def test_true_if_registry_entry_is_true(self):
+        api.portal.set_registry_record(
+            'is_feature_enabled', True, interface=IDossierTemplateSettings)
+
+        self.assertTrue(is_dossier_template_feature_enabled())
+
+    def test_false_if_registry_entry_is_false(self):
+        api.portal.set_registry_record(
+            'is_feature_enabled', False, interface=IDossierTemplateSettings)
+
+        self.assertFalse(is_dossier_template_feature_enabled())
+
+
+class TestDossierTemplate(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+
+    def setUp(self):
+        super(TestDossierTemplate, self).setUp()
+        self.templatedossier = create(Builder('templatedossier'))
+
+    def test_templatedosisers_does_not_provide_dossier_interface(self):
+        dossiertemplate = create(Builder('dossiertemplate'))
+        self.assertFalse(IDossierMarker.providedBy(dossiertemplate))
+
+    def test_id_is_sequence_number_prefixed_with_dossiertemplate(self):
+        dossiertemplate1 = create(Builder("dossiertemplate"))
+        dossiertemplate2 = create(Builder("dossiertemplate"))
+
+        self.assertEquals("dossiertemplate-1", dossiertemplate1.id)
+        self.assertEquals("dossiertemplate-2", dossiertemplate2.id)
+
+    def test_dossiertemplate_provides_the_IDossierTemplate_behavior(self):
+        dossiertemplate = create(Builder('dossiertemplate'))
+        self.assertTrue(IDossierTemplate.providedBy(dossiertemplate))
+
+    @browsing
+    def test_adding_dossiertemplate_works_properly(self, browser):
+        browser.login().open(self.portal)
+        factoriesmenu.add('Dossier template')
+        browser.fill({'Title': 'Template'}).submit()
+
+        self.assertEquals(['Item created'], info_messages())
+        self.assertEquals(['Template'], browser.css('h1').text)
+
+    @browsing
+    def test_addable_types(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatedossier))
+
+        browser.login().open(dossiertemplate)
+
+        self.assertEquals(
+            ['Document', 'Subdossier'],
+            factoriesmenu.addable_types())
+
+    @browsing
+    def test_a_subdossiers_is_a_dossiertemplate(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatedossier))
+
+        browser.login().open(dossiertemplate)
+
+        factoriesmenu.add('Subdossier')
+        browser.fill({'Title': 'Template'}).submit()
+
+        self.assertTrue(IDossierTemplate.providedBy(browser.context))
+
+    @browsing
+    def test_add_form_title_of_dossiertemplate_is_the_default_title(self, browser):
+
+        browser.login().open(self.templatedossier)
+        factoriesmenu.add('Dossier template')
+
+        self.assertEqual(
+            'Add Dossier template',
+            browser.css('#content h1').first.text)
+
+    @browsing
+    def test_add_form_title_of_dossiertemplate_as_a_subdossier_contains_subdossier(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatedossier))
+
+        browser.login().open(dossiertemplate)
+        factoriesmenu.add('Subdossier')
+
+        self.assertEqual(
+            'Add Subdossier',
+            browser.css('#content h1').first.text)
+
+    @browsing
+    def test_edit_form_title_of_dossiertemplate_is_the_default_title(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatedossier))
+
+        browser.login().visit(dossiertemplate, view="edit")
+
+        self.assertEqual(
+            'Edit Dossier template',
+            browser.css('#content h1').first.text)
+
+    @browsing
+    def test_edit_form_title_of_dossiertemplate_as_a_subdossier_contains_subdossier(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatedossier))
+
+        subdossiertemplate = create(Builder('dossiertemplate')
+                                    .within(dossiertemplate))
+
+        browser.login().visit(subdossiertemplate, view="edit")
+
+        self.assertEqual(
+            'Edit Subdossier',
+            browser.css('#content h1').first.text)

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.pages import plone
 from ftw.testing import freeze
 from ooxml_docprops import read_properties
 from opengever.contact.interfaces import IContactSettings
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.dossier.docprops import TemporaryDocFile
 from opengever.dossier.interfaces import ITemplateDossierProperties
@@ -688,3 +689,15 @@ class TestTemplateDocumentTabs(FunctionalTestCase):
         self.assertEquals([['Logged-in users', False, False, False],
                            [TEST_USER_ID, True, True, True]],
                           sharing_tab_data())
+
+
+class TestDossierTemplateFeature(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+
+    @browsing
+    def test_dossier_template_is_addable_if_dossier_template_feature_is_enabled(self, browser):
+        templatedossier = create(Builder('templatedossier'))
+        browser.login().open(templatedossier)
+
+        self.assertIn('Dossier template', factoriesmenu.addable_types())

--- a/opengever/dossier/upgrades/20161122103454_add_dossier_templates/registry.xml
+++ b/opengever/dossier/upgrades/20161122103454_add_dossier_templates/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" />
+</registry>

--- a/opengever/dossier/upgrades/20161122103454_add_dossier_templates/rolemap.xml
+++ b/opengever/dossier/upgrades/20161122103454_add_dossier_templates/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<rolemap>
+  <permissions>
+    <permission name="opengever.dossier: Add dossiertemplate" acquire="True">
+      <role name="Manager"/>
+      <role name="Contributor"/>
+      <role name="Administrator"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/dossier/upgrades/20161122103454_add_dossier_templates/types.xml
+++ b/opengever/dossier/upgrades/20161122103454_add_dossier_templates/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types">
+    <object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI" />
+</object>

--- a/opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.dossiertemplate.xml
+++ b/opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.dossiertemplate.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI"
+        i18n:domain="opengever.dossier" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- Basic metadata -->
+    <property name="title" i18n:translate="">Dossier template</property>
+    <property name="description" i18n:translate=""></property>
+    <property name="icon_expr"></property>
+    <property name="allow_discussion">False</property>
+    <property name="global_allow">True</property>
+    <property name="filter_content_types">True</property>
+    <property name="allowed_content_types">
+        <element value="opengever.dossier.dossiertemplate" />
+        <element value="opengever.document.document" />
+    </property>
+
+    <!-- schema interface -->
+    <property name="schema">opengever.dossier.dossiertemplate.IDossierTemplate</property>
+
+    <!-- class used for content items -->
+    <property name="klass">opengever.dossier.dossiertemplate.dossiertemplate.DossierTemplate</property>
+
+    <!-- add permission -->
+    <property name="add_permission">opengever.dossier.AddDossierTemplate</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+        <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+        <element value="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateNameFromTitle" />
+        <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+        <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    </property>
+
+    <!-- View information -->
+    <property name="immediate_view">view</property>
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(selected layout)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="view" to="@@view"/>
+
+    <!-- Actions -->
+    <action action_id="view"
+            visible="False"
+            title="View"
+            category="object"
+            url_expr="string:${object_url}"
+            condition_expr="">
+        <permission value="View"/>
+    </action>
+
+    <action action_id="edit"
+            visible="True"
+            title="Edit"
+            category="object"
+            url_expr="string:${object_url}/edit"
+            condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>

--- a/opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.templatedossier.xml
+++ b/opengever/dossier/upgrades/20161122103454_add_dossier_templates/types/opengever.dossier.templatedossier.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="opengever.dossier.templatedossier" meta_type="Dexterity FTI"
+        i18n:domain="opengever.dossier" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="opengever.dossier.dossiertemplate" />
+    </property>
+
+</object>

--- a/opengever/dossier/upgrades/20161122103454_add_dossier_templates/upgrade.py
+++ b/opengever/dossier/upgrades/20161122103454_add_dossier_templates/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDossierTemplates(UpgradeStep):
+    """Add dossier templates.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -39,6 +39,12 @@ class TemplateDossierBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
 builder_registry.register('templatedossier', TemplateDossierBuilder)
 
 
+class DossierTemplateBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
+    portal_type = 'opengever.dossier.dossiertemplate'
+
+builder_registry.register('dossiertemplate', DossierTemplateBuilder)
+
+
 class InboxBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.inbox.inbox'
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -13,3 +13,4 @@ auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
+


### PR DESCRIPTION
Dieser PR fügt einen neuen Inhaltstyp "Dossiertemplate" hinzu.

Der Inhaltstyp kann nur in einem `templatedossier` hinzugefügt werden.

In einem Dossiertemplate können Dokumente und weitere Dossiertemplates (Subdossier) hinzugefügt werden.

Das Feature kann in der Registry aktiviert bzw. deaktiviert werden.

Die Dossiertempalte-ID wird folgendermassen generiert: `dossietemplate-{squence-number}`

![screen2](https://cloud.githubusercontent.com/assets/557005/20529476/8fbe2c1c-b0d0-11e6-8109-e0fb2adb2ccf.gif)

see #2143