### PR TITLE
fügt Dossiertemplates-Tab zu Templatedossier-Tabbedview hinzu

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add templatefolder-tab for displaying dossiertemplates.
+  [elioschmutz]
+
 - Make disposition title editable, but prefill it with a default value.
   [phgross]
 

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -1,5 +1,6 @@
 from opengever.contact import is_contact_feature_enabled
 from opengever.dossier import _
+from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.tabbedview import GeverTabbedView
 
@@ -100,9 +101,18 @@ class TemplateDossierTabbedView(GeverTabbedView):
                                default=u'Sablon Templates'),
                     }
 
+    @property
+    def dossiertemplate_tab(self):
+        if is_dossier_template_feature_enabled():
+            return {'id': 'dossiertemplates',
+                    'title': _(u'label_dossier_templates',
+                               default=u'Dossier templates'),
+                    }
+
     def _get_tabs(self):
         return [
             self.template_tab,
+            self.dossiertemplate_tab,
             self.sablon_tab,
             self.tasktemplate_folders_tab
         ]

--- a/opengever/dossier/dossiertemplate/dossiertemplate.py
+++ b/opengever/dossier/dossiertemplate/dossiertemplate.py
@@ -29,3 +29,7 @@ class DossierTemplateEditForm(dexterity.EditForm):
 
 class DossierTemplate(Container):
     """Base class for template dossiers."""
+
+    def is_subdossier(self):
+        parent = aq_parent(aq_inner(self))
+        return bool(IDossierTemplate.providedBy(parent))

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-11-22 16:30+0000\n"
+"POT-Creation-Date: 2016-11-23 07:06+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -437,9 +437,14 @@ msgid "label_destination"
 msgstr "Zielposition / Zieldossier"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/tabbed.py:16
+#: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr "Dokumente"
+
+#. Default: "Dossier templates"
+#: ./opengever/dossier/browser/tabbed.py:108
+msgid "label_dossier_templates"
+msgstr "Dossier Vorlagen"
 
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatedossier/form.py:90
@@ -480,12 +485,12 @@ msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:36
+#: ./opengever/dossier/browser/tabbed.py:37
 msgid "label_info"
 msgstr "Info"
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:31
+#: ./opengever/dossier/browser/tabbed.py:32
 msgid "label_journal"
 msgstr "Journal"
 
@@ -525,12 +530,12 @@ msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:11
+#: ./opengever/dossier/browser/tabbed.py:12
 msgid "label_overview"
 msgstr "Übersicht"
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:67
+#: ./opengever/dossier/browser/tabbed.py:68
 msgid "label_participants"
 msgstr "Beteiligungen"
 
@@ -540,7 +545,7 @@ msgid "label_participation"
 msgstr "Beteiligung"
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:62
+#: ./opengever/dossier/browser/tabbed.py:63
 msgid "label_participations"
 msgstr "Beteiligungen"
 
@@ -550,7 +555,7 @@ msgid "label_phonenumber"
 msgstr "Telefonnummer"
 
 #. Default: "Proposals"
-#: ./opengever/dossier/browser/tabbed.py:52
+#: ./opengever/dossier/browser/tabbed.py:53
 msgid "label_proposals"
 msgstr "Anträge"
 
@@ -589,7 +594,7 @@ msgid "label_roles"
 msgstr "Rollen"
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:99
+#: ./opengever/dossier/browser/tabbed.py:100
 msgid "label_sablon_templates"
 msgstr "Sablon Vorlagen"
 
@@ -611,17 +616,17 @@ msgid "label_start_byline"
 msgstr "Beginn"
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:43
+#: ./opengever/dossier/browser/tabbed.py:44
 msgid "label_subdossiers"
 msgstr "Subdossiers"
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:21
+#: ./opengever/dossier/browser/tabbed.py:22
 msgid "label_tasks"
 msgstr "Aufgaben"
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:91
+#: ./opengever/dossier/browser/tabbed.py:92
 msgid "label_tasktemplate_folders"
 msgstr "Standardabläufe"
 
@@ -637,7 +642,7 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:26
+#: ./opengever/dossier/browser/tabbed.py:27
 msgid "label_trash"
 msgstr "Papierkorb"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-22 16:30+0000\n"
+"POT-Creation-Date: 2016-11-23 07:06+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -433,9 +433,14 @@ msgid "label_destination"
 msgstr "Destination"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/tabbed.py:16
+#: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr "Documents"
+
+#. Default: "Dossier templates"
+#: ./opengever/dossier/browser/tabbed.py:108
+msgid "label_dossier_templates"
+msgstr ""
 
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatedossier/form.py:90
@@ -476,12 +481,12 @@ msgid "label_former_reference_number"
 msgstr "Ancienne numéro référence"
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:36
+#: ./opengever/dossier/browser/tabbed.py:37
 msgid "label_info"
 msgstr "Info"
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:31
+#: ./opengever/dossier/browser/tabbed.py:32
 msgid "label_journal"
 msgstr "Historique"
 
