### PR TITLE
Development: re-add format-xml scripts.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -5,6 +5,7 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
     http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
     sphinx.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml.cfg
 
 always-checkout = false
 


### PR DESCRIPTION
The format-xml scripts were removed from default plone development in https://github.com/4teamwork/ftw-buildouts/pull/74 because I hate buildout.
This re-adds the scripts for GEVER.