### PR TITLE
Allow private dossiers to be resolved

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Allow private dossiers to be resolved.
+  [lgraf]
+
 - Escape dossiertemplate title_help field on display.
   [elioschmutz]
 

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -10,6 +10,7 @@ from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
+from opengever.private.dossier import IPrivateDossier
 from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer import indexer
 from Products.CMFCore.interfaces import ISiteRoot
@@ -51,6 +52,10 @@ grok.global_adapter(endIndexer, name="end")
 
 @indexer(IDossierMarker)
 def retention_expiration(obj):
+    if IPrivateDossier.providedBy(obj):
+        # Private dossiers don't have the Lifecycle behavior, and therefore
+        # don't have a retention period, or expiration thereof
+        return None
     return obj.get_retention_expiration_date()
 grok.global_adapter(retention_expiration, name="retention_expiration")
 

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -9,6 +9,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from plone.protect import createToken
 from zope.component import getUtility
@@ -189,3 +190,14 @@ class TestPrivateDossierWorkflow(FunctionalTestCase):
 
         self.assertEquals([u'the object My private document trashed'],
                           info_messages())
+
+    @browsing
+    def test_private_dossier_can_be_resolved(self, browser):
+        browser.login().open(self.dossier,
+                             {'_authenticator': createToken()},
+                             view='transition-resolve')
+        self.assertEquals(['The dossier has been succesfully resolved'],
+                          info_messages())
+
+        self.assertEqual('dossier-state-resolved',
+                         api.content.get_state(self.dossier))


### PR DESCRIPTION
Allow private dossiers to be resolved:

They don't have the `ILifeCycle` behavior, and therefore no retention period. Therefore we skip the calculation of the retention_expiration for private dosssiers
in the respective indexer.