### PR TITLE
Drop security declaration for nonexistent method 'schedule'.

### DIFF
--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -74,7 +74,6 @@
       name="unscheduled_proposals"
       class=".unscheduled_proposals.UnscheduledProposalsView"
       permission="zope2.View"
-      allowed_attributes="schedule"
       />
 
 </configure>


### PR DESCRIPTION
This gets rid of the last `WARNING` during instance bootup 🎉 .