### PR TITLE
Merge pull request #2619 from 4teamwork/lg-allow-form-prefilling-via-GET

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,10 +1,12 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+    test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
     http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
     sphinx.cfg
+
+always-checkout = false
 
 parts +=
     test-inbound-mail

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,13 @@ Changelog
 4.15.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow certain z3c forms to be prefilled via GET requests. This is required
+  after the introduction of Products.PloneHotfix20160830.
+  [lgraf]
+
+- Include Hotfixes in development and test buildouts.
+  [lgraf]
+
 
 
 4.15.3 (2017-03-13)

--- a/opengever/base/browser/modelforms.py
+++ b/opengever/base/browser/modelforms.py
@@ -66,6 +66,7 @@ class ModelEditForm(AutoExtensibleForm, EditForm):
     """
 
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
     has_model_breadcrumbs = True
     schema = None
 

--- a/opengever/inbox/browser/assign.py
+++ b/opengever/inbox/browser/assign.py
@@ -30,6 +30,7 @@ class AssignForwardingForm(AssignTaskForm):
     fields = Fields(IForwardingAssignSchema)
     fields['responsible'].widgetFactory[INPUT_MODE] = AutocompleteFieldWidget
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     label = _(u'title_assign_forwarding', u'Assign Forwarding')
 

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -47,6 +47,7 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
 
     """
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     schema = ISubmitAdditionalDocument
 

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -89,6 +89,7 @@ class GenerateExcerpt(AutoExtensibleForm, EditForm):
 
     has_model_breadcrumbs = True
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
     schema = IGenerateExcerpt
 
     template = ViewPageTemplateFile('templates/excerpt.pt')

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -60,6 +60,7 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
 
     """
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     schema = ISubmitAdditionalDocuments
 

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -37,6 +37,7 @@ class ModelProxyEditForm(object):
 
     content_type = None
     fields = None
+    allow_prefill_from_GET_request = True  # XXX
 
     def render(self):
         assert self.fields, 'must specify model fields to render!'

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -66,6 +66,7 @@ class AssignTaskForm(Form):
     fields['responsible'].widgetFactory[INPUT_MODE] = \
         AutocompleteFieldWidget
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     label = _(u'title_assign_task', u'Assign task')
 

--- a/opengever/task/browser/delegate/recipients.py
+++ b/opengever/task/browser/delegate/recipients.py
@@ -40,6 +40,8 @@ class ISelectRecipientsSchema(Schema):
 class SelectRecipientsForm(DelegateWizardFormMixin, Form):
     grok.context(ITask)
 
+    allow_prefill_from_GET_request = True  # XXX
+
     fields = Fields(ISelectRecipientsSchema)
     fields['responsibles'].widgetFactory = \
         autocomplete_widget.AutocompleteMultiFieldWidget

--- a/opengever/task/browser/modify_deadline.py
+++ b/opengever/task/browser/modify_deadline.py
@@ -44,6 +44,7 @@ class ModifyDeadlineForm(Form):
 
     fields = Fields(IModifyDeadlineSchema)
     ignoreContext = True
+    allow_prefill_from_GET_request = True  # XXX
 
     label = _(u'title_modify_deadline', u'Modify deadline')
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -143,6 +143,9 @@ class Base(BrowserView):
 
 
 class AddForm(form.AddForm, AutoExtensibleForm):
+
+    allow_prefill_from_GET_request = True  # XXX
+
     fields = field.Fields(IResponse)
     # keep widget for converters (even though field is hidden)
     fields['transition'].widgetFactory = radio.RadioFieldWidget

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -16,6 +16,8 @@ test-egg = opengever.core[api, tests]
 [test]
 arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
 
+eggs +=
+    ${buildout:hotfix-eggs}
 
 [test-jenkins]
 test-command = bin/mtest $@


### PR DESCRIPTION
 Allow certain z3c forms to be prefilled via GET requests