### PR TITLE
Facilitate standalone Sphinx buildout, by making schema docs building optional

### DIFF
--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -29,16 +29,19 @@ inline =
     set -euo pipefail
 
     # XXX: Hardcoded 'zopepy' in order to avoid dependency on
-    # the [zopypy] section for sphinx-standalone.cfg. This should
-    # later be solved by making the schema-docs update optional
+    # the [zopypy] section for sphinx-standalone.cfg.
     ZOPE_PY="${buildout:bin-directory}/zopepy"
     BUILDOUT_DIR="${buildout:directory}"
     export SPHINXBUILD="${buildout:bin-directory}/sphinx-build"
 
     echo -e "Building 'public' docs...\n"
 
-    # Update ReStructuredText .inc files based on JSON schema dumps
-    $ZOPE_PY scripts/update-schema-docs.py $BUILDOUT_DIR
+    if [ -f $ZOPE_PY ]; then
+        # Update ReStructuredText .inc files based on JSON schema dumps
+        $ZOPE_PY scripts/update-schema-docs.py $BUILDOUT_DIR
+    else
+        echo "Skipping schema docs update (no full GEVER dev-environment present)"
+    fi
 
     # Build the Sphinx documentation
     cd docs/public


### PR DESCRIPTION
This change makes the use of `bin/zopepy` to update schema docs optional (schema docs will only be updated if a `bin/zopepy` is found).

This facilitates the use of `sphinx.cfg` through the `sphinx-standalone.cfg` to have a buildout that is purely intended as an environment to work on documentation. This buildout has minimal dependencies and runs through in just a couple seconds.

The use of this buildout is already documented at https://intern.onegovgever.ch/meta/#arbeiten-an-der-dokumentation

@deiferni  