### PR TITLE
Disposition overview improvments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
-- Disposition overview: fix tooltips for appraisal buttons.
+- Disposition overview:
+
+  - Fix tooltips for appraisal buttons.
+  - Hide subtitles (active or inactive dossiers) when list is empty.
+
   [phgross]
 
 - Fix missing table-column width for checkbox column.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Disposition overview: fix tooltips for appraisal buttons.
+  [phgross]
+
 - Fix missing table-column width for checkbox column.
   [elioschmutz]
 

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -186,7 +186,7 @@
   </div>
 
   <div class="progress">
-    <h3 i18n:translate="progress">Progress:</h3>
+    <h3 i18n:translate="progress">Progress</h3>
 
     <div class="answers">
       <tal:repeat tal:repeat="entry view/get_history">

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -59,11 +59,11 @@
             <div class="repo-appraisal-button-group action-cell"
                  tal:condition="view/appraisal_buttons_available"
                  tal:attributes="data-intids python:[dossier.intid for dossier in dossiers]">
-              <a href="#" title="Archive" class="icon_button archive_all"
-                 data-archive="true" i18n:attributes="title label_archive" />
+              <a href="#" title="Archive all" class="icon_button archive_all"
+                 data-archive="true" i18n:attributes="title label_archive_all" />
 
-              <a href="#" title="Archive" class="icon_button not_archive_all"
-                 data-archive="false" i18n:attributes="title label_archive" />
+              <a href="#" title="Do not archive all" class="icon_button not_archive_all"
+                 data-archive="false" i18n:attributes="title label_dont_archive_all" />
             </div>
           </div>
 

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -16,7 +16,8 @@
 
   <ul class="list-group" tal:repeat="dossier_list view/get_dossier_lists">
     <tal:define tal:define="label python: dossier_list[0];
-                            mappings python: dossier_list[1]">
+                            mappings python: dossier_list[1]"
+                tal:condition="mappings">
 
       <li class="list-group-item label">
         <div class="list-group-cell data-cell">
@@ -204,11 +205,11 @@
               <div class="collapsible-content">
                 <ul>
                   <li tal:repeat="detail entry/details">
-                    <span tal:content="detail/reference_number" />
-                    <span tal:content="detail/title" />
-                    <span tal:condition="detail/appraisal"
+                    <span class="reference_number" tal:content="detail/reference_number" />
+                    <span class="title" tal:content="detail/title" />
+                    <span class="appraisal" tal:condition="detail/appraisal"
                           i18n:translate="label_archive">Archive</span>
-                    <span tal:condition="not: detail/appraisal"
+                    <span class="appraisal" tal:condition="not: detail/appraisal"
                           i18n:translate="label_dont_archive">Don't archive</span>
                   </li>
                 </ul>

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-12 14:43+0000\n"
+"POT-Creation-Date: 2017-03-12 14:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -245,10 +245,10 @@ msgstr "Aktualisiert durch ${user}"
 msgid "period"
 msgstr "Periode"
 
-#. Default: "Progress:"
+#. Default: "Progress"
 #: ./opengever/disposition/browser/templates/overview.pt:189
 msgid "progress"
-msgstr "Verlauf:"
+msgstr "Verlauf"
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
 #: ./opengever/disposition/activities.py:24

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-28 17:07+0000\n"
+"POT-Creation-Date: 2017-03-12 14:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,7 +50,7 @@ msgid "error_retention_period_not_expired"
 msgstr "Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen."
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:128
+#: ./opengever/disposition/disposition.py:132
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -74,18 +74,23 @@ msgstr "Bewertungsentscheid"
 msgid "label_archive"
 msgstr "Archivieren"
 
+#. Default: "Archive all"
+#: ./opengever/disposition/browser/templates/overview.pt:62
+msgid "label_archive_all"
+msgstr "Alle archivieren"
+
 #. Default: "Archived"
 #: ./opengever/disposition/browser/removal_protocol.py:68
 msgid "label_archived"
 msgstr "Archiviert"
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:207
+#: ./opengever/disposition/browser/templates/overview.pt:202
 msgid "label_details"
 msgstr "Details:"
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:118
+#: ./opengever/disposition/disposition.py:122
 msgid "label_disposition"
 msgstr "Angebot"
 
@@ -101,29 +106,34 @@ msgid "label_disposition_edited"
 msgstr "Angebot bearbeitet"
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:84
+#: ./opengever/disposition/browser/overview.py:81
 msgid "label_dispositon_package_download"
 msgstr "Ablieferungspaket herunterladen"
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:128
+#: ./opengever/disposition/browser/templates/overview.pt:123
 msgid "label_dont_archive"
 msgstr "Nicht archivieren"
+
+#. Default: "Do not archive all"
+#: ./opengever/disposition/browser/templates/overview.pt:65
+msgid "label_dont_archive_all"
+msgstr "Alle nicht archivieren"
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:122
 #: ./opengever/disposition/browser/templates/overview.pt:45
-#: ./opengever/disposition/disposition.py:141
+#: ./opengever/disposition/disposition.py:145
 msgid "label_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:90
