### PR TITLE
Replace reference field with a transfer_number field on disposition schema.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Replace reference field with a transfer_number field on disposition schema.
+  [phgross]
+
 - Add initial dossiertemplate type.
   [elioschmutz]
 

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -83,12 +83,6 @@ class RemovedDossierDispositionInformation(DossierDispositionInformation):
 
 class IDispositionSchema(form.Schema):
 
-    dexteritytextindexer.searchable('reference')
-    reference = schema.TextLine(
-        title=_(u"label_reference", default=u"Reference"),
-        required=False,
-    )
-
     dossiers = RelationList(
         title=_(u'label_dossiers', default=u'Dossiers'),
         default=[],
@@ -108,6 +102,11 @@ class IDispositionSchema(form.Schema):
         required=True,
     )
 
+    dexteritytextindexer.searchable('transfer_number')
+    transfer_number = schema.TextLine(
+        title=_(u"label_transfer_number", default=u"Transfer number"),
+        required=False,
+    )
 
 validator.WidgetValidatorDiscriminators(
     OfferedDossiersValidator,

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -83,6 +83,12 @@ class RemovedDossierDispositionInformation(DossierDispositionInformation):
 
 class IDispositionSchema(form.Schema):
 
+    form.fieldset(
+        u'common',
+        label=_(u'fieldset_common', default=u'Common'),
+        fields=[u'dossiers', u'transfer_number'],
+    )
+
     dossiers = RelationList(
         title=_(u'label_dossiers', default=u'Dossiers'),
         default=[],

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-23 14:56+0000\n"
+"POT-Creation-Date: 2016-11-24 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,14 +32,19 @@ msgid "document_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:25
+#: ./opengever/disposition/validators.py:27
 msgid "error_offered_in_a_different_disposition"
 msgstr "Das Dossier ${title} ist bereits in einem anderen Angebot angeboten."
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:19
+#: ./opengever/disposition/validators.py:21
 msgid "error_retention_period_not_expired"
 msgstr "Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen."
+
+#. Default: "Common"
+#: ./opengever/disposition/disposition.py:88
+msgid "fieldset_common"
+msgstr "Allgemein"
 
 #. Default: "Archive"
 #: ./opengever/disposition/browser/overview_templates/overview.pt:23
@@ -52,7 +57,7 @@ msgid "label_details"
 msgstr "Details:"
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:138
+#: ./opengever/disposition/disposition.py:144
 msgid "label_disposition"
 msgstr "Angebot"
 
@@ -73,7 +78,7 @@ msgid "label_dosisers"
 msgstr "Dossiers"
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/disposition.py:92
+#: ./opengever/disposition/disposition.py:93
 msgid "label_dossiers"
 msgstr "Dossiers"
 
@@ -82,15 +87,15 @@ msgstr "Dossiers"
 msgid "label_export_appraisal_list_as_excel"
 msgstr "Bewertungsliste als Excel exportieren"
 
-#. Default: "Reference"
-#: ./opengever/disposition/disposition.py:87
-msgid "label_reference"
-msgstr "Referenz"
-
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:29
 msgid "label_title"
 msgstr "Titel"
+
+#. Default: "Transfer number"
+#: ./opengever/disposition/disposition.py:113
+msgid "label_transfer_number"
+msgstr "Ablieferungsnummer"
 
 #. Default: "Added by ${user}"
 #: ./opengever/disposition/history.py:67

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-23 14:56+0000\n"
+"POT-Creation-Date: 2016-11-24 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,13 +32,18 @@ msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:25
+#: ./opengever/disposition/validators.py:27
 msgid "error_offered_in_a_different_disposition"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:19
+#: ./opengever/disposition/validators.py:21
 msgid "error_retention_period_not_expired"
+msgstr ""
+
+#. Default: "Common"
+#: ./opengever/disposition/disposition.py:88
+msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Archive"
@@ -52,7 +57,7 @@ msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:138
+#: ./opengever/disposition/disposition.py:144
 msgid "label_disposition"
 msgstr ""
 
@@ -72,7 +77,7 @@ msgid "label_dosisers"
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/disposition.py:92
+#: ./opengever/disposition/disposition.py:93
 msgid "label_dossiers"
 msgstr ""
 
@@ -81,14 +86,14 @@ msgstr ""
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
-#. Default: "Reference"
-#: ./opengever/disposition/disposition.py:87
-msgid "label_reference"
-msgstr ""
-
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:29
 msgid "label_title"
+msgstr ""
+
+#. Default: "Transfer number"
+#: ./opengever/disposition/disposition.py:113
+msgid "label_transfer_number"
 msgstr ""
 
 #. Default: "Added by ${user}"

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-23 14:56+0000\n"
+"POT-Creation-Date: 2016-11-24 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,13 +35,18 @@ msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:25
+#: ./opengever/disposition/validators.py:27
 msgid "error_offered_in_a_different_disposition"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:19
+#: ./opengever/disposition/validators.py:21
 msgid "error_retention_period_not_expired"
+msgstr ""
+
+#. Default: "Common"
+#: ./opengever/disposition/disposition.py:88
+msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Archive"
@@ -55,7 +60,7 @@ msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:138
+#: ./opengever/disposition/disposition.py:144
 msgid "label_disposition"
 msgstr ""
 
@@ -75,7 +80,7 @@ msgid "label_dosisers"
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/disposition.py:92
+#: ./opengever/disposition/disposition.py:93
 msgid "label_dossiers"
 msgstr ""
 
@@ -84,14 +89,14 @@ msgstr ""
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
-#. Default: "Reference"
-#: ./opengever/disposition/disposition.py:87
-msgid "label_reference"
-msgstr ""
-
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:29
 msgid "label_title"
+msgstr ""
+
+#. Default: "Transfer number"
+#: ./opengever/disposition/disposition.py:113
+msgid "label_transfer_number"
 msgstr ""
 
 #. Default: "Added by ${user}"

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -62,7 +62,7 @@ class TestDisposition(FunctionalTestCase):
     def test_can_be_added(self, browser):
         browser.login().open(self.root)
         factoriesmenu.add('Disposition')
-        browser.fill({'Reference': 'Ablieferung X29238',
+        browser.fill({'Transfer number': 'Ablieferung X29238',
                       'Dossiers': [self.dossier1, self.dossier3]})
         browser.find('Save').click()
 
@@ -76,7 +76,7 @@ class TestDisposition(FunctionalTestCase):
                              view='++add++opengever.disposition.disposition',
                              data=data)
 
-        browser.fill({'Reference': 'Ablieferung X29238'})
+        browser.fill({'Transfer number': 'Ablieferung X29238'})
         browser.find('Save').click()
 
         self.assertEquals([self.dossier1, self.dossier3],
@@ -125,7 +125,7 @@ class TestDisposition(FunctionalTestCase):
                              view='++add++opengever.disposition.disposition',
                              data=data)
 
-        browser.fill({'Reference': 'Ablieferung X29238'})
+        browser.fill({'Transfer number': 'Ablieferung X29238'})
         browser.find('Save').click()
 
         self.assertEquals(['There were some errors.'], error_messages())

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -49,7 +49,7 @@ class TestHistoryEntries(FunctionalTestCase):
     @browsing
     def test_add_history_entry_when_editing_a_disposition(self, browser):
         browser.login().open(self.disposition, view='edit')
-        browser.fill({'Reference': 'Ablieferung X29238',
+        browser.fill({'Transfer number': 'Ablieferung X29238',
                       'Dossiers': [self.dossier1, self.dossier2]})
         browser.find('Save').click()
 

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -86,8 +86,8 @@ class TestDossierListing(FunctionalTestCase):
             data={'dossier_state_filter': 'filter_retention_expired'})
 
         table = browser.css('.listing').first
-        self.assertEquals(['Dossier B', 'Dossier C'],
-                          [row.get('Title') for row in table.dicts()])
+        self.assertItemsEqual(['Dossier B', 'Dossier C'],
+                              [row.get('Title') for row in table.dicts()])
 
         # update retention_period for dossier_b, so that its no longer expired
         IDossier(self.dossier_b).end = date.today() - relativedelta(years=1)


### PR DESCRIPTION
An upgradestep, which migrates the data is not necessary, there exists no productive disposition content.

Besides that change I moved the disposition fields to the common fieldset, to have the same look and feel as all the other content types.

@deiferni or @lukasgraf 

- https://basecamp.com/2768704/projects/12554551/todos/274416348
