### PR TITLE
Add oggbundle pipeline and example data imports.

### DIFF
--- a/opengever/base/schemadump/__init__.py
+++ b/opengever/base/schemadump/__init__.py
@@ -1,3 +1,4 @@
+from opengever.base.schemadump.log import setup_logging
 from opengever.base.schemadump.schema import dump_oggbundle_schemas
 from opengever.base.schemadump.schema import dump_schemas
 from opengever.core.debughelpers import get_first_plone_site
@@ -7,6 +8,9 @@ from opengever.core.debughelpers import setup_plone
 def dump_schemas_zopectl_handler(app, args):
     """Handler for the 'bin/instance dump_schemas' zopectl command.
     """
+    setup_logging('opengever.base.schemadump.schema')
+    setup_logging('opengever.base.schemadump.field')
+
     setup_plone(get_first_plone_site(app))
     dump_schemas()
     dump_oggbundle_schemas()

--- a/opengever/base/schemadump/field.py
+++ b/opengever/base/schemadump/field.py
@@ -3,7 +3,6 @@ from opengever.base.schemadump.config import DEFAULT_OVERRIDES
 from opengever.base.schemadump.config import PYTHON_TO_JS_TYPES
 from opengever.base.schemadump.config import VOCAB_OVERRIDES
 from opengever.base.schemadump.helpers import translate_de
-from opengever.base.schemadump.log import setup_logging
 from plone.autoform.interfaces import MODES_KEY
 from plone.autoform.interfaces import OMITTED_KEY
 from pprint import pprint
@@ -16,9 +15,10 @@ from zope.component import queryMultiAdapter
 from zope.schema import Choice
 from zope.schema.interfaces import IVocabularyFactory
 import json
+import logging
 
 
-log = setup_logging(__name__)
+log = logging.getLogger(__name__)
 
 
 NO_DEFAULT_MARKER = object()

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -40,7 +40,7 @@ class SchemaDumper(object):
         for name, field in getFieldsInOrder(schema):
             dottedname = '.'.join((schema.__identifier__, field.getName()))
             if dottedname in IGNORED_FIELDS:
-                print "    Skipping field %s" % dottedname
+                log.info("  Skipping field %s" % dottedname)
                 continue
 
             field_dump = field_dumper.dump(field)

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -3,16 +3,15 @@ from jsonschema import Draft4Validator
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_NAMES
 from opengever.base.schemadump.config import GEVER_SQL_TYPES
 from opengever.base.schemadump.config import GEVER_TYPES
+from opengever.base.schemadump.config import GEVER_TYPES_TO_OGGBUNDLE_TYPES
 from opengever.base.schemadump.config import IGNORED_FIELDS
 from opengever.base.schemadump.config import IGNORED_OGGBUNDLE_FIELDS
 from opengever.base.schemadump.config import JSON_SCHEMA_FIELD_TYPES
-from opengever.base.schemadump.config import GEVER_TYPES_TO_OGGBUNDLE_TYPES
 from opengever.base.schemadump.field import FieldDumper
 from opengever.base.schemadump.field import SQLFieldDumper
 from opengever.base.schemadump.helpers import DirectoryHelperMixin
 from opengever.base.schemadump.helpers import mkdir_p
 from opengever.base.schemadump.helpers import translate_de
-from opengever.base.schemadump.log import setup_logging
 from opengever.base.utils import pretty_json
 from os.path import join as pjoin
 from plone import api
@@ -21,10 +20,11 @@ from plone.supermodel.interfaces import FIELDSETS_KEY
 from sqlalchemy.ext.declarative.base import _is_mapped_class
 from zope.dottedname.resolve import resolve as resolve_dotted
 from zope.schema import getFieldsInOrder
+import logging
 import transaction
 
 
-log = setup_logging(__name__)
+log = logging.getLogger(__name__)
 
 
 class SchemaDumper(object):