@@ -521,12 +526,12 @@ msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:11
+#: ./opengever/dossier/browser/tabbed.py:12
 msgid "label_overview"
 msgstr "Sommaire"
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:67
+#: ./opengever/dossier/browser/tabbed.py:68
 msgid "label_participants"
 msgstr "Participants"
 
@@ -536,7 +541,7 @@ msgid "label_participation"
 msgstr "Participation"
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:62
+#: ./opengever/dossier/browser/tabbed.py:63
 msgid "label_participations"
 msgstr "Participation"
 
@@ -546,7 +551,7 @@ msgid "label_phonenumber"
 msgstr ""
 
 #. Default: "Proposals"
-#: ./opengever/dossier/browser/tabbed.py:52
+#: ./opengever/dossier/browser/tabbed.py:53
 msgid "label_proposals"
 msgstr "Propositions"
 
@@ -585,7 +590,7 @@ msgid "label_roles"
 msgstr "Rôles"
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:99
+#: ./opengever/dossier/browser/tabbed.py:100
 msgid "label_sablon_templates"
 msgstr "Sablon Modèles"
 
@@ -607,17 +612,17 @@ msgid "label_start_byline"
 msgstr "De"
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:43
+#: ./opengever/dossier/browser/tabbed.py:44
 msgid "label_subdossiers"
 msgstr "Sous-dossiers"
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:21
+#: ./opengever/dossier/browser/tabbed.py:22
 msgid "label_tasks"
 msgstr "Tâches"
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:91
+#: ./opengever/dossier/browser/tabbed.py:92
 msgid "label_tasktemplate_folders"
 msgstr "Déroulements standards"
 
@@ -633,7 +638,7 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:26
+#: ./opengever/dossier/browser/tabbed.py:27
 msgid "label_trash"
 msgstr "Corbeille"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-22 16:30+0000\n"
+"POT-Creation-Date: 2016-11-23 07:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -434,8 +434,13 @@ msgid "label_destination"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/tabbed.py:16
+#: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
+msgstr ""
+
+#. Default: "Dossier templates"
+#: ./opengever/dossier/browser/tabbed.py:108
+msgid "label_dossier_templates"
 msgstr ""
 
 #. Default: "Edit after creation"
@@ -477,12 +482,12 @@ msgid "label_former_reference_number"
 msgstr ""
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:36
+#: ./opengever/dossier/browser/tabbed.py:37
 msgid "label_info"
 msgstr ""
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:31
+#: ./opengever/dossier/browser/tabbed.py:32
 msgid "label_journal"
 msgstr ""
 
@@ -522,12 +527,12 @@ msgid "label_number_of_containers"
 msgstr ""
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:11
+#: ./opengever/dossier/browser/tabbed.py:12
 msgid "label_overview"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:67
+#: ./opengever/dossier/browser/tabbed.py:68
 msgid "label_participants"
 msgstr ""
 
@@ -537,7 +542,7 @@ msgid "label_participation"
 msgstr ""
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:62
+#: ./opengever/dossier/browser/tabbed.py:63
 msgid "label_participations"
 msgstr ""
 
@@ -547,7 +552,7 @@ msgid "label_phonenumber"
 msgstr ""
 
 #. Default: "Proposals"
-#: ./opengever/dossier/browser/tabbed.py:52
+#: ./opengever/dossier/browser/tabbed.py:53
 msgid "label_proposals"
 msgstr ""
 
@@ -586,7 +591,7 @@ msgid "label_roles"
 msgstr ""
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:99
+#: ./opengever/dossier/browser/tabbed.py:100
 msgid "label_sablon_templates"
 msgstr ""
 
@@ -608,17 +613,17 @@ msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:43
+#: ./opengever/dossier/browser/tabbed.py:44
 msgid "label_subdossiers"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:21
+#: ./opengever/dossier/browser/tabbed.py:22
 msgid "label_tasks"
 msgstr ""
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:91
+#: ./opengever/dossier/browser/tabbed.py:92
 msgid "label_tasktemplate_folders"
 msgstr ""
 
@@ -634,7 +639,7 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:26
+#: ./opengever/dossier/browser/tabbed.py:27
 msgid "label_trash"
 msgstr ""
 

--- a/opengever/dossier/templatedossier/tabs.py
+++ b/opengever/dossier/templatedossier/tabs.py
@@ -1,6 +1,12 @@
 from five import grok
