### PR TITLE
Make disposition title editable, but prefill it with a default value.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Make disposition title editable, but prefill it with a default value.
+  [phgross]
+
 - Replace reference field with a transfer_number field on disposition schema.
   [phgross]
 

--- a/opengever/disposition/browser/excel_export.py
+++ b/opengever/disposition/browser/excel_export.py
@@ -51,7 +51,7 @@ class DispositionExcelExport(BrowserView):
         reporter = XLSReporter(
             self.request, self.get_attributes(),
             self.context.get_dossier_representations(),
-            sheet_title=self.context.title)
+            sheet_title=self.get_sheet_title())
 
         response = self.request.RESPONSE
         data = reporter()
@@ -68,3 +68,9 @@ class DispositionExcelExport(BrowserView):
             self.request, "disposition_report.xlsx")
 
         return data
+
+    def get_sheet_title(self):
+        """Returns current disposition title. Crop it to 30 characters
+        because openpyxl only accepts sheet titles with max 30 characters.
+        """
+        return self.context.title[:30]

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -9,7 +9,6 @@ from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testing import freeze
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.testing import FunctionalTestCase
-from opengever.testing import obj2brain
 from opengever.testing import obj2paths
 from plone import api
 from plone.protect import createToken
@@ -45,18 +44,21 @@ class TestDisposition(FunctionalTestCase):
         self.assertEquals('disposition-1', disposition_1.getId())
         self.assertEquals('disposition-2', disposition_2.getId())
 
-    def test_title_composed_disposition_label_adminunit_abbreviation_creation_year_and_sequence_number(self):
+    @browsing
+    def test_title_is_prefilled_with_default_suggestion(self, browser):
+        """Expected format:
+        Disposition {adminiunit-abbreviation} {today's date}'.
+        """
+
+        expected = 'Disposition Client1 Jan 01, 2014'
 
         with freeze(datetime(2014, 1, 1)):
-            disposition = create(Builder('disposition'))
+            browser.login().open(
+                self.repository,
+                view="++add++opengever.disposition.disposition")
 
-            expected = u'Disposition Client1 2014 1'
-            self.assertEquals(expected, disposition.title)
-            self.assertEquals(expected.decode('utf-8'), disposition.Title())
-            self.assertEquals(expected, obj2brain(disposition).Title)
-
-        with freeze(datetime(2016, 1, 1)):
-            self.assertEquals(u'Disposition Client1 2014 1', disposition.title)
+            self.assertEquals(
+                expected, browser.forms.get('form').find_field('Title').value)
 
     @browsing
     def test_can_be_added(self, browser):

--- a/opengever/disposition/tests/test_listing.py
+++ b/opengever/disposition/tests/test_listing.py
@@ -35,23 +35,26 @@ class TestDispositionListing(FunctionalTestCase):
         with freeze(datetime(2015, 1, 1)):
             repository = create(Builder('repository').within(self.root))
             self.disposition_a = create(Builder('disposition')
+                                        .titled(u'Angebot FD 23.11.2010')
                                         .within(repository))
             self.disposition_b = create(Builder('disposition')
+                                        .titled(u'Angebot FD 1.2.2003')
                                         .within(repository))
             self.disposition_c = create(Builder('disposition')
+                                        .titled(u'Angebot FD 1.2.1995')
                                         .within(repository))
 
         browser.login().open(self.root, view='tabbedview_view-dispositions')
         self.assertEquals(
             [{'': '',
               'Sequence Number': '1',
-              'Title': 'Disposition Client1 2015 1'},
+              'Title': 'Angebot FD 23.11.2010'},
              {'': '',
               'Sequence Number': '2',
-              'Title': 'Disposition Client1 2015 2'},
+              'Title': 'Angebot FD 1.2.2003'},
              {'': '',
               'Sequence Number': '3',
-              'Title': 'Disposition Client1 2015 3'}],
+              'Title': 'Angebot FD 1.2.1995'}],
             browser.css('.listing').first.dicts())
 
     @browsing

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -440,5 +440,12 @@ builder_registry.register('private_dossier', PrivateDossierBuilder)
 class DispositionBuilder(DexterityBuilder):
     portal_type = 'opengever.disposition.disposition'
 
+    def __init__(self, session):
+        super(DispositionBuilder, self).__init__(session)
+        # OfferedDossiersValidator is broken when this is import is in
+        # module scope.
+        from opengever.disposition.disposition import title_default
+        self.arguments['title'] = title_default()
+
 
 builder_registry.register('disposition', DispositionBuilder)


### PR DESCRIPTION
Default value format: `Disposition {admin unit abbreviation} {localized today's date}`

See https://basecamp.com/2768704/projects/12554551/todos/274416169

@deiferni or @lukasgraf 