### PR TITLE
Dossier Note Overlay: Enable CSRF protection by optimizing a test case.

### DIFF
--- a/opengever/dossier/browser/save_comments_entpoint.py
+++ b/opengever/dossier/browser/save_comments_entpoint.py
@@ -1,14 +1,12 @@
 from opengever.dossier.behaviors.dossier import IDossier
-from plone.protect.interfaces import IDisableCSRFProtection
 from Products.Five.browser import BrowserView
-from zope.interface import alsoProvides
 import json
 
 
 class SaveCommentsEndpoint(BrowserView):
 
     def __call__(self):
-        alsoProvides(self.request, IDisableCSRFProtection)
+        self.request.response.setHeader('Content-Type', 'application/json')
         self.request.response.setHeader('X-Theme-Disabled', 'True')
         self.request.response.setStatus(204)
 

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -8,6 +8,7 @@ from opengever.core.testing import activate_filing_number
 from opengever.core.testing import inactivate_filing_number
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import create_ogds_user
+from plone.protect import createToken
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
@@ -156,9 +157,12 @@ class TestDossierByline(TestBylineBase):
     @browsing
     def test_dossier_byline_save_comments_endpoint(self, browser):
         payload = '{"comments": "New comment"}'
-        browser.login().visit(self.dossier,
-                              view='save_comments',
-                              data={'data': payload})
+        browser.login().visit(self.dossier)
+
+        browser.visit(self.dossier,
+                      view='save_comments',
+                      data={'data': payload,
+                            '_authenticator': createToken()})
 
         dossier_data = IDossier(self.dossier)
         self.assertEquals("New comment", dossier_data.comments)


### PR DESCRIPTION
This is a fix of a feature introduced with #2582 
There's no changelog entry, since it's a bugfix of a feature in the same release. 