### PR TITLE
Unify schema dumping: Have bin/instance dump_schemas dump all schemas

### DIFF
--- a/docs/public/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/api/schemas/ftw.mail.mail.inc
@@ -174,26 +174,6 @@
        
 
 
-   .. py:attribute:: thumbnail
-
-       :Feldname: :field-title:`Kurzbild`
-       :Datentyp: ``NamedBlobFile``
-       
-       
-       
-       
-
-
-   .. py:attribute:: preview
-
-       :Feldname: :field-title:`Vorschau`
-       :Datentyp: ``NamedBlobFile``
-       
-       
-       :Beschreibung: Online Voransicht des Originaldokuments
-       
-
-
    .. py:attribute:: title
 
        :Feldname: :field-title:`Titel`
@@ -201,14 +181,4 @@
        
        
        
-       
-
-
-   .. py:attribute:: changeNote
-
-       :Feldname: :field-title:`Änderungsnotiz`
-       :Datentyp: ``TextLine``
-       
-       
-       :Beschreibung: Geben Sie einen Kommentar ein, der die von Ihnen gemachten Änderungen beschreibt.
        

--- a/docs/public/api/schemas/opengever.document.document.inc
+++ b/docs/public/api/schemas/opengever.document.document.inc
@@ -84,16 +84,6 @@
        
 
 
-   .. py:attribute:: changeNote
-
-       :Feldname: :field-title:`Änderungsnotiz`
-       :Datentyp: ``TextLine``
-       
-       
-       :Beschreibung: Geben Sie einen Kommentar ein, der die von Ihnen gemachten Änderungen beschreibt.
-       
-
-
    .. py:attribute:: description
 
        :Feldname: :field-title:`Beschreibung`
@@ -211,24 +201,4 @@
        
        
        
-       
-
-
-   .. py:attribute:: thumbnail
-
-       :Feldname: :field-title:`Kurzbild`
-       :Datentyp: ``NamedBlobFile``
-       
-       
-       
-       
-
-
-   .. py:attribute:: preview
-
-       :Feldname: :field-title:`Vorschau`
-       :Datentyp: ``NamedBlobFile``
-       
-       
-       :Beschreibung: Online Voransicht des Originaldokuments
        

--- a/docs/public/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -84,16 +84,6 @@
        :Wertebereich: ["department", "directorate", "administration", "personal", "government"]
 
 
-   .. py:attribute:: temporary_former_reference_number
-
-       :Feldname: :field-title:`Temporäres früheres Aktenzeichen`
-       :Datentyp: ``TextLine``
-       
-       
-       
-       
-
-
    .. py:attribute:: container_type
 
        :Feldname: :field-title:`Behältnis-Art`

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -62,12 +62,6 @@
             "description": "Nachname Vorname oder ein Benutzerk\u00fcrzel (wird automatisch nach Nachname Vorname aufgel\u00f6st).",
             "_zope_schema_type": "TextLine"
         },
-        "title": {
-            "type": "string",
-            "title": "Titel",
-            "description": "",
-            "_zope_schema_type": "TextLine"
-        },
         "archival_file_state": {
             "type": "integer",
             "title": "Status Archivdatei",
@@ -79,12 +73,6 @@
             "title": "Archivdatei",
             "description": "Archivtaugliche Version der Originaldatei",
             "_zope_schema_type": "NamedBlobFile"
-        },
-        "changeNote": {
-            "type": "string",
-            "title": "\u00c4nderungsnotiz",
-            "description": "Geben Sie einen Kommentar ein, der die von Ihnen gemachten \u00c4nderungen beschreibt.",
-            "_zope_schema_type": "TextLine"
         },
         "digitally_available": {
             "type": "boolean",
@@ -118,11 +106,11 @@
             "description": "",
             "_zope_schema_type": "Tuple"
         },
