### PR TITLE
Fix broken tests on master.

### DIFF
--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -444,7 +444,8 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
         # new = browser.css('#' + keywords.attrib['id'] + '_new')
         # self.assertFalse(new, 'It should not be possible to add new terms')
 
-        self.assertEquals(list(values['keywords']), keywords.options_labels)
+        self.assertItemsEqual(list(values['keywords']),
+                              keywords.options_labels)
         browser.click_on('Save')
         self.assertEquals((u'secret\xe4', u'special'),
                           IDossier(browser.context).keywords)

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -447,8 +447,8 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
         self.assertItemsEqual(list(values['keywords']),
                               keywords.options_labels)
         browser.click_on('Save')
-        self.assertEquals((u'secret\xe4', u'special'),
-                          IDossier(browser.context).keywords)
+        self.assertItemsEqual((u'secret\xe4', u'special'),
+                              IDossier(browser.context).keywords)
 
     @browsing
     def test_redirects_to_dossier_after_creating_dossier_from_template(self, browser):


### PR DESCRIPTION
We don't care about order, and this broke/changed with the latest `ftw.keywordwidget` release.