### PR TITLE
Implementiert ein neues Feld "Titelhilfe" für Dossiertemplates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Add a title_help field for dossiertemplates.
+  [elioschmutz]
+
 - Fix label translation and improve readability of the values in appraisal
   column in the excel export of a disposition.
   [phgross]

--- a/opengever/base/overrides.zcml
+++ b/opengever/base/overrides.zcml
@@ -29,6 +29,17 @@
       permission="zope.Public"
       />
 
+  <!-- Adds the feature to add a dynamic description to a widget. -->
+  <configure package="plone.app.z3cform">
+      <browser:page
+          name="ploneform-render-widget"
+          for="z3c.form.interfaces.IWidget"
+          layer=".interfaces.IPloneFormLayer"
+          class="opengever.base.widgets.GeverRenderWidget"
+          permission="zope.Public"
+          />
+  </configure>
+
 <adapter
     for="zope.annotation.interfaces.IAttributeAnnotatable"
     provides="zope.annotation.interfaces.IAnnotations"

--- a/opengever/base/templates/widget.pt
+++ b/opengever/base/templates/widget.pt
@@ -1,0 +1,38 @@
+<div
+   metal:define-macro="widget-wrapper"
+   i18n:domain="plone"
+   tal:define="widget nocall:context;
+               hidden python:widget.mode == 'hidden';
+               error widget/error;
+               error_class python:error and ' error' or '';
+               fieldname_class string:kssattr-fieldname-${widget/name};"
+   tal:attributes="class string:field z3cformInlineValidation ${fieldname_class}${error_class};
+                   data-fieldname widget/name;
+                   id string:formfield-${widget/id};">
+
+    <label for="" class="horizontal"
+        tal:attributes="for widget/id"
+        tal:condition="not:hidden">
+        <span i18n:translate="" tal:replace="widget/label">label</span>
+
+        <span class="required horizontal" title="Required"
+              tal:condition="python:widget.required and widget.mode == 'input'"
+              i18n:attributes="title title_required;">&nbsp;</span>
+
+        <span class="formHelp"
+            tal:define="description view/get_description"
+            i18n:translate=""
+            tal:content="structure description"
+            tal:condition="python:description and not hidden"
+            >field description
+        </span>
+    </label>
+
+    <div class="fieldErrorBox"
+        tal:content="structure error/render|nothing">
+        Error
+    </div>
+
+    <input type="text" tal:replace="structure widget/render"
+           metal:define-slot="widget" />
+</div>

--- a/opengever/base/tests/test_widget.py
+++ b/opengever/base/tests/test_widget.py
@@ -1,7 +1,48 @@
 from ftw.testbrowser import browsing
 from opengever.base.widgets import trix_strip_whitespace
 from opengever.testing import FunctionalTestCase
+from plone.app.z3cform.interfaces import IPloneFormLayer
 from unittest2 import TestCase
+from z3c.form.browser.text import TextWidget
+from zope.component import getMultiAdapter
+from zope.interface import alsoProvides
+from zope.schema._bootstrapfields import TextLine
+
+
+class TestGeverRenderWidget(FunctionalTestCase):
+    def setUp(self):
+        super(TestGeverRenderWidget, self).setUp()
+        textfield = TextLine()
+        textfield.description = u"A d\xfcscription"
+
+        self.widget = TextWidget(self.request)
+        self.widget.field = textfield
+
+        alsoProvides(self.request, IPloneFormLayer)
+
+    @browsing
+    def test_display_default_field_description(self, browser):
+        view = getMultiAdapter((self.widget, self.request),
+                               name="ploneform-render-widget")
+
+        browser.open_html(view())
+
+        self.assertEqual(
+            u'A d\xfcscription',
+            browser.css('.formHelp').first.text)
+
+    @browsing
+    def test_dispaly_dynamic_description_if_available(self, browser):
+        self.widget.dynamic_description = u"A d\xfcnamic description"
+
+        view = getMultiAdapter((self.widget, self.request),
+                               name="ploneform-render-widget")
+
+        browser.open_html(view())
+
+        self.assertEqual(
+            u'A d\xfcnamic description',
+            browser.css('.formHelp').first.text)
 
 
 class TestTrixWidget(FunctionalTestCase):

