### PR TITLE
Get rid of unnecessary column label in extract attachments view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,12 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Get rid of unnecessary column label in extract attachments view.
+  [lgraf]
+
+- Allow private dossiers to be resolved.
+  [lgraf]
+
 - Escape dossiertemplate title_help field on display.
   [elioschmutz]
 

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -10,12 +10,12 @@ from zope.component import getUtility
 import os.path
 
 
-def attachment_checkbox_helper(item, position):
+def attachment_checkbox_helper(item, value):
     attrs = {'type': 'checkbox',
              'class': 'noborder selectable',
              'name': 'attachments:list',
-             'id': 'attachment%s' % str(position),
-             'value': str(position)}
+             'id': 'attachment%s' % str(item['position']),
+             'value': str(item['position'])}
 
     return '<input %s />' % ' '.join(['%s="%s"' % (k, v)
                                       for k, v in attrs.items()])
@@ -85,8 +85,7 @@ class ExtractAttachments(grok.View):
         """
 
         columns = (
-            {'column': 'position',
-             'column_title': u'',
+            {'column': '',
              'transform': attachment_checkbox_helper,
              'width': 30},
 


### PR DESCRIPTION
Gets rid of a column header that isn't supposed to be shown. Apparently, in a recent version `ftw.tabbedview` falls back to the column ID if the `column_title` is falsy. 

**Before**:
![extract_before](https://cloud.githubusercontent.com/assets/405124/24111252/25aa9496-0d96-11e7-99e5-1bcddb228b01.png)

**After**:
![extract_after](https://cloud.githubusercontent.com/assets/405124/24111259/2c52863c-0d96-11e7-8688-24561eec66ef.png)
