### PR TITLE
OGGBundle schema dumps: Also allow 'null' for fields that aren't required.

### DIFF
--- a/docs/schema-dumps/oggbundle/documents.schema.json
+++ b/docs/schema-dumps/oggbundle/documents.schema.json
@@ -11,12 +11,16 @@
             "additionalProperties": false,
             "properties": {
                 "classification": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Klassifikation",
                     "description": "Grad, in dem die Unterlagen vor unberechtigter Einsicht gesch\u00fctzt werden m\u00fcssen",
                     "_zope_schema_type": "Choice",
                     "default": "unprotected",
                     "enum": [
+                        null,
                         "unprotected",
                         "confidential",
                         "classified"
@@ -26,7 +30,10 @@
                     "type": "string"
                 },
                 "keywords": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Schlagworte",
                     "description": "",
                     "_zope_schema_type": "Tuple"
@@ -35,7 +42,10 @@
                     "type": "string"
                 },
                 "document_date": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Dokumentdatum",
                     "format": "date",
                     "description": "Datum des Dokuments",
@@ -43,50 +53,70 @@
                     "default": "<Aktuelles Datum>"
                 },
                 "receipt_date": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Eingangsdatum",
                     "format": "date",
                     "description": "Datum, an dem das Dokument \u00fcber den Korrespondenzweg angekommen ist",
                     "_zope_schema_type": "Date"
                 },
                 "privacy_layer": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Datenschutzstufe",
                     "description": "Markierung, die angibt, ob die Unterlagen besonders sch\u00fctzenswerte Personendaten oder Pers\u00f6nlichkeitsprofile gem\u00e4ss Datenschutzrecht enthalten",
                     "_zope_schema_type": "Choice",
                     "default": "privacy_layer_no",
                     "enum": [
+                        null,
                         "privacy_layer_no",
                         "privacy_layer_yes"
                     ]
                 },
                 "document_author": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Autor",
                     "description": "Nachname Vorname oder ein Benutzerk\u00fcrzel (wird automatisch nach Nachname Vorname aufgel\u00f6st).",
                     "_zope_schema_type": "TextLine"
                 },
                 "relatedItems": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Verwandte Dokumente",
                     "description": "",
                     "_zope_schema_type": "RelationList",
                     "default": []
                 },
                 "public_trial_statement": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "_zope_schema_type": "Text",
                     "default": ""
                 },
                 "public_trial": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "\u00d6ffentlichkeitsstatus",
                     "description": "Angabe, ob die Unterlagen gem\u00e4ss \u00d6ffentlichkeitsgesetz zug\u00e4nglich sind oder nicht",
                     "_zope_schema_type": "Choice",
                     "default": "unchecked",
                     "enum": [
+                        null,
                         "unchecked",
                         "public",
                         "limited-public",
@@ -97,29 +127,42 @@
                     "type": "string"
                 },
                 "foreign_reference": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Fremdzeichen",
                     "description": "Referenz auf das entsprechende Dossier des Absenders",
                     "_zope_schema_type": "TextLine"
                 },
                 "description": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Beschreibung",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "digitally_available": {
-                    "type": "boolean",
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
                     "title": "Digital verf\u00fcgbar",
                     "description": "",
                     "_zope_schema_type": "Bool"
                 },
                 "document_type": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Dokumenttyp",
                     "description": "",
                     "_zope_schema_type": "Choice",
                     "enum": [
+                        null,
                         "question",
                         "request",
                         "report",
@@ -131,7 +174,10 @@
                     ]
                 },
                 "preserved_as_paper": {
-                    "type": "boolean",
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
                     "title": "In Papierform aufbewahrt",
                     "description": "In Papierform aufbewahrt",
                     "_zope_schema_type": "Bool",
@@ -147,13 +193,19 @@
                     "_zope_schema_type": "TextLine"
                 },
                 "creators": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Autoren",
                     "description": "",
                     "_zope_schema_type": "Tuple"
                 },
                 "delivery_date": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Ausgangsdatum",
                     "format": "date",
                     "description": "Datum, an dem das Dokument \u00fcber den Korrespondenzweg versandt worden ist",

