### PR TITLE
Fügt "Dossier aus Template"-Action für Repository-Folder hinzu

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add folder-factory actions to add a dossier from a dossiertemplate in a repository-folder.
+  [elioschmutz]
+
 - Add a whitelisted schema generator for dossiertemplates to avoid duplicate
   schema-definitions
   [elioschmutz]

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-18 14:56+0000\n"
+"POT-Creation-Date: 2016-11-23 16:10+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -387,3 +387,4 @@ msgstr "Nicht geprüft"
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr "Nicht klassifiziert"
+

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -74,6 +74,9 @@ msgstr "Status des Dossiers geändert zu Storniert"
 msgid "Dossier state changed to dossier-state-resolved"
 msgstr "Status des Dossiers geändert zu Abgeschlossen"
 
+msgid "Dossier with template"
+msgstr "Dossier aus Vorlage"
+
 msgid "Edit metadata"
 msgstr "Metadaten bearbeiten"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-18 14:56+0000\n"
+"POT-Creation-Date: 2016-11-23 16:10+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -74,6 +74,9 @@ msgstr "Etat du dossier modifié : Annulé"
 msgid "Dossier state changed to dossier-state-resolved"
 msgstr "Etat du dossier modifié : Fermé"
 
+msgid "Dossier with template"
+msgstr ""
+
 msgid "Edit metadata"
 msgstr "Modifier les méta-données"
 

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-18 14:56+0000\n"
+"POT-Creation-Date: 2016-11-23 16:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -96,6 +96,9 @@ msgstr ""
 msgid "document_with_template"
 msgstr ""
 
+msgid "Dossier with template"
+msgstr ""
+
 msgid "Dossier state changed to dossier-state-active"
 msgstr ""
 

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -18,6 +18,7 @@
   <include package=".viewlets" />
   <include package=".filing" />
   <include package=".browser" />
+  <include package=".dossiertemplate" />
   <include package=".templatedossier" />
 
   <include file="behaviors.zcml" />

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -1,0 +1,14 @@
+<configure
+      xmlns="http://namespaces.zope.org/zope"
+      xmlns:browser="http://namespaces.zope.org/browser"
+      i18n_domain="opengever.dossier">
+
+  <browser:page
+      for="opengever.repository.interfaces.IRepositoryFolder"
+      name="dossier_with_template"
+      class=".form.SelectTemplateDossierView"
+      permission="zope2.View"
+      allowed_attributes="is_available"
+      />
+
+</configure>

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -1,0 +1,14 @@
+from Products.Five import BrowserView
+from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
+
+
+class SelectTemplateDossierView(BrowserView):
+    """ NOT IMPLEMENTED YET
+    """
+
+    def is_available(self):
+        """Checks if it is allowed to add a 'dossier from template'
+        at the current context.
+        """
+        return is_dossier_template_feature_enabled() and \
+            self.context.is_leaf_node()

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+from opengever.core.testing import toggle_feature
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
@@ -203,3 +204,32 @@ class TestDossierTemplate(FunctionalTestCase):
             [u'Title', 'Description', 'Keywords', 'Comments', 'filing prefix'],
             browser.css('#content fieldset label').text
         )
