### PR TITLE
Hide private root from breadcrumbs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Hide private root from breadcrumbs.
+  [deiferni]
+
 - Prevent that too long proposal titles can be entered on meeting view.
   [deiferni]
 

--- a/opengever/private/root.py
+++ b/opengever/private/root.py
@@ -1,6 +1,8 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from plone.dexterity.content import Container
 from plone.directives import form
+from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
+from zope.interface import implements
 
 
 class IPrivateRoot(form.Schema):
@@ -11,5 +13,7 @@ class IPrivateRoot(form.Schema):
 class PrivateRoot(Container, TranslatedTitleMixin):
     """A private root, the container for all the PrivateFolders.
     """
+
+    implements(IHideFromBreadcrumbs)
 
     Title = TranslatedTitleMixin.Title

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -61,6 +61,13 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
             ['Dossiers'], browser.css('.formTab').text)
 
     @browsing
+    def test_private_root_is_hidden_from_breadcrumbs(self, browser):
+        browser.login().open(self.folder)
+        self.assertEqual(
+            'You are here: Client1 / Test User (test_user_1_)',
+            browser.css('#portal-breadcrumbs').first.text)
+
+    @browsing
     def test_dossier_tab_lists_all_containig_private_dossiers(self, browser):
         with freeze(datetime(2015, 9, 1)):
             create(Builder('private_dossier')


### PR DESCRIPTION
Since the private folder is the only content that is reachable for users
we do not show the parent private root for which they do not have any
permissions.

Closes #2244.