### PR TITLE
Use SQLFormSupport class

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -34,6 +34,15 @@ Changelog
 - Get rid of unnecessary column label in extract attachments view. [lgraf]
 - Allow private dossiers to be resolved. [lgraf]
 - Escape dossiertemplate title_help field on display. [elioschmutz]
+2017.1.0 (unreleased)
+-------------------
+
+- Refactor: Use SQLFormSupport class for: Meeting
+  [elioschmutz]
+
+- Escape dossiertemplate title_help field on display.
+  [elioschmutz]
+
 - Fix the common-fieldset translation in the add/edit-form if using the
   ITranslatedTitle behavior in combination with a
   dossier-type (i.e. the templatefolder). [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Refactor: Use SQLFormSupport class for: Meeting and Member [elioschmutz]
 
 
 2017.1.1 (2017-03-27)
@@ -34,15 +34,6 @@ Changelog
 - Get rid of unnecessary column label in extract attachments view. [lgraf]
 - Allow private dossiers to be resolved. [lgraf]
 - Escape dossiertemplate title_help field on display. [elioschmutz]
-2017.1.0 (unreleased)
--------------------
-
-- Refactor: Use SQLFormSupport class for: Meeting
-  [elioschmutz]
-
-- Escape dossiertemplate title_help field on display.
-  [elioschmutz]
-
 - Fix the common-fieldset translation in the add/edit-form if using the
   ITranslatedTitle behavior in combination with a
   dossier-type (i.e. the templatefolder). [elioschmutz]

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import Base
+from opengever.base.model import SQLFormSupport
 from opengever.base.model import UTCDateTime
 from opengever.base.oguid import Oguid
 from opengever.base.utils import escape_html
@@ -62,7 +63,7 @@ class CloseTransition(Transition):
         api.portal.show_message(msg, api.portal.get().REQUEST)
 
 
-class Meeting(Base):
+class Meeting(Base, SQLFormSupport):
 
     STATE_PENDING = State('pending', is_default=True,
                           title=_('pending', default='Pending'))
@@ -283,21 +284,9 @@ class Meeting(Base):
     def get_state(self):
         return self.workflow.get_state(self.workflow_state)
 
-    def get_edit_values(self, fieldnames):
-        values = {}
-        for fieldname in fieldnames:
-            value = getattr(self, fieldname, None)
-            if value:
-                values[fieldname] = value
-
-        return values
-
     def update_model(self, data):
         """Manually set the modified timestamp when updating meetings."""
-
-        for key, value in data.items():
-            setattr(self, key, value)
-
+        super(Meeting, self).update_model(data)
         self.modified = utcnow_tz_aware()
 
     def get_title(self):
@@ -382,7 +371,7 @@ class Meeting(Base):
             url, escape_html(self.get_title()), self.css_class)
         return link
 
-    def get_url(self, view='view'):
+    def get_url(self, context=None, view='view'):
         elements = [self.committee.get_admin_unit().public_url, self.physical_path]
         if view:
             elements.append(view)
@@ -394,6 +383,3 @@ class Meeting(Base):
 
     def get_dossier(self):
         return self.dossier_oguid.resolve_object()
-
-    def get_edit_url(self, context):
-        return self.get_url(view='edit')

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -1,4 +1,5 @@
 from opengever.base.model import Base
+from opengever.base.model import SQLFormSupport
 from opengever.base.utils import escape_html
 from opengever.ogds.models import EMAIL_LENGTH
 from opengever.ogds.models import FIRSTNAME_LENGTH
@@ -10,7 +11,7 @@ from sqlalchemy.orm import column_property
 from sqlalchemy.schema import Sequence
 
 
-class Member(Base):
+class Member(Base, SQLFormSupport):
 
     __tablename__ = 'members'
 
@@ -28,9 +29,6 @@ class Member(Base):
     def css_class(self):
         return 'contenttype-opengever-meeting-member'
 
-    def is_editable(self):
-        return True
-
     def get_link(self, context, title=None):
         title = title or self.fullname
         url = self.get_url(context)
@@ -44,25 +42,12 @@ class Member(Base):
     def get_lastname_link(self, context):
         return self.get_link(context, title=self.lastname)
 
