### PR TITLE
Remove unused tasktemplate table draggable column.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Remove unused tasktemplate table draggable column.
+  [elioschmutz]
+
 - Add the mail-in address of the parent dossier of a document as a BCC field to
   OfficeConnector email attach action payloads when said dossier is open.
   [Rotonen]

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -28,11 +28,6 @@ class TaskTemplates(BaseCatalogListingTab):
     columns = (
         {'column': '',
          'column_title': '',
-         'transform': helper.draggable,
-         'width': 30},
-
-        {'column': '',
-         'column_title': '',
          'transform': helper.path_checkbox,
          'sortable': False,
          'width': 30},

--- a/opengever/tasktemplates/browser/templatefolders.py
+++ b/opengever/tasktemplates/browser/templatefolders.py
@@ -15,12 +15,6 @@ class TaskTemplateFoldersTab(BaseCatalogListingTab):
 
         {'column': '',
          'column_title': '',
-         'transform': helper.draggable,
-         'sortable': False,
-         'width': 30},
-
-        {'column': '',
-         'column_title': '',
          'transform': helper.path_checkbox,
          'sortable': False,
          'width': 30},


### PR DESCRIPTION
Dieser PR entfernt die nicht mehr benötigte Draggable-Spalte für Tasktemplates.

Siehe #2726 für mehr Informationen

closes #2726 