### PR TITLE
Fix rendering of new agenda points in IE11.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix rendering of new agenda points in IE11.
+  [Kevin Bieri]
 
 
 4.15.1 (2017-02-07)

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -437,6 +437,10 @@
       agendaItemController.connectedTo = [proposalsController];
     }
 
+    window.addEventListener("pageshow", function() {
+      agendaItemController.update();
+    });
+
     if ($(".template-add-meeting").length) {
       new CommitteeController();
     }


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2437

IE11 does not render newly added agenda points in a new tab before an explicit reload.
This behavior is documented under http://go.microsoft.com/fwlink/?LinkID=291337.

So explicitly refresh the page after the `pageshow` event.
The pageshow event is fired when a session history entry is being traversed to.
This includes back/forward as well as initial page-showing after the onload event.

For some reasons the `persisted` attribute on the event is not set properly:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101518/
So the agenda points are re-rendered on every pageload.