### PR TITLE
🚧 Add PostgreSQL testing layer with basic isolation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Refactor: Use ZCML for registering reference number adapters for consistency. [jone]
 - Refactor: Use SQLFormSupport class for: Meeting and Member [elioschmutz]
 
 

--- a/opengever/core/postgresql_testing.py
+++ b/opengever/core/postgresql_testing.py
@@ -1,0 +1,199 @@
+from ftw.dictstorage.sql import DictStorageModel
+from opengever.base import model
+from opengever.ogds.models import BASE
+from plone.testing import Layer
+from sqlalchemy import create_engine
+from sqlalchemy import MetaData
+from sqlalchemy.orm import create_session
+from sqlalchemy_utils import create_database
+from sqlalchemy_utils import database_exists
+from sqlalchemy_utils import drop_database
+from z3c.saconfig.interfaces import IScopedSession
+from z3c.saconfig.utility import GloballyScopedSession
+from zope.component import provideUtility
+import os
+
+
+class PostgreSQLFixture(Layer):
+    """Fixture for running Plone tests against a PostgreSQL database.
+    It designed to be used with the OpengeverFixture.
+    """
+
+    def setUp(self):
+        self.matroska = Matroska()
+
+    def testSetUp(self):
+        self.matroska.push()
+
+    def testTearDown(self):
+        self.matroska.pop()
+
+    def tearDown(self):
+        model.Session.close_all()
+        model.Session.registry.clear()
+
+
+
+POSTGRES_FIXTURE = PostgreSQLFixture()
+
+
+class Matroska(object):
+    """The matroska lets us implement an sql isolation by copying the
+    database into new generations and switch back to the original.
+    """
+
+    def __init__(self):
+        engine = create_engine(new_engine_url())
+        create_database(engine.url)
+        create_tables(engine)
+        self.generation = MatroskaGeneration(None, engine).activate()
+
+    def push(self):
+        self.generation = self.generation.fork()
+
+    def pop(self):
+        self.generation = self.generation.uninstall()
+
+
+class MatroskaGeneration(object):
+    """A matroska generation represents exactly one database / engine.
+    It can be forked, which makes a copy of data and sequences into a
+    new database.
+    """
+
+    def __init__(self, parent, engine):
+        self.parent = parent
+        self.engine = engine
+        self._disposed_engine = None
+
+    def fork(self):
+        """Fork this generation with all its data into a new database.
+        """
+        if self._disposed_engine is not None:
+            # We have a disposed engine with the same data as this
+            # generation, so lets reuse it.
+            engine = self._disposed_engine
+            self._disposed_engine = None
+
+        else:
+            engine = create_engine(new_engine_url())
+            create_database(engine.url)
+            create_tables(engine)
+            copy_data(self.engine, engine)
+            copy_sequences(self.engine, engine)
+
+        return MatroskaGeneration(self, engine).activate()
+
+    def activate(self):
+        TestingScopedSession.install(self.engine)
+        return self
+
+    def uninstall(self):
+        if self._disposed_engine:
+            drop_database(self._disposed_engine)
+            self._disposed_engine = None
+
+        if self.parent is None:
+            # root generation
+            drop_database(self.engine.url)
+            return
+
+        if False:
+            # transaction rollback / abort
+            self.parent.dispose(self)
+        else:
+            drop_database(self.engine.url)
+
+        return self.parent.activate()
+
+    def dispose(self, fork):
+        """
+        A fork of our generation is disposed because nothing was changed.
+        Keep it for reuse later.
+        """
+        assert fork.parent == self, 'MatroskaGeneration mess: not my fork.'
+        self._disposed_engine = fork.engine
+
+
+class TestingScopedSession(GloballyScopedSession):
+
+    def __init__(self, engine):
+        self.engine = engine
+        super(TestingScopedSession, self).__init__()
+
+    def sessionFactory(self):
+        kw = self.kw.copy()
+        kw['bind'] = self.engine
+        return create_session(**kw)
+
+    @classmethod
+    def install(klass, engine):
+        provideUtility(klass(engine), provides=IScopedSession, name=u'opengever')
+        model.Session.bind = engine
+
+
+def new_engine_url():
+    """Create a postgresql engine URL with a new database name.
+    Makes sure that the database name is unique over the lieftime
+    of the process.
+    """
+    counter = globals()['_db_counter'] = globals().get('_db_counter', 0) + 1
+    database_name = 'opengever_test_{}_{}'.format(os.getpid(), counter)
+    url = 'postgresql+psycopg2:///{}'.format(database_name)
+    if database_exists(url):
+        drop_database(url)
+    return url
+
+
+def get_tables_of_engine(engine):
+    """Return the tables for an engine.
+    """
+    metadata = MetaData(engine)
+    metadata.reflect()
+    return metadata.sorted_tables
+
+
+def create_tables(engine):
+    """Create SQL tables in an engine.
+    """
+    model.Base.metadata.create_all(engine)
+    BASE.metadata.create_all(engine)
+    DictStorageModel.metadata.create_all(engine)
+
+
+def copy_data(source_engine, target_engine):
+    """Copy all data from one engine to antother.
+    The tables must be set up on the target.
+    """
+
+    for table in get_tables_of_engine(source_engine):
+        data = [{column.key: row[column.name] for column in table.c}
+                for row
+                in source_engine.execute(table.select())]
+
+        if data:
+            target_engine.execute(table.insert(), data)
+
+def copy_sequences(source_engine, target_engine):
+    """Copy sequences from one engine to antother.
+    """
+    if not source_engine.dialect.supports_sequences:
+        return
+
+    parent_sequence_names = source_engine.execute(
+        "SELECT c.relname "
+        "FROM pg_class c "
+        "WHERE c.relkind = 'S'").fetchall()
+
+    for sequence_name in parent_sequence_names:
+        # Get the last_value from a parent matroska sequence
+        parent_last_value = source_engine.execute(
+            "SELECT last_value FROM {0}"
+            .format(sequence_name[0])).fetchall()
+
+        # Reset the new matroska sequence to + 1
+        # https://www.postgresql.org/docs/current/static/sql-altersequence.html
+        target_engine.execute(
+            "ALTER SEQUENCE {0} RESTART WITH {1};"
+            .format(sequence_name[0],
+                    parent_last_value[0][0] + 1))

