### PR TITLE
Only set `required` flag in schema dumps if no default value exists

### DIFF
--- a/docs/public/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/api/schemas/ftw.mail.mail.inc
@@ -18,7 +18,7 @@
 
        :Feldname: :field-title:`Klassifikation`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unprotected"
        :Beschreibung: Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen
        :Wertebereich: ["unprotected", "confidential", "classified"]
@@ -28,7 +28,7 @@
 
        :Feldname: :field-title:`Datenschutzstufe`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "privacy_layer_no"
        :Beschreibung: Markierung, die angibt, ob die Unterlagen besonders schützenswerte Personendaten oder Persönlichkeitsprofile gemäss Datenschutzrecht enthalten
        :Wertebereich: ["privacy_layer_no", "privacy_layer_yes"]
@@ -38,7 +38,7 @@
 
        :Feldname: :field-title:`Öffentlichkeitsstatus`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unchecked"
        :Beschreibung: Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht
        :Wertebereich: ["unchecked", "public", "limited-public", "private"]

--- a/docs/public/api/schemas/opengever.document.document.inc
+++ b/docs/public/api/schemas/opengever.document.document.inc
@@ -38,7 +38,7 @@
 
        :Feldname: :field-title:`Klassifikation`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unprotected"
        :Beschreibung: Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen
        :Wertebereich: ["unprotected", "confidential", "classified"]
@@ -48,7 +48,7 @@
 
        :Feldname: :field-title:`Datenschutzstufe`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "privacy_layer_no"
        :Beschreibung: Markierung, die angibt, ob die Unterlagen besonders schützenswerte Personendaten oder Persönlichkeitsprofile gemäss Datenschutzrecht enthalten
        :Wertebereich: ["privacy_layer_no", "privacy_layer_yes"]
@@ -58,7 +58,7 @@
 
        :Feldname: :field-title:`Öffentlichkeitsstatus`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unchecked"
        :Beschreibung: Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht
        :Wertebereich: ["unchecked", "public", "limited-public", "private"]

--- a/docs/public/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -158,7 +158,7 @@
 
        :Feldname: :field-title:`Klassifikation`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unprotected"
        :Beschreibung: Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen
        :Wertebereich: ["unprotected", "confidential", "classified"]
@@ -168,7 +168,7 @@
 
        :Feldname: :field-title:`Datenschutzstufe`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "privacy_layer_no"
        :Beschreibung: Markierung, die angibt, ob die Unterlagen besonders schützenswerte Personendaten oder Persönlichkeitsprofile gemäss Datenschutzrecht enthalten
        :Wertebereich: ["privacy_layer_no", "privacy_layer_yes"]
@@ -178,7 +178,7 @@
 
        :Feldname: :field-title:`Öffentlichkeitsstatus`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unchecked"
        :Beschreibung: Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht
        :Wertebereich: ["unchecked", "public", "limited-public", "private"]
@@ -198,7 +198,7 @@
 
        :Feldname: :field-title:`Aufbewahrungsdauer (Jahre)`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: 5
        :Beschreibung: Zeitraum zwischen dem jüngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses für die Geschäftstätigkeit der Verwaltungseinheit nicht mehr benötigt wird
        :Wertebereich: [5, 10, 15, 20, 25]
@@ -218,7 +218,7 @@
 
        :Feldname: :field-title:`Archivwürdigkeit`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unchecked"
        :Beschreibung: Archivwürdigkeit
        :Wertebereich: ["unchecked", "prompt", "archival worthy", "not archival worthy", "archival worthy with sampling"]
@@ -238,7 +238,7 @@
 
        :Feldname: :field-title:`Archivische Schutzfrist (Jahre)`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: 30
        :Beschreibung: Dauer, während der nach der Archivierung die Dokumente vor öffentlicher Einsichtnahme geschützt sind
        :Wertebereich: [0, 30, 100, 150]

--- a/docs/public/api/schemas/opengever.repository.repositoryfolder.inc
+++ b/docs/public/api/schemas/opengever.repository.repositoryfolder.inc
@@ -78,7 +78,7 @@
 
        :Feldname: :field-title:`Klassifikation`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unprotected"
        :Beschreibung: Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen
        :Wertebereich: ["unprotected", "confidential", "classified"]
@@ -88,7 +88,7 @@
 
        :Feldname: :field-title:`Datenschutzstufe`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "privacy_layer_no"
        :Beschreibung: Markierung, die angibt, ob die Unterlagen besonders schützenswerte Personendaten oder Persönlichkeitsprofile gemäss Datenschutzrecht enthalten
        :Wertebereich: ["privacy_layer_no", "privacy_layer_yes"]
@@ -98,7 +98,7 @@
 
        :Feldname: :field-title:`Öffentlichkeitsstatus`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unchecked"
        :Beschreibung: Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht
        :Wertebereich: ["unchecked", "public", "limited-public", "private"]
@@ -118,7 +118,7 @@
 
        :Feldname: :field-title:`Titel (deutsch)`
        :Datentyp: ``TextLine``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        
        
        
@@ -128,7 +128,7 @@
 
        :Feldname: :field-title:`Titel (französisch)`
        :Datentyp: ``TextLine``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        
        
        
