### PR TITLE
Fixed select_all selection for ProxyTabbedViews as the document listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Fixed select_all selection for ProxyTabbedViews as the document listings.
+  [phgross]
+
 - Fixed schemamigration AddOrgRoleParticipations for deployments with MySQL
   backend.
   [phgross]

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -184,7 +184,6 @@ class MyDocumentsProxy(DocumentsProxy):
     grok.context(Interface)
 
     listview = "tabbedview_view-mydocuments"
-    select_all_template = "document_view-select_all"
     galleryview = "tabbedview_view-mydocuments-gallery"
 
 

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -83,6 +83,30 @@ class BaseTabProxy(BaseCatalogListingTab):
     def name_without_postfix(self):
         return self.__name__.rstrip(PROXY_VIEW_POSTFIX)
 
+    def select_all(self, pagenumber, selected_count):
+        """Called when select-all is clicked. Returns HTML containing
+        a hidden input field for each field which is not displayed (is outside
+        of the current batch) at the moment.
+
+        `pagenumber`: the current page number (1 is first page)
+        `selected_count`: number of items selected / displayed on this page
+        """
+
+        if not self.batching_enabled:
+            return
+
+        if self.table_options is None:
+            self.table_options = {}
+
+        # Fetch contents from the preferred_view (gallery or listing view)
+        # to use the query of the really display tabbedview.
+        view = self.context.restrictedTraverse(self.preferred_view_name)
+        view.update()
+
+        above, beneath = self._select_all_remove_visibles(
+            view.contents, pagenumber, selected_count)
+        return self.select_all_template(above=above, beneath=beneath)
+
 
 class DocumentsProxy(BaseTabProxy):
     """This proxyview is looking for the last used documents

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -8,6 +8,7 @@ from opengever.tabbedview.browser.bumblebee_gallery import BumblebeeGalleryMixin
 from opengever.tabbedview.browser.tabs import BaseTabProxy
 from opengever.tabbedview.interfaces import ITabbedViewProxy
 from opengever.testing import FunctionalTestCase
+from opengever.testing import obj2paths
 from plone import api
 from zExceptions import NotFound
 from zope.component import getMultiAdapter
@@ -538,3 +539,20 @@ class TestProxyViewsWithActivatedFeature(FunctionalTestCase):
         self.assertEqual(
             'Gallery',
             browser.css('.ViewChooser .active').first.text)
+
+    @browsing
+    def test_select_all_use_preferred_view_content_query(self, browser):
+        dossier = create(Builder('dossier'))
+
+        document_a = create(Builder('document').within(dossier))
+        create(Builder('document'))
+
+
+        data = {'view_name':'documents-proxy',
+                'initialize': 0,
+                'selected_count': 0}
+        browser.login().open(dossier, data, view='tabbed_view/select_all')
+
+        self.assertEqual(
+            obj2paths([document_a]),
+            [input.get('value') for input in browser.css('input')])


### PR DESCRIPTION
The current implementation included the current context, which leads to different bugs when calling tabbedview actions. Fixes #2387.

@deiferni or @lukasgraf 