--- a/opengever/core/sqlite_testing.py
+++ b/opengever/core/sqlite_testing.py
@@ -33,6 +33,10 @@ class SQLiteMemoryFixture(Layer):
         model.Session.close_all()
         truncate_tables()
 
+    def tearDown(self):
+        model.Session.registry.clear()
+
+
 
 SQLITE_MEMORY_FIXTURE = SQLiteMemoryFixture()
 

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -5,6 +5,7 @@ from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import set_builder_session_factory
 from ftw.bumblebee.tests.helpers import BumblebeeTestTaskQueue
 from ftw.testing import ComponentRegistryLayer
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from ftw.testing.quickinstaller import snapshots
 from opengever.activity.interfaces import IActivitySettings
 from opengever.base.model import create_session
@@ -18,7 +19,6 @@ from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -97,7 +97,7 @@ ANNOTATION_LAYER = AnnotationLayer()
 
 
 class OpengeverFixture(PloneSandboxLayer):
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
 
     def __init__(self, sql_layer):
         bases = self.defaultBases + (sql_layer, )

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -10,6 +10,7 @@ from ftw.testing.quickinstaller import snapshots
 from opengever.activity.interfaces import IActivitySettings
 from opengever.base.model import create_session
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
+from opengever.core import postgresql_testing
 from opengever.core import sqlite_testing
 from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings # noqa
 from opengever.meeting.interfaces import IMeetingSettings
