### PR TITLE
Implement setting of local roles in OGGBundle pipeline.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- OGGBundle pipeline: Implement setting of local roles and blocking
+  of local role inheritance.
+  [lgraf]
+
 - OGGBundle pipeline: Assign nav tree portlets for imported repo roots.
   [lgraf]
 

--- a/opengever/bundle/configure.zcml
+++ b/opengever/bundle/configure.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns="http://namespaces.zope.org/zope">
+
+  <include file="transmogrifier.zcml" />
+
+</configure>

--- a/opengever/bundle/sections/map_local_roles.py
+++ b/opengever/bundle/sections/map_local_roles.py
@@ -1,0 +1,68 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from zope.interface import classProvides, implements
+import logging
+
+
+BLOCK_INHERITANCE_KEY = 'block_inheritance'
+ROLEMAP_KEY = '_permissions'
+ROLE_NAME_MAPPING = {
+    'read': 'Reader',
+    'add': 'Contributor',
+    'edit': 'Editor',
+    'close': 'Reviewer',
+    'reactivate': 'Publisher',
+}
+
+
+class MapLocalRolesSection(object):
+    """Map local roles from short names used in OGGBundles to actual role names
+    and prepare them in a way so that collective.blueprint.jsonmigrator can
+    deal with them.
+
+    For example, this section transforms a rolemap from an OGGBundle looking
+    like this
+
+    '_permissions': {
+      'block_inheritance': True,
+      'read': ['regular_users', 'admin_users'],
+      'reactivate': ['admin_users']
+    }
+
+    to this:
+
+    'block_inheritance': True,
+    '_ac_local_roles': {'regular_users': ['Reader'],
+                        'admin_users': ['Reader', 'Publisher']},
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.logger = logging.getLogger(options['blueprint'])
+
+    def __iter__(self):
+        for item in self.previous:
+            rolemap = item.get(ROLEMAP_KEY)
+            if rolemap:
+                # Move block_inheritance flag to top-level (if present)
+                block = rolemap.get(BLOCK_INHERITANCE_KEY)
+                if block is not None:
+                    item[BLOCK_INHERITANCE_KEY] = block
+
+                # Map short names to actual role names, and invert the mapping
+                # from {role: principals} to {principal: roles}
+                roles_by_principal = {}
+                for role_shortname, role in ROLE_NAME_MAPPING.items():
+                    principals = rolemap[role_shortname]
+                    for principal in principals:
+                        if principal not in roles_by_principal:
+                            roles_by_principal[principal] = []
+                        roles_by_principal[principal].append(role)
+
+                item['_ac_local_roles'] = roles_by_principal
+                item.pop(ROLEMAP_KEY)
+
+            yield item

--- a/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
@@ -30,6 +30,7 @@
     "review_state": "dossier-state-resolved",
     "title": "Hanspeter Müller",
     "_permissions": {
+      "block_inheritance": true,
       "read": [
         "admin_users"
       ],

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
+    i18n_domain="opengever.bundle">
+
+  <utility
+      component=".sections.map_local_roles.MapLocalRolesSection"
+      name="opengever.bundle.map_local_roles"
+      />
+
+</configure>

--- a/opengever/setup/cfgs/oggbundle.cfg
+++ b/opengever/setup/cfgs/oggbundle.cfg
@@ -17,6 +17,7 @@ pipeline =
     workflowupdater
     placefulworkflowupdater
     propertiesupdater
+    map-local-roles
     local_roles
     block_local_roles
     constraintypes
@@ -39,6 +40,9 @@ blueprint = opengever.setup.constructor
 
 [fileloader]
 blueprint = opengever.setup.fileloader
+
+[map-local-roles]
+blueprint = opengever.bundle.map_local_roles
 
 [assignreporootnavigation]
 blueprint = opengever.setup.assignreporootnavigation

--- a/opengever/setup/cfgs/oggbundle.cfg
+++ b/opengever/setup/cfgs/oggbundle.cfg
@@ -19,7 +19,7 @@ pipeline =
     propertiesupdater
     map-local-roles
     local_roles
-    block_local_roles
+    blocklocalroles
     constraintypes
     interfaces
     annotations
@@ -43,6 +43,10 @@ blueprint = opengever.setup.fileloader
 
 [map-local-roles]
 blueprint = opengever.bundle.map_local_roles
+
+[blocklocalroles]
+blueprint = opengever.setup.blocklocalroles
+fields = python:['block_inheritance']
 
 [assignreporootnavigation]
 blueprint = opengever.setup.assignreporootnavigation

--- a/opengever/setup/tests/test_oggbundle_pipeline.py
+++ b/opengever/setup/tests/test_oggbundle_pipeline.py
@@ -231,7 +231,13 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertIsNone(getattr(folder_staff, 'guid', None))
         self.assertIsNone(getattr(folder_staff, 'parent_guid', None))
 
-        # XXX local roles
+        self.assertDictContainsSubset(
+            {'privileged_users':
+                ['Reader', 'Editor', 'Contributor', 'Reviewer'],
+             'admin_users':
+                ['Publisher']},
+            folder_staff.__ac_local_roles__)
+        self.assertTrue(folder_staff.__ac_local_roles_block__)
 
         return folder_staff
 
@@ -318,7 +324,11 @@ class TestOggBundlePipeline(FunctionalTestCase):
             u'Hanspeter M\xfcller',
             dossier_peter.title)
 
-        # XXX local roles
+        self.assertDictContainsSubset(
+            {'admin_users':
+                ['Reader', 'Editor', 'Contributor', 'Publisher', 'Reviewer']},
+            dossier_peter.__ac_local_roles__)
+        self.assertTrue(dossier_peter.__ac_local_roles_block__)
 
         return dossier_peter
 


### PR DESCRIPTION
Map local roles from short names used in OGGBundles to actual role names and prepare them in a way so that `collective.blueprint.jsonmigrator` can deal with them.

For example, this section transforms a rolemap from an OGGBundle looking like this

```
    '_permissions': {
      'block_inheritance': True,
      'read': ['regular_users', 'admin_users'],
      'reactivate': ['admin_users']
    }
```

to this:

```
    'block_inheritance': True,
    '_ac_local_roles': {'regular_users': ['Reader'],
                        'admin_users': ['Reader', 'Publisher']},
```

@deiferni - as discussed, implemented as a stand-alone section just to be used for OGGBundles.