-    def get_url(self, context):
-        return "{}/member-{}".format(context.absolute_url(), self.member_id)
+    def get_url(self, context, view=None):
+        elements = [context.absolute_url(), "member-{}".format(self.member_id)]
+        if view:
+            elements.append(view)
 
-    def get_edit_url(self, context):
-        return '/'.join((self.get_url(context), 'edit'))
-
-    def get_edit_values(self, fieldnames):
-        values = {}
-        for fieldname in fieldnames:
-            value = getattr(self, fieldname, None)
-            if not value:
-                continue
-
-            values[fieldname] = value
-        return values
-
-    def update_model(self, data):
-        for key, value in data.items():
-            setattr(self, key, value)
+        return '/'.join(elements)
 
     def get_title(self, show_email_as_link=True):
         fullname = escape_html(self.fullname)

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -58,9 +58,9 @@ class TestMeetingLocking(FunctionalTestCase):
 
     @browsing
     def test_editing_a_protocol_locks_meeting(self, browser):
-        browser.login().open(self.meeting.get_url('protocol'))
+        browser.login().open(self.meeting.get_url(view='protocol'))
 
-        browser.open(self.meeting.get_url('plone_lock_info/lock_info'))
+        browser.open(self.meeting.get_url(view='plone_lock_info/lock_info'))
         lock_infos = ILockable(
             MeetingWrapper.wrap(self.committee, self.meeting)).lock_info()
 
@@ -71,12 +71,12 @@ class TestMeetingLocking(FunctionalTestCase):
 
     @browsing
     def test_lock_refreshing_is_enabled(self, browser):
-        browser.login().open(self.meeting.get_url('protocol'))
+        browser.login().open(self.meeting.get_url(view='protocol'))
         self.assertIn('enableUnlockProtection', browser.css('#form').first.get('class'))
 
     @browsing
     def test_saving_protocol_unlock_meeting(self, browser):
-        browser.login().open(self.meeting.get_url('protocol'))
+        browser.login().open(self.meeting.get_url(view='protocol'))
         lock_infos = ILockable(
             MeetingWrapper.wrap(self.committee, self.meeting)).lock_info()
         self.assertEquals(1, len(lock_infos))
@@ -88,7 +88,7 @@ class TestMeetingLocking(FunctionalTestCase):
 
     @browsing
     def test_cancelling_protocol_unlock_meeting(self, browser):
-        browser.login().open(self.meeting.get_url('protocol'))
+        browser.login().open(self.meeting.get_url(view='protocol'))
         lock_infos = ILockable(
             MeetingWrapper.wrap(self.committee, self.meeting)).lock_info()
         self.assertEquals(1, len(lock_infos))
@@ -103,10 +103,10 @@ class TestMeetingLocking(FunctionalTestCase):
         user = create(Builder('user')
                       .named('Hugo', 'Boss')
                       .in_groups('client1_users'))
-        browser.login(username='hugo.boss').open(self.meeting.get_url('protocol'))
+        browser.login(username='hugo.boss').open(self.meeting.get_url(view='protocol'))
 
         with self.assertRaises(Redirect) as cm:
-            browser.login().open(self.meeting.get_url('protocol'))
+            browser.login().open(self.meeting.get_url(view='protocol'))
 
         self.assertEquals(
             'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1',
@@ -117,7 +117,7 @@ class TestMeetingLocking(FunctionalTestCase):
         user = create(Builder('user')
                       .named('Hugo', 'Boss')
                       .in_groups('client1_users'))
-        browser.login(username='hugo.boss').open(self.meeting.get_url('protocol'))
+        browser.login(username='hugo.boss').open(self.meeting.get_url(view='protocol'))
 
         browser.login().open(self.meeting.get_url(),
                              {'_authenticator': createToken()})


### PR DESCRIPTION
Dieser PR verwendet die `SQLFormSupport`-Klasse (siehe PR: #2012) für alle restlichen SQL-Basierten Typen welche Formulare verwenden.

Gewisse Typen wurden schon früher angepasst (siehe https://github.com/4teamwork/opengever.core/commit/5e21228).

closes #2028 