### PR TITLE
Circumvent an IE11 security feature for OfficeConnector

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,24 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Add 'mock OfficeConnector' tests for attach and direct checkin APIs
+  [Rotonen]
+
+- A new API endpoint for OfficeConnector direct checkin payloads
+  [Rotonen]
+
+- Issue newstyle OfficeConnector URLs for direct checkins
+  [Rotonen]
+
+- A new API endpoint for OfficeConnector attach payloads
+  [Rotonen]
+
+- Issue newstyle OfficeConnector URLs for attaching to email
+  [Rotonen]
+
+- Fix OfficeConnector URLs for IE11
+  [Rotonen]
+
 - Implement several display improvements for the Dossier note overlay
   according to the feedback of @phabegger. Check #2624 for details.
   [mathias.leimgruber]

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -36,7 +36,7 @@
     <ul class="file-actions" i18n:domain="opengever.document">
       <li tal:define="link view/overlay/get_checkout_url" tal:condition="nocall: link">
        <tal:cond tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
-         <a tal:attributes="data-officeconnector-checkout-token-url string:${context/absolute_url}/officeconnector_checkout_token"
+         <a tal:attributes="data-officeconnector-checkout-url string:${context/absolute_url}/officeconnector_checkout_url"
              id="officeconnector-checkout-url"
              class="function-edit"
              href="#"
@@ -54,7 +54,7 @@
       </li>
        <tal:cond tal:condition="context/@@officeconnector_settings/is_attach_enabled">
         <li>
-         <a tal:attributes="data-officeconnector-attach-token-url string:${context/absolute_url}/officeconnector_attach_token"
+         <a tal:attributes="data-officeconnector-attach-url string:${context/absolute_url}/officeconnector_attach_url"
              id="officeconnector-attach-url"
              class="function-attach"
              href="#"

--- a/opengever/document/browser/templates/file.pt
+++ b/opengever/document/browser/templates/file.pt
@@ -35,7 +35,7 @@
           </tal:preview_support>
           <tal:cond tal:condition="checkout_and_edit_available">
             <tal:cond tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
-              <a tal:attributes="data-officeconnector-checkout-token-url string:${context/absolute_url}/officeconnector_checkout_token"
+              <a tal:attributes="data-officeconnector-checkout-url string:${context/absolute_url}/officeconnector_checkout_url"
                   id="officeconnector-checkout-url"
                   class="function-edit"
                   href="#"
@@ -52,7 +52,7 @@
               </a>
             </tal:cond>
             <tal:cond tal:condition="context/@@officeconnector_settings/is_attach_enabled">
-              <a tal:attributes="data-officeconnector-attach-token-url string:${context/absolute_url}/officeconnector_attach_token"
+              <a tal:attributes="data-officeconnector-attach-url string:${context/absolute_url}/officeconnector_attach_url"
                   id="officeconnector-attach-url"
                   class="function-attach"
                   href="#"

