### PR TITLE
Fixed schemamigration for deployments with MySQL backend

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.13.1 (unreleased)
 -------------------
 
+- Fixed schemamigration AddOrgRoleParticipations for deployments with MySQL
+  backend.
+  [phgross]
+
 - Refactor CreateDocumentCommand and CreateEmailCommand.
   [elioschmutz]
 

--- a/opengever/contact/upgrades/20160824101726_add_org_role_participations/upgrade.py
+++ b/opengever/contact/upgrades/20160824101726_add_org_role_participations/upgrade.py
@@ -39,7 +39,7 @@ class AddOrgRoleParticipations(SchemaMigration):
 
     def make_participation_type_non_nullable(self):
         self.op.alter_column('participations', 'participation_type',
-                             existing_type=String, nullable=False)
+                             existing_type=String(30), nullable=False)
 
     def add_org_role_participation(self):
         self.op.add_column(


### PR DESCRIPTION
This PR adds the missing length parameter to the  `AddOrgRoleParticipations` upgradestep, which failed on deployments with MySQL Backend.

Traceback:
```
  File "/home/zope/eggs/SQLAlchemy-1.0.5-py2.7-linux-x86_64.egg/sqlalchemy/sql/compiler.py", line 2578, in visit_string
    return self.visit_VARCHAR(type_, **kw)
  File "/home/zope/eggs/SQLAlchemy-1.0.5-py2.7-linux-x86_64.egg/sqlalchemy/dialects/mysql/base.py", line 2306, in visit_VARCHAR
    self.dialect.name)
CompileError: VARCHAR requires a length on dialect mysql
```

@deiferni  or @lukasgraf please have a look