### PR TITLE
OGGBundle loader: Display basic stats when loading bundle

### DIFF
--- a/opengever/bundle/tests/test_bundle_loader.py
+++ b/opengever/bundle/tests/test_bundle_loader.py
@@ -15,7 +15,8 @@ class TestBundleLoader(TestCase):
     def load_bundle(self, bundle_path=None):
         if not bundle_path:
             bundle_path = get_bundle_path('basic.oggbundle')
-        bundle = BundleLoader(bundle_path)
+        loader = BundleLoader(bundle_path)
+        bundle = loader.load()
         return list(bundle)
 
     def test_loads_correct_number_of_items(self):

--- a/opengever/setup/sections/bundlesource.py
+++ b/opengever/setup/sections/bundlesource.py
@@ -36,7 +36,7 @@ class BundleSourceSection(object):
                 "IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = "
                 "'/path/to/bundle'")
 
-        self.bundle = BundleLoader(bundle_path)
+        self.bundle = BundleLoader(bundle_path).load()
 
     def __iter__(self):
         return iter(self.bundle)


### PR DESCRIPTION
Displays some basic stats (type counts) for items loaded from bundles.

At a later point we'll include counts for objects that have actually been migrated (catalog queries), and those two will hopefully match up 😉 

@deiferni