### PR TITLE
Add doc-property ogg.document.document_type for documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Add doc-property ogg.document.document_type for documents.
+  [deiferni]
+
 - Limit document selection when creating a manual journal entry.
   Only documents inside the dossier are selectable.
   [phgross]

--- a/docs/public/docproperties/list.rst
+++ b/docs/public/docproperties/list.rst
@@ -44,6 +44,7 @@ Doc-Properties Dokument:
 - ``ogg.document.sequence_number`` - Laufnummer des Dokuments
 - ``ogg.document.document_author``
 - ``ogg.document.document_date``
+- ``ogg.document.document_type`` - Dokumenttyp des Dokuments
 - ``ogg.document.reception_date``
 - ``ogg.document.delivery_date``
 

--- a/opengever/base/vocabulary.py
+++ b/opengever/base/vocabulary.py
@@ -1,0 +1,19 @@
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+
+def voc_term_title(field, value):
+    """Returns the vocabulary term title for the given field and value.
+    """
+
+    if value is None:
+        return None
+    factory = None
+    if field.vocabulary:
+        factory = field.vocabulary
+    elif field.vocabularyName:
+        factory = getUtility(IVocabularyFactory, name=field.vocabularyName)
+    if factory is not None:
+        voc = factory(None)
+        return voc.getTerm(value).title
+    return value

--- a/opengever/disposition/ech0160/utils.py
+++ b/opengever/disposition/ech0160/utils.py
@@ -1,6 +1,5 @@
-from zope.component import getUtility
-from zope.schema.interfaces import IVocabularyFactory
 from opengever.base.behaviors.classification import IClassification
+from opengever.base.vocabulary import voc_term_title
 import hashlib
 
 
@@ -13,22 +12,6 @@ def file_checksum(filename, chunksize=65536):
             h.update(chunk)
             chunk = f.read(chunksize)
         return u'MD5', h.hexdigest()
-
-
-def voc_term_title(field, value):
-    """Returns the vocabulary term title for the given field and value.
-    """
-    if value is None:
-        return None
-    factory = None
-    if field.vocabulary:
-        factory = field.vocabulary
-    elif field.vocabularyName:
-        factory = getUtility(IVocabularyFactory, name=field.vocabularyName)
-    if factory is not None:
-        voc = factory(None)
-        return voc.getTerm(value).title
-    return value
 
 
 def set_classification_attributes(binding, obj):

--- a/opengever/dossier/docprops.py
+++ b/opengever/dossier/docprops.py
@@ -7,6 +7,7 @@ from ooxml_docprops.properties import OOXMLDocument
 from opengever import journal
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.vocabulary import voc_term_title
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.document import IDocumentSchema
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -166,6 +167,11 @@ class DefaultDocumentDocPropertyProvider(DocPropertyProvider):
         return self._as_datetime(
             IDocumentMetadata(self.context).document_date)
 
+    def get_document_type_label(self):
+        return voc_term_title(
+            IDocumentMetadata['document_type'],
+            IDocumentMetadata(self.context).document_type)
+
     def get_reception_date(self):
         return self._as_datetime(
             IDocumentMetadata(self.context).receipt_date)
@@ -191,6 +197,7 @@ class DefaultDocumentDocPropertyProvider(DocPropertyProvider):
         self._add_property(properties, 'sequence_number', sequence_number)
         self._add_property(properties, 'document_author', self.get_document_author())
         self._add_property(properties, 'document_date', self.get_document_date())
+        self._add_property(properties, 'document_type', self.get_document_type_label())
         self._add_property(properties, 'reception_date', self.get_reception_date())
         self._add_property(properties, 'delivery_date', self.get_delivery_date())
 

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -66,6 +66,7 @@ EXPECTED_DOCUMENT_PROPERTIES = {
     'ogg.document.sequence_number': '1',
     'ogg.document.document_author': u'M\xfcller Peter',
     'ogg.document.document_date': datetime(2010, 1, 3),
+    'ogg.document.document_type': u'Contract',
     'ogg.document.reception_date': datetime(2010, 1, 3),
     'ogg.document.delivery_date': datetime(2010, 1, 3),
 }

--- a/opengever/dossier/tests/test_default_doc_property_adapters.py
+++ b/opengever/dossier/tests/test_default_doc_property_adapters.py
@@ -32,6 +32,7 @@ class TestDocProperties(FunctionalTestCase):
             .titled("My Document")
             .having(document_date=datetime(2010, 1, 3),
                     document_author=TEST_USER_ID,
+                    document_type='contract',
                     receipt_date=datetime(2010, 1, 3),
                     delivery_date=datetime(2010, 1, 3))
             .with_asset_file('with_gever_properties.docx'))

--- a/opengever/dossier/tests/test_doc_property_writer.py
+++ b/opengever/dossier/tests/test_doc_property_writer.py
@@ -76,6 +76,7 @@ class TestDocPropertyWriter(FunctionalTestCase):
             .titled("My Document")
             .having(document_date=datetime(2010, 1, 3),
                     document_author=TEST_USER_ID,
+                    document_type='contract',
                     receipt_date=datetime(2010, 1, 3),
                     delivery_date=datetime(2010, 1, 3))
             .with_asset_file('with_gever_properties.docx'))
@@ -126,6 +127,7 @@ class TestDocPropertyWriter(FunctionalTestCase):
             .titled("My Document")
             .having(document_date=datetime(2010, 1, 3),
                     document_author=TEST_USER_ID,
+                    document_type='contract',
                     receipt_date=datetime(2010, 1, 3),
                     delivery_date=datetime(2010, 1, 3))
             .with_asset_file('without_custom_properties.docx'))
@@ -143,6 +145,7 @@ class TestDocPropertyWriter(FunctionalTestCase):
             .titled("My Document")
             .having(document_date=datetime(2010, 1, 3),
                     document_author=TEST_USER_ID,
+                    document_type='contract',
                     receipt_date=datetime(2010, 1, 3),
                     delivery_date=datetime(2010, 1, 3))
             .with_asset_file('without_custom_properties.docx'))


### PR DESCRIPTION
This PR adds a new doc-property `ogg.document.document_type` for documents.

Closes #2426.