### PR TITLE
OGGBundle pipeline: Implement basic reports for imported objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OGGBundle pipeline: Implement basic reports for imported objects. After
+  a bundle import, a quick ASCII summary and a much more detailed XLSX
+  report will be generated.
+  [lgraf]
+
 - Fix send_documents view on the inbox.
   Allows the functionality to save sent files in the dossier
   only for IDossierMarker-types.

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -26,6 +26,7 @@ pipeline =
     reindexobject
     savepoint
     post-processing
+    report
 
 
 [bundlesource]
@@ -55,3 +56,6 @@ blueprint = opengever.setup.assignreporootnavigation
 
 [post-processing]
 blueprint = opengever.bundle.post_processing
+
+[report]
+blueprint = opengever.bundle.report

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,5 +1,6 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
 from opengever.bundle.ldap import DisabledLDAP
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
@@ -31,6 +32,11 @@ def import_oggbundle(app, args):
 
     with DisabledLDAP(plone):
         transmogrifier(u'opengever.bundle.oggbundle')
+
+    bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+    timings = bundle.stats['timings']
+    duration = timings['done_post_processing'] - timings['start_loading']
+    log.info("Duration: %.2fs" % duration.total_seconds())
 
     log.info("Committing transaction...")
     transaction.get().note("Finished import of OGGBundle %r" % bundle_path)

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime
 from jsonschema import FormatChecker
 from jsonschema import validate
 from pkg_resources import resource_filename as rf
@@ -62,10 +63,12 @@ class BundleLoader(object):
     def __init__(self, bundle_path):
         self.bundle_path = bundle_path
         self.json_schemas = self._load_schemas()
+        self._stats = {'bundle_counts': {}, 'timings': {}}
 
     def load(self):
         """Load the bundle from disk and return an iterable Bundle.
         """
+        self._stats['timings']['start_loading'] = datetime.now()
         self._load_items()
         bundle = Bundle(
             self._items, self.bundle_path, self.json_schemas, self._stats)
@@ -81,7 +84,6 @@ class BundleLoader(object):
 
     def _load_items(self):
         self._items = []
-        self._stats = {'bundle_counts': {}}
         for json_name, portal_type in BUNDLE_JSON_TYPES.items():
             json_path = os.path.join(self.bundle_path, json_name)
 

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -36,6 +36,8 @@ class Bundle(object):
         if stats is not None:
             self.stats = stats
 
+        self.errors = {}
+
     def __repr__(self):
         return '<%s %s>' % (self.__class__.__name__, self.bundle_path)
 

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -74,19 +74,19 @@ class BundleLoader(object):
         log.info('')
         log.info('Stats for %r' % bundle)
         log.info('=' * 80)
-        for json_name, count in bundle.stats['counts'].items():
+        for json_name, count in bundle.stats['bundle_counts'].items():
             log.info("%-20s %s" % (json_name, count))
 
     def _load_items(self):
         self._items = []
-        self._stats = {'counts': {}}
+        self._stats = {'bundle_counts': {}}
         for json_name, portal_type in BUNDLE_JSON_TYPES.items():
             json_path = os.path.join(self.bundle_path, json_name)
 
             try:
                 with codecs.open(json_path, 'r', 'utf-8-sig') as json_file:
                     items = json.load(json_file)
