### PR TITLE
Include organization name in org-role addresses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Include organization name in org-role addresses.
+  [deiferni]
+
 - Show expired filter for managers and record managers only and hide it on
   subdossier listings.
   [phgross]

--- a/opengever/contact/docprops.py
+++ b/opengever/contact/docprops.py
@@ -165,3 +165,21 @@ class URLDocPropertyProvider(PrefixableDocPropertyProvider):
                            self.url.url)
 
         return properties
+
+
+class OrgRoleAddressDocPropertyProvider(AddressDocPropertyProvider):
+    """Provides doc-properties for org role addresses."""
+
+    def __init__(self, address, organization, prefix):
+        super(OrgRoleAddressDocPropertyProvider, self).__init__(address,
+                                                                prefix)
+        self.organization = organization
+
+    def get_properties(self):
+        properties = super(
+            OrgRoleAddressDocPropertyProvider, self).get_properties()
+
+        self._add_property(properties, 'organization', 'name',
+                           self.organization.name)
+
+        return properties

--- a/opengever/contact/models/org_role.py
+++ b/opengever/contact/models/org_role.py
@@ -1,5 +1,6 @@
 from opengever.base.model import Base
 from opengever.base.model import CONTENT_TITLE_LENGTH
+from opengever.contact.docprops import OrgRoleAddressDocPropertyProvider
 from opengever.contact.docprops import OrgRoleDocPropertyProvider
 from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import Column
@@ -8,6 +9,67 @@ from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
+
+
+class OrgRoleAddress(object):
+    """Represents the addresses of a person at an organization.
+
+    Provide the same interface as Address.
+
+    """
+    def __init__(self, person, organization, organization_address):
+        self.person = person
+        self.organization = organization
+        self.organization_address = organization_address
+
+    def __eq__(self, other):
+        if isinstance(other, OrgRoleAddress):
+            return other.address_id == self.address_id
+        return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    def __hash__(self):
+        return hash(self.address_id)
+
+    @property
+    def address_id(self):
+        return u'org_role_address:{}'.format(
+            self.organization_address.address_id)
+
+    @property
+    def street(self):
+        return self.organization_address.street
+
+    @property
+    def zip_code(self):
+        return self.organization_address.zip_code
+
+    @property
+    def city(self):
+        return self.organization_address.city
+
+    @property
+    def country(self):
+        return self.organization_address.country
+
+    def get_lines(self):
+        return filter(None, [
+            self.person.get_title(),
+            self.organization.get_title(),
+            self.street,
+            u" ".join(filter(None,
+                      [self.zip_code, self.city])),
+            self.country,
+        ])
+
+    def get_doc_property_provider(self, prefix):
+        return OrgRoleAddressDocPropertyProvider(
+            self.organization_address, self.organization, prefix)
 
 
 class OrgRole(Base):
@@ -41,7 +103,8 @@ class OrgRole(Base):
 
     @property
     def addresses(self):
-        return self.person.addresses + self.organization.addresses
+        return [OrgRoleAddress(self.person, self.organization, address)
+                for address in self.organization.addresses]
 
     @property
     def mail_addresses(self):

--- a/opengever/contact/tests/test_docprops.py
+++ b/opengever/contact/tests/test_docprops.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.contact.models.org_role import OrgRoleAddress
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
 from opengever.dossier.tests import OGDS_USER_ATTRIBUTES
 from opengever.testing import FunctionalTestCase
@@ -116,6 +117,41 @@ class TestContactDocPropertyProvider(FunctionalTestCase):
             'ogg.recipient.address.street': u'Musterstrasse 283',
             'ogg.recipient.address.zip_code': '1234',
             'ogg.recipient.address.city': 'Hinterkappelen',
+            'ogg.recipient.address.country': 'Schweiz',
+        }
+        self.assertItemsEqual(expected_address_properties,
+                              provider.get_properties())
+
+    def test_org_role_address_doc_propety_provider(self):
+        peter = create(Builder('person')
+                       .having(firstname=u'Peter',
+                               lastname=u'M\xfcller',
+                               salutation='Herr',
+                               academic_title='Prof. Dr.',
+                               description='blablabla'))
+        organization = create(Builder('organization').having(name=u'Foo'))
+        address = create(Builder('address')
+                         .for_contact(organization)
+                         .labeled(u'Main')
+                         .having(street=u'Musterstrasse 1234',
+                                 zip_code=u'7335',
+                                 city=u'Obermumpf',
+                                 country=u'Schweiz'))
+        org_role = create(Builder('org_role')
+                          .having(organization=organization,
+                                  person=peter,
+                                  function=u'M\xe4dchen f\xfcr alles',
+                                  description=u'blub',
+                                  department=u'Informatik'))
+
+        org_role_address = org_role.addresses[0]
+        provider = org_role_address.get_doc_property_provider(
+            prefix='recipient')
+        expected_address_properties = {
+            'ogg.recipient.organization.name': u'Foo',
+            'ogg.recipient.address.street': u'Musterstrasse 1234',
+            'ogg.recipient.address.zip_code': '7335',
+            'ogg.recipient.address.city': 'Obermumpf',
             'ogg.recipient.address.country': 'Schweiz',
         }
         self.assertItemsEqual(expected_address_properties,

--- a/opengever/dossier/templatedossier/form.py
+++ b/opengever/dossier/templatedossier/form.py
@@ -328,7 +328,7 @@ class SelectAddressWizardStep(
             return
 
         dm = getUtility(IWizardDataStorage)
-        data .update(dm.get_data(get_dm_key(self.context)))
+        data.update(dm.get_data(get_dm_key(self.context)))
 
         return self.finish_document_creation(data)
 

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -301,7 +301,7 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
             person=peter, organization=organization, function=u'cheffe'))
 
         address1 = create(Builder('address')
-                          .for_contact(peter)
+                          .for_contact(organization)
                           .labeled(u'Home')
                           .having(street=u'Musterstrasse 283',
                                   zip_code=u'1234',
@@ -316,6 +316,7 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
         url = create(Builder('url')
                      .for_contact(organization)
                      .having(url=u'http://www.example.com'))
+        address_id = org_role.addresses[0].address_id
 
         with freeze(self.document_date):
             # submit first wizard step
@@ -325,7 +326,7 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
                           'Title': 'Test Docx'}).save()
             # submit second wizard step
             browser.fill(
-                {'form.widgets.address': str(address1.address_id),
+                {'form.widgets.address': address_id,
                  'form.widgets.mail_address': str(mailaddress.mailaddress_id),
                  'form.widgets.phonenumber': str(phonenumber.phone_number_id),
                  'form.widgets.url': str(url.url_id)}
@@ -333,12 +334,12 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
 
         document = self.dossier.listFolderContents()[0]
         self.assertEquals(u'test-docx.docx', document.file.filename)
-
         expected_org_role_properties = {
             'ogg.recipient.contact.title': u'M\xfcller Peter',
             'ogg.recipient.person.firstname': 'Peter',
             'ogg.recipient.person.lastname': u'M\xfcller',
             'ogg.recipient.orgrole.function': u'cheffe',
+            'ogg.recipient.organization.name': u'Meier AG',
             'ogg.recipient.address.street': u'Musterstrasse 283',
             'ogg.recipient.address.zip_code': '1234',
             'ogg.recipient.address.city': 'Hinterkappelen',


### PR DESCRIPTION
This PR includes introduces a combined address for person and organization when creating a template based on an org-role.
Also see https://basecamp.com/2768704/projects/12330648/todos/280602489.

Closes #2419.