### PR TITLE
Fix keyword widget installation order.

### DIFF
--- a/opengever/base/upgrades/20170221105056_fix_keyword_widget_rolemap_customization/rolemap.xml
+++ b/opengever/base/upgrades/20170221105056_fix_keyword_widget_rolemap_customization/rolemap.xml
@@ -1,0 +1,11 @@
+<rolemap>
+    <permissions>
+
+        <permission name="ftw.keywordwidget: Add new term" acquire="False">
+            <role name="Manager"/>
+            <role name="Site Administrator"/>
+            <role name="Contributor"/>
+        </permission>
+
+    </permissions>
+</rolemap>

--- a/opengever/base/upgrades/20170221105056_fix_keyword_widget_rolemap_customization/upgrade.py
+++ b/opengever/base/upgrades/20170221105056_fix_keyword_widget_rolemap_customization/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixKeywordWidgetRolemapCustomization(UpgradeStep):
+    """Fix keyword widget rolemap customization.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/policy/base/profiles/default/metadata.xml
+++ b/opengever/policy/base/profiles/default/metadata.xml
@@ -5,6 +5,9 @@
     <dependency>profile-plone.app.registry:default</dependency>
     <dependency>profile-plone.app.relationfield:default</dependency>
 
+    <dependency>profile-ftw.keywordwidget:default</dependency>
+    <dependency>profile-ftw.keywordwidget:select2js</dependency>
+
     <dependency>profile-opengever.ogds.base:default</dependency>
     <dependency>profile-opengever.globalindex:default</dependency>
     <dependency>profile-opengever.base:default</dependency>
@@ -33,8 +36,6 @@
     <dependency>profile-opengever.private:default</dependency>
     <dependency>profile-opengever.disposition:default</dependency>
     <dependency>profile-ftw.datepicker:default</dependency>
-    <dependency>profile-ftw.keywordwidget:default</dependency>
-    <dependency>profile-ftw.keywordwidget:select2js</dependency>
     <dependency>profile-ftw.contentmenu:default</dependency>
     <dependency>profile-ftw.zipexport:default</dependency>
     <dependency>profile-plone.formwidget.autocomplete:default</dependency>


### PR DESCRIPTION
`opengever.base:default` does reconfigure the rolemap configuration of `ftw.keywordwidget`.
But because `ftw.keywordwidget` was installed _after_ `opengever.base`, the customization was overwritten with the defaults on a fresh installation.

It did work in test, because the tests do not install GEVER exactly as it is installed in production. (We will prevent such problems with #2588).
It did work when upgrading, because the upgrade step did it in the right order.

The problem by verified by checking the security configuration on the Plone site (manage_access): it is correctly configured when the Contributor-role has the "ftw.keywordwidget: Add new term" permission on the site root.

-----

This change #2539, which is installing the keywordwidget, was not yet released. Therefore I did not add a changelog entry since this fix is not relevant compared to older versions.