### PR TITLE
Use correct upgrade command description for policies.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/upgrades/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/upgrades/configure.zcml.bob
@@ -12,7 +12,7 @@
         />
 
     <!-- Do not add more upgrade steps here.
-         use ./bin/create-upgrade opengever.{{{package.name}}} "Upgrade description"
+         use ./bin/upgrade create "Upgrade description"
          /-->
 
 </configure>


### PR DESCRIPTION
We don't have bin/create-upgrade there, that is `opengever.core` specific. Instead we should use the normal `ftw.upgrade` command.