### PR TITLE
Move "Aktenotiz" out of the byline, add icon next to title and display text in overview

### DIFF
--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -35,7 +35,7 @@
                 <span tal:content="box/content" />
               </tal:item>
               <tal:item tal:condition="not: box/content">
-                <span tal:condition="python: box.get('has_no_content_placeholder', True)" i18n:translate="" >No content</span>
+                <span tal:condition="python: box.get('has_empty_marker', True)" i18n:translate="" >No content</span>
               </tal:item>
             </tal:box>
 

--- a/opengever/base/browser/templates/gever-macros.pt
+++ b/opengever/base/browser/templates/gever-macros.pt
@@ -35,7 +35,7 @@
                 <span tal:content="box/content" />
               </tal:item>
               <tal:item tal:condition="not: box/content">
-                <span i18n:translate="" >No content</span>
+                <span tal:condition="python: box.get('has_no_content_placeholder', True)" i18n:translate="" >No content</span>
               </tal:item>
             </tal:box>
 

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -45,7 +45,7 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
 
     def boxes(self):
         return [[self.make_task_box(),
-                 self.make_comment_box(has_no_content_placeholder=False),
+                 self.make_comment_box(has_empty_marker=False),
                  self.make_participation_box(),
                  self.make_reference_box()],
                 [self.make_document_box(),
@@ -55,10 +55,10 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
         return truncate_ellipsis(
             IDossier(self.context).comments, self.comments_max_length)
 
-    def make_comment_box(self, has_no_content_placeholder=True):
+    def make_comment_box(self, has_empty_marker=True):
         return dict(id='comments', content=self.get_comments(),
                     label=_(u"label_comments", default="Comments"),
-                    has_no_content_placeholder=has_no_content_placeholder)
+                    has_empty_marker=has_empty_marker)
 
     def make_participation_box(self):
         if is_contact_feature_enabled():

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -209,6 +209,7 @@ class DossierTemplateOverview(DossierOverview):
         # Column 3 contains a listing of all documents within the template.
         return [[self.make_description_box(),
                  self.make_keyword_box(),
+                 self.make_comment_box(),
                  self.make_filing_prefix_box()],
                 [self.make_document_box()]]
 

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -16,6 +16,7 @@ from opengever.globalindex.model.task import Task
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.tabbedview import GeverTabMixin
+from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from sqlalchemy import desc
 from zc.relation.interfaces import ICatalog
@@ -44,8 +45,12 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
             sort_order=sort_order)
 
     def boxes(self):
