### PR TITLE
Update ftw.keywordwidget from 1.1.1 to 1.1.2 to fix an ie11 issue.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Update ftw.keywordwidget from 1.1.1 to 1.1.2 to fix an ie11 issue.
+  [elioschmutz]
+
 - Fix off-by-one bumblebee preview image for document versions. [deiferni]
 
 - Add scaffolding to OC checkout payloads in anticipation of plone.api direct


### PR DESCRIPTION
This PR uses the new ftw.keywordwidget version 1.1.2 to fix an ie11 issue.

See https://github.com/4teamwork/ftw.keywordwidget/pull/6 for more information.

Before:
![screen2](https://cloud.githubusercontent.com/assets/557005/23512142/e6cbe610-ff5f-11e6-84e3-eeaaa28aa18f.gif)

After:
![screen1](https://cloud.githubusercontent.com/assets/557005/23512141/e4f07a90-ff5f-11e6-826d-46f2c3433c58.gif)
