### PR TITLE
Make MSG content type upgrade step more defensive

### DIFF
--- a/opengever/mail/upgrades/20170308184726_set_correct_message_content_type_for_drag_drop_uploaded_mails/upgrade.py
+++ b/opengever/mail/upgrades/20170308184726_set_correct_message_content_type_for_drag_drop_uploaded_mails/upgrade.py
@@ -59,4 +59,8 @@ class SetCorrectMessageContentTypeForDragDropUploadedMails(UpgradeStep):
         mail.reindexObject(idxs=['id'])
 
     def has_expected_content_type(self, brain):
-        return brain.getContentType == 'message/rfc822'
+        # Defensive getattr access because some brains in production didn't
+        # have the getContentType metadata attribute. Those are fishy and
+        # deserve no better than to get reindexed.
+        content_type = getattr(brain, 'getContentType', '')
+        return content_type == 'message/rfc822'


### PR DESCRIPTION
Make MSG content type upgrade step more defensive: Some brains in production didn't have the `getContentType` metadata attribute. Those are fishy and deserve no better than to get reindexed.