### PR TITLE
Add recursive dossier creation for dossiertemplates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Enable dossier templates for local development ( examplecontent)
+  [elioschmutz]
+
 - Add sample dossiertemplate to examplecontent.
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Refactor CreateDocumentCommand and CreateEmailCommand.
+  [elioschmutz]
+
 - Enable dossier templates for local development ( examplecontent)
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add sample dossiertemplate to examplecontent.
+  [elioschmutz]
+
 - Create recursively documents and subdossiers when adding a dossier from template
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Create recursively documents and subdossiers when adding a dossier from template
+  [elioschmutz]
+
 - Enable zip exports for tasks
   [Rotonen]
 

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -1,14 +1,8 @@
-from Acquisition import aq_base
 from opengever.base.transforms.msg2mime import Msg2MimeTransform
 from os.path import join
 from os.path import splitext
-from plone.dexterity.utils import addContentToContainer
-from plone.dexterity.utils import createContent
 from plone.dexterity.utils import createContentInContainer
-from plone.rfc822.interfaces import IPrimaryFieldInfo
-from zope.event import notify
-from zope.lifecycleevent import ObjectCreatedEvent
-from zope.lifecycleevent import ObjectModifiedEvent
+from plone.namedfile.file import NamedBlobFile
 
 
 class BaseObjectCreatorCommand(object):
@@ -37,58 +31,25 @@ class CreateDocumentCommand(BaseObjectCreatorCommand):
     """
     portal_type = 'opengever.document.document'
     skip_defaults_fields = []
+    primary_field_name = 'file'
 
     def __init__(self, context, filename, data, title=None, content_type='',
                  **kwargs):
         super(CreateDocumentCommand, self).__init__(context, title, **kwargs)
+        self.set_file(filename, data, content_type)
+
+    def set_file(self, filename, data, content_type):
+        if not data:
+            return
 
         # filename must be unicode
         if not isinstance(filename, unicode):
             filename = filename.decode('utf-8')
 
-        self.data = data
-        self.filename = filename
-        self.content_type = content_type
-
-    def execute(self):
-        content = createContent(self.portal_type, title=self.title,
-                                **self.additional_args)
-
-        # Temporarily acquisition wrap content to make adaptation work
-        content = content.__of__(self.context)
-        self.set_primary_field_value(content)
-        self.notify_created(content)
-
-        # Remove temporary acquisition wrapper
-        content = aq_base(content)
-        obj = addContentToContainer(self.context,
-                                    content,
-                                    checkConstraints=True)
-        self.finish_creation(obj)
-
-        obj.reindexObject()
-        return obj
-
-    def notify_created(self, content):
-        """Fire ObjectCreatedEvent (again) to trigger
-        sync_title_and_filename_handler.
-
-        """
-        notify(ObjectCreatedEvent(content))
-
-    def finish_creation(self, content):
-        """Trigger rest of initialization."""
-
-        notify(ObjectModifiedEvent(content))
-
-    def set_primary_field_value(self, obj):
-        if not self.data:
-            return
-
-        field = IPrimaryFieldInfo(obj).field
-        value = field._type(data=self.data, filename=self.filename,
-                            contentType=self.content_type)
-        field.set(field.interface(obj), value)
+        self.additional_args.update({
+            self.primary_field_name: NamedBlobFile(
+                data=data, filename=filename, contentType=content_type)
+            })
 
 
 class CreateEmailCommand(CreateDocumentCommand):
@@ -99,24 +60,28 @@ class CreateEmailCommand(CreateDocumentCommand):
 
     """
     portal_type = 'ftw.mail.mail'
+    primary_field_name = 'message'
 
-    def notify_created(self, content):
-        """Make sure filename is updated from subject upon creation.
-        """
-        content._update_title_from_message_subject()
-        notify(ObjectCreatedEvent(content))
+    def __init__(self, context, filename, data, title=None, content_type='',
+                 **kwargs):
+        if self.is_msg_upload(filename):
+                filename, data = self.convert_to_mime(filename, data)
 
-    def is_msg_upload(self):
-        root, ext = splitext(self.filename)
+        super(CreateEmailCommand, self).__init__(
+            context, filename, data, title, content_type, **kwargs)
+
+    def is_msg_upload(self, filename):
+        root, ext = splitext(filename)
         return ext.lower() == '.msg'
 
