### PR TITLE
Allow add root content only for managers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Allow add root content only for managers.
+  [elioschmutz]
+
 - Fix newstyle OfficeConnector URL support for file tooltips and Bumblebee
   overlays.
   [Rotonen]

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -70,6 +70,7 @@ class TestTranslatedTitle(FunctionalTestCase):
 
     @browsing
     def test_both_title_fields_are_accessible_on_add_form(self, browser):
+        self.grant('Manager')
         browser.login().open()
         factoriesmenu.add('RepositoryRoot')
 

--- a/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/rolemap.xml
+++ b/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/rolemap.xml
@@ -3,7 +3,7 @@
       <permission name="opengever.inbox: Add Inbox" acquire="True">
           <role name="Manager"/>
       </permission>
-      <permission name="opengever.meeting: Add Committee" acquire="True">
+      <permission name="opengever.meeting: Add CommitteeContainer" acquire="True">
           <role name="Manager"/>
       </permission>
       <permission name="opengever.repository: Add repositoryroot" acquire="True">

--- a/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/rolemap.xml
+++ b/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/rolemap.xml
@@ -1,0 +1,16 @@
+<rolemap>
+  <permissions>
+      <permission name="opengever.inbox: Add Inbox" acquire="True">
+          <role name="Manager"/>
+      </permission>
+      <permission name="opengever.meeting: Add Committee" acquire="True">
+          <role name="Manager"/>
+      </permission>
+      <permission name="opengever.repository: Add repositoryroot" acquire="True">
+          <role name="Manager"/>
+      </permission>
+      <permission name="opengever.dossier: Add templatefolder" acquire="True">
+          <role name="Manager"/>
+      </permission>
+  </permissions>
+</rolemap>

--- a/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/types/opengever.meeting.committeecontainer.xml
+++ b/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/types/opengever.meeting.committeecontainer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="opengever.meeting.committeecontainer" meta_type="Dexterity FTI"
+        i18n:domain="opengever.meeting" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- add permission -->
+  <property name="add_permission">opengever.meeting.AddCommitteeContainer</property>
+
+</object>

