### PR TITLE
Use correct message factory import for dossier template table columns.

### DIFF
--- a/opengever/dossier/templatefolder/tabs.py
+++ b/opengever/dossier/templatefolder/tabs.py
@@ -1,10 +1,11 @@
 from five import grok
+from opengever.dossier import _
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
-from opengever.tabbedview import _
 from opengever.tabbedview import BaseCatalogListingTab
 from opengever.tabbedview.browser.tabs import Documents, Trash
 from opengever.tabbedview.helper import linked
+
 
 REMOVED_COLUMNS = ['receipt_date', 'delivery_date', 'containing_subdossier']
 


### PR DESCRIPTION
![screen shot 2017-02-28 at 18 04 09](https://cloud.githubusercontent.com/assets/736583/23415792/9eba5fbc-fde0-11e6-8584-47244f9a49b8.png)


Fixes #2598.

_CL should not be necessary_