### PR TITLE
Fixed SIP package name, include disposition transfer number if exists.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Fixed SIP package name, include disposition transfer number if exists.
+  [phgross]
+
 - Fix sorting for documents in template dossier "documents" tab.
   [lgraf]
 

--- a/opengever/disposition/browser/ech0160.py
+++ b/opengever/disposition/browser/ech0160.py
@@ -1,6 +1,5 @@
 from opengever.base.stream import TempfileStreamIterator
 from opengever.disposition.ech0160.sippackage import SIPPackage
-from plone import api
 from Products.Five import BrowserView
 from pyxb.utils.domutils import BindingDOMSupport
 from tempfile import TemporaryFile
@@ -16,7 +15,7 @@ class ECH0160ExportView(BrowserView):
     def __call__(self):
         BindingDOMSupport.SetDefaultNamespace(u'http://bar.admin.ch/arelda/v4')
 
-        package = SIPPackage(self.get_dossiers())
+        package = SIPPackage(self.context)
         tmpfile = self.create_zipfile(package)
 
         size = tmpfile.tell()
@@ -28,9 +27,6 @@ class ECH0160ExportView(BrowserView):
         response.setHeader("Content-Length", size)
 
         return TempfileStreamIterator(tmpfile, size)
-
-    def get_dossiers(self):
-        return [relation.to_object for relation in self.context.dossiers]
 
     def create_zipfile(self, package):
         tmpfile = TemporaryFile()

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -182,6 +182,9 @@ class Disposition(Container):
         self.update_added_dossiers(new - old)
         self.update_dropped_dossiers(old - new)
 
+    def get_dossiers(self):
+        return [relation.to_object for relation in self.dossiers]
+
     def get_history(self):
         return IHistoryStorage(self).get_history()
 

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -26,9 +26,10 @@ class SIPPackage(object):
     http://www.ech.ch/vechweb/page?p=dossier&documentNumber=eCH-0160
     """
 
-    def __init__(self, dossiers):
+    def __init__(self, disposition):
         self.xsd = self.create_xsd()
-        self.dossiers = self.create_dossiers(dossiers)
+        self.disposition = disposition
+        self.dossiers = self.create_dossiers(self.disposition.get_dossiers())
         self.repo = self.create_repository()
         self.content_folder = self.create_content_folder()
         self.ablieferung = self.create_ablieferung()

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -106,10 +106,13 @@ class SIPPackage(object):
         return ITranslatedTitle(parent).translated_title()
 
     def get_folder_name(self):
-        return 'SIP_{}_{}_{}'.format(
+        name = u'SIP_{}_{}'.format(
             DateTime().strftime('%Y%m%d'),
-            api.portal.get().getId().upper(),
-            'MyRef')
+            api.portal.get().getId().upper())
+        if self.disposition.transfer_number:
+            name = u'{}_{}'.format(name, self.disposition.transfer_number)
+
+        return name
 
     def write_to_zipfile(self, zipfile):
         self.add_schema_files(zipfile)

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -21,7 +21,8 @@ class TesteCH0160Deployment(FunctionalTestCase):
                            .within(self.folder))
         create(Builder('document').with_dummy_content().within(dossier_a))
         disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier_a])
+                             .having(dossiers=[dossier_a],
+                                     transfer_number=u'10xy')
                              .within(self.root))
 
         with freeze(datetime(2016, 6, 11)):
@@ -32,5 +33,5 @@ class TesteCH0160Deployment(FunctionalTestCase):
                 'application/zip',
                 self.request.response.headers.get('content-type'))
             self.assertEquals(
-                'inline; filename="SIP_20160611_PLONE_MyRef.zip"',
+                'inline; filename="SIP_20160611_PLONE_10xy.zip"',
                 self.request.response.headers.get('content-disposition'))

--- a/opengever/disposition/tests/test_model.py
+++ b/opengever/disposition/tests/test_model.py
@@ -322,7 +322,7 @@ class TestFolderAndFileModel(FunctionalTestCase):
                             .with_dummy_content())
 
         repo = Repository()
-        content = ContentRootFolder('SIP_20101212_FD_MyRef')
+        content = ContentRootFolder('SIP_20101212_FD_10xy')
 
         models = [Dossier(dossier_a), Dossier(dossier_b)]
         for dossier_model in models:

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -29,7 +29,14 @@ class TestSIPPackage(FunctionalTestCase):
         with freeze(datetime(2016, 11, 6)):
             package = SIPPackage(disposition)
             self.assertEquals(
-                'SIP_20161106_PLONE_MyRef', package.get_folder_name())
+                'SIP_20161106_PLONE', package.get_folder_name())
+
+        disposition.transfer_number = u'10\xe434'
+        with freeze(datetime(2016, 11, 6)):
+            package = SIPPackage(disposition)
+            self.assertEquals(
+                u'SIP_20161106_PLONE_10\xe434', package.get_folder_name())
+
 
     def test_ablieferungs_metadata(self):
         dossier = create(Builder('dossier').within(self.folder).as_expired())
@@ -73,7 +80,8 @@ class TestSIPPackage(FunctionalTestCase):
                .attach_archival_file_containing('TEST DATA')
                .within(dossier_b))
         disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier_a, dossier_b])
+                             .having(dossiers=[dossier_a, dossier_b],
+                                     transfer_number=u'10xy')
                              .within(self.folder))
 
         with freeze(datetime(2016, 6, 11)):
@@ -84,21 +92,21 @@ class TestSIPPackage(FunctionalTestCase):
             package.write_to_zipfile(zip_file)
 
             self.assertItemsEqual(
-                ['SIP_20160611_PLONE_MyRef/header/xsd/ablieferung.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/archivischeNotiz.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/archivischerVorgang.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/arelda.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/base.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/datei.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/dokument.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/dossier.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/ordner.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/ordnungssystem.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/ordnungssystemposition.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/paket.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/provenienz.xsd',
-                 'SIP_20160611_PLONE_MyRef/header/xsd/zusatzDaten.xsd',
-                 'SIP_20160611_PLONE_MyRef/content/d000001/p000001.doc',
-                 'SIP_20160611_PLONE_MyRef/content/d000002/p000002.pdf',
-                 'SIP_20160611_PLONE_MyRef/header/metadata.xml'],
+                ['SIP_20160611_PLONE_10xy/header/xsd/ablieferung.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/archivischeNotiz.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/archivischerVorgang.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/arelda.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/base.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/datei.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/dokument.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/dossier.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/ordner.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/ordnungssystem.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/ordnungssystemposition.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/paket.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/provenienz.xsd',
+                 'SIP_20160611_PLONE_10xy/header/xsd/zusatzDaten.xsd',
+                 'SIP_20160611_PLONE_10xy/content/d000001/p000001.doc',
+                 'SIP_20160611_PLONE_10xy/content/d000002/p000002.pdf',
+                 'SIP_20160611_PLONE_10xy/header/metadata.xml'],
                 zip_file.namelist())


### PR DESCRIPTION
Replaced the placeholder `myRef` with the transfer number if it exits.

Fix according to the users Testfeedback.