### PR TITLE
Fix error on agendaItemController update

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Fix error on agendaItemController update.
+  [Kevin Bieri]
+
 - Make sure the breadcrumb title tooltip only gets loaded if a data-uid attribute is present.
   [mathias.leimgruber]
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -435,11 +435,11 @@
 
       proposalsController.connectedTo = [agendaItemController];
       agendaItemController.connectedTo = [proposalsController];
-    }
 
-    window.addEventListener("pageshow", function() {
-      agendaItemController.update();
-    });
+      window.addEventListener("pageshow", function() {
+        agendaItemController.update();
+      });
+    }
 
     if ($(".template-add-meeting").length) {
       new CommitteeController();


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2545

The AgendaItemController is only initialized on a meeting page.
So the update after the `pageshow` event should also just happen
on a meeting page.

Explicitly tested on Chrome and IE11.