### PR TITLE
Use quickupload from source and ensure consistent configuration.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Ensure consistent collective.quickupload configuration across all
+  our installations.
+  [deiferni]
+
 - Make sure that items of a TOC are sorted as well.
   [deiferni]
 

--- a/opengever/base/upgrades/20161205175814_disable_quickupload_override/propertiestool.xml
+++ b/opengever/base/upgrades/20161205175814_disable_quickupload_override/propertiestool.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+ <object name="quickupload_properties" meta_type="Plone Property Sheet">
+  <property name="object_override" type="boolean">False</property>
+ </object>
+</object>

--- a/opengever/base/upgrades/20161205175814_disable_quickupload_override/propertiestool.xml
+++ b/opengever/base/upgrades/20161205175814_disable_quickupload_override/propertiestool.xml
@@ -2,5 +2,6 @@
 <object name="portal_properties" meta_type="Plone Properties Tool">
  <object name="quickupload_properties" meta_type="Plone Property Sheet">
   <property name="object_override" type="boolean">False</property>
+  <property name="object_unique_id" type="boolean">False</property>
  </object>
 </object>

--- a/opengever/base/upgrades/20161205175814_disable_quickupload_override/upgrade.py
+++ b/opengever/base/upgrades/20161205175814_disable_quickupload_override/upgrade.py
@@ -2,7 +2,7 @@ from ftw.upgrade import UpgradeStep
 
 
 class DisableQuickuploadOverride(UpgradeStep):
-    """Disable quickupload override.
+    """Disable quickupload override and unique id.
 
     The override default in collective.quickupload was inconsistent in the
     default profile and in the upgrade step.

--- a/opengever/base/upgrades/20161205175814_disable_quickupload_override/upgrade.py
+++ b/opengever/base/upgrades/20161205175814_disable_quickupload_override/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DisableQuickuploadOverride(UpgradeStep):
+    """Disable quickupload override.
+
+    The override default in collective.quickupload was inconsistent in the
+    default profile and in the upgrade step.
+
+    Even though this setting does not affect us currently this upgrade-step
+    makes sure that all of our installations have the same setting. You never
+    know ...
+
+    Also see https://github.com/collective/collective.quickupload/pull/60.
+
+    """
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/sources.cfg
+++ b/sources.cfg
@@ -14,6 +14,8 @@ development-packages =
   ftw.zipexport
 # Whitelist journal entries as safe writes for a new enough plone.protect
   ftw.journal
+# https://github.com/collective/collective.quickupload/pull/60
+  collective.quickupload
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
⚠️  depends on https://github.com/collective/collective.quickupload/pull/60

This PR makes sure that configuration is consistent across all our installations.

The override default in collective.quickupload was inconsistent in the
default profile and in the upgrade step.

For a detailed description please see https://github.com/collective/collective.quickupload/pull/60.

Fixes https://github.com/4teamwork/opengever.core/issues/2297.