### PR TITLE
Remove breadcrumb_titles index (metadata).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Remove breadcrumb_title from metadata.
+  [mathias.leimgruber]
+
 - Disable LDAP during OGGBundle import to avoid costly LDAP lookups.
   [lgraf]
 

--- a/opengever/base/browser/breadcrumb_by_uid.py
+++ b/opengever/base/browser/breadcrumb_by_uid.py
@@ -1,0 +1,32 @@
+from plone.app.uuid.utils import uuidToObject
+from Products.Five.browser import BrowserView
+from zope.component import getMultiAdapter
+
+
+def _breadcrumbs_from_obj(obj):
+    """Returns a list of titles for the items parent hierarchy (breadcrumbs).
+    """
+    breadcrumb_titles = []
+    breadcrumbs_view = getMultiAdapter((obj, obj.REQUEST),
+                                       name='breadcrumbs_view')
+    raw_breadcrumb_titles = breadcrumbs_view.breadcrumbs()
+
+    # Make sure all titles are utf-8
+    for elem in raw_breadcrumb_titles:
+        title = elem.get('Title')
+        if isinstance(title, unicode):
+            title = title.encode('utf-8')
+        breadcrumb_titles.append(title)
+    # Make sure all data used in the HTML snippet is properly escaped
+    return " > ".join(t for t in breadcrumb_titles)
+
+
+class ResolveUidToBreadcrumb(BrowserView):
+
+    def __call__(self):
+        uid = self.request.get('ploneuid', None)
+
+        if uid is None:
+            raise AttributeError('Missing a plone uid')
+
+        return _breadcrumbs_from_obj(uuidToObject(uid))

--- a/opengever/base/browser/breadcrumb_by_uid.py
+++ b/opengever/base/browser/breadcrumb_by_uid.py
@@ -21,7 +21,7 @@ def _breadcrumbs_from_obj(obj):
     return " > ".join(t for t in breadcrumb_titles)
 
 
-class ResolveUidToBreadcrumb(BrowserView):
+class ResolveUIDToBreadcrumb(BrowserView):
 
     def __call__(self):
         uid = self.request.get('ploneuid', None)

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -96,7 +96,7 @@
         name="breadcrumb_by_uid"
         for="*"
         permission="zope2.View"
-        class=".breadcrumb_by_uid.ResolveUidToBreadcrumb"
+        class=".breadcrumb_by_uid.ResolveUIDToBreadcrumb"
         />
 
 </configure>

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -92,4 +92,11 @@
         allowed_interface="plone.app.layout.globals.interfaces.IContextState"
         />
 
+    <browser:page
+        name="breadcrumb_by_uid"
+        for="*"
+        permission="zope2.View"
+        class=".breadcrumb_by_uid.ResolveUidToBreadcrumb"
+        />
+
 </configure>

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -55,3 +55,26 @@
   $(document).on("mouseover", ".tooltip-trigger", initTooltips);
 
 }(window, window.jQuery));
+
+
+(function(global, $) {
+
+  "use strict";
+
+  function setBreadcrumbAsTitleAttr(event) {
+    var target = $(event.currentTarget);
+    var title = target.attr('title');
+    if ((typeof title !== typeof undefined && title !== false)){
+      return;
+    }
+
+    $.get(portal_url + '/breadcrumb_by_uid', {ploneuid: target.data("uid")}).done(function(data){
+      target.attr('title', data);
+    });
+
+  }
+
+  $(document).on("mouseover", ".rollover-breadcrumb", setBreadcrumbAsTitleAttr);
+
+
+}(window, window.jQuery));

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -68,10 +68,18 @@
       return;
     }
 
-    $.get(portal_url + '/breadcrumb_by_uid', {ploneuid: target.data("uid")}).done(function(data){
-      target.attr('title', data);
-    });
+    setTimeout(function(){
+      if (!target.is(":hover")){
+        return;
+      }
 
+      $.get(portal_url + '/breadcrumb_by_uid', {ploneuid: target.data("uid")}).done(function(data){
+        target.attr('title', data);
+        // Force the browser to repaint - otherwise the tooltip is not directly displayed
+        target.hide(0);
+        target.show(0);
+      });
+    }, 100);
   }
 
   $(document).on("mouseover", ".rollover-breadcrumb", setBreadcrumbAsTitleAttr);

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -106,7 +106,10 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         return self.CroppedTitle().decode('utf-8')
 
     def get_breadcrumbs(self):
-        return self._brain.breadcrumb_titles
+        obj = self._brain.getObject()
+        breadcrumbs_view = getMultiAdapter((obj, obj.REQUEST),
+                                           name='breadcrumbs_view')
+        return breadcrumbs_view.breadcrumbs()
 
     def is_bumblebeeable(self):
         if not hasattr(self, '_is_bumblebeeable'):

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -4,15 +4,6 @@ from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.interfaces import IReferenceNumber
 from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer import indexer
