### PR TITLE
Add guid resolver section for oggbundles.

### DIFF
--- a/opengever/setup/sections/jsonsource.py
+++ b/opengever/setup/sections/jsonsource.py
@@ -32,13 +32,16 @@ class JSONSourceSection(object):
         self.transmogrifier = transmogrifier
 
         self.key = defaultMatcher(options, 'key', name)
-        self.json_dir = options.get('json_dir')
         self.filename = options.get('filename')
+        if hasattr(transmogrifier, 'bundle_dir'):
+            self.bundle_dir = transmogrifier.bundle_dir
+        else:
+            self.bundle_dir = options.get('bundle_dir')
 
         self.portal_type = options.get('portal_type')
         self.json_schema = self.get_content_type_json_schema()
 
-        self.filepath = os.path.join(self.json_dir, self.filename)
+        self.filepath = os.path.join(self.bundle_dir, self.filename)
 
     def get_content_type_json_schema(self):
         if not self.portal_type:

--- a/opengever/setup/tests/__init__.py
+++ b/opengever/setup/tests/__init__.py
@@ -1,0 +1,2 @@
+class MockTransmogrifier(object):
+    pass

--- a/opengever/setup/tests/test_section_jsonsource.py
+++ b/opengever/setup/tests/test_section_jsonsource.py
@@ -2,14 +2,11 @@ from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from jsonschema.exceptions import ValidationError
 from opengever.setup.sections.jsonsource import JSONSourceSection
+from opengever.setup.tests import MockTransmogrifier
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_filename
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
-
-
-class MockTransmogrifier(object):
-    pass
 
 
 class TestJSONSource(FunctionalTestCase):

--- a/opengever/setup/tests/test_section_jsonsource.py
+++ b/opengever/setup/tests/test_section_jsonsource.py
@@ -8,14 +8,22 @@ from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
 
 
+class MockTransmogrifier(object):
+    pass
+
+
 class TestJSONSource(FunctionalTestCase):
 
-    def setup_source(self, options, previous=None):
+    def setup_source(self, options, bundle_dir=None, previous=None):
         previous = previous or []
-        directory = resource_filename('opengever.setup.tests', 'assets')
+        bundle_dir = bundle_dir or resource_filename(
+            'opengever.setup.tests', 'assets')
+        transmogrifier = MockTransmogrifier()
+        transmogrifier.bundle_dir = bundle_dir
+
         options.setdefault('blueprint', 'opengever.setup.jsonsource')
-        options.setdefault('json_dir', directory)
-        return JSONSourceSection(None, '', options, previous)
+
+        return JSONSourceSection(transmogrifier, '', options, previous)
 
     def test_implements_interface(self):
         self.assertTrue(ISection.implementedBy(JSONSourceSection))
@@ -26,7 +34,7 @@ class TestJSONSource(FunctionalTestCase):
 
     def test_skips_missing_files(self):
         directory = resource_filename('opengever.setup.tests', 'nope')