+from ftw.table import helper
 from opengever.dossier.templatedossier.interfaces import ITemplateDossier
+from opengever.tabbedview import _
+from opengever.tabbedview import BaseCatalogListingTab
 from opengever.tabbedview.browser.tabs import Documents, Trash
+from opengever.tabbedview.helper import linked
+from opengever.tabbedview.helper import workflow_state
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 
 
 REMOVED_COLUMNS = ['receipt_date', 'delivery_date', 'containing_subdossier']
@@ -84,3 +90,26 @@ class TemplateDossierTrash(Trash):
     def columns(self):
         return drop_columns(
             super(TemplateDossierTrash, self).columns)
+
+
+class TemplateDossierDossierTemplates(BaseCatalogListingTab):
+    grok.name('tabbedview_view-dossiertemplates')
+
+    filterlist_available = False
+
+    object_provides = 'opengever.dossier.dossiertemplate.behaviors.IDossierTemplate'
+
+    search_options = {'is_subdossier': False}
+
+    columns = (
+
+        {'column': 'Title',
+         'column_title': _(u'label_title', default=u'Title'),
+         'sort_index': 'sortable_title',
+         'transform': linked},
+
+        )
+
+    enabled_actions = []
+    major_actions = []
+

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -128,3 +128,43 @@ class TestDossierTemplate(FunctionalTestCase):
         self.assertEqual(
             'Edit Subdossier',
             browser.css('#content h1').first.text)
+
+    @browsing
+    def test_dossiertemplates_tab_lists_only_dossiertemplates_without_subdossiers(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .titled(u'My Dossiertemplate')
+                                 .within(self.templatedossier))
+
+        create(Builder('dossiertemplate')
+               .titled(u'A Subdossiertemplate')
+               .within(dossiertemplate))
+
+        create(Builder('document')
+               .titled('Template A')
+               .within(self.templatedossier))
+
+        browser.login().visit(self.templatedossier, view="tabbedview_view-dossiertemplates")
+
+        self.assertEqual(
+            ['My Dossiertemplate'],
+            browser.css('.listing td .linkWrapper').text)
+
+    @browsing
+    def test_documents_inside_a_dossiertemplate_will_not_be_listed_in_documents_tab(self, browser):
+        create(Builder('document')
+               .titled('Good document')
+               .within(self.templatedossier))
+
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .titled(u'My Dossiertemplate')
+                                 .within(self.templatedossier))
+
+        create(Builder('document')
+               .titled('Bad document')
+               .within(dossiertemplate))
+
+        browser.login().visit(self.templatedossier, view="tabbedview_view-documents-proxy")
+
+        self.assertEqual(
+            ['Good document'],
+            browser.css('.listing td .linkWrapper').text)

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -506,6 +506,14 @@ class TestTemplateDossier(FunctionalTestCase):
         browser.find('DE').click()
         self.assertEquals(u'Vorlagen', browser.css('h1').first.text)
 
+    @browsing
+    def test_do_not_show_dossier_templates_tab(self, browser):
+        templatedossier = create(Builder('templatedossier'))
+
+        browser.login().visit(templatedossier)
+
+        self.assertEqual(0, len(browser.css('.formTab #tab-dossiertemplates')))
+
 
 class TestTemplateDossierMeetingEnabled(FunctionalTestCase):
 
@@ -701,3 +709,13 @@ class TestDossierTemplateFeature(FunctionalTestCase):
         browser.login().open(templatedossier)
 
         self.assertIn('Dossier template', factoriesmenu.addable_types())
+
+    @browsing
+    def test_show_dossier_templates_tab(self, browser):
+        templatedossier = create(Builder('templatedossier'))
+
+        browser.login().visit(templatedossier)
+
+        self.assertEqual(
+            'Dossier templates',
+            browser.css('.formTab #tab-dossiertemplates').first.text)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -54,7 +54,7 @@ class TemplateDossierBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
 builder_registry.register('templatedossier', TemplateDossierBuilder)
 
 
-class DossierTemplateBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
+class DossierTemplateBuilder(DexterityBuilder):
     portal_type = 'opengever.dossier.dossiertemplate'
 
 builder_registry.register('dossiertemplate', DossierTemplateBuilder)


### PR DESCRIPTION
Dieser PR fügt das Dossiertemplates-Tab der Templatedossier-Tabbedview hinzu.
Wenn das Feature deaktiviert ist, wird das Tab nicht angezeigt.

Die Auflistung zeigt alle Dossiertemplates auf (ohne Subdossiers, gem. Dossier-Listing). Angezeigt werden Titel und Review-State.

![screen2](https://cloud.githubusercontent.com/assets/557005/20559422/9daedcf0-b174-11e6-82f9-f820820c998b.gif)

see #2143