### PR TITLE
Hide newest tasks box for private dossiers overview tabbedview view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Hide newest tasks box for private dossiers overview tabbedview view because
+  it's not possible to add tasks in private dossiers.
+  [elioschmutz]
+
 - Fixed role guards for dossier's offer transition.
   [phgross]
 

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -307,6 +307,9 @@ class DossierContainer(Container):
     def has_participation_support(self):
         return IParticipationAwareMarker.providedBy(self)
 
+    def has_task_support(self):
+        return self.portal_types['opengever.task.task'] in self.allowedContentTypes()
+
     def get_reference_number(self):
         return IReferenceNumber(self).get_number()
 

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -65,7 +65,8 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
 
     def make_task_box(self):
         return dict(id='newest_tasks', content=self.tasks(),
-                    href='tasks', label=_("Newest tasks"))
+                    href='tasks', label=_("Newest tasks"),
+                    available=self.context.has_task_support())
 
     def make_reference_box(self):
         return dict(
@@ -94,6 +95,9 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
             review_state=DOSSIER_STATES_OPEN)[:5]
 
     def tasks(self):
+        if not self.context.has_task_support():
+            return []
+
         return Task.query.by_container(self.context, get_current_admin_unit())\
                          .in_pending_state()\
                          .order_by(desc('modified')).limit(5).all()

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -108,6 +108,10 @@ class TestDossierContainer(FunctionalTestCase):
         dossier = create(Builder("dossier"))
         self.assertTrue(dossier.has_participation_support())
 
+    def test_support_tasks(self):
+        dossier = create(Builder("dossier"))
+        self.assertTrue(dossier.has_task_support())
+
     def test_reference_number(self):
         root = create(Builder('repository_root'))
         repo = create(Builder('repository').within(root))

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -98,6 +98,12 @@ class TestPrivateDossier(FunctionalTestCase):
                          .having(responsible=TEST_USER_ID))
         self.assertFalse(dossier.has_participation_support())
 
+    def test_does_not_support_tasks(self):
+        dossier = create(Builder('private_dossier')
+                         .within(self.folder)
+                         .having(responsible=TEST_USER_ID))
+        self.assertFalse(dossier.has_task_support())
+
 
 class TestPrivateDossierTabbedView(FunctionalTestCase):
 
@@ -118,12 +124,12 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
             browser.css('.formTab').text)
 
     @browsing
-    def test_participation_box_is_not_shown_on_overview(self, browser):
+    def test_participation_and_task_box_are_hidden_on_overview(self, browser):
         dossier = create(Builder('private_dossier').within(self.folder))
         browser.login().open(dossier, view='tabbedview_view-overview')
 
         self.assertEquals(
-            ['Dossier structure', 'Newest tasks', 'Linked Dossiers',
+            ['Dossier structure', 'Linked Dossiers',
              'Newest documents', 'Description'],
             browser.css('.box h2').text)
 


### PR DESCRIPTION
Hide newest tasks box for private dossiers overview tabbedview view because it's not possible to add tasks in private dossiers.

Before:
![bildschirmfoto 2017-03-14 um 14 31 56](https://cloud.githubusercontent.com/assets/557005/23902912/010a7390-08c3-11e7-94cc-653d94df356f.png)

After:
![bildschirmfoto 2017-03-14 um 14 31 29](https://cloud.githubusercontent.com/assets/557005/23902906/ffa4831a-08c2-11e7-98e9-1a8549943e64.png)

closes #2730 