### PR TITLE
Disposition history and removal protocol fixes

### DIFF
--- a/opengever/disposition/browser/removal_protocol.py
+++ b/opengever/disposition/browser/removal_protocol.py
@@ -123,7 +123,8 @@ class RemovalProtocolLaTeXView(grok.MultiAdapter, MakoLaTeXView):
              'value': self.context.title},
             {'label': _('label_transfer_number',
                         default=u'Transfer number'),
-             'value': self.context.transfer_number}
+             'value': self.context.transfer_number if
+                 self.context.transfer_number else u''}
         ]
 
         for row in config:

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -6,6 +6,7 @@ from opengever.base.security import elevated_privileges
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
 from opengever.disposition.interfaces import IDisposition
+from opengever.disposition.interfaces import IDuringDossierDestruction
 from opengever.disposition.interfaces import IHistoryStorage
 from opengever.dossier.base import DOSSIER_STATES_OFFERABLE
 from opengever.dossier.behaviors.dossier import IDossier
@@ -24,6 +25,7 @@ from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.intid.interfaces import IIntIds
 
@@ -205,6 +207,7 @@ class Disposition(Container):
                 obj=relation.to_object, transition='dossier-transition-archive')
 
     def destroy_dossiers(self):
+        alsoProvides(getRequest(), IDuringDossierDestruction)
         dossiers = [relation.to_object for relation in self.dossiers]
         self.set_destroyed_dossiers(dossiers)
         with elevated_privileges():

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -1,3 +1,4 @@
+from opengever.disposition.interfaces import IDuringDossierDestruction
 from opengever.disposition.interfaces import IHistoryStorage
 from plone import api
 
@@ -26,6 +27,10 @@ def disposition_added(context, event):
 
 
 def disposition_modified(context, event):