-    def convert_to_mime(self):
-        data = Msg2MimeTransform().transform(self.data)
-        root, ext = splitext(self.filename)
+    def convert_to_mime(self, filename, data):
+        data = Msg2MimeTransform().transform(data)
+        root, ext = splitext(filename)
         filename = join(root, '.eml')
         return filename, data
 
     def execute(self):
-        if self.is_msg_upload():
-            self.filename, self.data = self.convert_to_mime()
-        return super(CreateEmailCommand, self).execute()
+        obj = super(CreateEmailCommand, self).execute()
+        obj._update_title_from_message_subject()
+
+        return obj

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -545,6 +545,37 @@ class TestDocumentDefaults(TestDefaultsBase):
 
         self.assertDictEqual(expected, persisted_values)
 
+    @browsing
+    def test_document_from_dossiertemplate(self, browser):
+        toggle_feature(IDossierTemplateSettings, enabled=True)
+
+        root = create(Builder('repository_root'))
+        leaf_node = create(Builder('repository').within(root))
+        template = create(Builder("dossiertemplate")
+                          .titled(DOSSIER_REQUIREDS['title']))
+        create(Builder('document')
+               .titled(DOCUMENT_REQUIREDS['title'])
+               .within(template)
+               .with_dummy_content())
+
+        with freeze(FROZEN_NOW):
+            browser.login().open(leaf_node)
+            factoriesmenu.add(u'Dossier with template')
+            token = browser.css(
+                'input[name="form.widgets.template"]').first.attrib.get('value')
+            browser.fill({'form.widgets.template': token}).submit()
+            browser.click_on('Save')
+
+            doc = browser.context.listFolderContents()[0]
+
+        persisted_values = get_persisted_values_for_obj(doc)
+        expected = self.get_type_defaults()
+
+        expected['digitally_available'] = True
+        expected['file'] = doc.file
+
+        self.assertDictEqual(expected, persisted_values)
+
 
 class TestMailDefaults(TestDefaultsBase):
 

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -18,11 +18,10 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
             title=title)
         self.recipient_data = recipient_data
 
-    def finish_creation(self, content):
-        """Also make sure doc-properties are updated from template."""
-
-        DocPropertyWriter(content, recipient_data=self.recipient_data).initialize()
-        super(CreateDocumentFromTemplateCommand, self).finish_creation(content)
+    def execute(self):
+        obj = super(CreateDocumentFromTemplateCommand, self).execute()
+        DocPropertyWriter(obj, recipient_data=self.recipient_data).initialize()
+        return obj
 
 
 class CreateDossierFromTemplateCommand(BaseObjectCreatorCommand):

--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -24,4 +24,8 @@
       <value key="is_feature_enabled">True</value>
     </records>
 
+    <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings">
+      <value key="is_feature_enabled">True</value>
+    </records>
+
 </registry>

