### PR TITLE
Fix flaky test

### DIFF
--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -131,8 +131,8 @@ class TestDossierListing(FunctionalTestCase):
             data={'dossier_state_filter': 'filter_retention_expired'})
 
         table = browser.css('.listing').first
-        self.assertEquals(['Dossier B', 'Dossier C'],
-                          [row.get('Title') for row in table.dicts()])
+        self.assertSetEqual(set(['Dossier B', 'Dossier C']),
+                            set([row.get('Title') for row in table.dicts()]))
 
     @browsing
     def test_expired_filters_is_hidden_on_subdossier_listings(self, browser):


### PR DESCRIPTION
Dossiers are sorted by `modified` by default (which is correct, or at the very least the way it's always been).

Because the modified timestamp as a one-second resolution, it occasionally can happen that sorting by `modified` in tests doesn't exactly equal actual creation order. Therefore we need to not assert on item order in this test.

@deiferni