--- a/opengever/setup/cfgs/oggbundle.cfg
+++ b/opengever/setup/cfgs/oggbundle.cfg
@@ -1,0 +1,56 @@
+[transmogrifier]
+include =
+    opengever.setup.content
+
+pipeline =
+    jsonsource-reporoots
+    jsonsource-repofolders
+    jsonsource-dossiers
+    jsonsource-documents
+    disabled-initial-version
+    resolveguid
+    constructor
+    resolvetree
+    fileinserter
+    criterions
+    resolveuuid
+    resolvepath
+    dx_schemaupdater
+    workflowupdater
+    placefulworkflowupdater
+    propertiesupdater
+    local_roles
+    block_local_roles
+    constraintypes
+    interfaces
+    annotations
+    manual-initial-version
+    reindexobject
+    savepoint
+
+
+[jsonsource-reporoots]
+blueprint = opengever.setup.jsonsource
+filename = reporoots.json
+portal_type = opengever.repository.repositoryroot
+
+[jsonsource-repofolders]
+blueprint = opengever.setup.jsonsource
+filename = repofolders.json
+portal_type = opengever.repository.repositoryfolder
+
+[jsonsource-dossiers]
+blueprint = opengever.setup.jsonsource
+filename = dossiers.json
+portal_type = opengever.dossier.businesscasedossier
+
+[jsonsource-documents]
+blueprint = opengever.setup.jsonsource
+filename = documents.json
+portal_type = opengever.document.document
+
+[resolveguid]
+blueprint = opengever.setup.resolveguid
+
+[constructor]
+blueprint = opengever.setup.constructor

--- a/opengever/setup/tests/assets/oggbundle/documents.json
+++ b/opengever/setup/tests/assets/oggbundle/documents.json
@@ -1,0 +1,31 @@
+[
+  {
+    "guid": "d65317ece1cb4dc797de1fc1e32bb4eb",
+    "parent_guid": "659645aec58d48a9b9663399ea2ec069",
+    "digitally_available": true,
+    "document_author": "david.erni",
+    "document_date": "2007-01-01",
+    "filepath": "files/bewerbung_pesche.docx",
+    "keywords": [],
+    "preserved_as_paper": true,
+    "relatedItems": [],
+    "review_state": "document-state-draft",
+    "title": "Bewerbung Hanspeter Müller"
+  },  {
+    "guid": "1d94ce18d336490f84ace260a87712d0",
+    "parent_guid": "659645aec58d48a9b9663399ea2ec069",
+    "digitally_available": true,
+    "document_author": "david.erni",
+    "document_date": "2011-01-01",
+    "document_type": "directive",
+    "filepath": "files/mueller.docx",
+    "keywords": [],
+    "preserved_as_paper": true,
+    "public_trial": "private",
+    "public_trial_statement": "Enthält private Daten",
+    "receipt_date": "2011-01-01",
+    "relatedItems": [],
+    "review_state": "document-state-draft",
+    "title": "Entlassung Hanspeter Müller"
+  }
+]

