### PR TITLE
OGGBundle constructor: Support setting local reference number part for dossiers (when provided by JSON item).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- OGGBundle constructor: Support setting local reference number part
+  for dossiers (when provided by JSON item).
+  [lgraf]
+
 - Include REST API in mainline GEVER:
 
   - Introduces a new role APIUser

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -17,6 +17,12 @@ class IDuringContentCreation(Interface):
     """
 
 
+class IDontIssueDossierReferenceNumber(Interface):
+    """Request layer to indicate that no reference number should be issued
+    when creating new dossiers.
+    """
+
+
 class IOpengeverCatalogBrain(ICatalogBrain):
     """Detailed Interface for opengever CatalogBrain.
     Used for add an opengever specific CatalogContentlisting Adapter.

--- a/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
@@ -22,7 +22,7 @@
     "end": "2011-01-06",
     "keywords": [],
     "privacy_layer": "privacy_layer_yes",
-    "reference_number": "2",
+    "reference_number": "7",
     "relatedDossier": [],
     "responsible": "lukas.graf",
     "retention_period": 5,

--- a/opengever/bundle/tests/assets/basic.oggbundle/repofolders.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/repofolders.json
@@ -10,7 +10,7 @@
     "privacy_layer": "privacy_layer_yes",
     "public_trial": "private",
     "public_trial_statement": "Enthält vertrauliche Personaldossiers.",
-    "reference_number_prefix": "1",
+    "reference_number_prefix": "3",
     "referenced_activity": "",
     "retention_period": 10,
     "retention_period_annotation": "",

--- a/opengever/core/debughelpers.py
+++ b/opengever/core/debughelpers.py
@@ -2,6 +2,7 @@ from AccessControl.SecurityManagement import newSecurityManager
 from Products.CMFPlone.Portal import PloneSite
 from Testing.makerequest import makerequest
 from zope.component.hooks import setSite
+from zope.globalrequest import setRequest
 import AccessControl
 
 
@@ -25,6 +26,7 @@ def setup_plone(plone, options=None):
 
     # Set up request for debug / bin/instance run mode.
     app = makerequest(app)
+    setRequest(app.REQUEST)
 
     # Get a reference to the Plone site *inside* the request-wrapped app
     plone = app.restrictedTraverse(plone.id)

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -9,6 +9,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.resolve import DossierResolver
 from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
+from opengever.setup.sections.constructor import IDontIssueDossierReferenceNumber
 from plone import api
 from Products.CMFCore.interfaces import IActionSucceededEvent
 from zope.component import getAdapter
@@ -62,6 +63,9 @@ def set_former_reference_after_moving(obj, event):
 # (IObjectAddedEvent inherits from IObjectMovedEvent)
 @grok.subscribe(IDossierMarker, IObjectMovedEvent)
 def save_reference_number_prefix(obj, event):
+    if IDontIssueDossierReferenceNumber.providedBy(obj.REQUEST):
+        return
+
     if IObjectRemovedEvent.providedBy(event):
         return
 

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -179,7 +179,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
 
     def assert_staff_folder_created(self, parent):
         folder_staff = parent.get('personal')
-        self.assertEqual('0.1. Personal', folder_staff.Title())
+        self.assertEqual('0.3. Personal', folder_staff.Title())
         self.assertEqual(u'Personal', folder_staff.title_de)
         self.assertIsNone(folder_staff.title_fr)
         self.assertEqual('personal', folder_staff.getId())
@@ -208,7 +208,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
             u'Enth\xe4lt vertrauliche Personaldossiers.',
             IClassification(folder_staff).public_trial_statement)
         self.assertEqual(
-            "1",
+            "3",
             IReferenceNumberPrefix(folder_staff).reference_number_prefix)
         self.assertEqual(
             u'',
@@ -296,7 +296,7 @@ class TestOggBundlePipeline(FunctionalTestCase):
             u'privacy_layer_yes',
             IClassification(dossier_peter).privacy_layer)
         self.assertEqual(
-            '2',
+            '7',
             IDossier(dossier_peter).reference_number)
         self.assertEqual(
             [],


### PR DESCRIPTION
OGGBundle constructor: Support setting local reference number part for dossiers (when provided by JSON item).

If (for dossiers) a key `reference_number` is provided, this will be used to prevent automatically issuing the next free reference number (local part), and set the given local part value instead.

I also updated some existing tests so that we test the setting of the local parts (called "reference_prefixes") for repository folders (which already worked) with non-sequential numbers.

TODO (separately): Validate uniqueness of reference number local parts on their respective levels.

@deiferni   