### PR TITLE
Hide 'Date of completion'-field on tasks add-form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Hide 'Date of completion'-field on tasks add-form.
+  [elioschmutz]
+
 - Introduce new feature: SPV Zip-Export.
   [mathias.leimgruber]
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -31,6 +31,8 @@ from Products.CMFCore.utils import _mergedLocalRoles
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from z3c.form import validator
+from z3c.form.interfaces import HIDDEN_MODE
+from z3c.form.interfaces import IAddForm
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
@@ -40,7 +42,6 @@ from zope.component import getUtility
 from zope.component import provideAdapter
 from zope.interface import implements
 from zope.schema.vocabulary import getVocabularyRegistry
-
 
 _marker = object()
 
@@ -132,6 +133,7 @@ class ITask(form.Schema):
         )
 
     form.widget(date_of_completion=DatePickerFieldWidget)
+    form.mode(IAddForm, date_of_completion=HIDDEN_MODE)
     date_of_completion = schema.Date(
         title=_(u"label_date_of_completion", default=u"Date of completion"),
         description=_(u"help_date_of_completion", default=u""),

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -76,6 +76,26 @@ class TestTaskIntegration(FunctionalTestCase):
         self.assertTrue(len(dossier.objectValues()),
                         'Expect one item in dossier')
 
+    @browsing
+    def test_hide_date_of_completion_field_in_add_form(self, browser):
+        dossier = create(Builder('dossier'))
+        browser.login().open(dossier, view='++add++opengever.task.task')
+
+        self.assertEqual(
+            'hidden',
+            browser.css('input#form-widgets-date_of_completion').first.type)
+
+    @browsing
+    def test_show_date_of_completion_field_in_edit_form(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').within(dossier).titled('Task 1'))
+
+        browser.login().visit(task, view="edit")
+
+        self.assertNotEqual(
+            'hidden',
+            browser.css('input#form-widgets-date_of_completion').first.type)
+
     def test_relateddocuments(self):
         # create document and append it to the relatedItems of the task
         doc3 = create(Builder("document").titled("a-testthree"))


### PR DESCRIPTION
Hide the 'date of copletion'-field on tasks add-form.

closes #2450 