### PR TITLE
Add restriction possibility for dossier templates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Add restriction possibility for dossier templates on a
+  specific repositoryfolder.
+  [phgross]
+
 - The document redirector now handles newstyle OC URLs.
   [Rotonen]
 

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -60,6 +60,7 @@ REPOFOLDER_DEFAULTS = {
 }
 REPOFOLDER_FORM_DEFAULTS = {}
 REPOFOLDER_MISSING_VALUES = {
+    'addable_dossier_templates': [],
     'addable_dossier_types': [],
     'archival_value_annotation': None,
     'date_of_cassation': None,
@@ -771,4 +772,3 @@ class TestContactDefaults(TestDefaultsBase):
         expected['description'] = None
 
         self.assertDictEqual(expected, persisted_values)
-

--- a/opengever/dossier/behaviors.zcml
+++ b/opengever/dossier/behaviors.zcml
@@ -60,6 +60,13 @@
       for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateSchema"
       />
 
+  <plone:behavior
+      title="Restrict addable dossier templates"
+      description="Adds addable dossiertemplate field for repositoryfolders"
+      provides=".dossiertemplate.behaviors.IRestrictAddableDossierTemplates"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
   <!-- Restricted dossier behavior -->
   <plone:behavior
       title="Restricted dossier"

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -6,6 +6,8 @@ from opengever.dossier.behaviors.dossier import IDossier
 from plone.app.content.interfaces import INameFromTitle
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
+from plone.formwidget.contenttree import ObjPathSourceBinder
+from z3c.relationfield.schema import RelationChoice, RelationList
 from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
@@ -90,3 +92,28 @@ class DossierTemplateNameFromTitle(dossiernamefromtitle.DossierNameFromTitle):
     implements(IDossierTemplateNameFromTitle)
 
     format = u'dossiertemplate-%i'
+
+
+class IRestrictAddableDossierTemplates(form.Schema):
+
+    addable_dossier_templates = RelationList(
+        title=_(u'label_addable_dossier_templates',
+                default=u'Addable dossier templates'),
+        default=[],
+        missing_value=[],
+        value_type=RelationChoice(
+            title=u'Addable dossiertemplate',
+            source=ObjPathSourceBinder(
+                portal_type=("opengever.dossier.dossiertemplate"),
+                is_subdossier=False,
+                navigation_tree_query={
+                    'object_provides':
+                    ['opengever.dossier.templatefolder.interfaces.ITemplateFolder',
+                     'opengever.dossier.dossiertemplate.behaviors.IDossierTemplateSchema']
+                }),
+            ),
+        required=False,
+    )
+
+
+alsoProvides(IRestrictAddableDossierTemplates, IFormFieldProvider)

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-02-16 16:28+0000\n"
+"POT-Creation-Date: 2017-03-06 23:34+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -33,7 +33,7 @@ msgstr "Beteiligung hinzufügen"
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
-#: ./opengever/dossier/dossiertemplate/form.py:104
+#: ./opengever/dossier/dossiertemplate/form.py:114
 msgid "Add dossier"
 msgstr "Dossier hinzufügen"
 
@@ -142,7 +142,7 @@ msgstr "Projektdossier"
 msgid "Select document"
 msgstr "Dokument auswählen"
 
-#: ./opengever/dossier/dossiertemplate/form.py:103
+#: ./opengever/dossier/dossiertemplate/form.py:113
 msgid "Select dossiertemplate"
 msgstr "Vorlage auswählen"
 
@@ -164,19 +164,19 @@ msgstr "Vorlagenordner"
 msgid "Templates"
 msgstr "Vorlagen"
 
-#: ./opengever/dossier/deactivate.py:51
+#: ./opengever/dossier/deactivate.py:58
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Das Dossier kann nicht storniert werden, es enthält aktive Anträge."
 
-#: ./opengever/dossier/deactivate.py:69
+#: ./opengever/dossier/deactivate.py:76
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
 
-#: ./opengever/dossier/deactivate.py:45
+#: ./opengever/dossier/deactivate.py:52
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokumente eingecheckt sind."
 
-#: ./opengever/dossier/deactivate.py:59
+#: ./opengever/dossier/deactivate.py:66
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr "Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} bereits abgeschlossen ist. Das Subdossier muss vorgängig wieder eröffnet werden."
 
@@ -184,7 +184,7 @@ msgstr "Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} 
 msgid "The Dossier has been activated"
 msgstr "Das Dossier wurde aktiviert."
 
-#: ./opengever/dossier/deactivate.py:33
+#: ./opengever/dossier/deactivate.py:36
 msgid "The Dossier has been deactivated"
 msgstr "Das Dossier wurde storniert."
 
@@ -260,12 +260,12 @@ msgstr "Speichern"
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:166
-#: ./opengever/dossier/dossiertemplate/form.py:138
+#: ./opengever/dossier/dossiertemplate/form.py:148
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:127
+#: ./opengever/dossier/dossiertemplate/form.py:137
 msgid "button_continue"
 msgstr "Weiter"
 
@@ -295,7 +295,7 @@ msgid "create_document_with_template"
 msgstr "Dokument aus Vorlage erstellen"
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:99
+#: ./opengever/dossier/dossiertemplate/form.py:109
 msgid "create_dossier_with_template"
 msgstr "Geschäftsdossier aus Vorlage erstellen"
 
@@ -421,7 +421,7 @@ msgid "help_text_edit_note"
 msgstr "Es wurde ein Kommentar erfasst!"
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:33
+#: ./opengever/dossier/dossiertemplate/behaviors.py:35
 msgid "help_title_help"
 msgstr "Empfehlung für Titel. Wird beim Erstellen eines Dossiers ab Vorlage als Hilfetext dargestellt"
 
@@ -439,6 +439,11 @@ msgstr "Die Beteiligungen wurde entfernt."
 #: ./opengever/dossier/viewlets/templates/note.pt:17
 msgid "label_add_note"
 msgstr "Erfassen"
+
+#. Default: "Addable dossier templates"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:100
+msgid "label_addable_dossier_templates"
+msgstr "Erlaubte Dossiervorlagen"
 
 #. Default: "Address"
 #: ./opengever/dossier/templatefolder/form.py:272
@@ -477,14 +482,14 @@ msgid "label_container_type"
 msgstr "Behältnis-Art"
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:87
+#: ./opengever/dossier/dossiertemplate/form.py:97
 #: ./opengever/dossier/templatefolder/form.py:69
 msgid "label_creator"
 msgstr "Erstellt von"
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:218
-#: ./opengever/dossier/templatefolder/tabs.py:110
+#: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr "Beschreibung"
 
@@ -589,7 +594,7 @@ msgid "label_mail_address"
 msgstr "Mail Addresse"
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:90
+#: ./opengever/dossier/dossiertemplate/form.py:100
 #: ./opengever/dossier/templatefolder/form.py:72
 msgid "label_modified"
 msgstr "Zuletzt Bearbeitet"
@@ -630,7 +635,7 @@ msgid "label_phonenumber"
 msgstr "Telefonnummer"
 
 #. Default: "Predefined Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:42
+#: ./opengever/dossier/dossiertemplate/behaviors.py:44
 msgid "label_predefined_keywords"
 msgstr "Schlagworte vorausfüllen"
 
@@ -664,7 +669,7 @@ msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:50
+#: ./opengever/dossier/dossiertemplate/behaviors.py:52
 msgid "label_restrict_keywords"
 msgstr "Schlagwortkatalog einschränken"
 
@@ -721,20 +726,20 @@ msgid "label_tasktemplate_folders"
 msgstr "Standardabläufe"
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:79
+#: ./opengever/dossier/dossiertemplate/form.py:89
 #: ./opengever/dossier/templatefolder/form.py:60
 msgid "label_template"
 msgstr "Vorlage"
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:84
+#: ./opengever/dossier/dossiertemplate/form.py:94
 #: ./opengever/dossier/templatefolder/form.py:65
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Title help"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:32
+#: ./opengever/dossier/dossiertemplate/behaviors.py:34
 msgid "label_title_help"
 msgstr "Titelhilfe"
 
@@ -838,4 +843,3 @@ msgstr "Dossier Journal ${today}"
 #: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
-

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-16 16:28+0000\n"
+"POT-Creation-Date: 2017-03-06 23:34+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -32,7 +32,7 @@ msgstr "Participant"
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
 
-#: ./opengever/dossier/dossiertemplate/form.py:104
+#: ./opengever/dossier/dossiertemplate/form.py:114
 msgid "Add dossier"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgstr "Dossier du projet"
 msgid "Select document"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:103
+#: ./opengever/dossier/dossiertemplate/form.py:113
 msgid "Select dossiertemplate"
 msgstr ""
 
@@ -160,19 +160,19 @@ msgstr "Dossier des modèles"
 msgid "Templates"
 msgstr "Modèles"
 
-#: ./opengever/dossier/deactivate.py:51
+#: ./opengever/dossier/deactivate.py:58
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Le dossier ne peut pas être détruit, il contient des requêtes actives."
 
-#: ./opengever/dossier/deactivate.py:69
+#: ./opengever/dossier/deactivate.py:76
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches qui ne sont pas accomplies."
 
-#: ./opengever/dossier/deactivate.py:45
+#: ./opengever/dossier/deactivate.py:52
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
 msgstr "Ce dossier ne peut pas être annulé, il contient encore des documents avec le statut checkout"
 
-#: ./opengever/dossier/deactivate.py:59
+#: ./opengever/dossier/deactivate.py:66
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr "Impossible d'annuler le dossier, parce que le sous-dossier ${dossier} est déja fermé. Le sous-dossier doit d'abord être réouvert."
 
@@ -180,7 +180,7 @@ msgstr "Impossible d'annuler le dossier, parce que le sous-dossier ${dossier} es
 msgid "The Dossier has been activated"
 msgstr "Le dossier a été activé."
 
-#: ./opengever/dossier/deactivate.py:33
+#: ./opengever/dossier/deactivate.py:36
 msgid "The Dossier has been deactivated"
 msgstr "Le dossier a été annulé."
 
@@ -256,12 +256,12 @@ msgstr "Enregistrer"
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:166
-#: ./opengever/dossier/dossiertemplate/form.py:138
+#: ./opengever/dossier/dossiertemplate/form.py:148
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:127
+#: ./opengever/dossier/dossiertemplate/form.py:137
 msgid "button_continue"
 msgstr "Continuer"
 
@@ -291,7 +291,7 @@ msgid "create_document_with_template"
 msgstr "Créer un document à partir d'un modèle"
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:99
+#: ./opengever/dossier/dossiertemplate/form.py:109
 msgid "create_dossier_with_template"
 msgstr ""
 
@@ -417,7 +417,7 @@ msgid "help_text_edit_note"
 msgstr ""
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:33
+#: ./opengever/dossier/dossiertemplate/behaviors.py:35
 msgid "help_title_help"
 msgstr ""
 
@@ -434,6 +434,11 @@ msgstr "Participations enlevées"
 #. Default: "Add Note"
 #: ./opengever/dossier/viewlets/templates/note.pt:17
 msgid "label_add_note"
+msgstr ""
+
+#. Default: "Addable dossier templates"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:100
+msgid "label_addable_dossier_templates"
 msgstr ""
 
 #. Default: "Address"
@@ -473,14 +478,14 @@ msgid "label_container_type"
 msgstr "Type de conteneur"
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:87
+#: ./opengever/dossier/dossiertemplate/form.py:97
 #: ./opengever/dossier/templatefolder/form.py:69
 msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:218
-#: ./opengever/dossier/templatefolder/tabs.py:110
+#: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr ""
 
@@ -585,7 +590,7 @@ msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:90
+#: ./opengever/dossier/dossiertemplate/form.py:100
 #: ./opengever/dossier/templatefolder/form.py:72
 msgid "label_modified"
 msgstr "Modifié"
@@ -626,7 +631,7 @@ msgid "label_phonenumber"
 msgstr ""
 
 #. Default: "Predefined Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:42
+#: ./opengever/dossier/dossiertemplate/behaviors.py:44
 msgid "label_predefined_keywords"
 msgstr ""
 
@@ -660,7 +665,7 @@ msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:50
+#: ./opengever/dossier/dossiertemplate/behaviors.py:52
 msgid "label_restrict_keywords"
 msgstr ""
 
@@ -717,20 +722,20 @@ msgid "label_tasktemplate_folders"
 msgstr "Déroulements standards"
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:79
+#: ./opengever/dossier/dossiertemplate/form.py:89
 #: ./opengever/dossier/templatefolder/form.py:60
 msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:84
+#: ./opengever/dossier/dossiertemplate/form.py:94
 #: ./opengever/dossier/templatefolder/form.py:65
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Title help"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:32
+#: ./opengever/dossier/dossiertemplate/behaviors.py:34
 msgid "label_title_help"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-16 16:28+0000\n"
+"POT-Creation-Date: 2017-03-06 23:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Add Subdossier"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:104
+#: ./opengever/dossier/dossiertemplate/form.py:114
 msgid "Add dossier"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Select document"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:103
+#: ./opengever/dossier/dossiertemplate/form.py:113
 msgid "Select dossiertemplate"
 msgstr ""
 
@@ -161,19 +161,19 @@ msgstr ""
 msgid "Templates"
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:51
+#: ./opengever/dossier/deactivate.py:58
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:69
+#: ./opengever/dossier/deactivate.py:76
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:45
+#: ./opengever/dossier/deactivate.py:52
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:59
+#: ./opengever/dossier/deactivate.py:66
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "The Dossier has been activated"
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:33
+#: ./opengever/dossier/deactivate.py:36
 msgid "The Dossier has been deactivated"
 msgstr ""
 
@@ -257,12 +257,12 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:166
-#: ./opengever/dossier/dossiertemplate/form.py:138
+#: ./opengever/dossier/dossiertemplate/form.py:148
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:127
+#: ./opengever/dossier/dossiertemplate/form.py:137
 msgid "button_continue"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgid "create_document_with_template"
 msgstr ""
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:99
+#: ./opengever/dossier/dossiertemplate/form.py:109
 msgid "create_dossier_with_template"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgid "help_text_edit_note"
 msgstr ""
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:33
+#: ./opengever/dossier/dossiertemplate/behaviors.py:35
 msgid "help_title_help"
 msgstr ""
 
@@ -435,6 +435,11 @@ msgstr ""
 #. Default: "Add Note"
 #: ./opengever/dossier/viewlets/templates/note.pt:17
 msgid "label_add_note"
+msgstr ""
+
+#. Default: "Addable dossier templates"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:100
+msgid "label_addable_dossier_templates"
 msgstr ""
 
 #. Default: "Address"
@@ -474,14 +479,14 @@ msgid "label_container_type"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:87
+#: ./opengever/dossier/dossiertemplate/form.py:97
 #: ./opengever/dossier/templatefolder/form.py:69
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:218
-#: ./opengever/dossier/templatefolder/tabs.py:110
+#: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr ""
 
@@ -586,7 +591,7 @@ msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:90
+#: ./opengever/dossier/dossiertemplate/form.py:100
 #: ./opengever/dossier/templatefolder/form.py:72
 msgid "label_modified"
 msgstr ""
@@ -627,7 +632,7 @@ msgid "label_phonenumber"
 msgstr ""
 
 #. Default: "Predefined Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:42
+#: ./opengever/dossier/dossiertemplate/behaviors.py:44
 msgid "label_predefined_keywords"
 msgstr ""
 
@@ -661,7 +666,7 @@ msgid "label_responsible"
 msgstr ""
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:50
+#: ./opengever/dossier/dossiertemplate/behaviors.py:52
 msgid "label_restrict_keywords"
 msgstr ""
 
@@ -718,20 +723,20 @@ msgid "label_tasktemplate_folders"
 msgstr ""
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:79
+#: ./opengever/dossier/dossiertemplate/form.py:89
 #: ./opengever/dossier/templatefolder/form.py:60
 msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:84
+#: ./opengever/dossier/dossiertemplate/form.py:94
 #: ./opengever/dossier/templatefolder/form.py:65
 msgid "label_title"
 msgstr ""
 
 #. Default: "Title help"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:32
+#: ./opengever/dossier/dossiertemplate/behaviors.py:34
 msgid "label_title_help"
 msgstr ""
 

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -357,6 +357,26 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
             browser.css('.listing tr td:nth-child(2)').text)
 
     @browsing
