### PR TITLE
Prevent that too long proposal titles can be entered on meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Prevent that too long proposal titles can be entered on meeting view.
+  [deiferni]
+
 - Ensure consistent collective.quickupload configuration across all
   our installations.
   [deiferni]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -1,6 +1,6 @@
 from opengever.base.response import JSONResponse
 from opengever.meeting import _
-from opengever.meeting.model import AgendaItem
+from opengever.meeting.proposal import ISubmittedProposalModel
 from opengever.meeting.service import meeting_service
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
@@ -181,7 +181,15 @@ class AgendaItemsView(BrowserView):
         if not title:
             return JSONResponse(self.request).error(
                 _('agenda_item_update_empty_string',
-                  default=u"Agenda Item title must not be empty.")).remain().dump()
+                  default=u"Agenda Item title must not be empty.")).proceed().dump()
+
+        title = title.decode('utf-8')
+        if self.agenda_item.has_proposal:
+            if len(title) > ISubmittedProposalModel['title'].max_length:
+                return JSONResponse(self.request).error(
+                    _('agenda_item_update_too_long_title',
+                      default=u"Agenda Item title is too long.")
+                ).proceed().dump()
 
         self.agenda_item.set_title(title)
         return JSONResponse(self.request).info(

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -12,6 +12,7 @@ from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.browser.protocol import UpdateProtocol
 from opengever.meeting.committee import ICommittee
 from opengever.meeting.model import Meeting
+from opengever.meeting.proposal import ISubmittedProposalModel
 from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
@@ -95,7 +96,7 @@ AGENDAITEMS_TEMPLATE = '''
         {{/if}}
         <div class="edit-box">
           <div class="input-group">
-            <input type="text" />
+            <input type="text" {{#if has_proposal}}maxlength="%(max_proposal_title_lengt)i"{{/if}} />
             <div class="button-group">
               <input value="%(label_edit_save)s" type="button" class="button edit-save" />
               <input value="%(label_edit_cancel)s" type="button" class="button edit-cancel" />
@@ -370,6 +371,7 @@ class MeetingView(BrowserView):
             _('label_revise_action', default='Revise this agenda item'),
             context=self.request)
         return AGENDAITEMS_TEMPLATE % {
+            'max_proposal_title_lengt': ISubmittedProposalModel['title'].max_length,
             'label_edit_cancel': label_edit_cancel,
             'label_edit_save': label_edit_save,
             'label_edit_action': label_edit_action,

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-09 14:20+0000\n"
+"POT-Creation-Date: 2016-12-07 10:03+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,12 +25,12 @@ msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 msgid "Actions"
 msgstr "Aktionen"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:71
+#: ./opengever/meeting/browser/meetings/meeting.py:72
 msgid "Add Dossier for Meeting"
 msgstr "Sitzungsdossier hinzufügen"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:70
+#: ./opengever/meeting/browser/meetings/meeting.py:71
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:416
+#: ./opengever/meeting/browser/meetings/meeting.py:418
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -220,7 +220,7 @@ msgstr "Sitzungsdossier"
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:288
+#: ./opengever/meeting/browser/meetings/meeting.py:289
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
@@ -319,7 +319,7 @@ msgstr "Eingereichten Antrag"
 msgid "Text:"
 msgstr "Freitext:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:240
+#: ./opengever/meeting/browser/meetings/meeting.py:241
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
@@ -362,17 +362,17 @@ msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:223
+#: ./opengever/meeting/browser/meetings/agendaitem.py:231
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:203
+#: ./opengever/meeting/browser/meetings/agendaitem.py:211
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:228
+#: ./opengever/meeting/browser/meetings/agendaitem.py:236
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
@@ -382,17 +382,17 @@ msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:220
+#: ./opengever/meeting/browser/meetings/agendaitem.py:228
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:244
+#: ./opengever/meeting/browser/meetings/agendaitem.py:252
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:257
+#: ./opengever/meeting/browser/meetings/agendaitem.py:265
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
@@ -401,15 +401,20 @@ msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
+#. Default: "Agenda Item title is too long."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:190
+msgid "agenda_item_update_too_long_title"
+msgstr "Der Traktandums-Titel ist zu lang."
+
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:188
+#: ./opengever/meeting/browser/meetings/agendaitem.py:196
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:186
+#: ./opengever/meeting/browser/meetings/meeting.py:187
 msgid "button_cancel"
 msgstr "Abbrechen"
 
@@ -420,7 +425,7 @@ msgstr "Periode abschliessen"
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:170
+#: ./opengever/meeting/browser/meetings/meeting.py:171
 msgid "button_continue"
 msgstr "Weiter"
 
@@ -567,12 +572,12 @@ msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:269
+#: ./opengever/meeting/browser/meetings/agendaitem.py:277
 msgid "empty_paragraph"
 msgstr "Der Abschnitt darf nicht leer sein."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:284
+#: ./opengever/meeting/browser/meetings/agendaitem.py:292
 msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
@@ -670,7 +675,7 @@ msgid "label_committe_reactivated"
 msgstr "Gremium erfolgreich reaktiviert."
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:51
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
@@ -728,7 +733,7 @@ msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:364
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
@@ -749,7 +754,7 @@ msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -766,7 +771,7 @@ msgstr "Zu eröffnen an"
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:314
+#: ./opengever/meeting/proposal.py:315
 msgid "label_discussion"
 msgstr "Diskussion"
 
@@ -776,7 +781,7 @@ msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:391
+#: ./opengever/meeting/proposal.py:392
 msgid "label_dossier_not_available"
 msgstr "Dossier nicht verfügbar"
 
@@ -785,28 +790,28 @@ msgid "label_download_agendaitem_list"
 msgstr "Traktandenliste herunterladen"
 
 #. Default: "download TOC alphabetical"
-#: ./opengever/meeting/browser/templates/periods.pt:13
+#: ./opengever/meeting/browser/templates/periods.pt:11
 msgid "label_download_alphabetical_toc"
 msgstr "Inhaltsverzeichnis alphabetisch"
 
 #. Default: "download TOC by repository"
-#: ./opengever/meeting/browser/templates/periods.pt:20
+#: ./opengever/meeting/browser/templates/periods.pt:18
 msgid "label_download_repository_toc"
 msgstr "Inhaltsverzeichnis nach Ordnungsposition"
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
-#: ./opengever/meeting/browser/templates/periods.pt:31
+#: ./opengever/meeting/browser/templates/periods.pt:27
 msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
@@ -821,7 +826,7 @@ msgid "label_edit_period"
 msgstr "Bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -832,7 +837,7 @@ msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:65
+#: ./opengever/meeting/browser/meetings/meeting.py:66
 #: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr "Ende"
@@ -897,7 +902,7 @@ msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:56
+#: ./opengever/meeting/browser/meetings/meeting.py:57
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Sitzungsort"
@@ -933,7 +938,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:384
+#: ./opengever/meeting/browser/meetings/meeting.py:386
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -995,12 +1000,12 @@ msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:367
+#: ./opengever/meeting/browser/meetings/meeting.py:368
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:370
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
@@ -1016,7 +1021,7 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:383
+#: ./opengever/meeting/browser/meetings/meeting.py:385
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "label_schedule"
 msgstr "Traktandieren"
@@ -1032,14 +1037,14 @@ msgid "label_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:61
+#: ./opengever/meeting/browser/meetings/meeting.py:62
 #: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:46
+#: ./opengever/meeting/browser/meetings/meeting.py:47
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titel"
@@ -1194,7 +1199,7 @@ msgid "overview"
 msgstr "Übersicht"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:273
+#: ./opengever/meeting/browser/meetings/agendaitem.py:281
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
@@ -1353,7 +1358,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:288
+#: ./opengever/meeting/browser/meetings/agendaitem.py:296
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-09 14:20+0000\n"
+"POT-Creation-Date: 2016-12-07 10:03+0000\n"
 "PO-Revision-Date: 2016-08-10 05:19+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -27,12 +27,12 @@ msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:71
+#: ./opengever/meeting/browser/meetings/meeting.py:72
 msgid "Add Dossier for Meeting"
 msgstr ""
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:70
+#: ./opengever/meeting/browser/meetings/meeting.py:71
 msgid "Add Meeting"
 msgstr "Ajouter la séance"
 
@@ -68,7 +68,7 @@ msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:416
+#: ./opengever/meeting/browser/meetings/meeting.py:418
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:288
+#: ./opengever/meeting/browser/meetings/meeting.py:289
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -321,7 +321,7 @@ msgstr "Proposition soumise"
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:240
+#: ./opengever/meeting/browser/meetings/meeting.py:241
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -364,17 +364,17 @@ msgid "active"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:223
+#: ./opengever/meeting/browser/meetings/agendaitem.py:231
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:203
+#: ./opengever/meeting/browser/meetings/agendaitem.py:211
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:228
+#: ./opengever/meeting/browser/meetings/agendaitem.py:236
 msgid "agenda_item_meeting_held"
 msgstr ""
 
@@ -384,17 +384,17 @@ msgid "agenda_item_order_updated"
 msgstr "Les points de l'ordre du jour ont été actualisés."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:220
+#: ./opengever/meeting/browser/meetings/agendaitem.py:228
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:244
+#: ./opengever/meeting/browser/meetings/agendaitem.py:252
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:257
+#: ./opengever/meeting/browser/meetings/agendaitem.py:265
 msgid "agenda_item_revised"
 msgstr ""
 
@@ -403,15 +403,20 @@ msgstr ""
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
+#. Default: "Agenda Item title is too long."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:190
+msgid "agenda_item_update_too_long_title"
+msgstr ""
+
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:188
+#: ./opengever/meeting/browser/meetings/agendaitem.py:196
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:186
+#: ./opengever/meeting/browser/meetings/meeting.py:187
 msgid "button_cancel"
 msgstr "Annuler"
 
@@ -422,7 +427,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:170
+#: ./opengever/meeting/browser/meetings/meeting.py:171
 msgid "button_continue"
 msgstr "Continuer"
 
@@ -569,12 +574,12 @@ msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:269
+#: ./opengever/meeting/browser/meetings/agendaitem.py:277
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:284
+#: ./opengever/meeting/browser/meetings/agendaitem.py:292
 msgid "empty_proposal"
 msgstr ""
 
@@ -672,7 +677,7 @@ msgid "label_committe_reactivated"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:51
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
@@ -730,7 +735,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:364
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_decide_action"
 msgstr ""
 
@@ -751,7 +756,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "label_delete_action"
 msgstr ""
 
@@ -768,7 +773,7 @@ msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:314
+#: ./opengever/meeting/proposal.py:315
 msgid "label_discussion"
 msgstr "Discussion"
 
@@ -778,7 +783,7 @@ msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:391
+#: ./opengever/meeting/proposal.py:392
 msgid "label_dossier_not_available"
 msgstr "Dossier indisponible"
 
@@ -787,28 +792,28 @@ msgid "label_download_agendaitem_list"
 msgstr ""
 
 #. Default: "download TOC alphabetical"
-#: ./opengever/meeting/browser/templates/periods.pt:13
+#: ./opengever/meeting/browser/templates/periods.pt:11
 msgid "label_download_alphabetical_toc"
 msgstr ""
 
 #. Default: "download TOC by repository"
-#: ./opengever/meeting/browser/templates/periods.pt:20
+#: ./opengever/meeting/browser/templates/periods.pt:18
 msgid "label_download_repository_toc"
 msgstr ""
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
-#: ./opengever/meeting/browser/templates/periods.pt:31
+#: ./opengever/meeting/browser/templates/periods.pt:27
 msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -823,7 +828,7 @@ msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 msgid "label_edit_save"
 msgstr ""
 
@@ -834,7 +839,7 @@ msgid "label_email"
 msgstr "Email"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:65
+#: ./opengever/meeting/browser/meetings/meeting.py:66
 #: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr "Fin"
@@ -899,7 +904,7 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:56
+#: ./opengever/meeting/browser/meetings/meeting.py:57
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Site"
@@ -935,7 +940,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:384
+#: ./opengever/meeting/browser/meetings/meeting.py:386
 msgid "label_no_proposals"
 msgstr ""
 
@@ -997,12 +1002,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:367
+#: ./opengever/meeting/browser/meetings/meeting.py:368
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:370
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 msgid "label_revise_action"
 msgstr ""
 
@@ -1018,7 +1023,7 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:383
+#: ./opengever/meeting/browser/meetings/meeting.py:385
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "label_schedule"
 msgstr ""
@@ -1034,14 +1039,14 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:61
+#: ./opengever/meeting/browser/meetings/meeting.py:62
 #: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:46
+#: ./opengever/meeting/browser/meetings/meeting.py:47
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titre"
@@ -1196,7 +1201,7 @@ msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:273
+#: ./opengever/meeting/browser/meetings/agendaitem.py:281
 msgid "paragraph_added"
 msgstr ""
 
@@ -1355,7 +1360,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:288
+#: ./opengever/meeting/browser/meetings/agendaitem.py:296
 msgid "text_added"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-11-09 14:20+0000\n"
+"POT-Creation-Date: 2016-12-07 10:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,11 +25,11 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:71
+#: ./opengever/meeting/browser/meetings/meeting.py:72
 msgid "Add Dossier for Meeting"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:70
+#: ./opengever/meeting/browser/meetings/meeting.py:71
 msgid "Add Meeting"
 msgstr ""
 
@@ -65,7 +65,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:416
+#: ./opengever/meeting/browser/meetings/meeting.py:418
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -219,7 +219,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:288
+#: ./opengever/meeting/browser/meetings/meeting.py:289
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:240
+#: ./opengever/meeting/browser/meetings/meeting.py:241
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -361,17 +361,17 @@ msgid "active"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:223
+#: ./opengever/meeting/browser/meetings/agendaitem.py:231
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:203
+#: ./opengever/meeting/browser/meetings/agendaitem.py:211
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:228
+#: ./opengever/meeting/browser/meetings/agendaitem.py:236
 msgid "agenda_item_meeting_held"
 msgstr ""
 
@@ -381,17 +381,17 @@ msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:220
+#: ./opengever/meeting/browser/meetings/agendaitem.py:228
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:244
+#: ./opengever/meeting/browser/meetings/agendaitem.py:252
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:257
+#: ./opengever/meeting/browser/meetings/agendaitem.py:265
 msgid "agenda_item_revised"
 msgstr ""
 
@@ -400,15 +400,20 @@ msgstr ""
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
+#. Default: "Agenda Item title is too long."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:190
+msgid "agenda_item_update_too_long_title"
+msgstr ""
+
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:188
+#: ./opengever/meeting/browser/meetings/agendaitem.py:196
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
 #: ./opengever/meeting/browser/documents/submit.py:95
-#: ./opengever/meeting/browser/meetings/meeting.py:186
+#: ./opengever/meeting/browser/meetings/meeting.py:187
 msgid "button_cancel"
 msgstr ""
 
@@ -419,7 +424,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:57
-#: ./opengever/meeting/browser/meetings/meeting.py:170
+#: ./opengever/meeting/browser/meetings/meeting.py:171
 msgid "button_continue"
 msgstr ""
 
@@ -566,12 +571,12 @@ msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:269
+#: ./opengever/meeting/browser/meetings/agendaitem.py:277
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:284
+#: ./opengever/meeting/browser/meetings/agendaitem.py:292
 msgid "empty_proposal"
 msgstr ""
 
@@ -669,7 +674,7 @@ msgid "label_committe_reactivated"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:51
+#: ./opengever/meeting/browser/meetings/meeting.py:52
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:48
 msgid "label_committee"
@@ -727,7 +732,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:364
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_decide_action"
 msgstr ""
 
@@ -748,7 +753,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "label_delete_action"
 msgstr ""
 
@@ -765,7 +770,7 @@ msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:314
+#: ./opengever/meeting/proposal.py:315
 msgid "label_discussion"
 msgstr ""
 
@@ -775,7 +780,7 @@ msgid "label_dossier"
 msgstr ""
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:391
+#: ./opengever/meeting/proposal.py:392
 msgid "label_dossier_not_available"
 msgstr ""
 
@@ -784,28 +789,28 @@ msgid "label_download_agendaitem_list"
 msgstr ""
 
 #. Default: "download TOC alphabetical"
-#: ./opengever/meeting/browser/templates/periods.pt:13
+#: ./opengever/meeting/browser/templates/periods.pt:11
 msgid "label_download_alphabetical_toc"
 msgstr ""
 
 #. Default: "download TOC by repository"
-#: ./opengever/meeting/browser/templates/periods.pt:20
+#: ./opengever/meeting/browser/templates/periods.pt:18
 msgid "label_download_repository_toc"
 msgstr ""
 
 #. Default: "Edit"
 #: ./opengever/meeting/browser/templates/member.pt:62
-#: ./opengever/meeting/browser/templates/periods.pt:31
+#: ./opengever/meeting/browser/templates/periods.pt:27
 msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:362
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -820,7 +825,7 @@ msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 msgid "label_edit_save"
 msgstr ""
 
@@ -831,7 +836,7 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:65
+#: ./opengever/meeting/browser/meetings/meeting.py:66
 #: ./opengever/meeting/browser/meetings/protocol.py:71
 msgid "label_end"
 msgstr ""
@@ -896,7 +901,7 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:56
+#: ./opengever/meeting/browser/meetings/meeting.py:57
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr ""
@@ -932,7 +937,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:384
+#: ./opengever/meeting/browser/meetings/meeting.py:386
 msgid "label_no_proposals"
 msgstr ""
 
@@ -994,12 +999,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:367
+#: ./opengever/meeting/browser/meetings/meeting.py:368
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:370
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 msgid "label_revise_action"
 msgstr ""
 
@@ -1015,7 +1020,7 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:383
+#: ./opengever/meeting/browser/meetings/meeting.py:385
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
 msgid "label_schedule"
 msgstr ""
@@ -1031,14 +1036,14 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:61
+#: ./opengever/meeting/browser/meetings/meeting.py:62
 #: ./opengever/meeting/browser/meetings/protocol.py:67
 msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:46
+#: ./opengever/meeting/browser/meetings/meeting.py:47
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr ""
@@ -1193,7 +1198,7 @@ msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:273
+#: ./opengever/meeting/browser/meetings/agendaitem.py:281
 msgid "paragraph_added"
 msgstr ""
 
@@ -1352,7 +1357,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:288
+#: ./opengever/meeting/browser/meetings/agendaitem.py:296
 msgid "text_added"
 msgstr ""
 

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -172,7 +172,24 @@ class TestAgendaItemEdit(TestAgendaItem):
                             u'messageClass': u'error',
                             u'messageTitle': u'Error'}],
                           browser.json.get('messages'))
-        self.assertEquals(False, browser.json.get('proceed'))
+        self.assertEquals(True, browser.json.get('proceed'))
+
+    @browsing
+    def test_when_title_is_too_long_returns_json_error(self, browser):
+        proposal = create(Builder('proposal_model'))
+        item = create(Builder('agenda_item').having(
+            title=u'foo', meeting=self.meeting, proposal=proposal))
+
+        browser.login().open(
+            self.meeting_wrapper,
+            view='agenda_items/{}/edit'.format(item.agenda_item_id),
+            data={'title': 257*u'a'})
+
+        self.assertEquals([{u'message': u'Agenda Item title is too long.',
+                            u'messageClass': u'error',
+                            u'messageTitle': u'Error'}],
+                          browser.json.get('messages'))
+        self.assertEquals(True, browser.json.get('proceed'))
 
     @browsing
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):


### PR DESCRIPTION
Add server-side validation and client-side maxlength to proposal-based agenda items title field to prevent too long titles being submitted.

Also fix displaying messages client-side.

Fixes #2378.