--- a/opengever/document/static/officeconnector.js
+++ b/opengever/document/static/officeconnector.js
@@ -1,6 +1,6 @@
 function openOfficeconnector(data) {
     // URLs the browser does not handle get passed onto the OS
-    window.location = 'officeconnector:' + JSON.parse(data)['token'];
+    window.location = JSON.parse(data)['url'];
 }
 
 var officeconnector_config = {
@@ -10,12 +10,12 @@ var officeconnector_config = {
 
 $(document).on('click', '#officeconnector-attach-url', function(event){
     event.preventDefault();
-    officeconnector_config.url = $('#officeconnector-attach-url').data('officeconnectorAttachTokenUrl');
+    officeconnector_config.url = $('#officeconnector-attach-url').data('officeconnectorAttachUrl');
     $.ajax(officeconnector_config).done(openOfficeconnector);
 });
 
 $(document).on('click', '#officeconnector-checkout-url', function(event){
     event.preventDefault();
-    officeconnector_config.url = $('#officeconnector-checkout-url').data('officeconnectorCheckoutTokenUrl')
+    officeconnector_config.url = $('#officeconnector-checkout-url').data('officeconnectorCheckoutUrl')
     $.ajax(officeconnector_config).done(openOfficeconnector);
 });

--- a/opengever/document/widgets/tooltip.pt
+++ b/opengever/document/widgets/tooltip.pt
@@ -24,7 +24,7 @@
     </li>
     <li tal:condition="view/checkout_and_edit_link_available">
       <tal:cond tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
-        <a tal:attributes="data-officeconnector-checkout-token-url string:${context/absolute_url}/officeconnector_checkout_token"
+        <a tal:attributes="data-officeconnector-checkout-url string:${context/absolute_url}/officeconnector_checkout_url"
             id="officeconnector-checkout-url"
             class="function-edit"
             href="#"
@@ -40,7 +40,7 @@
         </a>
       </tal:cond>
       <tal:cond tal:condition="context/@@officeconnector_settings/is_attach_enabled">
-        <a tal:attributes="data-officeconnector-attach-token-url string:${context/absolute_url}/officeconnector_attach_token"
+        <a tal:attributes="data-officeconnector-attach-url string:${context/absolute_url}/officeconnector_attach_url"
             id="officeconnector-attach-url"
             class="function-attach"
             href="#"

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -40,4 +40,13 @@
         permission="zope2.View"
         />
 
+    <plone:service
+        method="GET"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        accept="application/json"
+        factory=".service.OfficeConnectorAttachPayload"
+        name="oc_attach"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -49,4 +49,13 @@
         permission="zope2.View"
         />
 
+    <plone:service
+        method="GET"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        accept="application/json"
+        factory=".service.OfficeConnectorCheckoutPayload"
+        name="oc_checkout"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -26,8 +26,8 @@
         method="GET"
         for="opengever.document.document.IDocumentSchema"
         accept="application/json"
-        factory=".service.OfficeConnectorAttachToken"
-        name="officeconnector_attach_token"
+        factory=".service.OfficeConnectorAttachURL"
+        name="officeconnector_attach_url"
         permission="zope2.View"
         />
 
@@ -35,8 +35,8 @@
         method="GET"
         for="opengever.document.document.IDocumentSchema"
         accept="application/json"
-        factory=".service.OfficeConnectorCheckoutToken"
-        name="officeconnector_checkout_token"
+        factory=".service.OfficeConnectorCheckoutURL"
+        name="officeconnector_checkout_url"
         permission="zope2.View"
         />
 

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -11,7 +11,7 @@ from zExceptions import NotFound
 import json
 
 
-class OfficeConnectorToken(Service):
+class OfficeConnectorURL(Service):
 
     def create_officeconnector_url(self, payload):
         # Feature used wrong - an action is always required
@@ -56,7 +56,7 @@ class OfficeConnectorToken(Service):
         return json.dumps(response)
 
 
-class OfficeConnectorAttachToken(OfficeConnectorToken):
+class OfficeConnectorAttachURL(OfficeConnectorURL):
 
     def render(self):
         # Feature disabled or used wrong
@@ -66,7 +66,7 @@ class OfficeConnectorAttachToken(OfficeConnectorToken):
         return self.create_officeconnector_url(payload)
 
 
-class OfficeConnectorCheckoutToken(OfficeConnectorToken):
+class OfficeConnectorCheckoutURL(OfficeConnectorURL):
 
     def render(self):
         # Feature disabled or used wrong

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -161,3 +161,27 @@ class OfficeConnectorAttachPayload(OfficeConnectorPayload):
     def render(self):
         self.request.response.setHeader('Content-type', 'application/json')
         return json.dumps(self.get_base_payload())
+
+
+class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
+    """Issue JSON instruction payloads for OfficeConnector.
+
+    Consists of the minimal instruction set with which to perform a full
+    checkout checkin cycle for a file attached to a document.
+    """
+
+    def render(self):
+        payload = self.get_base_payload()
+
+        # A permission check to verify the user is also able to upload
+        if not api.user.has_permission('Modify portal content',
+                                       obj=self.document):
+            raise Forbidden
+
+        payload['checkin-with-comment'] = '@@checkin_document'
+        payload['checkin-without-comment'] = 'checkin_without_comment'
+        payload['checkout'] = '@@checkout_documents'
+        payload['edit-form'] = 'edit'
+
+        self.request.response.setHeader('Content-type', 'application/json')
+        return json.dumps(payload)

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -2,16 +2,17 @@ from opengever.document.document import IDocumentSchema
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from plone import api
-from plone.protect.utils import addTokenToUrl
 from plone.rest import Service
 from Products.CMFCore.utils import getToolByName
 from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
+from zExceptions import Forbidden
 from zExceptions import NotFound
 
 import json
 
 
 class OfficeConnectorURL(Service):
+    """Create oc:<JWT> URLs for javascript to fetch and pass to the OS."""
 
     def create_officeconnector_url(self, payload):
         # Feature used wrong - an action is always required
@@ -22,6 +23,8 @@ class OfficeConnectorURL(Service):
         if not IDocumentSchema.providedBy(self.context):
             raise NotFound
 
+        if not self.context.file:
+            raise NotFound
         plugin = None
         acl_users = getToolByName(self.context, "acl_users")
         plugins = acl_users._getOb('plugins')
@@ -39,24 +42,47 @@ class OfficeConnectorURL(Service):
                 break
 
         if not plugin:
-            raise NotFound
+            raise Forbidden
 
-        payload['download'] = addTokenToUrl('/'.join([self.context.absolute_url(), 'download_file_version'])) # noqa
-
-        # Attach the file info if this is a file
-        filename = self.context.get_filename()
-        if filename:
-            payload['filename'] = filename
-            payload['content-type'] = self.context.file.contentType
-
+        # Create a JWT for OfficeConnector - contents:
+        # action - tells OfficeConnector which code path to take
+        # url - tells OfficeConnector where from to fetch further instructions
+        payload['url'] = '/'.join([
+            api.portal.get().absolute_url(),
+            'oc_' + payload['action'],
+            api.content.get_uuid(self.context),
+            ])
         user_id = api.user.get_current().getId()
-        response = {}
-        response['token'] = plugin.create_token(user_id, data=payload)
+        token = plugin.create_token(user_id, data=payload)
 
-        return json.dumps(response)
+        # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
+        # IE11 only allows up to 507 characters for Application Protocols.
+        #
+        # This is eaten into by both the protocol identifier and the payload.
+        #
+        # In testing we've discovered for this to be a bit fuzzy and gotten
+        # arbitrary and inconsistent results of 506..509.
+        #
+        # For operational safety we've set the total url + separator + payload
+        # limit at 500 characters.
+        url = 'oc:' + token
+        self.request.response.setHeader('Content-type', 'application/json')
+        if len(url) <= 500:
+            return json.dumps(dict(url=url))
+        else:
+            self.request.response.setStatus(500)
+            return json.dumps(dict(error=dict(
+                type='Generated URL too long',
+                message='The URL is too long for IE11',
+            )))
 
 
 class OfficeConnectorAttachURL(OfficeConnectorURL):
+    """Create oc:<JWT> URLs for javascript to fetch and pass to the OS.
+
+    Instruct where to fetch an OfficeConnector 'attach' action payload for this
+    document.
+    """
 
     def render(self):
         # Feature disabled or used wrong
@@ -67,6 +93,11 @@ class OfficeConnectorAttachURL(OfficeConnectorURL):
 
 
 class OfficeConnectorCheckoutURL(OfficeConnectorURL):
+    """Create oc:<JWT> URLs for javascript to fetch and pass to the OS.
+
+    Instruct where to fetch an OfficeConnector 'checkout' action payload for
+    this document.
+    """
 
     def render(self):
         # Feature disabled or used wrong

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -49,7 +49,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
                                        'ordnungsposition/'
                                        'dossier-1/'
                                        'document-1/'
-                                       'officeconnector_attach_token')
+                                       'officeconnector_attach_url')
         self.assertEquals(404, attach_response.status_code)
 
         checkout_response = self.api.get('/'
@@ -57,7 +57,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
                                          'ordnungsposition/'
                                          'dossier-1/'
                                          'document-1/'
-                                         'officeconnector_checkout_token')
+                                         'officeconnector_checkout_url')
         self.assertEquals(404, checkout_response.status_code)
 
     def test_attach_to_outlook(self):
