### PR TITLE
Unprotect all buckets of a BTree, when unprotecting a BTree.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Unprotect all buckets when unprotecting a btree.
+  [phgross]
+
 - Add templatefolder-tab for displaying dossiertemplates.
   [elioschmutz]
 

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -48,8 +48,22 @@ def unprotected_write(obj):
         unprotected_write(getattr(obj.obj, '__annotations__', None))
         return obj
 
+    # safeWrite all buckets of a BTree
+    if getattr(obj, '_firstbucket', None):
+        for bucket in get_buckets_for_btree(obj):
+            safeWrite(bucket)
+
     safeWrite(obj)
     return obj
+
+
+def get_buckets_for_btree(tree):
+    bucket = tree._firstbucket
+    yield bucket
+
+    while bucket._next:
+        bucket = bucket._next
+        yield bucket
 
 
 class OGProtectTransform(ProtectTransform):

--- a/opengever/base/tests/test_protect.py
+++ b/opengever/base/tests/test_protect.py
@@ -1,8 +1,26 @@
+from BTrees.OOBTree import OOBTree
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from itertools import chain
+from opengever.base.protect import get_buckets_for_btree
 from opengever.testing import FunctionalTestCase
 import transaction
+import unittest2
+
+
+class TestBucketsForBTree(unittest2.TestCase):
+
+    def test_get_buckets_for_btree_yield_all_contained_buckets(self):
+        tree = OOBTree()
+        for i in range(0, 50):
+            tree['key-{}'.format(i)] = 'Lorem Ipsum'
+
+        buckets = list(get_buckets_for_btree(tree))
+        self.assertEquals(3, len(buckets))
+
+        keys = [bucket.keys() for bucket in buckets]
+        self.assertEquals(50, len(list(chain(*keys))))
 
 
 class TestProtect(FunctionalTestCase):


### PR DESCRIPTION
The current unprotection of the annotations BTree, hasn't worked, when the BTree were splitted into  multiple buckets. This PR resolves this problem.

@deiferni 