+#: ./opengever/disposition/browser/overview.py:87
 msgid "label_download_removal_protocol"
 msgstr "Löschprotokoll herunterladen"
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:78
+#: ./opengever/disposition/browser/overview.py:75
 msgid "label_export_appraisal_list_as_excel"
 msgstr "Bewertungsliste als Excel exportieren"
 
@@ -133,7 +143,7 @@ msgid "label_history"
 msgstr "Verlauf"
 
 #. Default: "Inactive Dossiers"
-#: ./opengever/disposition/browser/overview.py:56
+#: ./opengever/disposition/browser/overview.py:53
 msgid "label_inactive_dossiers"
 msgstr "Stornierte Dossiers"
 
@@ -153,7 +163,7 @@ msgid "label_removal_protocol"
 msgstr "Löschprotokoll"
 
 #. Default: "Resolved Dossiers"
-#: ./opengever/disposition/browser/overview.py:54
+#: ./opengever/disposition/browser/overview.py:51
 msgid "label_resolved_dossiers"
 msgstr "Abgeschlossene Dossiers"
 
@@ -170,13 +180,13 @@ msgstr "Zeitpunkt"
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:48
 #: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:134
+#: ./opengever/disposition/disposition.py:138
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:162
+#: ./opengever/disposition/disposition.py:166
 msgid "label_transfer_number"
 msgstr "Ablieferungsnummer"
 
@@ -231,12 +241,12 @@ msgid "msg_disposition_updated"
 msgstr "Aktualisiert durch ${user}"
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:91
+#: ./opengever/disposition/browser/templates/overview.pt:86
 msgid "period"
 msgstr "Periode"
 
 #. Default: "Progress:"
-#: ./opengever/disposition/browser/templates/overview.pt:194
+#: ./opengever/disposition/browser/templates/overview.pt:189
 msgid "progress"
 msgstr "Verlauf:"
 

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -223,7 +223,7 @@ msgstr "Angebot abgeschlossen und alle Dossiers vernichtet durch ${user}"
 #. Default: "Disposition disposed for the archive by ${user}"
 #: ./opengever/disposition/history.py:128
 msgid "msg_disposition_disposed"
-msgstr "Für die Archivierung angeboten durch ${user}"
+msgstr "Zur Archivierung angeboten durch ${user}"
 
 #. Default: "Edited by ${user}"
 #: ./opengever/disposition/history.py:98

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-12 14:43+0000\n"
+"POT-Creation-Date: 2017-03-12 14:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -245,7 +245,7 @@ msgstr ""
 msgid "period"
 msgstr ""
 
-#. Default: "Progress:"
+#. Default: "Progress"
 #: ./opengever/disposition/browser/templates/overview.pt:189
 msgid "progress"
 msgstr ""

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-28 17:07+0000\n"
+"POT-Creation-Date: 2017-03-12 14:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,7 +50,7 @@ msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:128
+#: ./opengever/disposition/disposition.py:132
 msgid "fieldset_common"
 msgstr ""
 
@@ -74,18 +74,23 @@ msgstr ""
 msgid "label_archive"
 msgstr ""
 
+#. Default: "Archive all"
+#: ./opengever/disposition/browser/templates/overview.pt:62
+msgid "label_archive_all"
+msgstr ""
+
 #. Default: "Archived"
 #: ./opengever/disposition/browser/removal_protocol.py:68
 msgid "label_archived"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:207
+#: ./opengever/disposition/browser/templates/overview.pt:202
 msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:118
+#: ./opengever/disposition/disposition.py:122
 msgid "label_disposition"
 msgstr ""
 
@@ -101,29 +106,34 @@ msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:84
+#: ./opengever/disposition/browser/overview.py:81
 msgid "label_dispositon_package_download"
 msgstr ""
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:128
+#: ./opengever/disposition/browser/templates/overview.pt:123
 msgid "label_dont_archive"
+msgstr ""
+
+#. Default: "Do not archive all"
+#: ./opengever/disposition/browser/templates/overview.pt:65
+msgid "label_dont_archive_all"
 msgstr ""
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:122
 #: ./opengever/disposition/browser/templates/overview.pt:45
-#: ./opengever/disposition/disposition.py:141
+#: ./opengever/disposition/disposition.py:145
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:90
+#: ./opengever/disposition/browser/overview.py:87
 msgid "label_download_removal_protocol"
 msgstr ""
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:78
+#: ./opengever/disposition/browser/overview.py:75
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
@@ -133,7 +143,7 @@ msgid "label_history"
 msgstr ""
 
 #. Default: "Inactive Dossiers"
-#: ./opengever/disposition/browser/overview.py:56
+#: ./opengever/disposition/browser/overview.py:53
 msgid "label_inactive_dossiers"
 msgstr ""
 
@@ -153,7 +163,7 @@ msgid "label_removal_protocol"
 msgstr ""
 
 #. Default: "Resolved Dossiers"
