### PR TITLE
Improved closing mechanism of `for information` multi-adminunit tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 4.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improved and reworked closing mechanism of `for information`
+  multi-adminunit tasks.
+  [phgross]
 
 
 4.14.0 (2016-12-12)

--- a/opengever/task/browser/close.py
+++ b/opengever/task/browser/close.py
@@ -113,10 +113,9 @@ class SelectDocumentsStepForm(CloseTaskWizardStepFormMixin, Form):
             dm.update(dmkey, data)
 
             if len(data['documents']) == 0:
-                url = '/'.join((
-                    self.context.absolute_url(),
-                    '@@close-task-wizard_close?oguid=%s' % oguid))
-                return self.request.RESPONSE.redirect(url)
+                self.close_task(data.get('text'))
+                return self.request.RESPONSE.redirect(
+                    self.context.absolute_url())
 
             else:
                 admin_unit = self.context.get_responsible_admin_unit()
@@ -131,6 +130,11 @@ class SelectDocumentsStepForm(CloseTaskWizardStepFormMixin, Form):
                       name='cancel')
     def handle_cancel(self, action):
         return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+    def close_task(self, text):
+        change_task_workflow_state(
+            self.context, 'task-transition-open-tested-and-closed', text=text)
+
 
 
 class SelectDocumentsStepView(FormWrapper, grok.View):

--- a/opengever/task/tests/test_close.py
+++ b/opengever/task/tests/test_close.py
@@ -1,0 +1,39 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+from plone import api
+from plone.app.testing import TEST_USER_ID
+from opengever.task.adapters import IResponseContainer
+
+class TestClosingForInformationTask(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestClosingForInformationTask, self).setUp()
+        additional_admin_unit = create(Builder('admin_unit').id(u'additional'))
+        create(Builder('org_unit')
+               .with_default_groups()
+               .having(admin_unit=additional_admin_unit)
+               .id(u'additional'))
+
+    @browsing
+    def test_closes_task_directly_when_no_document_is_selected(self, browser):
+        document = create(Builder('document'))
+        task = create(Builder('task')
+                      .having(task_type=u'information',
+                              responsible_client='additional',
+                              responsible=TEST_USER_ID,
+                              relatedItems=[document]))
+
+        browser.login().open(task, view=u'tabbedview_view-overview')
+        browser.click_on('task-transition-open-tested-and-closed')
+        browser.fill({'Response': u'OK!'})
+        browser.click_on('Continue')
+
+        self.assertEquals('task-state-tested-and-closed',
+                          api.content.get_state(task))
+
+        response = IResponseContainer(task)[-1]
+        self.assertEquals(u'OK!', response.text)
+        self.assertEquals('task-transition-open-tested-and-closed',
+                          response.transition)

--- a/opengever/task/tests/test_close.py
+++ b/opengever/task/tests/test_close.py
@@ -1,19 +1,24 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.task.adapters import IResponseContainer
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
-from opengever.task.adapters import IResponseContainer
+from plone.protect import createToken
+
 
 class TestClosingForInformationTask(FunctionalTestCase):
 
     def setUp(self):
         super(TestClosingForInformationTask, self).setUp()
-        additional_admin_unit = create(Builder('admin_unit').id(u'additional'))
+        additional = create(Builder('admin_unit')
+                            .having(public_url='http://nohost/plone',
+                                    site_url='http://nohost/plone')
+                            .id(u'additional'))
         create(Builder('org_unit')
                .with_default_groups()
-               .having(admin_unit=additional_admin_unit)
+               .having(admin_unit=additional)
                .id(u'additional'))
 
     @browsing
@@ -37,3 +42,40 @@ class TestClosingForInformationTask(FunctionalTestCase):
         self.assertEquals(u'OK!', response.text)
         self.assertEquals('task-transition-open-tested-and-closed',
                           response.transition)
+
+    @browsing
+    def test_closes_task_when_remote_close_view_is_called(self, browser):
+        task = create(Builder('task')
+                      .having(task_type=u'information',
+                              responsible_client='additional',
+                              responsible=TEST_USER_ID))
+
+        browser.login().open(task,
+                             data={'text': u'Danke sch\xf6n',
+                                   '_authenticator': createToken()},
+                             view=u'close-task-wizard-remote_close')
+
+        self.assertEquals('OK', browser.contents)
+
+        self.assertEquals('task-state-tested-and-closed',
+                          api.content.get_state(task))
+        response = IResponseContainer(task)[-1]
+        self.assertEquals(u'Danke sch\xf6n'.encode('utf-8'), response.text)
+        self.assertEquals('task-transition-open-tested-and-closed',
+                          response.transition)
+
+    @browsing
+    def test_ignores_conflict_retries(self, browser):
+        task = create(Builder('task')
+                      .having(task_type=u'information',
+                              responsible_client='additional',
+                              responsible=TEST_USER_ID))
+
+        data = {'text': u'Danke sch\xf6n', '_authenticator': createToken()}
+        browser.login().open(task, data=data,
+                             view=u'close-task-wizard-remote_close')
+        self.assertEquals('OK', browser.contents)
+
+        browser.login().open(task, data=data,
+                             view=u'close-task-wizard-remote_close')
+        self.assertEquals('OK', browser.contents)


### PR DESCRIPTION
After copying the selected documents, it no longer redirects to a close view instead it closes the task with an remote request. So the task closing and the document copying is done in the same transaction and fixes an known CSRF issues (fixes #1800 and #1365)

@deiferni or @lukasgraf 