### PR TITLE
Fix flaky test depending on journal entry sort order

### DIFF
--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -39,7 +39,7 @@ class TestManualJournalEntry(FunctionalTestCase):
              'Comments': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier',
              'References': u'',
              'Time': '09.12.2016 09:40'},
-            browser.css('.listing').first.rows[1].dict())
+            browser.css('.listing').first.rows[2].dict())
 
     @browsing
     def test_selected_documents_are_listed_and_linked_in_the_references_column(self, browser):


### PR DESCRIPTION
Fix flaky test: Journal entry sort order was fixed in fb18056f, so that journal entries are now sorted in chronological order. In combination with the timestamp used in this test (`09.12.2016 09:40`) and another journal entry (we don't care about) using the non-frozen, dynamic `datetime.today()`, this resulted in the sort order changing today (2016-12-09), and the test started to fail.

@phgross 