### PR TITLE
Update menu order and rename translation for "Dossier with template"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,14 +5,18 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
-- Introduce new feature: Restrict Keywords for DossierTemplates. 
+- Rename translation for "Dossier with template" and reorder it in
+  the factories-menu.
+  [elioschmutz]
+
+- Introduce new feature: Restrict Keywords for DossierTemplates.
   [mathias.leimgruber]
 
-- Introduce new feature: Predefined Keywords for DossierTemplates. 
+- Introduce new feature: Predefined Keywords for DossierTemplates.
   [mathias.leimgruber]
 
-- Introduce new feature: Use ftw.keywordwidget for Dossier and 
-  DossierTemplate Keywords. 
+- Introduce new feature: Use ftw.keywordwidget for Dossier and
+  DossierTemplate Keywords.
   [mathias.leimgruber]
 
 - OGGBundle pipeline: Implement basic reports for imported objects. After

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -75,7 +75,7 @@ msgid "Dossier state changed to dossier-state-resolved"
 msgstr "Status des Dossiers geändert zu Abgeschlossen"
 
 msgid "Dossier with template"
-msgstr "Dossier aus Vorlage"
+msgstr "Geschäftsdossier aus Vorlage"
 
 msgid "Edit metadata"
 msgstr "Metadaten bearbeiten"

--- a/opengever/base/menu.py
+++ b/opengever/base/menu.py
@@ -20,6 +20,9 @@ def order_factories(context, factories):
                        'Mail',
                        'Subdossier',
                        'Participant',
+                       'Business Case Dossier',
+                       'Dossier with template',
+                       'Disposition',
                        ]
 
     ordered_factories = []

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -292,7 +292,7 @@ msgstr "Dokument aus Vorlage erstellen"
 #. Default: "Create dossier from template"
 #: ./opengever/dossier/dossiertemplate/form.py:97
 msgid "create_dossier_with_template"
-msgstr "Dossier aus Vorlage erstellen"
+msgstr "Geschäftsdossier aus Vorlage erstellen"
 
 msgid "documents"
 msgstr "Dokumente"

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -197,7 +197,7 @@ class TestDossierTemplateFeatureEnabled(FunctionalTestCase):
         browser.login().open(leaf_node)
 
         self.assertEquals(
-            ['Business Case Dossier', 'Disposition', 'Dossier with template', 'RepositoryFolder'],
+            ['Business Case Dossier', 'Dossier with template', 'Disposition', 'RepositoryFolder'],
             factoriesmenu.addable_types())
 
     @browsing
@@ -215,5 +215,5 @@ class TestDossierTemplateFeatureEnabled(FunctionalTestCase):
         browser.login().open(leaf_node)
 
         self.assertEquals(
-            ['Business Case Dossier', 'Disposition', 'Dossier with template'],
+            ['Business Case Dossier', 'Dossier with template', 'Disposition'],
             factoriesmenu.addable_types())


### PR DESCRIPTION
This PR changes the translation for "Dossier with template"

![bildschirmfoto 2017-02-15 um 16 35 32](https://cloud.githubusercontent.com/assets/557005/22981571/0f0ddef4-f39d-11e6-897f-b4093e32b3d6.png)

closes #2560 