### PR TITLE
DefaultConstrainTypeDecider: read max dossier nesting levels from registry

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Make DefaultConstrainTypeDecider read max dossier nesting levels from
+  registry instead of hardcoding them.
+  [lgraf]
+
 - Fix an error when creating a SIP export of documents without a file.
   [phgross]
 

--- a/opengever/dossier/tests/test_constrain_type_decider.py
+++ b/opengever/dossier/tests/test_constrain_type_decider.py
@@ -1,0 +1,41 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.dossier.interfaces import IDossierContainerTypes
+from opengever.testing import FunctionalTestCase
+from plone import api
+from plone.app.testing import TEST_USER_ID
+import transaction
+
+
+class TestConstrainTypeDecider(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestConstrainTypeDecider, self).setUp()
+        self.dossier = self.create_test_dossier()
+
+    def create_test_dossier(self):
+        return create(Builder('dossier')
+                      .titled(u'Test Dossier')
+                      .having(responsible=TEST_USER_ID))
+
+    @browsing
+    def test_subdossier_addable_by_default(self, browser):
+        browser.login().open(self.dossier)
+        self.assertIn('Subdossier', factoriesmenu.addable_types())
+
+    @browsing
+    def test_subdossier_not_addable_if_nesting_level_restricted(self, browser):
+        api.portal.set_registry_record(
+            'maximum_dossier_depth', 0, interface=IDossierContainerTypes)
+        transaction.commit()
+
+        browser.login().open(self.dossier)
+        self.assertEquals([
+            'Document',
+            'document_with_template',
+            'Task',
+            'Add task from template',
+            'Participant'],
+            factoriesmenu.addable_types())


### PR DESCRIPTION
The `DefaultConstrainTypeDecider` used for dossiers used to have the maximum nesting levels hardcoded.

This change makes it determine these values dynamically from the according registry setting instead.

Also includes a **test that failed against the previous implementation**.

@deiferni 