-#: ./opengever/disposition/browser/overview.py:54
+#: ./opengever/disposition/browser/overview.py:51
 msgid "label_resolved_dossiers"
 msgstr ""
 
@@ -170,13 +180,13 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:48
 #: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:134
+#: ./opengever/disposition/disposition.py:138
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:162
+#: ./opengever/disposition/disposition.py:166
 msgid "label_transfer_number"
 msgstr ""
 
@@ -231,12 +241,12 @@ msgid "msg_disposition_updated"
 msgstr ""
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:91
+#: ./opengever/disposition/browser/templates/overview.pt:86
 msgid "period"
 msgstr ""
 
 #. Default: "Progress:"
-#: ./opengever/disposition/browser/templates/overview.pt:194
+#: ./opengever/disposition/browser/templates/overview.pt:189
 msgid "progress"
 msgstr ""
 

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-02-28 17:07+0000\n"
+"POT-Creation-Date: 2017-03-12 14:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:128
+#: ./opengever/disposition/disposition.py:132
 msgid "fieldset_common"
 msgstr ""
 
@@ -77,18 +77,23 @@ msgstr ""
 msgid "label_archive"
 msgstr ""
 
+#. Default: "Archive all"
+#: ./opengever/disposition/browser/templates/overview.pt:62
+msgid "label_archive_all"
+msgstr ""
+
 #. Default: "Archived"
 #: ./opengever/disposition/browser/removal_protocol.py:68
 msgid "label_archived"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:207
+#: ./opengever/disposition/browser/templates/overview.pt:202
 msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:118
+#: ./opengever/disposition/disposition.py:122
 msgid "label_disposition"
 msgstr ""
 
@@ -104,29 +109,34 @@ msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:84
+#: ./opengever/disposition/browser/overview.py:81
 msgid "label_dispositon_package_download"
 msgstr ""
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:128
+#: ./opengever/disposition/browser/templates/overview.pt:123
 msgid "label_dont_archive"
+msgstr ""
+
+#. Default: "Do not archive all"
+#: ./opengever/disposition/browser/templates/overview.pt:65
+msgid "label_dont_archive_all"
 msgstr ""
 
 #. Default: "Dossiers"
 #: ./opengever/disposition/browser/removal_protocol.py:122
 #: ./opengever/disposition/browser/templates/overview.pt:45
-#: ./opengever/disposition/disposition.py:141
+#: ./opengever/disposition/disposition.py:145
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:90
+#: ./opengever/disposition/browser/overview.py:87
 msgid "label_download_removal_protocol"
 msgstr ""
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:78
+#: ./opengever/disposition/browser/overview.py:75
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
@@ -136,7 +146,7 @@ msgid "label_history"
 msgstr ""
 
 #. Default: "Inactive Dossiers"
-#: ./opengever/disposition/browser/overview.py:56
+#: ./opengever/disposition/browser/overview.py:53
 msgid "label_inactive_dossiers"
 msgstr ""
 
@@ -156,7 +166,7 @@ msgid "label_removal_protocol"
 msgstr ""
 
 #. Default: "Resolved Dossiers"
-#: ./opengever/disposition/browser/overview.py:54
+#: ./opengever/disposition/browser/overview.py:51
 msgid "label_resolved_dossiers"
 msgstr ""
 
@@ -173,13 +183,13 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/disposition/browser/listing.py:48
 #: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:134
+#: ./opengever/disposition/disposition.py:138
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:162
+#: ./opengever/disposition/disposition.py:166
 msgid "label_transfer_number"
 msgstr ""
 
@@ -234,12 +244,12 @@ msgid "msg_disposition_updated"
 msgstr ""
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:91
+#: ./opengever/disposition/browser/templates/overview.pt:86
 msgid "period"
 msgstr ""
 
 #. Default: "Progress:"
-#: ./opengever/disposition/browser/templates/overview.pt:194
+#: ./opengever/disposition/browser/templates/overview.pt:189
 msgid "progress"
 msgstr ""
 

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-12 14:43+0000\n"
+"POT-Creation-Date: 2017-03-12 14:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -248,7 +248,7 @@ msgstr ""
 msgid "period"
 msgstr ""
 
-#. Default: "Progress:"
+#. Default: "Progress"
 #: ./opengever/disposition/browser/templates/overview.pt:189
 msgid "progress"
 msgstr ""


### PR DESCRIPTION
- Fixed tooltip for the appraisal buttons (closes #2704)
- Removed colon on progress subtitle and improved styling of details section in disposition progress (closes #2680)
- Hide subtitles (active or inactive dossiers) when list is empty (closes #2674)
- Change color of add answer from green to black (closes #2707)
- Use carets instead of plus/minus as collabsible triggers in disposition progress. (closes #2678)

<img width="819" alt="bildschirmfoto 2017-03-12 um 17 57 13" src="https://cloud.githubusercontent.com/assets/485755/23833906/5dd4e50a-074d-11e7-9a3b-417d82436bee.png">


Styling adjustments: https://github.com/4teamwork/plonetheme.teamraum/pull/517