+        can_modify = api.user.has_permission('Modify portal content',
+                                             obj=self.context)
+        has_empty_marker = (not can_modify and not self.get_comments())
+
         return [[self.make_task_box(),
-                 self.make_comment_box(has_empty_marker=False),
+                 self.make_comment_box(has_empty_marker=has_empty_marker),
                  self.make_participation_box(),
                  self.make_reference_box()],
                 [self.make_document_box(),

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -45,7 +45,7 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
 
     def boxes(self):
         return [[self.make_task_box(),
-                 self.make_comment_box(),
+                 self.make_comment_box(has_no_content_placeholder=False),
                  self.make_participation_box(),
                  self.make_reference_box()],
                 [self.make_document_box(),
@@ -55,9 +55,10 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
         return truncate_ellipsis(
             IDossier(self.context).comments, self.comments_max_length)
 
-    def make_comment_box(self):
+    def make_comment_box(self, has_no_content_placeholder=True):
         return dict(id='comments', content=self.get_comments(),
-                    label=_(u"label_comments", default="Comments"))
+                    label=_(u"label_comments", default="Comments"),
+                    has_no_content_placeholder=has_no_content_placeholder)
 
     def make_participation_box(self):
         if is_contact_feature_enabled():

--- a/opengever/dossier/browser/save_comments_entpoint.py
+++ b/opengever/dossier/browser/save_comments_entpoint.py
@@ -1,4 +1,5 @@
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.utils import truncate_ellipsis
 from Products.Five.browser import BrowserView
 import json
 
@@ -8,10 +9,10 @@ class SaveCommentsEndpoint(BrowserView):
     def __call__(self):
         self.request.response.setHeader('Content-Type', 'application/json')
         self.request.response.setHeader('X-Theme-Disabled', 'True')
-        self.request.response.setStatus(204)
 
         data = json.loads(self.request.get('data', '{}'))
         dossier = IDossier(self.context)
         dossier.comments = data['comments']
         self.context.reindexObject(idxs=['SearchableText'])
-        return None
+        return json.dumps({'comment': truncate_ellipsis(dossier.comments,
+                                                        400)})

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-03-06 23:34+0000\n"
+"POT-Creation-Date: 2017-03-14 19:29+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -28,7 +28,7 @@ msgstr "Geschäftsdossier hinzufügen"
 msgid "Add Participant"
 msgstr "Beteiligung hinzufügen"
 
-#: ./opengever/dossier/behaviors/dossier.py:235
+#: ./opengever/dossier/behaviors/dossier.py:234
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:48
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
@@ -54,7 +54,7 @@ msgstr "Report konnte nicht generiert werden."
 msgid "Delete"
 msgstr "Beteiligung löschen"
 
-#: ./opengever/dossier/browser/overview.py:81
+#: ./opengever/dossier/browser/overview.py:100
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -75,7 +75,7 @@ msgstr "Dossiervorlage"
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
-#: ./opengever/dossier/behaviors/dossier.py:257
+#: ./opengever/dossier/behaviors/dossier.py:256
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
@@ -105,11 +105,11 @@ msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossi
 msgid "Move Items"
 msgstr "Elemente verschieben"
 
-#: ./opengever/dossier/browser/overview.py:77
+#: ./opengever/dossier/browser/overview.py:96
 msgid "Newest documents"
 msgstr "Neuste Dokumente"
 
-#: ./opengever/dossier/browser/overview.py:68
+#: ./opengever/dossier/browser/overview.py:87
 msgid "Newest tasks"
 msgstr "Neuste Aufgaben"
 
@@ -125,11 +125,11 @@ msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 msgid "Participant"
 msgstr "Beteiligung"
 
-#: ./opengever/dossier/browser/overview.py:63
+#: ./opengever/dossier/browser/overview.py:82
 msgid "Participants"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/browser/overview.py:56
+#: ./opengever/dossier/browser/overview.py:75
 msgid "Participations"
 msgstr "Beteiligungen"
 
@@ -180,7 +180,7 @@ msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokum
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr "Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} bereits abgeschlossen ist. Das Subdossier muss vorgängig wieder eröffnet werden."
 
-#: ./opengever/dossier/activate.py:43
+#: ./opengever/dossier/activate.py:41
 msgid "The Dossier has been activated"
 msgstr "Das Dossier wurde aktiviert."
 
@@ -220,11 +220,11 @@ msgstr "Das angegeben Ablagejahr ist ungültig."
 msgid "The selected objects can't be found, please try it again."
 msgstr "Die selektierten Objekte konnten nicht gefunden werden, bitte versuchen Sie es erneut."
 
-#: ./opengever/dossier/behaviors/dossier.py:198
+#: ./opengever/dossier/behaviors/dossier.py:197
 msgid "The start date must be before the end date."
 msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 
-#: ./opengever/dossier/behaviors/dossier.py:264
+#: ./opengever/dossier/behaviors/dossier.py:263
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
@@ -318,7 +318,7 @@ msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:100
+#: ./opengever/dossier/behaviors/dossier.py:99
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Ablage"
@@ -356,8 +356,8 @@ msgstr "Ablagenummer"
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:112
-#: ./opengever/dossier/browser/overview.py:214
+#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/browser/overview.py:229
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
@@ -372,7 +372,7 @@ msgid "heading_archive_form"
 msgstr "Dossier ablegen"
 
 #. Default: "${title} notes / comments"
-#: ./opengever/dossier/viewlets/templates/note.pt:28
+#: ./opengever/dossier/viewlets/templates/note.pt:40
 msgid "heading_dossier_note"
 msgstr "Kommentar zu Dossier `${title}`"
 
@@ -385,11 +385,11 @@ msgstr "Elemente verschieben"
 msgid "help_contact"
 msgstr "Wählen Sie einen Benutzer oder einen Kontakt aus."
 
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py:147
 msgid "help_container_location"
 msgstr "Standortangabe des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
-#: ./opengever/dossier/behaviors/dossier.py:131
+#: ./opengever/dossier/behaviors/dossier.py:130
 msgid "help_container_type"
 msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
@@ -406,19 +406,24 @@ msgstr "Geben Sie die vollständige Ablagenummer an."
 msgid "help_keywords"
 msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
 
-#: ./opengever/dossier/behaviors/dossier.py:142
+#: ./opengever/dossier/behaviors/dossier.py:141
 msgid "help_number_of_containers"
 msgstr "Anzahl Behälter, die ein (grosses) Dossier in Papierform enthalten"
 
 #. Default: "Create a new note"
-#: ./opengever/dossier/viewlets/templates/note.pt:18
+#: ./opengever/dossier/viewlets/templates/note.pt:19
 msgid "help_text_add_note"
 msgstr "Neuen Kommentar erfassen."
 
 #. Default: "There is a note"
-#: ./opengever/dossier/viewlets/templates/note.pt:10
+#: ./opengever/dossier/viewlets/templates/note.pt:11
 msgid "help_text_edit_note"
 msgstr "Es wurde ein Kommentar erfasst!"
+
+#. Default: "View note"
+#: ./opengever/dossier/viewlets/templates/note.pt:28
+msgid "help_text_view_note"
+msgstr ""
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
 #: ./opengever/dossier/dossiertemplate/behaviors.py:35
@@ -436,7 +441,7 @@ msgid "info_removed_participations"
 msgstr "Die Beteiligungen wurde entfernt."
 
 #. Default: "Add Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:17
+#: ./opengever/dossier/viewlets/templates/note.pt:22
 msgid "label_add_note"
 msgstr "Erfassen"
 
@@ -456,13 +461,18 @@ msgid "label_by_author"
 msgstr "Federführend: ${author}"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/viewlets/templates/note.pt:41
+#: ./opengever/dossier/viewlets/templates/note.pt:55
 msgid "label_cancel"
 msgstr "Abbrechen"
 
+#. Default: "Close"
+#: ./opengever/dossier/viewlets/templates/note.pt:59
+msgid "label_close"
+msgstr "Schliessen"
+
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:87
-#: ./opengever/dossier/browser/overview.py:210
+#: ./opengever/dossier/behaviors/dossier.py:86
+#: ./opengever/dossier/browser/overview.py:67
 msgid "label_comments"
 msgstr "Kommentar"
 
@@ -472,12 +482,12 @@ msgid "label_contact"
 msgstr "Person"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:147
+#: ./opengever/dossier/behaviors/dossier.py:146
 msgid "label_container_location"
 msgstr "Behältnis-Standort"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py:129
 msgid "label_container_type"
 msgstr "Behältnis-Art"
 
@@ -488,7 +498,7 @@ msgid "label_creator"
 msgstr "Erstellt von"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:218
+#: ./opengever/dossier/browser/overview.py:233
 #: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr "Beschreibung"
@@ -499,18 +509,13 @@ msgid "label_destination"
 msgstr "Zielposition / Zieldossier"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:202
+#: ./opengever/dossier/browser/overview.py:221
 #: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr "Dokumente"
 
-#. Default: "Dossiernote"
-#: ./opengever/dossier/viewlets/byline.py:115
-msgid "label_dossier_note"
-msgstr "Kommentar"
-
 #. Default: "Create Dossier note"
-#: ./opengever/dossier/viewlets/templates/note.pt:33
+#: ./opengever/dossier/viewlets/templates/note.pt:45
 msgid "label_dossier_note_placeholder"
 msgstr "Kommentar erfassen"
 
@@ -525,25 +530,25 @@ msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
 #. Default: "Edit Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:9
+#: ./opengever/dossier/viewlets/templates/note.pt:14
 msgid "label_edit_note"
 msgstr "Bearbeiten"
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:102
+#: ./opengever/dossier/viewlets/byline.py:74
 msgid "label_email_address"
 msgstr "E-Mail"
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:82
+#: ./opengever/dossier/behaviors/dossier.py:81
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:83
+#: ./opengever/dossier/viewlets/byline.py:55
 msgid "label_end_byline"
 msgstr "Ende"
 
@@ -558,7 +563,7 @@ msgid "label_filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:175
+#: ./opengever/dossier/behaviors/dossier.py:174
 msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
@@ -574,7 +579,7 @@ msgstr "Journal"
 
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:60
-#: ./opengever/dossier/browser/overview.py:206
+#: ./opengever/dossier/browser/overview.py:225
 msgid "label_keywords"
 msgstr "Schlagworte"
 
@@ -584,7 +589,7 @@ msgid "label_label"
 msgstr "Label"
 
 #. Default: "Linked Dossiers"
-#: ./opengever/dossier/browser/overview.py:73
+#: ./opengever/dossier/browser/overview.py:92
 msgid "label_linked_dossiers"
 msgstr "Verlinkte Dossiers"
 
@@ -605,7 +610,7 @@ msgid "label_no_reference_number"
 msgstr "Die Archivnummer wird erst beim Erstellen generiert."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:140
+#: ./opengever/dossier/behaviors/dossier.py:139
 msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
@@ -650,19 +655,19 @@ msgid "label_recipient"
 msgstr "Empfänger"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:182
+#: ./opengever/dossier/behaviors/dossier.py:181
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:95
+#: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:153
+#: ./opengever/dossier/behaviors/dossier.py:152
 msgid "label_related_dossier"
 msgstr "Verwandte Dossiers"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:93
+#: ./opengever/dossier/behaviors/dossier.py:92
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
@@ -689,24 +694,29 @@ msgid "label_sablon_templates"
 msgstr "Sablon Vorlagen"
 
 #. Default: "Save"
-#: ./opengever/dossier/viewlets/templates/note.pt:39
+#: ./opengever/dossier/viewlets/templates/note.pt:53
 msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:89
+#: ./opengever/dossier/viewlets/byline.py:61
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
+#. Default: "Show Note"
+#: ./opengever/dossier/viewlets/templates/note.pt:31
+msgid "label_show_note"
+msgstr "Anzeigen"
+
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:74
+#: ./opengever/dossier/behaviors/dossier.py:73
 #: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:77
+#: ./opengever/dossier/viewlets/byline.py:49
 msgid "label_start_byline"
 msgstr "Beginn"
 
@@ -755,17 +765,17 @@ msgstr "URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:71
+#: ./opengever/dossier/viewlets/byline.py:43
 msgid "label_workflow_state"
 msgstr "Status"
 
 #. Default: "Changes not saved"
-#: ./opengever/dossier/viewlets/byline.py:38
+#: ./opengever/dossier/viewlets/comment.py:28
 msgid "message_body_error"
 msgstr "Änderungen wurde nicht gespeichert"
 
 #. Default: "Changes saved"
-#: ./opengever/dossier/viewlets/byline.py:37
+#: ./opengever/dossier/viewlets/comment.py:27
 msgid "message_body_info"
 msgstr "Änderungen gespeichert"
 
@@ -787,7 +797,7 @@ msgid "not all task are closed"
 msgstr "Es sind nicht alle Aufgaben abgeschlossen"
 
 #. Default: "Confirm abbord"
-#: ./opengever/dossier/viewlets/byline.py:34
+#: ./opengever/dossier/viewlets/comment.py:24
 msgid "note_text_confirm_abord"
 msgstr "Sie haben nicht gespeicherte Änderungen, wollen Sie wirklich abbrechen?"
 
@@ -821,7 +831,7 @@ msgid "tasks"
 msgstr "Aufgaben"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:124
+#: ./opengever/dossier/behaviors/dossier.py:123
 msgid "temporary_former_reference_number"
 msgstr "Temporäres früheres Aktenzeichen"
 
@@ -843,3 +853,4 @@ msgstr "Dossier Journal ${today}"
 #: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
+

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-06 23:34+0000\n"
+"POT-Creation-Date: 2017-03-14 19:29+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -27,7 +27,7 @@ msgstr "Insérer un dossier d'affaire"
 msgid "Add Participant"
 msgstr "Participant"
 
-#: ./opengever/dossier/behaviors/dossier.py:235
+#: ./opengever/dossier/behaviors/dossier.py:234
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:48
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
@@ -52,7 +52,7 @@ msgstr "Impossible de générer l'affichage"
 msgid "Delete"
 msgstr "Effacer la participation"
 
-#: ./opengever/dossier/browser/overview.py:81
+#: ./opengever/dossier/browser/overview.py:100
 msgid "Description"
 msgstr "Description"
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès"
 
-#: ./opengever/dossier/behaviors/dossier.py:257
+#: ./opengever/dossier/behaviors/dossier.py:256
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
@@ -103,11 +103,11 @@ msgstr "Il n'est pas possible d'ouvrir un sous-dossier, le dossier principale do
 msgid "Move Items"
 msgstr "Déplacer l'élément"
 
-#: ./opengever/dossier/browser/overview.py:77
+#: ./opengever/dossier/browser/overview.py:96
 msgid "Newest documents"
 msgstr "Derniers documents"
 
-#: ./opengever/dossier/browser/overview.py:68
+#: ./opengever/dossier/browser/overview.py:87
 msgid "Newest tasks"
 msgstr "Dernières tâches"
 
@@ -123,11 +123,11 @@ msgstr "Manque des champs obligatoires"
 msgid "Participant"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:63
+#: ./opengever/dossier/browser/overview.py:82
 msgid "Participants"
 msgstr "Participants"
 
-#: ./opengever/dossier/browser/overview.py:56
+#: ./opengever/dossier/browser/overview.py:75
 msgid "Participations"
 msgstr "Participants"
 
@@ -176,7 +176,7 @@ msgstr "Ce dossier ne peut pas être annulé, il contient encore des documents a
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr "Impossible d'annuler le dossier, parce que le sous-dossier ${dossier} est déja fermé. Le sous-dossier doit d'abord être réouvert."
 
-#: ./opengever/dossier/activate.py:43
+#: ./opengever/dossier/activate.py:41
 msgid "The Dossier has been activated"
 msgstr "Le dossier a été activé."
 
@@ -216,11 +216,11 @@ msgstr "L'année de dépôt attribuée n'est pas valable"
 msgid "The selected objects can't be found, please try it again."
 msgstr "Impossible de trouver les objets sélectionnés, merci de réessayer."
 
-#: ./opengever/dossier/behaviors/dossier.py:198
+#: ./opengever/dossier/behaviors/dossier.py:197
 msgid "The start date must be before the end date."
 msgstr "La date de début doit être plus récente que la date de clôture."
 
-#: ./opengever/dossier/behaviors/dossier.py:264
+#: ./opengever/dossier/behaviors/dossier.py:263
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
@@ -314,7 +314,7 @@ msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun objet."
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:100
+#: ./opengever/dossier/behaviors/dossier.py:99
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Classeur"
@@ -352,8 +352,8 @@ msgstr "Numéro d'inventaire"
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:112
-#: ./opengever/dossier/browser/overview.py:214
+#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/browser/overview.py:229
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
@@ -368,7 +368,7 @@ msgid "heading_archive_form"
 msgstr "Classer le dossier"
 
 #. Default: "${title} notes / comments"
-#: ./opengever/dossier/viewlets/templates/note.pt:28
+#: ./opengever/dossier/viewlets/templates/note.pt:40
 msgid "heading_dossier_note"
 msgstr ""
 
@@ -381,11 +381,11 @@ msgstr "Déplacer des éléments"
 msgid "help_contact"
 msgstr "Choix d'un utilisateur ou un contact."
 
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py:147
 msgid "help_container_location"
 msgstr "Emplacement du dossier imprimé"
 
-#: ./opengever/dossier/behaviors/dossier.py:131
+#: ./opengever/dossier/behaviors/dossier.py:130
 msgid "help_container_type"
 msgstr "Type de conteneur du dossier imprimé"
 
@@ -402,18 +402,23 @@ msgstr "Saisir le numéro d'inventaire complet"
 msgid "help_keywords"
 msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de la position"
 
-#: ./opengever/dossier/behaviors/dossier.py:142
+#: ./opengever/dossier/behaviors/dossier.py:141
 msgid "help_number_of_containers"
 msgstr "Nombre de conteneurs contenant des dossiers imprimés (volumineux)"
 
 #. Default: "Create a new note"
-#: ./opengever/dossier/viewlets/templates/note.pt:18
+#: ./opengever/dossier/viewlets/templates/note.pt:19
 msgid "help_text_add_note"
 msgstr ""
 
 #. Default: "There is a note"
-#: ./opengever/dossier/viewlets/templates/note.pt:10
+#: ./opengever/dossier/viewlets/templates/note.pt:11
 msgid "help_text_edit_note"
+msgstr ""
+
+#. Default: "View note"
+#: ./opengever/dossier/viewlets/templates/note.pt:28
+msgid "help_text_view_note"
 msgstr ""
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
@@ -432,7 +437,7 @@ msgid "info_removed_participations"
 msgstr "Participations enlevées"
 
 #. Default: "Add Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:17
+#: ./opengever/dossier/viewlets/templates/note.pt:22
 msgid "label_add_note"
 msgstr ""
 
@@ -452,13 +457,18 @@ msgid "label_by_author"
 msgstr "Responsable: ${author}"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/viewlets/templates/note.pt:41
+#: ./opengever/dossier/viewlets/templates/note.pt:55
 msgid "label_cancel"
 msgstr ""
 
+#. Default: "Close"
+#: ./opengever/dossier/viewlets/templates/note.pt:59
+msgid "label_close"
+msgstr ""
+
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:87
-#: ./opengever/dossier/browser/overview.py:210
+#: ./opengever/dossier/behaviors/dossier.py:86
+#: ./opengever/dossier/browser/overview.py:67
 msgid "label_comments"
 msgstr "Commentaire"
 
@@ -468,12 +478,12 @@ msgid "label_contact"
 msgstr "Personne"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:147
+#: ./opengever/dossier/behaviors/dossier.py:146
 msgid "label_container_location"
 msgstr "Emplacement du conteneur"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py:129
 msgid "label_container_type"
 msgstr "Type de conteneur"
 
@@ -484,7 +494,7 @@ msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:218
+#: ./opengever/dossier/browser/overview.py:233
 #: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr ""
@@ -495,18 +505,13 @@ msgid "label_destination"
 msgstr "Destination"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:202
+#: ./opengever/dossier/browser/overview.py:221
 #: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr "Documents"
 
-#. Default: "Dossiernote"
-#: ./opengever/dossier/viewlets/byline.py:115
-msgid "label_dossier_note"
-msgstr ""
-
 #. Default: "Create Dossier note"
-#: ./opengever/dossier/viewlets/templates/note.pt:33
+#: ./opengever/dossier/viewlets/templates/note.pt:45
 msgid "label_dossier_note_placeholder"
 msgstr ""
 
@@ -521,25 +526,25 @@ msgid "label_edit_after_creation"
 msgstr "Modifier après avoir créé"
 
 #. Default: "Edit Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:9
+#: ./opengever/dossier/viewlets/templates/note.pt:14
 msgid "label_edit_note"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:102
+#: ./opengever/dossier/viewlets/byline.py:74
 msgid "label_email_address"
 msgstr "Email"
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:82
+#: ./opengever/dossier/behaviors/dossier.py:81
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr "Date de fin :"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:83
+#: ./opengever/dossier/viewlets/byline.py:55
 msgid "label_end_byline"
 msgstr "Jusqu'au"
 
@@ -554,7 +559,7 @@ msgid "label_filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:175
+#: ./opengever/dossier/behaviors/dossier.py:174
 msgid "label_former_reference_number"
 msgstr "Ancienne numéro référence"
 
@@ -570,7 +575,7 @@ msgstr "Historique"
 
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:60
-#: ./opengever/dossier/browser/overview.py:206
+#: ./opengever/dossier/browser/overview.py:225
 msgid "label_keywords"
 msgstr "Mots-clés"
 
@@ -580,7 +585,7 @@ msgid "label_label"
 msgstr ""
 
 #. Default: "Linked Dossiers"
-#: ./opengever/dossier/browser/overview.py:73
+#: ./opengever/dossier/browser/overview.py:92
 msgid "label_linked_dossiers"
 msgstr "Dossiers liés"
 
@@ -601,7 +606,7 @@ msgid "label_no_reference_number"
 msgstr "Le numéro de classement est généré lors de la création du document."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:140
+#: ./opengever/dossier/behaviors/dossier.py:139
 msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
@@ -646,19 +651,19 @@ msgid "label_recipient"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:182
+#: ./opengever/dossier/behaviors/dossier.py:181
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:95
+#: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:153
+#: ./opengever/dossier/behaviors/dossier.py:152
 msgid "label_related_dossier"
 msgstr "Dossiers liés"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:93
+#: ./opengever/dossier/behaviors/dossier.py:92
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
@@ -685,24 +690,29 @@ msgid "label_sablon_templates"
 msgstr "Sablon Modèles"
 
 #. Default: "Save"
-#: ./opengever/dossier/viewlets/templates/note.pt:39
+#: ./opengever/dossier/viewlets/templates/note.pt:53
 msgid "label_save"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:89
+#: ./opengever/dossier/viewlets/byline.py:61
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
+#. Default: "Show Note"
+#: ./opengever/dossier/viewlets/templates/note.pt:31
+msgid "label_show_note"
+msgstr ""
+
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:74
+#: ./opengever/dossier/behaviors/dossier.py:73
 #: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr "Date début"
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:77
+#: ./opengever/dossier/viewlets/byline.py:49
 msgid "label_start_byline"
 msgstr "De"
 
@@ -751,17 +761,17 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:71
+#: ./opengever/dossier/viewlets/byline.py:43
 msgid "label_workflow_state"
 msgstr "Etat"
 
 #. Default: "Changes not saved"
-#: ./opengever/dossier/viewlets/byline.py:38
+#: ./opengever/dossier/viewlets/comment.py:28
 msgid "message_body_error"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/dossier/viewlets/byline.py:37
+#: ./opengever/dossier/viewlets/comment.py:27
 msgid "message_body_info"
 msgstr ""
 
@@ -783,7 +793,7 @@ msgid "not all task are closed"
 msgstr "Toutes les tâches ne sont pas fermées"
 
 #. Default: "Confirm abbord"
-#: ./opengever/dossier/viewlets/byline.py:34
+#: ./opengever/dossier/viewlets/comment.py:24
 msgid "note_text_confirm_abord"
 msgstr ""
 
@@ -817,7 +827,7 @@ msgid "tasks"
 msgstr "Tâches"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:124
+#: ./opengever/dossier/behaviors/dossier.py:123
 msgid "temporary_former_reference_number"
 msgstr "Ancien numéro de référence temporaire"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-06 23:34+0000\n"
+"POT-Creation-Date: 2017-03-14 19:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Add Participant"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:235
+#: ./opengever/dossier/behaviors/dossier.py:234
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:48
 msgid "Add Subdossier"
 msgstr ""
@@ -53,7 +53,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:81
+#: ./opengever/dossier/browser/overview.py:100
 msgid "Description"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:257
+#: ./opengever/dossier/behaviors/dossier.py:256
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
 msgid "Edit Subdossier"
 msgstr ""
@@ -104,11 +104,11 @@ msgstr ""
 msgid "Move Items"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:77
+#: ./opengever/dossier/browser/overview.py:96
 msgid "Newest documents"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:68
+#: ./opengever/dossier/browser/overview.py:87
 msgid "Newest tasks"
 msgstr ""
 
@@ -124,11 +124,11 @@ msgstr ""
 msgid "Participant"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:63
+#: ./opengever/dossier/browser/overview.py:82
 msgid "Participants"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:56
+#: ./opengever/dossier/browser/overview.py:75
 msgid "Participations"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr ""
 
-#: ./opengever/dossier/activate.py:43
+#: ./opengever/dossier/activate.py:41
 msgid "The Dossier has been activated"
 msgstr ""
 
@@ -217,11 +217,11 @@ msgstr ""
 msgid "The selected objects can't be found, please try it again."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:198
+#: ./opengever/dossier/behaviors/dossier.py:197
 msgid "The start date must be before the end date."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:264
+#: ./opengever/dossier/behaviors/dossier.py:263
 msgid "The start or end date is invalid"
 msgstr ""
 
@@ -315,7 +315,7 @@ msgid "error_no_items"
 msgstr ""
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:100
+#: ./opengever/dossier/behaviors/dossier.py:99
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr ""
@@ -353,8 +353,8 @@ msgstr ""
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:112
-#: ./opengever/dossier/browser/overview.py:214
+#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/browser/overview.py:229
 msgid "filing_prefix"
 msgstr ""
 
@@ -369,7 +369,7 @@ msgid "heading_archive_form"
 msgstr ""
 
 #. Default: "${title} notes / comments"
-#: ./opengever/dossier/viewlets/templates/note.pt:28
+#: ./opengever/dossier/viewlets/templates/note.pt:40
 msgid "heading_dossier_note"
 msgstr ""
 
@@ -382,11 +382,11 @@ msgstr ""
 msgid "help_contact"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py:147
 msgid "help_container_location"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:131
+#: ./opengever/dossier/behaviors/dossier.py:130
 msgid "help_container_type"
 msgstr ""
 
@@ -403,18 +403,23 @@ msgstr ""
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:142
+#: ./opengever/dossier/behaviors/dossier.py:141
 msgid "help_number_of_containers"
 msgstr ""
 
 #. Default: "Create a new note"
-#: ./opengever/dossier/viewlets/templates/note.pt:18
+#: ./opengever/dossier/viewlets/templates/note.pt:19
 msgid "help_text_add_note"
 msgstr ""
 
 #. Default: "There is a note"
-#: ./opengever/dossier/viewlets/templates/note.pt:10
+#: ./opengever/dossier/viewlets/templates/note.pt:11
 msgid "help_text_edit_note"
+msgstr ""
+
+#. Default: "View note"
+#: ./opengever/dossier/viewlets/templates/note.pt:28
+msgid "help_text_view_note"
 msgstr ""
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
@@ -433,7 +438,7 @@ msgid "info_removed_participations"
 msgstr ""
 
 #. Default: "Add Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:17
+#: ./opengever/dossier/viewlets/templates/note.pt:22
 msgid "label_add_note"
 msgstr ""
 
@@ -453,13 +458,18 @@ msgid "label_by_author"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/dossier/viewlets/templates/note.pt:41
+#: ./opengever/dossier/viewlets/templates/note.pt:55
 msgid "label_cancel"
 msgstr ""
 
+#. Default: "Close"
+#: ./opengever/dossier/viewlets/templates/note.pt:59
+msgid "label_close"
+msgstr ""
+
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:87
-#: ./opengever/dossier/browser/overview.py:210
+#: ./opengever/dossier/behaviors/dossier.py:86
+#: ./opengever/dossier/browser/overview.py:67
 msgid "label_comments"
 msgstr ""
 
@@ -469,12 +479,12 @@ msgid "label_contact"
 msgstr ""
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:147
+#: ./opengever/dossier/behaviors/dossier.py:146
 msgid "label_container_location"
 msgstr ""
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py:129
 msgid "label_container_type"
 msgstr ""
 
@@ -485,7 +495,7 @@ msgid "label_creator"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:218
+#: ./opengever/dossier/browser/overview.py:233
 #: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr ""
@@ -496,18 +506,13 @@ msgid "label_destination"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:202
+#: ./opengever/dossier/browser/overview.py:221
 #: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr ""
 
-#. Default: "Dossiernote"
-#: ./opengever/dossier/viewlets/byline.py:115
-msgid "label_dossier_note"
-msgstr ""
-
 #. Default: "Create Dossier note"
-#: ./opengever/dossier/viewlets/templates/note.pt:33
+#: ./opengever/dossier/viewlets/templates/note.pt:45
 msgid "label_dossier_note_placeholder"
 msgstr ""
 
@@ -522,25 +527,25 @@ msgid "label_edit_after_creation"
 msgstr ""
 
 #. Default: "Edit Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:9
+#: ./opengever/dossier/viewlets/templates/note.pt:14
 msgid "label_edit_note"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:102
+#: ./opengever/dossier/viewlets/byline.py:74
 msgid "label_email_address"
 msgstr ""
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:82
+#: ./opengever/dossier/behaviors/dossier.py:81
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr ""
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:83
+#: ./opengever/dossier/viewlets/byline.py:55
 msgid "label_end_byline"
 msgstr ""
 
@@ -555,7 +560,7 @@ msgid "label_filing_number"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:175
+#: ./opengever/dossier/behaviors/dossier.py:174
 msgid "label_former_reference_number"
 msgstr ""
 
@@ -571,7 +576,7 @@ msgstr ""
 
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:60
-#: ./opengever/dossier/browser/overview.py:206
+#: ./opengever/dossier/browser/overview.py:225
 msgid "label_keywords"
 msgstr ""
 
@@ -581,7 +586,7 @@ msgid "label_label"
 msgstr ""
 
 #. Default: "Linked Dossiers"
-#: ./opengever/dossier/browser/overview.py:73
+#: ./opengever/dossier/browser/overview.py:92
 msgid "label_linked_dossiers"
 msgstr ""
 
@@ -602,7 +607,7 @@ msgid "label_no_reference_number"
 msgstr ""
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:140
+#: ./opengever/dossier/behaviors/dossier.py:139
 msgid "label_number_of_containers"
 msgstr ""
 
@@ -647,19 +652,19 @@ msgid "label_recipient"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:182
+#: ./opengever/dossier/behaviors/dossier.py:181
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:95
+#: ./opengever/dossier/viewlets/byline.py:67
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:153
+#: ./opengever/dossier/behaviors/dossier.py:152
 msgid "label_related_dossier"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:93
+#: ./opengever/dossier/behaviors/dossier.py:92
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
@@ -686,24 +691,29 @@ msgid "label_sablon_templates"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/dossier/viewlets/templates/note.pt:39
+#: ./opengever/dossier/viewlets/templates/note.pt:53
 msgid "label_save"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:89
+#: ./opengever/dossier/viewlets/byline.py:61
 msgid "label_sequence_number"
 msgstr ""
 
+#. Default: "Show Note"
+#: ./opengever/dossier/viewlets/templates/note.pt:31
+msgid "label_show_note"
+msgstr ""
+
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:74
+#: ./opengever/dossier/behaviors/dossier.py:73
 #: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr ""
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:77
+#: ./opengever/dossier/viewlets/byline.py:49
 msgid "label_start_byline"
 msgstr ""
 
@@ -752,17 +762,17 @@ msgstr ""
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:71
+#: ./opengever/dossier/viewlets/byline.py:43
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "Changes not saved"
-#: ./opengever/dossier/viewlets/byline.py:38
+#: ./opengever/dossier/viewlets/comment.py:28
 msgid "message_body_error"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/dossier/viewlets/byline.py:37
+#: ./opengever/dossier/viewlets/comment.py:27
 msgid "message_body_info"
 msgstr ""
 
@@ -784,7 +794,7 @@ msgid "not all task are closed"
 msgstr ""
 
 #. Default: "Confirm abbord"
-#: ./opengever/dossier/viewlets/byline.py:34
+#: ./opengever/dossier/viewlets/comment.py:24
 msgid "note_text_confirm_abord"
 msgstr ""
 
@@ -818,7 +828,7 @@ msgid "tasks"
 msgstr ""
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:124
+#: ./opengever/dossier/behaviors/dossier.py:123
 msgid "temporary_former_reference_number"
 msgstr ""
 

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -48,6 +48,10 @@
             event.preventDefault();
             closeNote();
           });
+          overlay.getOverlay().on('click', 'button.close', function(event){
+            event.preventDefault();
+            closeNote();
+          });
 
           overlay.getOverlay().on('onBeforeClose', function(event){
             // Show message if there are unsaved changes

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -8,21 +8,20 @@
 
       var noteBox;
       var editNoteLink;
+      var editNoteWrapper;
       var overlay;
       var overlayElement;
       var i18n;
 
       function init(){
         noteBox = $('#commentsBox');
-        editNoteLink = $('#editNoteLink');
-        if (!editNoteLink.length && !noteBox.length) {
+        editNoteLink = $('.editNoteLink');
+        if (!editNoteLink.length) {
           return;
         }
 
-        // Move add/edit link to comment section in overview tab
-        editNoteLink.clone().insertAfter(noteBox.find('h2'));
-
-        i18n = editNoteLink.data('i18n');
+        editNoteWrapper = $('.editNoteWrapper');
+        i18n = editNoteWrapper.data('i18n');
         // Move for correct stacking with overlaymask
         overlayElement = $('#editNoteOverlay');
         $('body').append(overlayElement);
@@ -34,6 +33,8 @@
             textarea.height(($(window).height() - textarea.offset().top) * 0.7);
           }
         };
+
+        manipulateDom();
 
         if (!overlay) {
           overlay = overlayElement.overlay(options).data('overlay');
@@ -60,10 +61,10 @@
 
             To fix this issue, we replace the CR+LF newlines with the LF newlines.
              */
-            var notecache = editNoteLink.data('notecache').replace(/\r\n/g, '\n');
+            var notecache = editNoteWrapper.data('notecache').replace(/\r\n/g, '\n');
             if (notecache !== overlay.getOverlay().find('textarea').val()){
               if (confirm(i18n.note_text_confirm_abord)){
-                overlay.getOverlay().find('textarea').val(editNoteLink.data('notecache'));
+                overlay.getOverlay().find('textarea').val(editNoteWrapper.data('notecache'));
                 return true;
               } else {
                 return false;
@@ -72,6 +73,20 @@
           });
 
         }
+      }
+
+      function manipulateDom() {
+        // Move add/edit link to commentBox on overview tab
+        if (noteBox.find('.editNoteLink').length === 0) {
+          editNoteLink.eq(0).clone().insertAfter(noteBox.find('h2'));  
+        }
+
+        // Move add/edit link to title
+        if (!overlay) {
+          editNoteLink.eq(0).clone().appendTo('h1.documentFirstHeading');
+        }
+
+        editNoteLink = $('.editNoteLink');
       }
 
       function successMessage() {
@@ -100,8 +115,8 @@
 
       function saveNote() {
         makeRequest({comments: overlay.getOverlay().find('textarea').val()}).done(function(data){
-          editNoteLink.data('notecache', overlay.getOverlay().find('textarea').val());
-          if (editNoteLink.data('notecache').length) {
+          editNoteWrapper.data('notecache', overlay.getOverlay().find('textarea').val());
+          if (editNoteWrapper.data('notecache').length) {
             editNoteLink.find('.edit').removeClass('hide');
             editNoteLink.find('.add').addClass('hide');
           } else {
@@ -123,7 +138,7 @@
       }
 
       // Bind Edit note link
-      $(document).on('click', '#editNoteLink', function(event){
+      $(document).on('click', '.editNoteLink', function(event){
         event.preventDefault();
         showNote();
       });

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -78,7 +78,13 @@
       function manipulateDom() {
         // Move add/edit link to commentBox on overview tab
         if (noteBox.find('.editNoteLink').length === 0) {
-          editNoteLink.eq(0).clone().insertAfter(noteBox.find('h2'));  
+          // insert after text if we have a span
+          var elem = noteBox.find('span');
+          if (elem.length === 0) {
+            // insert after header if there is no text yet
+            elem = noteBox.find('h2');
+          }
+          editNoteLink.eq(0).clone().insertAfter(elem);
         }
 
         // Move add/edit link to title
@@ -115,6 +121,7 @@
 
       function saveNote() {
         makeRequest({comments: overlay.getOverlay().find('textarea').val()}).done(function(data){
+          var comment_container;
           editNoteWrapper.data('notecache', overlay.getOverlay().find('textarea').val());
           if (editNoteWrapper.data('notecache').length) {
             editNoteLink.find('.edit').removeClass('hide');
@@ -125,7 +132,12 @@
           }
           closeNote();
           successMessage();
-          $('#commentsBox > span').html(data.comment);
+
+          comment_container = $('#commentsBox > span');
+          if (comment_container.length === 0) {
+            comment_container = $('<span></span>').insertAfter($('#commentsBox > h2'));
+          }
+          comment_container.html(data.comment);
         }).fail(errorMessage);
       }
 

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -6,19 +6,23 @@
 
     var DossierNote = (function () {
 
+      var noteBox;
       var editNoteLink;
       var overlay;
       var overlayElement;
       var i18n;
 
       function init(){
+        noteBox = $('#commentsBox');
         editNoteLink = $('#editNoteLink');
-        if (!editNoteLink.length) {
+        if (!editNoteLink.length && !noteBox.length) {
           return;
         }
 
-        i18n = editNoteLink.data('i18n');
+        // Move add/edit link to comment section in overview tab
+        editNoteLink.clone().insertAfter(noteBox.find('h2'));
 
+        i18n = editNoteLink.data('i18n');
         // Move for correct stacking with overlaymask
         overlayElement = $('#editNoteOverlay');
         $('body').append(overlayElement);
@@ -126,6 +130,6 @@
 
     })();
 
-    DossierNote.init();
+    $(document).on('reload', '.tabbedview_view', DossierNote.init);
   });
 })(window.Handlebars, window.jQuery, window.MessageFactory);

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -125,6 +125,7 @@
           }
           closeNote();
           successMessage();
+          $('#commentsBox > span').html(data.comment);
         }).fail(errorMessage);
       }
 

--- a/opengever/dossier/resources/edit_note.js
+++ b/opengever/dossier/resources/edit_note.js
@@ -34,40 +34,44 @@
             textarea.height(($(window).height() - textarea.offset().top) * 0.7);
           }
         };
-        overlay = overlayElement.overlay(options).data('overlay');
 
-        // Bind overlay events
-        overlay.getOverlay().on('click', 'button.confirm', function(event){
-          event.preventDefault();
-          saveNote();
-        });
-        overlay.getOverlay().on('click', 'button.decline', function(event){
-          event.preventDefault();
-          closeNote();
-        });
+        if (!overlay) {
+          overlay = overlayElement.overlay(options).data('overlay');
 
-        overlay.getOverlay().on('onBeforeClose', function(event){
-          // Show message if there are unsaved changes
+          // Bind overlay events
+          overlay.getOverlay().on('click', 'button.confirm', function(event){
+            event.preventDefault();
+            saveNote();
+          });
+          overlay.getOverlay().on('click', 'button.decline', function(event){
+            event.preventDefault();
+            closeNote();
+          });
 
-          /*
-          FIX: If you modify the textarea field for comments in the dossier
-          edit form, the newline encoding will be CR+LF (\r\n). After rendering the
-          template, the newline-encoding in the textarea will be LF (\n) and in the
-          data-attribute it is still CR+LF. Comparing these two strings will always
-          return false.
+          overlay.getOverlay().on('onBeforeClose', function(event){
+            // Show message if there are unsaved changes
 
-          To fix this issue, we replace the CR+LF newlines with the LF newlines.
-           */
-          var notecache = editNoteLink.data('notecache').replace(/\r\n/g, '\n');
-          if (notecache !== overlay.getOverlay().find('textarea').val()){
-            if (confirm(i18n.note_text_confirm_abord)){
-              overlay.getOverlay().find('textarea').val(editNoteLink.data('notecache'));
-              return true;
-            } else {
-              return false;
+            /*
+            FIX: If you modify the textarea field for comments in the dossier
+            edit form, the newline encoding will be CR+LF (\r\n). After rendering the
+            template, the newline-encoding in the textarea will be LF (\n) and in the
+            data-attribute it is still CR+LF. Comparing these two strings will always
+            return false.
+
+            To fix this issue, we replace the CR+LF newlines with the LF newlines.
+             */
+            var notecache = editNoteLink.data('notecache').replace(/\r\n/g, '\n');
+            if (notecache !== overlay.getOverlay().find('textarea').val()){
+              if (confirm(i18n.note_text_confirm_abord)){
+                overlay.getOverlay().find('textarea').val(editNoteLink.data('notecache'));
+                return true;
+              } else {
+                return false;
+              }
             }
-          }
-        });
+          });
+
+        }
       }
 
       function successMessage() {

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -6,13 +6,10 @@ from ftw.testbrowser import browsing
 from opengever.base.tests.byline_base_test import TestBylineBase
 from opengever.core.testing import activate_filing_number
 from opengever.core.testing import inactivate_filing_number
-from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import create_ogds_user
-from plone.protect import createToken
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
-import json
 import transaction
 
 
@@ -96,87 +93,6 @@ class TestDossierByline(TestBylineBase):
 
         self.assertEquals(None,
                           self.get_byline_value_by_label('Filing Number:'))
-
-    @browsing
-    def test_dossier_byline_editlink_for_comments(self, browser):
-        browser.login().visit(self.dossier)
-        comment = self.get_byline_value_by_label('Dossiernote:')
-        # There are both labels (show/hide by css/js)
-        self.assertEquals(['Edit Note', 'Add Note'],
-                          comment.css('#editNoteLink .linkLabel').text)
-
-    @browsing
-    def test_dossier_byline_show_comments_editlink_on_maindossier_only(
-            self, browser):
-        browser.login().visit(self.dossier)
-        comment = self.get_byline_value_by_label('Dossiernote:')
-        self.assertTrue(comment,
-                        'Expect the edit comment link in dossier byline')
-
-        subdossier = create(Builder('dossier').within(self.dossier))
-        browser.visit(subdossier)
-        comment = self.get_byline_value_by_label('Dossiernote:')
-        self.assertFalse(comment,
-                         'Expect NO edit comment link on subdossier')
-
-    @browsing
-    def test_dossier_byline_hide_comments_editlink_without_modify_rights(
-            self, browser):
-        self.dossier.manage_permission('Modify portal content',
-                                       roles=[],
-                                       acquire=False)
-        transaction.commit()
-        browser.login().visit(self.dossier)
-        comment = self.get_byline_value_by_label('Dossiernote:')
-        self.assertFalse(comment,
-                         'Expect NO edit comment link on dossier')
-
-    @browsing
-    def test_dossier_byline_comments_editlink_data(self, browser):
-        browser.login().visit(self.dossier)
-        link = browser.css('#editNoteLink').first
-        dossier_data = IDossier(self.dossier)
-
-        # No comments
-        self.assertEquals(type(json.loads(link.attrib['data-i18n'])),
-                          dict)
-        self.assertEquals('',
-                          link.attrib['data-notecache'])
-        self.assertEquals('Add Note', link.css('.add .linkLabel').first.text)
-
-        # With comments
-        dossier_data.comments = u'This is a comment'
-        transaction.commit()
-
-        browser.open(self.dossier)
-        link = browser.css('#editNoteLink').first
-        self.assertEquals(str(dossier_data.comments),
-                          link.attrib['data-notecache'])
-        self.assertEquals('Edit Note', link.css('.edit .linkLabel').first.text)
-
-    @browsing
-    def test_dossier_byline_save_comments_endpoint(self, browser):
-        payload = '{"comments": "New comment"}'
-        browser.login().visit(self.dossier)
-
-        browser.visit(self.dossier,
-                      view='save_comments',
-                      data={'data': payload,
-                            '_authenticator': createToken()})
-
-        dossier_data = IDossier(self.dossier)
-        self.assertEquals("New comment", dossier_data.comments)
-
-        with self.assertRaises(KeyError):
-            payload = '{"invalidkey": "New comment"}'
-            browser.login().visit(self.dossier,
-                                  view='save_comments',
-                                  data={'data': payload})
-
-        query = {'SearchableText': 'New comment'}
-        result = self.portal.portal_catalog(**query)
-        self.assertEquals(1, len(result), 'Expect one result')
-        self.assertEquals(self.dossier, result[0].getObject())
 
 
 class TestFilingBusinessCaseByline(TestBylineBase):

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -5,7 +5,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from lxml.etree import tostring
 from opengever.contact.interfaces import IContactSettings
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
 from opengever.core.testing import toggle_feature
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -7,7 +7,11 @@ from lxml.etree import tostring
 from opengever.contact.interfaces import IContactSettings
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
 from opengever.core.testing import toggle_feature
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
+from plone.protect import createToken
+import json
+import transaction
 
 
 class TestOverview(FunctionalTestCase):
@@ -183,3 +187,83 @@ class TestOverview(FunctionalTestCase):
         self.assertEquals(['Dossier B'], references.text)
         self.assertEquals([dossier_b.absolute_url()],
                           [link.get('href') for link in references])
+
+    @browsing
+    def test_dossier_editlink_for_comments(self, browser):
+        browser.login().visit(self.dossier)
+        # There are both labels (show/hide by css/js)
+        self.assertEquals(['Edit Note', 'Add Note'],
+                          browser.css('#editNoteLink .linkLabel').text)
+
+    @browsing
+    def test_dossier_show_comments_editlink_on_maindossier_only(
+            self, browser):
+        browser.login().visit(self.dossier)
+        comment = browser.css('#editNoteLink')
+        self.assertTrue(comment,
+                        'Expect the edit comment link in dossier byline')
+
+        subdossier = create(Builder('dossier').within(self.dossier))
+        browser.visit(subdossier)
+        comment = browser.css('#editNoteLink')
+        self.assertFalse(comment,
+                         'Expect NO edit comment link on subdossier')
+
+    @browsing
+    def test_dossier_hide_comments_editlink_without_modify_rights(
+            self, browser):
+        self.dossier.manage_permission('Modify portal content',
+                                       roles=[],
+                                       acquire=False)
+        transaction.commit()
+        browser.login().visit(self.dossier)
+        comment = browser.css('#editNoteLink')
+        self.assertFalse(comment,
+                         'Expect NO edit comment link on dossier')
+
+    @browsing
+    def test_dossier_comments_editlink_data(self, browser):
+        browser.login().visit(self.dossier)
+        link = browser.css('#editNoteLink').first
+        dossier_data = IDossier(self.dossier)
+
+        # No comments
+        self.assertEquals(type(json.loads(link.attrib['data-i18n'])),
+                          dict)
+        self.assertEquals('',
+                          link.attrib['data-notecache'])
+        self.assertEquals('Add Note', link.css('.add .linkLabel').first.text)
+
+        # With comments
+        dossier_data.comments = u'This is a comment'
+        transaction.commit()
+
+        browser.open(self.dossier)
+        link = browser.css('#editNoteLink').first
+        self.assertEquals(str(dossier_data.comments),
+                          link.attrib['data-notecache'])
+        self.assertEquals('Edit Note', link.css('.edit .linkLabel').first.text)
+
+    @browsing
+    def test_dossier_save_comments_endpoint(self, browser):
+        payload = '{"comments": "New comment"}'
+        browser.login().visit(self.dossier)
+
+        browser.visit(self.dossier,
+                      view='save_comments',
+                      data={'data': payload,
+                            '_authenticator': createToken()})
+
+        dossier_data = IDossier(self.dossier)
+        self.assertEquals("New comment", dossier_data.comments)
+
+        with self.assertRaises(KeyError):
+            payload = '{"invalidkey": "New comment"}'
+            browser.login().visit(self.dossier,
+                                  view='save_comments',
+                                  data={'data': payload})
+
+        query = {'SearchableText': 'New comment'}
+        result = self.portal.portal_catalog(**query)
+        self.assertEquals(1, len(result), 'Expect one result')
+        self.assertEquals(self.dossier, result[0].getObject())

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -193,19 +193,19 @@ class TestOverview(FunctionalTestCase):
         browser.login().visit(self.dossier)
         # There are both labels (show/hide by css/js)
         self.assertEquals(['Edit Note', 'Add Note'],
-                          browser.css('#editNoteLink .linkLabel').text)
+                          browser.css('.editNoteLink .linkLabel').text)
 
     @browsing
     def test_dossier_show_comments_editlink_on_maindossier_only(
             self, browser):
         browser.login().visit(self.dossier)