@@ -73,7 +73,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
                                 'ordnungsposition/'
                                 'dossier-1/'
                                 'document-1/'
-                                'officeconnector_attach_token')
+                                'officeconnector_attach_url')
         self.assertEquals(200, response.status_code)
 
         response_json = response.json()
@@ -97,7 +97,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
                                 'ordnungsposition/'
                                 'dossier-1/'
                                 'document-1/'
-                                'officeconnector_checkout_token')
+                                'officeconnector_checkout_url')
         self.assertEquals(200, response.status_code)
 
         response_json = response.json()

--- a/opengever/officeconnector/tests/test_templates.py
+++ b/opengever/officeconnector/tests/test_templates.py
@@ -54,7 +54,7 @@ class TestOfficeConnectorTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
         self.assertTrue(
-            'data-officeconnector-attach-token-url'
+            'data-officeconnector-attach-url'
             in browser.css('#officeconnector-attach-url')[0].outerHTML)
 
         self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
@@ -73,7 +73,7 @@ class TestOfficeConnectorTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
         self.assertTrue(
-            'data-officeconnector-checkout-token-url'
+            'data-officeconnector-checkout-url'
             in browser.css('#officeconnector-checkout-url')[0].outerHTML)
 
     @browsing
@@ -92,12 +92,12 @@ class TestOfficeConnectorTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
         self.assertTrue(
-            'data-officeconnector-attach-token-url'
+            'data-officeconnector-attach-url'
             in browser.css('#officeconnector-attach-url')[0].outerHTML)
 
         self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
         self.assertTrue(
-            'data-officeconnector-checkout-token-url'
+            'data-officeconnector-checkout-url'
             in browser.css('#officeconnector-checkout-url')[0].outerHTML)
 
     @browsing
