### PR TITLE
Implement SPV zip file export

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Introduce new feature: SPV Zip-Export.
+  [mathias.leimgruber]
+
 - Allow certain z3c forms to be prefilled via GET requests. This is required
   after the introduction of Products.PloneHotfix20160830.
   [lgraf]

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -76,4 +76,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IMeetingWrapper"
+      name="zipexport"
+      class=".zipexport.MeetingZipExport"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -341,6 +341,9 @@ class MeetingView(BrowserView):
     def url_agendaitem_list(self):
         return self.model.get_url(view='agenda_item_list')
 
+    def url_zipexport(self):
+        return self.model.get_url(view='zipexport')
+
     def url_manually_generate_excerpt(self):
         return self.model.get_url(view='generate_excerpt')
 

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -208,6 +208,15 @@
                 </div>
               </div>
 
+              <div class="item zip-download" i18n:domain="ftw.zipexport">
+                <span class="title" i18n:translate="">Export as Zip</span>
+                <a href="#" class="download-zipexport-btn"
+                   tal:attributes="href view/url_zipexport"
+                   title="label_zip_download"
+                   i18n:attributes="title">
+                </a>
+              </div>
+
             </div>
 
             <div class="list-group-item excerpts" tal:define="excerpts view/manually_generated_excerpts">

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -208,8 +208,8 @@
                 </div>
               </div>
 
-              <div class="item zip-download" i18n:domain="ftw.zipexport">
-                <span class="title" i18n:translate="">Export as Zip</span>
+              <div class="item zip-download">
+                <span class="title" i18n:translate="" i18n:domain="ftw.zipexport">Export as Zip</span>
                 <a href="#" class="download-zipexport-btn"
                    tal:attributes="href view/url_zipexport"
                    title="label_zip_download"

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -37,7 +37,7 @@ class MeetingZipExport(BrowserView):
 
             # Return zip
             zip_file = generator.generate()
