### PR TITLE
Amend the JS redirector mechanism to support OC URLs

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- The document redirector now handles newstyle OC URLs.
+  [Rotonen]
+
 - Set preserved as paper to false for generated journal pdfs.
   [phgross]
 

--- a/opengever/base/redirector.py
+++ b/opengever/base/redirector.py
@@ -1,7 +1,5 @@
 from five import grok
 from opengever.base.interfaces import IRedirector
-from persistent.dict import PersistentDict
-from persistent.list import PersistentList
 from plone.app.layout.viewlets.interfaces import IAboveContentTitle
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
@@ -29,7 +27,8 @@ class RedirectorCookie(object):
         return value
 
     def _get(self):
-        # Load from response cookie in case this request added / updated the cookie
+        # Load from response cookie in case this request added or updated the
+        # cookie
         cookie = self.request.response.cookies.get(REDIRECTOR_COOKIE_NAME, {})
         value = cookie.get('value', None)
         if value == 'deleted':
@@ -81,8 +80,7 @@ class Redirector(grok.Adapter):
 
 
 class RedirectorViewlet(grok.Viewlet):
-    """ Viewlet which adds the redirects for the IRedirector.
-    """
+    """Viewlet which adds the redirects for the IRedirector."""
 
     grok.name('redirector')
     grok.context(Interface)

--- a/opengever/base/redirector.py
+++ b/opengever/base/redirector.py
@@ -90,7 +90,11 @@ class RedirectorViewlet(grok.Viewlet):
     JS_TEMPLATE = '''
 <script type="text/javascript" class="redirector">
 $(function() {
+  if ('%(url)s'.split(':')[0] == 'oc') {
+    window.location = '%(url)s';
+  } else {
     window.setTimeout("window.open('%(url)s', '%(target)s');", %(timeout)s);
+  }
 });
 </script>
 '''

--- a/opengever/document/checkout/checkout.py
+++ b/opengever/document/checkout/checkout.py
@@ -3,6 +3,8 @@ from opengever.base.interfaces import IRedirector
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.officeconnector.helpers import create_oc_url
+from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
@@ -24,7 +26,6 @@ class CheckoutDocuments(grok.View):
     grok.name('checkout_documents')
 
     def render(self):
-
         # check whether we have paths or not
         paths = self.request.get('paths')
 
@@ -71,11 +72,14 @@ class CheckoutDocuments(grok.View):
         external_edit = self.request.get('mode') == 'external'
         if len(objects) == 1 and external_edit:
             redirector = IRedirector(self.request)
-            redirector.redirect(
-                '%s/external_edit' % objects[0].absolute_url(),
-                target='_self',
-                timeout=1000)
-
+            if not is_officeconnector_checkout_feature_enabled():
+                redirector.redirect(
+                    '%s/external_edit' % objects[0].absolute_url(),
+                    target='_self',
+                    timeout=1000)
+            else:
+                redirector.redirect(
+                    create_oc_url(self.context, dict(action='checkout')))
         # now lets redirect to an appropriate target..
         if len(objects) == 1:
             return self.request.RESPONSE.redirect(

--- a/opengever/document/checkout/checkout.py
+++ b/opengever/document/checkout/checkout.py
@@ -86,10 +86,8 @@ class CheckoutDocuments(grok.View):
                 '%s#documents' % self.context.absolute_url())
 
     def checkout(self, obj):
-        """Checks out a single document object.
-        """
-
-        # check out the document
+        """Checks out a single document object."""
+        # Check out the document
         manager = getMultiAdapter((obj, self.request), ICheckinCheckoutManager)
 
         # is checkout allowed for this document?

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -1,5 +1,10 @@
-from plone import api
+from opengever.document.document import IDocumentSchema
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
+from plone import api
+from Products.CMFCore.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
+from zExceptions import Forbidden
+from zExceptions import NotFound
 
 
 def is_officeconnector_attach_feature_enabled():
@@ -10,3 +15,63 @@ def is_officeconnector_attach_feature_enabled():
 def is_officeconnector_checkout_feature_enabled():
     return api.portal.get_registry_record('direct_checkout_and_edit_enabled',
                                           interface=IOfficeConnectorSettings)