@@ -112,7 +112,7 @@ class TestOfficeConnectorTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
         self.assertTrue(
-            'data-officeconnector-attach-token-url'
+            'data-officeconnector-attach-url'
             in browser.css('#officeconnector-attach-url')[0].outerHTML)
 
         self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
@@ -131,7 +131,7 @@ class TestOfficeConnectorTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
         self.assertTrue(
-            'data-officeconnector-checkout-token-url'
+            'data-officeconnector-checkout-url'
             in browser.css('#officeconnector-checkout-url')[0].outerHTML)
 
     @browsing
@@ -150,12 +150,12 @@ class TestOfficeConnectorTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
         self.assertTrue(
-            'data-officeconnector-attach-token-url'
+            'data-officeconnector-attach-url'
             in browser.css('#officeconnector-attach-url')[0].outerHTML)
 
         self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
         self.assertTrue(
-            'data-officeconnector-checkout-token-url'
+            'data-officeconnector-checkout-url'
             in browser.css('#officeconnector-checkout-url')[0].outerHTML)
 
 
@@ -198,7 +198,7 @@ class TestOfficeConnectorBumblebeeTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
         self.assertTrue(
-            'data-officeconnector-attach-token-url'
+            'data-officeconnector-attach-url'
             in browser.css('#officeconnector-attach-url')[0].outerHTML)
 
         self.assertEqual(0, len(browser.css('#officeconnector-checkout-url')))
@@ -217,7 +217,7 @@ class TestOfficeConnectorBumblebeeTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
         self.assertTrue(
-            'data-officeconnector-checkout-token-url'
+            'data-officeconnector-checkout-url'
             in browser.css('#officeconnector-checkout-url')[0].outerHTML)
 
     @browsing
@@ -236,10 +236,10 @@ class TestOfficeConnectorBumblebeeTemplates(FunctionalTestCase):
 
         self.assertEqual(1, len(browser.css('#officeconnector-attach-url')))
         self.assertTrue(
-            'data-officeconnector-attach-token-url'
+            'data-officeconnector-attach-url'
             in browser.css('#officeconnector-attach-url')[0].outerHTML)
 
         self.assertEqual(1, len(browser.css('#officeconnector-checkout-url')))
         self.assertTrue(
-            'data-officeconnector-checkout-token-url'
+            'data-officeconnector-checkout-url'
             in browser.css('#officeconnector-checkout-url')[0].outerHTML)


### PR DESCRIPTION
* New API endpoint behaviour for OfficeConnector URLs to stay under the 500 character limit
* New API endpoints for fetching action instructions per document UUID per OfficeConnector action
* 'OfficeConnector mock testing'

Fixes #2509