### PR TITLE
Add missing upgradestep directory for the disposition profile

### DIFF
--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -21,6 +21,8 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <include package=".upgrades" />
+
   <permission
       id="opengever.disposition.AddDisposition"
       title="opengever.disposition: Add disposition"

--- a/opengever/disposition/upgrades/configure.zcml
+++ b/opengever/disposition/upgrades/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    i18n_domain="opengever.disposition">
+
+  <include package="ftw.upgrade" file="meta.zcml" />
+
+  <upgrade-step:directory
+      profile="opengever.disposition:default"
+      directory="."
+      />
+
+  <!-- Do not add upgrade steps here.
+       use ./bin/create-upgrade opengever.disposition "Upgrade description"
+       /-->
+
+</configure>


### PR DESCRIPTION
Otherwise ftw.upgrade does not mark the `opengever.disposition` profile as installed, when setting up a new GEVER.

IMO: it's just a fix of #2299 so a changelog entry is not necessary.

@lukasgraf as discussed 