--- a/opengever/base/widgets.py
+++ b/opengever/base/widgets.py
@@ -3,6 +3,7 @@ from ftw.table.interfaces import ITableGenerator
 from opengever.base import _
 from opengever.base.transforms import trix2sablon
 from opengever.base.utils import escape_html
+from plone.app.z3cform.templates import RenderWidget
 from plone.z3cform.textlines.textlines import TextLinesFieldWidget
 from z3c.form import util
 from z3c.form.browser import widget
@@ -14,6 +15,7 @@ from z3c.form.interfaces import ITextAreaWidget
 from z3c.form.widget import FieldWidget
 from z3c.form.widget import SequenceWidget
 from z3c.form.widget import Widget
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import adapter
 from zope.component import adapts
 from zope.component import getUtility
@@ -26,6 +28,31 @@ from zope.schema.interfaces import ISequence
 from zope.schema.interfaces import ITextLine
 from zope.schema.interfaces import ITitledTokenizedTerm
 import re
+
+
+class GeverRenderWidget(RenderWidget):
+    """Renders the widget with the possiblity to add a dynamic description.
+
+    Add a new property to the widget in your form to display a dynamic
+    description instead the default field description:
+
+    widget.dynamic_description = u"My dynamic description"
+
+
+    Motivation:
+    The default behavior is, that the field description will be displayed
+    if it's available.
+
+    If you want to change the description for a specific widget only for
+    a specific request there was no possiblity to do that. Changing the
+    fields description is not an option because it is persistent.
+    """
+    index = ViewPageTemplateFile('templates/widget.pt')
+
+    def get_description(self):
+        if hasattr(self.context, 'dynamic_description') and self.context.dynamic_description:
+            return self.context.dynamic_description
+        return self.context.field.description
 
 
 class ITableRadioWidget(ISequenceWidget):

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -1,9 +1,12 @@
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
+from opengever.base import _ as base_mf
+from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossiernamefromtitle import DossierNameFromTitle
 from plone.app.content.interfaces import INameFromTitle
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
+from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import Interface
@@ -14,6 +17,23 @@ class IDossierTemplateSchema(form.Schema):
 
     Use this type of dossier to create a reusable template structures.
     """
+
+    form.fieldset(
+        u'common',
+        label=base_mf(u'fieldset_common', default=u'Common'),
+        fields=[
+            u'title_help',
+        ],
+    )
+
+    title_help = schema.TextLine(
+        title=_(u'label_title_help', default=u'Title help'),
+        description=_(u'help_title_help',
+                      default=u'Recommendation for the title. Will be '
+                              u'displayed as a help text if you create '
+                              u'a dossier from template'),
+        required=False,
+    )
 
 
 class IDossierTemplateMarker(Interface, ITabbedviewUploadable):

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -172,6 +172,7 @@ class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
                         '{}/dossier_with_template'.format(self.context.absolute_url()))
 
                 template_values = template_obj.get_schema_values()
+                title_help = IDossierTemplateSchema(template_obj).title_help
 
                 for group in self.groups:
                     for widgetname in group.widgets:
@@ -185,6 +186,14 @@ class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
 
                         value = template_values.get(template_widget_name)
                         widget = group.widgets.get(widgetname)
+
+                        # If the current field is the title field and the
+                        # title_help is set, we remove the input-value and
+                        # add a field description with the title_help text
+                        # instead.
+                        if widget.field == IDossierTemplateSchema['title_help'] and title_help:
+                            widget.dynamic_description = title_help
+                            value = ''
 
                         # Set the template value to the dossier add-form widget.
                         widget.value = IDataConverter(widget).toWidgetValue(value)

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -1,6 +1,7 @@
 from AccessControl import getSecurityManager
 from five import grok
 from ftw.table import helper
+from opengever.base.behaviors.base import IOpenGeverBase
 from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.form import WizzardWrappedAddForm
@@ -9,7 +10,6 @@ from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.command import CreateDossierFromTemplateCommand
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
@@ -191,7 +191,7 @@ class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
                         # title_help is set, we remove the input-value and
                         # add a field description with the title_help text
                         # instead.
-                        if widget.field == IDossierTemplateSchema['title_help'] and title_help:
+                        if widget.field == IOpenGeverBase['title'] and title_help:
                             widget.dynamic_description = title_help
                             value = ''
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-02-09 11:59+0000\n"
+"POT-Creation-Date: 2017-02-13 13:31+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -415,6 +415,11 @@ msgstr "Neuen Kommentar erfassen."
 msgid "help_text_edit_note"
 msgstr "Es wurde ein Kommentar erfasst!"
 
+#. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:31
+msgid "help_title_help"
+msgstr "Empfehlung für Titel. Wird beim Erstellen eines Dossiers ab Vorlage als Hilfetext dargestellt"
+
 #. Default: "Participation created"
 #: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
@@ -490,7 +495,7 @@ msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Dossiernote"
-#: ./opengever/dossier/viewlets/byline.py:114
+#: ./opengever/dossier/viewlets/byline.py:115
 msgid "label_dossier_note"
 msgstr "Dossier Kommentar"
 
@@ -515,7 +520,7 @@ msgid "label_edit_note"
 msgstr "Bearbeiten"
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:101
+#: ./opengever/dossier/viewlets/byline.py:102
 msgid "label_email_address"
 msgstr "E-Mail"
 
@@ -528,7 +533,7 @@ msgstr "Ende"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:82
+#: ./opengever/dossier/viewlets/byline.py:83
 msgid "label_end_byline"
 msgstr "Ende"
 
@@ -632,7 +637,7 @@ msgstr "Empfänger"
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:179
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:94
+#: ./opengever/dossier/viewlets/byline.py:95
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
@@ -669,7 +674,7 @@ msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:88
+#: ./opengever/dossier/viewlets/byline.py:89
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
@@ -681,7 +686,7 @@ msgstr "Beginn"
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:76
+#: ./opengever/dossier/viewlets/byline.py:77
 msgid "label_start_byline"
 msgstr "Beginn"
 
@@ -713,6 +718,11 @@ msgstr "Vorlage"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "Title help"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:30
+msgid "label_title_help"
+msgstr "Titelhilfe"
+
 #. Default: "Trash"
 #: ./opengever/dossier/browser/tabbed.py:27
 msgid "label_trash"
@@ -725,7 +735,7 @@ msgstr "URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:70
+#: ./opengever/dossier/viewlets/byline.py:71
 msgid "label_workflow_state"
 msgstr "Status"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-09 11:59+0000\n"
+"POT-Creation-Date: 2017-02-13 13:31+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -411,6 +411,11 @@ msgstr ""
 msgid "help_text_edit_note"
 msgstr ""
 
+#. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:31
+msgid "help_title_help"
+msgstr ""
+
 #. Default: "Participation created"
 #: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
@@ -486,7 +491,7 @@ msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Dossiernote"
-#: ./opengever/dossier/viewlets/byline.py:114
+#: ./opengever/dossier/viewlets/byline.py:115
 msgid "label_dossier_note"
 msgstr ""
 
@@ -511,7 +516,7 @@ msgid "label_edit_note"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:101
+#: ./opengever/dossier/viewlets/byline.py:102
 msgid "label_email_address"
 msgstr "Email"
 
@@ -524,7 +529,7 @@ msgstr "Date de fin :"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:82
+#: ./opengever/dossier/viewlets/byline.py:83
 msgid "label_end_byline"
 msgstr "Jusqu'au"
 
@@ -628,7 +633,7 @@ msgstr ""
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:179
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:94
+#: ./opengever/dossier/viewlets/byline.py:95
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
@@ -665,7 +670,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:88
+#: ./opengever/dossier/viewlets/byline.py:89
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
@@ -677,7 +682,7 @@ msgstr "Date début"
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:76
+#: ./opengever/dossier/viewlets/byline.py:77
 msgid "label_start_byline"
 msgstr "De"
 
@@ -709,6 +714,11 @@ msgstr ""
 msgid "label_title"
 msgstr "Titre"
 
+#. Default: "Title help"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:30
+msgid "label_title_help"
+msgstr ""
+
 #. Default: "Trash"
 #: ./opengever/dossier/browser/tabbed.py:27
 msgid "label_trash"
@@ -721,7 +731,7 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:70
+#: ./opengever/dossier/viewlets/byline.py:71
 msgid "label_workflow_state"
 msgstr "Etat"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-09 11:59+0000\n"
+"POT-Creation-Date: 2017-02-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -412,6 +412,11 @@ msgstr ""
 msgid "help_text_edit_note"
 msgstr ""
 
+#. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:31
+msgid "help_title_help"
+msgstr ""
+
 #. Default: "Participation created"
 #: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
@@ -487,7 +492,7 @@ msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossiernote"
-#: ./opengever/dossier/viewlets/byline.py:114
+#: ./opengever/dossier/viewlets/byline.py:115
 msgid "label_dossier_note"
 msgstr ""
 
@@ -512,7 +517,7 @@ msgid "label_edit_note"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:101
+#: ./opengever/dossier/viewlets/byline.py:102
 msgid "label_email_address"
 msgstr ""
 
@@ -525,7 +530,7 @@ msgstr ""
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:82
+#: ./opengever/dossier/viewlets/byline.py:83
 msgid "label_end_byline"
 msgstr ""
 
@@ -629,7 +634,7 @@ msgstr ""
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py:179
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:94
+#: ./opengever/dossier/viewlets/byline.py:95
 msgid "label_reference_number"
 msgstr ""
 
@@ -666,7 +671,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:88
+#: ./opengever/dossier/viewlets/byline.py:89
 msgid "label_sequence_number"
 msgstr ""
 
@@ -678,7 +683,7 @@ msgstr ""
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:76
+#: ./opengever/dossier/viewlets/byline.py:77
 msgid "label_start_byline"
 msgstr ""
 
@@ -710,6 +715,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "Title help"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:30
+msgid "label_title_help"
+msgstr ""
+
 #. Default: "Trash"
 #: ./opengever/dossier/browser/tabbed.py:27
 msgid "label_trash"
@@ -722,7 +732,7 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:70
+#: ./opengever/dossier/viewlets/byline.py:71
 msgid "label_workflow_state"
 msgstr ""
 

--- a/opengever/dossier/tests/test_templatedossier.py
+++ b/opengever/dossier/tests/test_templatedossier.py
@@ -162,7 +162,11 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
     def test_form_does_not_inlcude_participants_with_disabled_feature(self, browser):
         browser.login().open(self.dossier, view='document_with_template')
 
-        self.assertEqual([u'Template', u'Title', u'Edit after creation'],
+        # The CheckBoxWidget is rendered with two labels (only in testing).
+        # The reason for that is a wrong widget renderer adapter lookup because
+        # of the stacked globalregistry (see plone.testing.zca: pushGlobalRegistry
+        # for more information).
+        self.assertEqual([u'Template', u'Title', u'', u'Edit after creation'],
                          browser.css('#form label').text)
 
     @browsing


### PR DESCRIPTION
Dieser PR implementiert das neue Feld `Titelhilfe` für Dossiertemplates.

![screen1](https://cloud.githubusercontent.com/assets/557005/21683978/028a5114-d35c-11e6-957d-71301ed443ea.gif)

closes #2444 