-                    self._stats['counts'][json_name] = len(items)
+                    self._stats['bundle_counts'][json_name] = len(items)
             except IOError as exc:
                 log.info('%s: %s, skipping' % (json_name, exc.strerror))
                 continue

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -47,6 +47,11 @@ class Bundle(object):
         """
         return iter(self.items)
 
+    def get_repository_roots(self):
+        roots = [item for item in self.items
+                 if item['_type'] == 'opengever.repository.repositoryroot']
+        return roots
+
 
 class BundleLoader(object):
     """Loads an OGGBundle from the filesystem and yields the contained items

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -1,0 +1,64 @@
+from collections import OrderedDict
+from opengever.bundle.loader import BUNDLE_JSON_TYPES
+from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
+from plone import api
+from zope.annotation import IAnnotations
+import logging
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+class DataCollector(object):
+    """Collect report data from Plone.
+    """
+
+    def __init__(self, bundle):
+        self.bundle = bundle
+
+    def __call__(self):
+        data = {}
+        catalog = api.portal.get_tool('portal_catalog')
+
+        portal_types = BUNDLE_JSON_TYPES.values()
+        portal_types.append('ftw.mail.mail')
+
+        for portal_type in portal_types:
+            data[portal_type] = []
+            log.info("Collecting %s" % portal_type)
+
+            brains = catalog.unrestrictedSearchResults(portal_type=portal_type)
+            for brain in brains:
+                item_info = self.get_item_info(brain)
+                data[portal_type].append(item_info)
+
+        return data
+
+    def get_item_info(self, brain):
+        obj = brain.getObject()
+        path = '/'.join(obj.getPhysicalPath())
+        title = brain.Title
+        guid = IAnnotations(obj).get(BUNDLE_GUID_KEY)
+        item_info = OrderedDict(
+            [('guid', guid), ('path', path), ('title', title)])
+        return item_info
+
+
+class ASCIISummaryBuilder(object):
+    """Build a quick ASCII summary of object counts based on report data.
+    """
+
+    def __init__(self, report_data):
+        self.report_data = report_data
+
+    def build(self):
+        report = []
+        report.append('Imported objects:')
+        report.append('=================')
+
+        for portal_type, items in self.report_data.items():
+            line = "%s: %s" % (portal_type, len(items))
+            report.append(line)
+
+        return '\n'.join(report)

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -30,16 +30,20 @@ class DataCollector(object):
 
             brains = catalog.unrestrictedSearchResults(portal_type=portal_type)
             for brain in brains:
-                item_info = self.get_item_info(brain)
+                obj = brain.getObject()
+                guid = IAnnotations(obj).get(BUNDLE_GUID_KEY)
+                if guid not in self.bundle.item_by_guid:
+                    # Skip object, not part of current import
+                    continue
+                item_info = self.get_item_info(brain, guid)
                 data[portal_type].append(item_info)
 
         return data
 
-    def get_item_info(self, brain):
+    def get_item_info(self, brain, guid):
         obj = brain.getObject()
         path = '/'.join(obj.getPhysicalPath())
         title = brain.Title
-        guid = IAnnotations(obj).get(BUNDLE_GUID_KEY)
         item_info = OrderedDict(
             [('guid', guid), ('path', path), ('title', title)])
         return item_info

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -1,6 +1,10 @@
 from collections import OrderedDict
+from opengever.base.behaviors.translated_title import ITranslatedTitle
+from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.bundle.loader import BUNDLE_JSON_TYPES
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
+from openpyxl import Workbook
+from openpyxl.styles import Font
 from plone import api
 from zope.annotation import IAnnotations
 import logging
@@ -51,7 +55,11 @@ class DataCollector(object):
     def get_item_info(self, brain, guid):
         obj = brain.getObject()
         path = '/'.join(obj.getPhysicalPath())
-        title = brain.Title
+
+        if ITranslatedTitleSupport.providedBy(obj):
+            title = ITranslatedTitle(obj).title_de
+        else:
+            title = obj.title
         item_info = OrderedDict(
             [('guid', guid), ('path', path), ('title', title)])
         return item_info
@@ -74,3 +82,55 @@ class ASCIISummaryBuilder(object):
             report.append(line)
 
         return '\n'.join(report)