-from zope.component import getMultiAdapter
-
-
-@indexer(IDexterityContent)
-def breadcrumb_titlesIndexer(obj):
-    breadcrumbs_view = getMultiAdapter((obj, obj.REQUEST),
-                                       name='breadcrumbs_view')
-    return breadcrumbs_view.breadcrumbs()
-grok.global_adapter(breadcrumb_titlesIndexer, name="breadcrumb_titles")
 
 
 @indexer(IDexterityContent)

--- a/opengever/base/profiles/default/catalog.xml
+++ b/opengever/base/profiles/default/catalog.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <object name="portal_catalog">
     <column value="css_icon_class" />
-    <column value="breadcrumb_titles"/>
     <index name="reference" meta_type="FieldIndex">
         <indexed_attr value="reference"/>
     </index>

--- a/opengever/base/tests/test_breadcrum_by_uid.py
+++ b/opengever/base/tests/test_breadcrum_by_uid.py
@@ -1,0 +1,35 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from plone.uuid.interfaces import IUUID
+
+
+class TestBreadcrumbByUidView(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestBreadcrumbByUidView, self).setUp()
+
+        self.root = create(Builder('repository_root').titled(u'Repository'))
+        self.repo = create(Builder('repository')
+                           .within(self.root)
+                           .titled(u'Testposition'))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repo)
+                              .titled(u'Dossier 1'))
+
+        self.view = self.portal.restrictedTraverse('breadcrumb_by_uid')
+
+    def test_resolve_dossier(self):
+        self.portal.REQUEST['ploneuid'] = IUUID(self.dossier)
+        view = self.portal.restrictedTraverse('breadcrumb_by_uid')
+        self.assertEquals('Repository > 1. Testposition > Dossier 1', view())
+
+    def test_raise_attributerror_if_no_uid_is_provided(self):
+        with self.assertRaises(AttributeError):
+            self.portal.restrictedTraverse('breadcrumb_by_uid')()
+
+    def test_raise_attributerror_if_uid_is_unkown(self):
+        self.portal.REQUEST['ploneuid'] = 'doesnotexists'
+        view = self.portal.restrictedTraverse('breadcrumb_by_uid')
+        with self.assertRaises(AttributeError):
+            view()

--- a/opengever/base/tests/test_breadcrumb_by_uid.py
+++ b/opengever/base/tests/test_breadcrumb_by_uid.py
@@ -4,10 +4,10 @@ from opengever.testing import FunctionalTestCase
 from plone.uuid.interfaces import IUUID
 
 
-class TestBreadcrumbByUidView(FunctionalTestCase):
+class TestBreadcrumbByUIDView(FunctionalTestCase):
 
     def setUp(self):
-        super(TestBreadcrumbByUidView, self).setUp()
+        super(TestBreadcrumbByUIDView, self).setUp()
 
         self.root = create(Builder('repository_root').titled(u'Repository'))
         self.repo = create(Builder('repository')

--- a/opengever/base/upgrades/20161222184858_remove_breadcrumb_titles_from_metadata/catalog.xml
+++ b/opengever/base/upgrades/20161222184858_remove_breadcrumb_titles_from_metadata/catalog.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_catalog">
+    <column value="breadcrumb_titles" remove="True"/>
+</object>

--- a/opengever/base/upgrades/20161222184858_remove_breadcrumb_titles_from_metadata/upgrade.py
+++ b/opengever/base/upgrades/20161222184858_remove_breadcrumb_titles_from_metadata/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveBreadcrumbTitlesFromMetadata(UpgradeStep):
+    """Remove breadcrumb_titles from metadata.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -2,10 +2,13 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.tabbedview.helper import linked
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
+from plone.uuid.interfaces import IUUID
 import transaction
 
 
@@ -148,3 +151,16 @@ class TestDossierListing(FunctionalTestCase):
 
         self.assertEquals(['all', 'Active'],
                           browser.css('.state_filters a').text)
+
+    def test_linked_helper_adds_uid_data_attribute_using_obj(self):
+
+        browser.open_html(linked(self.dossier_c, 'Title'))
+        self.assertEquals(browser.css('a').first.attrib['data-uid'],
+                          IUUID(self.dossier_c))
+
+    def test_linked_helper_adds_uid_data_attribute_using_brain(self):
+        uid = IUUID(self.dossier_c)
+        brain = self.portal.portal_catalog(UID=uid)[0]
+
+        browser.open_html(linked(brain, 'Dummy'))
+        self.assertEquals(browser.css('a').first.attrib['data-uid'], uid)

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -153,7 +153,6 @@ class TestDossierListing(FunctionalTestCase):
                           browser.css('.state_filters a').text)
 
     def test_linked_helper_adds_uid_data_attribute_using_obj(self):
-
         browser.open_html(linked(self.dossier_c, 'Title'))
         self.assertEquals(browser.css('a').first.attrib['data-uid'],
                           IUUID(self.dossier_c))


### PR DESCRIPTION
This makes indexing (without searchableText 30% faster).

Trade off (reading):
- Get the breadcrumb titles on dossier listings async
- Makes some latex and maintenance script slower.