### PR TITLE
Fügt dem Dossiertemplate ein Schema hinzu

### DIFF
--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -1,6 +1,15 @@
+from collective import dexteritytextindexer
+from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base import _ as opengever_base_mf
+from opengever.dossier import _
 from opengever.dossier.behaviors.dossiernamefromtitle import DossierNameFromTitle
 from plone.app.content.interfaces import INameFromTitle
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.dexterity.i18n import MessageFactory as pd_mf  # noqa
 from plone.directives import form
+from plone.z3cform.textlines.textlines import TextLinesFieldWidget
+from zope import schema
+from zope.interface import alsoProvides
 from zope.interface import implements
 
 
@@ -9,6 +18,51 @@ class IDossierTemplate(form.Schema):
 
     Use this type of dossier to create a reusable template structures.
     """
+    form.fieldset(
+        u'common',
+        label=opengever_base_mf(u'fieldset_common', default=u'Common'),
+        fields=[
+            u'keywords',
+            u'comments',
+        ],
+    )
+
+    form.order_after(keywords='IOpenGeverBase.description')
+    dexteritytextindexer.searchable('keywords')
+    keywords = schema.Tuple(
+        title=_(u'label_keywords', default=u'Keywords'),
+        description=_(u'help_keywords', default=u''),
+        value_type=schema.TextLine(),
+        required=False,
+        missing_value=(),
+        default=(),
+    )
+    form.widget(keywords=TextLinesFieldWidget)
+
+    form.order_after(comments='keywords')
+    comments = schema.Text(
+        title=_(u'label_comments', default=u'Comments'),
+        required=False,
+    )
+
+    form.fieldset(
+        u'filing',
+        label=_(u'fieldset_filing', default=u'Filing'),
+        fields=[
+            u'filing_prefix',
+        ],
+    )
+
+    filing_prefix = schema.Choice(
+        title=_(u'filing_prefix', default="filing prefix"),
+        source=wrap_vocabulary(
+            'opengever.dossier.type_prefixes',
+            visible_terms_from_registry="opengever.dossier"
+            '.interfaces.IDossierContainerTypes.type_prefixes'),
+        required=False,
+    )
+
+alsoProvides(IDossierTemplate, IFormFieldProvider)
 
 
 class IDossierTemplateNameFromTitle(INameFromTitle):

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -168,3 +168,13 @@ class TestDossierTemplate(FunctionalTestCase):
         self.assertEqual(
             ['Good document'],
             browser.css('.listing td .linkWrapper').text)
+
+    @browsing
+    def test_dossiertemplate_schema_fields_sort_order(self, browser):
+        browser.login().open(self.portal)
+        factoriesmenu.add('Dossier template')
+
+        self.assertEqual(
+            [u'Title', 'Description', 'Keywords', 'Comments', 'filing prefix'],
+            browser.css('#content fieldset label').text
+        )


### PR DESCRIPTION
⚠️  merge #2318 first ⚠️ 

Dieser PR erstellt ein Schema für ein Dossiertemplate.

Damit das Schema korrekt mit dem IOpengeverBase-Behavior funktioniert musste ich ein weiteres Behavior `IDossierTemplateBase` erstellen welches das Schema beinhaltet.

Es werden die Felder angezeigt die in #2143 definiert wurden:

![screen2](https://cloud.githubusercontent.com/assets/557005/20563810/747d6688-b18a-11e6-9b8a-2dc4588419a0.gif)

see #2143