### PR TITLE
Fixed translations on the disposition overview.

### DIFF
--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -125,6 +125,7 @@
                            title transition/title;
                            id transition/id | nothing;
                            class string: ${transition/id} "
+           i18n:domain="plone"
            i18n:attributes="title">
           <span tal:content="transition/title" class="transition actionText"
                 i18n:translate="" i18n:domain="plone">

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -94,9 +94,8 @@ msgstr "Ablieferungspaket herunterladen"
 
 #. Default: "Don't archive"
 #: ./opengever/disposition/browser/templates/overview.pt:90
-#, fuzzy
 msgid "label_dont_archive"
-msgstr "Nicht archvieren"
+msgstr "Nicht archivieren"
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/templates/overview.pt:20


### PR DESCRIPTION
- Fixed `Don't archive` translation (fixes #2513)
- Translate title of transition actions (fixes #2514)