### PR TITLE
Add entry point to run OGGBundle import from console

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+-  Add entry point to run OGGBundle import from console via
+   bin/instance import <path_to_oggbundle>
+   [lgraf]
+
 - Add folder-factory actions to add a dossier from a dossiertemplate in a repository-folder.
   [elioschmutz]
 

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,0 +1,31 @@
+from collective.transmogrifier.transmogrifier import Transmogrifier
+from opengever.core.debughelpers import get_first_plone_site
+from opengever.core.debughelpers import setup_plone
+import logging
+import sys
+import transaction
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+def import_oggbundle(app, args):
+    """Handler for the 'bin/instance import' zopectl command.
+    """
+    # Set Zope's default StreamHandler's level to INFO (default is WARNING)
+    # to make sure output gets logged on console
+    stream_handler = logging.root.handlers[0]
+    stream_handler.setLevel(logging.INFO)
+
+    bundle_dir = sys.argv[3]
+    log.info("Importing OGGBundle %s" % bundle_dir)
+
+    plone = setup_plone(get_first_plone_site(app))
+    transmogrifier = Transmogrifier(plone)
+    transmogrifier.bundle_dir = bundle_dir
+    transmogrifier(u'opengever.setup.oggbundle')
+
+    log.info("Committing transaction...")
+    transaction.commit()
+    log.info("Done.")

--- a/opengever/setup/sections/jsonsource.py
+++ b/opengever/setup/sections/jsonsource.py
@@ -39,6 +39,9 @@ class JSONSourceSection(object):
         else:
             self.bundle_dir = options.get('bundle_dir')
 
+        if not os.path.exists(self.bundle_dir):
+            raise Exception("Bundle %s not found" % self.bundle_dir)
+
         self.portal_type = options.get('portal_type')
         self.json_schema = self.get_content_type_json_schema()
 

--- a/opengever/setup/sections/jsonsource.py
+++ b/opengever/setup/sections/jsonsource.py
@@ -13,6 +13,7 @@ import os.path
 
 
 logger = logging.getLogger('opengever.setup.jsonsource')
+logger.setLevel(logging.INFO)
 
 
 class JSONSourceSection(object):
@@ -73,6 +74,7 @@ class JSONSourceSection(object):
         return data
 
     def __iter__(self):
+        logger.info('Yielding items from %s' % self.filename)
         for item in self.previous:
             yield item
 

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ setup(name='opengever.core',
       [zopectl.command]
       sync_ogds = opengever.ogds.base:sync_ogds_zopectl_handler
       dump_schemas = opengever.base.schemadump:dump_schemas_zopectl_handler
+      import = opengever.bundle.console:import_oggbundle
 
       [izug.basetheme]
       version = opengever.core


### PR DESCRIPTION
Adds a zopectl entry point to run OGGBundle import from console via `bin/instance import <path_to_oggbundle>`

@deiferni 