### PR TITLE
testing: remove assertPageContains[Not].

### DIFF
--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -164,12 +164,6 @@ class FunctionalTestCase(TestCase):
     opengever.testing.browser whenever possible.
     """
 
-    def assertPageContains(self, text):
-        self.assertIn(text, self.browser.contents)
-
-    def assertPageContainsNot(self, text):
-        self.assertNotIn(text, self.browser.contents)
-
     def assertResponseStatus(self, code):
         self.assertEquals(code, self.portal.REQUEST.response.status)
 


### PR DESCRIPTION
The helper methods "assertPageContains" and "assertPageContainsNot" assert the complete HTML, which should never be done. They are not used. Therefore we remove them.