### PR TITLE
Made CSS for outdated and overdue items consistent

### DIFF
--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -101,7 +101,7 @@ class BumblebeeBaseDocumentOverlay(object):
         dc_helper = DownloadConfirmationHelper()
         return dc_helper.get_html_tag(
             self.context.absolute_url(),
-            additional_classes=[''],
+            additional_classes=['function-download-copy'],
             include_token=True
             )
 

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -63,8 +63,7 @@
            i18n:domain="plone"
            i18n:translate="">Edit metadata</a>
       </li>
-      <li id="action-download"
-          tal:define="link view/overlay/get_download_copy_link"
+      <li tal:define="link view/overlay/get_download_copy_link"
           tal:condition="nocall: link"
           tal:content="structure link">
       </li>

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -127,7 +127,10 @@ class DownloadConfirmationHelper(object):
                      viewname='download', include_token=False):
         if self.is_active():
             viewname = 'file_download_confirmation'
-            clazz = 'link-overlay modal {0}'.format(' '.join(additional_classes))
+            clazz = (('link-overlay '
+                      'modal '
+                      '{0}')
+                     .format(' '.join(additional_classes)))
         else:
             clazz = ' '.join(additional_classes)
 
@@ -138,7 +141,9 @@ class DownloadConfirmationHelper(object):
         label = translate(_(u'label_download_copy', default='Download copy'),
                           context=self.request).encode('utf-8')
 
-        return '<a href="{0}" class="{1}">{2}</a>'.format(url, clazz, label)
+        return ('<a href="{0}" '
+                'id="action-download" '
+                'class="{1}">{2}</a>').format(url, clazz, label)
 
     def process_request_form(self):
         """Process a request containing the rendered form."""

--- a/opengever/document/browser/templates/submitted_with.pt
+++ b/opengever/document/browser/templates/submitted_with.pt
@@ -16,7 +16,7 @@
         </div>
         <div class="updateActions">
           <a tal:attributes="href python: view.get_update_document_url(submitted_document);
-                             class python: 'outdated' if is_outdated else ''"
+                             class python: 'document-proposal-outdated' if is_outdated else ''"
              i18n:translate=""
             >
             Update document in proposal

--- a/opengever/document/widgets/tooltip.pt
+++ b/opengever/document/widgets/tooltip.pt
@@ -28,9 +28,8 @@
         Checkout and edit
       </a>
     </li>
-    <li tal:condition="view/download_link_available" id="action-download">
-      <a id="action-download"
-         tal:replace="structure view/download_link" />
+    <li tal:condition="view/download_link_available">
+      <a tal:replace="structure view/download_link" />
     </li>
   </ul>
 

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -31,4 +31,6 @@ class TooltipView(BrowserView):
 
     def download_link(self):
         dc_helper = DownloadConfirmationHelper()
-        return dc_helper.get_html_tag(self.get_url())
+        return (dc_helper
+                .get_html_tag(self.get_url(),
+                              additional_classes=['function-download-copy']))

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -216,7 +216,7 @@ class Task(Base):
             return u''
 
         if self.is_overdue:
-            label = u'<span class="overdue">{}</span>'
+            label = u'<span class="task-overdue">{}</span>'
         else:
             label = u'<span>{}</span>'
 

--- a/opengever/globalindex/tests/test_sql_task.py
+++ b/opengever/globalindex/tests/test_sql_task.py
@@ -39,7 +39,7 @@ class TestGlobalindexTaskDeadlineLabel(FunctionalTestCase):
         overdue = create(Builder('globalindex_task').having(deadline=deadline))
 
         self.assertEquals(
-            '<span class="overdue">{}</span>'.format(deadline.strftime('%d.%m.%Y')),
+            '<span class="task-overdue">{}</span>'.format(deadline.strftime('%d.%m.%Y')),
             overdue.get_deadline_label())
 
     def test_deadline_returns_empty_string_for_tasks_without_a_deadline(self):
@@ -67,7 +67,7 @@ class TestGlobalindexTaskDeadlineLabel(FunctionalTestCase):
                       .having(int_id=1, deadline=yesterday))
 
         self.assertEqual(
-            '<span class="overdue">{}</span>'.format(
+            '<span class="task-overdue">{}</span>'.format(
                 yesterday.strftime('%d.%m.%Y')),
             task.get_deadline_label())
 

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -45,7 +45,7 @@
                           </span>
 
                         <div class="updateActions">
-                          <a class="outdated"
+                          <a class="proposal-outdated"
                              tal:attributes="href python: view.get_update_document_url(document);"
                              i18n:translate="">
                             Update document in proposal

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -223,7 +223,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         self.assertEqual(
             ['Update document in proposal'],
-            browser.css('a.outdated').text,
+            browser.css('a.proposal-outdated').text,
             "The outdated link should be visible on a proposal")
 
         browser.login().visit(
@@ -236,7 +236,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
             "submittedproposal listing")
 
         self.assertEqual(
-            [], browser.css('a.outdated'),
+            [], browser.css('a.proposal-outdated'),
             "The outdated link should not be visible on a submitted proposal")
 
     @browsing


### PR DESCRIPTION
The change on the `plonetheme.teamraum` side:
https://github.com/4teamwork/plonetheme.teamraum/pull/493

All related styling for is now prefixed and contained consistently in the anchor elements.