--- a/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/upgrade.py
+++ b/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/upgrade.py
@@ -7,4 +7,3 @@ class AllowAddRootContentOnlyForManager(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-

--- a/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/upgrade.py
+++ b/opengever/base/upgrades/20170215175054_allow_add_root_content_only_for_manager/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowAddRootContentOnlyForManager(UpgradeStep):
+    """Allow add root content only for manager.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+

--- a/opengever/dossier/profiles/default/rolemap.xml
+++ b/opengever/dossier/profiles/default/rolemap.xml
@@ -16,9 +16,6 @@
     </permission>
     <permission name="opengever.dossier: Add templatefolder" acquire="True">
       <role name="Manager"/>
-      <role name="Owner"/>
-      <role name="Contributor"/>
-      <role name="Administrator"/>
     </permission>
     <permission name="opengever.dossier: Add dossiertemplate" acquire="True">
       <role name="Manager"/>

--- a/opengever/inbox/profiles/default/rolemap.xml
+++ b/opengever/inbox/profiles/default/rolemap.xml
@@ -4,9 +4,6 @@
 
     <permission name="opengever.inbox: Add Inbox" acquire="True">
       <role name="Manager"/>
-      <role name="Owner"/>
-      <role name="Contributor"/>
-      <role name="Administrator"/>
     </permission>
 
     <permission name="opengever.inbox: Add Forwarding" acquire="True">

--- a/opengever/inbox/tests/test_inbox.py
+++ b/opengever/inbox/tests/test_inbox.py
@@ -10,12 +10,6 @@ import transaction
 
 class TestInbox(FunctionalTestCase):
 
-    def setUp(self):
-        super(TestInbox, self).setUp()
-
-        self.org_unit2 = create(Builder('org_unit').id('client2')
-                                .having(admin_unit=self.admin_unit))
-
     @browsing
     def test_adding(self, browser):
         self.grant('Manager')

--- a/opengever/inbox/tests/test_inbox_container.py
+++ b/opengever/inbox/tests/test_inbox_container.py
@@ -3,8 +3,40 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
+from opengever.inbox.container import IInboxContainer
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
+
+
+class TestInboxContainer(FunctionalTestCase):
+
+    @browsing
+    def test_adding(self, browser):
+        self.grant('Manager')
+        add_languages(['de-ch'])
+        browser.login().open()
+        factoriesmenu.add('Inbox Container')
+        browser.fill({'Title': 'Inbox Container'}).save()
+
+        self.assertTrue(IInboxContainer.providedBy(browser.context))
+
+    @browsing
+    def test_is_only_addable_by_manager(self, browser):
+        browser.login().open()
+
+        self.grant('Administrator')
+        browser.reload()
+        self.assertNotIn(
+            'Inbox Container',
+            factoriesmenu.addable_types()
+            )
+
+        self.grant('Manager')
+        browser.reload()
+        self.assertIn(
+            'Inbox Container',
+            factoriesmenu.addable_types()
+            )
 
 
 class TestInboxView(FunctionalTestCase):
@@ -40,6 +72,7 @@ class TestInboxView(FunctionalTestCase):
     @browsing
     def test_supports_translated_title(self, browser):
         add_languages(['de-ch', 'fr-ch'])
+        self.grant('Manager')
 
         browser.login().open()
         factoriesmenu.add('Inbox Container')

--- a/opengever/meeting/permissions.zcml
+++ b/opengever/meeting/permissions.zcml
@@ -8,6 +8,11 @@
           />
 
     <permission
+          id="opengever.meeting.AddCommitteeContainer"
+          title="opengever.meeting: Add CommitteeContainer"
+          />
+
+    <permission
           id="opengever.meeting.AddCommittee"
           title="opengever.meeting: Add Committee"
           />

--- a/opengever/meeting/profiles/default/rolemap.xml
+++ b/opengever/meeting/profiles/default/rolemap.xml
@@ -13,8 +13,14 @@
       <role name="Administrator"/>
     </permission>
 
+    <permission name="opengever.meeting: Add CommitteeContainer" acquire="True">
+      <role name="Manager"/>
+    </permission>
+
     <permission name="opengever.meeting: Add Committee" acquire="True">
       <role name="Manager"/>
+      <role name="Contributor"/>
+      <role name="Administrator"/>
     </permission>
 
     <permission name="opengever.meeting: Add Member" acquire="True">

--- a/opengever/meeting/profiles/default/rolemap.xml
+++ b/opengever/meeting/profiles/default/rolemap.xml
@@ -15,8 +15,6 @@
 
     <permission name="opengever.meeting: Add Committee" acquire="True">
       <role name="Manager"/>
-      <role name="Contributor"/>
-      <role name="Administrator"/>
     </permission>
 
     <permission name="opengever.meeting: Add Member" acquire="True">

--- a/opengever/meeting/profiles/default/types/opengever.meeting.committeecontainer.xml
+++ b/opengever/meeting/profiles/default/types/opengever.meeting.committeecontainer.xml
@@ -20,7 +20,7 @@
   <property name="klass">opengever.meeting.committeecontainer.CommitteeContainer</property>
 
   <!-- add permission -->
-  <property name="add_permission">opengever.meeting.AddCommittee</property>
+  <property name="add_permission">opengever.meeting.AddCommitteeContainer</property>
 
   <!-- enabled behaviors -->
   <property name="behaviors">

--- a/opengever/repository/profiles/default/rolemap.xml
+++ b/opengever/repository/profiles/default/rolemap.xml
@@ -10,9 +10,6 @@
     </permission>
     <permission name="opengever.repository: Add repositoryroot" acquire="True">
       <role name="Manager"/>
-      <role name="Owner"/>
-      <role name="Contributor"/>
-      <role name="Administrator"/>
     </permission>
     <permission name="opengever.repository: Unlock Reference Prefix" acquire="True">
       <role name="Manager" />

--- a/opengever/repository/tests/test_repository_root.py
+++ b/opengever/repository/tests/test_repository_root.py
@@ -1,9 +1,41 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.repository.repositoryroot import IRepositoryRoot
+from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
 
 
 class TestRepositoryRoot(FunctionalTestCase):
+
+    @browsing
+    def test_adding(self, browser):
+        self.grant('Manager')
+        add_languages(['de-ch'])
+        browser.login().open()
+        factoriesmenu.add('RepositoryRoot')
+        browser.fill({'Title': 'RepositoryRoot'}).save()
+
+        self.assertTrue(IRepositoryRoot.providedBy(browser.context))
+
+    @browsing
+    def test_is_only_addable_by_manager(self, browser):
+        browser.login().open()
+
+        self.grant('Administrator')
+        browser.reload()
+        self.assertNotIn(
+            'RepositoryRoot',
+            factoriesmenu.addable_types()
+            )
+
+        self.grant('Manager')
+        browser.reload()
+        self.assertIn(
+            'RepositoryRoot',
+            factoriesmenu.addable_types()
+            )
 
     def test_repository_root_name_from_title(self):
         root = create(Builder('repository_root').having(title_de=u'Foob\xe4r'))


### PR DESCRIPTION
This PR removes the permission to add root content for administrators.

GIF as Administartor:
![screen2](https://cloud.githubusercontent.com/assets/557005/23018252/9ba932d2-f43d-11e6-8e01-c77ea59f3492.gif)

closes #2246 