### PR TITLE
Fix an error if the user tries to unlock a referencenumber

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Fix an error if the user tries to unlock a referencenumber in the referenceprefix manager
+  which is still in use. The user will see an error status-message instead the
+  full error-traceback.
+  [elioschmutz]
+
 - Allow add root content only for managers.
   [elioschmutz]
 

--- a/opengever/repository/browser/referenceprefix_manager.py
+++ b/opengever/repository/browser/referenceprefix_manager.py
@@ -1,13 +1,12 @@
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
 from opengever.repository import _
 from opengever.repository.events import RepositoryPrefixUnlocked
-from Products.statusmessages.interfaces import IStatusMessage
+from plone import api
 from zope.event import notify
 from zope.publisher.browser import BrowserView
 
 
 class ReferencePrefixManager(BrowserView):
-
 
     def __call__(self, *args, **kwargs):
         prefix_num = self.request.get('prefix')
@@ -18,13 +17,22 @@ class ReferencePrefixManager(BrowserView):
 
     def free_reference_prefix(self, prefix_num):
         refs = ReferenceNumberPrefixAdpater(self.context)
-        refs.free_number(prefix_num)
 
+        if refs.is_prefix_used(prefix_num):
+            api.portal.show_message(
+                _(u'statmsg_prefix_unlock_failure',
+                  default='The reference you try to unlock is still in use.'),
+                request=self.request,
+                type="error")
+            return
+
+        refs.free_number(prefix_num)
         notify(RepositoryPrefixUnlocked(self.context, prefix_num))
-        messages = IStatusMessage(self.request)
-        messages.add(_("statmsg_prefix_unlocked",
-                    default=u"Reference prefix has been unlocked."),
-                    type=u"info")
+        api.portal.show_message(
+            _("statmsg_prefix_unlocked",
+              default=u"Reference prefix has been unlocked."),
+            request=self.request,
+            type="info")
 
     def prefix_mapping(self):
         refs = ReferenceNumberPrefixAdpater(self.context)

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2016-10-18 15:37+0000\n"
+"POT-Creation-Date: 2017-02-20 15:20+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -114,18 +114,18 @@ msgstr "Die Ordnungsposition wurde erfolgreich gelöscht."
 
 #. Default: "Valid from"
 #: ./opengever/repository/repositoryfolder.py:50
-#: ./opengever/repository/repositoryroot.py:20
+#: ./opengever/repository/repositoryroot.py:22
 msgid "label_valid_from"
 msgstr "Gültig ab"
 
 #. Default: "Valid until"
 #: ./opengever/repository/repositoryfolder.py:55
-#: ./opengever/repository/repositoryroot.py:25
+#: ./opengever/repository/repositoryroot.py:27
 msgid "label_valid_until"
 msgstr "Gültig bis"
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:30
+#: ./opengever/repository/repositoryroot.py:32
 msgid "label_version"
 msgstr "Version"
 
@@ -145,7 +145,7 @@ msgid "msg_delete_confirmation"
 msgstr "Möchten Sie die aktuelle Ordnungsposition wirklich löschen?"
 
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
-#: ./opengever/repository/repositoryfolder.py:194
+#: ./opengever/repository/repositoryfolder.py:196
 msgid "msg_leafnode_warning"
 msgstr "Sie fügen eine Ordnungsposition einem Blattknoten hinzu, der bereits Dossiers enthält. Dies ist nur vorübergehend erlaubt und darin enthaltene Dossiers müssen anschliessend wieder in einen Blattknoten verschoben werden."
 
@@ -169,8 +169,13 @@ msgstr "Aktenzeichen Präfix Manager"
 msgid "responsible_org_unit"
 msgstr "Federführendes Amt"
 
+#. Default: "The reference you try to unlock is still in use."
+#: ./opengever/repository/browser/referenceprefix_manager.py:23
+msgid "statmsg_prefix_unlock_failure"
+msgstr "Das Aktenzeichen Präfix wird noch verwendet."
+
 #. Default: "Reference prefix has been unlocked."
-#: ./opengever/repository/browser/referenceprefix_manager.py:25
+#: ./opengever/repository/browser/referenceprefix_manager.py:32
 msgid "statmsg_prefix_unlocked"
 msgstr "Aktenzeichen Präfix wurde freigegeben."
 
@@ -193,3 +198,4 @@ msgstr "Aufgaben"
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt:25
 msgid "unlock"
 msgstr "Freigeben"
+

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-18 15:37+0000\n"
+"POT-Creation-Date: 2017-02-20 15:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,18 +110,18 @@ msgstr "Le numéro de la position a été effacé avec succès."
 
 #. Default: "Valid from"
 #: ./opengever/repository/repositoryfolder.py:50
