### PR TITLE
Fix attribute error if send documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Fix send_documents view on the inbox.
+  Allows the functionality to save sent files in the dossier
+  only for IDossierMarker-types.
+  [elioschmutz]
+
 - Use a request layer instead of monkey patch to disable automatic creation
   of initial versions.
   [lgraf]

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -258,6 +258,15 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
             "See the field: {}".format(
                 fieldname, field))
 
+    @browsing
+    def test_file_copy_field_not_shown_if_not_on_dossier(self, browser):
+        inbox = create(Builder('inbox'))
+
+        browser.login().open(inbox, view="send_documents")
+
+        field = browser.find('File a copy of the sent mail in dossier')
+        self.assertIsNone(field, "The field should not be visible")
+
     def send_documents(self, container, documents, browser=default_browser, **kwargs):
         documents = ['/'.join(doc.getPhysicalPath()) for doc in documents]
         attr = TEST_FORM_DATA.copy()


### PR DESCRIPTION
Fix send_documents view on the inbox.

Allows the functionality to save sent files in the dossier only for IDossierMarker-types.

fixes #2301 