+    def test_selectable_templates_are_restricted_when_addable_templates_are_selected(self, browser):
+        template1 = create(Builder("dossiertemplate")
+                           .within(self.templatefolder)
+                           .titled(u"Template 1"))
+        template2 = create(Builder("dossiertemplate")
+                           .within(self.templatefolder)
+                           .titled(u"Template 2"))
+
+        leaf_node_2 = create(Builder('repository')
+                             .having(addable_dossier_templates=[template2])
+                             .within(self.branch_node))
+
+        browser.login().visit(leaf_node_2)
+        factoriesmenu.add('Dossier with template')
+
+        self.assertEqual(
+            ['Template 2'],
+            browser.css('.listing tr td:nth-child(2)').text)
+
+    @browsing
     def test_dossiertemplate_values_are_prefilled_properly_in_the_dossier(self, browser):
         values = {
             'title': u'My template',

--- a/opengever/dossier/tests/test_restricted_addable_dossiertemplate.py
+++ b/opengever/dossier/tests/test_restricted_addable_dossiertemplate.py
@@ -1,0 +1,61 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.dossier.dossiertemplate.behaviors import IRestrictAddableDossierTemplates
+from opengever.testing import FunctionalTestCase
+
+
+class TestRestrictAddableDossierTemplatesBehavior(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRestrictAddableDossierTemplatesBehavior, self).setUp()
+        self.root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository')
+                                 .having(title_de=u'Anfragen',
+                                         title_fr=u'Demandes')
+                                 .within(self.root))
+        self.templatefolder = create(Builder('templatefolder'))
+
+        self.grant('Editor', 'Contributor', 'Administrator')
+
+    @browsing
+    def test_only_templatedossiers_are_selectable(self, browser):
+        doc = create(Builder('document').within(self.templatefolder))
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatefolder))
+
+        browser.login().open(self.repository, view='edit')
+        browser.fill({'Addable dossier templates': [doc]})
+        browser.click_on('Save')
+        self.assertEquals(
+            [],
+            IRestrictAddableDossierTemplates(self.repository).addable_dossier_templates)
+
+        browser.login().open(self.repository, view='edit')
+        browser.fill({'Addable dossier templates': [dossiertemplate]})
+        browser.click_on('Save')
+        relations = IRestrictAddableDossierTemplates(self.repository).addable_dossier_templates
+        self.assertEquals([dossiertemplate],
+                          [rel.to_object for rel in relations])
+
+    @browsing
+    def test_only_main_templatedossiers_are_selectable(self, browser):
+        dossiertemplate = create(Builder('dossiertemplate')
+                                 .within(self.templatefolder))
+        sub_dossiertemplate = create(Builder('dossiertemplate')
+                                     .within(dossiertemplate))
+
+        browser.login().open(self.repository, view='edit')
+        browser.fill({'Addable dossier templates': [sub_dossiertemplate]})
+        browser.click_on('Save')
+
+        relations = IRestrictAddableDossierTemplates(self.repository).addable_dossier_templates
+        self.assertEquals([], relations)
+
+        browser.login().open(self.repository, view='edit')
+        browser.fill({'Addable dossier templates': [dossiertemplate]})
+        browser.click_on('Save')
+
+        relations = IRestrictAddableDossierTemplates(self.repository).addable_dossier_templates
+        self.assertEquals([dossiertemplate],
+                          [rel.to_object for rel in relations])