-#: ./opengever/repository/repositoryroot.py:20
+#: ./opengever/repository/repositoryroot.py:22
 msgid "label_valid_from"
 msgstr "Valable de :"
 
 #. Default: "Valid until"
 #: ./opengever/repository/repositoryfolder.py:55
-#: ./opengever/repository/repositoryroot.py:25
+#: ./opengever/repository/repositoryroot.py:27
 msgid "label_valid_until"
 msgstr "Valable jusqu'à :"
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:30
+#: ./opengever/repository/repositoryroot.py:32
 msgid "label_version"
 msgstr "Version"
 
@@ -141,7 +141,7 @@ msgid "msg_delete_confirmation"
 msgstr "Voulez-vous vraiment effacer le numéro de la position actuel?"
 
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
-#: ./opengever/repository/repositoryfolder.py:194
+#: ./opengever/repository/repositoryfolder.py:196
 msgid "msg_leafnode_warning"
 msgstr ""
 
@@ -165,8 +165,13 @@ msgstr "Gestionnaire de préfixes de référence"
 msgid "responsible_org_unit"
 msgstr "Service responsable"
 
+#. Default: "The reference you try to unlock is still in use."
+#: ./opengever/repository/browser/referenceprefix_manager.py:23
+msgid "statmsg_prefix_unlock_failure"
+msgstr ""
+
 #. Default: "Reference prefix has been unlocked."
-#: ./opengever/repository/browser/referenceprefix_manager.py:25
+#: ./opengever/repository/browser/referenceprefix_manager.py:32
 msgid "statmsg_prefix_unlocked"
 msgstr "Le préfixe de référence à été débloqué"
 

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-10-18 15:37+0000\n"
+"POT-Creation-Date: 2017-02-20 15:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,18 +113,18 @@ msgstr ""
 
 #. Default: "Valid from"
 #: ./opengever/repository/repositoryfolder.py:50
-#: ./opengever/repository/repositoryroot.py:20
+#: ./opengever/repository/repositoryroot.py:22
 msgid "label_valid_from"
 msgstr ""
 
 #. Default: "Valid until"
 #: ./opengever/repository/repositoryfolder.py:55
-#: ./opengever/repository/repositoryroot.py:25
+#: ./opengever/repository/repositoryroot.py:27
 msgid "label_valid_until"
 msgstr ""
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:30
+#: ./opengever/repository/repositoryroot.py:32
 msgid "label_version"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgid "msg_delete_confirmation"
 msgstr ""
 
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
-#: ./opengever/repository/repositoryfolder.py:194
+#: ./opengever/repository/repositoryfolder.py:196
 msgid "msg_leafnode_warning"
 msgstr ""
 
@@ -168,8 +168,13 @@ msgstr ""
 msgid "responsible_org_unit"
 msgstr ""
 
+#. Default: "The reference you try to unlock is still in use."
+#: ./opengever/repository/browser/referenceprefix_manager.py:23
+msgid "statmsg_prefix_unlock_failure"
+msgstr ""
+
 #. Default: "Reference prefix has been unlocked."
-#: ./opengever/repository/browser/referenceprefix_manager.py:25
+#: ./opengever/repository/browser/referenceprefix_manager.py:32
 msgid "statmsg_prefix_unlocked"
 msgstr ""
 

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
 from opengever.journal.tests.utils import get_journal_entry
 from opengever.testing import FunctionalTestCase
@@ -109,3 +110,20 @@ class TestReferencePrefixManager(FunctionalTestCase):
         self.assertEquals(
             'Unlocked prefix 1 in weiterbildung.',
             translate(journal.get('action').get('title')))
+
+    @browsing
+    def test_successfully_unlock_shows_statusmessage(self, browser):
+        browser.login().open(self.repo, view='referenceprefix_manager')
+        browser.css('.unlock').first.click()
+
+        self.assertEqual(
+            ['Reference prefix has been unlocked.'],
+            statusmessages.info_messages())
+
+    @browsing
+    def test_error_while_unlock_shows_statusmessage(self, browser):
+        browser.login().open(self.repo, view='referenceprefix_manager?prefix=2')
+
+        self.assertEqual(
+            ['The reference you try to unlock is still in use.'],
+            statusmessages.error_messages())


### PR DESCRIPTION
Fix an error if the user tries to unlock a referencenumber in the referenceprefix manager which is still in use.

The user will see an error status-message instead the full errror-traceback.

![bildschirmfoto 2017-02-16 um 18 05 06](https://cloud.githubusercontent.com/assets/557005/23031924/0a0bdd58-f473-11e6-89b9-bbf1661cb4c0.png)

closes #2465 