### PR TITLE
OGGBundle reports: Also store raw JSON data for errors and stats

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OGGBundle reports: Also store raw JSON data for errors and stats.
+  [lgraf]
+
 - FileLoader: Add support for loading files from UNC paths.
   [lgraf]
 

--- a/opengever/bundle/sections/report.py
+++ b/opengever/bundle/sections/report.py
@@ -1,5 +1,6 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from datetime import datetime
 from opengever.base.pathfinder import PathFinder
 from opengever.bundle.report import ASCIISummaryBuilder
 from opengever.bundle.report import DataCollector
@@ -51,7 +52,8 @@ class ReportSection(object):
 
         During tests, a temporary directory will be created.
         """
-        dirname = 'import-report'
+        ts = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+        dirname = 'import-report-%s' % ts
         try:
             report_dir = os.path.join(PathFinder().var, dirname)
             try:


### PR DESCRIPTION
Also **store raw JSON data** for errors and stats.

This makes sure that we have all the raw data tracked during import, in order to
- create more detailed reports after the fact
- have a fail-safe to make sure this data is stored on disk, even if an exception happens during the more complex and error-prone XLSX generation

This also unifies the report structure, by making it a **self-contained, timestamped directory**. A report directly containing all relevant files will be created:

```
var/
    import-report-2017-02-15_18-58-43/
        main-report.xlsx
        errors.json
        stats.json
```

*(To be added later: Full log of stderr (`import.log`) and validation report (`validation-report.xlsx`))*

@deiferni 