### PR TITLE
Patch CMFCatalogAware object to improve performance.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Patch CMFCatalogAware object to improve performance.
+  [elioschmutz]
 
 
 4.14.1 (2016-12-15)

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,3 +1,4 @@
+from .cmf_catalog_aware import PatchCMFCatalogAware
 from .create_mail_defaults import PatchCreateMailInContainer
 from .default_values import PatchBuilderCreate
 from .default_values import PatchDexterityContentGetattr
@@ -36,3 +37,4 @@ PatchTransmogrifyDXSchemaUpdater()()
 PatchWebDAVLockTimeout()()
 PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()
+PatchCMFCatalogAware()()

--- a/opengever/base/monkey/patches/cmf_catalog_aware.py
+++ b/opengever/base/monkey/patches/cmf_catalog_aware.py
@@ -1,0 +1,86 @@
+from opengever.base.monkey.patching import MonkeyPatch
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+from zope.interface import Interface
+from zope.interface import noLongerProvides
+
+
+class IDisableCatalogIndexing(Interface):
+    """Marker-interface to disable the catalog
+    indexing functions.
+
+    If this interface is provided by the request, all the
+    catalog-index-methods will be disabled.
+
+    Use the DeactivatedCatalogIndexing contextmanager to
+    get in use of this functionality.
+    """
+
+
+class DeactivatedCatalogIndexing(object):
+    """Contextmanager: Deactivates catalog-indexing
+    """
+    def __enter__(self):
+        alsoProvides(getRequest(), IDisableCatalogIndexing)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        noLongerProvides(getRequest(), IDisableCatalogIndexing)
+
+
+class PatchCMFCatalogAware(MonkeyPatch):
+    """Patch the Products.CMFCore.CMFCatalogAware indexObject, reindexObject
+    and unindexObject methods.
+
+    This patch is deactivated by default and can be activated through
+    the DeactivatedCatalogIndexing context manager:
+
+    >>> with DeactivatedCatalogIndexing():
+    ...     object.reindexObject  # Does nothing
+    ...     object.unindexObject  # Does nothing
+    ...     object.indexObject  # Does nothing
+
+    If the patch is activated, it skips the catalog index-methods.
+
+    What's the motivation behind this patch?
+
+    While creating an object, the object will be reindexed up to 4 times.
+    This behavior takes a lot of time and is not performance-friendly. Creating
+    one object through the web might be not a performance issue. But in several
+    parts of the GEVER-system we're creating a lot of content programatically
+    (i.e. dossiertemplates).
+
+    To improve the performance in that case, you can decativate the index-methods
+    and do it manually at the end of your tasks.
+    """
+
+    def __call__(self):
+
+        def _is_indexing_disabled():
+            return IDisableCatalogIndexing.providedBy(getRequest())
+
+        def indexObject(self):
+            if _is_indexing_disabled():
+                # do nothing if indexing is disabled
+                return
+            return original_indexObject(self)
+
+        def unindexObject(self):
+            if _is_indexing_disabled():
+                # do nothing if indexing is disabled
+                return
+            return original_unindexObject(self)
+
+        def reindexObject(self, idxs=[]):
+            if _is_indexing_disabled():
+                # do nothing if indexing is disabled
+                return
+            return original_reindexObject(self, idxs)
+
+        from Products.CMFCore.CMFCatalogAware import CMFCatalogAware
+        __patch_refs__ = False
+        original_indexObject = CMFCatalogAware.indexObject
+        original_unindexObject = CMFCatalogAware.unindexObject
+        original_reindexObject = CMFCatalogAware.reindexObject
+        self.patch_refs(CMFCatalogAware, 'indexObject', indexObject)
+        self.patch_refs(CMFCatalogAware, 'unindexObject', unindexObject)
+        self.patch_refs(CMFCatalogAware, 'reindexObject', reindexObject)

--- a/opengever/base/tests/test_patch_catalog_aware.py
+++ b/opengever/base/tests/test_patch_catalog_aware.py
@@ -1,0 +1,57 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.monkey.patches.cmf_catalog_aware import DeactivatedCatalogIndexing
+from opengever.testing import FunctionalTestCase
+from plone import api
+
+
+class TestPatchCMFCatalogAware(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPatchCMFCatalogAware, self).setUp()
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.dossier = create(Builder('dossier'))
+
+    def test_do_not_change_catalog_reindexObject_in_normal_usage(self):
+        self.dossier.title = "Foo Bar"
+        self.dossier.reindexObject()
+
+        brain = self.catalog(UID=self.dossier.UID())[0]
+
+        self.assertEqual('Foo Bar', brain.Title)
+
+    def test_do_not_reindexObject_in_context_manager(self):
+        self.dossier.title = "Foo Bar"
+
+        with DeactivatedCatalogIndexing():
+            self.dossier.reindexObject()
+
+        brain = self.catalog(UID=self.dossier.UID())[0]
+
+        self.assertEqual('', brain.Title)
+
+    def test_do_not_change_catalog_unindexObject_in_normal_usage(self):
+        self.dossier.unindexObject()
+
+        self.assertEqual(0, len(self.catalog(UID=self.dossier.UID())))
+
+    def test_do_not_unindexObject_in_context_manager(self):
+        with DeactivatedCatalogIndexing():
+            self.dossier.unindexObject()
+
+        self.assertEqual(1, len(self.catalog(UID=self.dossier.UID())))
+
+    def test_do_not_change_catalog_indexObject_in_normal_usage(self):
+        self.dossier.unindexObject()
+
+        self.dossier.indexObject()
+
+        self.assertEqual(1, len(self.catalog(UID=self.dossier.UID())))
+
+    def test_do_not_indexObject_in_context_manager(self):
+        self.dossier.unindexObject()
+
+        with DeactivatedCatalogIndexing():
+            self.dossier.indexObject()
+
+        self.assertEqual(0, len(self.catalog(UID=self.dossier.UID())))


### PR DESCRIPTION
Patch the Products.CMFCore.CMFCatalogAware indexObject, reindexObject
and unindexObject methods.

This patch is deactivated by default and can be activated through
the `DeactivateCatalogIndexing` context manager:

```
>>> with DeactivateCatalogIndexing():
...     object.reindexObject  # Does nothing
...     object.unindexObject  # Does nothing
...     object.indexObject  # Does nothing
```
If the patch is activated, it skips the catalog index-methods.

What's the motivation behind this patch?

While creating an object, the object will be reindexed up to 4 times.
This behavior takes a lot of time and is not performance-friendly. Creating
one object through the web might be not a performance issue. But in several
parts of the GEVER-system we're creating a lot of content programatically
(i.e. dossiertemplates).

To improve the performence in such case, you can decativate the index-methods
and do it manually at the end of your tasks.

see #2143