### PR TITLE
Make sure the breadcrumb title tooltip only gets loaded if a data-uid attribute is present

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Make sure the breadcrumb title tooltip only gets loaded if a data-uid attribute is present.
+  [mathias.leimgruber]
+
 - OGGBundle schemas: Include enums for valid review_states.
   [lgraf]
 

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -82,7 +82,7 @@
     }, 100);
   }
 
-  $(document).on("mouseover", ".rollover-breadcrumb", setBreadcrumbAsTitleAttr);
+  $(document).on("mouseover", ".rollover-breadcrumb[data-uid]", setBreadcrumbAsTitleAttr);
 
 
 }(window, window.jQuery));


### PR DESCRIPTION
**Cause**
With the removal of the breadcrumb_title index, the data for the title attribute is now fetched async. 
The event handler is registered on `rollover-breadcrumb`. 
For some reason the boxes on the overview tab may have this class too. Only if [this](https://github.com/4teamwork/opengever.core/blob/033e68ae4de64908e89cd7726cf516f26ec5ce8b/opengever/base/browser/boxes_view.py#L17) mixing is used. 

**Solution**
I cannot say why, nor what's the reason for this. 
But with this change, the event handler is registered more specific and makes sure the `data-uid` attribute is present. 

This avoids an accidentally trigger of the tootlip. 

Fixes #2542

