### PR TITLE
Defer creation of initial versions to end of OGGBundle pipeline

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Use a request layer instead of monkey patch to disable automatic creation
+  of initial versions.
+  [lgraf]
+
 - Do intermediate commits during creation of initial versions. This addresses
   a performance issue where the time to write initial versions increases
   exponentially with the number of previous initial versions created in the

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OGGBundle pipeline: Fix suppression of automatically created initial
+  versions by moving the disabled-initial-version section after the
+  resolveguid one.
+  [lgraf]
+
 - Add a title_help field for dossiertemplates.
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Defer creation of initial versions to end of pipeline by creating a
+  dedicated section for post-processing steps.
+  [lgraf]
+
 - OGGBundle pipeline: Fix suppression of automatically created initial
   versions by moving the disabled-initial-version section after the
   resolveguid one.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Do intermediate commits during creation of initial versions. This addresses
+  a performance issue where the time to write initial versions increases
+  exponentially with the number of previous initial versions created in the
+  same transaction.
+  [lgraf]
+
 - Defer creation of initial versions to end of pipeline by creating a
   dedicated section for post-processing steps.
   [lgraf]

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -4,8 +4,8 @@ include =
 
 pipeline =
     bundlesource
-    disabled-initial-version
     resolveguid
+    disabled-initial-version
     constructor
     resolvetree
     fileinserter

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -22,10 +22,10 @@ pipeline =
     constraintypes
     interfaces
     annotations
-    manual-initial-version
     assignreporootnavigation
     reindexobject
     savepoint
+    post-processing
 
 
 [bundlesource]
@@ -52,3 +52,6 @@ fields = python:['block_inheritance']
 
 [assignreporootnavigation]
 blueprint = opengever.setup.assignreporootnavigation
+
+[post-processing]
+blueprint = opengever.bundle.post_processing

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -33,5 +33,6 @@ def import_oggbundle(app, args):
         transmogrifier(u'opengever.bundle.oggbundle')
 
     log.info("Committing transaction...")
+    transaction.get().note("Finished import of OGGBundle %r" % bundle_path)
     transaction.commit()
     log.info("Done.")

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -16,6 +16,7 @@ import logging
 
 
 logger = logging.getLogger('opengever.bundle.constructor')
+logger.setLevel(logging.INFO)
 
 
 class InvalidType(Exception):
@@ -95,6 +96,7 @@ class ConstructorSection(object):
                                 prefix_adapter.set_number(obj)
 
                 parent_path = '/'.join(context.getPhysicalPath())
