### PR TITLE
Escape dossiertemplate title_help field on display.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Escape dossiertemplate title_help field on display.
+  [elioschmutz]
+
 - Fix the common-fieldset translation in the add/edit-form if using the
   ITranslatedTitle behavior in combination with a dossier-type (i.e. the templatefolder).
   [elioschmutz]

--- a/opengever/base/tests/test_widget.py
+++ b/opengever/base/tests/test_widget.py
@@ -44,6 +44,17 @@ class TestGeverRenderWidget(FunctionalTestCase):
             u'A d\xfcnamic description',
             browser.css('.formHelp').first.text)
 
+    @browsing
+    def test_escape_dynamic_description(self, browser):
+        self.widget.dynamic_description = u"<script>alert('bad');</script>"
+
+        widget_renderer = getMultiAdapter(
+            (self.widget, self.request), name='ploneform-render-widget')
+
+        self.assertEqual(
+            u'&lt;script&gt;alert(&apos;bad&apos;);&lt;/script&gt;',
+            widget_renderer.get_description())
+
 
 class TestTrixWidget(FunctionalTestCase):
 

--- a/opengever/base/widgets.py
+++ b/opengever/base/widgets.py
@@ -3,6 +3,7 @@ from ftw.table.interfaces import ITableGenerator
 from opengever.base import _
 from opengever.base.transforms import trix2sablon
 from opengever.base.utils import escape_html
+from opengever.base.utils import escape_html
 from plone.app.z3cform.templates import RenderWidget
 from plone.z3cform.textlines.textlines import TextLinesFieldWidget
 from z3c.form import util
@@ -51,7 +52,7 @@ class GeverRenderWidget(RenderWidget):
 
     def get_description(self):
         if hasattr(self.context, 'dynamic_description') and self.context.dynamic_description:
-            return self.context.dynamic_description
+            return escape_html(self.context.dynamic_description)
         return self.context.field.description
 
 


### PR DESCRIPTION
This PR escapes the dynamic_description field for the textfield-widget.

![screen1](https://cloud.githubusercontent.com/assets/557005/24109572/5b0da074-0d91-11e7-87bd-8f7083e0e6be.gif)