@@ -217,15 +218,25 @@ MEMORY_DB_LAYER = sqlite_testing.StandaloneMemoryDBLayer(
 OPENGEVER_FIXTURE_SQLITE = OpengeverFixture(
     sqlite_testing.SQLITE_MEMORY_FIXTURE)
 
+OPENGEVER_FIXTURE_POSTGRES = OpengeverFixture(
+    postgresql_testing.POSTGRES_FIXTURE)
+
 OPENGEVER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(OPENGEVER_FIXTURE_SQLITE,
            set_builder_session_factory(integration_session_factory)),
     name="opengever.core:integration")
 
-OPENGEVER_FUNCTIONAL_TESTING = FunctionalTesting(
+OPENGEVER_FUNCTIONAL_TESTING_SQLITE = FunctionalTesting(
     bases=(OPENGEVER_FIXTURE_SQLITE,
            set_builder_session_factory(functional_session_factory)),
-    name="opengever.core:functional")
+    name="opengever.core:sqlite:functional")
+
+OPENGEVER_FUNCTIONAL_TESTING_POSTGRES = FunctionalTesting(
+    bases=(OPENGEVER_FIXTURE_POSTGRES,
+           set_builder_session_factory(functional_session_factory)),
+    name="opengever.core:postgres:functional")
+
+OPENGEVER_FUNCTIONAL_TESTING = OPENGEVER_FUNCTIONAL_TESTING_SQLITE
 
 OPENGEVER_FUNCTIONAL_ZSERVER_TESTING = FunctionalTesting(
     bases=(z2.ZSERVER_FIXTURE,

--- a/opengever/dossier/tests/test_activate.py
+++ b/opengever/dossier/tests/test_activate.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_TESTING_POSTGRES
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
 from plone import api
@@ -11,6 +12,11 @@ from plone.protect import createToken
 
 
 class TestDossierActivation(FunctionalTestCase):
+    # This test uses the postgres layer in order to profe that postgres can
+    # be used in tests. It was chose randomly.
+    # The layer should be removed when "FunctionalTestCase" has been switched
+    # to postgres testing as default.
+    layer = OPENGEVER_FUNCTIONAL_TESTING_POSTGRES
 
     def setUp(self):
         super(TestDossierActivation, self).setUp()

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -21,7 +21,7 @@ class TestOGDSUpdater(FunctionalTestCase):
         ldap_plugin = FakeLDAPPlugin(FAKE_LDAP_USERFOLDER)
         self.portal.acl_users._setObject('ldap', ldap_plugin)
 
-        provideAdapter(FakeLDAPSearchUtility)
+        self.portal.getSiteManager().registerAdapter(FakeLDAPSearchUtility)
 
     def test_imports_users(self):
         FAKE_LDAP_USERFOLDER.users = [

--- a/opengever/repository/behaviors/configure.zcml
+++ b/opengever/repository/behaviors/configure.zcml
@@ -13,6 +13,12 @@
       marker=".referenceprefix.IReferenceNumberPrefixMarker"
       />
 
+  <adapter factory=".referenceprefix.ReferenceNumberPrefixValidator" />
+  <adapter
+      factory=".referenceprefix.ReferenceNumberPrefixErrorMessage"
+      name="message"
+      />
+
   <plone:behavior
       title="ResponsibleOrgUnit"
       description="OpenGever ResponsibleOrgUnit Behavior"

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -6,7 +6,6 @@ from plone.directives import form
 from z3c.form import validator, error
 from z3c.form.interfaces import IAddForm
 from zope import schema
-from zope.component import provideAdapter
 from zope.interface import alsoProvides
 from zope.interface import Interface
 from zope.interface import provider
@@ -66,16 +65,12 @@ validator.WidgetValidatorDiscriminators(
     field=IReferenceNumberPrefix['reference_number_prefix'],
     )
 
-provideAdapter(ReferenceNumberPrefixValidator)
-
-provideAdapter(error.ErrorViewMessage(
-        _('error_sibling_reference_number_existing',
-          default=u'A Sibling with the same reference number is existing'),
-        error=schema.interfaces.ConstraintNotSatisfied,
-        field=IReferenceNumberPrefix['reference_number_prefix'],
-        ),
-        name='message'
-        )
+ReferenceNumberPrefixErrorMessage = error.ErrorViewMessage(
+    _('error_sibling_reference_number_existing',
+      default=u'A Sibling with the same reference number is existing'),
+    error=schema.interfaces.ConstraintNotSatisfied,
+    field=IReferenceNumberPrefix['reference_number_prefix'],
+)
 
 
 class IReferenceNumberPrefixMarker(Interface):

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -3,10 +3,8 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefixMarker
-from opengever.repository.behaviors.referenceprefix import ReferenceNumberPrefixValidator
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
-from zope.component import provideAdapter
 from ftw.testbrowser.pages import factoriesmenu
 
 
@@ -18,9 +16,6 @@ class TestReferenceBehavior(FunctionalTestCase):
 
     def setUp(self):
         super(TestReferenceBehavior, self).setUp()
-        # Since plone tests sucks, we need to re-register
-        # the reference number validator again.
-        provideAdapter(ReferenceNumberPrefixValidator)
 
         add_languages(['de-ch'])
         self.repo = create(Builder('repository'))
@@ -53,7 +48,7 @@ class TestReferenceBehavior(FunctionalTestCase):
         browser.click_on('Save')
 
         self.assertEquals(
-            ['Constraint not satisfied'],
+            ['A Sibling with the same reference number is existing'],
             browser.css('#formfield-form-widgets-IReferenceNumberPrefix'
                         '-reference_number_prefix .error').text)
 

--- a/opengever/testing/event_recorder.py
+++ b/opengever/testing/event_recorder.py
@@ -1,0 +1,50 @@
+from persistent.list import PersistentList
+from zope.component.hooks import getSite
+
+
+EVENT_RECORD_ATTRIBUTE_NAME = '_og_testing_events_record'
+EVENT_RECORD_SERIALIZERS = {}
+_marker = object()
+
+
+def register_event_recorder(*required):
+    """Register a generic event subscriber for recording certain events.
+
+    In order to be able to use the testbrowser, the transaction must be able to
+    synchronize the threads. The easiest way to do that is to store the infos
+    in the database. We do that by just attaching them to the Plone site.
+    """
+    getSite().getSiteManager().registerHandler(
+        recording_event_subscriber, list(required))
+
+
+def get_recorded_events():
+    """Return all recorded events as tuple of the event classname (string)
+    """
+    return getattr(getSite(), EVENT_RECORD_ATTRIBUTE_NAME, ())
+
+
+def get_last_recorded_event():
+    """Returns the tuple of the last recorded event.
+    The tuple contains the string of the event class name and the serialized
+    data of the event.
+    """
+    events = get_recorded_events()
+    if events:
+        return events[-1]
+    else:
+        return None
+
+
+def recording_event_subscriber(*args):
+    site = getSite()
+    if not hasattr(site, EVENT_RECORD_ATTRIBUTE_NAME):
+        events = PersistentList()
+        setattr(site, EVENT_RECORD_ATTRIBUTE_NAME, events)
+    else:
+        events = getattr(site, EVENT_RECORD_ATTRIBUTE_NAME)
+
+    if len(args) == 1:
+        events.append(args[0])
+    else:
+        events.append(args)

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -18,6 +18,8 @@ arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--aut
 
 eggs +=
     ${buildout:hotfix-eggs}
+    psycopg2
+
 
 [test-jenkins]
 test-command = bin/mtest $@


### PR DESCRIPTION
🚧 *Rebase and change target branch when #2798 (`Isolate component registry between tests `) is merged.*

This change introduces a new PostgreSQL layer with the Matroska isolation concept adopted from the `POC layer isolation` PR #2557. But it does not yet provide any fixture as #2557 proposes; I want to do that at a later point.

This change introduces a new `OPENGEVER_FUNCTIONAL_TESTING_POSTGRES` testing layer which is not used at this point at all.

🚧 This is not yet finished.