### PR TITLE
Protect dossier destruction with a separate permission 'Destroy Dossier'.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Protect dossier destruction with a separate permission 'Destroy Dossier'.
+  [phgross]
+
 - OGGBundle: Don't reindex during pipeline.
   Have reindexing only happen once per object instead at the end of the
   pipeline.

--- a/opengever/dossier/permissions.zcml
+++ b/opengever/dossier/permissions.zcml
@@ -23,4 +23,9 @@
         title="opengever.dossier: Add dossiertemplate"
         />
 
+    <permission
+        id="opengever.dossier.DestroyDossier"
+        title="opengever.dossier: Destroy dossier"
+        />
+
 </configure>

--- a/opengever/dossier/profiles/default/workflows/opengever_dossier_workflow/definition.xml
+++ b/opengever/dossier/profiles/default/workflows/opengever_dossier_workflow/definition.xml
@@ -27,6 +27,7 @@
   <permission>Delete objects</permission>
   <permission>Remove GEVER content</permission>
   <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
   <state state_id="dossier-state-active" title="dossier-state-active">
     <exit-transition transition_id="dossier-transition-deactivate"/>
     <exit-transition transition_id="dossier-transition-resolve"/>
@@ -176,6 +177,8 @@
       <permission-role>Manager</permission-role>
       <permission-role>Administrator</permission-role>
     </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False">
+    </permission-map>
   </state>
   <state state_id="dossier-state-archived" title="dossier-state-archived">
     <permission-map name="opengever.meeting: Add Proposal" acquired="False">
@@ -267,6 +270,10 @@
     <permission-map name="opengever.trash: Trash content" acquired="False">
     </permission-map>
     <permission-map name="opengever.trash: Untrash content" acquired="False">
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Records Manager</permission-role>
     </permission-map>
   </state>
   <state state_id="dossier-state-inactive" title="dossier-state-inactive">
@@ -360,6 +367,8 @@
     <permission-map name="opengever.trash: Trash content" acquired="False">
     </permission-map>
     <permission-map name="opengever.trash: Untrash content" acquired="False">
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False">
     </permission-map>
   </state>
   <state state_id="dossier-state-resolved" title="dossier-state-resolved">
@@ -457,6 +466,8 @@
     <permission-map name="opengever.trash: Trash content" acquired="False">
     </permission-map>
     <permission-map name="opengever.trash: Untrash content" acquired="False">
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False">
     </permission-map>
   </state>
   <state state_id="dossier-state-offered" title="dossier-state-offered">
@@ -559,6 +570,8 @@
     <permission-map name="opengever.trash: Trash content" acquired="False">
     </permission-map>
     <permission-map name="opengever.trash: Untrash content" acquired="False">
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False">
     </permission-map>
   </state>
 

--- a/opengever/dossier/upgrades/20170301235934_add_new_destroy_dossier_permission/upgrade.py
+++ b/opengever/dossier/upgrades/20170301235934_add_new_destroy_dossier_permission/upgrade.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewDestroyDossierPermission(UpgradeStep):
+    """Add new destroy dossier permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        self.update_workflow_security(
+            ['opengever_dossier_workflow'], reindex_security=False)


### PR DESCRIPTION
Only Records Managers and Manager has the `Destroy  Dossier` permission and only on dossiers in the archived state.

Closes #1764