### PR TITLE
Fix sorting for documents in template dossier "documents" tab.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Fix sorting for documents in template dossier "documents" tab.
+  [lgraf]
+
 - Remove ftw.footer, replace with static footer viewlet. [jone]
 
 - OGGBundle pipeline: Implement setting of local roles and blocking

--- a/opengever/dossier/dossiertemplate/tabs.py
+++ b/opengever/dossier/dossiertemplate/tabs.py
@@ -25,8 +25,11 @@ class DossierTemplateDocuments(TemplateDossierDocuments):
     # Reset depth from super-class because we want do display
     # all sub-docouments in the dossiertemplate.
     depth = -1
+    sort_on = 'sortable_title'
 
 
 class DossierTemplateDocumentsGallery(DocumentsGallery):
     grok.context(IDossierTemplateMarker)
     grok.name('tabbedview_view-documents-gallery')
+
+    sort_on = 'sortable_title'

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -594,11 +594,11 @@ class TestDossierTemplateDocuments(FunctionalTestCase):
                .within(self.dossiertemplate)
                .titled('Document 1'))
         create(Builder('document')
-               .within(subdossier)
-               .titled('Document 2'))
-        create(Builder('document')
                .within(self.dossiertemplate)
                .titled('Document 3'))
+        create(Builder('document')
+               .within(subdossier)
+               .titled('Document 2'))
 
     @browsing
     def test_show_documents_in_list_view_sorted_alphabetically(self, browser):


### PR DESCRIPTION
This ensures that documents in both list and gallery views are sorted alphabetically.

This also makes sure an associated, flaky test now consistently passes: https://ci.4teamwork.ch/builds/56559/tasks/80536#bottom

@deiferni @Rotonen 