### PR TITLE
Use ftw.upgrade colors extra for development.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -27,6 +27,9 @@ instance-eggs +=
     opengever.maintenance
     ${buildout:ogds-db-driver}
 
+[upgrade]
+eggs += ftw.upgrade[colors]
+
 [instance]
 zserver-threads = 4
 user = zopemaster:admin


### PR DESCRIPTION
We should use colors to visually distinguish orphaned upgrade steps. Having an orphaned upgrade step may require action, i.e. touching the upgrade to avoid re-installing an already installed upgrade. This PR includes the  `colors` extra from `ftw.upgrade` for local development.

**no colors:**

![screen shot 2017-02-07 at 13 24 53](https://cloud.githubusercontent.com/assets/736583/22691379/8248ee22-ed3a-11e6-86fd-3ac9cf95d981.png)

**vs. colors:**

![screen shot 2017-02-07 at 13 24 45](https://cloud.githubusercontent.com/assets/736583/22691378/821743e0-ed3a-11e6-99ef-226f93091b4d.png)
