### PR TITLE
Replace INameFromTitle behavior with adapter for repository roots.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Replace INameFromTitle behavior with adapter for repository roots.
+  [deiferni]
+
 - Add separate permission "Download SIP Package".
   [phgross]
 

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -132,13 +132,13 @@ class TestOpengeverContentListing(FunctionalTestCase):
                           .with_dummy_content())
 
         self.assertEquals(
-            ({'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot',
+            ({'absolute_url': 'http://nohost/plone/ordnungssystem',
               'Title': 'Ordnungssystem'},
-             {'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot/ablage-1',
+             {'absolute_url': 'http://nohost/plone/ordnungssystem/ablage-1',
               'Title': '1. Ablage 1'},
-             {'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot/ablage-1/dossier-1',
+             {'absolute_url': 'http://nohost/plone/ordnungssystem/ablage-1/dossier-1',
               'Title': 'hans m\xc3\xbcller'},
-             {'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot/ablage-1/dossier-1/document-1',
+             {'absolute_url': 'http://nohost/plone/ordnungssystem/ablage-1/dossier-1/document-1',
               'Title': 'Anfrage Meier'}),
             IContentListingObject(obj2brain(document)).get_breadcrumbs())
 

--- a/opengever/base/tests/test_source_binder.py
+++ b/opengever/base/tests/test_source_binder.py
@@ -1,6 +1,7 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.testing import FunctionalTestCase
-from plone.dexterity.utils import createContentInContainer
 
 
 class TestSourceBinder(FunctionalTestCase):
@@ -10,21 +11,24 @@ class TestSourceBinder(FunctionalTestCase):
         self.grant('Administrator', 'Contributor', 'Editor', 'Reader')
 
         # Repository 1
-        reporoot1 = createContentInContainer(self.portal, 'opengever.repository.repositoryroot', title="Ordnungssystem1")
-        createContentInContainer(reporoot1, 'opengever.repository.repositoryfolder', title="Ordnungsposition1")
-        repofolder2 = createContentInContainer(reporoot1, 'opengever.repository.repositoryfolder', title="Ordnungsposition2")
-        createContentInContainer(reporoot1, 'opengever.repository.repositoryfolder', title="Ordnungsposition3")
-        self.repofolder2_1 = createContentInContainer(repofolder2, 'opengever.repository.repositoryfolder', title="Ordnungsposition2-1")
+        reporoot1 = create(Builder('repository_root').titled('Ordnungssystem1'))
+        repofolder1 = create(Builder('repository').within(reporoot1))
+        repofolder2 = create(Builder('repository').within(repofolder1))
+        create(Builder('repository').within(reporoot1))
+        self.repofolder2_1 = create(Builder('repository').within(repofolder2))
         # Repository 2
-        reporoot2 = createContentInContainer(self.portal, 'opengever.repository.repositoryroot', title="Ordnungssystem2")
-        createContentInContainer(reporoot2, 'opengever.repository.repositoryfolder', title="Ordnungsposition4")
-        createContentInContainer(reporoot2, 'opengever.repository.repositoryfolder', title="Ordnungsposition5")
-        createContentInContainer(reporoot2, 'opengever.repository.repositoryfolder', title="Ordnungsposition6")
+        reporoot2 = create(Builder('repository_root').titled('Ordnungssystem2'))
+        for index in range(3):
+            create(Builder('repository').within(reporoot2))
 
     def test_sourcebinder(self):
         """
         Check if SourceBinder works correctly without a querymodificator
         """
         query = RepositoryPathSourceBinder()(self.repofolder2_1)
-        self.assertEqual(query.navigation_tree_query['path'], {'query': '/plone/ordnungssystem1'})
-        self.assertEqual(len(query.catalog.searchResults(query.navigation_tree_query)), 5)
+        self.assertEqual(
+            {'query': '/plone/ordnungssystem1'},
+            query.navigation_tree_query['path'])
+        self.assertEqual(
+            5,
+            len(query.catalog.searchResults(query.navigation_tree_query)))

--- a/opengever/document/tests/test_contentlisting.py
+++ b/opengever/document/tests/test_contentlisting.py
@@ -75,13 +75,13 @@ class TestDocumentContentListingObject(FunctionalTestCase):
                           .with_dummy_content())
 
         self.assertEquals(
-            ({'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot',
+            ({'absolute_url': 'http://nohost/plone/ordnungssystem',
               'Title': 'Ordnungssystem'},
-             {'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot/ablage-1',
+             {'absolute_url': 'http://nohost/plone/ordnungssystem/ablage-1',
               'Title': '1. Ablage 1'},
-             {'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot/ablage-1/dossier-1',
+             {'absolute_url': 'http://nohost/plone/ordnungssystem/ablage-1/dossier-1',
               'Title': 'hans m\xc3\xbcller'},
-             {'absolute_url': 'http://nohost/plone/opengever-repository-repositoryroot/ablage-1/dossier-1/document-1',
+             {'absolute_url': 'http://nohost/plone/ordnungssystem/ablage-1/dossier-1/document-1',
               'Title': 'Anfrage Meier'}),
             IContentListingObject(document).get_breadcrumbs())
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -322,7 +322,7 @@ class TestProposal(FunctionalTestCase):
         moved_proposal = moved_dossier['proposal-1']
         model = moved_proposal.load_model()
         self.assertEqual(
-            'opengever-repository-repositoryroot/new/dossier-1/proposal-1',
+            'ordnungssystem/new/dossier-1/proposal-1',
             model.physical_path)
         self.assertEqual(u'New', model.repository_folder_title)
         self.assertEqual(u'Client1 2', model.dossier_reference_number)

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -52,7 +52,7 @@ class TestDossierProposalListing(ProposalListingTests):
         self.assertEquals('My Proposal', link.text)
 
         self.assertEquals(
-            'http://example.com/opengever-repository-repositoryroot/'
+            'http://example.com/ordnungssystem/'
             'opengever-repository-repositoryfolder/dossier-1/proposal-1',
             link.get('href'))
 

--- a/opengever/repository/profiles/default/types/opengever.repository.repositoryroot.xml
+++ b/opengever/repository/profiles/default/types/opengever.repository.repositoryroot.xml
@@ -25,7 +25,6 @@
 
     <!-- enabled behaviors -->
     <property name="behaviors">
-        <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
         <element value="opengever.sharing.behaviors.IDossier" />
         <element value="plone.app.lockingbehavior.behaviors.ILocking" />

--- a/opengever/repository/repositoryroot.py
+++ b/opengever/repository/repositoryroot.py
@@ -1,8 +1,10 @@
 from five import grok
+from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
 from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.repository import _
+from plone.app.content.interfaces import INameFromTitle
 from plone.dexterity.content import Container
 from plone.directives import form
 from Products.CMFCore.utils import getToolByName
@@ -88,3 +90,18 @@ class PrimaryRepositoryRoot(grok.View):
         brains.sort(sorter)
 
         return brains[-1]
+
+
+class RepositoryRootNameFromTitle(grok.Adapter):
+    """ An INameFromTitle adapter for namechooser gets the name from the
+    translated_title.
+    """
+    grok.implements(INameFromTitle)
+    grok.context(IRepositoryRoot)
+
+    def __init__(self, context):
+        self.context = context
+
+    @property
+    def title(self):
+        return ITranslatedTitle(self.context).translated_title()

--- a/opengever/repository/tests/test_repository_root.py
+++ b/opengever/repository/tests/test_repository_root.py
@@ -1,0 +1,10 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+
+
+class TestRepositoryRoot(FunctionalTestCase):
+
+    def test_repository_root_name_from_title(self):
+        root = create(Builder('repository_root').having(title_de=u'Foob\xe4r'))
+        self.assertEqual('foobar', root.getId())

--- a/opengever/repository/upgrades/20161130162544_drop_i_name_from_title_from_repo_roots/types/opengever.repository.repositoryroot.xml
+++ b/opengever/repository/upgrades/20161130162544_drop_i_name_from_title_from_repo_roots/types/opengever.repository.repositoryroot.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="opengever.repository.repositoryroot" meta_type="Dexterity FTI"
+        i18n:domain="opengever.repository" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <property name="behaviors" purge="False">
+        <element value="plone.app.content.interfaces.INameFromTitle" remove="True" />
+    </property>
+
+</object>

--- a/opengever/repository/upgrades/20161130162544_drop_i_name_from_title_from_repo_roots/upgrade.py
+++ b/opengever/repository/upgrades/20161130162544_drop_i_name_from_title_from_repo_roots/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DropINameFromTitleFromRepoRoots(UpgradeStep):
+    """Drop INameFromTitle from repo roots.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/task/tests/test_assign_to_dossier.py
+++ b/opengever/task/tests/test_assign_to_dossier.py
@@ -47,7 +47,7 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         browser.fill(
             {'form.widgets.repositoryfolder.widgets.query': 'Repo A'}).submit()
         browser.fill({'form.widgets.repositoryfolder':
-                      '/plone/opengever-repository-repositoryroot/repo-a'})
+                      '/plone/ordnungssystem/repo-a'})
         browser.css('#form-buttons-save').first.click()
 
         # Step 3 - dossier add form

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -277,6 +277,12 @@ builder_registry.register('contact', ContactBuilder)
 class RepositoryRootBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.repository.repositoryroot'
 
+    def __init__(self, session):
+        super(RepositoryRootBuilder, self).__init__(session)
+        self.arguments = {
+            'title_de': u'Ordnungssystem',
+        }
+
 builder_registry.register('repository_root', RepositoryRootBuilder)
 
 


### PR DESCRIPTION
This fixes choosing names from the title in combination with ITranslatedTitle.

Fixes #2350.