+
+
+class XLSXReportBuilder(object):
+    """Build a detailed report in XLSX format based on report data.
+    """
+
+    def __init__(self, report_data):
+        self.report_data = {}
+        self.report_data.update(report_data)
+
+        # Include mails in documents by moving them over
+        docs = self.report_data.get('opengever.document.document', [])
+        mails = self.report_data.get('ftw.mail.mail', [])
+        self.report_data['opengever.document.document'] = docs + mails
+        self.report_data.pop('ftw.mail.mail', None)
+
+    def build_and_save(self, report_path):
+        workbook = self.build_report()
+        self.save_report(workbook, report_path)
+
+    def save_report(self, workbook, path):
+        with open(path, 'w') as report_xlsx:
+            workbook.save(report_xlsx)
+            log.info("Wrote report to %s" % path)
+        return path
+
+    def _write_row(self, sheet, rownum, values, bold=False):
+        for col_num, value in enumerate(values, 1):
+            cell = sheet.cell(row=rownum + 1, column=col_num)
+            cell.value = value
+            if bold:
+                cell.font = Font(bold=True)
+
+    def build_report(self):
+        workbook = Workbook()
+        workbook.remove_sheet(workbook.active)
+
+        for json_name, portal_type in BUNDLE_JSON_TYPES.items():
+            short_name = json_name.replace('.json', '')
+            log.info("Creating sheet %s" % short_name)
+            sheet = workbook.create_sheet(short_name)
+            sheet.title = short_name
+
+            # Label Row
+            self._write_row(
+                sheet, 0, self.report_data[portal_type][0].keys(), bold=True)
+
+            # Data rows
+            for rownum, info in enumerate(self.report_data[portal_type], 1):
+                self._write_row(sheet, rownum, info.values())
+
+        return workbook

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -52,16 +52,33 @@ class DataCollector(object):
 
         return data
 
+    def get_file_field(self, obj):
+        if obj.portal_type == 'opengever.document.document':
+            file_field = obj.file
+        elif obj.portal_type == 'ftw.mail.mail':
+            file_field = obj.message
+        else:
+            file_field = None
+
+        return file_field
+
+    def get_title(self, obj):
+        if ITranslatedTitleSupport.providedBy(obj):
+            return ITranslatedTitle(obj).title_de
+        return obj.title
+
     def get_item_info(self, brain, guid):
         obj = brain.getObject()
         path = '/'.join(obj.getPhysicalPath())
+        title = self.get_title(obj)
 
-        if ITranslatedTitleSupport.providedBy(obj):
-            title = ITranslatedTitle(obj).title_de
-        else:
-            title = obj.title
         item_info = OrderedDict(
             [('guid', guid), ('path', path), ('title', title)])
+
+        file_field = self.get_file_field(obj)
+        if file_field:
+            item_info['file_size'] = file_field.getSize()
+
         return item_info
 
 

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -24,11 +24,19 @@ class DataCollector(object):
         portal_types = BUNDLE_JSON_TYPES.values()
         portal_types.append('ftw.mail.mail')
 
+        # Determine paths of repository roots that were part of the current
+        # import to limit catalog search accordingly
+        portal = api.portal.get()
+        root_paths = [
+            '/'.join(portal.getPhysicalPath() + (r['_path'], ))
+            for r in self.bundle.get_repository_roots()]
+
         for portal_type in portal_types:
             data[portal_type] = []
             log.info("Collecting %s" % portal_type)
 
-            brains = catalog.unrestrictedSearchResults(portal_type=portal_type)
+            brains = catalog.unrestrictedSearchResults(
+                portal_type=portal_type, path=root_paths)
             for brain in brains:
                 obj = brain.getObject()
                 guid = IAnnotations(obj).get(BUNDLE_GUID_KEY)

--- a/opengever/bundle/sections/bundlesource.py
+++ b/opengever/bundle/sections/bundlesource.py
@@ -11,8 +11,8 @@ logger = logging.getLogger('opengever.bundle.bundlesource')
 logger.setLevel(logging.INFO)
 
 
-BUNDLE_PATH_KEY = 'opengever.setup.bundle_path'
-JSON_STATS_KEY = 'opengever.setup.json_stats'
+BUNDLE_PATH_KEY = 'opengever.bundle.bundle_path'
+JSON_STATS_KEY = 'opengever.bundle.json_stats'
 
 
 class BundleSourceSection(object):

--- a/opengever/bundle/sections/bundlesource.py
+++ b/opengever/bundle/sections/bundlesource.py
@@ -11,6 +11,7 @@ logger = logging.getLogger('opengever.bundle.bundlesource')
 logger.setLevel(logging.INFO)
 
 