@@ -148,7 +148,7 @@
 
        :Feldname: :field-title:`Aufbewahrungsdauer (Jahre)`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: 5
        :Beschreibung: Zeitraum zwischen dem jüngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses für die Geschäftstätigkeit der Verwaltungseinheit nicht mehr benötigt wird
        :Wertebereich: [5, 10, 15, 20, 25]
@@ -168,7 +168,7 @@
 
        :Feldname: :field-title:`Archivwürdigkeit`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: "unchecked"
        :Beschreibung: Archivwürdigkeit
        :Wertebereich: ["unchecked", "prompt", "archival worthy", "not archival worthy", "archival worthy with sampling"]
@@ -188,7 +188,7 @@
 
        :Feldname: :field-title:`Archivische Schutzfrist (Jahre)`
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        :Default: 30
        :Beschreibung: Dauer, während der nach der Archivierung die Dokumente vor öffentlicher Einsichtnahme geschützt sind
        :Wertebereich: [0, 30, 100, 150]

--- a/docs/public/api/schemas/opengever.repository.repositoryroot.inc
+++ b/docs/public/api/schemas/opengever.repository.repositoryroot.inc
@@ -38,7 +38,7 @@
 
        :Feldname: :field-title:`Titel (deutsch)`
        :Datentyp: ``TextLine``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        
        
        
@@ -48,7 +48,7 @@
 
        :Feldname: :field-title:`Titel (französisch)`
        :Datentyp: ``TextLine``
-       :Pflichtfeld: Ja :required:`(*)`
+       
        
        
        

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -165,11 +165,6 @@
             "_zope_schema_type": "TextLine"
         }
     },
-    "required": [
-        "classification",
-        "privacy_layer",
-        "public_trial"
-    ],
     "field_order": [
         "message",
         "classification",

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -178,11 +178,6 @@
             "_zope_schema_type": "Date"
         }
     },
-    "required": [
-        "classification",
-        "privacy_layer",
-        "public_trial"
-    ],
     "field_order": [
         "title",
         "file",

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -224,13 +224,7 @@
     },
     "required": [
         "title",
-        "responsible",
-        "classification",
-        "privacy_layer",
-        "public_trial",
-        "retention_period",
-        "archival_value",
-        "custody_period"
+        "responsible"
     ],
     "field_order": [
         "title",

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -184,16 +184,6 @@
             "_zope_schema_type": "Tuple"
         }
     },
-    "required": [
-        "classification",
-        "privacy_layer",
-        "public_trial",
-        "title_de",
-        "title_fr",
-        "retention_period",
-        "archival_value",
-        "custody_period"
-    ],
     "anyOf": [
         {
             "required": [

--- a/docs/schema-dumps/opengever.repository.repositoryroot.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryroot.schema.json
@@ -37,10 +37,6 @@
             "_zope_schema_type": "TextLine"
         }
     },
-    "required": [
-        "title_de",
-        "title_fr"
-    ],
     "anyOf": [
         {
             "required": [

--- a/opengever/api/docsbuilder/schemadocs.py
+++ b/opengever/api/docsbuilder/schemadocs.py
@@ -62,7 +62,7 @@ class SchemaDocsBuilder(DirectoryHelperMixin):
             field_docs = []
 
             for field_name, field_info in self.ordered_fields(json_schema):
-                required = field_name in json_schema['required']
+                required = field_name in json_schema.get('required', [])
                 field_doc = self._build_docs_for_field(
                     field_name, field_info, required)
                 field_docs.append(field_doc)

--- a/opengever/base/schemadump/field.py
+++ b/opengever/base/schemadump/field.py
@@ -56,6 +56,11 @@ class FieldDumper(object):
         default_value = self._get_default(field)
         if default_value is not NO_DEFAULT_MARKER:
             field_dump['default'] = default_value
+            # Also remove a potential `required` flag from the field if there
+            # is a default. The field may be tagged as being required on a
+            # zope.schema level, but functionally it's not actually required
+            # if a default value is defined.
+            field_dump['required'] = False
 
         # Determine vocabulary, if applicable
         log.debug("      Determining vocabulary...")

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -26,6 +26,9 @@ import transaction
 log = setup_logging(__name__)
 
 
+TRANSLATED_TITLE_NAMES = ('title_de', 'title_fr')
+
+
 class SchemaDumper(object):
     """Dumps a simple Python representation of a zope.schema Schema interface.
     """
@@ -224,9 +227,10 @@ class JSONSchemaGenerator(object):
                 json_schema_type['properties'][name] = json_schema_field
 
                 if field.get('required', False):
-                    constraints['required'].append(name)
+                    if name not in TRANSLATED_TITLE_NAMES:
+                        constraints['required'].append(name)
 
-                if name in ('title_de', 'title_fr'):
+                if name in TRANSLATED_TITLE_NAMES:
                     constraints['anyOf'].append({'required': [name]})
 
         for c_name, c_value in constraints.items():


### PR DESCRIPTION
Only set `required` flag in schema dumps if no default value  is present for the given field.

The field may have a `required` flag on a `zope.schema` level, but functionally it's not really required if a default value is defined.

@deiferni @phgross 