--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/05_dossiertemplates.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/05_dossiertemplates.json
@@ -1,0 +1,210 @@
+[{
+    "_path": "/vorlagen/dossiertemplate-1",
+    "_type": "opengever.dossier.dossiertemplate",
+    "title": "Investitionsvorhaben",
+    "_children": [
+        {
+            "_id": "dossiertemplate-3",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Projektgrundlagen",
+            "_children": [
+                {
+                    "_id": "dossiertemplate-12",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Auftrag, Organistaion",
+                    "description": "Projektauftrag, Projekthandbuch, Projektorganisation, Adressen"
+                },
+                {
+                    "_id": "dossiertemplate-13",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Termin-, Bauprogramme",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-14",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Bestandsaufnahmen",
+                    "description": "Schadstoffuntersuchungen, Gebäude- (Rissprotokolle) und Terrainaufnahme"
+                },
+                {
+                    "_id": "dossiertemplate-15",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Masterplan",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-16",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Vorstudien",
+                    "description": "Machbarkeitsstudien, Überbauungskonzepte, best. Nutzungsvereinbarung"
+                },
+                {
+                    "_id": "dossiertemplate-17",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Wettbewerb",
+                    "description": "Planerwahl, Projektwettbewerb"
+                },
+                {
+                    "_id": "dossiertemplate-18",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Vorprojekt",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-19",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Bauprojekt",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-20",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Konzepte / Simulationen",
+                    "description": "Betriebskonzept, Energiekonzept, Bauphysik, Schallschutz- und Akkustikkonzept, Sicherheitskonzept, Brandschutzkonzept, Statikkonzept, etc"
+                },
+                {
+                    "_id": "dossiertemplate-21",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Servitute, Dienstbarkeitsverträge",
+                    "description": "Dienstbarkeitsverträge, Servitute, Nutzungsverträge, Verträge"
+                },
+                {
+                    "_id": "dossiertemplate-22",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Grundstück, Lage",
+                    "description": "Situationsplan, Berichte Geologie, Hydrologie, Naturgefahren, Grundwassererhebung"
+                },
+                {
+                    "_id": "dossiertemplate-23",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Übriges",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "_id": "dossiertemplate-4",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Kredit und Rechnungswesen",
+            "_children": [
+                {
+                    "_id": "dossiertemplate-24",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Kreditbegehren",
+                    "description": "Budget, Botschaft, Zusatzkredit, Kreditumlagerung"
+                },
+                {
+                    "_id": "dossiertemplate-25",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Kosten",
+                    "description": "Kostenschätzung, Kostenvoranschlag, Material- und Baubeschrieb, Kostenkontrolle, Änderungswesen, etc."
+                },
+                {
+                    "_id": "dossiertemplate-26",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Kreditabrechnung",
+                    "description": "Bauabrechung, Revisionsbericht, RRB"
+                },
+                {
+                    "_id": "dossiertemplate-27",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Subventionen",
+                    "description": "Zuschüsse Dritter, Bundesbeitrag"
+                },
+                {
+                    "_id": "dossiertemplate-28",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Übriges",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "_id": "dossiertemplate-5",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Behörden",
+            "_children": [
+                {
+                    "_id": "dossiertemplate-29",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Gutachten",
+                    "description": "UVP, Parkraum, Verkehr, etc."
+                },
+                {
+                    "_id": "dossiertemplate-30",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Sondernutzungspläne",
+                    "description": "Gestaltungsplan, Überbauungsplan"
+                },
+                {
+                    "_id": "dossiertemplate-31",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Baubewilligung",
+                    "description": "Baugesuch, Bewilligungsunterlagen, usw."
+                },
+                {
+                    "_id": "dossiertemplate-32",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Korrektureingaben",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-33",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Einsprachenverfahren",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-34",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Betriebsbewilligung",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-35",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Übriges",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "_id": "dossiertemplate-6",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Korrespondenz"
+        },
+        {
+            "_id": "dossiertemplate-7",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Protokolle"
+        },
+        {
+            "_id": "dossiertemplate-8",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Dienstleistungsverträge"
+        },
+        {
+            "_id": "dossiertemplate-9",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Bau- und Lieferverträge"
+        },
+        {
+            "_id": "dossiertemplate-10",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Pläne / Dokumentation"
+        },
+        {
+            "_id": "dossiertemplate-11",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Abschlussarbeiten"
+        }
+
+    ]
+},
+{
+    "_path": "/vorlagen/dossiertemplate-2",
+    "_type": "opengever.dossier.dossiertemplate",
+    "title": "Kleinvorhaben",
+    "_children": []
+}
+]

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -194,11 +194,8 @@ class CreateGeneratedDocumentCommand(CreateDocumentCommand):
         self.lock_document_after_creation = lock_document_after_creation
 
         super(CreateGeneratedDocumentCommand, self).__init__(
-            context,
-            self.document_operations.get_filename(self.meeting),
-            data=None,
-            title=self.document_operations.get_title(self.meeting),
-            content_type=MIME_DOCX)
+            context, filename=None, data=None,
+            title=self.document_operations.get_title(self.meeting))
 
     def generate_file_data(self):
         template = self.document_operations.get_sablon_template(self.meeting)
@@ -208,7 +205,11 @@ class CreateGeneratedDocumentCommand(CreateDocumentCommand):
         return sablon.file_data
 
     def execute(self):
-        self.data = self.generate_file_data()
+        self.set_file(
+            self.document_operations.get_filename(self.meeting),
+            self.generate_file_data(),
+            MIME_DOCX
+            )
 
         document = super(CreateGeneratedDocumentCommand, self).execute()
         self.lock_document(document)


### PR DESCRIPTION
Dieser PR erstellt rekursiv Dossiers und Dokumente anhand des Dossiertemplates.
Zusätzlich fügt er zwei Dossiertemplates als Examplecontent hinzu.

![screen3](https://cloud.githubusercontent.com/assets/557005/20840789/b44a84fc-b8b1-11e6-90f7-b70d11915341.gif)

see #2143