### PR TITLE
LDAP util: Skip referrals that are supposed to be hunted by client-chasing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- LDAP util: Skip referrals that are supposed to be hunted by client-chasing.
+  [lgraf]
+
 - Make containing_dossier indexer more defensive in order to account for an
   odd corner case during upgrades.
   [lgraf]

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -289,6 +289,12 @@ class LDAPSearch(grok.Adapter):
                               filter=search_filter)
         mapped_results = []
         for result in results:
+            dn, entry = result
+            if dn is None:
+                # This is likely a referral to be hunted down by
+                # client-chasing. We don't support those.
+                logger.info('Skipping referral: %r' % (result, ))
+                continue
             mapped_results.append(self.apply_schema_map(result))
 
         return mapped_results
@@ -372,6 +378,7 @@ class LDAPSearch(grok.Adapter):
         # LDAPUserFolder mapping to those
         is_user = False
         obj_classes = attrs['objectClass']
+
         for obj_class in obj_classes:
             if obj_class.lower() in [uc.lower() for uc in
                                      self.context._user_objclasses]:


### PR DESCRIPTION
LDAP util: Skip LDAP referrals that are supposed to be hunted down by client-chasing. We don't support these, and can simply skip them.