### PR TITLE
Make keywords searchable

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Extend searchable text with dossier keywords. [deiferni]
+
 - No longer set incorrect contentType for drag-drop uploaded mails. [deiferni]
 
 - OfficeConnector now gets given the latest working copy of a file instead of

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -56,6 +56,7 @@ class IDossier(form.Schema):
     )
 
     dexteritytextindexer.searchable('keywords')
+    form.widget(keywords=KeywordFieldWidget)
     keywords = schema.Tuple(
         title=_(u'label_keywords', default=u'Keywords'),
         description=_(u'help_keywords', default=u''),
@@ -66,7 +67,6 @@ class IDossier(form.Schema):
         missing_value=(),
         default=(),
     )
-    form.widget(keywords=KeywordFieldWidget)
 
     # workaround because ftw.datepicker wasn't working on the edit form
     form.widget(start=DatePickerFieldWidget)

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -55,7 +55,6 @@ class IDossier(form.Schema):
         ],
     )
 
-    dexteritytextindexer.searchable('keywords')
     form.widget(keywords=KeywordFieldWidget)
     keywords = schema.Tuple(
         title=_(u'label_keywords', default=u'Keywords'),

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -154,7 +154,9 @@ class SearchableTextExtender(grok.Adapter):
         keywords = IDossier(self.context).keywords
         if keywords:
             searchable.extend(
-                keyword.encode('utf-8') for keyword in keywords)
+                keyword.encode('utf-8') if isinstance(keyword, unicode)
+                else keyword
+                for keyword in keywords)
 
         return ' '.join(searchable)
 

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -5,6 +5,8 @@ from five import grok
 from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.behaviors.filing import IFilingNumber
+from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.utils import get_main_dossier
 from plone.dexterity.interfaces import IDexterityContent
@@ -133,16 +135,15 @@ class SearchableTextExtender(grok.Adapter):
         # sequence_number
         seqNumb = getUtility(ISequenceNumber)
         searchable.append(str(seqNumb.get_number(self.context)))
-        # responsible
-        searchable.append(
-            self.context.responsible_label.encode('utf-8'))
 
-        dossier = IDossier(self.context)
-        # filling_no
-        dossier = IDossierMarker(self.context)
-        if getattr(dossier, 'filing_no', None):
-            searchable.append(str(getattr(dossier, 'filing_no',
-                                          None)).encode('utf-8'))
+        # responsible
+        searchable.append(self.context.responsible_label.encode('utf-8'))
+
+        # filing_no
+        if IFilingNumberMarker.providedBy(self.context):
+            filing_no = getattr(IFilingNumber(self.contxt), 'filing_no', None)
+            if filing_no:
+                searchable.append(filing_no.encode('utf-8'))
 
         # comments
         comments = getattr(IDossier(self.context), 'comments', None)
@@ -150,8 +151,9 @@ class SearchableTextExtender(grok.Adapter):
             searchable.append(comments.encode('utf-8'))
 
         # keywords
-        keywords = dossier.keywords
+        keywords = IDossier(self.context).keywords
         if keywords:
-            searchable.append(keywords.encode('utf-8'))
+            searchable.extend(
+                keyword.encode('utf-8') for keyword in keywords)
 
         return ' '.join(searchable)

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -157,3 +157,9 @@ class SearchableTextExtender(grok.Adapter):
                 keyword.encode('utf-8') for keyword in keywords)
 
         return ' '.join(searchable)
+
+
+class DossierTemplateSearchableTextExtender(SearchableTextExtender):
+    grok.context(IDossierTemplateMarker)
+    grok.name('IDossierTemplate')
+    grok.implements(dexteritytextindexer.IDynamicTextIndexExtender)

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -149,4 +149,9 @@ class SearchableTextExtender(grok.Adapter):
         if comments:
             searchable.append(comments.encode('utf-8'))
 
+        # keywords
+        keywords = dossier.keywords
+        if keywords:
+            searchable.append(keywords.encode('utf-8'))
+
         return ' '.join(searchable)

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -114,7 +114,7 @@ class TestIndexers(FunctionalTestCase):
         self.assertEquals((u'Keyword 1', u'Keyword 2', u'Keyword with \xf6'),
                           catalog.uniqueValuesFor('Subject'))
 
-    def test_searchable_text_contains_keywords(self):
+    def test_dossier_searchable_text_contains_keywords(self):
         dossier_with_keywords = create(
             Builder("dossier")
             .titled(u"Dossier")
@@ -124,6 +124,18 @@ class TestIndexers(FunctionalTestCase):
         self.assertItemsEqual(
             [u'1', u'3', 'client1', 'dossier', 'keyword', 'me', 'pick'],
             index_data_for(dossier_with_keywords).get('SearchableText'))
+
+    def test_dossiertemplate_searchable_text_contains_keywords(self):
+        folder = create(Builder('templatefolder'))
+        template_with_keywords = create(
+            Builder("dossiertemplate")
+            .titled(u"Dossiertemplate")
+            .having(keywords=(u'Thingy', u'Keyw\xf6rd',))
+            .within(folder))
+
+        self.assertItemsEqual(
+            [u'1', 'client1', 'dossiertemplate', 'keyword', 'thingy'],
+            index_data_for(template_with_keywords).get('SearchableText'))
 
 
 class TestFilingNumberIndexer(FunctionalTestCase):

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -114,6 +114,17 @@ class TestIndexers(FunctionalTestCase):
         self.assertEquals((u'Keyword 1', u'Keyword 2', u'Keyword with \xf6'),
                           catalog.uniqueValuesFor('Subject'))
 
+    def test_searchable_text_contains_keywords(self):
+        dossier_with_keywords = create(
+            Builder("dossier")
+            .titled(u"Dossier")
+            .having(keywords=(u'Pick me!', u'Keyw\xf6rd'))
+            .within(self.repo_folder))
+
+        self.assertItemsEqual(
+            [u'1', u'3', 'client1', 'dossier', 'keyword', 'me', 'pick'],
+            index_data_for(dossier_with_keywords).get('SearchableText'))
+
 
 class TestFilingNumberIndexer(FunctionalTestCase):
 

--- a/opengever/dossier/upgrades/20170307184059_reindex_searchable_text_for_dossier_templates/upgrade.py
+++ b/opengever/dossier/upgrades/20170307184059_reindex_searchable_text_for_dossier_templates/upgrade.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexSearchableTextForDossierTemplates(UpgradeStep):
+    """Reindex SearchableText for dossier templates.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.catalog_reindex_objects(
+            {'portal_type': 'opengever.dossier.dossiertemplate'},
+            idxs=['SearchableText'])


### PR DESCRIPTION
With this PR keywords of dossiers and dossiertemplates are appended to searchable text and thus one can search for dossiers and dossiertemplates based on their keywords.

 ![screen shot 2017-03-07 at 19 18 50](https://cloud.githubusercontent.com/assets/736583/23671299/0c73fa60-036b-11e7-9c6f-a7ab3bbf27f1.png)

Fixes #2606.