### PR TITLE
testing: install opengever.policy.base:default.

### DIFF
--- a/opengever/base/tests/test_pasting_allowed.py
+++ b/opengever/base/tests/test_pasting_allowed.py
@@ -18,7 +18,7 @@ class TestPastingAllowed(FunctionalTestCase):
 
         browser.open(contactfolder)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(['Export as Zip'], actions)
+        self.assertSequenceEqual([], actions)
 
     @browsing
     def test_paste_action_not_displayed_for_templatefolder(self, browser):
@@ -47,7 +47,7 @@ class TestPastingAllowed(FunctionalTestCase):
         browser.open(mail)
         actions = browser.css('#plone-contentmenu-actions li').text
         self.assertSequenceEqual(
-            ['Export as Zip', 'Properties', 'save attachments'], actions)
+            ['Properties', 'save attachments'], actions)
 
     @browsing
     def test_pasting_not_allowed_if_disallowed_subobject_type(self, browser):

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -196,6 +196,7 @@ class OpengeverFixture(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         self.installOpengeverProfiles(portal)
         self.setupLanguageTool(portal)
+        self.allowAllTypes(portal)
         deactivate_activity_center()
         deactivate_bumblebee_feature()
 
@@ -212,45 +213,7 @@ class OpengeverFixture(PloneSandboxLayer):
         os.environ['BUMBLEBEE_DEACTIVATE'] = "True"
 
     def installOpengeverProfiles(self, portal):
-        # Copied from metadata.zxml of opengever.policy.base:default
-        # The aim is to use the opengever.policy.base:default here, but it
-        # changes some things such as the language which will result in
-        # lots of failing tests.
-        applyProfile(portal, 'plone.app.dexterity:default')
-        applyProfile(portal, 'plone.app.registry:default')
-        applyProfile(portal, 'plone.app.relationfield:default')
-        applyProfile(portal, 'opengever.globalindex:default')
-        applyProfile(portal, 'opengever.ogds.base:default')
-        applyProfile(portal, 'opengever.base:default')
-        applyProfile(portal, 'opengever.document:default')
-        applyProfile(portal, 'opengever.mail:default')
-        applyProfile(portal, 'opengever.dossier:default')
-        applyProfile(portal, 'opengever.repository:default')
-        applyProfile(portal, 'opengever.journal:default')
-        applyProfile(portal, 'opengever.task:default')
-        applyProfile(portal, 'opengever.tabbedview:default')
-        applyProfile(portal, 'opengever.trash:default')
-        applyProfile(portal, 'opengever.inbox:default')
-        applyProfile(portal, 'opengever.tasktemplates:default')
-        applyProfile(portal, 'opengever.portlets.tree:default')
-        applyProfile(portal, 'opengever.contact:default')
-        applyProfile(portal, 'opengever.advancedsearch:default')
-        applyProfile(portal, 'opengever.sharing:default')
-        applyProfile(portal, 'opengever.latex:default')
-        applyProfile(portal, 'opengever.meeting:default')
-        applyProfile(portal, 'opengever.activity:default')
-        applyProfile(portal, 'opengever.bumblebee:default')
-        applyProfile(portal, 'opengever.officeatwork:default')
-        applyProfile(portal, 'opengever.officeconnector:default')
-        applyProfile(portal, 'opengever.private:default')
-        applyProfile(portal, 'ftw.datepicker:default')
-        applyProfile(portal, 'plone.formwidget.autocomplete:default')
-        applyProfile(portal, 'plone.formwidget.contenttree:default')
-        applyProfile(portal, 'ftw.contentmenu:default')
-        applyProfile(portal, 'ftw.zipexport:default')
-        applyProfile(portal, 'opengever.disposition:default')
-        applyProfile(portal, 'plone.restapi:default')
-
+        applyProfile(portal, 'opengever.policy.base:default')
         applyProfile(portal, 'opengever.testing:testing')
 
     def createMemberFolder(self, portal):
@@ -263,22 +226,19 @@ class OpengeverFixture(PloneSandboxLayer):
     def setupLanguageTool(self, portal):
         """Configure the language tool as close as possible to production,
         without breaking most of the existing tests.
-
-        For production, the language tool is configured in
-        opengever.policy.base:default, which we don't import here
-        (see comment in installOpengeverProfiles() above).
         """
         lang_tool = api.portal.get_tool('portal_languages')
-        lang_tool.use_combined_language_codes = True
-        lang_tool.display_flags = False
-        lang_tool.start_neutral = False
-        lang_tool.use_subdomain_negotiation = False
-        lang_tool.authenticated_users_only = False
-        lang_tool.use_request_negotiation = True
+        lang_tool.setDefaultLanguage('en')
+        lang_tool.supported_langs = ['en']
 
-        # These would be (possible) production defaults, but will break tests
-        # lang_tool.setDefaultLanguage('de-ch')
-        # lang_tool.supported_langs = ['fr-ch', 'de-ch']
+    def allowAllTypes(self, portal):
+        """Some tests rely on being able to add things to the site root.
+        Because of historical reasons we therefore set filter_content_types
+        to False in order to allow that.
+        We need to change the tests in the future so that we no longer need
+        to do that.
+        """
+        portal.portal_types['Plone Site'].filter_content_types = False
 
 
 class MemoryDBLayer(Layer):

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -256,7 +256,7 @@ class TestProposal(FunctionalTestCase):
         submitted_proposal = api.portal.get().restrictedTraverse(
             proposal.load_model().submitted_physical_path.encode('utf-8'))
         browser.login().open(submitted_proposal)
-        self.assertEqual(['Edit', 'Sharing'],
+        self.assertEqual(['Edit'],
                          browser.css('#content-views li').text)
 
         proposal_model = submitted_proposal.load_model()
@@ -265,7 +265,7 @@ class TestProposal(FunctionalTestCase):
 
         # cannot edit decided SubmittedProposal
         browser.open(submitted_proposal)
-        self.assertEqual(['Sharing'],
+        self.assertEqual([],
                          browser.css('#content-views li').text)
         with self.assertRaises(Unauthorized):
             browser.open(submitted_proposal, view='edit')

--- a/opengever/repository/tests/test_deletion.py
+++ b/opengever/repository/tests/test_deletion.py
@@ -69,8 +69,7 @@ class TestRepositoryDeletion(FunctionalTestCase):
         create(Builder('dossier').within(self.repository))
         browser.login().open(self.repository)
         self.assertEquals(
-            ['Export as Zip',
-             'Prefix Manager',
+            ['Prefix Manager',
              'Properties',
              'Sharing',
              'repositoryfolder-transition-inactivate'],
@@ -81,7 +80,6 @@ class TestRepositoryDeletion(FunctionalTestCase):
         browser.login().open(self.repository)
         self.assertEquals(
             ['Delete',
-             'Export as Zip',
              'Prefix Manager',
              'Properties',
              'Sharing',


### PR DESCRIPTION
Change the test setup so that we install ``opengever.policy.base:default`` rather than its dependencies, so that we include the configuration from the policy profile.

The language is reset to English so that we do not have to change all the tests.

Because a bunch of tests rely on having ``filter_content_types=False`` configured for the ``Plone Site`` FTI, we still keep that for now. This should be awoided for future tests and can be elminiated step by step.

----

This change was initially planned to be part of the profile merge, but it makes sense as a standalone change too.