--- a/opengever/setup/tests/assets/oggbundle/documents.json
+++ b/opengever/setup/tests/assets/oggbundle/documents.json
@@ -2,7 +2,6 @@
   {
     "guid": "d65317ece1cb4dc797de1fc1e32bb4eb",
     "parent_guid": "659645aec58d48a9b9663399ea2ec069",
-    "digitally_available": true,
     "document_author": "david.erni",
     "document_date": "2007-01-01",
     "filepath": "files/bewerbung_pesche.docx",
@@ -14,7 +13,6 @@
   },  {
     "guid": "1d94ce18d336490f84ace260a87712d0",
     "parent_guid": "659645aec58d48a9b9663399ea2ec069",
-    "digitally_available": true,
     "document_author": "david.erni",
     "document_date": "2011-01-01",
     "document_type": "directive",

--- a/opengever/setup/tests/assets/oggbundle/dossiers.json
+++ b/opengever/setup/tests/assets/oggbundle/dossiers.json
@@ -27,7 +27,7 @@
     "responsible": "lukas.graf",
     "retention_period": 5,
     "retention_period_annotation": null,
-    "review_state": "dossier-state-active",
+    "review_state": "dossier-state-resolved",
     "title": "Hanspeter Müller",
     "_permissions": {
       "read": [

--- a/opengever/setup/tests/assets/oggbundle/dossiers.json
+++ b/opengever/setup/tests/assets/oggbundle/dossiers.json
@@ -1,0 +1,51 @@
+[
+  {
+    "guid": "4ed93561c4004c668feb8124b55897fa",
+    "parent_guid": "aed9f3db7b3b4713b61a7d7295362ea4",
+    "comments": "Vreni Meier ist ein Tausendsassa",
+    "keywords": [],
+    "reference_number": "1",
+    "relatedDossier": [],
+    "responsible": "lukas.graf",
+    "review_state": "dossier-state-active",
+    "start": "2010-11-11",
+    "title": "Dossier Vreni Meier"
+  },  {
+    "guid": "659645aec58d48a9b9663399ea2ec069",
+    "parent_guid": "aed9f3db7b3b4713b61a7d7295362ea4",
+    "archival_value": "archival worthy",
+    "archival_value_annotation": "Beinhaltet Informationen zum Verfahren",
+    "classification": "classified",
+    "custody_period": 150,
+    "description": "Wir haben Hanspeter Müller in einem Verfahren entlassen.",
+    "start": "2007-01-01",
+    "end": "2011-01-06",
+    "keywords": [],
+    "privacy_layer": "privacy_layer_yes",
+    "reference_number": "2",
+    "relatedDossier": [],
+    "responsible": "lukas.graf",
+    "retention_period": 5,
+    "retention_period_annotation": null,
+    "review_state": "dossier-state-active",
+    "title": "Hanspeter Müller",
+    "_permissions": {
+      "read": [
+        "admin_users"
+      ],
+      "add": [
+        "admin_users"
+      ],
+      "edit": [
+        "admin_users"
+      ],
+      "close": [
+        "admin_users"
+      ],
+      "reactivate": [
+        "admin_users"
+      ]
+    }
+  }
+
+]

--- a/opengever/setup/tests/assets/oggbundle/files/beschluss.pdf
+++ b/opengever/setup/tests/assets/oggbundle/files/beschluss.pdf
@@ -1,0 +1,1 @@
+Lorem Ipsum

--- a/opengever/setup/tests/assets/oggbundle/files/bewerbung_pesche.docx
+++ b/opengever/setup/tests/assets/oggbundle/files/bewerbung_pesche.docx
@@ -1,0 +1,1 @@
+mueller

--- a/opengever/setup/tests/assets/oggbundle/files/mueller.docx
+++ b/opengever/setup/tests/assets/oggbundle/files/mueller.docx
@@ -1,0 +1,1 @@
+mueller

--- a/opengever/setup/tests/assets/oggbundle/repofolders.json
+++ b/opengever/setup/tests/assets/oggbundle/repofolders.json
@@ -1,0 +1,78 @@
+[
+  {
+    "guid": "aed9f3db7b3b4713b61a7d7295362ea4",
+    "parent_guid": "e3718c24d4284b319639057187d86c0e",
+    "archival_value": "prompt",
+    "custody_period": 100,
+    "classification": "confidential",
+    "description": "",
+    "former_reference": "",
+    "privacy_layer": "privacy_layer_yes",
+    "public_trial": "private",
+    "public_trial_statement": "Enthält vertrauliche Personaldossiers.",
+    "reference_number_prefix": "1",
+    "referenced_activity": "",
+    "retention_period": 10,
+    "retention_period_annotation": "",
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Personal",
+    "valid_from": "2005-01-01",
+    "valid_until": "2050-01-01",
+    "_permissions": {
+      "block_inheritance": true,
+      "read": [
+        "privileged_users"
+      ],
+      "add": [
+        "privileged_users"
+      ],
+      "edit": [
+        "privileged_users"
+      ],
+      "close": [
+        "privileged_users"
+      ],
+      "reactivate": [
+        "admin_users"
+      ]
+    }
+  }, {
+    "guid": "xed7f3db7b3b4713b61a7d729536abcd",
+    "parent_guid": "e3718c24d4284b319639057187d86c0e",
+    "custody_period": 30,
+    "description": "",
+    "former_reference": "",
+    "privacy_layer": "privacy_layer_no",
+    "public_trial": "unchecked",
+    "public_trial_statement": "",
+    "reference_number_prefix": "0",
+    "referenced_activity": "",
+    "retention_period": 5,
+    "retention_period_annotation": "",
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Organigramm, Prozesse",
+    "valid_from": "2005-01-01",
+    "valid_until": "2020-01-01"
+  }, {
+    "guid": "e3718c24d4284b319639057187d86c0e",
+    "parent_guid": "754daf80623f45659004a8c38c78dc3e",
+    "archival_value": "unchecked",
+    "archival_value_annotation": "",
+    "classification": "unprotected",
+    "custody_period": 30,
+    "date_of_cassation": "2016-10-1",
+    "date_of_submission": "2016-10-2",
+    "description": "",
+    "location": "Aktenschrank 123",
+    "privacy_layer": "privacy_layer_no",
+    "public_trial": "unchecked",
+    "public_trial_statement": "",
+    "reference_number_prefix": "0",
+    "referenced_activity": "",
+    "retention_period": 5,
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Organisation",
+    "valid_from": "2005-01-01",
+    "valid_until": "2030-01-01"
+  }
+]

--- a/opengever/setup/tests/assets/oggbundle/reporoots.json
+++ b/opengever/setup/tests/assets/oggbundle/reporoots.json
@@ -1,0 +1,28 @@
+[
+  {
+    "guid": "754daf80623f45659004a8c38c78dc3e",
+    "review_state": "repositoryroot-state-active",
+    "title_de": "Ordnungssystem",
+    "title_fr": "",
+    "valid_from": "2000-01-01",
+    "valid_until": "2099-12-31",
+    "version": "",
+    "_permissions": {
+      "read": [
+        "all_users"
+      ],
+      "add": [
+        "all_users"
+      ],
+      "edit": [
+        "all_users"
+      ],
+      "close": [
+        "all_users"
+      ],
+      "reactivate": [
+        "admin_users"
+      ]
+    }
+  }
+]

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_filename
 from plone import api
@@ -33,7 +34,8 @@ class TestOggBundlePipeline(FunctionalTestCase):
         # test content creation
         # XXX use separate test-cases based on a layer
         root = self.assert_repo_root_created()
-        self.assert_repo_folders_created(root)
+        folder_staff = self.assert_repo_folders_created(root)
+        self.assert_dossiers_created(folder_staff)
 
     def assert_repo_root_created(self):
         root = self.portal.get('ordnungssystem')
@@ -49,7 +51,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
     def assert_repo_folders_created(self, root):
         folder_organisation = self.assert_organization_folder_created(root)
         self.assert_processes_folder_created(folder_organisation)
-        self.assert_staff_folder_created(folder_organisation)
+        return self.assert_staff_folder_created(folder_organisation)
 
     def assert_organization_folder_created(self, root):
         folder_organisation = root.get('organisation')
@@ -221,3 +223,30 @@ class TestOggBundlePipeline(FunctionalTestCase):
         # XXX local roles
 
         return folder_staff
+
+    def assert_dossiers_created(self, parent):
+        dossier_vreni = parent.get('dossier-1')
+        self.assertEqual(
+            u'Vreni Meier ist ein Tausendsassa',
+            IDossier(dossier_vreni).comments)
+        self.assertEqual(
+            tuple(),
+            IDossier(dossier_vreni).keywords)
+        self.assertEqual(
+            '1',
+            IDossier(dossier_vreni).reference_number)
+        self.assertEqual(
+            [],
+            IDossier(dossier_vreni).relatedDossier)
+        self.assertEqual(
+            u'lukas.graf',
+            IDossier(dossier_vreni).responsible)
+        self.assertEqual(
+            'dossier-state-active',
+            api.content.get_state(dossier_vreni))
+        self.assertEqual(
+            date(2010, 11, 11),
+            IDossier(dossier_vreni).start)
+        self.assertEqual(
+            u'Dossier Vreni Meier',
+            dossier_vreni.title)

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -49,6 +49,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
     def assert_repo_folders_created(self, root):
         folder_organisation = self.assert_organization_folder_created(root)
         self.assert_processes_folder_created(folder_organisation)
+        self.assert_staff_folder_created(folder_organisation)
 
     def assert_organization_folder_created(self, root):
         folder_organisation = root.get('organisation')
@@ -162,3 +163,61 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertIsNone(getattr(folder_process, 'guid', None))
         self.assertIsNone(getattr(folder_process, 'parent_guid', None))
         return folder_process
+
+    def assert_staff_folder_created(self, parent):
+        folder_staff = parent.get('personal')
+        self.assertEqual('0.1. Personal', folder_staff.Title())
+        self.assertEqual(u'Personal', folder_staff.title_de)
+        self.assertIsNone(folder_staff.title_fr)
+        self.assertEqual('personal', folder_staff.getId())
+        self.assertEqual(
+            u'prompt',
+            ILifeCycle(folder_staff).archival_value)
+        self.assertEqual(
+            u'confidential',
+            IClassification(folder_staff).classification)
+        self.assertEqual(
+            100,
+            ILifeCycle(folder_staff).custody_period)
+        self.assertEqual(
+            u'',
+            folder_staff.description)
+        self.assertEqual(
+            u'',
+            folder_staff.former_reference)
+        self.assertEqual(
+            u'privacy_layer_yes',
+            IClassification(folder_staff).privacy_layer)
+        self.assertEqual(
+            u'private',
+            IClassification(folder_staff).public_trial)
+        self.assertEqual(
+            u'Enth\xe4lt vertrauliche Personaldossiers.',
+            IClassification(folder_staff).public_trial_statement)
+
+        # XXX reference_number_prefix
+
+        self.assertEqual(
+            u'',
+            folder_staff.referenced_activity)
+        self.assertEqual(
+            10,
+            ILifeCycle(folder_staff).retention_period)
+        self.assertEqual(
+            u'',
+            ILifeCycle(folder_staff).retention_period_annotation)
+        self.assertEqual(
+            date(2005, 1, 1),
+            folder_staff.valid_from)
+        self.assertEqual(
+            date(2050, 1, 1),
+            folder_staff.valid_until)
+        self.assertEqual(
+            'repositoryfolder-state-active',
+            api.content.get_state(folder_staff))
+        self.assertIsNone(getattr(folder_staff, 'guid', None))
+        self.assertIsNone(getattr(folder_staff, 'parent_guid', None))
+
+        # XXX local roles
+
+        return folder_staff

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_filename
 from plone import api
@@ -99,9 +100,9 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(
             u'',
             IClassification(folder_organisation).public_trial_statement)
-
-        # XXX reference_number_prefix
-
+        self.assertEqual(
+            "0",
+            IReferenceNumberPrefix(folder_organisation).reference_number_prefix)
         self.assertEqual(
             u'',
             folder_organisation.referenced_activity)
@@ -145,9 +146,9 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(
             u'',
             IClassification(folder_process).public_trial_statement)
-
-        # XXX reference_number_prefix
-
+        self.assertEqual(
+            "0",
+            IReferenceNumberPrefix(folder_process).reference_number_prefix)
         self.assertEqual(
             u'',
             folder_process.referenced_activity)
@@ -197,9 +198,9 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(
             u'Enth\xe4lt vertrauliche Personaldossiers.',
             IClassification(folder_staff).public_trial_statement)
-
-        # XXX reference_number_prefix
-
+        self.assertEqual(
+            "1",
+            IReferenceNumberPrefix(folder_staff).reference_number_prefix)
         self.assertEqual(
             u'',
             folder_staff.referenced_activity)

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -225,6 +225,10 @@ class TestOggBundlePipeline(FunctionalTestCase):
         return folder_staff
 
     def assert_dossiers_created(self, parent):
+        self.assert_dossier_vreni_created(parent)
+        self.assert_dossier_peter_created(parent)
+
+    def assert_dossier_vreni_created(self, parent):
         dossier_vreni = parent.get('dossier-1')
         self.assertEqual(
             u'Vreni Meier ist ein Tausendsassa',
@@ -250,3 +254,57 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(
             u'Dossier Vreni Meier',
             dossier_vreni.title)
+
+    def assert_dossier_peter_created(self, parent):
+        dossier_peter = parent.get('dossier-2')
+        self.assertEqual(
+            u'archival worthy',
+            ILifeCycle(dossier_peter).archival_value)
+        self.assertEqual(
+            u'Beinhaltet Informationen zum Verfahren',
+            ILifeCycle(dossier_peter).archival_value_annotation)
+        self.assertEqual(
+            u'classified',
+            IClassification(dossier_peter).classification)
+        self.assertEqual(
+            150,
+            ILifeCycle(dossier_peter).custody_period)
+        self.assertEqual(
+            u'Wir haben Hanspeter M\xfcller in einem Verfahren entlassen.',
+            dossier_peter.description)
+        self.assertEqual(
+            date(2007, 1, 1),
+            IDossier(dossier_peter).start)
+        self.assertEqual(
+            date(2011, 1, 6),
+            IDossier(dossier_peter).end)
+        self.assertEqual(
+            tuple(),
+            IDossier(dossier_peter).keywords)
+        self.assertEqual(
+            u'privacy_layer_yes',
+            IClassification(dossier_peter).privacy_layer)
+        self.assertEqual(
+            '2',
+            IDossier(dossier_peter).reference_number)
+        self.assertEqual(
+            [],
+            IDossier(dossier_peter).relatedDossier)
+        self.assertEqual(
+            u'lukas.graf',
+            IDossier(dossier_peter).responsible)
+        self.assertEqual(
+            5,
+            ILifeCycle(dossier_peter).retention_period)
+        self.assertIsNone(
+            ILifeCycle(dossier_peter).retention_period_annotation)
+
+        # XXX workflow transitions/states
+        # self.assertEqual(
+        #     'dossier-state-resolved',
+        #     api.content.get_state(dossier_peter))
+        self.assertEqual(
+            u'Hanspeter M\xfcller',
+            dossier_peter.title)
+
+        # XXX local roles

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -2,6 +2,8 @@ from collective.transmogrifier.transmogrifier import Transmogrifier
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.behaviors.classification import IClassification
+from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_filename
 from plone import api
@@ -30,7 +32,8 @@ class TestOggBundlePipeline(FunctionalTestCase):
 
         # test content creation
         # XXX use separate test-cases based on a layer
-        self.assert_repo_root_created()
+        root = self.assert_repo_root_created()
+        self.assert_repo_folders_created(root)
 
     def assert_repo_root_created(self):
         root = self.portal.get('ordnungssystem')
@@ -40,3 +43,74 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual('ordnungssystem', root.getId())
         self.assertEqual(date(2000, 1, 1), root.valid_from)
         self.assertEqual(date(2099, 12, 31), root.valid_until)
+        self.assertIsNone(getattr(root, 'guid', None))
+        return root
+
+    def assert_repo_folders_created(self, root):
+        folder_organisation = self.assert_organization_folder_created(root)
+
+    def assert_organization_folder_created(self, root):
+        folder_organisation = root.get('organisation')
+        self.assertEqual('0. Organisation', folder_organisation.Title())
+        self.assertEqual(u'Organisation', folder_organisation.title_de)
+        self.assertIsNone(folder_organisation.title_fr)
+        self.assertEqual('organisation', folder_organisation.getId())
+        self.assertEqual(
+            date(2016, 10, 1),
+            ILifeCycle(folder_organisation).date_of_cassation)
+        self.assertEqual(
+            date(2016, 10, 2),
+            ILifeCycle(folder_organisation).date_of_submission)
+        self.assertEqual(
+            u'unchecked',
+            ILifeCycle(folder_organisation).archival_value)
+        self.assertEqual(
+            u'',
+            ILifeCycle(folder_organisation).archival_value_annotation)
+        self.assertEqual(
+            u'unprotected',
+            IClassification(folder_organisation).classification)
+        self.assertEqual(
+            30,
+            ILifeCycle(folder_organisation).custody_period)
+        self.assertEqual(
+            date(2016, 10, 1),
+            ILifeCycle(folder_organisation).date_of_cassation)
+        self.assertEqual(
+            date(2016, 10, 2),
+            ILifeCycle(folder_organisation).date_of_submission)
+        self.assertEqual(
+            u'',
+            folder_organisation.description)
+        self.assertEqual(
+            u'Aktenschrank 123',
+            folder_organisation.location)
+        self.assertEqual(
+            u'privacy_layer_no',
+            IClassification(folder_organisation).privacy_layer)
+        self.assertEqual(
+            u'unchecked',
+            IClassification(folder_organisation).public_trial)
+        self.assertEqual(
+            u'',
+            IClassification(folder_organisation).public_trial_statement)
+
+        # XXX reference_number_prefix
+
+        self.assertEqual(
+            u'',
+            folder_organisation.referenced_activity)
+        self.assertEqual(
+            5,
+            ILifeCycle(folder_organisation).retention_period)
+        self.assertEqual(
+            date(2005, 1, 1),
+            folder_organisation.valid_from)
+        self.assertEqual(
+            date(2030, 1, 1),
+            folder_organisation.valid_until)
+        self.assertEqual(
+            'repositoryfolder-state-active',
+            api.content.get_state(folder_organisation))
+        self.assertIsNone(getattr(folder_organisation, 'guid', None))
+        self.assertIsNone(getattr(folder_organisation, 'parent_guid', None))

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -1,4 +1,5 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import FunctionalTestCase
@@ -8,15 +9,16 @@ from plone import api
 
 class TestOggBundlePipeline(FunctionalTestCase):
 
+    use_default_fixture = False
+
     def test_oggbundle_transmogrifier(self):
         # this is a bit hackish, but since builders currently don't work in
         # layer setup/teardown and isolation of database content is ensured
         # on a per test level we abuse just one test to setup the pipeline and
         # test its data.
-        # i'd like to this in a fixture instead, but as things are for now
-        # we depend on content
 
         # load pipeline
+        # XXX move this to a layer
         self.grant("Manager")
         user, org_unit, admin_unit = create(
             Builder('fixture').with_all_unit_setup())
@@ -26,3 +28,15 @@ class TestOggBundlePipeline(FunctionalTestCase):
             'opengever.setup.tests', 'assets/oggbundle')
         transmogrifier(u'opengever.setup.oggbundle')
 
+        # test content creation
+        # XXX use separate test-cases based on a layer
+        self.assert_repo_root_created()
+
+    def assert_repo_root_created(self):
+        root = self.portal.get('ordnungssystem')
+        self.assertEqual('Ordnungssystem', root.Title())
+        self.assertEqual(u'Ordnungssystem', root.title_de)
+        self.assertEqual(u'', root.title_fr)
+        self.assertEqual('ordnungssystem', root.getId())
+        self.assertEqual(date(2000, 1, 1), root.valid_from)
+        self.assertEqual(date(2099, 12, 31), root.valid_until)

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -1,0 +1,28 @@
+from collective.transmogrifier.transmogrifier import Transmogrifier
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from pkg_resources import resource_filename
+from plone import api
+
+
+class TestOggBundlePipeline(FunctionalTestCase):
+
+    def test_oggbundle_transmogrifier(self):
+        # this is a bit hackish, but since builders currently don't work in
+        # layer setup/teardown and isolation of database content is ensured
+        # on a per test level we abuse just one test to setup the pipeline and
+        # test its data.
+        # i'd like to this in a fixture instead, but as things are for now
+        # we depend on content
+
+        # load pipeline
+        self.grant("Manager")
+        user, org_unit, admin_unit = create(
+            Builder('fixture').with_all_unit_setup())
+
+        transmogrifier = Transmogrifier(api.portal.get())
+        transmogrifier.bundle_dir = resource_filename(
+            'opengever.setup.tests', 'assets/oggbundle')
+        transmogrifier(u'opengever.setup.oggbundle')
+

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -35,7 +35,8 @@ class TestOggBundlePipeline(FunctionalTestCase):
         # XXX use separate test-cases based on a layer
         root = self.assert_repo_root_created()
         folder_staff = self.assert_repo_folders_created(root)
-        self.assert_dossiers_created(folder_staff)
+        dossier_peter = self.assert_dossiers_created(folder_staff)
+        self.assert_documents_created(dossier_peter)
 
     def assert_repo_root_created(self):
         root = self.portal.get('ordnungssystem')
@@ -226,7 +227,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
 
     def assert_dossiers_created(self, parent):
         self.assert_dossier_vreni_created(parent)
-        self.assert_dossier_peter_created(parent)
+        return self.assert_dossier_peter_created(parent)
 
     def assert_dossier_vreni_created(self, parent):
         dossier_vreni = parent.get('dossier-1')
@@ -308,3 +309,32 @@ class TestOggBundlePipeline(FunctionalTestCase):
             dossier_peter.title)
 
         # XXX local roles
+
+        return dossier_peter
+
+    def assert_documents_created(self, parent):
+        document_1 = parent.get('document-1')
+
+        # XXX load files
+        # self.assertTrue(document_1.digitally_available)
+
+        self.assertEqual(
+            u'david.erni',
+            document_1.document_author)
+        self.assertEqual(
+            date(2007, 1, 1),
+            document_1.document_date)
+        self.assertEqual(
+            tuple(),
+            document_1.keywords)
+        self.assertTrue(
+            document_1.preserved_as_paper)
+        self.assertEqual(
+            [],
+            document_1.relatedItems)
+        self.assertEqual(
+            'document-state-draft',
+            api.content.get_state(document_1))
+        self.assertEqual(
+            u'Bewerbung Hanspeter M\xfcller',
+            document_1.title)

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -48,6 +48,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
 
     def assert_repo_folders_created(self, root):
         folder_organisation = self.assert_organization_folder_created(root)
+        self.assert_processes_folder_created(folder_organisation)
 
     def assert_organization_folder_created(self, root):
         folder_organisation = root.get('organisation')
@@ -114,3 +115,50 @@ class TestOggBundlePipeline(FunctionalTestCase):
             api.content.get_state(folder_organisation))
         self.assertIsNone(getattr(folder_organisation, 'guid', None))
         self.assertIsNone(getattr(folder_organisation, 'parent_guid', None))
+        return folder_organisation
+
+    def assert_processes_folder_created(self, parent):
+        folder_process = parent.get('organigramm-prozesse')
+        self.assertEqual('0.0. Organigramm, Prozesse', folder_process.Title())
+        self.assertEqual(u'Organigramm, Prozesse', folder_process.title_de)
+        self.assertIsNone(folder_process.title_fr)
+        self.assertEqual('organigramm-prozesse', folder_process.getId())
+        self.assertEqual(
+            30,
+            ILifeCycle(folder_process).custody_period)
+        self.assertEqual(
+            u'',
+            folder_process.description)
+        self.assertEqual(
+            u'',
+            folder_process.former_reference)
+        self.assertEqual(
+            u'privacy_layer_no',
+            IClassification(folder_process).privacy_layer)
+        self.assertEqual(
+            u'unchecked',
+            IClassification(folder_process).public_trial)
+        self.assertEqual(
+            u'',
+            IClassification(folder_process).public_trial_statement)
+
+        # XXX reference_number_prefix
+
+        self.assertEqual(
+            u'',
+            folder_process.referenced_activity)
+        self.assertEqual(
+            5,
+            ILifeCycle(folder_process).retention_period)
+        self.assertEqual(
+            date(2005, 1, 1),
+            folder_process.valid_from)
+        self.assertEqual(
+            date(2020, 1, 1),
+            folder_process.valid_until)
+        self.assertEqual(
+            'repositoryfolder-state-active',
+            api.content.get_state(folder_process))
+        self.assertIsNone(getattr(folder_process, 'guid', None))
+        self.assertIsNone(getattr(folder_process, 'parent_guid', None))
+        return folder_process

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -313,6 +313,10 @@ class TestOggBundlePipeline(FunctionalTestCase):
         return dossier_peter
 
     def assert_documents_created(self, parent):
+        self.assert_document_1_created(parent)
+        self.assert_document_2_created(parent)
+
+    def assert_document_1_created(self, parent):
         document_1 = parent.get('document-1')
 
         # XXX load files
@@ -338,3 +342,42 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(
             u'Bewerbung Hanspeter M\xfcller',
             document_1.title)
+
+    def assert_document_2_created(self, parent):
+        document_2 = parent.get('document-2')
+
+        # XXX load files
+        # self.assertTrue(document_1.digitally_available)
+
+        self.assertEqual(
+            u'david.erni',
+            document_2.document_author)
+        self.assertEqual(
+            date(2011, 1, 1),
+            document_2.document_date)
+        self.assertEqual(
+            u'directive',
+            document_2.document_type)
+        self.assertEqual(
+            tuple(),
+            document_2.keywords)
+        self.assertTrue(
+            document_2.preserved_as_paper)
+        self.assertEqual(
+            u'private',
+            IClassification(document_2).public_trial)
+        self.assertEqual(
+            u'Enth\xe4lt private Daten',
+            IClassification(document_2).public_trial_statement)
+        self.assertEqual(
+            date(2011, 1, 1),
+            document_2.receipt_date)
+        self.assertEqual(
+            [],
+            document_2.relatedItems)
+        self.assertEqual(
+            'document-state-draft',
+            api.content.get_state(document_2))
+        self.assertEqual(
+            u'Entlassung Hanspeter M\xfcller',
+            document_2.title)

--- a/opengever/setup/transmogrifier.zcml
+++ b/opengever/setup/transmogrifier.zcml
@@ -19,6 +19,13 @@
       />
 
   <transmogrifier:registerConfig
+      name="opengever.setup.oggbundle"
+      title="Opengever Setup OGGBundle Import"
+      description="Import a OneGov GEVER Bundle which contains initial content"
+      configuration="cfgs/oggbundle.cfg"
+      />
+
+  <transmogrifier:registerConfig
       name="opengever.setup.repository"
       title="Opengever Repositorysystem import"
       description="Pipeline configuration for Opengever Setup"


### PR DESCRIPTION
First implementation of the pipeline to import a bundle. It is based on our already customised `ftw.inflator` pipeline `opengever.setup.content`.

