### PR TITLE
Implement dossier behavior inheritance for dossiertemplates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add a whitelisted schema generator for dossiertemplates to avoid duplicate
+  schema-definitions
+  [elioschmutz]
+
 - Add removal protocol PDF export for dispositions.
   [phgross]
 

--- a/opengever/dossier/behaviors.zcml
+++ b/opengever/dossier/behaviors.zcml
@@ -40,13 +40,24 @@
         for="opengever.dossier.behaviors.dossier.IDossierMarker"
         />
 
-    <!-- dossiertemplate name from title beahvior -->
+    <!-- Dossiertemplate -->
+
+    <plone:behavior
+        title="OpenGever Dossiertemplate"
+        description="Adds the dossier behavior with an own marker interface"
+        provides=".dossiertemplate.behaviors.IDossierTemplate"
+        factory="plone.behavior.AnnotationStorage"
+        marker=".dossiertemplate.behaviors.IDossierTemplateMarker"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
+    <!-- Dossiertemplate name from title beahvior -->
     <plone:behavior
         title="dossiertemplate name from title"
         description=""
         provides=".dossiertemplate.behaviors.IDossierTemplateNameFromTitle"
         factory=".dossiertemplate.behaviors.DossierTemplateNameFromTitle"
-        for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplate"
+        for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateSchema"
         />
 
     <!-- Restricted dossier behavior -->

--- a/opengever/dossier/dossiertemplate/__init__.py
+++ b/opengever/dossier/dossiertemplate/__init__.py
@@ -1,5 +1,4 @@
 from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
-from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate  # keep!
 from plone import api
 
 

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -1,14 +1,41 @@
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossiernamefromtitle import DossierNameFromTitle
 from plone.app.content.interfaces import INameFromTitle
+from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
+from zope.interface import Interface
+from zope.interface import alsoProvides
 from zope.interface import implements
 
 
-class IDossierTemplate(form.Schema):
-    """Behaviour interface for dossier template types.
+class IDossierTemplateSchema(form.Schema):
+    """Schema interface for dossier template types.
 
     Use this type of dossier to create a reusable template structures.
     """
+
+
+class IDossierTemplateMarker(Interface):
+    """Marker Interface for dossiertemplates.
+    """
+
+
+class IDossierTemplate(IDossier):
+    """Behavior Interface for dossiertemplates.
+
+    We need the IDossier behavior fields for the dossier template.
+    Unfortunately we cannot use the IDossier behavior directly because
+    it's providing the IDossierMarker interface which will destroy
+    some functionality of the dossiertemplate.
+
+    To fix that, we have to create a subclass of the IDosser behavior
+    and register it with an own IDossierTemplateMarker interface.
+
+    With this workaround we get the schema of the IDossier but
+    not its marker interfaces.
+    """
+
+alsoProvides(IDossierTemplate, IFormFieldProvider)
 
 
 class IDossierTemplateNameFromTitle(INameFromTitle):

--- a/opengever/dossier/dossiertemplate/menu.py
+++ b/opengever/dossier/dossiertemplate/menu.py
@@ -1,12 +1,12 @@
 from five import grok
 from opengever.base.menu import FilteredPostFactoryMenu
 from opengever.dossier import _
-from opengever.dossier.dossiertemplate import IDossierTemplate
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from zope.interface import Interface
 
 
 class DossierTemplatePostFactoryMenu(FilteredPostFactoryMenu):
-    grok.adapts(IDossierTemplate, Interface)
+    grok.adapts(IDossierTemplateSchema, Interface)
 
     subdossier_types = [u'opengever.dossier.dossiertemplate']
 

--- a/opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
+++ b/opengever/dossier/profiles/default/types/opengever.dossier.dossiertemplate.xml
@@ -15,7 +15,7 @@
     </property>
 
     <!-- schema interface -->
-    <property name="schema">opengever.dossier.dossiertemplate.IDossierTemplate</property>
+    <property name="schema">opengever.dossier.dossiertemplate.behaviors.IDossierTemplateSchema</property>
 
     <!-- class used for content items -->
     <property name="klass">opengever.dossier.dossiertemplate.dossiertemplate.DossierTemplate</property>
@@ -27,6 +27,7 @@
     <property name="behaviors">
         <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
         <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+        <element value="opengever.dossier.dossiertemplate.behaviors.IDossierTemplate" />
         <element value="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateNameFromTitle" />
         <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
         <element value="plone.app.lockingbehavior.behaviors.ILocking" />

--- a/opengever/dossier/templatedossier/tabs.py
+++ b/opengever/dossier/templatedossier/tabs.py
@@ -1,13 +1,10 @@
 from five import grok
-from ftw.table import helper
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.templatedossier.interfaces import ITemplateDossier
 from opengever.tabbedview import _
 from opengever.tabbedview import BaseCatalogListingTab
 from opengever.tabbedview.browser.tabs import Documents, Trash
 from opengever.tabbedview.helper import linked
-from opengever.tabbedview.helper import workflow_state
-from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
-
 
 REMOVED_COLUMNS = ['receipt_date', 'delivery_date', 'containing_subdossier']
 
@@ -97,7 +94,7 @@ class TemplateDossierDossierTemplates(BaseCatalogListingTab):
 
     filterlist_available = False
 
-    object_provides = 'opengever.dossier.dossiertemplate.behaviors.IDossierTemplate'
+    object_provides = IDossierTemplateSchema.__identifier__
 
     search_options = {'is_subdossier': False}
 

--- a/opengever/dossier/upgrades/20161130093146_add_i_dossier_behavior_to_dossier_template/types/opengever.dossier.dossiertemplate.xml
+++ b/opengever/dossier/upgrades/20161130093146_add_i_dossier_behavior_to_dossier_template/types/opengever.dossier.dossiertemplate.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI"
+        i18n:domain="opengever.dossier" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <!-- schema interface -->
+    <property name="schema">opengever.dossier.dossiertemplate.behaviors.IDossierTemplateSchema</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors" purge="False">
+        <element value="opengever.dossier.dossiertemplate.behaviors.IDossierTemplate" />
+    </property>
+
+</object>

--- a/opengever/dossier/upgrades/20161130093146_add_i_dossier_behavior_to_dossier_template/upgrade.py
+++ b/opengever/dossier/upgrades/20161130093146_add_i_dossier_behavior_to_dossier_template/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddIDossierBehaviorToDossierTemplate(UpgradeStep):
+    """Add IDossier behavior to dossiertemplate.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Dieser PR ersetzt den PR #2319.

Mit diesem PR können Schema-Felder welche über Behaviors dem Typ hinzugefügt werden über eine Whitelist aktiviert werden.

Alle anderen Schema-Felder werden nicht angezeigt.

So ist es möglich, dass ein Schema nicht mehrere Male erfasst werden muss.