### PR TITLE
Improve disposal of inactive dossiers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Improve disposal of inactive dossiers:
 
   - Set end date to current date when deactivating a dossier.
+  - Display inactive dossiers in a separate listing on the disposition overview.
 
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Improve disposal of inactive dossiers:
+
+  - Set end date to current date when deactivating a dossier.
+
+  [phgross]
+
 - Protect dossier destruction with a separate permission 'Destroy Dossier'.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 
   - Set end date to current date when deactivating a dossier.
   - Display inactive dossiers in a separate listing on the disposition overview.
+  - Preappraisal: Handle inactive dossier always as not archival worthy.
 
   [phgross]
 

--- a/opengever/disposition/appraisal.py
+++ b/opengever/disposition/appraisal.py
@@ -42,7 +42,11 @@ class Appraisal(object):
         it if exists.
 
         Sampling, unchecked and prompt aren't handled as a preselection.
+        Inactive dossiers are always handled as not archival worthy.
         """
+        if dossier.get_former_state() == 'dossier-state-inactive':
+            return False
+
         archival_value = ILifeCycle(dossier).archival_value
         if archival_value == ARCHIVAL_VALUE_UNWORTHY:
             return False

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -14,56 +14,58 @@
     </div>
   </div>
 
-  <ul class="list-group">
+  <ul class="list-group" tal:repeat="dossier_list view/get_dossier_lists">
+    <tal:define tal:define="label python: dossier_list[0];
+                            mappings python: dossier_list[1]">
 
-    <li class="list-group-item label">
-      <div class="list-group-cell data-cell">
-        <h3 i18n:translate="label_dosisers">Dossiers</h3>
-      </div>
-      <div class="list-group-cell action-cell">
-        <h3 i18n:translate="label_archive">Archive</h3>
-      </div>
-    </li>
-
-    <li tal:repeat="item view/get_dossiers_grouped_by_repository"
-        class="repository-list-item collapsible">
-
-      <tal:define tal:define="repository python: item[0]; dossiers python: item[1];">
-
-        <div class="repository_cell">
-          <div class="repository_title" tal:condition="not: context/is_closed">
-            <h3 tal:content="repository/Title" />
-            <div class="meta" i18n:domain="opengever.base" >
-              <span i18n:translate="label_archival_value">Archival value</span>:
-              <span tal:content="repository/get_archival_value" i18n:translate=""/>
-            </div>
-            <div class="collapsible-header dossier-header">
-              <span>
-                <span tal:content="python: len(dossiers)" />
-                <span i18n:translate="label_dossiers">Dossiers</span>
-              </span>
-            </div>
-          </div>
-          <div class="repository_title" tal:condition="context/is_closed">
-            <h3 tal:condition="context/is_closed" tal:content="repository" />
-            <div class="collapsible-header dossier-header">
-              <span>
-                <span tal:content="python: len(dossiers)" />
-                <span i18n:translate="label_dossiers">Dossiers</span>
-              </span>
-            </div>
-          </div>
-
-          <div class="repo-appraisal-button-group action-cell"
-               tal:condition="view/appraisal_buttons_available"
-               tal:attributes="data-intids python:[dossier.intid for dossier in dossiers]">
-            <a href="#" title="Archive" class="icon_button archive_all"
-               data-archive="true" i18n:attributes="title label_archive" />
-
-            <a href="#" title="Archive" class="icon_button not_archive_all"
-               data-archive="false" i18n:attributes="title label_archive" />
-          </div>
+      <li class="list-group-item label">
+        <div class="list-group-cell data-cell">
+          <h3 tal:content="label" i18n:translate="" />
         </div>
+        <div class="list-group-cell action-cell">
+          <h3 i18n:translate="label_archive">Archive</h3>
+        </div>
+      </li>
+
+      <li tal:repeat="item mappings"
+          class="repository-list-item collapsible">
+
+        <tal:define tal:define="repository python: item[0]; dossiers python: item[1];">
+
+          <div class="repository_cell">
+            <div class="repository_title" tal:condition="not: context/is_closed">
+              <h3 tal:content="repository/Title" />
+              <div class="meta" i18n:domain="opengever.base" >
+                <span i18n:translate="label_archival_value">Archival value</span>:
+                <span tal:content="repository/get_archival_value" i18n:translate=""/>
+              </div>
+              <div class="collapsible-header dossier-header">
+                <span>
+                  <span tal:content="python: len(dossiers)" />
+                  <span i18n:translate="label_dossiers">Dossiers</span>
+                </span>
+              </div>
+            </div>
+            <div class="repository_title" tal:condition="context/is_closed">
+              <h3 tal:condition="context/is_closed" tal:content="repository" />
+              <div class="collapsible-header dossier-header">
+                <span>
+                  <span tal:content="python: len(dossiers)" />
+                  <span i18n:translate="label_dossiers">Dossiers</span>
+                </span>
+              </div>
+            </div>
+
+            <div class="repo-appraisal-button-group action-cell"
+                 tal:condition="view/appraisal_buttons_available"
+                 tal:attributes="data-intids python:[dossier.intid for dossier in dossiers]">
+              <a href="#" title="Archive" class="icon_button archive_all"
+                 data-archive="true" i18n:attributes="title label_archive" />
+
+              <a href="#" title="Archive" class="icon_button not_archive_all"
+                 data-archive="false" i18n:attributes="title label_archive" />
+            </div>
+          </div>
 
           <ul class="dossiers">
             <li tal:repeat="dossier dossiers" class="dispositions list-group-item">
@@ -143,10 +145,11 @@
 
                 </div>
 
-            </li>
-          </ul>
+              </li>
+            </ul>
+          </tal:define>
+        </li>
       </tal:define>
-    </li>
   </ul>
 
   <div class="actionButtons clearfix">

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -59,6 +59,7 @@ class DossierDispositionInformation(object):
         self.archival_value = ILifeCycle(dossier).archival_value
         self.archival_value_annotation = ILifeCycle(dossier).archival_value_annotation
         self.appraisal = IAppraisal(disposition).get(dossier)
+        self.former_state = dossier.get_former_state()
 
     @property
     def additional_metadata_available(self):
@@ -66,6 +67,9 @@ class DossierDispositionInformation(object):
 
     def get_grouping_key(self):
         return self.parent
+
+    def was_inactive(self):
+        return self.former_state == 'dossier-state-inactive'
 
     def get_repository_title(self):
         return self.parent.Title().decode('utf-8')
@@ -78,7 +82,8 @@ class DossierDispositionInformation(object):
             'intid': self.intid,
             'reference_number': self.reference_number,
             'repository_title': self.get_repository_title(),
-            'appraisal': self.appraisal})
+            'appraisal': self.appraisal,
+            'former_state': self.former_state})
 
 
 class RemovedDossierDispositionInformation(DossierDispositionInformation):
@@ -95,6 +100,7 @@ class RemovedDossierDispositionInformation(DossierDispositionInformation):
         self.public_trial = None
         self.archival_value = None
         self.archival_value_annotation = None
+        self.former_state = dossier_mapping.get('former_state')
 
     @property
     def additional_metadata_available(self):

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-21 17:31+0000\n"
+"POT-Creation-Date: 2017-02-28 17:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,7 +50,7 @@ msgid "error_retention_period_not_expired"
 msgstr "Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen."
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:122
+#: ./opengever/disposition/disposition.py:128
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -70,7 +70,7 @@ msgid "label_appraisal"
 msgstr "Bewertungsentscheid"
 
 #. Default: "Archive"
-#: ./opengever/disposition/browser/templates/overview.pt:24
+#: ./opengever/disposition/browser/templates/overview.pt:26
 msgid "label_archive"
 msgstr "Archivieren"
 
@@ -80,12 +80,12 @@ msgid "label_archived"
 msgstr "Archiviert"
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:199
+#: ./opengever/disposition/browser/templates/overview.pt:207
 msgid "label_details"
 msgstr "Details:"
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:112
+#: ./opengever/disposition/disposition.py:118
 msgid "label_disposition"
 msgstr "Angebot"
 
@@ -101,34 +101,29 @@ msgid "label_disposition_edited"
 msgstr "Angebot bearbeitet"
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:58
+#: ./opengever/disposition/browser/overview.py:84
 msgid "label_dispositon_package_download"
 msgstr "Ablieferungspaket herunterladen"
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:121
+#: ./opengever/disposition/browser/templates/overview.pt:128
 msgid "label_dont_archive"
 msgstr "Nicht archivieren"
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/browser/templates/overview.pt:21
-msgid "label_dosisers"
-msgstr "Dossiers"
-
-#. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:122
-#: ./opengever/disposition/browser/templates/overview.pt:43
-#: ./opengever/disposition/disposition.py:135
+#: ./opengever/disposition/browser/templates/overview.pt:45
+#: ./opengever/disposition/disposition.py:141
 msgid "label_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:64
+#: ./opengever/disposition/browser/overview.py:90
 msgid "label_download_removal_protocol"
 msgstr "Löschprotokoll herunterladen"
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:52
+#: ./opengever/disposition/browser/overview.py:78
 msgid "label_export_appraisal_list_as_excel"
 msgstr "Bewertungsliste als Excel exportieren"
 
@@ -136,6 +131,11 @@ msgstr "Bewertungsliste als Excel exportieren"
 #: ./opengever/disposition/browser/removal_protocol.py:126
 msgid "label_history"
 msgstr "Verlauf"
+
+#. Default: "Inactive Dossiers"
+#: ./opengever/disposition/browser/overview.py:56
+msgid "label_inactive_dossiers"
+msgstr "Stornierte Dossiers"
 
 #. Default: "No"
 #: ./opengever/disposition/browser/removal_protocol.py:55
@@ -152,6 +152,11 @@ msgstr "Aktenzeichen"
 msgid "label_removal_protocol"
 msgstr "Löschprotokoll"
 
+#. Default: "Resolved Dossiers"
+#: ./opengever/disposition/browser/overview.py:54
+msgid "label_resolved_dossiers"
+msgstr "Abgeschlossene Dossiers"
+
 #. Default: "Review state"
 #: ./opengever/disposition/browser/listing.py:53
 msgid "label_review_state"
@@ -165,13 +170,13 @@ msgstr "Zeitpunkt"
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:48
 #: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:128
+#: ./opengever/disposition/disposition.py:134
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:156
+#: ./opengever/disposition/disposition.py:162
 msgid "label_transfer_number"
 msgstr "Ablieferungsnummer"
 
@@ -226,12 +231,12 @@ msgid "msg_disposition_updated"
 msgstr "Aktualisiert durch ${user}"
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:84
+#: ./opengever/disposition/browser/templates/overview.pt:91
 msgid "period"
 msgstr "Periode"
 
 #. Default: "Progress:"
-#: ./opengever/disposition/browser/templates/overview.pt:186
+#: ./opengever/disposition/browser/templates/overview.pt:194
 msgid "progress"
 msgstr "Verlauf:"
 

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-21 17:31+0000\n"
+"POT-Creation-Date: 2017-02-28 17:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,7 +50,7 @@ msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:122
+#: ./opengever/disposition/disposition.py:128
 msgid "fieldset_common"
 msgstr ""
 
@@ -70,7 +70,7 @@ msgid "label_appraisal"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/disposition/browser/templates/overview.pt:24
+#: ./opengever/disposition/browser/templates/overview.pt:26
 msgid "label_archive"
 msgstr ""
 
@@ -80,12 +80,12 @@ msgid "label_archived"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:199
+#: ./opengever/disposition/browser/templates/overview.pt:207
 msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:112
+#: ./opengever/disposition/disposition.py:118
 msgid "label_disposition"
 msgstr ""
 
@@ -101,40 +101,40 @@ msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:58
+#: ./opengever/disposition/browser/overview.py:84
 msgid "label_dispositon_package_download"
 msgstr ""
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:121
+#: ./opengever/disposition/browser/templates/overview.pt:128
 msgid "label_dont_archive"
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/browser/templates/overview.pt:21
-msgid "label_dosisers"
-msgstr ""
-
-#. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:122
-#: ./opengever/disposition/browser/templates/overview.pt:43
-#: ./opengever/disposition/disposition.py:135
+#: ./opengever/disposition/browser/templates/overview.pt:45
+#: ./opengever/disposition/disposition.py:141
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:64
+#: ./opengever/disposition/browser/overview.py:90
 msgid "label_download_removal_protocol"
 msgstr ""
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:52
+#: ./opengever/disposition/browser/overview.py:78
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
 #. Default: "History"
 #: ./opengever/disposition/browser/removal_protocol.py:126
 msgid "label_history"
+msgstr ""
+
+#. Default: "Inactive Dossiers"
+#: ./opengever/disposition/browser/overview.py:56
+msgid "label_inactive_dossiers"
 msgstr ""
 
 #. Default: "No"
@@ -152,6 +152,11 @@ msgstr ""
 msgid "label_removal_protocol"
 msgstr ""
 
+#. Default: "Resolved Dossiers"
+#: ./opengever/disposition/browser/overview.py:54
+msgid "label_resolved_dossiers"
+msgstr ""
+
 #. Default: "Review state"
 #: ./opengever/disposition/browser/listing.py:53
 msgid "label_review_state"
@@ -165,13 +170,13 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:48
 #: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:128
+#: ./opengever/disposition/disposition.py:134
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:156
+#: ./opengever/disposition/disposition.py:162
 msgid "label_transfer_number"
 msgstr ""
 
@@ -226,12 +231,12 @@ msgid "msg_disposition_updated"
 msgstr ""
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:84
+#: ./opengever/disposition/browser/templates/overview.pt:91
 msgid "period"
 msgstr ""
 
 #. Default: "Progress:"
-#: ./opengever/disposition/browser/templates/overview.pt:186
+#: ./opengever/disposition/browser/templates/overview.pt:194
 msgid "progress"
 msgstr ""
 

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-21 17:31+0000\n"
+"POT-Creation-Date: 2017-02-28 17:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:122
+#: ./opengever/disposition/disposition.py:128
 msgid "fieldset_common"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgid "label_appraisal"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/disposition/browser/templates/overview.pt:24
+#: ./opengever/disposition/browser/templates/overview.pt:26
 msgid "label_archive"
 msgstr ""
 
@@ -83,12 +83,12 @@ msgid "label_archived"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:199
+#: ./opengever/disposition/browser/templates/overview.pt:207
 msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:112
+#: ./opengever/disposition/disposition.py:118
 msgid "label_disposition"
 msgstr ""
 
@@ -104,40 +104,40 @@ msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:58
+#: ./opengever/disposition/browser/overview.py:84
 msgid "label_dispositon_package_download"
 msgstr ""
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:121
+#: ./opengever/disposition/browser/templates/overview.pt:128
 msgid "label_dont_archive"
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/browser/templates/overview.pt:21
-msgid "label_dosisers"
-msgstr ""
-
-#. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:122
-#: ./opengever/disposition/browser/templates/overview.pt:43
-#: ./opengever/disposition/disposition.py:135
+#: ./opengever/disposition/browser/templates/overview.pt:45
+#: ./opengever/disposition/disposition.py:141
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:64
+#: ./opengever/disposition/browser/overview.py:90
 msgid "label_download_removal_protocol"
 msgstr ""
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:52
+#: ./opengever/disposition/browser/overview.py:78
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
 #. Default: "History"
 #: ./opengever/disposition/browser/removal_protocol.py:126
 msgid "label_history"
+msgstr ""
+
+#. Default: "Inactive Dossiers"
+#: ./opengever/disposition/browser/overview.py:56
+msgid "label_inactive_dossiers"
 msgstr ""
 
 #. Default: "No"
@@ -155,6 +155,11 @@ msgstr ""
 msgid "label_removal_protocol"
 msgstr ""
 
+#. Default: "Resolved Dossiers"
+#: ./opengever/disposition/browser/overview.py:54
+msgid "label_resolved_dossiers"
+msgstr ""
+
 #. Default: "Review state"
 #: ./opengever/disposition/browser/listing.py:53
 msgid "label_review_state"
@@ -168,13 +173,13 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:48
 #: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:128
+#: ./opengever/disposition/disposition.py:134
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:156
+#: ./opengever/disposition/disposition.py:162
 msgid "label_transfer_number"
 msgstr ""
 
@@ -229,12 +234,12 @@ msgid "msg_disposition_updated"
 msgstr ""
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:84
+#: ./opengever/disposition/browser/templates/overview.pt:91
 msgid "period"
 msgstr ""
 
 #. Default: "Progress:"
-#: ./opengever/disposition/browser/templates/overview.pt:186
+#: ./opengever/disposition/browser/templates/overview.pt:194
 msgid "progress"
 msgstr ""
 

--- a/opengever/disposition/tests/test_appraisal.py
+++ b/opengever/disposition/tests/test_appraisal.py
@@ -57,6 +57,25 @@ class TestAppraisal(FunctionalTestCase):
         self.assertIsNone(IAppraisal(disposition).get(dossier4))
         self.assertIsNone(IAppraisal(disposition).get(dossier5))
 
+    def test_inactive_dossiers_are_always_not_archival_worthy(self):
+        dossier1 = create(Builder('dossier')
+                          .having(archival_value=ARCHIVAL_VALUE_SAMPLING)
+                          .as_expired()
+                          .in_state('dossier-state-inactive')
+                          .within(self.repository))
+        dossier2 = create(Builder('dossier')
+                          .having(archival_value=ARCHIVAL_VALUE_WORTHY)
+                          .as_expired()
+                          .in_state('dossier-state-inactive')
+                          .within(self.repository))
+
+        disposition = create(Builder('disposition')
+                             .having(dossiers=[dossier1, dossier2])
+                             .within(self.root))
+
+        self.assertFalse(IAppraisal(disposition).get(dossier1))
+        self.assertFalse(IAppraisal(disposition).get(dossier2))
+
     @browsing
     def test_is_updated_when_editing_the_dossier_list(self, browser):
         disposition = create(Builder('disposition')

--- a/opengever/disposition/tests/test_destruction.py
+++ b/opengever/disposition/tests/test_destruction.py
@@ -60,17 +60,20 @@ class TestDestruction(FunctionalTestCase):
              'title': u'D\xf6ssier 1',
              'appraisal': False,
              'reference_number': 'Client1 1 / 1',
-             'repository_title': u'1. Anfragen'},
+             'repository_title': u'1. Anfragen',
+             'former_state': u'dossier-state-resolved'},
             {'intid': self.dossier_intids[1],
              'title': u'D\xf6ssier 2',
              'appraisal': True,
              'reference_number': 'Client1 1 / 2',
-             'repository_title': u'1. Anfragen'},
+             'repository_title': u'1. Anfragen',
+             'former_state': u'dossier-state-resolved'},
             {'intid': self.dossier_intids[2],
              'title': u'D\xf6ssier 3',
              'appraisal': True,
              'reference_number': 'Client1 1 / 3',
-             'repository_title': u'1. Anfragen'}]
+             'repository_title': u'1. Anfragen',
+             'former_state': u'dossier-state-resolved'}]
 
         self.assertEquals(expected,
                           list(self.disposition.get_destroyed_dossiers()))

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -28,6 +28,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
         self.dossier2 = create(Builder('dossier')
                                .as_expired()
+                               .in_state('dossier-state-inactive')
                                .within(self.repository)
                                .having(title=u'Dossier B',
                                        start=date(2015, 1, 19),
@@ -216,8 +217,30 @@ class TestDispositionOverview(FunctionalTestCase):
         browser.login().open(self.disposition, view='tabbedview_view-overview')
 
         self.assertEquals(
-            ['Archival value: archival worthy with sampling'],
-            browser.css('.repository_title .meta').text)
+            'Archival value: archival worthy with sampling',
+            browser.css('.repository_title .meta').first.text)
+
+    @browsing
+    def test_displays_active_and_inactive_dossiers_separately(self, browser):
+        browser.login().open(self.disposition, view='tabbedview_view-overview')
+
+        resolved_list, inactive_list = browser.css('ul.list-group')
+
+        # resolved
+        self.assertEquals(
+            ['Resolved Dossiers', 'Archive'],
+            resolved_list.css('.label h3').text)
+        self.assertEquals(
+            ['Client1 1 / 1 Dossier A'],
+            resolved_list.css('.dispositions h3.title').text)
+
+        # inactive
+        self.assertEquals(
+            ['Inactive Dossiers', 'Archive'],
+            inactive_list.css('.label h3').text)
+        self.assertEquals(
+            ['Client1 1 / 2 Dossier B'],
+            inactive_list.css('.dispositions h3.title').text)
 
     @browsing
     def test_are_grouped_by_repository_and_sorted(self, browser):

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -337,10 +337,20 @@ class DossierContainer(Container):
         api.content.transition(obj=self, to_state=self.get_former_state())
 
     def get_former_state(self):
+        """Returns the end state of the active dossier lifecycle,
+        so `dossier-state-resolved` for resolved dossiers or
+        `dossier-state-inactive` for deactivated dossiers.
+        """
+        end_states = ['dossier-state-resolved', 'dossier-state-inactive']
+
         workflow = api.portal.get_tool('portal_workflow')
         workflow_id = workflow.getWorkflowsFor(self)[0].getId()
         history = workflow.getHistoryOf(workflow_id, self)
-        return history[1].get('review_state')
+        for entry in reversed(history):
+            if entry.get('review_state') in end_states:
+                return entry.get('review_state')
+
+        return None
 
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):

--- a/opengever/dossier/deactivate.py
+++ b/opengever/dossier/deactivate.py
@@ -1,7 +1,9 @@
 from five import grok
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.behaviors.dossier import IDossier
 from plone import api
+from datetime import date
 
 
 class DossierDeactivateView(grok.View):
@@ -26,6 +28,7 @@ class DossierDeactivateView(grok.View):
                     transition=u'dossier-transition-deactivate')
 
         # deactivate main dossier
+        self.set_end_date(self.context)
         api.content.transition(obj=self.context,
                                transition='dossier-transition-deactivate')
 
@@ -33,6 +36,10 @@ class DossierDeactivateView(grok.View):
             _("The Dossier has been deactivated"), self.request, type='info')
 
         return self.redirect()
+
+    def set_end_date(self, dossier):
+        if not IDossier(dossier).end:
+            IDossier(dossier).end = date.today()
 
     def redirect(self):
         return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from ftw.testing import freeze
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
+from plone import api
 
 
 class TestDossierContainer(FunctionalTestCase):
@@ -299,3 +300,22 @@ class TestDateCalculations(FunctionalTestCase):
             end=date(2012, 01, 01)))
 
         self.assertTrue(dossier.has_valid_enddate())
+
+    def test_get_former_state_returns_last_end_state_in_history(self):
+        self.grant('Manager', 'Editor', 'Publisher', 'Reviewer')
+
+        dossier = create(Builder("dossier"))
+
+        api.content.transition(obj=dossier, transition='dossier-transition-deactivate')
+        api.content.transition(obj=dossier, transition='dossier-transition-activate')
+        api.content.transition(obj=dossier, transition='dossier-transition-resolve')
+        api.content.transition(obj=dossier, transition='dossier-transition-offer')
+        api.content.transition(obj=dossier, transition='dossier-transition-archive')
+
+        self.assertEquals('dossier-state-resolved', dossier.get_former_state())
+
+    def test_get_former_state_returns_none_for_dossiers_was_never_in_an_end_state(self):
+        self.grant('Manager', 'Editor', 'Publisher', 'Reviewer')
+
+        dossier = create(Builder("dossier"))
+        self.assertIsNone(dossier.get_former_state())

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -1,7 +1,11 @@
+from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testing import freeze
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.protect import createToken
@@ -107,3 +111,12 @@ class TestDossierDeactivation(FunctionalTestCase):
                          api.content.get_state(subdossier1))
         self.assertEqual('dossier-state-inactive',
                          api.content.get_state(subdossier2))
+
+    @browsing
+    def test_sets_end_date_to_current_date(self, browser):
+        with freeze(datetime(2016, 3, 29)):
+            browser.login().open(self.dossier,
+                                 view='transition-deactivate',
+                                 data={'_authenticator': createToken()})
+
+        self.assertEqual(date(2016, 3, 29), IDossier(self.dossier).end)

--- a/opengever/dossier/upgrades/20170228172522_set_end_date_for_inactive_dossiers/upgrade.py
+++ b/opengever/dossier/upgrades/20170228172522_set_end_date_for_inactive_dossiers/upgrade.py
@@ -1,0 +1,31 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from plone import api
+
+
+class SetEndDateForInactiveDossiers(UpgradeStep):
+    """Set end date for inactive dossiers.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.wf_tool = api.portal.get_tool('portal_workflow')
+
+        for dossier in self.objects(
+                {'object_provides': IDossierMarker.__identifier__,
+                 'review_states': 'dossier-state-inactive'},
+                'Set endate for inactive dossiers'):
+
+            self.set_end_date(dossier)
+
+    def set_end_date(self, dossier):
+        if not IDossier(dossier).end:
+            IDossier(dossier).end = self.get_last_deactivation_date(dossier)
+
+    def get_last_deactivation_date(self, dossier):
+        workflow_id = self.wf_tool.getWorkflowsFor(dossier)[0].getId()
+        history = self.wf_tool.getHistoryOf(workflow_id, dossier)
+        for entry in reversed(history):
+            if entry.get('review_state') == 'dossier-state-inactive':
+                return entry.get('time').asdatetime().date()


### PR DESCRIPTION
- Set end date to current date when deactivating a dossier, including an upgradestep which set the end date for inactive dossiers.
- Pre appraisal: Handle inactive dossier always as not archival worthy.
- Display inactive dossiers in a separate listing on the disposition overview.

<img width="860" alt="bildschirmfoto 2017-03-01 um 17 33 48" src="https://cloud.githubusercontent.com/assets/485755/23471702/83668c16-feaa-11e6-8390-635482b7efaf.png">

