### PR TITLE
Testing A1: Refactor sqlite testing setup

### DIFF
--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -6,6 +6,7 @@ from opengever.base.oguid import Oguid
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
+import transaction
 
 
 class TestMyNotifications(FunctionalTestCase):
@@ -55,6 +56,7 @@ class TestMyNotifications(FunctionalTestCase):
             {'de': u'Neue Aufgabe hinzugef\xfcgt durch Peter M\xfcller'},
             'peter.mueller',
             {'de': None}).get('activity')
+        transaction.commit()
 
     @browsing
     def test_lists_only_notifications_of_current_user(self, browser):
@@ -64,7 +66,8 @@ class TestMyNotifications(FunctionalTestCase):
         links = [link.get('href') for link in browser.css('.listing a')]
         self.assertEquals(
             ['http://example.com/@@resolve_notification?notification_id=1',
-             'http://example.com/@@resolve_notification?notification_id=2'],
+             'http://example.com/@@resolve_notification?notification_id=2',
+             'http://example.com/@@resolve_notification?notification_id=3'],
             links)
 
     @browsing
@@ -72,6 +75,7 @@ class TestMyNotifications(FunctionalTestCase):
         browser.login().open(self.portal,
                              view='tabbedview_view-mynotifications')
 
+        self.maxDiff = None
         self.assertEquals(
             [{'Actor': u'B\xf6ss Hugo (hugo.boss)',
               'Created': api.portal.get_localized_time(
@@ -82,6 +86,11 @@ class TestMyNotifications(FunctionalTestCase):
               'Created': api.portal.get_localized_time(
                   self.activity_2.created, long_format=True),
               'Kind': u'Aufgabe akzeptiert',
+              'Title': u'Kennzahlen 2014 \xfcbertragen'},
+             {'Actor': u'M\xfcller Peter (peter.mueller)',
+              'Created': api.portal.get_localized_time(
+                  self.activity_3.created, long_format=True),
+              'Kind': u'Aufgabe hinzugef\xfcgt',
               'Title': u'Kennzahlen 2014 \xfcbertragen'}],
             browser.css('.listing').first.dicts())
 

--- a/opengever/bundle/tests/test_business_rule_violations.py
+++ b/opengever/bundle/tests/test_business_rule_violations.py
@@ -1,7 +1,5 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
 from datetime import datetime
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testing import freeze
 from opengever.base.security import elevated_privileges
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
@@ -16,8 +14,6 @@ FROZEN_NOW = datetime(2016, 12, 20, 9, 40)
 
 class TestBusinessRuleViolations(FunctionalTestCase):
 
-    use_default_fixture = False
-
     def test_oggbundle_transmogrifier(self):
         # this is a bit hackish, but since builders currently don't work in
         # layer setup/teardown and isolation of database content is ensured
@@ -27,8 +23,6 @@ class TestBusinessRuleViolations(FunctionalTestCase):
         # load pipeline
         # XXX move this to a layer
         self.grant("Manager")
-        user, org_unit, admin_unit = create(
-            Builder('fixture').with_all_unit_setup())
 
         transmogrifier = Transmogrifier(api.portal.get())
         IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = resource_filename(

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -1,8 +1,6 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
 from datetime import date
 from datetime import datetime
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testing import freeze
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
@@ -23,8 +21,6 @@ FROZEN_NOW = datetime(2016, 12, 20, 9, 40)
 
 class TestOggBundlePipeline(FunctionalTestCase):
 
-    use_default_fixture = False
-
     def test_oggbundle_transmogrifier(self):
         # this is a bit hackish, but since builders currently don't work in
         # layer setup/teardown and isolation of database content is ensured
@@ -34,8 +30,6 @@ class TestOggBundlePipeline(FunctionalTestCase):
         # load pipeline
         # XXX move this to a layer
         self.grant("Manager")
-        user, org_unit, admin_unit = create(
-            Builder('fixture').with_all_unit_setup())
 
         transmogrifier = Transmogrifier(api.portal.get())
         annotations = IAnnotations(transmogrifier)

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -21,9 +21,7 @@ from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
-from plone.app.testing import PLONE_ZSERVER
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import ploneSite
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.browserlayer.utils import unregister_layer
@@ -149,10 +147,6 @@ class OpengeverFixture(PloneSandboxLayer):
         setup_sql_tables()
 
     def testTearDown(self):
-        from opengever.testing.sql import reset_ogds_sync_stamp
-        with ploneSite() as portal:
-            reset_ogds_sync_stamp(portal)
-
         # Tear down the sql session because we use the keep_session flag.
         model.Session.close_all()
         truncate_sql_tables()

--- a/opengever/inbox/tests/test_overview.py
+++ b/opengever/inbox/tests/test_overview.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.globalindex.handlers.task import sync_task
 from opengever.testing import FunctionalTestCase
+import transaction
 
 
 class TestBaseInboxOverview(FunctionalTestCase):
@@ -155,6 +156,7 @@ class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
                         .in_state('forwarding-state-closed')
                         .titled('Closed'))
         sync_task(closed, None)
+        transaction.commit()
 
         browser.login().open(self.inbox, view='tabbedview_view-overview')
         self.assertSequenceEqual(
@@ -212,6 +214,7 @@ class TestInboxOverviewIssuedInboxTasks(TestBaseInboxOverview):
                         .in_state('forwarding-state-closed')
                         .titled('Closed'))
         sync_task(closed, None)
+        transaction.commit()
 
         browser.login().open(self.inbox, view='tabbedview_view-overview')
         self.assertSequenceEqual(

--- a/opengever/meeting/tests/test_agendaitem_list.py
+++ b/opengever/meeting/tests/test_agendaitem_list.py
@@ -133,10 +133,10 @@ class TestAgendaItemList(FunctionalTestCase):
                           .as_submitted())
 
         create(Builder('agenda_item')
+               .having(title=u'foo', number=u'2', meeting=meeting))
+        create(Builder('agenda_item')
                .having(meeting=meeting, proposal=proposal.load_model(),
                        discussion=u'I say Nay!', number=u'1'))
-        create(Builder('agenda_item')
-               .having(title=u'foo', number=u'2', meeting=meeting))
 
         browser.login().open(meeting.get_url(view='agenda_item_list/as_json'))
 

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -4,7 +4,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
-from opengever.meeting.browser.members import MemberView
 from opengever.meeting.model import Member
 from opengever.meeting.wrapper import MemberWrapper
 from opengever.testing import FunctionalTestCase
@@ -164,7 +163,8 @@ class TestMemberView(FunctionalTestCase):
 
     @browsing
     def test_remove_membership_works_correctly(self, browser):
-        browser.login().open(self.member.get_url(self.container))
+        url = self.member.get_url(self.container)
+        browser.login().open(url)
         self.assertEqual(2, len(browser.css('#membership_listing').first.rows))
 
         link = browser.css('a.remove_membership').first
@@ -173,6 +173,8 @@ class TestMemberView(FunctionalTestCase):
         self.assertEqual(['The membership was deleted successfully'],
                          info_messages())
 
+        # I do not know why we need to reload. Feel free to fix this.
+        browser.open(url)
         self.assertEqual(1, len(browser.css('#membership_listing').first.rows))
         self.assertEqual(['My Committee Jan 01, 2008 Jan 01, 2015 Leitung'],
                          browser.css('#membership_listing').first.rows.text)

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
-from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testbrowser.pages.z3cform import erroneous_fields
 from opengever.base.model import create_session
@@ -11,7 +10,6 @@ from opengever.locking.lock import SYS_LOCK
 from opengever.locking.model import Lock
 from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.command import MIME_DOCX
-from opengever.meeting.exceptions import ProtocolAlreadyGenerated
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import GeneratedProtocol
 from opengever.meeting.model import Meeting
@@ -419,9 +417,9 @@ class TestProtocol(FunctionalTestCase):
         numbers = browser.css('.protocol_title .number')
 
         self.assertEqual(map(lambda nav: nav.text, navigation),
-                         ['1. Mach doch', '2. Mach ize'])
+                         ['1. Mach ize', '2. Mach doch'])
         self.assertEqual(map(lambda heading: heading.text, headings),
-                         ['Mach doch', 'Mach ize'])
+                         ['Mach ize', 'Mach doch'])
 
         self.assertEqual(map(lambda number: number.text, numbers),
                          ['1.', '2.'])

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -72,13 +72,6 @@ class TestProtocolJsonData(FunctionalTestCase):
             presidency=self.member_peter,
             secretary=self.member_franz,))
 
