### PR TITLE
 Allow certain z3c forms to be prefilled via GET requests

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,10 +1,12 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+    test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
     http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
     sphinx.cfg
+
+always-checkout = false
 
 parts +=
     test-inbound-mail

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Include Hotfixes in development and test buildouts.
+  [lgraf]
+
 - Translate missing "open detail view" in bumblebee-overlay.
   [elioschmutz]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Allow certain z3c forms to be prefilled via GET requests. This is required
+  after the introduction of Products.PloneHotfix20160830.
+  [lgraf]
+
 - Include Hotfixes in development and test buildouts.
   [lgraf]
 

--- a/opengever/base/browser/modelforms.py
+++ b/opengever/base/browser/modelforms.py
@@ -66,6 +66,7 @@ class ModelEditForm(AutoExtensibleForm, EditForm):
     """
 
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
     has_model_breadcrumbs = True
     schema = None
 

--- a/opengever/inbox/browser/assign.py
+++ b/opengever/inbox/browser/assign.py
@@ -30,6 +30,7 @@ class AssignForwardingForm(AssignTaskForm):
     fields = Fields(IForwardingAssignSchema)
     fields['responsible'].widgetFactory[INPUT_MODE] = AutocompleteFieldWidget
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     label = _(u'title_assign_forwarding', u'Assign Forwarding')
 

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -47,6 +47,7 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
 
     """
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     schema = ISubmitAdditionalDocument
 

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -89,6 +89,7 @@ class GenerateExcerpt(AutoExtensibleForm, EditForm):
 
     has_model_breadcrumbs = True
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
     schema = IGenerateExcerpt
 
     template = ViewPageTemplateFile('templates/excerpt.pt')

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -60,6 +60,7 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
 
     """
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     schema = ISubmitAdditionalDocuments
 

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -37,6 +37,7 @@ class ModelProxyEditForm(object):
 
     content_type = None
     fields = None
+    allow_prefill_from_GET_request = True  # XXX
 
     def render(self):
         assert self.fields, 'must specify model fields to render!'

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -66,6 +66,7 @@ class AssignTaskForm(Form):
     fields['responsible'].widgetFactory[INPUT_MODE] = \
         AutocompleteFieldWidget
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     label = _(u'title_assign_task', u'Assign task')
 

--- a/opengever/task/browser/delegate/recipients.py
+++ b/opengever/task/browser/delegate/recipients.py
@@ -40,6 +40,8 @@ class ISelectRecipientsSchema(Schema):
 class SelectRecipientsForm(DelegateWizardFormMixin, Form):
     grok.context(ITask)
 
+    allow_prefill_from_GET_request = True  # XXX
+
     fields = Fields(ISelectRecipientsSchema)
     fields['responsibles'].widgetFactory = \
         autocomplete_widget.AutocompleteMultiFieldWidget

--- a/opengever/task/browser/modify_deadline.py
+++ b/opengever/task/browser/modify_deadline.py
@@ -44,6 +44,7 @@ class ModifyDeadlineForm(Form):
 
     fields = Fields(IModifyDeadlineSchema)
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     label = _(u'title_modify_deadline', u'Modify deadline')
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -143,6 +143,9 @@ class Base(BrowserView):
 
 
 class AddForm(form.AddForm, AutoExtensibleForm):
+
+    allow_prefill_from_GET_request = True  # XXX
+
     fields = field.Fields(IResponse)
     # keep widget for converters (even though field is hidden)
     fields['transition'].widgetFactory = radio.RadioFieldWidget

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -16,6 +16,8 @@ test-egg = opengever.core[api, tests]
 [test]
 arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
 
+eggs +=
+    ${buildout:hotfix-eggs}
 
 [test-jenkins]
 test-command = bin/mtest $@


### PR DESCRIPTION
This **whitelists the prefilling of certain forms via `GET` request.**

This is necessary after the inclusion of [`Products.PloneHotfix20160830`](https://pypi.python.org/pypi/Products.PloneHotfix20160830), which disallows this behavior by default (potential for XSS and reflexive XSS).

Issues / failures happened pretty much where I expected them, and were easy to debug and fix. So even if I missed one here because it wasn't covered by our test suite, it should be trivial to ship a quick fix to address those.

---

This PR also makes sure that the **Hotfixes we use in production are also included in development and test buildouts** - besides this being a good idea anyway, this is needed to actually have the issues with form prefilling surface via failing tests (see [failed build log](https://ci.4teamwork.ch/builds/62470/tasks/89018#bottom)).

<img width="991" alt="prefill_forms_tests" src="https://cloud.githubusercontent.com/assets/405124/23212900/138c1be6-f909-11e6-8295-18bc80e9a3dd.png">


In order to get the Hotfixes included in the development buildout, I had to switch the extends order for `plone-development.cfg` and `test-plone-4.3.x.cfg`. Short of having to make sure `always-checkout` is still `False` for our development buildout, this should not result in any significant change (see `bin/buildout annotate` diff below).


---

Before / after diff for `bin/buildout annotate` for the change in `development.cfg`:


```diff
--- before.annotate    2017-02-21 18:06:23.000000000 +0100
+++ after.annotate    2017-02-21 18:07:46.000000000 +0100
@@ -5460,7 +5460,7 @@
 always-accept-server-certificate= true
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
 always-checkout= false
-    https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+    /Users/lukasgraf/Plone/buildouts/opengever/og-include-hotfixes-in-tests/development.cfg
 auto-checkout= ${buildout:development-packages}
     /Users/lukasgraf/Plone/buildouts/opengever/og-include-hotfixes-in-tests/sources.cfg
 bin-directory= bin
@@ -5517,8 +5517,14 @@
     http://plonesource.org/sources.cfg
 github-ssh= git@github.com:
     http://plonesource.org/sources.cfg
-hotfix-eggs=
-    https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+hotfix-eggs= Products.PloneHotfix20131210
+Products.PloneHotfix20150910
+Products.PloneHotfix20151208
+Products.PloneHotfix20160419
+Products.PloneHotfix20160830
+Products.PloneHotfix20161129
+Products.PloneHotfix20170117
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/hotfixes/4.3.2.cfg
 i18n-domain= ${buildout:package-namespace}
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 index= http://pypi.python.org/simple/
@@ -5578,11 +5584,6 @@
 check-translations
 dependencychecker
 test-jenkins
-instance
-zopepy
-i18n-build
-upgrade
-omelette
 gems
 sphinx
 docs-build-script-public
@@ -5590,12 +5591,17 @@
 docs-build-script-intern
 docs-build-and-publish-script-intern
 test-inbound-mail
+instance
+zopepy
+i18n-build
+upgrade
+omelette
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-base.cfg
 +=  https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
-+=  https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 +=  http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
 +=  /Users/lukasgraf/Plone/buildouts/opengever/og-include-hotfixes-in-tests/sphinx.cfg
 +=  /Users/lukasgraf/Plone/buildouts/opengever/og-include-hotfixes-in-tests/buildout.cfg
++=  https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 parts-directory= parts
     DEFAULT_VALUE
 prefer-final= false
@@ -5609,7 +5615,7 @@
 sablon-executable= ${buildout:ruby-gem-directory}/bin/sablon
     http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
 show-picked-versions= true
-    https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-base.cfg
 socket-timeout=
     DEFAULT_VALUE
 sources= sources
 ```

@deiferni 