### PR TITLE
Completely remove digitally_available, add sequence_number to jsonschema.

### DIFF
--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -74,12 +74,6 @@
             "description": "Archivtaugliche Version der Originaldatei",
             "_zope_schema_type": "NamedBlobFile"
         },
-        "digitally_available": {
-            "type": "boolean",
-            "title": "Digital verf\u00fcgbar",
-            "description": "",
-            "_zope_schema_type": "Bool"
-        },
         "delivery_date": {
             "type": "string",
             "title": "Ausgangsdatum",
@@ -161,7 +155,6 @@
         "delivery_date",
         "document_type",
         "document_author",
-        "digitally_available",
         "preserved_as_paper",
         "archival_file",
         "archival_file_state",

--- a/docs/schema-dumps/oggbundle/documents.schema.json
+++ b/docs/schema-dumps/oggbundle/documents.schema.json
@@ -144,15 +144,6 @@
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
-                "digitally_available": {
-                    "type": [
-                        "null",
-                        "boolean"
-                    ],
-                    "title": "Digital verf\u00fcgbar",
-                    "description": "",
-                    "_zope_schema_type": "Bool"
-                },
                 "document_type": {
                     "type": [
                         "null",
@@ -229,7 +220,6 @@
                 "delivery_date",
                 "document_type",
                 "document_author",
-                "digitally_available",
                 "preserved_as_paper",
                 "archival_file",
                 "archival_file_state"

--- a/docs/schema-dumps/oggbundle/documents.schema.json
+++ b/docs/schema-dumps/oggbundle/documents.schema.json
@@ -183,6 +183,14 @@
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
+                "sequence_number": {
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
+                    "description": "Fortlaufend gez\u00e4hlte Nummer eines Dokumentes.",
+                    "title": "Laufnummer"
+                },
                 "creators": {
                     "type": [
                         "null",

--- a/docs/schema-dumps/oggbundle/dossiers.schema.json
+++ b/docs/schema-dumps/oggbundle/dossiers.schema.json
@@ -309,6 +309,14 @@
                 },
                 "_permissions": {
                     "$ref": "#/definitions/permission"
+                },
+                "sequence_number": {
+                    "type": [
+                        "null",
+                        "integer"
+                    ],
+                    "description": "Fortlaufend gez\u00e4hlte Nummer eines Dossiers.",
+                    "title": "Laufnummer"
                 }
             },
             "required": [

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -66,12 +66,6 @@
             "description": "",
             "_zope_schema_type": "TextLine"
         },
-        "digitally_available": {
-            "type": "boolean",
-            "title": "Digital verf\u00fcgbar",
-            "description": "",
-            "_zope_schema_type": "Bool"
-        },
         "archival_file": {
             "type": "string",
             "title": "Archivdatei",
@@ -177,7 +171,6 @@
         "delivery_date",
         "document_type",
         "document_author",
-        "digitally_available",
         "preserved_as_paper",
         "archival_file",
         "archival_file_state"

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -52,6 +52,7 @@ DEFAULT_OVERRIDES = {
 # Dropped from all schema dumps
 IGNORED_FIELDS = [
     'plone.app.versioningbehavior.behaviors.IVersionable.changeNote',
+    'opengever.document.behaviors.metadata.IDocumentMetadata.digitally_available',
     'opengever.document.behaviors.metadata.IDocumentMetadata.preview',
     'opengever.document.behaviors.metadata.IDocumentMetadata.thumbnail',
     'opengever.dossier.behaviors.dossier.IDossier.temporary_former_reference_number',  # noqa

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -327,8 +327,22 @@ class OGGBundleJSONSchemaBuilder(object):
 
         if portal_type == 'opengever.document.document':
             core_schema['properties']['filepath'] = {'type': 'string'}
+            core_schema['properties']['sequence_number'] = {
+                'type': 'integer',
+                'title': 'Laufnummer',
+                'description': u'Fortlaufend gez\xe4hlte Nummer eines '
+                               'Dokumentes.'
+            }
             core_schema['required'].extend(['title', 'filepath'])
             # XXX: Documents without files?
+
+        if portal_type == 'opengever.dossier.businesscasedossier':
+            core_schema['properties']['sequence_number'] = {
+                'type': 'integer',
+                'title': 'Laufnummer',
+                'description': u'Fortlaufend gez\xe4hlte Nummer eines '
+                               'Dossiers.'
+            }
 
         self._filter_fields(short_name, core_schema)
         self._make_optional_fields_nullable(core_schema)


### PR DESCRIPTION
Completely remove `digitally_available` from all schema dumps. That field is de facto a property and is always set automatically depending on file availability. I think it is reasonable to also drop it from the schema dumps for the documentation.

Also add `sequence_number` to JSON-Schema for dossiers and documents.

Closes #2365