### PR TITLE
Cleanup OC API tests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OfficeConnector now gets given the latest working copy of a file instead of
+  the latest checked in copy of a file.
+  [Rotonen]
+
 - Update ftw.keywordwidget from 1.1.1 to 1.1.2 to fix an ie11 issue.
   [elioschmutz]
 

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -142,7 +142,7 @@ class OfficeConnectorPayload(Service):
             'content-type': self.document.file.contentType,
             'csrf-token': createToken(),
             'document-url': self.document.absolute_url(),
-            'download': 'download_file_version',
+            'download': 'download',
             'filename': self.document.get_filename(),
             }
 


### PR DESCRIPTION
* Better readability
* Better reflect what OC actually does
* Also sneak in an usability / user expectation matching improvement to the OC payload