### PR TITLE
Make containing_dossier indexer more defensive

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Make containing_dossier indexer more defensive in order to account for an
+  odd corner case during upgrades.
+  [lgraf]
+
 - Extend searchable text with dossier keywords. [deiferni]
 
 - No longer set incorrect contentType for drag-drop uploaded mails. [deiferni]


### PR DESCRIPTION
Make containing_dossier indexer more defensive in order to account for an odd corner case during upgrades:

During upgrades, the odd case can happen that a mail inside a forwarding inside the inbox wants to have its `containing_dossier` reindexed. This can lead to a situation where we attempt to adapt the `Inbox` to `ITranslatedTitle`, but it doesn't provide this behavior yet because that behavior is going to be actived in the very same upgrade.

Account for this case, and fall back to `inbox.title`, which will contain the original title (in unicode though).