--- a/docs/schema-dumps/oggbundle/dossiers.schema.json
+++ b/docs/schema-dumps/oggbundle/dossiers.schema.json
@@ -11,19 +11,26 @@
             "additionalProperties": false,
             "properties": {
                 "date_of_submission": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Anbietezeitpunkt",
                     "format": "date",
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
                 "classification": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Klassifikation",
                     "description": "Grad, in dem die Unterlagen vor unberechtigter Einsicht gesch\u00fctzt werden m\u00fcssen",
                     "_zope_schema_type": "Choice",
                     "default": "unprotected",
                     "enum": [
+                        null,
                         "unprotected",
                         "confidential",
                         "classified"
@@ -33,19 +40,26 @@
                     "type": "string"
                 },
                 "relatedDossier": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Verwandte Dossiers",
                     "description": "",
                     "_zope_schema_type": "RelationList",
                     "default": []
                 },
                 "retention_period": {
-                    "type": "integer",
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
                     "title": "Aufbewahrungsdauer (Jahre)",
                     "description": "Zeitraum zwischen dem j\u00fcngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses f\u00fcr die Gesch\u00e4ftst\u00e4tigkeit der Verwaltungseinheit nicht mehr ben\u00f6tigt wird",
                     "_zope_schema_type": "Choice",
                     "default": 5,
                     "enum": [
+                        null,
                         5,
                         10,
                         15,
@@ -54,22 +68,30 @@
                     ]
                 },
                 "container_type": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Beh\u00e4ltnis-Art",
                     "description": "Art des Beh\u00e4lters, in dem ein Dossier in Papierform abgelegt ist",
                     "_zope_schema_type": "Choice",
                     "enum": [
+                        null,
                         "dossier",
                         "folder",
                         "box"
                     ]
                 },
                 "filing_prefix": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Ablage Pr\u00e4fix",
                     "description": "",
                     "_zope_schema_type": "Choice",
                     "enum": [
+                        null,
                         "department",
                         "directorate",
                         "administration",
@@ -78,13 +100,19 @@
                     ]
                 },
                 "keywords": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Schlagworte",
                     "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition",
                     "_zope_schema_type": "Tuple"
                 },
                 "date_of_cassation": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kassationsdatum",
                     "format": "date",
                     "description": "",
@@ -94,13 +122,19 @@
                     "type": "string"
                 },
                 "retention_period_annotation": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kommentar zur Aufbewahrungsdauer",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "end": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Ende",
                     "format": "date",
                     "description": "",
@@ -113,12 +147,16 @@
                     "_zope_schema_type": "TextLine"
                 },
                 "custody_period": {
-                    "type": "integer",
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
                     "title": "Archivische Schutzfrist (Jahre)",
                     "description": "Dauer, w\u00e4hrend der nach der Archivierung die Dokumente vor \u00f6ffentlicher Einsichtnahme gesch\u00fctzt sind",
                     "_zope_schema_type": "Choice",
                     "default": 30,
                     "enum": [
+                        null,
                         0,
                         30,
                         100,
@@ -126,12 +164,16 @@
                     ]
                 },
                 "archival_value": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Archivw\u00fcrdigkeit",
                     "description": "Archivw\u00fcrdigkeit",
                     "_zope_schema_type": "Choice",
                     "default": "unchecked",
                     "enum": [
+                        null,
                         "unchecked",
                         "prompt",
                         "archival worthy",
@@ -147,13 +189,19 @@
                     "_vocabulary": "<G\u00fcltige User-ID>"
                 },
                 "comments": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kommentar",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "start": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Beginn",
                     "format": "date",
                     "description": "",
@@ -161,18 +209,25 @@
                     "default": "<Aktuelles Datum>"
                 },
                 "number_of_containers": {
-                    "type": "integer",
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
                     "title": "Anzahl Beh\u00e4ltnisse",
                     "description": "Anzahl Beh\u00e4lter, die ein (grosses) Dossier in Papierform enthalten",
                     "_zope_schema_type": "Int"
                 },
                 "public_trial": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "\u00d6ffentlichkeitsstatus",
                     "description": "Angabe, ob die Unterlagen gem\u00e4ss \u00d6ffentlichkeitsgesetz zug\u00e4nglich sind oder nicht",
                     "_zope_schema_type": "Choice",
                     "default": "unchecked",
                     "enum": [
+                        null,
                         "unchecked",
                         "public",
                         "limited-public",
@@ -180,7 +235,10 @@
                     ]
                 },
                 "container_location": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Beh\u00e4ltnis-Standort",
                     "description": "Standortangabe des Beh\u00e4lters, in dem ein Dossier in Papierform abgelegt ist",
                     "_zope_schema_type": "TextLine"
