### PR TITLE
Add tests for Sphinx docs builds

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Add tests for Sphinx docs builds.
+  [lgraf]
+
 - Fix error on agendaItemController update.
   [Kevin Bieri]
 

--- a/test-docs-intern.cfg
+++ b/test-docs-intern.cfg
@@ -1,0 +1,31 @@
+[buildout]
+extends =
+    sphinx-standalone.cfg
+
+parts +=
+    bin-test-jenkins
+
+jenkins_python = $PYTHON27
+
+[bin-test-jenkins]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/bash
+    set -eo pipefail
+
+    BUILD_LOG="sphinx_build.log"
+
+    bin/docs-build-intern 2>&1 | tee $BUILD_LOG
+    BUILD_RETCODE=$?
+
+    ! grep -q 'WARNING: ' $BUILD_LOG
+    WARNINGS=$?
+
+    if [[ $WARNINGS = 1 || $BUILD_RETCODE = 1 ]]; then
+        exit 1
+    else
+        exit 0
+    fi
+
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755

--- a/test-docs-public.cfg
+++ b/test-docs-public.cfg
@@ -1,0 +1,31 @@
+[buildout]
+extends =
+    sphinx-standalone.cfg
+
+parts +=
+    bin-test-jenkins
+
+jenkins_python = $PYTHON27
+
+[bin-test-jenkins]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/bash
+    set -eo pipefail
+
+    BUILD_LOG="sphinx_build.log"
+
+    bin/docs-build-public 2>&1 | tee $BUILD_LOG
+    BUILD_RETCODE=$?
+
+    ! grep -q 'WARNING: ' $BUILD_LOG
+    WARNINGS=$?
+
+    if [[ $WARNINGS = 1 || $BUILD_RETCODE = 1 ]]; then
+        exit 1
+    else
+        exit 0
+    fi
+
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755


### PR DESCRIPTION
Adds tests for Sphinx docs builds.

Warnings will be interpreted as errors, causing the build to fail.

`public` and `intern` docs will be tested separately. Each of those tests currently takes ~1.5 min to run.

Example build with one failing, one passing:
https://ci.4teamwork.ch/builds/59126/