+                logger.info("Constructed %r" % obj)
             except ValueError as e:
                 logger.warning(
                     u'Could not create object at {} with guid {}. {}'.format(

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -12,6 +12,7 @@ log.setLevel(logging.INFO)
 
 
 INTERMEDIATE_COMMIT_INTERVAL = 1000
+VERSIONABLE_TYPES = ('opengever.document.document', 'ftw.mail.mail')
 
 
 class PostProcessingSection(object):
@@ -46,8 +47,9 @@ class PostProcessingSection(object):
         # Any operations performed here will be applied after all the previous
         # sections have been run for all the items
         for count, item in enumerate(items_to_post_process, start=1):
-            log.info("Creating initial version: %s" % item['_path'])
-            create_initial_version(item['_object'])
+            if item['_type'] in VERSIONABLE_TYPES:
+                log.info("Creating initial version: %s" % item['_path'])
+                create_initial_version(item['_object'])
 
             if count % INTERMEDIATE_COMMIT_INTERVAL == 0:
                 self.commit_and_log(

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -1,0 +1,43 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.document.checkout.handlers import create_initial_version
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+
+
+log = logging.getLogger('opengever.bundle.post_processing')
+log.setLevel(logging.INFO)
+
+
+class PostProcessingSection(object):
+    """
+    Section to perform post-processing steps that need to be done after
+    the import is otherwise finished.
+
+    Currently includes:
+
+    - Creation of initial versions
+      (which have been disabled during regular pipeline)
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.context = transmogrifier.context
+
+    def __iter__(self):
+        # Yield all items and collect them, so we can apply post-processing
+        # steps *after* all the other sections have been executed
+        items_to_post_process = []
+        for item in self.previous:
+            items_to_post_process.append(item)
+            yield item
+
+        # Any operations performed here will be applied after all the previous
+        # sections have been run for all the items
+        for item in items_to_post_process:
+            log.info("Creating initial version: %s" % item['_path'])
+            create_initial_version(item['_object'])

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -4,10 +4,14 @@ from opengever.document.checkout.handlers import create_initial_version
 from zope.interface import classProvides
 from zope.interface import implements
 import logging
+import transaction
 
 
 log = logging.getLogger('opengever.bundle.post_processing')
 log.setLevel(logging.INFO)
+
+
+INTERMEDIATE_COMMIT_INTERVAL = 1000
 
 
 class PostProcessingSection(object):
@@ -29,6 +33,9 @@ class PostProcessingSection(object):
         self.context = transmogrifier.context
 
     def __iter__(self):
+        self.commit_and_log("Committing transaction before post-processing.")
+        log.info("Transaction committed.")
+
         # Yield all items and collect them, so we can apply post-processing
         # steps *after* all the other sections have been executed
         items_to_post_process = []
@@ -38,6 +45,20 @@ class PostProcessingSection(object):
 
         # Any operations performed here will be applied after all the previous
         # sections have been run for all the items
-        for item in items_to_post_process:
+        for count, item in enumerate(items_to_post_process, start=1):
             log.info("Creating initial version: %s" % item['_path'])
             create_initial_version(item['_object'])
+
+            if count % INTERMEDIATE_COMMIT_INTERVAL == 0:
+                self.commit_and_log(
+                    "Intermediate commit during OGGBundle post-processing. "
+                    "%s of %s items." % (count, len(items_to_post_process)))
+
+        self.commit_and_log(
+            "Final commit after OGGBundle post-processing. "
+            "%s of %s items." % (count, len(items_to_post_process)))
+
+    def commit_and_log(self, msg):
+        transaction.get().note(msg)
+        log.info(msg)
+        transaction.commit()

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -369,6 +369,10 @@ class TestOggBundlePipeline(FunctionalTestCase):
             u'Bewerbung Hanspeter M\xfcller',
             document_1.title)
 
+        repo_tool = api.portal.get_tool('portal_repository')
+        history = repo_tool.getHistoryMetadata(document_1)
+        self.assertEqual(1, len(history))
+
     def assert_document_2_created(self, parent):
         document_2 = parent.get('document-2')
 
@@ -408,6 +412,10 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(
             u'Entlassung Hanspeter M\xfcller',
             document_2.title)
+
+        repo_tool = api.portal.get_tool('portal_repository')
+        history = repo_tool.getHistoryMetadata(document_2)
+        self.assertEqual(1, len(history))
 
     def assert_mail_created(self, parent):
         mail = parent.get('document-3')

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -43,4 +43,9 @@
       name="opengever.bundle.map_local_roles"
       />
 
+  <utility
+      component=".sections.post_processing.PostProcessingSection"
+      name="opengever.bundle.post_processing"
+      />
+
 </configure>

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -112,3 +112,12 @@ class IDocumentIndexer(Interface):
     def extract_text():
         """Extract plain text from the adapted document.
         """
+
+
+class INoAutomaticInitialVersion(Interface):
+    """Request layer to disable automatic creation of initial versions
+    via event handler.
+
+    This is sometimes necessary when a transmogrifier pipeline is involved,
+    i.e. during setup or migration.
+    """

--- a/opengever/setup/sections/versioning.py
+++ b/opengever/setup/sections/versioning.py
@@ -1,8 +1,8 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultMatcher
-from opengever.document.checkout import handlers
 from opengever.document.checkout.handlers import create_initial_version
+from opengever.document.checkout.handlers import NoAutomaticInitialVersion
 from zope.interface import classProvides
 from zope.interface import implements
 
@@ -21,12 +21,9 @@ class DisabledInitialVersion(object):
         self.previous = previous
 
     def __iter__(self):
-        handlers.DISABLE_INITIAL_VERSION = True
-        try:
+        with NoAutomaticInitialVersion():
             for item in self.previous:
                 yield item
-        finally:
-            handlers.DISABLE_INITIAL_VERSION = False
 
 
 class ManualInitialVersion(object):


### PR DESCRIPTION
- Defer the creation of initial versions to the **end of the OGGBundle pipeline** by introducing a dedicated post-processing section
- Make sure the *automatic* creation of initial versions is actually disabled
- Use a **request layer** instead of monkey patching to disable automatic creation of initial versions
- Do **intermediate commits** during creation of initial versions. This addresses
  a **performance issue** where the time to write initial versions increases
  exponentially with the number of previous initial versions created in the
  same transaction.

Explicit commits of the transaction will be logged and indicated in the transaction note. Example how this will look in the ZMI Undo tab:

<img width="1256" alt="undo" src="https://cloud.githubusercontent.com/assets/405124/22889725/72791146-f20a-11e6-9f5f-1c0a60333673.png">

@deiferni 