-        self.agenda_item_proposal = create(
-            Builder('agenda_item').having(
-                proposal=self.proposal,
-                meeting=self.meeting,
-                decision=u'<div>Die Bauherren werden gest\xfctzt auf \xa7 160 und in Anwendung von \xa7 162 des Baugesetzes wegen Bauens ohne Baubewilligung gesamthaft bestraft. Der Betrag von je Fr. 1000.-- ist - sofern keine Einsprache erfolgt - innert 30 Tagen der Finanzverwaltung der Gemeinde zu bezahlen.</div><ol><li>Erster Punkt</li><li>Zweiter Punkt<ol><li>Subpunkt</li></ol></li></ol>',
-                discussion=u'<div>Der Gemeinderat setzt sich geschlossen f\xfcr eine Busse ein.</div>',
-                decision_number=1))
         self.agend_item_text = create(
             Builder('agenda_item').having(
                 title=u'R\xfccktritt Hans Muster',
@@ -86,6 +79,14 @@ class TestProtocolJsonData(FunctionalTestCase):
                 discussion=u'<div>Hans Muster tritt als Gemeinderat zur\xfcck.</div>',
                 decision=u'<div>Der Gemeinderat hat den R\xfccktritt genehmigt. Die Neuwahl eines Ersatzmitglieds f\xfcr Hans Muster erfolgt bald. Die Wahlvorschl\xe4ge sind n\xe4chstens bei der Kanzlei einzureichen. Falls ein 2. Wahlgang notwendig werden sollte, wird dieser danach durchgef\xfchrt. Die detaillierten Angaben \xfcber den Eingang der Wahlvorschl\xe4ge usw. sind ab sofort auf der Gemeindehomepage publiziert.</div>',
                 decision_number=2,))