-        comment = browser.css('#editNoteLink')
+        comment = browser.css('.editNoteLink')
         self.assertTrue(comment,
                         'Expect the edit comment link in dossier byline')
 
         subdossier = create(Builder('dossier').within(self.dossier))
         browser.visit(subdossier)
-        comment = browser.css('#editNoteLink')
+        comment = browser.css('.editNoteLink')
         self.assertFalse(comment,
                          'Expect NO edit comment link on subdossier')
 
@@ -217,14 +217,14 @@ class TestOverview(FunctionalTestCase):
                                        acquire=False)
         transaction.commit()
         browser.login().visit(self.dossier)
-        comment = browser.css('#editNoteLink')
+        comment = browser.css('.editNoteLink')
         self.assertFalse(comment,
                          'Expect NO edit comment link on dossier')
 
     @browsing
     def test_dossier_comments_editlink_data(self, browser):
         browser.login().visit(self.dossier)
-        link = browser.css('#editNoteLink').first
+        link = browser.css('.editNoteWrapper').first
         dossier_data = IDossier(self.dossier)
 
         # No comments
@@ -239,7 +239,7 @@ class TestOverview(FunctionalTestCase):
         transaction.commit()
 
         browser.open(self.dossier)
-        link = browser.css('#editNoteLink').first
+        link = browser.css('.editNoteWrapper').first
         self.assertEquals(str(dossier_data.comments),
                           link.attrib['data-notecache'])
         self.assertEquals('Edit Note', link.css('.edit .linkLabel').first.text)

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -209,7 +209,7 @@ class TestOverview(FunctionalTestCase):
                          'Expect NO edit comment link on subdossier')
 
     @browsing
