### PR TITLE
Add get_filename method to documents and mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.1 (unreleased)
 -------------------
 
+- Add get_filename method to documents and mails.
+  [deiferni]
+
 - Adjustments for the dossiertemplates:
 
   - Protect dossiertemplate wizard with opengever.dossier: Add businesscasedossier permission.

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -61,3 +61,6 @@ class BaseDocumentMixin(object):
 
     def get_current_version(self):
         raise NotImplementedError
+
+    def get_filename(self):
+        raise NotImplementedError

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -257,6 +257,11 @@ class Document(Item, BaseDocumentMixin):
             filename=filename,
             contentType=content_type)
 
+    def get_filename(self):
+        if not self.file:
+            return None
+        return self.file.filename
+
     security.declareProtected(webdav_unlock_items, 'UNLOCK')
     def UNLOCK(self, REQUEST, RESPONSE):
         """Leave shadow state if a shadow-document is unlocked.

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -70,6 +70,16 @@ class TestDocument(FunctionalTestCase):
         field.set(document, file)
         self.assertTrue(field.get(document).data == 'bla bla')
 
+    def test_filename_getter_returns_filename_if_file_is_available(self):
+        document = create(Builder('document')
+                          .titled('Foo')
+                          .attach_file_containing('foo', name=u'foo.txt'))
+        self.assertEqual(u'foo.txt', document.get_filename())
+
+    def test_filename_getter_return_none_if_no_file_is_available(self):
+        document = create(Builder('document'))
+        self.assertIsNone(document.get_filename())
+
     def test_document_with_file_is_digitally_available(self):
         document_with_file = create(Builder("document").with_dummy_content())
         self.assertTrue(document_with_file.digitally_available)

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -288,6 +288,11 @@ class OGMail(Mail, BaseDocumentMixin):
         normalized_subject = normalizer.normalize(self.title)
         self.message.filename = u'{}.eml'.format(normalized_subject)
 
+    def get_filename(self):
+        if not self.message:
+            return None
+        return self.message.filename
+
 
 class OGMailBase(metadata.MetadataBase):
     """Behavior that adds a title field.

--- a/opengever/mail/tests/test_message_filename_initialized.py
+++ b/opengever/mail/tests/test_message_filename_initialized.py
@@ -11,7 +11,12 @@ class TestMessageFilenameInitialized(FunctionalTestCase):
 
     def test_message_filename_initialized_with_builder(self):
         mail = create(Builder("mail").with_message(MAIL_DATA))
+        self.assertEquals('die-burgschaft.eml', mail.get_filename())
         self.assertEquals('die-burgschaft.eml', mail.message.filename)
+
+    def test_filename_is_none_when_no_file_is_present(self):
+        mail = create(Builder("mail"))
+        self.assertIsNone(mail.get_filename())
 
     def test_message_filename_initialized_with_quickupload(self):
         dossier = create(Builder("dossier"))

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -30,6 +30,9 @@ SAMPLE_MEETING_DATA = {
             "filename": u"beweisaufna-hme.txt"
             }, {
             "title": "Strafbefehl"
+            }, {
+            "title": u"L\xf6rem",
+            "filename": u"lorem.eml"
         }]
     }, {
         'description': u'R\xfccktritt Hans Muster',

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -154,8 +154,9 @@ class AgendaItem(Base):
         attachment_data = []
         for document in documents:
             attachment = {'title': document.title}
-            if document.file:
-                attachment['filename'] = document.file.filename
+            filename = document.get_filename()
+            if filename:
+                attachment['filename'] = filename
             attachment_data.append(attachment)
         data['attachments'] = attachment_data
 

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -26,6 +26,9 @@ class TestProtocolJsonData(FunctionalTestCase):
         self.doc2 = create(Builder("document")
                            .titled("Strafbefehl")
                            .within(self.dossier))
+        self.mail1 = create(Builder("mail")
+                            .titled(u"L\xf6rem")
+                            .with_message("lorem", filename=u"lorem.eml"))
 
         self.proposal = create(
             Builder('proposal_model')
@@ -40,7 +43,7 @@ class TestProtocolJsonData(FunctionalTestCase):
                     disclose_to=u'<div>Jans\xf6rg</div>',
                     decision_draft=u'<div>Der Gemeinderat erstattet Strafanzeige gegen Unbekannt und informiert zudem den Vermieter (Herr. Meier).</div>',
                     publish_in=u'<div>Tagblatt</div>',)
-            .with_submitted_documents(self.doc1, self.doc2))
+            .with_submitted_documents(self.doc1, self.doc2, self.mail1))
         self.committee = create(Builder('committee_model')
                                 .having(title=u'Gemeinderat'))
         self.member_peter = create(Builder('member'))


### PR DESCRIPTION
This adds a common interface to access the filename to documents and mails.

Fixes #2430.