### PR TITLE
Disable LDAP during OGGBundle import to avoid costly LDAP lookups.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Disable LDAP during OGGBundle import to avoid costly LDAP lookups.
+  [lgraf]
+
 - Fixed SIP package name, include disposition transfer number if exists.
   [phgross]
 

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,4 +1,6 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
+from opengever.bundle.ldap import disable_ldap
+from opengever.bundle.ldap import enable_ldap
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
@@ -24,9 +26,14 @@ def import_oggbundle(app, args):
     log.info("Importing OGGBundle %s" % bundle_path)
 
     plone = setup_plone(get_first_plone_site(app))
+
+    disable_ldap(plone)
+
     transmogrifier = Transmogrifier(plone)
     IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = bundle_path
     transmogrifier(u'opengever.bundle.oggbundle')
+
+    enable_ldap(plone)
 
     log.info("Committing transaction...")
     transaction.commit()

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,6 +1,5 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
-from opengever.bundle.ldap import disable_ldap
-from opengever.bundle.ldap import enable_ldap
+from opengever.bundle.ldap import DisabledLDAP
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
@@ -27,13 +26,11 @@ def import_oggbundle(app, args):
 
     plone = setup_plone(get_first_plone_site(app))
 
-    disable_ldap(plone)
-
     transmogrifier = Transmogrifier(plone)
     IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = bundle_path
-    transmogrifier(u'opengever.bundle.oggbundle')
 
-    enable_ldap(plone)
+    with DisabledLDAP(plone):
+        transmogrifier(u'opengever.bundle.oggbundle')
 
     log.info("Committing transaction...")
     transaction.commit()

--- a/opengever/bundle/ldap.py
+++ b/opengever/bundle/ldap.py
@@ -1,0 +1,35 @@
+from plone import api
+import logging
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+original_plugins = None
+
+
+def disable_ldap(portal):
+    ldap_plugins = []
+    uf = api.portal.get_tool('acl_users')
+    plugin_registry = uf._getOb('plugins')
+    for plugin in uf.objectValues():
+        if plugin.meta_type in ['Plone LDAP plugin',
+                                'Plone Active Directory plugin']:
+            ldap_plugins.append(plugin.getId())
+
+    global original_plugins
+    original_plugins = plugin_registry._plugins
+    plugins_without_ldap = {}
+    for interface, plugins in original_plugins.items():
+        actives = tuple([p for p in plugins if p not in ldap_plugins])
+        plugins_without_ldap[interface] = actives
+
+    plugin_registry._plugins = plugins_without_ldap
+    log.info('Disabled LDAP plugin.')
+
+
+def enable_ldap(portal):
+    uf = api.portal.get_tool('acl_users')
+    plugin_registry = uf._getOb('plugins')
+    plugin_registry._plugins = original_plugins
+    log.info('Enabled LDAP plugin.')


### PR DESCRIPTION
Based on code that's already been used/tested in `opengever.bsmigration`.

@deiferni 