### PR TITLE
Caching: enable tabbedview etag value.

### DIFF
--- a/opengever/policy/base/profiles/default/registry.xml
+++ b/opengever/policy/base/profiles/default/registry.xml
@@ -22,4 +22,16 @@
         <value>False</value>
     </record>
 
+    <record name="plone.app.caching.weakCaching.plone.content.itemView.etags">
+        <value purge="False">
+            <element>tabbedview</element>
+        </value>
+    </record>
+
+    <record name="plone.app.caching.weakCaching.plone.content.folderView.etags">
+        <value purge="False">
+            <element>tabbedview</element>
+        </value>
+    </record>
+
 </registry>

--- a/opengever/policy/base/upgrades/20170302092654_configure_tabbedview_etag_in_caching/registry.xml
+++ b/opengever/policy/base/upgrades/20170302092654_configure_tabbedview_etag_in_caching/registry.xml
@@ -1,0 +1,15 @@
+<registry>
+
+    <record name="plone.app.caching.weakCaching.plone.content.itemView.etags">
+        <value purge="False">
+            <element>tabbedview</element>
+        </value>
+    </record>
+
+    <record name="plone.app.caching.weakCaching.plone.content.folderView.etags">
+        <value purge="False">
+            <element>tabbedview</element>
+        </value>
+    </record>
+
+</registry>

--- a/opengever/policy/base/upgrades/20170302092654_configure_tabbedview_etag_in_caching/upgrade.py
+++ b/opengever/policy/base/upgrades/20170302092654_configure_tabbedview_etag_in_caching/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ConfigureTabbedviewEtagInCaching(UpgradeStep):
+    """Configure tabbedview etag in caching.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The tabbedview's defaulttab needs to be part of the cachekey so that the
cache gets flushed when the default tab is changed.

- https://github.com/4teamwork/ftw.tabbedview/pull/66
- https://github.com/4teamwork/kgs/commit/3a5cf996365b4621753a07625972470ae199f27b