--- a/opengever/repository/profiles/default/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/repository/profiles/default/types/opengever.repository.repositoryfolder.xml
@@ -32,6 +32,7 @@
     <element value="opengever.sharing.behaviors.IDossier" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    <element value="opengever.dossier.dossiertemplate.behaviors.IRestrictAddableDossierTemplates" />
   </property>
 
   <!-- View information -->

--- a/opengever/repository/upgrades/20170306132837_add_i_addable_dossier_templates_to_repositoryfolders/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/repository/upgrades/20170306132837_add_i_addable_dossier_templates_to_repositoryfolders/types/opengever.repository.repositoryfolder.xml
@@ -1,0 +1,7 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.repository.repositoryfolder" meta_type="Dexterity FTI" i18n:domain="opengever.repository">
+
+  <property name="behaviors" purge="False">
+    <element value="opengever.dossier.dossiertemplate.behaviors.IRestrictAddableDossierTemplates" />
+  </property>
+
+</object>

--- a/opengever/repository/upgrades/20170306132837_add_i_addable_dossier_templates_to_repositoryfolders/upgrade.py
+++ b/opengever/repository/upgrades/20170306132837_add_i_addable_dossier_templates_to_repositoryfolders/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddIRestrictAddableDossierTemplatesToRepositoryfolders(UpgradeStep):
+    """Add IRestrictAddableDossierTemplates to repositoryfolders.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Adds an additional behavior IAddableDossierTemplates with a RelationList field to repositoryfolders.
If the `addable_dossier_templates` is filled, the selectable templates are restricted otherwise not.

Closes #2625