### PR TITLE
Compare strings in the dossier-comments-overlay newline encoding insensitive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Compare strings in the dossier-comments-overlay newline encoding insensitive.
+  [elioschmutz]
+
 - Improve removal protocol title.
   [phgross]
 

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -36,7 +36,18 @@
 
         overlay.getOverlay().on('onBeforeClose', function(event){
           // Show message if there are unsaved changes
-          if (editNoteLink.data('notecache') !== overlay.getOverlay().find('textarea').val()){
+
+          /*
+          FIX: If you modify the textarea field for comments in the dossier
+          edit form, the newline encoding will be CR+LF (\r\n). After rendering the
+          template, the newline-encoding in the textarea will be LF (\n) and in the
+          data-attribute it is still CR+LF. Comparing these two strings will always
+          return false.
+
+          To fix this issue, we replace the CR+LF newlines with the LF newlines.
+           */
+          var notecache = editNoteLink.data('notecache').replace(/\r\n/g, '\n');
+          if (notecache !== overlay.getOverlay().find('textarea').val()){
             if (confirm(i18n.note_text_confirm_abord)){
               overlay.getOverlay().find('textarea').val(editNoteLink.data('notecache'));
               return true;
@@ -79,7 +90,7 @@
             editNoteLink.find('.add').addClass('hide');
           } else {
             editNoteLink.find('.edit').addClass('hide');
-            editNoteLink.find('.add').removeClass('hide');            
+            editNoteLink.find('.add').removeClass('hide');
           }
           closeNote();
           successMessage();


### PR DESCRIPTION
Removes unnecessary warning-hint after aborting the comments form.

Before:
![screen1](https://cloud.githubusercontent.com/assets/557005/23207254/f8d441a6-f8f0-11e6-96f5-7544ea5f7d1e.gif)


After:
![screen2](https://cloud.githubusercontent.com/assets/557005/23207223/d7093cb6-f8f0-11e6-95fa-1cd77c7d60b8.gif)


closes #2616 