-        "preview": {
+        "title": {
             "type": "string",
-            "title": "Vorschau",
-            "description": "Online Voransicht des Originaldokuments",
-            "_zope_schema_type": "NamedBlobFile"
+            "title": "Titel",
+            "description": "",
+            "_zope_schema_type": "TextLine"
         },
         "message": {
             "type": "string",
@@ -144,12 +132,6 @@
             "description": "In Papierform aufbewahrt",
             "_zope_schema_type": "Bool",
             "default": true
-        },
-        "thumbnail": {
-            "type": "string",
-            "title": "Kurzbild",
-            "description": "",
-            "_zope_schema_type": "NamedBlobFile"
         },
         "public_trial_statement": {
             "type": "string",
@@ -183,9 +165,6 @@
         "preserved_as_paper",
         "archival_file",
         "archival_file_state",
-        "thumbnail",
-        "preview",
-        "title",
-        "changeNote"
+        "title"
     ]
 }

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -4,30 +4,6 @@
     "title": "Dokument",
     "additionalProperties": false,
     "properties": {
-        "classification": {
-            "type": "string",
-            "title": "Klassifikation",
-            "description": "Grad, in dem die Unterlagen vor unberechtigter Einsicht gesch\u00fctzt werden m\u00fcssen",
-            "_zope_schema_type": "Choice",
-            "default": "unprotected",
-            "enum": [
-                "unprotected",
-                "confidential",
-                "classified"
-            ]
-        },
-        "file": {
-            "type": "string",
-            "title": "Datei",
-            "description": "Datei, die zu einem Dossier hinzugef\u00fcgt wird",
-            "_zope_schema_type": "NamedBlobFile"
-        },
-        "keywords": {
-            "type": "array",
-            "title": "Schlagworte",
-            "description": "",
-            "_zope_schema_type": "Tuple"
-        },
         "document_date": {
             "type": "string",
             "title": "Dokumentdatum",
@@ -43,11 +19,29 @@
             "description": "Datum, an dem das Dokument \u00fcber den Korrespondenzweg angekommen ist",
             "_zope_schema_type": "Date"
         },
-        "changeNote": {
+        "foreign_reference": {
             "type": "string",
-            "title": "\u00c4nderungsnotiz",
-            "description": "Geben Sie einen Kommentar ein, der die von Ihnen gemachten \u00c4nderungen beschreibt.",
+            "title": "Fremdzeichen",
+            "description": "Referenz auf das entsprechende Dossier des Absenders",
             "_zope_schema_type": "TextLine"
+        },
+        "file": {
+            "type": "string",
+            "title": "Datei",
+            "description": "Datei, die zu einem Dossier hinzugef\u00fcgt wird",
+            "_zope_schema_type": "NamedBlobFile"
+        },
+        "classification": {
+            "type": "string",
+            "title": "Klassifikation",
+            "description": "Grad, in dem die Unterlagen vor unberechtigter Einsicht gesch\u00fctzt werden m\u00fcssen",
+            "_zope_schema_type": "Choice",
+            "default": "unprotected",
+            "enum": [
+                "unprotected",
+                "confidential",
+                "classified"
+            ]
         },
         "privacy_layer": {
             "type": "string",
@@ -66,68 +60,23 @@
             "description": "Nachname Vorname oder ein Benutzerk\u00fcrzel (wird automatisch nach Nachname Vorname aufgel\u00f6st).",
             "_zope_schema_type": "TextLine"
         },
-        "archival_file_state": {
-            "type": "integer",
-            "title": "Status Archivdatei",
+        "title": {
+            "type": "string",
+            "title": "Titel",
             "description": "",
-            "_zope_schema_type": "Int"
-        },
-        "relatedItems": {
-            "type": "array",
-            "title": "Verwandte Dokumente",
-            "description": "",
-            "_zope_schema_type": "RelationList",
-            "default": []
-        },
-        "public_trial_statement": {
-            "type": "string",
-            "title": "Bearbeitungsinformation",
-            "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text",
-            "default": ""
-        },
-        "public_trial": {
-            "type": "string",
-            "title": "\u00d6ffentlichkeitsstatus",
-            "description": "Angabe, ob die Unterlagen gem\u00e4ss \u00d6ffentlichkeitsgesetz zug\u00e4nglich sind oder nicht",
-            "_zope_schema_type": "Choice",
-            "default": "unchecked",
-            "enum": [
-                "unchecked",
-                "public",
-                "limited-public",
-                "private"
-            ]
-        },
-        "foreign_reference": {
-            "type": "string",
-            "title": "Fremdzeichen",
-            "description": "Referenz auf das entsprechende Dossier des Absenders",
             "_zope_schema_type": "TextLine"
-        },
-        "thumbnail": {
-            "type": "string",
-            "title": "Kurzbild",
-            "description": "",
-            "_zope_schema_type": "NamedBlobFile"
-        },
-        "description": {
-            "type": "string",
-            "title": "Beschreibung",
-            "description": "",
-            "_zope_schema_type": "Text"
-        },
-        "archival_file": {
-            "type": "string",
-            "title": "Archivdatei",
-            "description": "Archivtaugliche Version der Originaldatei",
-            "_zope_schema_type": "NamedBlobFile"
         },
         "digitally_available": {
             "type": "boolean",
             "title": "Digital verf\u00fcgbar",
             "description": "",
             "_zope_schema_type": "Bool"
+        },
+        "archival_file": {
+            "type": "string",
+            "title": "Archivdatei",
+            "description": "Archivtaugliche Version der Originaldatei",
+            "_zope_schema_type": "NamedBlobFile"
         },
         "document_type": {
             "type": "string",
@@ -145,30 +94,12 @@
                 "directive"
             ]
         },
-        "preserved_as_paper": {
-            "type": "boolean",
-            "title": "In Papierform aufbewahrt",
-            "description": "In Papierform aufbewahrt",
-            "_zope_schema_type": "Bool",
-            "default": true
-        },
-        "preview": {
-            "type": "string",
-            "title": "Vorschau",
-            "description": "Online Voransicht des Originaldokuments",
-            "_zope_schema_type": "NamedBlobFile"
-        },
-        "title": {
-            "type": "string",
-            "title": "Titel",
-            "description": "",
-            "_zope_schema_type": "TextLine"
-        },
-        "creators": {
+        "relatedItems": {
             "type": "array",
-            "title": "Autoren",
+            "title": "Verwandte Dokumente",
             "description": "",
-            "_zope_schema_type": "Tuple"
+            "_zope_schema_type": "RelationList",
+            "default": []
         },
         "delivery_date": {
             "type": "string",
@@ -176,6 +107,57 @@
             "format": "date",
             "description": "Datum, an dem das Dokument \u00fcber den Korrespondenzweg versandt worden ist",
             "_zope_schema_type": "Date"
+        },
+        "public_trial": {
+            "type": "string",
+            "title": "\u00d6ffentlichkeitsstatus",
+            "description": "Angabe, ob die Unterlagen gem\u00e4ss \u00d6ffentlichkeitsgesetz zug\u00e4nglich sind oder nicht",
+            "_zope_schema_type": "Choice",
+            "default": "unchecked",
+            "enum": [
+                "unchecked",
+                "public",
+                "limited-public",
+                "private"
+            ]
+        },
+        "keywords": {
+            "type": "array",
+            "title": "Schlagworte",
+            "description": "",
+            "_zope_schema_type": "Tuple"
+        },
+        "archival_file_state": {
+            "type": "integer",
+            "title": "Status Archivdatei",
+            "description": "",
+            "_zope_schema_type": "Int"
+        },
+        "creators": {
+            "type": "array",
+            "title": "Autoren",
+            "description": "",
+            "_zope_schema_type": "Tuple"
+        },
+        "preserved_as_paper": {
+            "type": "boolean",
+            "title": "In Papierform aufbewahrt",
+            "description": "In Papierform aufbewahrt",
+            "_zope_schema_type": "Bool",
+            "default": true
+        },
+        "public_trial_statement": {
+            "type": "string",
+            "title": "Bearbeitungsinformation",
+            "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
+            "_zope_schema_type": "Text",
+            "default": ""
+        },
+        "description": {
+            "type": "string",
+            "title": "Beschreibung",
+            "description": "",
+            "_zope_schema_type": "Text"
         }
     },
     "field_order": [
@@ -187,7 +169,6 @@
         "public_trial",
         "public_trial_statement",
         "relatedItems",
-        "changeNote",
         "description",
         "keywords",
         "foreign_reference",
@@ -199,8 +180,6 @@
         "digitally_available",
         "preserved_as_paper",
         "archival_file",
-        "archival_file_state",
-        "thumbnail",
-        "preview"
+        "archival_file_state"
     ]
 }

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -214,12 +214,6 @@
             "title": "Fr\u00fcheres Aktenzeichen",
             "description": "",
             "_zope_schema_type": "TextLine"
-        },
-        "temporary_former_reference_number": {
-            "type": "string",
-            "title": "Tempor\u00e4res fr\u00fcheres Aktenzeichen",
-            "description": "",
-            "_zope_schema_type": "TextLine"
         }
     },
     "required": [
@@ -235,7 +229,6 @@
         "comments",
         "responsible",
         "filing_prefix",
-        "temporary_former_reference_number",
         "container_type",
         "number_of_containers",
         "container_location",

--- a/opengever/base/schemadump/__init__.py
+++ b/opengever/base/schemadump/__init__.py
@@ -9,10 +9,4 @@ def dump_schemas_zopectl_handler(app, args):
     """
     setup_plone(get_first_plone_site(app))
     dump_schemas()
-
-
-def dump_oggbundle_schemas_zopectl_handler(app, args):
-    """Handler for the 'bin/instance dump_oggbundle_schemas' zopectl command.
-    """
-    setup_plone(get_first_plone_site(app))
     dump_oggbundle_schemas()

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,6 @@ setup(name='opengever.core',
       [zopectl.command]
       sync_ogds = opengever.ogds.base:sync_ogds_zopectl_handler
       dump_schemas = opengever.base.schemadump:dump_schemas_zopectl_handler
-      dump_oggbundle_schemas = opengever.base.schemadump:dump_oggbundle_schemas_zopectl_handler
 
       [izug.basetheme]
       version = opengever.core


### PR DESCRIPTION
Unify schema dumping: Have the `bin/instance dump_schemas` zopectl handler dump both regular JSON schemas and OGGBundle JSON schemas.

Also updated the currently existing schema dumps with recent changes.

@phgross 