+
+
+def create_oc_url(context, payload):
+    # Feature used wrong - an action is always required
+    if 'action' not in payload:
+        raise NotFound
+
+    # Feature enabled for the wrong content type
+    if not IDocumentSchema.providedBy(context):
+        raise NotFound
+
+    if not context.file:
+        raise NotFound
+
+    plugin = None
+    acl_users = getToolByName(context, "acl_users")
+    plugins = acl_users._getOb('plugins')
+    authenticators = plugins.listPlugins(IAuthenticationPlugin)
+
+    # Assumes there is only one JWT auth plugin present in the acl_users
+    # which manages the user/session in question.
+    #
+    # This will work as long as the plugin this finds uses the same secret
+    # as whatever it ends up authenticating against - this is in all
+    # likelihood the Plone site keyring.
+    for id_, authenticator in authenticators:
+        if authenticator.meta_type == "JWT Authentication Plugin":
+            plugin = authenticator
+            break
+
+    if not plugin:
+        raise Forbidden
+
+    # Create a JWT for OfficeConnector - contents:
+    # action - tells OfficeConnector which code path to take
+    # url - tells OfficeConnector where from to fetch further instructions
+    payload['url'] = '/'.join([
+        api.portal.get().absolute_url(),
+        'oc_' + payload['action'],
+        api.content.get_uuid(context),
+        ])
+    user_id = api.user.get_current().getId()
+    token = plugin.create_token(user_id, data=payload)
+
+    # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
+    # IE11 only allows up to 507 characters for Application Protocols.
+    #
+    # This is eaten into by both the protocol identifier and the payload.
+    #
+    # In testing we've discovered for this to be a bit fuzzy and gotten
+    # arbitrary and inconsistent results of 506..509.
+    #
+    # For operational safety we've set the total url + separator + payload
+    # limit at 500 characters.
+    url = 'oc:' + token
+
+    if len(url) <= 500:
+        return url
+    else:
+        return None

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -1,11 +1,9 @@
-from opengever.document.document import IDocumentSchema
+from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from plone import api
 from plone.protect import createToken
 from plone.rest import Service
-from Products.CMFCore.utils import getToolByName
-from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
 from zExceptions import Forbidden
 from zExceptions import NotFound
 from zope.interface import implements
@@ -17,60 +15,12 @@ import json
 class OfficeConnectorURL(Service):
     """Create oc:<JWT> URLs for javascript to fetch and pass to the OS."""
 
-    def create_officeconnector_url(self, payload):
-        # Feature used wrong - an action is always required
-        if 'action' not in payload:
-            raise NotFound
-
-        # Feature enabled for the wrong content type
-        if not IDocumentSchema.providedBy(self.context):
-            raise NotFound
-
-        if not self.context.file:
-            raise NotFound
-        plugin = None
-        acl_users = getToolByName(self.context, "acl_users")
-        plugins = acl_users._getOb('plugins')
-        authenticators = plugins.listPlugins(IAuthenticationPlugin)
-
-        # Assumes there is only one JWT auth plugin present in the acl_users
-        # which manages the user/session in question.
-        #
-        # This will work as long as the plugin this finds uses the same secret
-        # as whatever it ends up authenticating against - this is in all
-        # likelihood the Plone site keyring.
-        for id_, authenticator in authenticators:
-            if authenticator.meta_type == "JWT Authentication Plugin":
-                plugin = authenticator
-                break
-
-        if not plugin:
-            raise Forbidden
-
-        # Create a JWT for OfficeConnector - contents:
-        # action - tells OfficeConnector which code path to take
-        # url - tells OfficeConnector where from to fetch further instructions
-        payload['url'] = '/'.join([
-            api.portal.get().absolute_url(),
-            'oc_' + payload['action'],
-            api.content.get_uuid(self.context),
-            ])
-        user_id = api.user.get_current().getId()
-        token = plugin.create_token(user_id, data=payload)
-
-        # https://blogs.msdn.microsoft.com/ieinternals/2014/08/13/url-length-limits/
-        # IE11 only allows up to 507 characters for Application Protocols.
-        #
-        # This is eaten into by both the protocol identifier and the payload.
-        #
-        # In testing we've discovered for this to be a bit fuzzy and gotten
-        # arbitrary and inconsistent results of 506..509.
-        #
-        # For operational safety we've set the total url + separator + payload
-        # limit at 500 characters.
-        url = 'oc:' + token
+    def create_officeconnector_url_json(self, payload):
         self.request.response.setHeader('Content-type', 'application/json')
-        if len(url) <= 500:
+
+        url = create_oc_url(self.context, payload)
+
+        if url:
             return json.dumps(dict(url=url))
         else:
             self.request.response.setStatus(500)
@@ -92,7 +42,7 @@ class OfficeConnectorAttachURL(OfficeConnectorURL):
         if not is_officeconnector_attach_feature_enabled():
             raise NotFound
         payload = {'action': 'attach'}
-        return self.create_officeconnector_url(payload)
+        return self.create_officeconnector_url_json(payload)
 
 
 class OfficeConnectorCheckoutURL(OfficeConnectorURL):
@@ -109,7 +59,7 @@ class OfficeConnectorCheckoutURL(OfficeConnectorURL):
 
         payload = {'action': 'checkout'}
 
-        return self.create_officeconnector_url(payload)
+        return self.create_officeconnector_url_json(payload)
 
 
 class OfficeConnectorPayload(Service):


### PR DESCRIPTION
* Amend the OfficeConnector `plone.rest` URL services to allow one to init them in ~any `BrowserView`
* Amend the redirector to issue out an OC URL in case of the OC URL checkout feature being enabled
* Amend the JS redirector to handle `oc:foobar` URLs

Considerations:
* Diving deep into portal site_actions would not have squashed #2696
* Not amending the JS redirector trips up the popup blocker on Chrome
* Could avoid the JSON parsing within the redirector, but did not want to break up the service logic

Fixes #2689 
Fixes #2696