### PR TITLE
Improve dossiertemplate performance

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Use the DeactivatedCatalogIndexing contextmanager while generating dossiers from
+  a dossiertemplate to improve the performance.
+  [elioschmutz]
+
 - Patch CMFCatalogAware object to improve performance.
   [elioschmutz]
 


### PR DESCRIPTION
Dieser PR verwendet den Patch von #2428 um die Performance für die Erstellung von Dossiers anhand von Dossiertemplates zu erhöhen.

Mit diesem Patch wird die Zeit für die Erstellung um bis zu 65% verringert.

Ein Dossier aus einer Dossiervorlage mit 35 Dossiers zu erstellen dauert im Schnitt:
ohne Patch: ~ 20 Sekunden
mit Patch ~ 7 Sekunden

see #2382
see #2143