### PR TITLE
Merge pull request #2543 from 4teamwork/mle-fix-breadcrumb-tooltip

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Make sure the breadcrumb title tooltip only gets loaded if a data-uid attribute is present.
+  [mathias.leimgruber]
+
 - Fix off-by-one bumblebee preview image for document versions. [deiferni]
 
 - Caching: enable tabbedview etag value. [jone]

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -82,7 +82,7 @@
     }, 100);
   }
 
-  $(document).on("mouseover", ".rollover-breadcrumb", setBreadcrumbAsTitleAttr);
+  $(document).on("mouseover", ".rollover-breadcrumb[data-uid]", setBreadcrumbAsTitleAttr);
 
 
 }(window, window.jQuery));


### PR DESCRIPTION
Make sure the breadcrumb title tooltip only gets loaded if a data-uid attribute is present