### PR TITLE
Fix an error when creating a SIP export of documents without a file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Fix an error when creating a SIP export of documents without a file.
+  [phgross]
+
 - Allow `Administrator` to view and edit private dossiers and private
   folders.
   [deiferni]

--- a/opengever/disposition/ech0160/model/folder.py
+++ b/opengever/disposition/ech0160/model/folder.py
@@ -18,7 +18,8 @@ class Folder(object):
             self.folders.append(Folder(toc, dossier, self.path))
 
         for doc in dossier.documents.values():
-            self.files.append(File(toc, doc))
+            if doc.obj.archival_file or doc.obj.file:
+                self.files.append(File(toc, doc))
 
     def binding(self):
         ordner = arelda.ordnerSIP(self.name)

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -37,7 +37,6 @@ class TestSIPPackage(FunctionalTestCase):
             self.assertEquals(
                 u'SIP_20161106_PLONE_10\xe434', package.get_folder_name())
 
-
     def test_ablieferungs_metadata(self):
         dossier = create(Builder('dossier').within(self.folder).as_expired())
         disposition = create(Builder('disposition')
@@ -70,6 +69,20 @@ class TestSIPPackage(FunctionalTestCase):
         dossier_a_model, dossier_b_model = package.content_folder.folders
         self.assertEquals(1, len(dossier_a_model.files))
         self.assertEquals(0, len(dossier_b_model.files))
+
+    def test_handles_documents_without_a_file_correctly(self):
+        dossier_a = create(Builder('dossier').within(self.folder).as_expired())
+        create(Builder('document').with_dummy_content().within(dossier_a))
+        create(Builder('document').within(dossier_a))
+        disposition = create(Builder('disposition')
+                             .having(dossiers=[dossier_a])
+                             .within(self.folder))
+
+        package = SIPPackage(disposition)
+
+        dossier_a_model = package.content_folder.folders[0]
+        self.assertEquals(1, len(dossier_a_model.files))
+        self.assertEquals(2, len(package.dossiers[0].documents))
 
     def test_zipfile_structure(self):
         dossier_a = create(Builder('dossier').within(self.folder).as_expired())


### PR DESCRIPTION
Skip documents without a file when adding files to the schema during SIP generation, the document  without a file is still registered in the metadata.

Closes #2538 