### PR TITLE
Remove unused variable in the ObjectCreatorCommand

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Add example dossiertemplates with recursive dossier from template object creation.
+  [elioschmutz]
+
 - Add a wizard to add a dossier from a dossiertemplate.
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Remove unused skip_defaults_fields for ObjectCreatorCommands.
+  [elioschmutz]
+
 - Add example dossiertemplates with recursive dossier from template object creation.
   [elioschmutz]
 

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -10,7 +10,36 @@ from zope.lifecycleevent import ObjectCreatedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 
 
-class CreateDocumentCommand(object):
+class BaseObjectCreatorCommand(object):
+    """Base class to create an object in a container.
+    """
+    portal_type = None
+    skip_defaults_fields = []
+
+    def __init__(self, context, title, **kwargs):
+        self.context = context
+        self.title = title
+        self.additional_args = kwargs
+
+    def execute(self):
+        content = createContent(self.portal_type, title=self.title,
+                                **self.additional_args)
+
+        obj = addContentToContainer(
+            self.context, content, checkConstraints=True)
+
+        self.finish_creation(obj)
+
+        obj.reindexObject()
+        return obj
+
+    def finish_creation(self, content):
+        """Trigger rest of initialization."""
+
+        notify(ObjectModifiedEvent(content))
+
+
+class CreateDocumentCommand(BaseObjectCreatorCommand):
     """Create a new opengever.document.document object and update its fields
     with default values.
 
@@ -20,16 +49,15 @@ class CreateDocumentCommand(object):
 
     def __init__(self, context, filename, data, title=None, content_type='',
                  **kwargs):
+        super(CreateDocumentCommand, self).__init__(context, title, **kwargs)
+
         # filename must be unicode
         if not isinstance(filename, unicode):
             filename = filename.decode('utf-8')
 
-        self.context = context
         self.data = data
         self.filename = filename
-        self.title = title
         self.content_type = content_type
-        self.additional_args = kwargs
 
     def execute(self):
         content = createContent(self.portal_type, title=self.title,
@@ -56,11 +84,6 @@ class CreateDocumentCommand(object):
 
         """
         notify(ObjectCreatedEvent(content))
-
-    def finish_creation(self, content):
-        """Trigger rest of initialization."""
-
-        notify(ObjectModifiedEvent(content))
 
     def set_primary_field_value(self, obj):
         if not self.data:

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -14,7 +14,6 @@ class BaseObjectCreatorCommand(object):
     """Base class to create an object in a container.
     """
     portal_type = None
-    skip_defaults_fields = []
 
     def __init__(self, context, title, **kwargs):
         self.context = context
