### PR TITLE
OGGBundle: Don't reindex during pipeline.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OGGBundle: Don't reindex during pipeline.
+  Have reindexing only happen once per object instead at the end of the
+  pipeline.
+  [lgraf]
+
 - Fix updating the proposal attachement-list after submitting a new document.
   [elioschmutz]
 

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -5,6 +5,7 @@ include =
 pipeline =
     bundlesource
     resolveguid
+    disabled-catalog-indexing
     disabled-initial-version
     constructor
     resolvetree
@@ -33,6 +34,9 @@ pipeline =
 
 [bundlesource]
 blueprint = opengever.bundle.bundlesource
+
+[disabled-catalog-indexing]
+blueprint = opengever.bundle.disabled_indexing
 
 [resolveguid]
 blueprint = opengever.bundle.resolveguid

--- a/opengever/bundle/sections/disabled_indexing.py
+++ b/opengever/bundle/sections/disabled_indexing.py
@@ -1,0 +1,24 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.base.monkey.patches.cmf_catalog_aware import DeactivatedCatalogIndexing  # noqa
+from zope.interface import classProvides
+from zope.interface import implements
+
+
+class DisabledCatalogIndexing(object):
+    """Disable automatic indexing of objects during the pipeline.
+
+    Indexing will be performed for all objects once at the end of the
+    pipeline.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+
+    def __iter__(self):
+        with DeactivatedCatalogIndexing():
+            for item in self.previous:
+                yield item

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -19,6 +19,11 @@
       />
 
   <utility
+      component=".sections.disabled_indexing.DisabledCatalogIndexing"
+      name="opengever.bundle.disabled_indexing"
+      />
+
+  <utility
     component=".sections.resolveguid.ResolveGUIDSection"
     name="opengever.bundle.resolveguid"
     />


### PR DESCRIPTION
Have reindexing only happen once per object instead at the end of the
pipeline.

@deiferni 