### PR TITLE
OGGBundle: Add support to map local role principal names during import

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- OGGBundle: Add support to map local role principal names during
+  import based on ingestion settings.
+  [lgraf]
+
 - Display archival value in the repositoryfolder byline.
   [phgross]
 

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -18,6 +18,7 @@ pipeline =
     workflow
     propertiesupdater
     map-local-roles
+    map-principals
     local_roles
     blocklocalroles
     constraintypes
@@ -52,6 +53,9 @@ blueprint = opengever.bundle.workflow
 
 [map-local-roles]
 blueprint = opengever.bundle.map_local_roles
+
+[map-principals]
+blueprint = opengever.bundle.map_principals
 
 [blocklocalroles]
 blueprint = opengever.setup.blocklocalroles

--- a/opengever/bundle/sections/map_principals.py
+++ b/opengever/bundle/sections/map_principals.py
@@ -1,0 +1,46 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+
+
+AC_LOCAL_ROLES_KEY = '_ac_local_roles'
+
+
+class MapPrincipalsSection(object):
+    """Map local role principal names based on a mapping given in
+    ingestion settings.
+
+    Must be applied after the map-local-roles section.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.logger = logging.getLogger(options['blueprint'])
+        self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+
+    def __iter__(self):
+        ingestion_settings = self.bundle.ingestion_settings
+        principal_mapping = ingestion_settings.get('principal_mapping', {})
+
+        for item in self.previous:
+            if not principal_mapping:
+                yield item
+                continue
+
+            local_roles = item.get(AC_LOCAL_ROLES_KEY)
+            if local_roles:
+                for old_principal, new_principal in principal_mapping.items():
+                    if old_principal in local_roles:
+                        # We wouldn't want to overwrite existing entries
+                        assert new_principal not in local_roles
+                        local_roles[new_principal] = local_roles[old_principal]
+                        local_roles.pop(old_principal)
+
+            yield item

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -49,6 +49,11 @@
       />
 
   <utility
+      component=".sections.map_principals.MapPrincipalsSection"
+      name="opengever.bundle.map_principals"
+      />
+
+  <utility
       component=".sections.progress.ProgressSection"
       name="opengever.bundle.progress"
       />


### PR DESCRIPTION
OGGBundle: Add support to map local role principal names during import based on ingestion settings. This is necessary in order to handle mapping -LS to -GS groups during OSLW import.