-            filename = '{}.zip'.format(self.model.title.encode('utf-8'))
+            filename = '{}.zip'.format(normalize_path(self.model.title))
             response.setHeader(
                 "Content-Disposition",
                 'inline; filename="{0}"'.format(

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -92,7 +92,5 @@ class MeetingZipExport(BrowserView):
 
         if self.model.agenda_items and has_template:
             view = self.context.restrictedTraverse('@@agenda_item_list')
-            doc = view()
-            filename = cgi.parse_header(view.request.response.getHeader(
-                "Content-Disposition"))[1]['filename']
-            generator.add_file(filename, StringIO(doc))
+            generator.add_file(view.get_document_filename(),
+                               StringIO(view.create_agenda_item_list()))

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -1,0 +1,66 @@
+from ftw.zipexport.generation import ZipGenerator
+from opengever.meeting import _
+from opengever.meeting.command import CreateGeneratedDocumentCommand
+from opengever.meeting.command import ProtocolOperations
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
+from StringIO import StringIO
+from zope.i18n import translate
+from ZPublisher.Iterators import filestream_iterator
+import os
+import pytz
+
+
+class MeetingZipExport(BrowserView):
+
+    def __init__(self, context, request):
+        super(MeetingZipExport, self).__init__(context, request)
+        self.model = self.context.model
+
+    def __call__(self):
+        # Download zip file
+
+        return self.generate_zip()
+
+    def generate_zip(self):
+        response = self.request.response
+
+        with ZipGenerator() as generator:
+            # Protocol
+            generator.add_file(*self.get_protocol())
+
+            # Return zip
+            zip_file = generator.generate()
+            filename = '{}.zip'.format(self.model.title.encode('utf-8'))
+            response.setHeader(
+                "Content-Disposition",
+                'inline; filename="{0}"'.format(
+                    safe_unicode(filename).encode('utf-8')))
+            response.setHeader("Content-type", "application/zip")
+            response.setHeader(
+                "Content-Length",
+                os.stat(zip_file.name).st_size)
+
+            return filestream_iterator(zip_file.name, 'rb')
+
+    def get_protocol(self):
+        if self.model.has_protocol_document():
+            protocol = self.model.protocol_document.resolve_document()
+            protocol_modified = protocol.modified().asdatetime().astimezone(
+                pytz.utc)
+
+            if self.model.modified < protocol_modified:
+                # Return current protocol
+                namedfile = protocol.file
+                return (namedfile.filename, namedfile.open())
+
+        # Create new protocol
+        operations = ProtocolOperations()
+        command = CreateGeneratedDocumentCommand(
+            self.context,
+            self.model,
+            operations,
+            lock_document_after_creation=False)
+
+        filename = operations.get_filename(self.model)
+        return (filename, StringIO(command.generate_file_data()))

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -57,8 +57,8 @@ class MeetingZipExport(BrowserView):
 
             if self.model.modified < protocol_modified:
                 # Return current protocol
-                namedfile = protocol.file
-                return (namedfile.filename, namedfile.open())
+                return (u'{}.docx'.format(safe_unicode(protocol.Title())),
+                        protocol.file.open())
 
         # Create new protocol
         operations = ProtocolOperations()
@@ -68,7 +68,7 @@ class MeetingZipExport(BrowserView):
             operations,
             lock_document_after_creation=False)
 
-        filename = operations.get_filename(self.model)
+        filename = u'{}.docx'.format(operations.get_title(self.model))
         return (filename, StringIO(command.generate_file_data()))
 
     def add_agenda_items_attachments(self, generator):
@@ -78,13 +78,13 @@ class MeetingZipExport(BrowserView):
                 continue
 
             for document in agenda_item.proposal.resolve_submitted_documents():
-                namedfile = document.file                
+                extension = os.path.splitext(document.file.filename)[1]
                 path = u'{} {}/{}'.format(
                     agenda_item.number,
                     agenda_item.proposal.title,
-                    namedfile.filename
+                    safe_unicode(document.Title()) + extension
                 )
-                generator.add_file(path, namedfile.open())
+                generator.add_file(path, document.file.open())
 
     def add_agenda_item_list(self, generator):
         has_template = AgendaItemListOperations().get_sablon_template(

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-07 10:03+0000\n"
+"POT-Creation-Date: 2017-02-23 07:21+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:365
+#: ./opengever/meeting/command.py:364
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:293
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -57,16 +57,16 @@ msgstr "Neue Periode hinzufügen"
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:399
+#: ./opengever/meeting/command.py:398
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:418
+#: ./opengever/meeting/browser/meetings/meeting.py:421
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -122,11 +122,11 @@ msgstr "Traktandum löschen"
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ./opengever/meeting/command.py:328
+#: ./opengever/meeting/command.py:327
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:283
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -155,7 +155,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -232,7 +232,7 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:281
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:290
 msgid "Number"
 msgstr "Nummer"
 
@@ -240,15 +240,15 @@ msgstr "Nummer"
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:288
 msgid "Order"
 msgstr "Sortierung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:253
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:262
 msgid "Paragraph:"
 msgstr "Abschnitt:"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:133
+#: ./opengever/meeting/browser/meetings/excerpt.py:134
 msgid "Please select at least one agenda item."
 msgstr "Bitte wählen Sie mindestens ein Traktandum aus."
 
@@ -266,7 +266,7 @@ msgstr "Eigenschaften"
 msgid "Proposal"
 msgstr "Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:263
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:272
 msgid "Proposals:"
 msgstr "Anträge"
 
@@ -298,7 +298,7 @@ msgid "Sablon Template"
 msgstr "Sablon Vorlage"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:120
+#: ./opengever/meeting/browser/meetings/excerpt.py:121
 #: ./opengever/meeting/browser/meetings/protocol.py:204
 msgid "Save"
 msgstr "Speichern"
@@ -315,7 +315,7 @@ msgstr "Mehr anzeigen"
 msgid "Submitted Proposal"
 msgstr "Eingereichten Antrag"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:242
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:251
 msgid "Text:"
 msgstr "Freitext:"
 
@@ -327,7 +327,7 @@ msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich ers
 msgid "The proposal has been rejected successfully"
 msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:282
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:291
 msgid "Title"
 msgstr "Titel"
 
@@ -343,7 +343,7 @@ msgstr "Traktandum detraktandieren"
 msgid "Update or create the protocol"
 msgstr "Das Protokoll wird erstellt oder aktualisiert"
 
-#: ./opengever/meeting/browser/submitdocuments.py:200
+#: ./opengever/meeting/browser/submitdocuments.py:201
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
@@ -351,7 +351,7 @@ msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier übe
 msgid "Updated with a newer excerpt version."
 msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
 
-#: ./opengever/meeting/command.py:260
+#: ./opengever/meeting/command.py:259
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
@@ -413,7 +413,7 @@ msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
-#: ./opengever/meeting/browser/documents/submit.py:95
+#: ./opengever/meeting/browser/documents/submit.py:96
 #: ./opengever/meeting/browser/meetings/meeting.py:187
 msgid "button_cancel"
 msgstr "Abbrechen"
@@ -430,8 +430,8 @@ msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Submit Attachments"
-#: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:78
+#: ./opengever/meeting/browser/documents/submit.py:82
+#: ./opengever/meeting/browser/submitdocuments.py:79
 msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
@@ -591,7 +591,7 @@ msgstr "Inhaltsverzeichnis ${period} ${committee} alphabetisch"
 msgid "filename_repository_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} nach Ordnungsposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:226
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
@@ -654,7 +654,7 @@ msgid "label_attachments"
 msgstr "Anhänge"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:152
+#: ./opengever/meeting/browser/meetings/excerpt.py:153
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
 msgstr "Abbrechen"
@@ -733,7 +733,7 @@ msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py:368
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
@@ -754,7 +754,7 @@ msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py:366
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -806,12 +806,12 @@ msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
@@ -826,7 +826,7 @@ msgid "label_edit_period"
 msgstr "Bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:364
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -848,7 +848,7 @@ msgid "label_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:274
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -870,7 +870,7 @@ msgid "label_initial_position"
 msgstr "Ausgangslage"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:256
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -928,7 +928,7 @@ msgid "label_next_meeting"
 msgstr "Nächste Sitzung:"
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:222
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:231
 msgid "label_no_excerpts"
 msgstr "Es wurden noch keine zusätzlichen Protokollauszüge generiert."
 
@@ -938,7 +938,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:386
+#: ./opengever/meeting/browser/meetings/meeting.py:389
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -1000,12 +1000,12 @@ msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:371
+#: ./opengever/meeting/browser/meetings/meeting.py:374
 msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
@@ -1021,8 +1021,8 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:385
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
+#: ./opengever/meeting/browser/meetings/meeting.py:388
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:254
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -1084,6 +1084,10 @@ msgstr "Kommende Sitzungen"
 #: ./opengever/meeting/proposal.py:229
 msgid "label_workflow_state"
 msgstr "Status"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:213
+msgid "label_zip_download"
+msgstr "Zip-Datei herunterladen"
 
 #. Default: "Language"
 #: ./opengever/meeting/proposal.py:88
@@ -1149,7 +1153,7 @@ msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
 #. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:25
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:26
 msgid "msg_no_agenaitem_list_template"
 msgstr "Es ist keine Vorlage für die Traktandenliste konfiguriert, die Traktandenliste konnte nicht generiert werden."
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-07 10:03+0000\n"
+"POT-Creation-Date: 2017-02-23 07:21+0000\n"
 "PO-Revision-Date: 2016-08-10 05:19+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/meeting/command.py:365
+#: ./opengever/meeting/command.py:364
 msgid "A new submitted version of document ${title} has been created"
 msgstr "Une nouvelle version soumis du document ${title} a été créeé"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:293
 msgid "Actions"
 msgstr ""
 
@@ -59,16 +59,16 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:399
+#: ./opengever/meeting/command.py:398
 msgid "Additional document ${title} has been submitted successfully"
 msgstr "Le document supplémentaire ${title} a été soumis avec succès"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:418
+#: ./opengever/meeting/browser/meetings/meeting.py:421
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -124,11 +124,11 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:328
+#: ./opengever/meeting/command.py:327
 msgid "Document ${title} has already been submitted in that version"
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:283
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
 msgid "Documents"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
 msgid "Excerpts"
 msgstr ""
 
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:281
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:290
 msgid "Number"
 msgstr ""
 
@@ -242,15 +242,15 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:288
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:253
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:262
 msgid "Paragraph:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:133
+#: ./opengever/meeting/browser/meetings/excerpt.py:134
 msgid "Please select at least one agenda item."
 msgstr ""
 
@@ -268,7 +268,7 @@ msgstr "Propriétés"
 msgid "Proposal"
 msgstr "Proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:263
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:272
 msgid "Proposals:"
 msgstr ""
 
@@ -300,7 +300,7 @@ msgid "Sablon Template"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:120
+#: ./opengever/meeting/browser/meetings/excerpt.py:121
 #: ./opengever/meeting/browser/meetings/protocol.py:204
 msgid "Save"
 msgstr "Enregistrer"
@@ -317,7 +317,7 @@ msgstr "Afficher plus"
 msgid "Submitted Proposal"
 msgstr "Proposition soumise"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:242
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:251
 msgid "Text:"
 msgstr ""
 
@@ -329,7 +329,7 @@ msgstr ""
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:282
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:291
 msgid "Title"
 msgstr ""
 
@@ -345,7 +345,7 @@ msgstr ""
 msgid "Update or create the protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:200
+#: ./opengever/meeting/browser/submitdocuments.py:201
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
 
@@ -353,7 +353,7 @@ msgstr "Le document a été écrasé par une version plus récente du dossier pr
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:260
+#: ./opengever/meeting/command.py:259
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé avec une nouvelle version de la séance ${title}."
 
@@ -415,7 +415,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
-#: ./opengever/meeting/browser/documents/submit.py:95
+#: ./opengever/meeting/browser/documents/submit.py:96
 #: ./opengever/meeting/browser/meetings/meeting.py:187
 msgid "button_cancel"
 msgstr "Annuler"
@@ -432,8 +432,8 @@ msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Submit Attachments"
-#: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:78
+#: ./opengever/meeting/browser/documents/submit.py:82
+#: ./opengever/meeting/browser/submitdocuments.py:79
 msgid "button_submit_attachments"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "filename_repository_toc"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:226
 msgid "generate new excerpt"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgid "label_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:152
+#: ./opengever/meeting/browser/meetings/excerpt.py:153
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
 msgstr ""
@@ -735,7 +735,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py:368
 msgid "label_decide_action"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py:366
 msgid "label_delete_action"
 msgstr ""
 
@@ -808,12 +808,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:364
 msgid "label_edit_save"
 msgstr ""
 
@@ -850,7 +850,7 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:274
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -872,7 +872,7 @@ msgid "label_initial_position"
 msgstr "Situation initiale"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:256
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
 msgid "label_insert"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgid "label_next_meeting"
 msgstr "Prochaine séance:"
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:222
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:231
 msgid "label_no_excerpts"
 msgstr ""
 
@@ -940,7 +940,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:386
+#: ./opengever/meeting/browser/meetings/meeting.py:389
 msgid "label_no_proposals"
 msgstr ""
 
@@ -1002,12 +1002,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:371
+#: ./opengever/meeting/browser/meetings/meeting.py:374
 msgid "label_revise_action"
 msgstr ""
 
@@ -1023,8 +1023,8 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:385
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
+#: ./opengever/meeting/browser/meetings/meeting.py:388
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:254
 msgid "label_schedule"
 msgstr ""
 
@@ -1086,6 +1086,10 @@ msgstr "Prochaines séances"
 #: ./opengever/meeting/proposal.py:229
 msgid "label_workflow_state"
 msgstr "Etat"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:213
+msgid "label_zip_download"
+msgstr ""
 
 #. Default: "Language"
 #: ./opengever/meeting/proposal.py:88
@@ -1151,7 +1155,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:25
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:26
 msgid "msg_no_agenaitem_list_template"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-07 10:03+0000\n"
+"POT-Creation-Date: 2017-02-23 07:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:365
+#: ./opengever/meeting/command.py:364
 msgid "A new submitted version of document ${title} has been created"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:293
 msgid "Actions"
 msgstr ""
 
@@ -56,16 +56,16 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:399
+#: ./opengever/meeting/command.py:398
 msgid "Additional document ${title} has been submitted successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:418
+#: ./opengever/meeting/browser/meetings/meeting.py:421
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -121,11 +121,11 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:328
+#: ./opengever/meeting/command.py:327
 msgid "Document ${title} has already been submitted in that version"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:283
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
 msgid "Documents"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:215
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:224
 msgid "Excerpts"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:281
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:290
 msgid "Number"
 msgstr ""
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:288
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:253
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:262
 msgid "Paragraph:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:133
+#: ./opengever/meeting/browser/meetings/excerpt.py:134
 msgid "Please select at least one agenda item."
 msgstr ""
 
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:263
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:272
 msgid "Proposals:"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgid "Sablon Template"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:120
+#: ./opengever/meeting/browser/meetings/excerpt.py:121
 #: ./opengever/meeting/browser/meetings/protocol.py:204
 msgid "Save"
 msgstr ""
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Submitted Proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:242
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:251
 msgid "Text:"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:282
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:291
 msgid "Title"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Update or create the protocol"
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:200
+#: ./opengever/meeting/browser/submitdocuments.py:201
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:260
+#: ./opengever/meeting/command.py:259
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
@@ -412,7 +412,7 @@ msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:69
-#: ./opengever/meeting/browser/documents/submit.py:95
+#: ./opengever/meeting/browser/documents/submit.py:96
 #: ./opengever/meeting/browser/meetings/meeting.py:187
 msgid "button_cancel"
 msgstr ""
@@ -429,8 +429,8 @@ msgid "button_continue"
 msgstr ""
 
 #. Default: "Submit Attachments"
-#: ./opengever/meeting/browser/documents/submit.py:81
-#: ./opengever/meeting/browser/submitdocuments.py:78
+#: ./opengever/meeting/browser/documents/submit.py:82
+#: ./opengever/meeting/browser/submitdocuments.py:79
 msgid "button_submit_attachments"
 msgstr ""
 
@@ -590,7 +590,7 @@ msgstr ""
 msgid "filename_repository_toc"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:217
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:226
 msgid "generate new excerpt"
 msgstr ""
 
@@ -653,7 +653,7 @@ msgid "label_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:152
+#: ./opengever/meeting/browser/meetings/excerpt.py:153
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
 msgstr ""
@@ -732,7 +732,7 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py:368
 msgid "label_decide_action"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py:366
 msgid "label_delete_action"
 msgstr ""
 
@@ -805,12 +805,12 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:362
+#: ./opengever/meeting/browser/meetings/meeting.py:365
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:363
 msgid "label_edit_cancel"
 msgstr ""
 
@@ -825,7 +825,7 @@ msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:361
+#: ./opengever/meeting/browser/meetings/meeting.py:364
 msgid "label_edit_save"
 msgstr ""
 
@@ -847,7 +847,7 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:274
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -869,7 +869,7 @@ msgid "label_initial_position"
 msgstr ""
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:256
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:265
 msgid "label_insert"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgid "label_next_meeting"
 msgstr ""
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:222
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:231
 msgid "label_no_excerpts"
 msgstr ""
 
@@ -937,7 +937,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:386
+#: ./opengever/meeting/browser/meetings/meeting.py:389
 msgid "label_no_proposals"
 msgstr ""
 
@@ -999,12 +999,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:371
+#: ./opengever/meeting/browser/meetings/meeting.py:374
 msgid "label_revise_action"
 msgstr ""
 
@@ -1020,8 +1020,8 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:385
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt:245
+#: ./opengever/meeting/browser/meetings/meeting.py:388
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:254
 msgid "label_schedule"
 msgstr ""
 
@@ -1082,6 +1082,10 @@ msgstr ""
 #. Default: "State"
 #: ./opengever/meeting/proposal.py:229
 msgid "label_workflow_state"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt:213
+msgid "label_zip_download"
 msgstr ""
 
 #. Default: "Language"
@@ -1148,7 +1152,7 @@ msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:25
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:26
 msgid "msg_no_agenaitem_list_template"
 msgstr ""
 

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -82,7 +82,7 @@ class TestMeetingZipExportView(FunctionalTestCase):
         meeting = Meeting.query.get(meeting.meeting_id)
 
         self.assertFalse(meeting.has_protocol_document())
-        self.assertIn('Protocol-community-meeting.docx',
+        self.assertIn('Protocol-Community meeting.docx',
                       zip_file.namelist())
 
     @browsing
@@ -109,7 +109,7 @@ class TestMeetingZipExportView(FunctionalTestCase):
         meeting = Meeting.query.get(meeting.meeting_id)
 
         self.assertTrue(meeting.has_protocol_document())
-        self.assertIn('protocol-community-meeting.docx',
+        self.assertIn('Protocol-Community meeting.docx',
                       zip_file.namelist())
 
     @browsing
@@ -140,7 +140,7 @@ class TestMeetingZipExportView(FunctionalTestCase):
         # Do a modification
         browser.login().open(meeting.get_url(view='protocol'))
         browser.fill({'Title': u'This is the modified different title than '
-                               u' before'}).submit()
+                               u'before'}).submit()
         browser.open(meeting.get_url(view='zipexport'))
 
         zip_file = ZipFile(StringIO(browser.contents), 'r')
@@ -149,22 +149,22 @@ class TestMeetingZipExportView(FunctionalTestCase):
                              zip_file.filelist[0].filename)
         self.assertNotEquals(protocol.file.getSize(),
                              zip_file.filelist[0].file_size)
-        self.assertIn('Protocol-this-is-the-modified-different-title'
-                      '-than-before.docx',
+        self.assertIn('Protocol-This is the modified different title than'
+                      ' before.docx',
                       zip_file.namelist())
 
     @browsing
     def test_zip_export_agenda_items_attachments(self, browser):
         attachement1 = create(
             Builder('document')
-            .without_default_title()
+            .titled(u'Attachem\xe4nt 1')
             .attach_file_containing(u"attachement",
                                     u"attachement1.docx")
             .within(self.dossier))
 
         attachement2 = create(
             Builder('document')
-            .without_default_title()
+            .titled(u'Attachem\xe4nt 2')
             .attach_file_containing(u"attachement",
                                     u"attachement2.docx")
             .within(self.dossier))

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -1,0 +1,149 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.zipexport.zipfilestream import ZipFile
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
+from opengever.meeting.model import Meeting
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.testing import FunctionalTestCase
+from StringIO import StringIO
+import transaction
+
+
+class TestMeetingZipExportView(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+
+    def setUp(self):
+        super(TestMeetingZipExportView, self).setUp()
+        self.admin_unit.public_url = 'http://nohost/plone'
+
+        self.repo, self.repo_folder = create(Builder('repository_tree'))
+        self.dossier = create(Builder('dossier')
+                              .within(self.repo_folder))
+
+        self.meeting_dossier = create(Builder('meeting_dossier')
+                                      .titled(u'Meeting Dossier')
+                                      .within(self.repo_folder))
+
+        self.sablon_template = create(
+            Builder('sablontemplate')
+            .with_asset_file('excerpt_template.docx'))
+
+        container = create(Builder('committee_container'))
+        self.committee = create(Builder('committee')
+                                .having(protocol_template=self.sablon_template)
+                                .within(container))
+
+        self.hugo = create(Builder('member').having(firstname=u'h\xfcgo',
+                                                    lastname="Boss",
+                                                    email="boss@foo.ch"))
+
+        self.sile = create(Builder('member').having(firstname="Silvia",
+                                                    lastname="Pangani",
+                                                    email="pangani@foo.ch"))
+
+        self.peter = create(Builder('member').having(firstname="Peter",
+                                                     lastname="Meter",
+                                                     email="meter@foo.ch"))
+
+        self.hans = create(Builder('member').having(firstname="Hans",
+                                                    lastname="Besen"))
+
+        self.roland = create(Builder('member').having(firstname="Roland",
+                                                      lastname="Kuppler"))
+
+        # set correct public url, used for generated meeting urls
+        get_current_admin_unit().public_url = self.portal.absolute_url()
+        transaction.commit()
+
+    @browsing
+    def test_zip_export_generate_protocol_if_there_is_none(self, browser):
+        meeting = create(
+            Builder('meeting')
+            .having(committee=self.committee.load_model(),
+                    start=self.localized_datetime(2013, 1, 1, 8, 30),
+                    end=self.localized_datetime(2013, 1, 1, 10, 30),
+                    location='There',
+                    presidency=self.hugo,
+                    participants=[self.peter,
+                                  self.hans,
+                                  self.roland],
+                    secretary=self.sile)
+            .link_with(self.meeting_dossier))
+
+        browser.login().open(meeting.get_url(view='zipexport'))
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+        meeting = Meeting.query.get(meeting.meeting_id)
+
+        self.assertFalse(meeting.has_protocol_document())
+        self.assertIn('Protocol-community-meeting.docx',
+                      zip_file.namelist())
+
+    @browsing
+    def test_zip_export_generated_protocol(self, browser):
+        meeting = create(
+            Builder('meeting')
+            .having(committee=self.committee.load_model(),
+                    start=self.localized_datetime(2013, 1, 1, 8, 30),
+                    end=self.localized_datetime(2013, 1, 1, 10, 30),
+                    location='There',
+                    presidency=self.hugo,
+                    participants=[self.peter,
+                                  self.hans,
+                                  self.roland],
+                    secretary=self.sile)
+            .link_with(self.meeting_dossier))
+
+        # Add new protocol
+        browser.login().visit(meeting.get_url())
+        browser.css('a[href*="@@generate_protocol"]').first.click()
+        browser.open(meeting.get_url(view='zipexport'))
+
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+        meeting = Meeting.query.get(meeting.meeting_id)
+
+        self.assertTrue(meeting.has_protocol_document())
+        self.assertIn('protocol-community-meeting.docx',
+                      zip_file.namelist())
+
+    @browsing
+    def test_zip_export_generate_protocol_if_outdated(self, browser):
+        protocol = create(Builder('document')
+                          .titled(u'Protocol')
+                          .attach_file_containing(u"protocol",
+                                                  u"protocol.docx")
+                          .within(self.dossier))
+
+        generated_protocol = create(Builder('generated_protocol')
+                                    .for_document(protocol))
+
+        meeting = create(
+            Builder('meeting')
+            .having(committee=self.committee.load_model(),
+                    start=self.localized_datetime(2013, 1, 1, 8, 30),
+                    end=self.localized_datetime(2013, 1, 1, 10, 30),
+                    location='There',
+                    presidency=self.hugo,
+                    participants=[self.peter,
+                                  self.hans,
+                                  self.roland],
+                    secretary=self.sile,
+                    protocol_document=generated_protocol)
+            .link_with(self.meeting_dossier))
+
+        # Do a modification
+        browser.login().open(meeting.get_url(view='protocol'))
+        browser.fill({'Title': u'This is the modified different title than '
+                               u' before'}).submit()
+        browser.open(meeting.get_url(view='zipexport'))
+
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+
+        self.assertNotEquals(protocol.file.filename,
+                             zip_file.filelist[0].filename)
+        self.assertNotEquals(protocol.file.getSize(),
+                             zip_file.filelist[0].file_size)
+        self.assertIn('Protocol-this-is-the-modified-different-title'
+                      '-than-before.docx',
+                      zip_file.namelist())


### PR DESCRIPTION
Minimal requirements are defined in #2183, they are:
- [x] Export Protocol (DOCX)
- [x] Export AgendaItems list (DOCX)
- [x] AgendaItems Attachments

And...

- [x] AgendaItem order: prefix by agendaitem {number}
- [x] AgendaItem not in subfolder.
- [x] Move action below protocol. --> https://github.com/4teamwork/plonetheme.teamraum/pull/511
- [x] GUI Integration:
<img width="1031" alt="screen shot 2017-02-16 at 10 07 05" src="https://cloud.githubusercontent.com/assets/437933/23017375/44b67e60-f43a-11e6-927c-c3e96df9f58d.png">


Software design decision:
- [x] Use `Title` as filename when possible. (discussed with @deiferni 
- [x] Currently it uses the [ftw.zipexport default path_normalizer](https://github.com/4teamwork/ftw.zipexport/blob/master/ftw/zipexport/utils.py#L7) Umlauts for example are replaced by ascii characters (ä -> a). This normalizer is optimized and used always if ftw.zipexport is installed.
- [x] All AgendaItems attachments are in a subfolder titled like the AgendaItem
  Example structure:
```
normalized-title-of-meeting.zip
├── Agenda items attachments
│   ├── AgendaItem 1
│   │   ├── some_attachment-xyz.pdf
│   │   └── some_attachment.pdf
│   ├── AgendaItem 2
│   │   └── bla.docx
│   └── AgendaItem 3
│       ├── example.doc
│       ├── example2.pdf
│       └── example3.pdf
├── agendaitems-xyc.docx
└── protocol-xyz.docx
```
--> Example ZIP: 
[Gemeindeversammlung- 09.06.2017.zip](https://github.com/4teamwork/opengever.core/files/780259/Gemeindeversammlung-.09.06.2017.zip)
- [x] Zip filename is not normalized
- [x] Changelog entry and translations will follow if everything else is OK. 
- [x] Styles: Are allready in plontheme.teamraum master branch. https://github.com/4teamwork/plonetheme.teamraum/pull/508