### PR TITLE
Shorten version label in footer.

### DIFF
--- a/opengever/base/viewlets/footer.pt
+++ b/opengever/base/viewlets/footer.pt
@@ -5,7 +5,7 @@
         <p><a href="https://github.com/OneGov/onegov.gever">Quellcode</a></p>
         <p><a href="https://jenkins.4teamwork.ch">Software Tests</a></p>
         <p><a href="http://www.onegov.ch/gever/aktuell">Release-Informationen</a></p>
-        <p>GEVER Version: <span tal:content="view/get_gever_version" /></p>
+        <p>Version: <span tal:content="view/get_gever_version" /></p>
     </div>
 
     <div id="footer-column-2" class="column cell position-4 width-4">


### PR DESCRIPTION
The footer now shows a version, this PR shortens the label from "GEVER Version" to "Version".

![screen shot 2017-02-06 at 13 23 11](https://cloud.githubusercontent.com/assets/736583/22647061/a9757c70-ec6f-11e6-9317-7ae69d5b361a.png)

Closes #2527.