### PR TITLE
Dossiertemplates add wizard

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add a wizard to add a dossier from a dossiertemplate.
+  [elioschmutz]
+
 -  Add entry point to run OGGBundle import from console via
    bin/instance import <path_to_oggbundle>
    [lgraf]

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -6,7 +6,7 @@
   <browser:page
       for="opengever.repository.interfaces.IRepositoryFolder"
       name="dossier_with_template"
-      class=".form.SelectTemplateDossierView"
+      class=".form.SelectDossierTemplateView"
       permission="zope2.View"
       allowed_attributes="is_available"
       />

--- a/opengever/dossier/dossiertemplate/dossiertemplate.py
+++ b/opengever/dossier/dossiertemplate/dossiertemplate.py
@@ -7,6 +7,7 @@ from plone.dexterity.content import Container
 from plone.dexterity.utils import getAdditionalSchemata
 from plone.directives import dexterity
 from plone.z3cform.fieldsets.utils import remove
+from zope.schema import getFieldsInOrder
 
 TEMPLATABLE_FIELDS = [
     'IOpenGeverBase.title',
@@ -15,6 +16,10 @@ TEMPLATABLE_FIELDS = [
     'IDossierTemplate.comments',
     'IDossierTemplate.filing_prefix',
     ]
+
+BEHAVIOR_INTERFACE_MAPPING = {
+    'IDossier': 'IDossierTemplate'
+    }
 
 
 def whitelist_form_fields(form, whitlisted_fields):
@@ -64,3 +69,14 @@ class DossierTemplate(Container):
     def is_subdossier(self):
         parent = aq_parent(aq_inner(self))
         return bool(IDossierTemplateSchema.providedBy(parent))
+
+    def get_schema_values(self):
+        values = {}
+        for schema in getAdditionalSchemata(self):
+            for fieldname, field in getFieldsInOrder(schema):
+                key = '{}.{}'.format(schema.__name__, fieldname)
+                if key not in TEMPLATABLE_FIELDS:
+                    continue
+
+                values[key] = getattr(field.interface(self), fieldname)
+        return values

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -1,10 +1,218 @@
-from Products.Five import BrowserView
+from AccessControl import getSecurityManager
+from five import grok
+from ftw.table import helper
+from opengever.base.browser.wizard import BaseWizardStepForm
+from opengever.base.browser.wizard.interfaces import IWizardDataStorage
+from opengever.base.form import WizzardWrappedAddForm
+from opengever.base.oguid import Oguid
+from opengever.base.schema import TableChoice
+from opengever.dossier import _
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
+from opengever.dossier.dossiertemplate.dossiertemplate import BEHAVIOR_INTERFACE_MAPPING
+from opengever.dossier.dossiertemplate.dossiertemplate import TEMPLATABLE_FIELDS
+from opengever.repository.interfaces import IRepositoryFolder
+from plone import api
+from plone.autoform.form import AutoExtensibleForm
+from plone.dexterity.i18n import MessageFactory as pd_mf
+from plone.dexterity.i18n import MessageFactory as PDMF
+from plone.directives import form
+from plone.z3cform.layout import FormWrapper
+from z3c.form import button
+from z3c.form.button import buttonAndHandler
+from z3c.form.form import Form
+from z3c.form.interfaces import IDataConverter
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.vocabulary import SimpleVocabulary
 
 
-class SelectTemplateDossierView(BrowserView):
-    """ NOT IMPLEMENTED YET
+@grok.provider(IContextSourceBinder)
+def get_dossier_templates(context):
+    templates = api.portal.get_tool('portal_catalog')({
+        'portal_type': 'opengever.dossier.dossiertemplate',
+        'is_subdossier': False
+        })
+
+    intids = getUtility(IIntIds)
+    terms = []
+    for brain in templates:
+        template = brain.getObject()
+        terms.append(SimpleVocabulary.createTerm(
+            template,
+            str(intids.getId(template)),
+            template.title))
+
+    return SimpleVocabulary(terms)
+
+
+def get_wizard_storage_key(context):
+    """Return the key used to store template-data in the wizard-storage.
     """
+    container_oguid = Oguid.for_object(context)
+    return 'add_dossier_from_template:{}'.format(container_oguid)
+
+
+def set_wizard_storage(context, data):
+    storage = getUtility(IWizardDataStorage)
+    storage.update(get_wizard_storage_key(context), data)
+
+
+def get_wizard_storage(context):
+    storage = getUtility(IWizardDataStorage)
+    return storage.get_data(get_wizard_storage_key(context))
+
+
+class ICreateDossierFromTemplate(form.Schema):
+    """Schema for first wizard step to select the dossiertemplate
+    """
+    template = TableChoice(
+        title=_(u"label_template", default=u"Template"),
+        source=get_dossier_templates,
+        required=True,
+        columns=(
+            {'column': 'title',
+             'column_title': _(u'label_title', default=u'Title'),
+             'sort_index': 'sortable_title'},
+            {'column': 'Creator',
+             'column_title': _(u'label_creator', default=u'Creator'),
+             'sort_index': 'document_author'},
+            {'column': 'modified',
+             'column_title': _(u'label_modified', default=u'Modified'),
+             'transform': helper.readable_date}
+            )
+    )
+
+
+class CreateDossierMixin(object):
+    """Mixin for all wizard steps to set and name the steps.
+    """
+    label = _(u'create_dossier_with_template',
+              default=u'Create dossier from template')
+
+    steps = [
+        ('select-template', _(u'Select dossiertemplate')),
+        ('add-dossier-from-template', _(u'Add dossier'))]
+
+
+class SelectDossierTemplateWizardStep(
+        CreateDossierMixin, AutoExtensibleForm, BaseWizardStepForm, Form):
+    """First wizard step - select dossiertemplate
+    """
+    step_name = 'select-template'
+
+    @property
+    def schema(self):
+        return ICreateDossierFromTemplate
+
+    @button.buttonAndHandler(_('button_save', default=u'Save'), name='save')
+    def handleApply(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+
+        set_wizard_storage(self.context, data)
+        return self.request.RESPONSE.redirect(
+            "{}/add-dossier-from-template".format(self.context.absolute_url()))
+
+    @button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'), name='cancel')
+    def cancel(self, action):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+
+class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
+    """Second wizard step - add the dossier from previeously selected template.
+    """
+    grok.context(IRepositoryFolder)
+    grok.name('add-dossier-from-template')
+
+    typename = 'opengever.dossier.businesscasedossier'
+
+    def _create_form_class(self, parent_form_class, steptitle):
+        class WrappedForm(CreateDossierMixin, BaseWizardStepForm, parent_form_class):
+            step_name = 'add-dossier-from-template'
+
+            def update(self):
+                """Update the widget-values of the dossier add-form
+                with the values of the selected dossiertemplate values.
+                """
+                super(WrappedForm, self).update()
+
+                if not getSecurityManager().getUser().getId():
+                    # this happens during ++widget++ traversal
+                    return
+
+                template_obj = get_wizard_storage(self.context).get('template')
+
+                if not template_obj:
+                    # This happens if the user access the step directly and
+                    # the wizard storage was expired or never existent.
+                    return self.request.RESPONSE.redirect(
+                        '{}/dossier_with_template'.format(self.context.absolute_url()))
+
+                template_values = template_obj.get_schema_values()
+
+                for group in self.groups:
+                    for widgetname in group.widgets:
+
+                        # Skip not whitelisted template fields.
+                        # We don't want to update fields which are not
+                        # whitelisted in the template.
+                        template_widget_name = self.get_template_widget_name(widgetname)
+                        if template_widget_name not in TEMPLATABLE_FIELDS:
+                            continue
+
+                        value = template_values.get(template_widget_name)
+                        widget = group.widgets.get(widgetname)
+
+                        # Set the template value to the dossier add-form widget.
+                        widget.value = IDataConverter(widget).toWidgetValue(value)
+
+            def get_template_widget_name(self, widgetname):
+                """The dossiertemplates uses the same fields as the
+                dossier (IDossier) but it includes it with another interface.
+                We have to map this two interface names to get the correct
+                value or widget.
+
+                This function maps an original interface to the DossierTemplate
+                interfaces:
+
+                Example:
+
+                IDossier.keywords => IDossierTemplate.keyworkds
+                """
+                interface_name, name = widgetname.split('.')
+                return '.'.join([
+                    BEHAVIOR_INTERFACE_MAPPING.get(interface_name, interface_name),
+                    name])
+
+            @buttonAndHandler(pd_mf(u'Save'), name='save')
+            def handleAdd(self, action):
+                data, errors = self.extractData()
+                if errors:
+                    self.status = self.formErrorsMessage
+                    return
+
+                obj = self.createAndAdd(data)
+                if obj is not None:
+                    # mark only as finished if we get the new object
+                    self._finishedAdd = True
+
+                    api.portal.show_message(
+                        PDMF(u"Item created"), request=self.request, type="info")
+
+            @buttonAndHandler(pd_mf(u'Cancel'), name='cancel')
+            def handleCancel(self, action):
+                return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+        return WrappedForm
+
+
+class SelectDossierTemplateView(FormWrapper):
+    """The wizard itself to add a new dossier from a template.
+    """
+    form = SelectDossierTemplateWizardStep
 
     def is_available(self):
         """Checks if it is allowed to add a 'dossier from template'

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-11-23 07:06+0000\n"
+"POT-Creation-Date: 2016-12-05 16:10+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -25,9 +25,13 @@ msgid "Add Business Case Dossier"
 msgstr "Geschäftsdossier hinzufügen"
 
 #: ./opengever/dossier/behaviors/dossier.py:232
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:19
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:44
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
+
+#: ./opengever/dossier/dossiertemplate/form.py:81
+msgid "Add dossier"
+msgstr "Dossier hinzufügen"
 
 #. Default: "Business Case Dossier"
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -68,7 +72,7 @@ msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
 #: ./opengever/dossier/behaviors/dossier.py:254
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:33
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:62
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
@@ -130,11 +134,15 @@ msgstr "Beteiligungen"
 msgid "Project Dossier"
 msgstr "Projektdossier"
 
-#: ./opengever/dossier/templatedossier/form.py:112
+#: ./opengever/dossier/templatedossier/form.py:89
 msgid "Select document"
 msgstr "Dokument auswählen"
 
-#: ./opengever/dossier/templatedossier/form.py:113
+#: ./opengever/dossier/dossiertemplate/form.py:80
+msgid "Select dossiertemplate"
+msgstr "Vorlage auswählen"
+
+#: ./opengever/dossier/templatedossier/form.py:90
 msgid "Select recipient address"
 msgstr "Empfänger-Adresse auswählen"
 
@@ -247,12 +255,13 @@ msgstr "Speichern"
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:166
-#: ./opengever/dossier/move_items.py:126
+#: ./opengever/dossier/dossiertemplate/form.py:105
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Save"
-#: ./opengever/dossier/templatedossier/form.py:180
+#: ./opengever/dossier/dossiertemplate/form.py:94
+#: ./opengever/dossier/templatedossier/form.py:157
 msgid "button_save"
 msgstr "Speichern"
 
@@ -272,9 +281,14 @@ msgid "column_rolelist"
 msgstr "Rolle"
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatedossier/form.py:105
+#: ./opengever/dossier/templatedossier/form.py:82
 msgid "create_document_with_template"
 msgstr "Dokument aus Vorlage erstellen"
+
+#. Default: "Create dossier from template"
+#: ./opengever/dossier/dossiertemplate/form.py:76
+msgid "create_dossier_with_template"
+msgstr "Dossier aus Vorlage erstellen"
 
 msgid "documents"
 msgstr "Dokumente"
@@ -397,7 +411,7 @@ msgid "label_add_participant"
 msgstr "Beteiligung hinzufügen"
 
 #. Default: "Address"
-#: ./opengever/dossier/templatedossier/form.py:272
+#: ./opengever/dossier/templatedossier/form.py:249
 msgid "label_address"
 msgstr "Adresse"
 
@@ -427,7 +441,8 @@ msgid "label_container_type"
 msgstr "Behältnis-Art"
 
 #. Default: "Creator"
-#: ./opengever/dossier/templatedossier/form.py:69
+#: ./opengever/dossier/dossiertemplate/form.py:64
+#: ./opengever/dossier/templatedossier/form.py:46
 msgid "label_creator"
 msgstr "Erstellt von"
 
@@ -447,7 +462,7 @@ msgid "label_dossier_templates"
 msgstr "Dossier Vorlagen"
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatedossier/form.py:90
+#: ./opengever/dossier/templatedossier/form.py:67
 msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
@@ -500,7 +515,7 @@ msgid "label_keywords"
 msgstr "Schlagworte"
 
 #. Default: "Label"
-#: ./opengever/dossier/templatedossier/form.py:277
+#: ./opengever/dossier/templatedossier/form.py:254
 msgid "label_label"
 msgstr "Label"
 
@@ -510,12 +525,13 @@ msgid "label_linked_dossiers"
 msgstr "Verlinkte Dossiers"
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatedossier/form.py:284
+#: ./opengever/dossier/templatedossier/form.py:261
 msgid "label_mail_address"
 msgstr "Mail Addresse"
 
 #. Default: "Modified"
-#: ./opengever/dossier/templatedossier/form.py:72
+#: ./opengever/dossier/dossiertemplate/form.py:67
+#: ./opengever/dossier/templatedossier/form.py:49
 msgid "label_modified"
 msgstr "Zuletzt Bearbeitet"
 
@@ -550,7 +566,7 @@ msgid "label_participations"
 msgstr "Beteiligungen"
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatedossier/form.py:295
+#: ./opengever/dossier/templatedossier/form.py:272
 msgid "label_phonenumber"
 msgstr "Telefonnummer"
 
@@ -560,7 +576,7 @@ msgid "label_proposals"
 msgstr "Anträge"
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatedossier/form.py:83
+#: ./opengever/dossier/templatedossier/form.py:60
 msgid "label_recipient"
 msgstr "Empfänger"
 
@@ -631,13 +647,15 @@ msgid "label_tasktemplate_folders"
 msgstr "Standardabläufe"
 
 #. Default: "Template"
-#: ./opengever/dossier/templatedossier/form.py:60
+#: ./opengever/dossier/dossiertemplate/form.py:56
+#: ./opengever/dossier/templatedossier/form.py:37
 msgid "label_template"
 msgstr "Vorlage"
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/templatedossier/form.py:65
+#: ./opengever/dossier/dossiertemplate/form.py:61
+#: ./opengever/dossier/templatedossier/form.py:42
 msgid "label_title"
 msgstr "Titel"
 
@@ -647,7 +665,7 @@ msgid "label_trash"
 msgstr "Papierkorb"
 
 #. Default: "URL"
-#: ./opengever/dossier/templatedossier/form.py:306
+#: ./opengever/dossier/templatedossier/form.py:283
 msgid "label_url"
 msgstr "URL"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-23 07:06+0000\n"
+"POT-Creation-Date: 2016-12-05 16:10+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -24,9 +24,13 @@ msgid "Add Business Case Dossier"
 msgstr "Insérer un dossier d'affaire"
 
 #: ./opengever/dossier/behaviors/dossier.py:232
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:19
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:44
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
+
+#: ./opengever/dossier/dossiertemplate/form.py:81
+msgid "Add dossier"
+msgstr ""
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
 msgid "Business Case Dossier"
@@ -66,7 +70,7 @@ msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès"
 
 #: ./opengever/dossier/behaviors/dossier.py:254
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:33
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:62
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
@@ -127,11 +131,15 @@ msgstr "Participants"
 msgid "Project Dossier"
 msgstr "Dossier du projet"
 
-#: ./opengever/dossier/templatedossier/form.py:112
+#: ./opengever/dossier/templatedossier/form.py:89
 msgid "Select document"
 msgstr ""
 
-#: ./opengever/dossier/templatedossier/form.py:113
+#: ./opengever/dossier/dossiertemplate/form.py:80
+msgid "Select dossiertemplate"
+msgstr ""
+
+#: ./opengever/dossier/templatedossier/form.py:90
 msgid "Select recipient address"
 msgstr ""
 
@@ -243,12 +251,13 @@ msgstr "Enregistrer"
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:166
-#: ./opengever/dossier/move_items.py:126
+#: ./opengever/dossier/dossiertemplate/form.py:105
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Save"
-#: ./opengever/dossier/templatedossier/form.py:180
+#: ./opengever/dossier/dossiertemplate/form.py:94
+#: ./opengever/dossier/templatedossier/form.py:157
 msgid "button_save"
 msgstr ""
 
@@ -268,9 +277,14 @@ msgid "column_rolelist"
 msgstr "Rôle"
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatedossier/form.py:105
+#: ./opengever/dossier/templatedossier/form.py:82
 msgid "create_document_with_template"
 msgstr "Créer un document à partir d'un modèle"
+
+#. Default: "Create dossier from template"
+#: ./opengever/dossier/dossiertemplate/form.py:76
+msgid "create_dossier_with_template"
+msgstr ""
 
 msgid "documents"
 msgstr "Documents"
@@ -393,7 +407,7 @@ msgid "label_add_participant"
 msgstr "Participant"
 
 #. Default: "Address"
-#: ./opengever/dossier/templatedossier/form.py:272
+#: ./opengever/dossier/templatedossier/form.py:249
 msgid "label_address"
 msgstr ""
 
@@ -423,7 +437,8 @@ msgid "label_container_type"
 msgstr "Type de conteneur"
 
 #. Default: "Creator"
-#: ./opengever/dossier/templatedossier/form.py:69
+#: ./opengever/dossier/dossiertemplate/form.py:64
+#: ./opengever/dossier/templatedossier/form.py:46
 msgid "label_creator"
 msgstr "Créé par"
 
@@ -443,7 +458,7 @@ msgid "label_dossier_templates"
 msgstr ""
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatedossier/form.py:90
+#: ./opengever/dossier/templatedossier/form.py:67
 msgid "label_edit_after_creation"
 msgstr "Modifier après avoir créé"
 
@@ -496,7 +511,7 @@ msgid "label_keywords"
 msgstr "Mots-clés"
 
 #. Default: "Label"
-#: ./opengever/dossier/templatedossier/form.py:277
+#: ./opengever/dossier/templatedossier/form.py:254
 msgid "label_label"
 msgstr ""
 
@@ -506,12 +521,13 @@ msgid "label_linked_dossiers"
 msgstr "Dossiers liés"
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatedossier/form.py:284
+#: ./opengever/dossier/templatedossier/form.py:261
 msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/dossier/templatedossier/form.py:72
+#: ./opengever/dossier/dossiertemplate/form.py:67
+#: ./opengever/dossier/templatedossier/form.py:49
 msgid "label_modified"
 msgstr "Modifié"
 
@@ -546,7 +562,7 @@ msgid "label_participations"
 msgstr "Participation"
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatedossier/form.py:295
+#: ./opengever/dossier/templatedossier/form.py:272
 msgid "label_phonenumber"
 msgstr ""
 
@@ -556,7 +572,7 @@ msgid "label_proposals"
 msgstr "Propositions"
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatedossier/form.py:83
+#: ./opengever/dossier/templatedossier/form.py:60
 msgid "label_recipient"
 msgstr ""
 
@@ -627,13 +643,15 @@ msgid "label_tasktemplate_folders"
 msgstr "Déroulements standards"
 
 #. Default: "Template"
-#: ./opengever/dossier/templatedossier/form.py:60
+#: ./opengever/dossier/dossiertemplate/form.py:56
+#: ./opengever/dossier/templatedossier/form.py:37
 msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/templatedossier/form.py:65
+#: ./opengever/dossier/dossiertemplate/form.py:61
+#: ./opengever/dossier/templatedossier/form.py:42
 msgid "label_title"
 msgstr "Titre"
 
@@ -643,7 +661,7 @@ msgid "label_trash"
 msgstr "Corbeille"
 
 #. Default: "URL"
-#: ./opengever/dossier/templatedossier/form.py:306
+#: ./opengever/dossier/templatedossier/form.py:283
 msgid "label_url"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-23 07:06+0000\n"
+"POT-Creation-Date: 2016-12-05 16:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,8 +25,12 @@ msgid "Add Business Case Dossier"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:232
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:19
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:44
 msgid "Add Subdossier"
+msgstr ""
+
+#: ./opengever/dossier/dossiertemplate/form.py:81
+msgid "Add dossier"
 msgstr ""
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -67,7 +71,7 @@ msgid "Dossiers successfully reactivated."
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py:254
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:33
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:62
 msgid "Edit Subdossier"
 msgstr ""
 
@@ -128,11 +132,15 @@ msgstr ""
 msgid "Project Dossier"
 msgstr ""
 
-#: ./opengever/dossier/templatedossier/form.py:112
+#: ./opengever/dossier/templatedossier/form.py:89
 msgid "Select document"
 msgstr ""
 
-#: ./opengever/dossier/templatedossier/form.py:113
+#: ./opengever/dossier/dossiertemplate/form.py:80
+msgid "Select dossiertemplate"
+msgstr ""
+
+#: ./opengever/dossier/templatedossier/form.py:90
 msgid "Select recipient address"
 msgstr ""
 
@@ -244,12 +252,13 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:166
-#: ./opengever/dossier/move_items.py:126
+#: ./opengever/dossier/dossiertemplate/form.py:105
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/dossier/templatedossier/form.py:180
+#: ./opengever/dossier/dossiertemplate/form.py:94
+#: ./opengever/dossier/templatedossier/form.py:157
 msgid "button_save"
 msgstr ""
 
@@ -269,8 +278,13 @@ msgid "column_rolelist"
 msgstr ""
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatedossier/form.py:105
+#: ./opengever/dossier/templatedossier/form.py:82
 msgid "create_document_with_template"
+msgstr ""
+
+#. Default: "Create dossier from template"
+#: ./opengever/dossier/dossiertemplate/form.py:76
+msgid "create_dossier_with_template"
 msgstr ""
 
 msgid "documents"
@@ -394,7 +408,7 @@ msgid "label_add_participant"
 msgstr ""
 
 #. Default: "Address"
-#: ./opengever/dossier/templatedossier/form.py:272
+#: ./opengever/dossier/templatedossier/form.py:249
 msgid "label_address"
 msgstr ""
 
@@ -424,7 +438,8 @@ msgid "label_container_type"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/dossier/templatedossier/form.py:69
+#: ./opengever/dossier/dossiertemplate/form.py:64
+#: ./opengever/dossier/templatedossier/form.py:46
 msgid "label_creator"
 msgstr ""
 
@@ -444,7 +459,7 @@ msgid "label_dossier_templates"
 msgstr ""
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatedossier/form.py:90
+#: ./opengever/dossier/templatedossier/form.py:67
 msgid "label_edit_after_creation"
 msgstr ""
 
@@ -497,7 +512,7 @@ msgid "label_keywords"
 msgstr ""
 
 #. Default: "Label"
-#: ./opengever/dossier/templatedossier/form.py:277
+#: ./opengever/dossier/templatedossier/form.py:254
 msgid "label_label"
 msgstr ""
 
@@ -507,12 +522,13 @@ msgid "label_linked_dossiers"
 msgstr ""
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatedossier/form.py:284
+#: ./opengever/dossier/templatedossier/form.py:261
 msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/dossier/templatedossier/form.py:72
+#: ./opengever/dossier/dossiertemplate/form.py:67
+#: ./opengever/dossier/templatedossier/form.py:49
 msgid "label_modified"
 msgstr ""
 
@@ -547,7 +563,7 @@ msgid "label_participations"
 msgstr ""
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatedossier/form.py:295
+#: ./opengever/dossier/templatedossier/form.py:272
 msgid "label_phonenumber"
 msgstr ""
 
@@ -557,7 +573,7 @@ msgid "label_proposals"
 msgstr ""
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatedossier/form.py:83
+#: ./opengever/dossier/templatedossier/form.py:60
 msgid "label_recipient"
 msgstr ""
 
@@ -628,13 +644,15 @@ msgid "label_tasktemplate_folders"
 msgstr ""
 
 #. Default: "Template"
-#: ./opengever/dossier/templatedossier/form.py:60
+#: ./opengever/dossier/dossiertemplate/form.py:56
+#: ./opengever/dossier/templatedossier/form.py:37
 msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/templatedossier/form.py:65
+#: ./opengever/dossier/dossiertemplate/form.py:61
+#: ./opengever/dossier/templatedossier/form.py:42
 msgid "label_title"
 msgstr ""
 
@@ -644,7 +662,7 @@ msgid "label_trash"
 msgstr ""
 
 #. Default: "URL"
-#: ./opengever/dossier/templatedossier/form.py:306
+#: ./opengever/dossier/templatedossier/form.py:283
 msgid "label_url"
 msgstr ""
 


### PR DESCRIPTION
Dieser PR fügt den Add-Wizard für "Dossier aus Template" hinzu:

![screen3](https://cloud.githubusercontent.com/assets/557005/20834001/dedb2222-b892-11e6-977a-e98802e793ec.gif)

ACHTUNG: Dieser PR behandelt nicht das rekursive erstellen von Dossiers und Dokumenten. Es geht hier lediglich um den Wizard und um das initiale Erstellen eines Basisdossiers aufgrund der Template-Attribute.

see #2143