### PR TITLE
Adjust dossiers retention expiration calculation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Adjust dossiers retention expiration calculation.
+  [phgross]
+
 - Disallow record manager to archive a disposition.
   [phgross]
 

--- a/docs/public/user-manual/aussonderung.rst
+++ b/docs/public/user-manual/aussonderung.rst
@@ -10,6 +10,12 @@ Abgelaufene Dossiers
 --------------------
 Das Aussondern von Inhalten im OneGov GEVER wird ausschliesslich auf Stufe Dossier angeboten. Dabei können nur stornierte oder abgeschlossen Dossier, bei welchen die Aufbewahrungsfrist abgelaufen ist, ausgesondert werden.
 
+Die Berechnung der Aufbewahrungsdauer erfolgt nach Geschäftsjahr.
+Beispiel:
+   - Dossierabschluss: 03.01.2013
+   - Aufbewahrungsdauer: 10 Jahre
+   - Aussonderung möglich ab: 1.1.2024
+
 Eine Übersicht über Abgelaufene Dossiers, also Dossiers welche für eine Aussonderung in Frage kommen, bietet der Status-Filter `angeboten` welcher auf allen Dossierauflistungen zur Verfügung steht.
 
 

--- a/opengever/dossier/upgrades/20161117162220_add_new_index_retention_expiration/upgrade.py
+++ b/opengever/dossier/upgrades/20161117162220_add_new_index_retention_expiration/upgrade.py
@@ -9,12 +9,18 @@ class AddNewIndexRetentionExpiration(UpgradeStep):
     def __call__(self):
         self.install_upgrade_profile()
         self.catalog_add_index('retention_expiration', 'DateIndex')
-        self.reindex_resolved_dossiers()
 
-    def reindex_resolved_dossiers(self):
-        for obj in self.objects(
-                {'object_provides': IDossierMarker.__identifier__,
-                 'review_state': 'dossier-state-resolved'},
-                'Enable exclude from navigation for files'):
 
-            obj.reindexObject(idxs=['retention_expiration'])
+    # The calculation of the retention period has been changed, because of
+    # that there is another upgrade step `UpdateRetentionPeriodCalculation`
+    # which recalculate the retention expiration for every resolved dossier.
+    # Therefore the reindex for those dossiers is not necessary ann will be
+    # done by the newer upgradestep `UpdateRetentionPeriodCalculation`
+
+    # def reindex_resolved_dossiers(self):
+    #     for obj in self.objects(
+    #             {'object_provides': IDossierMarker.__identifier__,
+    #              'review_state': 'dossier-state-resolved'},
+    #             'Enable exclude from navigation for files'):
+
+    #         obj.reindexObject(idxs=['retention_expiration'])

--- a/opengever/dossier/upgrades/20170116224918_update_retention_period_calculation/upgrade.py
+++ b/opengever/dossier/upgrades/20170116224918_update_retention_period_calculation/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+
+
+class UpdateRetentionPeriodCalculation(UpgradeStep):
+    """Update retention period calculation.
+    """
+
+    def __call__(self):
+        self.reindex_resolved_dossiers()
+
+    def reindex_resolved_dossiers(self):
+        for obj in self.objects(
+                {'object_provides': IDossierMarker.__identifier__,
+                 'review_state': 'dossier-state-resolved'},
+                'Calculate retention expiration for resolved dossiers'):
+
+            obj.reindexObject(idxs=['retention_expiration'])


### PR DESCRIPTION
The retention period of a dossier should expire at the beginning of the year after the retention period, see https://basecamp.com/2768704/projects/12554551/todos/286197285. This PR changes the calculation and reindex the expiration date for all resolved dossiers. Closes #2425.

Note: This PR also disables the calculation of the retention_expiration date for all resolved dossiers in a earlier upgradestep. This makes sense for all deployments which has not installed the newest GEVER release yet otherwise the expiration date would be calculate twice. For deployments where the retention_expiration is already installed the disabled calculation has no impact.