### PR TITLE
Fixed permission check in document overview is_archivale_file_visible.

### DIFF
--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -196,7 +196,9 @@ class Overview(DisplayForm, GeverTabMixin):
         return not submitted_document.is_up_to_date(self.context)
 
     def is_archivale_file_visible(self):
-        return api.user.has_permission('opengever.document.ModifyArchivalFile')
+        return api.user.has_permission(
+            'opengever.document: Modify archival file',
+            obj=self.context)
 
     def render_submitted_version(self, submitted_document):
         return _(u"Submitted version: ${version}",


### PR DESCRIPTION
1. Test permission on the current context not the portal.
2. Fixed permission identifier.

_IMO: Changelog entry not necessary_

@deiferni 