### PR TITLE
OGGBundle pipeline: Assign nav tree portlets for imported repo roots.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- OGGBundle pipeline: Assign nav tree portlets for imported repo roots.
+  [lgraf]
+
 - OGGBundle loader: Strip extension for title if necessary.
   [lgraf]
 

--- a/opengever/setup/cfgs/oggbundle.cfg
+++ b/opengever/setup/cfgs/oggbundle.cfg
@@ -23,6 +23,7 @@ pipeline =
     interfaces
     annotations
     manual-initial-version
+    assignreporootnavigation
     reindexobject
     savepoint
 
@@ -38,3 +39,6 @@ blueprint = opengever.setup.constructor
 
 [fileloader]
 blueprint = opengever.setup.fileloader
+
+[assignreporootnavigation]
+blueprint = opengever.setup.assignreporootnavigation


### PR DESCRIPTION
Assigns nav tree portlets for repo roots imported via OGGBundle pipeline.

In theory, this affects examplecontent / new site setup in general as well, but *functionally* it shouldn't change anything. The new strategy now is as follows:

- For the Plone Site root, assign a navtree portlet with the first reporoot in the pipeline.
- For the 95% case with exactly one root during setup, that'll be that one
- All other global tabs that inherit that portlet will therefore show the primary root in the navigation
- For all reporoots, portlet inheritance is blocked and they get their own nav tree portlet (obviously with *their* repo root ID configured)