@@ -189,43 +247,62 @@
                     "type": "string"
                 },
                 "description": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Beschreibung",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "archival_value_annotation": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kommentar zur Archivw\u00fcrdigkeit",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "public_trial_statement": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "_zope_schema_type": "Text",
                     "default": ""
                 },
                 "reference_number": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Aktenzeichen",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "privacy_layer": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Datenschutzstufe",
                     "description": "Markierung, die angibt, ob die Unterlagen besonders sch\u00fctzenswerte Personendaten oder Pers\u00f6nlichkeitsprofile gem\u00e4ss Datenschutzrecht enthalten",
                     "_zope_schema_type": "Choice",
                     "default": "privacy_layer_no",
                     "enum": [
+                        null,
                         "privacy_layer_no",
                         "privacy_layer_yes"
                     ]
                 },
                 "former_reference_number": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Fr\u00fcheres Aktenzeichen",
                     "description": "",
                     "_zope_schema_type": "TextLine"

--- a/docs/schema-dumps/oggbundle/repofolders.schema.json
+++ b/docs/schema-dumps/oggbundle/repofolders.schema.json
@@ -11,25 +11,35 @@
             "additionalProperties": false,
             "properties": {
                 "title_de": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Titel (deutsch)",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "date_of_submission": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Anbietezeitpunkt",
                     "format": "date",
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
                 "classification": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Klassifikation",
                     "description": "Grad, in dem die Unterlagen vor unberechtigter Einsicht gesch\u00fctzt werden m\u00fcssen",
                     "_zope_schema_type": "Choice",
                     "default": "unprotected",
                     "enum": [
+                        null,
                         "unprotected",
                         "confidential",
                         "classified"
@@ -39,12 +49,16 @@
                     "type": "string"
                 },
                 "retention_period": {
-                    "type": "integer",
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
                     "title": "Aufbewahrungsdauer (Jahre)",
                     "description": "Zeitraum zwischen dem j\u00fcngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses f\u00fcr die Gesch\u00e4ftst\u00e4tigkeit der Verwaltungseinheit nicht mehr ben\u00f6tigt wird",
                     "_zope_schema_type": "Choice",
                     "default": 5,
                     "enum": [
+                        null,
                         5,
                         10,
                         15,
@@ -53,7 +67,10 @@
                     ]
                 },
                 "date_of_cassation": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kassationsdatum",
                     "format": "date",
                     "description": "",
@@ -63,42 +80,59 @@
                     "type": "string"
                 },
                 "title_fr": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Titel (franz\u00f6sisch)",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "retention_period_annotation": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kommentar zur Aufbewahrungsdauer",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "valid_from": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "G\u00fcltig ab",
                     "format": "date",
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
                 "privacy_layer": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Datenschutzstufe",
                     "description": "Markierung, die angibt, ob die Unterlagen besonders sch\u00fctzenswerte Personendaten oder Pers\u00f6nlichkeitsprofile gem\u00e4ss Datenschutzrecht enthalten",
                     "_zope_schema_type": "Choice",
                     "default": "privacy_layer_no",
                     "enum": [
+                        null,
                         "privacy_layer_no",
                         "privacy_layer_yes"
                     ]
                 },
                 "custody_period": {
-                    "type": "integer",
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
                     "title": "Archivische Schutzfrist (Jahre)",
                     "description": "Dauer, w\u00e4hrend der nach der Archivierung die Dokumente vor \u00f6ffentlicher Einsichtnahme gesch\u00fctzt sind",
                     "_zope_schema_type": "Choice",
                     "default": 30,
                     "enum": [
+                        null,
                         0,
                         30,
                         100,
@@ -106,12 +140,16 @@
                     ]
                 },
                 "archival_value": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Archivw\u00fcrdigkeit",
                     "description": "Archivw\u00fcrdigkeit",
                     "_zope_schema_type": "Choice",
                     "default": "unchecked",
                     "enum": [
+                        null,
                         "unchecked",
                         "prompt",
                         "archival worthy",
@@ -120,18 +158,25 @@
                     ]
                 },
                 "location": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Standort",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "public_trial": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "\u00d6ffentlichkeitsstatus",
                     "description": "Angabe, ob die Unterlagen gem\u00e4ss \u00d6ffentlichkeitsgesetz zug\u00e4nglich sind oder nicht",
                     "_zope_schema_type": "Choice",
                     "default": "unchecked",
                     "enum": [
+                        null,
                         "unchecked",
                         "public",
                         "limited-public",
@@ -145,58 +190,85 @@
                     "$ref": "#/definitions/permission"
                 },
                 "valid_until": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "G\u00fcltig bis",
                     "format": "date",
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
                 "description": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Beschreibung",
                     "description": "Eine kurze Beschreibung des Inhalts.",
                     "_zope_schema_type": "Text"
                 },
                 "referenced_activity": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Leistung",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "archival_value_annotation": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Kommentar zur Archivw\u00fcrdigkeit",
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
                 "public_trial_statement": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
                     "_zope_schema_type": "Text",
                     "default": ""
                 },
                 "addable_dossier_types": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Erlaubte Spezialdossiers",
                     "description": "W\u00e4hlen Sie die Spezialdossiers aus, die in dieser Ordnungsposition erlaubt sind.",
                     "_zope_schema_type": "List"
                 },
                 "former_reference": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Fr\u00fcheres Zeichen",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "reference_number_prefix": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Pr\u00e4fix des Aktenzeichens",
                     "description": "",
                     "_zope_schema_type": "TextLine",
                     "default": "<H\u00f6chste auf dieser Ebene vergebene Nummer + 1>"
                 },
                 "creators": {
-                    "type": "array",
+                    "type": [
+                        "null",
+                        "array"
+                    ],
                     "title": "Autoren",
                     "description": "",
                     "_zope_schema_type": "Tuple"

--- a/docs/schema-dumps/oggbundle/reporoots.schema.json
+++ b/docs/schema-dumps/oggbundle/reporoots.schema.json
@@ -11,30 +11,45 @@
             "additionalProperties": false,
             "properties": {
                 "valid_until": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "G\u00fcltig bis",
                     "format": "date",
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
                 "title_de": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Titel (deutsch)",
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
                 "valid_from": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "G\u00fcltig ab",
                     "format": "date",
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
                 "parent_guid": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "version": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Version",
                     "description": "",
                     "_zope_schema_type": "TextLine"
@@ -49,7 +64,10 @@
                     "type": "string"
                 },
                 "title_fr": {
-                    "type": "string",
+                    "type": [
+                        "null",
+                        "string"
+                    ],
                     "title": "Titel (franz\u00f6sisch)",
                     "description": "",
                     "_zope_schema_type": "TextLine"

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -331,6 +331,7 @@ class OGGBundleJSONSchemaBuilder(object):
             # XXX: Documents without files?
 
         self._filter_fields(short_name, core_schema)
+        self._make_optional_fields_nullable(core_schema)
 
         return schema
 
@@ -340,6 +341,22 @@ class OGGBundleJSONSchemaBuilder(object):
             core_schema['properties'].pop(field_name, None)
             if field_name in core_schema['required']:
                 core_schema['required'].remove(field_name)
+
+    def _make_optional_fields_nullable(self, core_schema):
+        for field_name, field in core_schema['properties'].items():
+            if field_name not in core_schema['required']:
+                existing_type = field.get('type')
+                if not existing_type:
+                    continue
+
+                # Add null/None as one of the allowed data types
+                assert isinstance(existing_type, basestring)
+                field['type'] = ['null'] + [existing_type]
+
+                # If the field has a vocabulary, null/None also needs to be
+                # part of that vocabulary in order for the schema to validate
+                if 'enum' in field:
+                    field['enum'].insert(0, None)
 
 
 class JSONSchemaDumpWriter(DirectoryHelperMixin):


### PR DESCRIPTION
This change brings the JSON schema dump implementation in sync with what was used to produce the schemas in 4teamwork/ubitpoc#2.

(null values also need to be accepted for several fields in order for the data to validate against the schemas).

@deiferni 