### PR TITLE
Fix OfficeConnector CSS IDs in templates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Fix newstyle OfficeConnector URL support for file tooltips and Bumblebee
+  overlays.
+  [Rotonen]
+
 - Rename portal-type opengever.dossier.templatedossier to
   opengever.dossier.templatefolder.
   [elioschmutz]

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -37,7 +37,7 @@
       <li tal:define="link view/overlay/get_checkout_url" tal:condition="nocall: link">
        <tal:cond tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
          <a tal:attributes="data-officeconnector-checkout-token-url string:${context/absolute_url}/officeconnector_checkout_token"
-             id="checkout_url"
+             id="officeconnector-checkout-url"
              class="function-edit"
              href="#"
              i18n:translate="label_checkout_and_edit">
@@ -55,7 +55,7 @@
        <tal:cond tal:condition="context/@@officeconnector_settings/is_attach_enabled">
         <li>
          <a tal:attributes="data-officeconnector-attach-token-url string:${context/absolute_url}/officeconnector_attach_token"
-             id="attach_url"
+             id="officeconnector-attach-url"
              class="function-attach"
              href="#"
              i18n:translate="label_attach_to_email">

--- a/opengever/document/widgets/tooltip.pt
+++ b/opengever/document/widgets/tooltip.pt
@@ -25,7 +25,7 @@
     <li tal:condition="view/checkout_and_edit_link_available">
       <tal:cond tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
         <a tal:attributes="data-officeconnector-checkout-token-url string:${context/absolute_url}/officeconnector_checkout_token"
-            id="checkout_url"
+            id="officeconnector-checkout-url"
             class="function-edit"
             href="#"
             i18n:translate="label_checkout_and_edit">
@@ -41,7 +41,7 @@
       </tal:cond>
       <tal:cond tal:condition="context/@@officeconnector_settings/is_attach_enabled">
         <a tal:attributes="data-officeconnector-attach-token-url string:${context/absolute_url}/officeconnector_attach_token"
-            id="attach_url"
+            id="officeconnector-attach-url"
             class="function-attach"
             href="#"
             i18n:translate="label_attach_to_email">

