### PR TITLE
OGGBundle schemas: Restrict allowed workflow states even further

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OGGBundle schemas: Restrict allowed workflow states even further.
+  We don't currently support migration to most of non-active states, so
+  let's not advertise them.
+  [lgraf]
+
 - Add tests for Sphinx docs builds.
   [lgraf]
 

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -19,24 +19,25 @@ GEVER_TYPES_TO_OGGBUNDLE_TYPES = {
 }
 
 # Workflow states allowed in JSON schemas. The state that's listed first
-# indicates the initial workflow state (i.e. default state)
+# indicates the initial workflow state (i.e. default state).
+#
+# Many workflow states are disabled here because we don't support migrating
+# objects in these states from OGGBundle at this point.
 ALLOWED_REVIEW_STATES = {
     'opengever.repository.repositoryroot': [
         'repositoryroot-state-active',
     ],
     'opengever.repository.repositoryfolder': [
         'repositoryfolder-state-active',
-        'repositoryfolder-state-inactive',
+        # 'repositoryfolder-state-inactive',
     ],
     'opengever.dossier.businesscasedossier': [
         'dossier-state-active',
-        'dossier-state-archived',
-        'dossier-state-inactive',
+        # 'dossier-state-archived',
+        # 'dossier-state-inactive',
         'dossier-state-resolved',
-        'dossier-state-offered',
+        # 'dossier-state-offered',
     ],
-    # We don't support migrating types in their removed
-    # or shadow states
     'opengever.document.document': [
         'document-state-draft',
         # 'document-state-removed',

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -246,10 +246,7 @@
                 "review_state": {
                     "enum": [
                         "dossier-state-active",
-                        "dossier-state-archived",
-                        "dossier-state-inactive",
-                        "dossier-state-resolved",
-                        "dossier-state-offered"
+                        "dossier-state-resolved"
                     ],
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -185,8 +185,7 @@
                 },
                 "review_state": {
                     "enum": [
-                        "repositoryfolder-state-active",
-                        "repositoryfolder-state-inactive"
+                        "repositoryfolder-state-active"
                     ],
                     "type": "string"
                 },


### PR DESCRIPTION
OGGBundle schemas: Restrict allowed workflow states even further: We don't currently support migration to most of non-active states, so let's not advertise them.