### PR TITLE
Fixed acquired_default_factory for choice fields with a vocabulary.

### DIFF
--- a/opengever/base/acquisition.py
+++ b/opengever/base/acquisition.py
@@ -66,7 +66,8 @@ def acquired_default_factory(field, default=None):
     def default_value_generator(context):
         container = context
 
-        acquired_value = acquire_field_value(field, container)
+        bound_field = field.bind(container)
+        acquired_value = acquire_field_value(bound_field, container)
         if acquired_value is not NO_VALUE_FOUND:
             return acquired_value
 


### PR DESCRIPTION
Bound field before accessing the default value otherwise the zope.schema field validation will raise an `TypeError: argument of type 'function' is not iterable` when validating the aquired value.

I've found this problem during rewriting the default values to defaultFactories for PHVS specific choice fields.