### PR TITLE
Fixed content type encoding for archival files

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Fixed contenttype encoding for archival files.
+  [phgross]
+
 - Add missing field description for predefined_keywords and restrcit_keywords.
   [elioschmutz]
 

--- a/opengever/document/archival_file.py
+++ b/opengever/document/archival_file.py
@@ -41,6 +41,9 @@ class ArchivalFileConverter(object):
             self.document.absolute_url())
 
     def store_file(self, data, mimetype='application/pdf'):
+        if isinstance(mimetype, unicode):
+            mimetype = mimetype.encode('utf-8')
+
         IDocumentMetadata(self.document).archival_file = NamedBlobFile(
             data=data,
             contentType=mimetype,

--- a/opengever/document/tests/test_archival_file.py
+++ b/opengever/document/tests/test_archival_file.py
@@ -68,6 +68,13 @@ class TestArchivalFile(FunctionalTestCase):
             STATE_CONVERTED,
             IDocumentMetadata(self.document).archival_file_state)
 
+    def test_store_file_decodes_unicode_contenttypes(self):
+        ArchivalFileConverter(self.document).store_file(
+            'TEST DATA', mimetype=u'application/pdf')
+
+        archival_file = IDocumentMetadata(self.document).archival_file
+        self.assertTrue(isinstance(archival_file.contentType, str))
+
 
 class TestArchivalFileState(FunctionalTestCase):
 

--- a/opengever/document/upgrades/20170317095333_fix_contentypes_encoding_for_archival_files/upgrade.py
+++ b/opengever/document/upgrades/20170317095333_fix_contentypes_encoding_for_archival_files/upgrade.py
@@ -1,0 +1,34 @@
+from ftw.upgrade import UpgradeStep
+from opengever.document.behaviors.metadata import IDocumentMetadata
+from opengever.dossier.interfaces import IDossierResolveProperties
+from plone import api
+
+
+class FixContentypesEncodingForArchivalFiles(UpgradeStep):
+    """Fix contentypes encoding for archival files.
+    """
+
+    def __call__(self):
+        # Skip contentype fixing for installation where the conversion
+        # has not be enabled yet.
+        if not self.is_conversion_enabled():
+            return
+
+        for obj in self.objects(
+                {'object_provides': IDocumentMetadata.__identifier__},
+                'Fix contenttype encoding for archival files'):
+
+            self.fix_contenttype_encoding(obj)
+
+    def is_conversion_enabled(self):
+        return api.portal.get_registry_record(
+            'archival_file_conversion_enabled',
+            interface=IDossierResolveProperties)
+
+    def fix_contenttype_encoding(self, document):
+        if not IDocumentMetadata(document).archival_file:
+            return
+
+        content_type = document.archival_file.contentType
+        if isinstance(content_type, unicode):
+            document.archival_file.contentType = content_type.encode('utf-8')


### PR DESCRIPTION
The content type of the archival_file, automatically generated by Bumblebee, was added by with a wrong contenttype encoding (unicode instead of utf-8). This lead to an ValidationError when editing the document.

Closes #2698 