-        source = self.setup_source({'json_dir': directory,
+        source = self.setup_source({'bundle_dir': directory,
                                     'filename': 'nope.json'},
                                    previous=['Foo'])
 

--- a/opengever/setup/tests/test_section_resolveguid.py
+++ b/opengever/setup/tests/test_section_resolveguid.py
@@ -1,9 +1,14 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.setup.sections.jsonsource import JSONSourceSection
 from opengever.setup.sections.resolveguid import DuplicateGuid
 from opengever.setup.sections.resolveguid import MissingGuid
 from opengever.setup.sections.resolveguid import MissingParent
 from opengever.setup.sections.resolveguid import ResolveGUIDSection
 from opengever.setup.tests import MockTransmogrifier
 from opengever.testing import FunctionalTestCase
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
 
 
 class TestResolveGUID(FunctionalTestCase):
@@ -14,6 +19,13 @@ class TestResolveGUID(FunctionalTestCase):
         options = {'blueprint', 'opengever.setup.resolveguid'}
 
         return ResolveGUIDSection(transmogrifier, '', options, previous)
+
+    def test_implements_interface(self):
+        self.assertTrue(ISection.implementedBy(JSONSourceSection))
+        verifyClass(ISection, JSONSourceSection)
+
+        self.assertTrue(ISectionBlueprint.providedBy(JSONSourceSection))
+        verifyObject(ISectionBlueprint, JSONSourceSection)
 
     def test_requires_guid(self):
         section = self.setup_section(
@@ -38,3 +50,30 @@ class TestResolveGUID(FunctionalTestCase):
 
         with self.assertRaises(MissingParent):
             list(section)
+
+    def test_reorders_items_parents_before_children(self):
+        section = self.setup_section(previous=[
+            {'guid': 3, 'parent_guid': 2},
+            {'guid': 1337},
+            {'guid': 2, 'parent_guid': 1},
+            {'guid': 1},
+            {'guid': 'qux', 'parent_guid': 1337},
+        ])
+
+        self.assertEqual([
+                {'guid': 1337},
+                {'guid': 'qux', 'parent_guid': 1337},
+                {'guid': 1},
+                {'guid': 2, 'parent_guid': 1},
+                {'guid': 3, 'parent_guid': 2},
+            ],
+            list(section)
+        )
+
+    def test_defines_guid_mapping_on_transmogrifier(self):
+        item = {'guid': 'marvin'}
+        section = self.setup_section(previous=[item])
+        transmogrifier = section.transmogrifier
+
+        list(section)
+        self.assertEqual(item, transmogrifier.item_by_guid['marvin'])

--- a/opengever/setup/tests/test_section_resolveguid.py
+++ b/opengever/setup/tests/test_section_resolveguid.py
@@ -1,5 +1,6 @@
 from opengever.setup.sections.resolveguid import DuplicateGuid
 from opengever.setup.sections.resolveguid import MissingGuid
+from opengever.setup.sections.resolveguid import MissingParent
 from opengever.setup.sections.resolveguid import ResolveGUIDSection
 from opengever.setup.tests import MockTransmogrifier
 from opengever.testing import FunctionalTestCase
@@ -28,4 +29,12 @@ class TestResolveGUID(FunctionalTestCase):
         )
 
         with self.assertRaises(DuplicateGuid):
+            list(section)
+
+    def test_validates_parent_guid(self):
+        section = self.setup_section(
+            previous=[{'guid': 1234, 'parent_guid': 1337}]
+        )
+
+        with self.assertRaises(MissingParent):
             list(section)

--- a/opengever/setup/tests/test_section_resolveguid.py
+++ b/opengever/setup/tests/test_section_resolveguid.py
@@ -1,0 +1,31 @@
+from opengever.setup.sections.resolveguid import DuplicateGuid
+from opengever.setup.sections.resolveguid import MissingGuid
+from opengever.setup.sections.resolveguid import ResolveGUIDSection
+from opengever.setup.tests import MockTransmogrifier
+from opengever.testing import FunctionalTestCase
+
+
+class TestResolveGUID(FunctionalTestCase):
+
+    def setup_section(self, previous=None):
+        previous = previous or []
+        transmogrifier = MockTransmogrifier()
+        options = {'blueprint', 'opengever.setup.resolveguid'}
+
+        return ResolveGUIDSection(transmogrifier, '', options, previous)
+
+    def test_requires_guid(self):
+        section = self.setup_section(
+            previous=[{'foo': 1234}]
+        )
+
+        with self.assertRaises(MissingGuid):
+            list(section)
+
+    def test_prevents_duplicate_guid(self):
+        section = self.setup_section(
+            previous=[{'guid': 1234}, {'guid': 1234}]
+        )
+
+        with self.assertRaises(DuplicateGuid):
+            list(section)

--- a/opengever/setup/transmogrifier.zcml
+++ b/opengever/setup/transmogrifier.zcml
@@ -80,4 +80,9 @@
     name="opengever.setup.jsonsource"
     />
 
+  <utility
+    component=".sections.resolveguid.ResolveGUIDSection"
+    name="opengever.setup.resolveguid"
+    />
+
 </configure>


### PR DESCRIPTION
See https://github.com/4teamwork/opengever.core/issues/2306.

This PR adds a transmogrifier section that resolves and validate GUIDs.

It also yields items in an order that guarantees that parents are always positioned before their children. This is achieved by building a temporary tree, then re-yielding the nodes in pre-order.

This section also validates that:
- each item has a guid
- each guid is unique
- parent pointers are valid, should they exist

*CL will follow in a later PR*