### PR TITLE
hide columns from private dossier documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 4.15.2 (unreleased)
 -------------------
 
+- Hide columns "public trial", "receipt date" and "delivery date" from the
+  documents tab in private dossiers. [jone]
+
 - Add a journal event for attaching documents to emails via OfficeConnector.
   [Rotonen]
 

--- a/opengever/private/browser/tabbed.py
+++ b/opengever/private/browser/tabbed.py
@@ -1,8 +1,10 @@
 from five import grok
 from opengever.dossier.browser.tabbed import DossierTabbedView
 from opengever.private import _
+from opengever.private.dossier import IPrivateDossier
 from opengever.private.folder import IPrivateFolder
 from opengever.tabbedview import GeverTabbedView
+from opengever.tabbedview.browser.tabs import Documents
 from opengever.tabbedview.browser.tabs import Dossiers
 
 
@@ -34,3 +36,16 @@ class PrivateDossierTabbedView(DossierTabbedView):
                 self.documents_tab,
                 self.trash_tab,
                 self.journal_tab]
+
+
+class PrivateDossierDocuments(Documents):
+    grok.context(IPrivateDossier)
+
+    @property
+    def columns(self):
+        columns = super(PrivateDossierDocuments, self).columns
+        cols_by_name = {col['column']: col for col in columns}
+        cols_by_name['public_trial']['hidden'] = True
+        cols_by_name['receipt_date']['hidden'] = True
+        cols_by_name['delivery_date']['hidden'] = True
+        return columns

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -133,6 +133,18 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
              'Newest documents', 'Description'],
             browser.css('.box h2').text)
 
+    def test_columns_are_hidden_in_documents_tab(self):
+        """Some columns do not make a lot of sense in a private dossier.
+        We hide them in the default configuration.
+        """
+
+        dossier = create(Builder('private_dossier').within(self.folder))
+        view = dossier.unrestrictedTraverse('tabbedview_view-documents')
+        columns_by_name = {col['column']: col for col in view.columns}
+        self.assertTrue(columns_by_name['public_trial'].get('hidden', None))
+        self.assertTrue(columns_by_name['receipt_date'].get('hidden', None))
+        self.assertTrue(columns_by_name['delivery_date'].get('hidden', None))
+
 
 class TestPrivateDossierWorkflow(FunctionalTestCase):
 


### PR DESCRIPTION
Some document tab columns are not important in the context of private dossiers, therefore we hide them in the default configuration.

Closes #2736 

![bildschirmfoto 2017-03-15 um 13 43 40](https://cloud.githubusercontent.com/assets/7469/23948898/6b0a4ee2-0985-11e7-9eb4-df32aaf3e94d.png)