+BUNDLE_KEY = 'opengever.bundle.bundle'
 BUNDLE_PATH_KEY = 'opengever.bundle.bundle_path'
 JSON_STATS_KEY = 'opengever.bundle.json_stats'
 
@@ -37,6 +38,7 @@ class BundleSourceSection(object):
                 "'/path/to/bundle'")
 
         self.bundle = BundleLoader(bundle_path).load()
+        IAnnotations(transmogrifier)[BUNDLE_KEY] = self.bundle
 
     def __iter__(self):
         return iter(self.bundle)

--- a/opengever/bundle/sections/bundlesource.py
+++ b/opengever/bundle/sections/bundlesource.py
@@ -13,7 +13,6 @@ logger.setLevel(logging.INFO)
 
 BUNDLE_KEY = 'opengever.bundle.bundle'
 BUNDLE_PATH_KEY = 'opengever.bundle.bundle_path'
-JSON_STATS_KEY = 'opengever.bundle.json_stats'
 
 
 class BundleSourceSection(object):
@@ -26,8 +25,6 @@ class BundleSourceSection(object):
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
         self.transmogrifier = transmogrifier
-
-        IAnnotations(transmogrifier)[JSON_STATS_KEY] = {'errors': {}}
 
         bundle_path = IAnnotations(transmogrifier).get(BUNDLE_PATH_KEY)
         if not bundle_path:

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -7,6 +7,7 @@ from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from plone import api
 from plone.dexterity.utils import createContentInContainer
+from zope.annotation import IAnnotations
 from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import classProvides
@@ -17,6 +18,9 @@ import logging
 
 logger = logging.getLogger('opengever.bundle.constructor')
 logger.setLevel(logging.INFO)
+
+
+BUNDLE_GUID_KEY = 'bundle_guid'
 
 
 class InvalidType(Exception):
@@ -71,6 +75,12 @@ class ConstructorSection(object):
         title_args = dict((key, item.get(key)) for key in title_keys)
         return title_args
 
+    def _set_guid(self, obj, item):
+        """Store the GUID from the bundle in item's annotations in order to
+        later be able to match up Plone objects with bundle items.
+        """
+        IAnnotations(obj)[BUNDLE_GUID_KEY] = item['guid']
+
     def _construct_object(self, container, portal_type, item):
         fti = self._get_fti(portal_type)
         title_args = self._get_title_args(fti, item)
@@ -92,6 +102,8 @@ class ConstructorSection(object):
                         prefix_adapter.set_number(obj, local_refnum)
                     else:
                         prefix_adapter.set_number(obj)
+
+        self._set_guid(obj, item)
         return obj
 
     def __iter__(self):

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -4,6 +4,7 @@ from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_NAMES
 from opengever.base.interfaces import IDontIssueDossierReferenceNumber
 from opengever.base.interfaces import IReferenceNumberPrefix
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from plone import api
 from plone.dexterity.utils import createContentInContainer
@@ -49,7 +50,7 @@ class ConstructorSection(object):
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
         self.transmogrifier = transmogrifier
-        self.item_by_guid = self.transmogrifier.item_by_guid
+        self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
 
         self.site = api.portal.get()
         self.ttool = api.portal.get_tool(u'portal_types')
@@ -112,7 +113,7 @@ class ConstructorSection(object):
 
             parent_guid = item.get(u'parent_guid')
             if parent_guid:
-                context = self.item_by_guid[parent_guid][u'_object']
+                context = self.bundle.item_by_guid[parent_guid][u'_object']
             else:
                 context = self.site
 

--- a/opengever/bundle/sections/map_local_roles.py
+++ b/opengever/bundle/sections/map_local_roles.py
@@ -14,6 +14,9 @@ ROLE_NAME_MAPPING = {
     'reactivate': 'Publisher',
 }
 
