### PR TITLE
Add description for predefined_keywords and restrcit_keywords fields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Add missing field description for predefined_keywords and restrcit_keywords.
+  [elioschmutz]
+
 - Disable grouping for checkbox columns in tables.
   [elioschmutz]
 

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -42,6 +42,9 @@ class IDossierTemplateSchema(form.Schema):
     form.order_after(predefined_keywords='IDossierTemplate.keywords')
     predefined_keywords = schema.Bool(
         title=_(u'label_predefined_keywords', default=u'Predefined Keywords'),
+        description=_(u'description_predefined_keywords',
+                      default=u'The defined keywords will be preselected for '
+                              u'new dossies from template.'),
         required=False,
         missing_value=True,
         default=True,
@@ -50,6 +53,10 @@ class IDossierTemplateSchema(form.Schema):
     form.order_after(restrict_keywords='predefined_keywords')
     restrict_keywords = schema.Bool(
         title=_(u'label_restrict_keywords', default=u'Restrict Keywords'),
+        description=_(u'description_restrict_keywords',
+                      default=u'The user can choose only from the defined keywords '
+                              u'in a new dossier from template. It also prevents '
+                              u'the user for creating new keywords'),
         required=False,
         missing_value=False,
         default=False,

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-03-14 19:29+0000\n"
+"POT-Creation-Date: 2017-03-16 10:01+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -109,7 +109,7 @@ msgstr "Elemente verschieben"
 msgid "Newest documents"
 msgstr "Neuste Dokumente"
 
-#: ./opengever/dossier/browser/overview.py:87
+#: ./opengever/dossier/browser/overview.py:86
 msgid "Newest tasks"
 msgstr "Neuste Aufgaben"
 
@@ -125,11 +125,11 @@ msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 msgid "Participant"
 msgstr "Beteiligung"
 
-#: ./opengever/dossier/browser/overview.py:82
+#: ./opengever/dossier/browser/overview.py:81
 msgid "Participants"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/browser/overview.py:75
+#: ./opengever/dossier/browser/overview.py:74
 msgid "Participations"
 msgstr "Beteiligungen"
 
@@ -299,6 +299,16 @@ msgstr "Dokument aus Vorlage erstellen"
 msgid "create_dossier_with_template"
 msgstr "Geschäftsdossier aus Vorlage erstellen"
 
+#. Default: "The defined keywords will be preselected for new dossies from template."
+#: ./opengever/dossier/dossiertemplate/behaviors.py:45
+msgid "description_predefined_keywords"
+msgstr "Durch Aktivieren dieser Option werden bei der Erstellung des Dossiers ab Vorlage die angegebenen Schlagworte bereits vorausgefüllt."
+
+#. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:56
+msgid "description_restrict_keywords"
+msgstr "Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab Vorlage nur noch die in der Vorlage angegebenen Schlagworte zur Auswahl.<br>Der Benutzer kann dadurch auch keine neuen Schlagworte erfassen."
+
 msgid "documents"
 msgstr "Dokumente"
 
@@ -357,7 +367,7 @@ msgstr "Ablagenummer"
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
 #: ./opengever/dossier/behaviors/dossier.py:111
-#: ./opengever/dossier/browser/overview.py:229
+#: ./opengever/dossier/browser/overview.py:235
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
@@ -446,7 +456,7 @@ msgid "label_add_note"
 msgstr "Erfassen"
 
 #. Default: "Addable dossier templates"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:100
+#: ./opengever/dossier/dossiertemplate/behaviors.py:107
 msgid "label_addable_dossier_templates"
 msgstr "Erlaubte Dossiervorlagen"
 
@@ -472,7 +482,7 @@ msgstr "Schliessen"
 
 #. Default: "Comments"
 #: ./opengever/dossier/behaviors/dossier.py:86
-#: ./opengever/dossier/browser/overview.py:67
+#: ./opengever/dossier/browser/overview.py:66
 msgid "label_comments"
 msgstr "Kommentar"
 
@@ -498,7 +508,7 @@ msgid "label_creator"
 msgstr "Erstellt von"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:233
+#: ./opengever/dossier/browser/overview.py:239
 #: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr "Beschreibung"
@@ -509,7 +519,7 @@ msgid "label_destination"
 msgstr "Zielposition / Zieldossier"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:221
+#: ./opengever/dossier/browser/overview.py:231
 #: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr "Dokumente"
@@ -579,7 +589,7 @@ msgstr "Journal"
 
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:60
-#: ./opengever/dossier/browser/overview.py:225
+#: ./opengever/dossier/browser/overview.py:213
 msgid "label_keywords"
 msgstr "Schlagworte"
 
@@ -674,7 +684,7 @@ msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:52
+#: ./opengever/dossier/dossiertemplate/behaviors.py:55
 msgid "label_restrict_keywords"
 msgstr "Schlagwortkatalog einschränken"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-14 19:29+0000\n"
+"POT-Creation-Date: 2017-03-16 10:01+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -107,7 +107,7 @@ msgstr "Déplacer l'élément"
 msgid "Newest documents"
 msgstr "Derniers documents"
 
-#: ./opengever/dossier/browser/overview.py:87
+#: ./opengever/dossier/browser/overview.py:86
 msgid "Newest tasks"
 msgstr "Dernières tâches"
 
@@ -123,11 +123,11 @@ msgstr "Manque des champs obligatoires"
 msgid "Participant"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:82
+#: ./opengever/dossier/browser/overview.py:81
 msgid "Participants"
 msgstr "Participants"
 
-#: ./opengever/dossier/browser/overview.py:75
+#: ./opengever/dossier/browser/overview.py:74
 msgid "Participations"
 msgstr "Participants"
 
@@ -295,6 +295,16 @@ msgstr "Créer un document à partir d'un modèle"
 msgid "create_dossier_with_template"
 msgstr ""
 
+#. Default: "The defined keywords will be preselected for new dossies from template."
+#: ./opengever/dossier/dossiertemplate/behaviors.py:45
+msgid "description_predefined_keywords"
+msgstr ""
+
+#. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:56
+msgid "description_restrict_keywords"
+msgstr ""
+
 msgid "documents"
 msgstr "Documents"
 
@@ -353,7 +363,7 @@ msgstr "Numéro d'inventaire"
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
 #: ./opengever/dossier/behaviors/dossier.py:111
-#: ./opengever/dossier/browser/overview.py:229
+#: ./opengever/dossier/browser/overview.py:235
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
@@ -442,7 +452,7 @@ msgid "label_add_note"
 msgstr ""
 
 #. Default: "Addable dossier templates"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:100
+#: ./opengever/dossier/dossiertemplate/behaviors.py:107
 msgid "label_addable_dossier_templates"
 msgstr ""
 
@@ -468,7 +478,7 @@ msgstr ""
 
 #. Default: "Comments"
 #: ./opengever/dossier/behaviors/dossier.py:86
-#: ./opengever/dossier/browser/overview.py:67
+#: ./opengever/dossier/browser/overview.py:66
 msgid "label_comments"
 msgstr "Commentaire"
 
@@ -494,7 +504,7 @@ msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:233
+#: ./opengever/dossier/browser/overview.py:239
 #: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr ""
@@ -505,7 +515,7 @@ msgid "label_destination"
 msgstr "Destination"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:221
+#: ./opengever/dossier/browser/overview.py:231
 #: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr "Documents"
@@ -575,7 +585,7 @@ msgstr "Historique"
 
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:60
-#: ./opengever/dossier/browser/overview.py:225
+#: ./opengever/dossier/browser/overview.py:213
 msgid "label_keywords"
 msgstr "Mots-clés"
 
@@ -670,7 +680,7 @@ msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:52
+#: ./opengever/dossier/dossiertemplate/behaviors.py:55
 msgid "label_restrict_keywords"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-14 19:29+0000\n"
+"POT-Creation-Date: 2017-03-16 10:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Newest documents"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:87
+#: ./opengever/dossier/browser/overview.py:86
 msgid "Newest tasks"
 msgstr ""
 
@@ -124,11 +124,11 @@ msgstr ""
 msgid "Participant"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:82
+#: ./opengever/dossier/browser/overview.py:81
 msgid "Participants"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:75
+#: ./opengever/dossier/browser/overview.py:74
 msgid "Participations"
 msgstr ""
 
@@ -296,6 +296,16 @@ msgstr ""
 msgid "create_dossier_with_template"
 msgstr ""
 
+#. Default: "The defined keywords will be preselected for new dossies from template."
+#: ./opengever/dossier/dossiertemplate/behaviors.py:45
+msgid "description_predefined_keywords"
+msgstr ""
+
+#. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
+#: ./opengever/dossier/dossiertemplate/behaviors.py:56
+msgid "description_restrict_keywords"
+msgstr ""
+
 msgid "documents"
 msgstr ""
 
@@ -354,7 +364,7 @@ msgstr ""
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
 #: ./opengever/dossier/behaviors/dossier.py:111
-#: ./opengever/dossier/browser/overview.py:229
+#: ./opengever/dossier/browser/overview.py:235
 msgid "filing_prefix"
 msgstr ""
 
@@ -443,7 +453,7 @@ msgid "label_add_note"
 msgstr ""
 
 #. Default: "Addable dossier templates"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:100
+#: ./opengever/dossier/dossiertemplate/behaviors.py:107
 msgid "label_addable_dossier_templates"
 msgstr ""
 
@@ -469,7 +479,7 @@ msgstr ""
 
 #. Default: "Comments"
 #: ./opengever/dossier/behaviors/dossier.py:86
-#: ./opengever/dossier/browser/overview.py:67
+#: ./opengever/dossier/browser/overview.py:66
 msgid "label_comments"
 msgstr ""
 
@@ -495,7 +505,7 @@ msgid "label_creator"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:233
+#: ./opengever/dossier/browser/overview.py:239
 #: ./opengever/dossier/templatefolder/tabs.py:111
 msgid "label_description"
 msgstr ""
@@ -506,7 +516,7 @@ msgid "label_destination"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:221
+#: ./opengever/dossier/browser/overview.py:231
 #: ./opengever/dossier/browser/tabbed.py:17
 msgid "label_documents"
 msgstr ""
@@ -576,7 +586,7 @@ msgstr ""
 
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py:60
-#: ./opengever/dossier/browser/overview.py:225
+#: ./opengever/dossier/browser/overview.py:213
 msgid "label_keywords"
 msgstr ""
 
@@ -671,7 +681,7 @@ msgid "label_responsible"
 msgstr ""
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:52
+#: ./opengever/dossier/dossiertemplate/behaviors.py:55
 msgid "label_restrict_keywords"
 msgstr ""
 

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -209,7 +209,10 @@ class TestDossierTemplate(FunctionalTestCase):
             u'Title',
             u'Description',
             u'Keywords',
+            u'The defined keywords will be preselected for new dossies from template.',
             u'Predefined Keywords',
+            u'The user can choose only from the defined keywords in a new dossier '
+            u'from template. It also prevents the user for creating new keywords',
             u'Restrict Keywords',
             u'Comments',
             u'filing prefix'],
@@ -230,7 +233,10 @@ class TestDossierTemplate(FunctionalTestCase):
             u'Title',
             u'Description',
             u'Keywords',
+            u'The defined keywords will be preselected for new dossies from template.',
             u'Predefined Keywords',
+            u'The user can choose only from the defined keywords in a new dossier '
+            u'from template. It also prevents the user for creating new keywords',
             u'Restrict Keywords',
             u'Comments',
             u'filing prefix'],


### PR DESCRIPTION
Fügt die Beschreibung der `predefined_keywords` und `restrcit_keywords` Felder hinzu.

![bildschirmfoto 2017-03-16 um 11 24 33](https://cloud.githubusercontent.com/assets/557005/23991886/3472e482-0a3b-11e7-8572-648616952643.png)

closes #2749 