### PR TITLE
Load ZCML of plone.rest before using plone:service directive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.14.2 (unreleased)
 -------------------
 
+- Load ZCML of plone.rest before using plone:service directive.
+  [lgraf]
+
 - Modified opengever.document to conditionally use the new Office Connector
   functionality.
   [Rotonen]

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -19,6 +19,9 @@
 
     <include package=".upgrades" />
 
+    <!-- Need to load meta.zcml of plone.rest in order to use plone:service directive -->
+    <include package="plone.rest" />
+
     <plone:service
         method="GET"
         for="opengever.document.document.IDocumentSchema"


### PR DESCRIPTION
The `<plone:service />` directive is defined by [`plone.rest`'s `meta.zcml`](https://github.com/plone/plone.rest/blob/375c7c8306fd3f68f4ba8a327ee73950286ac453/src/plone/rest/meta.zcml#L5-L9).

Therefore we first need to load the ZCML of `plone.rest` before using this directive. Otherwise we're implicitly relying on a particular load order that might or might not be given.

Fixes this test failure: https://ci.4teamwork.ch/builds/57963/tasks/82506#bottom

@deiferni @Rotonen 