--- a/opengever/officeconnector/tests/test_templates.py
+++ b/opengever/officeconnector/tests/test_templates.py
@@ -1,0 +1,245 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
+from ftw.testbrowser import browsing
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+from opengever.officeconnector.interfaces import IOfficeConnectorSettings
+from opengever.testing import FunctionalTestCase
+from plone import api
+
+import transaction
+
+
+class TestOfficeConnectorTemplates(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestOfficeConnectorTemplates, self).setUp()
+
+        self.root = create(Builder('repository_root'))
+        self.repo = create(Builder('repository').within(self.root))
+        self.dossier = create(Builder('dossier').within(self.repo))
+        self.document = create(Builder('document')
+                               .titled('testdocu')
+                               .within(self.dossier)
+                               .attach_file_containing(
+                                   bumblebee_asset('example.docx')
+                                   .bytes(),
+                                   u'example.docx',
+                                   )
+                               )
+
+    @browsing
+    def test_overview_template_without_officeconnector(self, browser):
+        browser.login().open(self.document, view='tabbedview_view-overview')
+
+        self.assertEqual(0, len(browser.css('#officeconnector-attach-url')))
+        self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
+
+    @browsing
+    def test_tooltip_template_without_officeconnector(self, browser):
+        browser.login().open(self.document, view='tooltip')
+
+        self.assertEqual(0, len(browser.css('#officeconnector-attach-url')))
+        self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
+
+    @browsing
+    def test_overview_template_with_officeconnector_attach(self, browser):
+        api.portal.set_registry_record(
+            'attach_to_outlook_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='tabbedview_view-overview')
+
+        self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
+        self.assertTrue(
+            'data-officeconnector-attach-token-url'
+            in browser.css('#officeconnector-attach-url')[0].outerHTML)
+
+        self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
+
+    @browsing
+    def test_overview_template_with_officeconnector_checkout(self, browser):
+        api.portal.set_registry_record(
+            'direct_checkout_and_edit_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='tabbedview_view-overview')
+
+        self.assertEqual(0, len(browser.css('#officeconnector-attach-url')))
+
+        self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
+        self.assertTrue(
+            'data-officeconnector-checkout-token-url'
+            in browser.css('#officeconnector-checkout-url')[0].outerHTML)
+
+    @browsing
+    def test_overview_template_with_officeconnector_attach_and_checkout(self, browser): # noqa
+        api.portal.set_registry_record(
+            'direct_checkout_and_edit_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record(
+            'attach_to_outlook_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='tabbedview_view-overview')
+
+        self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
+        self.assertTrue(
+            'data-officeconnector-attach-token-url'
+            in browser.css('#officeconnector-attach-url')[0].outerHTML)
+
+        self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
+        self.assertTrue(
+            'data-officeconnector-checkout-token-url'
+            in browser.css('#officeconnector-checkout-url')[0].outerHTML)
+
+    @browsing
+    def test_tooltip_template_with_officeconnector_attach(self, browser):
+        api.portal.set_registry_record(
+            'attach_to_outlook_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='tooltip')
+
+        self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
+        self.assertTrue(
+            'data-officeconnector-attach-token-url'
+            in browser.css('#officeconnector-attach-url')[0].outerHTML)
+
+        self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
+
+    @browsing
+    def test_tooltip_template_with_officeconnector_checkout(self, browser):
+        api.portal.set_registry_record(
+            'direct_checkout_and_edit_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='tooltip')
+
+        self.assertEqual(0, len(browser.css('#officeconnector-attach-url')))
+
+        self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
+        self.assertTrue(
+            'data-officeconnector-checkout-token-url'
+            in browser.css('#officeconnector-checkout-url')[0].outerHTML)
+
+    @browsing
+    def test_tooltip_template_with_officeconnector_attach_and_checkout(self, browser): #noqa
+        api.portal.set_registry_record(
+            'attach_to_outlook_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record(
+            'direct_checkout_and_edit_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='tooltip')
+
+        self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
+        self.assertTrue(
+            'data-officeconnector-attach-token-url'
+            in browser.css('#officeconnector-attach-url')[0].outerHTML)
+
+        self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
+        self.assertTrue(
+            'data-officeconnector-checkout-token-url'
+            in browser.css('#officeconnector-checkout-url')[0].outerHTML)
+
+
+class TestOfficeConnectorBumblebeeTemplates(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
+    def setUp(self):
+        super(TestOfficeConnectorBumblebeeTemplates, self).setUp()
+
+        self.root = create(Builder('repository_root'))
+        self.repo = create(Builder('repository').within(self.root))
+        self.dossier = create(Builder('dossier').within(self.repo))
+        self.document = create(Builder('document')
+                               .titled('testdocu')
+                               .within(self.dossier)
+                               .attach_file_containing(
+                                   bumblebee_asset('example.docx')
+                                   .bytes(),
+                                   u'example.docx',
+                                   )
+                               )
+
+    @browsing
+    def test_bumblebeeoverlay_template_without_officeconnector(self, browser):
+        browser.login().open(self.document, view='bumblebee-overlay-listing')
+
+        self.assertEqual(0, len(browser.css('#officeconnector-attach-url')))
+        self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
+
+    @browsing
+    def test_bumblebeeoverlay_template_with_officeconnector_attach(self, browser): #noqa
+        api.portal.set_registry_record(
+            'attach_to_outlook_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='bumblebee-overlay-listing')
+
+        self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
+        self.assertTrue(
+            'data-officeconnector-attach-token-url'
+            in browser.css('#officeconnector-attach-url')[0].outerHTML)
+
+        self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
+
+    @browsing
+    def test_bumblebeeoverlay_template_with_officeconnector_checkout(self, browser): #noqa
+        api.portal.set_registry_record(
+            'direct_checkout_and_edit_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='bumblebee-overlay-listing')
+
+        self.assertEqual(0, len(browser.css('#officeconnector-attach-url')))
+
+        self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
+        self.assertTrue(
+            'data-officeconnector-checkout-token-url'
+            in browser.css('#officeconnector-checkout-url')[0].outerHTML)
+
+    @browsing
+    def test_bumblebeeoverlay_template_with_officeconnector_attach_and_checkout(self, browser): #noqa
+        api.portal.set_registry_record(
+            'attach_to_outlook_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record(
+            'direct_checkout_and_edit_enabled',
+            True,
+            interface=IOfficeConnectorSettings)
+        transaction.commit()
+
+        browser.login().open(self.document, view='bumblebee-overlay-listing')
+
+        self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
+        self.assertTrue(
+            'data-officeconnector-attach-token-url'
+            in browser.css('#officeconnector-attach-url')[0].outerHTML)
+
+        self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
+        self.assertTrue(
+            'data-officeconnector-checkout-token-url'
+            in browser.css('#officeconnector-checkout-url')[0].outerHTML)


### PR DESCRIPTION
* Add tests for template integrity for the various similar subviews.
* Fix the subviews.

Fixes #2581.