+# Inverted mapping of the above
+NAME_ROLE_MAPPING = {v: k for k, v in ROLE_NAME_MAPPING.iteritems()}
+
 
 class MapLocalRolesSection(object):
     """Map local roles from short names used in OGGBundles to actual role names

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -38,8 +38,8 @@ class PostProcessingSection(object):
         self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
 
     def __iter__(self):
-        self.commit_and_log("Committing transaction before post-processing.")
-        log.info("Transaction committed.")
+        log.info("Committing transaction...")
+        self.commit_and_log("Committed transaction before post-processing.")
 
         # Yield all items and collect them, so we can apply post-processing
         # steps *after* all the other sections have been executed
@@ -67,5 +67,5 @@ class PostProcessingSection(object):
 
     def commit_and_log(self, msg):
         transaction.get().note(msg)
-        log.info(msg)
         transaction.commit()
+        log.info(msg)

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -1,6 +1,9 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from datetime import datetime
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.document.checkout.handlers import create_initial_version
+from zope.annotation import IAnnotations
 from zope.interface import classProvides
 from zope.interface import implements
 import logging
@@ -32,6 +35,7 @@ class PostProcessingSection(object):
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
         self.context = transmogrifier.context
+        self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
 
     def __iter__(self):
         self.commit_and_log("Committing transaction before post-processing.")
@@ -59,6 +63,7 @@ class PostProcessingSection(object):
         self.commit_and_log(
             "Final commit after OGGBundle post-processing. "
             "%s of %s items." % (count, len(items_to_post_process)))
+        self.bundle.stats['timings']['done_post_processing'] = datetime.now()
 
     def commit_and_log(self, msg):
         transaction.get().note(msg)

--- a/opengever/bundle/sections/report.py
+++ b/opengever/bundle/sections/report.py
@@ -1,0 +1,38 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.bundle.report import ASCIISummaryBuilder
+from opengever.bundle.report import DataCollector
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
+from zope.annotation import IAnnotations
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+
+
+log = logging.getLogger('opengever.bundle.report')
+log.setLevel(logging.INFO)
+
+
+class ReportSection(object):
+    """Create import reports for the current OGGBundle.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.context = transmogrifier.context
+        self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+
+    def __iter__(self):
+        for item in self.previous:
+            yield item
+
+        log.info("Creating import reports...")
+
+        report_data = DataCollector(self.bundle)()
+        self.bundle.report_data = report_data
+
+        summary = ASCIISummaryBuilder(report_data).build()
+        log.info('\n\n%s\n' % summary)

--- a/opengever/bundle/sections/report.py
+++ b/opengever/bundle/sections/report.py
@@ -1,12 +1,16 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.base.pathfinder import PathFinder
 from opengever.bundle.report import ASCIISummaryBuilder
 from opengever.bundle.report import DataCollector
+from opengever.bundle.report import XLSXReportBuilder
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from zope.annotation import IAnnotations
 from zope.interface import classProvides
 from zope.interface import implements
 import logging
+import os
+import tempfile
 
 
 log = logging.getLogger('opengever.bundle.report')
@@ -34,5 +38,22 @@ class ReportSection(object):
         report_data = DataCollector(self.bundle)()
         self.bundle.report_data = report_data
 
+        self.build_ascii_summary(report_data)
+        self.build_xlsx_report(report_data)
+
+    def build_ascii_summary(self, report_data):
         summary = ASCIISummaryBuilder(report_data).build()
         log.info('\n\n%s\n' % summary)
+
+    def build_xlsx_report(self, report_data):
+        try:
+            report_path = os.path.join(PathFinder().var, 'report.xlsx')
+        except RuntimeError:
+            # During tests
+            tmp_file = tempfile.NamedTemporaryFile(
+                delete=False, suffix='.xlsx')
+            tmp_file.close()
+            report_path = tmp_file.name
+
+        xlsx_builder = XLSXReportBuilder(report_data)
+        xlsx_builder.build_and_save(report_path)

--- a/opengever/bundle/tests/__init__.py
+++ b/opengever/bundle/tests/__init__.py
@@ -5,6 +5,9 @@ from zope.interface import implementer
 
 @implementer(IAttributeAnnotatable)
 class MockTransmogrifier(object):
