### PR TITLE
Fix quota usage recalculation to count correctly.

### DIFF
--- a/opengever/private/tests/__init__.py
+++ b/opengever/private/tests/__init__.py
@@ -1,3 +1,4 @@
+from AccessControl import getSecurityManager
 from plone import api
 from plone.app.testing import TEST_USER_ID
 import transaction
@@ -11,4 +12,4 @@ def create_members_folder(private_root):
     mtool.createMemberArea()
     transaction.commit()
 
-    return private_root.get(TEST_USER_ID)
+    return private_root.get(getSecurityManager().getUser().getId())

--- a/opengever/private/upgrades/20170308172109_install_private_dossier_quota/upgrade.py
+++ b/opengever/private/upgrades/20170308172109_install_private_dossier_quota/upgrade.py
@@ -1,5 +1,4 @@
 from ftw.upgrade import UpgradeStep
-from opengever.quota.sizequota import ISizeQuota
 
 
 class InstallPrivateDossierQuota(UpgradeStep):
@@ -9,8 +8,11 @@ class InstallPrivateDossierQuota(UpgradeStep):
     def __call__(self):
         self.install_upgrade_profile()
         self.index_new_behaviors()
-        self.calculate_private_folder_usage()
         self.configure_error_log()
+
+        # recalculation was moved to upgrade
+        # 20170314200202_fix_private_folder_usage_calculation
+        # because it had errors.
 
     def index_new_behaviors(self):
         msg = 'Update `object_provides` for objects with new behavior.'
@@ -23,12 +25,6 @@ class InstallPrivateDossierQuota(UpgradeStep):
             catalog.reindexObject(obj,
                                   idxs=['object_provides'],
                                   update_metadata=False)
-
-    def calculate_private_folder_usage(self):
-        msg = 'Calculate usage in private folders.'
-        for obj in self.objects({'portal_type': ['opengever.private.folder']},
-                                msg):
-            ISizeQuota(obj).recalculate()
 
     def configure_error_log(self):
         error_log = self.getToolByName('error_log')

--- a/opengever/private/upgrades/20170314200202_fix_private_folder_usage_calculation/upgrade.py
+++ b/opengever/private/upgrades/20170314200202_fix_private_folder_usage_calculation/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from opengever.quota.sizequota import ISizeQuota
+
+
+class FixPrivateFolderUsageCalculation(UpgradeStep):
+    """Fix private folder usage calculation.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.calculate_private_folder_usage()
+
+    def calculate_private_folder_usage(self):
+        msg = 'Calculate usage in private folders.'
+        for obj in self.objects({'portal_type': ['opengever.private.folder']},
+                                msg):
+            ISizeQuota(obj).recalculate()

--- a/opengever/quota/sizequota.py
+++ b/opengever/quota/sizequota.py
@@ -99,7 +99,10 @@ class SizeQuota(object):
         catalog = api.portal.get_tool('portal_catalog')
         portal = api.portal.get()
 
+        self.get_usage_map(for_writing=True).clear()
+
         for brain in catalog.unrestrictedSearchResults({
+                'path': '/'.join(self.context.getPhysicalPath()),
                 'object_provides': IQuotaSubject.__identifier__}):
             obj = portal.unrestrictedTraverse(brain.getPath())
             self.update_object_usage(obj)


### PR DESCRIPTION
Fixes two problems in the quota usage recalculation method:

1. The usage was calculated for all documents on the site, but it should only be calculated for the documents within the quota container.
2. By clearing the usage map before recalculating we make sure that objects, which are no longer there, are no longer counted.