### PR TITLE
Extend OGGBundle fileloader to handle mails correctly.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Extend OGGBundle fileloader to handle mails correctly.
+  [lgraf]
+
 - Add dossiertemplate tabbedview views.
   [elioschmutz]
 

--- a/opengever/bundle/tests/assets/basic.oggbundle/files/sample.eml
+++ b/opengever/bundle/tests/assets/basic.oggbundle/files/sample.eml
@@ -2,9 +2,9 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset="us-ascii"
 Content-Transfer-Encoding: 7bit
 To: to@example.org
-From: from@example.org
+From: Peter Muster <from@example.org>
 Subject: Lorem Ipsum
-Date: Thu, 01 Jan 1970 01:00:00 +0100
+Date: Thu, 01 Jan 2013 01:00:00 +0100
 Message-Id: <1>
 
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit,

--- a/opengever/setup/tests/test_section_constructor.py
+++ b/opengever/setup/tests/test_section_constructor.py
@@ -16,6 +16,8 @@ class TestConstructor(FunctionalTestCase):
 
         lang_tool = api.portal.get_tool('portal_languages')
         lang_tool.setDefaultLanguage('de-ch')
+        # Required to create mails, but not dossiers - no idea why
+        self.grant('Manager')
 
     def setup_section(self, previous=None):
         previous = previous or []
@@ -97,3 +99,17 @@ class TestConstructor(FunctionalTestCase):
         self.assertEqual(obj_brain.portal_type,
                          'opengever.repository.repositoryroot')
         self.assertEqual(obj_brain.Title, u'Reporoot')
+
+    def test_can_create_eml_emails(self):
+        item = {
+            u"_type": u"ftw.mail.mail",
+            u"title": u"My Mail",
+            u"_path": u"/foo/bar"
+        }
+        section = self.setup_section(previous=[item])
+        list(section)
+
+        content = item['_object']
+        self.assertEqual(u'My Mail', content.title)
+        self.assertFalse(hasattr(content, 'title_de'))
+        self.assertFalse(hasattr(content, 'title_Fr'))

--- a/opengever/setup/tests/test_section_fileloader.py
+++ b/opengever/setup/tests/test_section_fileloader.py
@@ -98,3 +98,22 @@ class TestFileLoader(FunctionalTestCase):
         self.assertEqual(
             {abs_filepath: '/relative/path/to/doc'},
             stats['errors']['msgs'])
+
+    def test_handles_eml_mails(self):
+        mail = create(Builder('mail'))
+        self.assertIsNone(mail.message)
+        relative_path = '/'.join(mail.getPhysicalPath()[2:])
+        item = {
+            u"_type": u"ftw.mail.mail",
+            u"_path": relative_path,
+            u"filepath": u"files/sample.eml",
+            u"_object": mail,
+        }
+        section = self.setup_section(previous=[item])
+        list(section)
+
+        self.assertEqual(u'Lorem Ipsum', mail.title)
+        self.assertEqual(920, len(mail.message.data))
+        self.assertEqual('message/rfc822', mail.message.contentType)
+        self.assertEqual('lorem-ipsum.eml', mail.message.filename)
+        self.assertEqual(True, mail.digitally_available)


### PR DESCRIPTION
Extends the fileloader in the OGGBundle pipeline to properly deal with `*.eml` mails, and adds some additional tests.

@deiferni 