+    pass
 
+
+class MockBundle(object):
     def __init__(self):
         self.item_by_guid = OrderedDict()

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -461,6 +461,8 @@ class TestOggBundlePipeline(FunctionalTestCase):
 
     def assert_report_data_collected(self, bundle):
         report_data = bundle.report_data
+        metadata = report_data['metadata']
+
         self.assertSetEqual(
             set([
                 'opengever.repository.repositoryroot',
@@ -468,13 +470,13 @@ class TestOggBundlePipeline(FunctionalTestCase):
                 'opengever.dossier.businesscasedossier',
                 'opengever.document.document',
                 'ftw.mail.mail']),
-            set(report_data.keys()))
+            set(metadata.keys()))
 
-        reporoots = report_data['opengever.repository.repositoryroot']
-        repofolders = report_data['opengever.repository.repositoryfolder']
-        dossiers = report_data['opengever.dossier.businesscasedossier']
-        documents = report_data['opengever.document.document']
-        mails = report_data['ftw.mail.mail']
+        reporoots = metadata['opengever.repository.repositoryroot']
+        repofolders = metadata['opengever.repository.repositoryfolder']
+        dossiers = metadata['opengever.dossier.businesscasedossier']
+        documents = metadata['opengever.document.document']
+        mails = metadata['ftw.mail.mail']
 
         self.assertEqual(1, len(reporoots))
         self.assertEqual(3, len(repofolders))

--- a/opengever/bundle/tests/test_section_bundlesource.py
+++ b/opengever/bundle/tests/test_section_bundlesource.py
@@ -1,5 +1,7 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.bundle.loader import Bundle
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.bundlesource import BundleSourceSection
 from opengever.bundle.tests import MockTransmogrifier
@@ -38,3 +40,8 @@ class TestBundleSource(FunctionalTestCase):
         transmogrifier = MockTransmogrifier()
         with self.assertRaises(Exception):
             BundleSourceSection(transmogrifier, '', {}, [])
+
+    def test_adds_reference_to_bundle_to_transmogrifier(self):
+        source = self.setup_source({})
+        self.assertIsInstance(
+            IAnnotations(source.transmogrifier)[BUNDLE_KEY], Bundle)

--- a/opengever/bundle/tests/test_section_constructor.py
+++ b/opengever/bundle/tests/test_section_constructor.py
@@ -1,10 +1,12 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.bundle.sections.constructor import ConstructorSection
 from opengever.bundle.sections.constructor import InvalidType
 from opengever.bundle.tests import MockTransmogrifier
 from opengever.testing import FunctionalTestCase
 from plone import api
+from zope.annotation import IAnnotations
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
 
@@ -35,6 +37,7 @@ class TestConstructor(FunctionalTestCase):
 
     def test_raises_for_invalid_types(self):
         section = self.setup_section(previous=[{
+            "guid": "12345xy",
             "_type": "foo.bar.qux",
         }])
         with self.assertRaises(InvalidType):
@@ -42,6 +45,7 @@ class TestConstructor(FunctionalTestCase):
 
     def test_updates_item_with_object_information(self):
         item = {
+            u"guid": "12345xy",
             u"_type": u"opengever.repository.repositoryroot",
             u"title_de": u"Reporoot",
         }
@@ -54,6 +58,7 @@ class TestConstructor(FunctionalTestCase):
 
     def test_creates_itranslated_title_content(self):
         item = {
+            u"guid": "12345xy",
             u"_type": u"opengever.repository.repositoryroot",
             u"title_de": u"Reporoot",
         }
@@ -68,6 +73,7 @@ class TestConstructor(FunctionalTestCase):
 
     def test_creates_simple_title_content(self):
         item = {
+            u"guid": "12345xy",
             u"_type": u"opengever.dossier.businesscasedossier",
             u"title": u"Dossier",
         }