+
+        self.agenda_item_proposal = create(
+            Builder('agenda_item').having(
+                proposal=self.proposal,
+                meeting=self.meeting,
+                decision=u'<div>Die Bauherren werden gest\xfctzt auf \xa7 160 und in Anwendung von \xa7 162 des Baugesetzes wegen Bauens ohne Baubewilligung gesamthaft bestraft. Der Betrag von je Fr. 1000.-- ist - sofern keine Einsprache erfolgt - innert 30 Tagen der Finanzverwaltung der Gemeinde zu bezahlen.</div><ol><li>Erster Punkt</li><li>Zweiter Punkt<ol><li>Subpunkt</li></ol></li></ol>',
+                discussion=u'<div>Der Gemeinderat setzt sich geschlossen f\xfcr eine Busse ein.</div>',
+                decision_number=1))
 
     def test_protocol_json(self):
         data = ProtocolData(self.meeting).data

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,8 +7,15 @@ development-packages =
   collective.js.timeago
   plonetheme.teamraum
   ftw.pdfgenerator
+# https://github.com/4teamwork/opengever.ogds.models/pull/45
+  opengever.ogds.models
 
 auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
+
+
+[branches]
+# https://github.com/4teamwork/opengever.ogds.models/pull/45
+opengever.ogds.models = jone-sql-builder-commit


### PR DESCRIPTION
Change the setup of the sqlite database and the connection to the builder.
These changes make the sql builders actually commit instead of just flushing the session.

The ability to actually commit is important in order to move towards testing with PostgreSQL.
