### PR TITLE
Make sure request url is always ascii.

### DIFF
--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -239,7 +239,8 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
 
         # Test we can upload a new version of the file
         browser.login()
-        browser.open(self.document_with_attachment, view=payload['edit-form'])
+        browser.open(self.document_with_attachment,
+                     view=str(payload['edit-form']))
         # The DATA in the file tuple needs to be seekable
         browser.fill({
             'form.widgets.file.action': 'replace',
@@ -280,7 +281,8 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
 
         # Test we can upload a new version of the file
         browser.login()
-        browser.open(self.document_with_attachment, view=payload['edit-form'])
+        browser.open(self.document_with_attachment,
+                     view=str(payload['edit-form']))
         # The DATA in the file tuple needs to be seekable
         browser.fill({
             'form.widgets.file.action': 'replace',


### PR DESCRIPTION
This circumvents unicode errors in zope.testbrowser that would happen
when concatenating ascii request body and the unicode request url that
is passed on as referer.

_This fixes the currently broken master ci builds._