### PR TITLE
testcase: reword ExtJS comment.

### DIFF
--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -53,8 +53,8 @@ class FunctionalTestCase(TestCase):
 
         self.grant('Contributor', 'Editor', 'Reader')
 
-        # necessary to force tabbed-view into correct mode, otherwise it only
-        # renders empty views/tabs.
+        # necessary to force tabbed-view into HTML mode, because
+        # ftw.testbrowser does not support JavaScript.
         api.portal.set_registry_record(
             'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled', False)
 


### PR DESCRIPTION
We are not enalbing the "correct mode", but just switching to HTML mode because the testbrowser does not understand JavaScript.