### PR TITLE
Fix missing table-column width for checkbox rows.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Fix missing table-column width for checkbox column.
+  [elioschmutz]
+
 - OGGBundle: Add support to map local role principal names during
   import based on ingestion settings.
   [lgraf]

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -87,7 +87,8 @@ class ExtractAttachments(grok.View):
         columns = (
             {'column': 'position',
              'column_title': u'',
-             'transform': attachment_checkbox_helper},
+             'transform': attachment_checkbox_helper,
+             'width': 30},
 
             {'column': 'content-type',
              'column_title': _(u'column_attachment_type',

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -68,7 +68,8 @@ class GlobalTaskListingTab(BaseListingTab):
     columns = (
         {'column': '',
          'sortable': False,
-         'transform': task_id_checkbox_helper},
+         'transform': task_id_checkbox_helper,
+         'width': 30},
 
         {'column': 'review_state',
          'column_title': _(u'column_review_state', default=u'Review state'),


### PR DESCRIPTION
This PR adds missing table-column width.

Before:
![bildschirmfoto 2017-03-09 um 17 55 06](https://cloud.githubusercontent.com/assets/557005/23760950/8c134906-04f1-11e7-9366-cae55390051d.png)

After:
![bildschirmfoto 2017-03-09 um 17 44 19](https://cloud.githubusercontent.com/assets/557005/23760925/7a992498-04f1-11e7-9611-07795715e71a.png)

closes #2529 