### PR TITLE
OGGBundle loader: Strip extension for title if necessary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- OGGBundle loader: Strip extension for title if necessary.
+  [lgraf]
+
 - OGGBundle constructor: Support setting local reference number part
   for dossiers (when provided by JSON item).
   [lgraf]

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -53,7 +53,22 @@ class BundleLoader(object):
             self.validate_schema(items, json_name)
             for item in items:
                 item['_type'] = self.determine_portal_type(json_name, item)
+                if json_name == 'documents.json':
+                    self.strip_extension_from_title(item)
                 self.items.append(item)
+
+    def strip_extension_from_title(self, item):
+        """Strip extension from title if present. Otherwise we'd end up with
+        the extension in the final title.
+        """
+        title = item['title']
+        basename, ext = os.path.splitext(title)
+        if item['filepath'].lower().endswith(ext.lower()):
+            # Only strip what looks like a file extension from title if
+            # filename ends with the same extension
+            item['title'] = basename
+            item['_original_filename'] = title
+        return item
 
     def load_schemas(self):
         schema_dir = rf('opengever.bundle', 'schemas/')


### PR DESCRIPTION
⚠️ Builds upon #2481 - merge that one first ⚠️  

Removes any file extension from the title if necessary, so it doesn't end up in the final title.