### PR TITLE
Install collective.indexing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Install collective.indexing.
+  [mathias.leimgruber]
+
 - Protect date of cassation and submission with a separate edit permission.
   Only managers should be allowed to edit those dates.
   [phgross]

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(name='opengever.core',
         'zc.relation',
         'zope.globalrequest',
         'PyXB',
+        'collective.indexing',
         # -*- Extra requirements: -*-
         ],
       tests_require=tests_require,


### PR DESCRIPTION
local performance measurements. 

**Test-Case: Creating 40 different files incl. tika.**
WITHOUT: 37s
WITH: 21s


**Test-Case: 5 parallel users uploading files with quickupload**
WITHOUT: 2s pro Request
WITH: 3.3s pro Request

**Test-Case: 1 seriell users uploading files with quickupload**
WITHOUT: 1 rps (880ms per Request)
WITH: 1.6 rps (880ms per Request)
