### PR TITLE
JSON source: Open JSON files using codecs module and 'utf-8-sig' codec

### DIFF
--- a/opengever/setup/sections/jsonsource.py
+++ b/opengever/setup/sections/jsonsource.py
@@ -7,6 +7,7 @@ from opengever.base.schemadump import config
 from opengever.base.schemadump.schema import OGGBundleJSONSchemaBuilder
 from zope.interface import classProvides
 from zope.interface import implements
+import codecs
 import json
 import logging
 import os.path
@@ -58,7 +59,7 @@ class JSONSourceSection(object):
 
     def read_json_file(self):
         try:
-            with open(self.filepath, "rb") as file_:
+            with codecs.open(self.filepath, 'r', 'utf-8-sig') as file_:
                 return json.load(file_)
         except IOError:
             logger.info("Could not read file '{}'. Skipping...".format(


### PR DESCRIPTION
JSON source: Open JSON files using codecs module and `'utf-8-sig'` codec in order to handle JSON files that contain an UTF-8 BOM (byte order marker) at the beginning.

@deiferni 