### PR TITLE
OGGBundle pipeline: Tune savepoint and intermediate commit settings

### DIFF
--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -60,6 +60,10 @@ fields = python:['block_inheritance']
 [assignreporootnavigation]
 blueprint = opengever.setup.assignreporootnavigation
 
+[savepoint]
+blueprint = collective.transmogrifier.sections.savepoint
+every = 500
+
 [progress]
 blueprint = opengever.bundle.progress
 

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -14,7 +14,7 @@ log = logging.getLogger('opengever.bundle.post_processing')
 log.setLevel(logging.INFO)
 
 
-INTERMEDIATE_COMMIT_INTERVAL = 1000
+INTERMEDIATE_COMMIT_INTERVAL = 200
 VERSIONABLE_TYPES = ('opengever.document.document', 'ftw.mail.mail')
 
 


### PR DESCRIPTION
OGGBundle pipeline: Tune savepoint and intermediate commit settings to be more appropriate for medium sized imports.