### PR TITLE
Make sure reference number sorters also support sorting repofolder-only numbers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Make sure reference number sorters also support sorting
+  repofolder-only numbers (i.e., no dossier/document parts).
+  [lgraf]
+
 - Extend OGGBundle fileloader to handle mails correctly.
   [lgraf]
 

--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -129,8 +129,15 @@ class GroupedByThreeReferenceFormatter(DottedReferenceFormatter):
         # 'OG 010.123.43-1.1-7'  -->  '010.123.43-1.1-7'
         clientid, remainder = value.split(clientid_repository_separator, 1)
 
-        # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
-        refnums_part, remainder = remainder.split(self.repository_dossier_seperator, 1)
+        if self.repository_dossier_seperator in remainder:
+            # Dossier or document reference number
+            # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
+            refnums_part, remainder = remainder.split(
+                self.repository_dossier_seperator, 1)
+        else:
+            # Repofolder-only reference number
+            # Nothing left to do, should already be sortable as string
+            return remainder
 
         # Return a tuple with the different parts separated.
         # Cast document and (sub)dossier parts to integers to achieve proper
@@ -139,7 +146,8 @@ class GroupedByThreeReferenceFormatter(DottedReferenceFormatter):
 
         if remainder.count(self.dossier_document_seperator) > 0:
             # Document Reference Number
-            dossier_part, document_part = remainder.split(self.dossier_document_seperator, 1)
+            dossier_part, document_part = remainder.split(
+                self.dossier_document_seperator, 1)
             subdossier_parts = [int(d) for d in dossier_part.split('.')]
             return (refnums_part, tuple(subdossier_parts), int(document_part))
         else:
@@ -211,8 +219,14 @@ class NoClientIdGroupedByThreeFormatter(GroupedByThreeReferenceFormatter):
             # It's already a string value
             value = brain_or_value
 
-        # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
-        refnums_part, remainder = value.split(self.repository_dossier_seperator, 1)
+        if self.repository_dossier_seperator in value:
+            # '010.123.43-1.1-7'  -->  '010.123.43', '1.1-7'
+            refnums_part, remainder = value.split(
+                self.repository_dossier_seperator, 1)
+        else:
+            # Repofolder-only reference number
+            # Nothing left to do, should already be sortable as string
+            return value
 
         # Return a tuple with the different parts separated.
         # Cast document and (sub)dossier parts to integers to achieve proper
@@ -221,7 +235,8 @@ class NoClientIdGroupedByThreeFormatter(GroupedByThreeReferenceFormatter):
 
         if remainder.count(self.dossier_document_seperator) > 0:
             # Document Reference Number
-            dossier_part, document_part = remainder.split(self.dossier_document_seperator, 1)
+            dossier_part, document_part = remainder.split(
+                self.dossier_document_seperator, 1)
             subdossier_parts = [int(d) for d in dossier_part.split('.')]
             return (refnums_part, tuple(subdossier_parts), int(document_part))
         else:

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -236,6 +236,19 @@ class TestNoClientIDGroupedbyThreeFormatter(FunctionalTestCase):
 
 
 class TestDottedFormatSorter(TestDottedFormatter):
+
+    def test_orders_standalone_repofolders_correctly(self):
+        expected = ['OG 1.9.9',
+                    'OG 3.9.9',
+                    'OG 11.9.9']
+
+        unordered = ['OG 3.9.9',
+                     'OG 1.9.9',
+                     'OG 11.9.9']
+
+        actual = sorted(unordered, key=self.formatter.sorter)
+        self.assertEquals(expected, actual)
+
     def test_orders_first_level_refnums_correctly(self):
         expected = ['OG 1.9.9 / 9.9.9',
                     'OG 3.9.9 / 9.9.9',
@@ -298,6 +311,49 @@ class TestDottedFormatSorter(TestDottedFormatter):
 
 
 class TestGroupedbyThreeFormatSorter(TestGroupedbyThreeFormatter):
+
+    def test_orders_standalone_repofolders_correctly(self):
+        # Zero-padded
+        expected_1 = [
+            'OG 01.0',
+            'OG 010.0',
+            'OG 011.0',
+            'OG 02.0',
+            'OG 020.0',
+            'OG 021.0']
+
+        unordered_1 = [
+            'OG 021.0',
+            'OG 010.0',
+            'OG 020.0',
+            'OG 011.0',
+            'OG 02.0',
+            'OG 01.0']
+
+        # Unpadded
+        expected_2 = [
+            'OG 0',
+            'OG 00',
+            'OG 000',
+            'OG 001',
+            'OG 01',
+            'OG 011',
+            'OG 1']
+
+        unordered_2 = [
+            'OG 1',
+            'OG 000',
+            'OG 0',
+            'OG 00',
+            'OG 011',
+            'OG 01',
+            'OG 001']
+
+        actual_1 = sorted(unordered_1, key=self.formatter.sorter)
+        self.assertEquals(expected_1, actual_1)
+
+        actual_2 = sorted(unordered_2, key=self.formatter.sorter)
+        self.assertEquals(expected_2, actual_2)
 
     def test_orders_first_level_refnums_correctly(self):
         expected = ['OG 01.0-9.9.9-99',
@@ -367,6 +423,49 @@ class TestGroupedbyThreeFormatSorter(TestGroupedbyThreeFormatter):
 
 
 class TestNoClientIDGBTSorter(TestNoClientIDGroupedbyThreeFormatter):
+
+    def test_orders_standalone_repofolders_correctly(self):
+        # Zero-padded
+        expected_1 = [
+            '01.0',
+            '010.0',
+            '011.0',
+            '02.0',
+            '020.0',
+            '021.0']
+
+        unordered_1 = [
+            '021.0',
+            '010.0',
+            '020.0',
+            '011.0',
+            '02.0',
+            '01.0']
+
+        # Unpadded
+        expected_2 = [
+            'OG 0',
+            'OG 00',
+            'OG 000',
+            'OG 001',
+            'OG 01',
+            'OG 011',
+            'OG 1']
+
+        unordered_2 = [
+            'OG 1',
+            'OG 000',
+            'OG 0',
+            'OG 00',
+            'OG 011',
+            'OG 01',
+            'OG 001']
+
+        actual_1 = sorted(unordered_1, key=self.formatter.sorter)
+        self.assertEquals(expected_1, actual_1)
+
+        actual_2 = sorted(unordered_2, key=self.formatter.sorter)
+        self.assertEquals(expected_2, actual_2)
 
     def test_orders_first_level_refnums_correctly(self):
         expected = ['01.0-9.9.9-99',


### PR DESCRIPTION
Make sure reference number sorters also support sorting repofolder-only numbers (i.e., no dossier/document parts).