### PR TITLE
Creates successor-tasks of forwardings with a default task type.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.1 (unreleased)
 -------------------
 
+- Creates successor-tasks of forwardings with a default task type.
+  [phgross]
+
 - Display former contact id in the byline of contacts.
   [phgross]
 

--- a/opengever/inbox/tests/test_accept.py
+++ b/opengever/inbox/tests/test_accept.py
@@ -1,0 +1,36 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.task.browser.accept.utils import accept_forwarding_with_successor
+from opengever.task.browser.accept.utils import assign_forwarding_to_dossier
+from opengever.testing import FunctionalTestCase
+from plone.app.testing import TEST_USER_ID
+
+
+class TestForwardingAccepting(FunctionalTestCase):
+
+    def test_successor_task_is_created_with_information_task_type(self):
+        inbox = create(Builder('inbox'))
+        dossier = create(Builder('dossier'))
+        forwarding = create(Builder('forwarding')
+                            .having(responsible=TEST_USER_ID,
+                                    issuer='hugo.boss')
+                            .within(inbox))
+        task = accept_forwarding_with_successor(
+            self.portal, forwarding.oguid.id, 'OK, thx.', dossier=dossier)
+
+        self.assertEquals('information', task.task_type)
+
+
+class TestAssignToDossier(FunctionalTestCase):
+
+    def test_successor_task_is_created_with_information_task_type(self):
+        inbox = create(Builder('inbox'))
+        dossier = create(Builder('dossier'))
+        forwarding = create(Builder('forwarding')
+                            .having(responsible=TEST_USER_ID,
+                                    issuer='hugo.boss')
+                            .within(inbox))
+        task = assign_forwarding_to_dossier(
+            self.portal, forwarding.oguid.id, dossier,  'OK, thx.')
+
+        self.assertEquals('information', task.task_type)

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -30,6 +30,9 @@ import transaction
 
 ACCEPT_TASK_TRANSITION = 'task-transition-open-in-progress'
 
+# default task type for successor tasks of a forwarding
+FORWARDING_SUCCESSOR_TYPE = u'information'
+
 
 def _copy_documents_from_forwarding(from_obj, to_obj):
     # set prevent copyname key on the request
@@ -117,12 +120,14 @@ def accept_forwarding_with_successor(
             value = ITask.get(fieldname).get(successor_forwarding)
             fielddata[fieldname] = value
 
+        # Predefine the task_type to avoid tasks with an invalid task_type
+        fielddata['task_type'] = FORWARDING_SUCCESSOR_TYPE
+
         # lets create a new task - the successor task
         task = createContentInContainer(
             dossier, 'opengever.task.task', **fielddata)
 
         # copy documents and map the intids
-
         intids_mapping = _copy_documents_from_forwarding(
             successor_forwarding, task)
 
@@ -191,6 +196,9 @@ def assign_forwarding_to_dossier(
 
     # Reset issuer to the current inbox
     fielddata['issuer'] = get_current_org_unit().inbox().id()
+
+    # Predefine the task_type to avoid tasks with an invalid task_type
+    fielddata['task_type'] = FORWARDING_SUCCESSOR_TYPE
 
     # lets create a new task - the successor task
     task = createContentInContainer(


### PR DESCRIPTION
To avoid tasks with an invalid task_type when canceling the `edit`-form or close the browser after creation, we creates the successor task with a default task type (`For information` - `zur Kenntnisnahme`).

Fixes #2125.

Further details in the [Extranet Issue](https://extranet.4teamwork.ch/extern/opengever-kanton-zug/sprint-backlog/20191)