+
+
+class TestDossierTemplateAddWizard(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+
+    def test_is_not_available_if_dossiertempalte_feature_is_disabled(self):
+        root = create(Builder('repository_root'))
+        leaf_node = create(Builder('repository').within(root))
+
+        toggle_feature(IDossierTemplateSettings, enabled=False)
+
+        self.assertFalse(
+            leaf_node.restrictedTraverse('@@dossier_with_template/is_available')())
+
+    def test_is_not_available_on_branch_node(self):
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        self.assertFalse(
+            branch_node.restrictedTraverse('@@dossier_with_template/is_available')())
+
+    def test_is_available_on_leaf_node_when_feature_is_enabled(self):
+        root = create(Builder('repository_root'))
+        leaf_node = create(Builder('repository').within(root))
+
+        self.assertTrue(
+            leaf_node.restrictedTraverse('@@dossier_with_template/is_available')())

--- a/opengever/dossier/upgrades/20161123153724_add_factory_action_to_repository_folder_to_add_dossier_from_template/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/dossier/upgrades/20161123153724_add_factory_action_to_repository_folder_to_add_dossier_from_template/types/opengever.repository.repositoryfolder.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="opengever.repository.repositoryfolder" meta_type="Dexterity FTI"
+        i18n:domain="opengever.repository" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <action action_id="dossier_with_template"
+            visible="True"
+            title="Dossier with template"
+            category="folder_factories"
+            url_expr="string:${object_url}/dossier_with_template"
+            icon_expr=""
+            condition_expr="object/@@dossier_with_template/is_available"
+            i18n:domain="opengever.dossier">
+        <permission value="Add portal content"/>
+    </action>
+
+</object>

--- a/opengever/dossier/upgrades/20161123153724_add_factory_action_to_repository_folder_to_add_dossier_from_template/upgrade.py
+++ b/opengever/dossier/upgrades/20161123153724_add_factory_action_to_repository_folder_to_add_dossier_from_template/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddFactoryActionToRepositoryFolderToAddDossierFromTemplate(UpgradeStep):
+    """Add factory action to repository folder to add dossier from template.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/repository/profiles/default/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/repository/profiles/default/types/opengever.repository.repositoryfolder.xml
@@ -64,6 +64,16 @@
         <permission value="Modify portal content"/>
     </action>
 
+    <action action_id="dossier_with_template"
+            visible="True"
+            title="Dossier with template"
+            category="folder_factories"
+            url_expr="string:${object_url}/dossier_with_template"
+            icon_expr=""
+            condition_expr="object/@@dossier_with_template/is_available"
+            i18n:domain="opengever.dossier">
+        <permission value="Add portal content"/>
+    </action>
 
     <!-- Tabbedview tabs-->
 

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -114,6 +114,14 @@ class RepositoryFolder(content.Container):
             sep=reference_adapter.get_active_formatter().repository_title_seperator,
             title=title)
 
+    def is_leaf_node(self):
+        """ Checks if the current repository folder is a leaf-node.
+        """
+        for id, obj in self.contentItems():
+            if obj.portal_type == self.portal_type:
+                return False
+        return True
+
     def allowedContentTypes(self, *args, **kwargs):
         """
         We have to follow some rules:
@@ -148,15 +156,9 @@ class RepositoryFolder(content.Container):
                 # depth exceeded
                 # RepositoryFolder not allowed, but any other type
                 types = filter(lambda a: a != fti, types)
-        # check if self contains any similar objects
-        contains_similar_objects = False
-        for id, obj in self.contentItems():
-            if obj.portal_type == self.portal_type:
-                contains_similar_objects = True
-                break
 
         # filter content types, if required
-        if contains_similar_objects:
+        if not self.is_leaf_node():
             # only allow same types
             types = filter(lambda a: a == fti, types)
 

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -5,11 +5,14 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages.statusmessages import warning_messages
 from opengever.base.interfaces import IReferenceNumberSettings
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix
+from opengever.repository.interfaces import IRepositoryFolderRecords
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
 from opengever.testing import obj2brain
 from opengever.testing import set_preferred_language
+from plone import api
 from plone.protect import createToken
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
@@ -109,3 +112,108 @@ class TestRepositoryFolderWithBrowser(FunctionalTestCase):
              'temporarily allowed and all dossiers must be moved into '
              'a new leafnode afterwards.'],
             warning_messages())
+
+    @browsing
+    def test_addable_types_on_a_repository_folder_containing_other_repo_folders(self, browser):
+        self.grant('Manager')
+
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        browser.login().open(branch_node)
+
+        self.assertEquals(
+            ['RepositoryFolder'],
+            factoriesmenu.addable_types())
+
+    @browsing
+    def test_addable_types_on_a_repository_leaf_folder(self, browser):
+        self.grant('Manager')
+
+        api.portal.set_registry_record(
+            'maximum_repository_depth', 3,
+            interface=IRepositoryFolderRecords)
+
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        browser.login().open(leaf_node)
+
+        self.assertEquals(
+            ['Business Case Dossier', 'Disposition', 'RepositoryFolder'],
+            factoriesmenu.addable_types())
+
+    @browsing
+    def test_addable_types_on_a_repository_leaf_folder_if_max_rep_depth_reached(self, browser):
+        self.grant('Manager')
+
+        api.portal.set_registry_record(
+            'maximum_repository_depth', 2,
+            interface=IRepositoryFolderRecords)
+
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        browser.login().open(leaf_node)
+
+        self.assertEquals(
+            ['Business Case Dossier', 'Disposition'],
+            factoriesmenu.addable_types())
+
+
+class TestDossierTemplateFeatureEnabled(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+
+    @browsing
+    def test_addable_types_on_a_repository_folder_containing_other_repo_folders(self, browser):
+        self.grant('Manager')
+
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        browser.login().open(branch_node)
+
+        self.assertEquals(
+            ['RepositoryFolder'],
+            factoriesmenu.addable_types())
+
+    @browsing
+    def test_addable_types_on_a_repository_leaf_folder(self, browser):
+        self.grant('Manager')
+
+        api.portal.set_registry_record(
+            'maximum_repository_depth', 3,
+            interface=IRepositoryFolderRecords)
+
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        browser.login().open(leaf_node)
+
+        self.assertEquals(
+            ['Business Case Dossier', 'Disposition', 'Dossier with template', 'RepositoryFolder'],
+            factoriesmenu.addable_types())
+
+    @browsing
+    def test_addable_types_on_a_repository_leaf_folder_if_max_rep_depth_reached(self, browser):
+        self.grant('Manager')
+
+        api.portal.set_registry_record(
+            'maximum_repository_depth', 2,
+            interface=IRepositoryFolderRecords)
+
+        root = create(Builder('repository_root'))
+        branch_node = create(Builder('repository').within(root))
+        leaf_node = create(Builder('repository').within(branch_node))
+
+        browser.login().open(leaf_node)
+
+        self.assertEquals(
+            ['Business Case Dossier', 'Disposition', 'Dossier with template'],
+            factoriesmenu.addable_types())


### PR DESCRIPTION
Dieser PR fügt eine neue Action: "Dossier aus Template" dem Repository-Folder hinzu.

![screen2](https://cloud.githubusercontent.com/assets/557005/20702269/6585c30a-b617-11e6-98a3-9330ce7cfafd.gif)

Das Icon wurde in diesem PR hinzugefügt: https://github.com/4teamwork/plonetheme.teamraum/pull/484

see #2143