+    # Skip modified events during dossier destruction
+    if IDuringDossierDestruction.providedBy(context.REQUEST):
+        return
+
     storage = IHistoryStorage(context)
     storage.add('edited',
                 api.user.get_current().getId(),

--- a/opengever/disposition/history.py
+++ b/opengever/disposition/history.py
@@ -80,6 +80,13 @@ class Added(DispositionHistory):
         return _('msg_disposition_added', default=u'Added by ${user}',
                  mapping=self._msg_mapping)
 
+    @property
+    def transition_label(self):
+        return translate(
+            _('label_disposition_added', default=u'Disposition added'),
+            context=getRequest())
+
+
 DispositionHistory.add_description(Added)
 
 
@@ -91,6 +98,12 @@ class Edited(DispositionHistory):
         return _('msg_disposition_edited',
                  default=u'Edited by ${user}',
                  mapping=self._msg_mapping)
+
+    @property
+    def transition_label(self):
+        return translate(
+            _('label_disposition_edited', default=u'Disposition edited'),
+            context=getRequest())
 
 DispositionHistory.add_description(Edited)
 

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -11,3 +11,8 @@ class IHistoryStorage(Interface):
 
 class IDisposition(Interface):
     """The disposition Interface."""
+
+
+class IDuringDossierDestruction(Interface):
+    """Request layer to indicate that dossiers are currently being destroyed.
+    """

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -179,7 +179,7 @@ msgstr "Archivierung bestätigt durch ${user}"
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
 #: ./opengever/disposition/history.py:152
 msgid "msg_disposition_close"
-msgstr "Angebot abgeschlossen und alle Dossiers vernicht durch ${user}"
+msgstr "Angebot abgeschlossen und alle Dossiers vernichtet durch ${user}"
 
 #. Default: "Disposition disposed for the archive by ${user}"
 #: ./opengever/disposition/history.py:128
@@ -205,4 +205,3 @@ msgstr "Periode"
 #: ./opengever/disposition/browser/templates/overview.pt:143
 msgid "progress"
 msgstr "Verlauf:"
-

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-01 12:47+0000\n"
+"POT-Creation-Date: 2016-12-05 13:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,17 +32,17 @@ msgid "document_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:27
+#: ./opengever/disposition/validators.py:29
 msgid "error_offered_in_a_different_disposition"
 msgstr "Das Dossier ${title} ist bereits in einem anderen Angebot angeboten."
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:21
+#: ./opengever/disposition/validators.py:23
 msgid "error_retention_period_not_expired"
 msgstr "Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen."
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:101
+#: ./opengever/disposition/disposition.py:99
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -72,9 +72,19 @@ msgid "label_details"
 msgstr "Details:"
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:91
+#: ./opengever/disposition/disposition.py:89
 msgid "label_disposition"
 msgstr "Angebot"
+
+#. Default: "Disposition added"
+#: ./opengever/disposition/history.py:86
+msgid "label_disposition_added"
+msgstr "Angebot hinzugefügt"
+
+#. Default: "Disposition edited"
+#: ./opengever/disposition/history.py:105
+msgid "label_disposition_edited"
+msgstr "Angebot bearbeitet"
 
 #. Default: "Download disposition package"
 #: ./opengever/disposition/browser/overview.py:45
@@ -94,7 +104,7 @@ msgstr "Dossiers"
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:111
-#: ./opengever/disposition/disposition.py:114
+#: ./opengever/disposition/disposition.py:112
 msgid "label_dossiers"
 msgstr "Dossiers"
 
@@ -136,13 +146,13 @@ msgstr "Zeitpunkt"
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:29
 #: ./opengever/disposition/browser/removal_protocol.py:53
-#: ./opengever/disposition/disposition.py:107
+#: ./opengever/disposition/disposition.py:105
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:124
-#: ./opengever/disposition/disposition.py:134
+#: ./opengever/disposition/disposition.py:132
 msgid "label_transfer_number"
 msgstr "Ablieferungsnummer"
 
@@ -157,27 +167,27 @@ msgid "msg_disposition_added"
 msgstr "Hinzugefügt durch ${user}"
 
 #. Default: "Appraisal finalized by ${user}"
-#: ./opengever/disposition/history.py:103
+#: ./opengever/disposition/history.py:116
 msgid "msg_disposition_appraised"
 msgstr "Bewertung finalisiert durch ${user}"
 
 #. Default: "The archiving confirmed by ${user}"
-#: ./opengever/disposition/history.py:127
+#: ./opengever/disposition/history.py:140
 msgid "msg_disposition_archived"
 msgstr "Archivierung bestätigt durch ${user}"
 
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
-#: ./opengever/disposition/history.py:139
+#: ./opengever/disposition/history.py:152
 msgid "msg_disposition_close"
 msgstr "Angebot abgeschlossen und alle Dossiers vernicht durch ${user}"
 
 #. Default: "Disposition disposed for the archive by ${user}"
-#: ./opengever/disposition/history.py:115
+#: ./opengever/disposition/history.py:128
 msgid "msg_disposition_disposed"
 msgstr "Für die Archivierung angeboten durch ${user}"
 
 #. Default: "Edited by ${user}"
-#: ./opengever/disposition/history.py:91
+#: ./opengever/disposition/history.py:98
 msgid "msg_disposition_edited"
 msgstr "Editiert durch ${user}"
 
@@ -195,3 +205,4 @@ msgstr "Periode"
 #: ./opengever/disposition/browser/templates/overview.pt:143
 msgid "progress"
 msgstr "Verlauf:"
+

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-01 12:47+0000\n"
+"POT-Creation-Date: 2016-12-05 13:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,17 +32,17 @@ msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:27
+#: ./opengever/disposition/validators.py:29
 msgid "error_offered_in_a_different_disposition"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:21
+#: ./opengever/disposition/validators.py:23
 msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:101
+#: ./opengever/disposition/disposition.py:99
 msgid "fieldset_common"
 msgstr ""
 
@@ -72,8 +72,18 @@ msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:91
+#: ./opengever/disposition/disposition.py:89
 msgid "label_disposition"
+msgstr ""
+
+#. Default: "Disposition added"
+#: ./opengever/disposition/history.py:86
+msgid "label_disposition_added"
+msgstr ""
+
+#. Default: "Disposition edited"
+#: ./opengever/disposition/history.py:105
+msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
@@ -93,7 +103,7 @@ msgstr ""
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:111
-#: ./opengever/disposition/disposition.py:114
+#: ./opengever/disposition/disposition.py:112
 msgid "label_dossiers"
 msgstr ""
 
@@ -135,13 +145,13 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:29
 #: ./opengever/disposition/browser/removal_protocol.py:53
-#: ./opengever/disposition/disposition.py:107
+#: ./opengever/disposition/disposition.py:105
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:124
-#: ./opengever/disposition/disposition.py:134
+#: ./opengever/disposition/disposition.py:132
 msgid "label_transfer_number"
 msgstr ""
 
@@ -156,27 +166,27 @@ msgid "msg_disposition_added"
 msgstr ""
 
 #. Default: "Appraisal finalized by ${user}"
-#: ./opengever/disposition/history.py:103
+#: ./opengever/disposition/history.py:116
 msgid "msg_disposition_appraised"
 msgstr ""
 
 #. Default: "The archiving confirmed by ${user}"
-#: ./opengever/disposition/history.py:127
+#: ./opengever/disposition/history.py:140
 msgid "msg_disposition_archived"
 msgstr ""
 
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
-#: ./opengever/disposition/history.py:139
+#: ./opengever/disposition/history.py:152
 msgid "msg_disposition_close"
 msgstr ""
 
 #. Default: "Disposition disposed for the archive by ${user}"
-#: ./opengever/disposition/history.py:115
+#: ./opengever/disposition/history.py:128
 msgid "msg_disposition_disposed"
 msgstr ""
 
 #. Default: "Edited by ${user}"
-#: ./opengever/disposition/history.py:91
+#: ./opengever/disposition/history.py:98
 msgid "msg_disposition_edited"
 msgstr ""
 

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-01 12:47+0000\n"
+"POT-Creation-Date: 2016-12-05 13:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,17 +35,17 @@ msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:27
+#: ./opengever/disposition/validators.py:29
 msgid "error_offered_in_a_different_disposition"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:21
+#: ./opengever/disposition/validators.py:23
 msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:101
+#: ./opengever/disposition/disposition.py:99
 msgid "fieldset_common"
 msgstr ""
 
@@ -75,8 +75,18 @@ msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:91
+#: ./opengever/disposition/disposition.py:89
 msgid "label_disposition"
+msgstr ""
+
+#. Default: "Disposition added"
+#: ./opengever/disposition/history.py:86
+msgid "label_disposition_added"
+msgstr ""
+
+#. Default: "Disposition edited"
+#: ./opengever/disposition/history.py:105
+msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
@@ -96,7 +106,7 @@ msgstr ""
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:111
-#: ./opengever/disposition/disposition.py:114
+#: ./opengever/disposition/disposition.py:112
 msgid "label_dossiers"
 msgstr ""
 
@@ -138,13 +148,13 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:29
 #: ./opengever/disposition/browser/removal_protocol.py:53
-#: ./opengever/disposition/disposition.py:107
+#: ./opengever/disposition/disposition.py:105
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:124
-#: ./opengever/disposition/disposition.py:134
+#: ./opengever/disposition/disposition.py:132
 msgid "label_transfer_number"
 msgstr ""
 
@@ -159,27 +169,27 @@ msgid "msg_disposition_added"
 msgstr ""
 
 #. Default: "Appraisal finalized by ${user}"
-#: ./opengever/disposition/history.py:103
+#: ./opengever/disposition/history.py:116
 msgid "msg_disposition_appraised"
 msgstr ""
 
 #. Default: "The archiving confirmed by ${user}"
-#: ./opengever/disposition/history.py:127
+#: ./opengever/disposition/history.py:140
 msgid "msg_disposition_archived"
 msgstr ""
 
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
-#: ./opengever/disposition/history.py:139
+#: ./opengever/disposition/history.py:152
 msgid "msg_disposition_close"
 msgstr ""
 
 #. Default: "Disposition disposed for the archive by ${user}"
-#: ./opengever/disposition/history.py:115
+#: ./opengever/disposition/history.py:128
 msgid "msg_disposition_disposed"
 msgstr ""
 
 #. Default: "Edited by ${user}"
-#: ./opengever/disposition/history.py:91
+#: ./opengever/disposition/history.py:98
 msgid "msg_disposition_edited"
 msgstr ""
 

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -124,6 +124,23 @@ class TestHistoryEntries(FunctionalTestCase):
                 self.user_link),
             translate(entry.msg(), context=self.request))
 
+    @browsing
+    def test_ignores_modified_events_during_dossier_destruction(self, browser):
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-dispose')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-archive')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-close')
+
+        history = IHistoryStorage(self.disposition).get_history()
+        self.assertEquals(
+            'disposition-transition-close', history[0].transition)
+        self.assertEquals(
+            'disposition-transition-archive', history[1].transition)
+
 
 class TestHistoryListingInOverview(FunctionalTestCase):
 


### PR DESCRIPTION
- Make sure that destroying dossiers doesn't get logged to disposition history as an edited event.
Currently the modified event handler creates a history entry for each dossiers which gets removed, this is unnecessary and wrong. Therefore we mark the request with a marker interface, to ignore ModifiedEvents while destroying dossiers.
- Fixed transition label for the added and edited action.
- Fixed typo in german translations.
- Don't display `None` as transfer number in the removal protocol, if there is no transfer number.

@deiferni  or @lukasgraf 