@@ -79,8 +85,22 @@ class TestConstructor(FunctionalTestCase):
         self.assertFalse(hasattr(content, 'title_de'))
         self.assertFalse(hasattr(content, 'title_Fr'))
 
+    def test_sets_bundle_guid_on_obj(self):
+        guid = "12345xy"
+        item = {
+            u"guid": guid,
+            u"_type": u"opengever.dossier.businesscasedossier",
+            u"title": u"My Dossier",
+        }
+        section = self.setup_section(previous=[item])
+        list(section)
+
+        content = item['_object']
+        self.assertEqual(guid, IAnnotations(content)[BUNDLE_GUID_KEY])
+
     def test_catalog(self):
         item = {
+            u"guid": "12345xy",
             u"_type": u"opengever.repository.repositoryroot",
             u"title_de": u"Reporoot",
         }
@@ -102,6 +122,7 @@ class TestConstructor(FunctionalTestCase):
 
     def test_can_create_eml_emails(self):
         item = {
+            u"guid": "12345xy",
             u"_type": u"ftw.mail.mail",
             u"title": u"My Mail",
             u"_path": u"/foo/bar"

--- a/opengever/bundle/tests/test_section_constructor.py
+++ b/opengever/bundle/tests/test_section_constructor.py
@@ -1,8 +1,10 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.bundle.sections.constructor import ConstructorSection
 from opengever.bundle.sections.constructor import InvalidType
+from opengever.bundle.tests import MockBundle
 from opengever.bundle.tests import MockTransmogrifier
 from opengever.testing import FunctionalTestCase
 from plone import api
@@ -24,6 +26,7 @@ class TestConstructor(FunctionalTestCase):
     def setup_section(self, previous=None):
         previous = previous or []
         transmogrifier = MockTransmogrifier()
+        IAnnotations(transmogrifier)[BUNDLE_KEY] = MockBundle()
         options = {}
 
         return ConstructorSection(transmogrifier, '', options, previous)

--- a/opengever/bundle/tests/test_section_resolveguid.py
+++ b/opengever/bundle/tests/test_section_resolveguid.py
@@ -1,11 +1,14 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.resolveguid import DuplicateGuid
 from opengever.bundle.sections.resolveguid import MissingGuid
 from opengever.bundle.sections.resolveguid import MissingParent
 from opengever.bundle.sections.resolveguid import ResolveGUIDSection
+from opengever.bundle.tests import MockBundle
 from opengever.bundle.tests import MockTransmogrifier
 from opengever.testing import FunctionalTestCase
+from zope.annotation import IAnnotations
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
 
@@ -15,6 +18,9 @@ class TestResolveGUID(FunctionalTestCase):
     def setup_section(self, previous=None):
         previous = previous or []
         transmogrifier = MockTransmogrifier()
+        self.bundle = MockBundle()
+        IAnnotations(transmogrifier)[BUNDLE_KEY] = self.bundle
+
         options = {'blueprint', 'opengever.bundle.resolveguid'}
 
         return ResolveGUIDSection(transmogrifier, '', options, previous)
@@ -72,7 +78,6 @@ class TestResolveGUID(FunctionalTestCase):
     def test_defines_guid_mapping_on_transmogrifier(self):
         item = {'guid': 'marvin'}
         section = self.setup_section(previous=[item])
-        transmogrifier = section.transmogrifier
 
         list(section)
-        self.assertEqual(item, transmogrifier.item_by_guid['marvin'])
+        self.assertEqual(item, self.bundle.item_by_guid['marvin'])

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -48,4 +48,9 @@
       name="opengever.bundle.post_processing"
       />
 
+  <utility
+      component=".sections.report.ReportSection"
+      name="opengever.bundle.report"
+      />
+
 </configure>


### PR DESCRIPTION
This implements some basic reports for imported objects.

In addition to the summary at the start, right after reading the contents from the bundle, this will also produce reports at the end of the import that are based on what objects actually could be found in **Plone** (i.e. based on catalog queries).

This includes a very short summary of object counts in ASCII, and a much more detailed XLSX report.

@deiferni 
 