@@ -45,7 +44,6 @@ class CreateDocumentCommand(BaseObjectCreatorCommand):
 
     """
     portal_type = 'opengever.document.document'
-    skip_defaults_fields = []
 
     def __init__(self, context, filename, data, title=None, content_type='',
                  **kwargs):

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -8,8 +8,6 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
     """Store a copy of the template in the new document's primary file field
     """
 
-    skip_defaults_fields = ['title', 'file']
-
     def __init__(self, context, template_doc, title, recipient_data=tuple()):
         super(CreateDocumentFromTemplateCommand, self).__init__(
             context, template_doc.file.filename, template_doc.file.data,

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -1,4 +1,6 @@
+from opengever.base.command import BaseObjectCreatorCommand
 from opengever.base.command import CreateDocumentCommand
+from opengever.base.default_values import get_persisted_values_for_obj
 from opengever.dossier.docprops import DocPropertyWriter
 
 
@@ -19,3 +21,24 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
 
         DocPropertyWriter(content, recipient_data=self.recipient_data).initialize()
         super(CreateDocumentFromTemplateCommand, self).finish_creation(content)
+
+
+class CreateDossierFromTemplateCommand(BaseObjectCreatorCommand):
+    """Store a copy of the dossiertemplate with all its attributes.
+    """
+    portal_type = 'opengever.dossier.businesscasedossier'
+
+    def __init__(self, context, template):
+        super(CreateDossierFromTemplateCommand, self).__init__(
+            context, template.title, **self._get_additional_attributes(template))
+
+    def _get_additional_attributes(self, template):
+        """Extracts the template attributes to use it as additional attributes.
+        """
+        data = get_persisted_values_for_obj(template)
+        del data['title']  # the titel is already given as a parameter
+        for key, val in data.items():
+            if not val:
+                del data[key]  # Remove unused attributes to get the default value
+
+        return data

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -7,7 +7,10 @@ from opengever.base.form import WizzardWrappedAddForm
 from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
 from opengever.dossier import _
+from opengever.dossier.command import CreateDocumentFromTemplateCommand
+from opengever.dossier.command import CreateDossierFromTemplateCommand
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.dossiertemplate.dossiertemplate import BEHAVIOR_INTERFACE_MAPPING
 from opengever.dossier.dossiertemplate.dossiertemplate import TEMPLATABLE_FIELDS
 from opengever.repository.interfaces import IRepositoryFolder
@@ -196,15 +199,28 @@ class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
 
                 obj = self.createAndAdd(data)
                 if obj is not None:
-                    # mark only as finished if we get the new object
-                    self._finishedAdd = True
+                    obj = api.content.find(context=self.context, depth=1, id=obj.getId())[0].getObject()
+                    template_obj = get_wizard_storage(self.context).get('template')
+                    self.recursive_content_creation(template_obj, obj)
 
+                    self._finishedAdd = True
                     api.portal.show_message(
                         PDMF(u"Item created"), request=self.request, type="info")
 
             @buttonAndHandler(pd_mf(u'Cancel'), name='cancel')
             def handleCancel(self, action):
                 return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+            def recursive_content_creation(self, template_obj, target_container):
+                for child_obj in template_obj.listFolderContents():
+                    if IDossierTemplateSchema.providedBy(child_obj):
+                        dossier = CreateDossierFromTemplateCommand(
+                            target_container, child_obj).execute()
+
+                        self.recursive_content_creation(child_obj, dossier)
+                    else:
+                        CreateDocumentFromTemplateCommand(
+                            target_container, child_obj, child_obj.title).execute()
 
         return WrappedForm
 

--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -24,4 +24,8 @@
       <value key="is_feature_enabled">True</value>
     </records>
 
+    <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings">
+      <value key="is_feature_enabled">True</value>
+    </records>
+
 </registry>

--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/05_dossiertemplates.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/05_dossiertemplates.json
@@ -1,0 +1,210 @@
+[{
+    "_path": "/vorlagen/dossiertemplate-1",
+    "_type": "opengever.dossier.dossiertemplate",
+    "title": "Investitionsvorhaben",
+    "_children": [
+        {
+            "_id": "dossiertemplate-3",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Projektgrundlagen",
+            "_children": [
+                {
+                    "_id": "dossiertemplate-12",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Auftrag, Organistaion",
+                    "description": "Projektauftrag, Projekthandbuch, Projektorganisation, Adressen"
+                },
+                {
+                    "_id": "dossiertemplate-13",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Termin-, Bauprogramme",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-14",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Bestandsaufnahmen",
+                    "description": "Schadstoffuntersuchungen, Gebäude- (Rissprotokolle) und Terrainaufnahme"
+                },
+                {
+                    "_id": "dossiertemplate-15",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Masterplan",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-16",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Vorstudien",
+                    "description": "Machbarkeitsstudien, Überbauungskonzepte, best. Nutzungsvereinbarung"
+                },
+                {
+                    "_id": "dossiertemplate-17",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Wettbewerb",
+                    "description": "Planerwahl, Projektwettbewerb"
+                },
+                {
+                    "_id": "dossiertemplate-18",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Vorprojekt",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-19",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Bauprojekt",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-20",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Konzepte / Simulationen",
+                    "description": "Betriebskonzept, Energiekonzept, Bauphysik, Schallschutz- und Akkustikkonzept, Sicherheitskonzept, Brandschutzkonzept, Statikkonzept, etc"
+                },
+                {
+                    "_id": "dossiertemplate-21",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Servitute, Dienstbarkeitsverträge",
+                    "description": "Dienstbarkeitsverträge, Servitute, Nutzungsverträge, Verträge"
+                },
+                {
+                    "_id": "dossiertemplate-22",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Grundstück, Lage",
+                    "description": "Situationsplan, Berichte Geologie, Hydrologie, Naturgefahren, Grundwassererhebung"
+                },
+                {
+                    "_id": "dossiertemplate-23",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Übriges",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "_id": "dossiertemplate-4",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Kredit und Rechnungswesen",
+            "_children": [
+                {
+                    "_id": "dossiertemplate-24",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Kreditbegehren",
+                    "description": "Budget, Botschaft, Zusatzkredit, Kreditumlagerung"
+                },
+                {
+                    "_id": "dossiertemplate-25",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Kosten",
+                    "description": "Kostenschätzung, Kostenvoranschlag, Material- und Baubeschrieb, Kostenkontrolle, Änderungswesen, etc."
+                },
+                {
+                    "_id": "dossiertemplate-26",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Kreditabrechnung",
+                    "description": "Bauabrechung, Revisionsbericht, RRB"
+                },
+                {
+                    "_id": "dossiertemplate-27",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Subventionen",
+                    "description": "Zuschüsse Dritter, Bundesbeitrag"
+                },
+                {
+                    "_id": "dossiertemplate-28",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Übriges",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "_id": "dossiertemplate-5",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Behörden",
+            "_children": [
+                {
+                    "_id": "dossiertemplate-29",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Gutachten",
+                    "description": "UVP, Parkraum, Verkehr, etc."
+                },
+                {
+                    "_id": "dossiertemplate-30",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Sondernutzungspläne",
+                    "description": "Gestaltungsplan, Überbauungsplan"
+                },
+                {
+                    "_id": "dossiertemplate-31",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Baubewilligung",
+                    "description": "Baugesuch, Bewilligungsunterlagen, usw."
+                },
+                {
+                    "_id": "dossiertemplate-32",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Korrektureingaben",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-33",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Einsprachenverfahren",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-34",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Betriebsbewilligung",
+                    "description": ""
+                },
+                {
+                    "_id": "dossiertemplate-35",
+                    "_type": "opengever.dossier.dossiertemplate",
+                    "title": "Übriges",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "_id": "dossiertemplate-6",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Korrespondenz"
+        },
+        {
+            "_id": "dossiertemplate-7",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Protokolle"
+        },
+        {
+            "_id": "dossiertemplate-8",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Dienstleistungsverträge"
+        },
+        {
+            "_id": "dossiertemplate-9",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Bau- und Lieferverträge"
+        },
+        {
+            "_id": "dossiertemplate-10",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Pläne / Dokumentation"
+        },
+        {
+            "_id": "dossiertemplate-11",
+            "_type": "opengever.dossier.dossiertemplate",
+            "title": "Abschlussarbeiten"
+        }
+
+    ]
+},
+{
+    "_path": "/vorlagen/dossiertemplate-2",
+    "_type": "opengever.dossier.dossiertemplate",
+    "title": "Kleinvorhaben",
+    "_children": []
+}
+]

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -181,8 +181,6 @@ class ManualExcerptOperations(object):
 
 class CreateGeneratedDocumentCommand(CreateDocumentCommand):
 
-    skip_defaults_fields = ['title', ]
-
     def __init__(self, context, meeting, document_operations,
                  lock_document_after_creation=False):
         """Data will be initialized lazily since it is only available after the


### PR DESCRIPTION
Remove the `skip_defaults_fields` variable from the `ObjectCreatorCommand` and its subobjects because it's never used.