-    def test_dossier_hide_comments_editlink_without_modify_rights(
+    def test_dossier_show_comments_editlink_without_modify_rights(
             self, browser):
         self.dossier.manage_permission('Modify portal content',
                                        roles=[],
@@ -217,8 +217,7 @@ class TestOverview(FunctionalTestCase):
         transaction.commit()
         browser.login().visit(self.dossier)
         comment = browser.css('.editNoteLink')
-        self.assertFalse(comment,
-                         'Expect NO edit comment link on dossier')
+        self.assertEqual('Show Note', comment.first.text)
 
     @browsing
     def test_dossier_comments_editlink_data(self, browser):

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -3,6 +3,10 @@ from Acquisition import aq_parent
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.inbox.inbox import IInbox
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+import unicodedata
+
+
+ELLIPSIS = unicodedata.lookup('HORIZONTAL ELLIPSIS')
 
 
 def get_containing_dossier(obj):
@@ -27,3 +31,7 @@ def get_main_dossier(obj):
         obj = aq_parent(aq_inner(obj))
 
     return dossier
+
+
+def truncate_ellipsis(text, threshold, ellipsis=ELLIPSIS):
+    return (text[:threshold] + ellipsis) if len(text) > threshold else text

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.inbox.inbox import IInbox
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from Products.CMFPlone.utils import safe_unicode
 import unicodedata
 
 
@@ -34,4 +35,8 @@ def get_main_dossier(obj):
 
 
 def truncate_ellipsis(text, threshold, ellipsis=ELLIPSIS):
-    return (text[:threshold] + ellipsis) if len(text) > threshold else text
+    if text:
+        text = safe_unicode(text)
+        return (text[:threshold] + ellipsis) if len(text) > threshold else text
+    else:
+        return ''

--- a/opengever/dossier/viewlets/byline.py
+++ b/opengever/dossier/viewlets/byline.py
@@ -1,15 +1,9 @@
 from ftw.mail.interfaces import IEmailAddress
-from opengever.base import _ as ogbmf
 from opengever.base.viewlets.byline import BylineBase
 from opengever.dossier import _
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.dossier.utils import get_main_dossier
 from opengever.ogds.base.actor import Actor
-from plone import api
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from zope.i18n import translate
-import json
 
 
 class BusinessCaseByline(BylineBase):
@@ -26,28 +20,6 @@ class BusinessCaseByline(BylineBase):
     def end(self):
         dossier = IDossier(self.context)
         return self.to_localized_time(dossier.end)
-
-    note_template = ViewPageTemplateFile('templates/note.pt')
-
-    def note(self):
-        dossier = IDossier(self.context)
-        msg_confirm = _(u'note_text_confirm_abord', default=u'Confirm abbord')
-        msg_title_info = ogbmf(u'message_title_info', default=u'Information')
-        msg_title_error = ogbmf(u'message_title_error', default=u'Error')
-        msg_body_info = _(u'message_body_info', default=u'Changes saved')
-        msg_body_error = _(u'message_body_error', default=u'Changes not saved')
-        create_translations = lambda msg: translate(msg, context=self.request)
-
-        translations = json.dumps(
-            {'note_text_confirm_abord': create_translations(msg_confirm),
-             'message_title_info': create_translations(msg_title_info),
-             'message_title_error': create_translations(msg_title_error),
-             'message_body_info': create_translations(msg_body_info),
-             'message_body_error': create_translations(msg_body_error)
-             })
-        comments = '' if not dossier.comments else dossier.comments
-        return self.note_template(note=comments,
-                                  translations=translations)
 
     def mailto_link(self):
         """Displays email-address if the IMailInAddressMarker behavior
@@ -105,16 +77,4 @@ class BusinessCaseByline(BylineBase):
             }
         ]
 
-        can_edit = api.user.has_permission('Modify portal content',
-                                           obj=self.context)
-        is_main_dossier = self.context == get_main_dossier(self.context)
-        if is_main_dossier and can_edit:
-            items += [
-                {
-                    'class': 'note',
-                    'label': _('label_dossier_note', default='Dossiernote'),
-                    'content': self.note(),
-                    'replace': True
-                }
-            ]
         return items

--- a/opengever/dossier/viewlets/comment.py
+++ b/opengever/dossier/viewlets/comment.py
@@ -1,0 +1,36 @@
+from opengever.base import _ as ogbmf
+from opengever.dossier import _
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.utils import get_main_dossier
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.i18n import translate
+import json
+
+
+class BusinessCaseCommentViewlet(ViewletBase):
+
+    index = ViewPageTemplateFile('templates/note.pt')
+
+    def available(self):
+        return self.context == get_main_dossier(self.context)
+
+    def translations(self):
+        msg_confirm = _(u'note_text_confirm_abord', default=u'Confirm abbord')
+        msg_title_info = ogbmf(u'message_title_info', default=u'Information')
+        msg_title_error = ogbmf(u'message_title_error', default=u'Error')
+        msg_body_info = _(u'message_body_info', default=u'Changes saved')
+        msg_body_error = _(u'message_body_error', default=u'Changes not saved')
+        create_translations = lambda msg: translate(msg, context=self.request)
+
+        return json.dumps(
+            {'note_text_confirm_abord': create_translations(msg_confirm),
+             'message_title_info': create_translations(msg_title_info),
+             'message_title_error': create_translations(msg_title_error),
+             'message_body_info': create_translations(msg_body_info),
+             'message_body_error': create_translations(msg_body_error)
+             })
+
+    def note(self):
+        dossier = IDossier(self.context)
+        return '' if not dossier.comments else dossier.comments

--- a/opengever/dossier/viewlets/comment.py
+++ b/opengever/dossier/viewlets/comment.py
@@ -2,6 +2,7 @@ from opengever.base import _ as ogbmf
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.utils import get_main_dossier
+from plone import api
 from plone.app.layout.viewlets import ViewletBase
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
@@ -14,6 +15,10 @@ class BusinessCaseCommentViewlet(ViewletBase):
 
     def available(self):
         return self.context == get_main_dossier(self.context)
+
+    def has_edit_permission(self):
+        return api.user.has_permission(
+            'Modify portal content', obj=self.context)
 
     def translations(self):
         msg_confirm = _(u'note_text_confirm_abord', default=u'Confirm abbord')

--- a/opengever/dossier/viewlets/configure.zcml
+++ b/opengever/dossier/viewlets/configure.zcml
@@ -10,4 +10,12 @@
       permission="zope2.View"
       />
 
+  <browser:viewlet
+      name="opengever.dossier.comment"
+      for="opengever.dossier.businesscase.IBusinessCaseDossier"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+      class=".comment.BusinessCaseCommentViewlet"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/dossier/viewlets/configure.zcml
+++ b/opengever/dossier/viewlets/configure.zcml
@@ -15,7 +15,7 @@
       for="opengever.dossier.businesscase.IBusinessCaseDossier"
       manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
       class=".comment.BusinessCaseCommentViewlet"
-      permission="cmf.ModifyPortalContent"
+      permission="zope2.View"
       />
 
 </configure>

--- a/opengever/dossier/viewlets/templates/note.pt
+++ b/opengever/dossier/viewlets/templates/note.pt
@@ -1,24 +1,24 @@
 <span class="editNoteWrapper"
       i18n:domain="opengever.dossier"
       tal:condition="view/available"
-      tal:define="has_notes view/note">
-  <a href="#" id='editNoteLink'
-     tal:attributes="data-notecache string:${view/note};
-                     data-i18n string:${view/translations}">
+      tal:define="has_notes view/note"
+      tal:attributes="data-notecache string:${view/note};
+                      data-i18n string:${view/translations}">
+  <a href="#" class='editNoteLink'>
     <span tal:define="hide_class python: '' if has_notes else 'hide'"
           tal:attributes="class string:edit ${hide_class}">
-      <span class="linkLabel" i18n:translate="label_edit_note">Edit Note</span>
       <span class="visualHint"
             title="There is a note"
             i18n:attributes="title help_text_edit_note"></span>
+      <span class="linkLabel" i18n:translate="label_edit_note">Edit Note</span>
     </span>
 
     <span tal:define="hide_class python: 'hide' if has_notes else ''"
           tal:attributes="class string:add ${hide_class}">
-      <span class="linkLabel" i18n:translate="label_add_note">Add Note</span>
       <span class="visualHint noNote"
         title="Create a new note"
         i18n:attributes="title help_text_add_note"></span>
+      <span class="linkLabel" i18n:translate="label_add_note">Add Note</span>
     </span>
   </a>
 

--- a/opengever/dossier/viewlets/templates/note.pt
+++ b/opengever/dossier/viewlets/templates/note.pt
@@ -1,9 +1,10 @@
 <span class="editNoteWrapper"
       i18n:domain="opengever.dossier"
-      tal:define="has_notes options/note">
+      tal:condition="view/available"
+      tal:define="has_notes view/note">
   <a href="#" id='editNoteLink'
-     tal:attributes="data-notecache string:${options/note};
-                     data-i18n string:${options/translations}">
+     tal:attributes="data-notecache string:${view/note};
+                     data-i18n string:${view/translations}">
     <span tal:define="hide_class python: '' if has_notes else 'hide'"
           tal:attributes="class string:edit ${hide_class}">
       <span class="linkLabel" i18n:translate="label_edit_note">Edit Note</span>
@@ -32,7 +33,7 @@
       <form>
         <textarea name="note"
                   placeholder="Create Dossier note"
-                  tal:content="options/note"
+                  tal:content="view/note"
                   i18n:attributes="placeholder label_dossier_note_placeholder"/>
 
         <div class="formControls">

--- a/opengever/dossier/viewlets/templates/note.pt
+++ b/opengever/dossier/viewlets/templates/note.pt
@@ -5,21 +5,32 @@
       tal:attributes="data-notecache string:${view/note};
                       data-i18n string:${view/translations}">
   <a href="#" class='editNoteLink'>
-    <span tal:define="hide_class python: '' if has_notes else 'hide'"
-          tal:attributes="class string:edit ${hide_class}">
-      <span class="visualHint"
-            title="There is a note"
-            i18n:attributes="title help_text_edit_note"></span>
-      <span class="linkLabel" i18n:translate="label_edit_note">Edit Note</span>
-    </span>
+    <tal:editcontrols tal:condition="view/has_edit_permission">
+      <span tal:define="hide_class python: '' if has_notes else 'hide'"
+            tal:attributes="class string:edit ${hide_class}">
+        <span class="visualHint editNoteIcon"
+              title="There is a note"
+              i18n:attributes="title help_text_edit_note"></span>
+        <span class="linkLabel" i18n:translate="label_edit_note">Edit Note</span>
+      </span>
 
-    <span tal:define="hide_class python: 'hide' if has_notes else ''"
-          tal:attributes="class string:add ${hide_class}">
-      <span class="visualHint noNote"
-        title="Create a new note"
-        i18n:attributes="title help_text_add_note"></span>
-      <span class="linkLabel" i18n:translate="label_add_note">Add Note</span>
-    </span>
+      <span tal:define="hide_class python: 'hide' if has_notes else ''"
+            tal:attributes="class string:add ${hide_class}">
+        <span class="visualHint editNoteIcon noNote"
+          title="Create a new note"
+          i18n:attributes="title help_text_add_note"></span>
+        <span class="linkLabel" i18n:translate="label_add_note">Add Note</span>
+      </span>
+    </tal:editcontrols>
+    <tal:closecontrol tal:condition="not: view/has_edit_permission">
+      <span tal:define="hide_class python: '' if has_notes else 'hide'"
+            tal:attributes="class string:close ${hide_class}">
+        <span class="visualHint"
+          title="View note"
+          i18n:attributes="title help_text_view_note"></span>
+        <span class="linkLabel" i18n:translate="label_show_note">Show Note</span>
+      </span>
+    </tal:closecontrol>
   </a>
 
   <div id="editNoteOverlay" class="overlay">
@@ -34,13 +45,20 @@
         <textarea name="note"
                   placeholder="Create Dossier note"
                   tal:content="view/note"
-                  i18n:attributes="placeholder label_dossier_note_placeholder"/>
+                  i18n:attributes="placeholder label_dossier_note_placeholder"
+                  tal:attributes="readonly python: 'readonly' if not view.has_edit_permission() else ''"/>
 
         <div class="formControls">
-          <button class="button confirm context"
-                  i18n:translate="label_save">Save</button>
-          <button class="button decline"
-                  i18n:translate="label_cancel">Cancel</button>
+          <tal:editcontrols tal:condition="view/has_edit_permission">
+            <button class="button confirm context"
+                    i18n:translate="label_save">Save</button>
+            <button class="button decline"
+                    i18n:translate="label_cancel">Cancel</button>
+          </tal:editcontrols>
+          <tal:closecontrol tal:condition="not: view/has_edit_permission">
+            <button class="button close"
+                    i18n:translate="label_close">Close</button>
+          </tal:closecontrol>
         </div>
       </form>
     </div>

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -34,4 +34,12 @@
       permission="zope2.View"
       />
 
+  <browser:viewlet
+      name="opengever.dossier.comment"
+      for="opengever.meeting.interfaces.IMeetingDossier"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+      class="opengever.dossier.viewlets.comment.BusinessCaseCommentViewlet"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -129,7 +129,7 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
         browser.login().open(dossier, view='tabbedview_view-overview')
 
         self.assertEquals(
-            ['Dossier structure', 'Linked Dossiers', 'Comments',
+            ['Dossier structure', 'Comments', 'Linked Dossiers',
              'Newest documents', 'Description'],
             browser.css('.box h2').text)
 

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -129,7 +129,7 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
         browser.login().open(dossier, view='tabbedview_view-overview')
 
         self.assertEquals(
-            ['Dossier structure', 'Linked Dossiers',
+            ['Dossier structure', 'Linked Dossiers', 'Comments',
              'Newest documents', 'Description'],
             browser.css('.box h2').text)
 


### PR DESCRIPTION
Styles in https://github.com/4teamwork/plonetheme.teamraum/pull/518

Display a sticky note icon next to the title and an edit link if there is a comment:



![screen shot 2017-03-14 at 11 56 06](https://cloud.githubusercontent.com/assets/736583/23897477/9c829480-08ad-11e7-878d-e4ffe33f2a23.png)

Display an add link in the overview if there is no comment yet:


![screen shot 2017-03-14 at 11 56 22](https://cloud.githubusercontent.com/assets/736583/23897478/9c82d846-08ad-11e7-9052-02fe07e88af5.png)



Follow-up for https://github.com/4teamwork/opengever.core/pull/2695.