### PR TITLE
Limit document selection when creating a manual journal entry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Make sure DossierPathSourceBinder limits selectable objects also for
+  the autocomplete widget.
+  [phgross]
+
 - Include organization name in org-role addresses.
   [deiferni]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Limit document selection when creating a manual journal entry.
+  Only documents inside the dossier are selectable.
+  [phgross]
+
 - Make sure DossierPathSourceBinder limits selectable objects also for
   the autocomplete widget.
   [phgross]

--- a/opengever/base/source.py
+++ b/opengever/base/source.py
@@ -78,7 +78,12 @@ class DossierPathSourceBinder(ObjPathSourceBinder):
             parent = aq_parent(aq_inner(parent))
         if not self.navigation_tree_query:
             self.navigation_tree_query = {}
+
         self.navigation_tree_query['path'] = {'query': dossier_path}
+
+        # Extend path in selectable_filter, to make sure only objects
+        # inside the current dossier are selectable.
+        self.selectable_filter.criteria['path'] = {'query': dossier_path}
 
         source = self.path_source(
             context,

--- a/opengever/base/tests/test_source_binder.py
+++ b/opengever/base/tests/test_source_binder.py
@@ -5,34 +5,31 @@ from opengever.base.source import RepositoryPathSourceBinder
 from opengever.testing import FunctionalTestCase
 
 
-class TestSourceBinder(FunctionalTestCase):
+class TestRepositoryPathSourceBinder(FunctionalTestCase):
 
     def setUp(self):
-        super(TestSourceBinder, self).setUp()
+        super(TestRepositoryPathSourceBinder, self).setUp()
         self.grant('Administrator', 'Contributor', 'Editor', 'Reader')
 
-        # Repository 1
-        reporoot1 = create(Builder('repository_root').titled('Ordnungssystem1'))
-        repofolder1 = create(Builder('repository').within(reporoot1))
-        repofolder2 = create(Builder('repository').within(repofolder1))
-        create(Builder('repository').within(reporoot1))
-        self.repofolder2_1 = create(Builder('repository').within(repofolder2))
-        # Repository 2
-        reporoot2 = create(Builder('repository_root').titled('Ordnungssystem2'))
-        for index in range(3):
-            create(Builder('repository').within(reporoot2))
+        self.reporoot_1 = create(Builder('repository_root')
+                                 .titled(u'Ordnungssystem1'))
+        self.repofolder1 = create(Builder('repository')
+                                  .within(self.reporoot_1))
+        self.repofolder1_1 = create(Builder('repository')
+                                    .within(self.repofolder1))
 
-    def test_sourcebinder(self):
-        """
-        Check if SourceBinder works correctly without a querymodificator
-        """
-        query = RepositoryPathSourceBinder()(self.repofolder2_1)
-        self.assertEqual(
-            {'query': '/plone/ordnungssystem1'},
-            query.navigation_tree_query['path'])
-        self.assertEqual(
-            5,
-            len(query.catalog.searchResults(query.navigation_tree_query)))
+        self.reporoot2 = create(Builder('repository_root')
+                                 .titled(u'Ordnungssystem2'))
+        self.repofolder2 = create(Builder('repository').within(self.reporoot2))
+
+    def test_navigation_tree_query_is_limited_to_current_repository(self):
+        source_binder = RepositoryPathSourceBinder()
+        source = source_binder(self.repofolder1_1)
+        self.assertEqual({'query': '/plone/ordnungssystem1'},
+                         source.navigation_tree_query['path'])
+        source = source_binder(self.repofolder1)
+        self.assertEqual({'query': '/plone/ordnungssystem1'},
+                         source.navigation_tree_query['path'])
 
 
 class TestDossierSourceBinder(FunctionalTestCase):

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -1,4 +1,4 @@
-from opengever.base.source import RepositoryPathSourceBinder
+from opengever.base.source import DossierPathSourceBinder
 from opengever.journal import _
 from opengever.journal.entry import ManualJournalEntry
 from plone.directives import form
@@ -36,15 +36,14 @@ class IManualJournalEntry(form.Schema):
         missing_value=[],
         value_type=RelationChoice(
             title=u"Related",
-            source=RepositoryPathSourceBinder(
+            source=DossierPathSourceBinder(
                 portal_type=("opengever.document.document", "ftw.mail.mail"),
                 navigation_tree_query={
                     'object_provides':
-                    ['opengever.repository.repositoryroot.IRepositoryRoot',
-                     'opengever.repository.repositoryfolder.IRepositoryFolderSchema',
-                     'opengever.dossier.behaviors.dossier.IDossierMarker',
+                    ['opengever.dossier.behaviors.dossier.IDossierMarker',
                      'opengever.document.document.IDocumentSchema',
-                     'ftw.mail.mail.IMail', ]
+                     'opengever.task.task.ITask',
+                     'ftw.mail.mail.IMail']
                 }),
             ),
         required=False,

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
+from opengever.journal.tests.utils import get_journal_entry
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import get_contacts_vocabulary
 
@@ -133,3 +134,22 @@ class TestManualJournalEntry(FunctionalTestCase):
 
         self.assertEquals('Manual entry: Phone call', row.dict().get('Title'))
         self.assertEquals('', row.dict().get('Comments'))
+
+    @browsing
+    def test_only_documents_from_the_dossier_are_selectable(self, browser):
+        doc1 = create(Builder('document')
+                      .titled(u'Test A')
+                      .within(self.dossier))
+
+        dossier2 = create(Builder('dossier'))
+        doc2 = create(Builder('document')
+                      .titled(u'Test B')
+                      .within(dossier2))
+
+        browser.login().open(self.dossier, view='add-journal-entry')
+        browser.fill(
+            {'form.widgets.related_documents.widgets.query': 'test'}).submit()
+
+        self.assertEquals(
+            ['Test A'],
+            browser.css('#form-widgets-related_documents-autocomplete .option').text)

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -121,7 +121,7 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
     @browsing
     def test_send_empty_documents(self, browser):
         dossier = create(Builder("dossier"))
-        document = create(Builder("document"))
+        document = create(Builder("document").within(dossier))
 
         mail = self.send_documents(dossier, [document, ])
 
@@ -130,7 +130,9 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
     @browsing
     def test_send_documents_as_links(self, browser):
         dossier = create(Builder("dossier"))
-        document = create(Builder("document").with_dummy_content())
+        document = create(Builder("document")
+                          .within(dossier)
+                          .with_dummy_content())
 
         mail = self.send_documents(dossier, [document, ], as_links=True)
 
@@ -176,7 +178,9 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
     @browsing
     def test_sent_mail_gets_filed_in_dossier(self, browser):
         dossier = create(Builder("dossier"))
-        document = create(Builder("document").with_dummy_content())
+        document = create(Builder("document")
+                          .within(dossier)
+                          .with_dummy_content())
 
         self.send_documents(dossier, [document], file_copy_in_dossier=True)
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -61,13 +61,6 @@ class TestProposal(FunctionalTestCase):
         self.assertIsNotNone(model)
         self.assertEqual(Oguid.for_object(proposal), model.oguid)
 
-    def search_for_document(self, browser, document):
-        """Relation-widget, search for one document."""
-
-        title = document.Title()
-        browser.fill(
-            {'form.widgets.relatedItems.widgets.query': title}).submit()
-
     @browsing
     def test_dossier_title_is_default_value_for_proposal_title(self, browser):
         browser.login()
@@ -85,11 +78,9 @@ class TestProposal(FunctionalTestCase):
         browser.login()
         browser.open(self.dossier, view='++add++opengever.meeting.proposal')
 
-        self.search_for_document(browser, document)
         browser.fill({
             'Title': u'A pr\xf6posal',
             'Committee': str(committee.committee_id),
-            'form.widgets.relatedItems:list': True,
             'Legal basis': u'<div>possible</div>',
             'Initial position': u'<div>My pr\xf6posal</div>',
             'Proposed action': u'<div>Lorem ips\xfcm</div>',
@@ -97,6 +88,7 @@ class TestProposal(FunctionalTestCase):
             'Publish in': u'<div>B\xe4rner Zeitung</div>',
             'Disclose to': u'<div>Hansj\xf6rg</div>',
             'Copy for attention': u'<div>   &nbsp; \n  &nbsp;</div>',
+            'Attachments': [document],
         })
         browser.css('#form-buttons-save').first.click()
         self.assertIn('Item created',
@@ -139,8 +131,6 @@ class TestProposal(FunctionalTestCase):
         form = browser.css('#content-core form').first
         self.assertEqual(u'My Proposal', form.find_field('Title').value)
 
-        self.search_for_document(browser, document)
-
         browser.fill({
             'Title': u'A pr\xf6posal',
             'Legal basis': u'<div>not possible</div>',
@@ -150,7 +140,7 @@ class TestProposal(FunctionalTestCase):
             'Publish in': u'<div>B\xe4rner Zeitung</div>',
             'Disclose to': u'<div>Hansj\xf6rg</div>',
             'Copy for attention': u'<div>P\xe4tra</div>',
-            'form.widgets.relatedItems:list': True,
+            'Attachments': [document],
             })
 
         browser.css('#form-buttons-save').first.click()
@@ -389,14 +379,13 @@ class TestProposal(FunctionalTestCase):
 
         browser.login()
         browser.open(self.dossier, view='++add++opengever.meeting.proposal')
-        self.search_for_document(browser, document)
         browser.fill({
             'Title': u'A pr\xf6posal',
             'Legal basis': u'possible',
             'Initial position': u'My pr\xf6posal',
             'Proposed action': u'Lorem ips\xfcm',
             'Committee': str(committee.committee_id),
-            'form.widgets.relatedItems:list': True,
+            'Attachments': [document],
         })
         browser.find('Save').click()
 
@@ -414,14 +403,13 @@ class TestProposal(FunctionalTestCase):
 
         browser.login()
         browser.open(subdossier, view='++add++opengever.meeting.proposal')
-        self.search_for_document(browser, document)
         browser.fill({
             'Title': u'A pr\xf6posal',
             'Legal basis': u'possible',
             'Initial position': u'My pr\xf6posal',
             'Proposed action': u'Lorem ips\xfcm',
             'Committee': str(committee.committee_id),
-            'form.widgets.relatedItems:list': True,
+            'Attachments': [document],
         })
         browser.find('Save').click()
 


### PR DESCRIPTION
to only documents inside the dossier. Closes #2416 

Besides that I've found and fixed an issue in the DossierPathSourceBinder, which only limits the selectable objects for the selection in the tree widget but not for the selection with the autocomplete field.

