### PR TITLE
Scaffold OC payloads for future-proof in regards of direct file uploads via plone.api

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Add scaffolding to OC checkout payloads in anticipation of plone.api direct
+  file uploads.
+  [Rotonen]
+
 - Improve disposal of inactive dossiers:
 
   - Set end date to current date when deactivating a dossier.

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -178,10 +178,14 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
                                        obj=self.document):
             raise Forbidden
 
+        # Upload API will be included as a registry setting in the future when
+        # the plone.api endpoint gets made - for now we've made a custom upload
+        # form.
         payload['checkin-with-comment'] = '@@checkin_document'
         payload['checkin-without-comment'] = 'checkin_without_comment'
         payload['checkout'] = '@@checkout_documents'
-        payload['edit-form'] = 'edit'
+        payload['upload-form'] = 'file_upload'
+        payload['upload-api'] = None
 
         self.request.response.setHeader('Content-type', 'application/json')
         return json.dumps(payload)

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -240,7 +240,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         # Test we can upload a new version of the file
         browser.login()
         browser.open(self.document_with_attachment,
-                     view=str(payload['edit-form']))
+                     view=str(payload['upload-form']))
         # The DATA in the file tuple needs to be seekable
         browser.fill({
             'form.widgets.file.action': 'replace',
@@ -282,7 +282,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         # Test we can upload a new version of the file
         browser.login()
         browser.open(self.document_with_attachment,
-                     view=str(payload['edit-form']))
+                     view=str(payload['upload-form']))
         # The DATA in the file tuple needs to be seekable
         browser.fill({
             'form.widgets.file.action': 'replace',


### PR DESCRIPTION
https://github.com/4teamwork/opengever.core/pull/2645

Support that OC-side and also forwards-support the thing that is a quick fix for.