### PR TITLE
Sphinx buildout: Pin setuptools and buildout versions.

### DIFF
--- a/sphinx-standalone.cfg
+++ b/sphinx-standalone.cfg
@@ -1,2 +1,6 @@
 [buildout]
 extends = sphinx.cfg
+
+[versions]
+setuptools = 33.1.1
+zc.buildout = 2.5.3


### PR DESCRIPTION
The `sphinx-standalone.cfg` buildout doesn't inherit the `opengever.core` version pinnings, so `setuptools` and `zc.buildout` need to be pinned separately.

See 4teamwork/ftw-buildouts#68