### PR TITLE
Enable keywordswidget for IDocumentMetadata behavior.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Enable keywordswidget for IDocumentMetadata behavior.  [elioschmutz]
 - Refactor: Use SQLFormSupport class for: Meeting and Member [elioschmutz]
 
 

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -3,6 +3,8 @@ from collective.elephantvocabulary import wrap_vocabulary
 from datetime import date
 from five import grok
 from ftw.datepicker.widget import DatePickerFieldWidget
+from ftw.keywordwidget.field import ChoicePlus
+from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.mail.mail import IMail
 from opengever.document import _
 from opengever.document.interfaces import IDocumentSettings
@@ -65,15 +67,17 @@ class IDocumentMetadata(form.Schema):
         required=False,
         )
 
-    dexteritytextindexer.searchable('keywords')
-    form.widget(keywords=TextLinesFieldWidget)
+    form.widget(keywords=KeywordFieldWidget)
     keywords = schema.Tuple(
         title=_(u'label_keywords', default=u'Keywords'),
-        value_type=schema.TextLine(),
+        description=_(u'help_keywords', default=u''),
+        value_type=ChoicePlus(
+            vocabulary='plone.app.vocabularies.Keywords'
+        ),
         required=False,
         missing_value=(),
         default=(),
-        )
+    )
 
     foreign_reference = schema.TextLine(
         title=_(u'label_foreign_reference', default='Foreign Reference'),

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -265,6 +265,25 @@ class TestDocument(FunctionalTestCase):
 
         self.assertIsNone(document.get_parent_inbox())
 
+    @browsing
+    def test_regular_user_can_add_new_keywords_in_document(self, browser):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+
+        self.grant('Reader', 'Contributor', 'Editor')
+
+        browser.login().visit(document, view='@@edit')
+
+        keywords = browser.find_field_by_text(u'Keywords')
+        new = browser.css('#' + keywords.attrib['id'] + '_new').first
+        new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
+        browser.find_button_by_label('Save').click()
+
+        browser.visit(document, view='edit')
+        keywords = browser.find_field_by_text(u'Keywords')
+        self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
+                              tuple(keywords.value))
+
 
 class TestDocumentDefaultValues(FunctionalTestCase):
 

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -89,9 +89,10 @@ class TestDocumentIndexers(FunctionalTestCase):
             document_date=datetime.date(2011,1,1),
             receipt_date=datetime.date(2011, 2, 1))
 
-        self.assertEquals(
-            index_data_for(doc1).get('SearchableText'),
-            ['doc', 'one', 'foo', 'bar', 'hugo', 'boss', 'client1', '1', '1'])
+        self.assertItemsEqual(
+            ['doc', 'one', 'foo', 'bar', 'hugo', 'boss', 'client1', '1', '1'],
+            index_data_for(doc1).get('SearchableText')
+            )
 
     def test_full_text_indexing_with_plain_text(self):
         sample_file = NamedBlobFile('foobar barfoo', filename=u'test.txt')
@@ -116,6 +117,17 @@ class TestDocumentIndexers(FunctionalTestCase):
         fulltext_indexer = getAdapter(doc1, IDocumentIndexer)
         self.assertEquals(fulltext_indexer.__class__,
                           DefaultDocumentIndexer)
+
+    def test_keywords_field_is_indexed_in_Subject_index(self):
+        catalog = self.portal.portal_catalog
+
+        create(Builder("document")
+               .having(keywords=(u'Keyword 1', u'Keyword with \xf6')))
+
+        self.assertTrue(len(catalog(Subject=u'Keyword 1')),
+                        'Expect one item with Keyword 1')
+        self.assertTrue(len(catalog(Subject=u'Keyword with \xf6')),
+                        u'Expect one item with Keyword with \xf6')
 
 
 class TestDefaultDocumentIndexer(MockTestCase):

--- a/opengever/document/upgrades/20170321120536_enable_ftw_keywordwidget_for_document_metadata_behavior/upgrade.py
+++ b/opengever/document/upgrades/20170321120536_enable_ftw_keywordwidget_for_document_metadata_behavior/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+from opengever.document.behaviors.metadata import IDocumentMetadata
+
+
+class EnableFtwKeywordwidgetForDocumentMetadataBehavior(UpgradeStep):
+    """Enable ftw keywordwidget for document metadata behavior.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.catalog_reindex_objects(
+            {'object_provides': [IDocumentMetadata.__identifier__]},
+            idxs=['Subject', ])

--- a/opengever/mail/indexer.py
+++ b/opengever/mail/indexer.py
@@ -2,7 +2,9 @@ from collective import dexteritytextindexer
 from five import grok
 from ftw.mail.mail import IMail
 from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
+from opengever.document.behaviors.metadata import IDocumentMetadata
 from plone.indexer import indexer
+from Products.CMFDiffTool.utils import safe_utf8
 from zope.component import getAdapter, getUtility
 
 
@@ -36,5 +38,10 @@ class SearchableTextExtender(grok.Adapter):
         # sequence_number
         seqNumb = getUtility(ISequenceNumber)
         searchable.append(str(seqNumb.get_number(self.context)))
+
+        # keywords
+        keywords = IDocumentMetadata(self.context).keywords
+        if keywords:
+            searchable.extend(safe_utf8(keyword) for keyword in keywords)
 
         return ' '.join(searchable)

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -1,26 +1,56 @@
 from collective.dexteritytextindexer.interfaces import IDynamicTextIndexExtender
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.mail.mail import IMail
 from ftw.testing import MockTestCase
 from grokcore.component.testing import grok
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.mail.indexer import checked_out
+from opengever.testing import FunctionalTestCase
+from opengever.testing import index_data_for
 from zope.component import getAdapter
 from zope.component import getAdapters
 from zope.interface import Interface
 
 
-class TestMailIndexers(MockTestCase):
+class TestMailIndexers(FunctionalTestCase):
+
+    def test_keywords_field_is_indexed_in_Subject_index(self):
+        catalog = self.portal.portal_catalog
+
+        create(Builder("mail")
+               .having(keywords=(u'Keyword 1', u'Keyword with \xf6')))
+
+        self.assertTrue(len(catalog(Subject=u'Keyword 1')),
+                        'Expect one item with Keyword 1')
+        self.assertTrue(len(catalog(Subject=u'Keyword with \xf6')),
+                        u'Expect one item with Keyword with \xf6')
+
+    def test_mail_searchable_text_contains_keywords(self):
+        mail = create(
+            Builder("mail")
+            .having(keywords=(u'Pick me!', u'Keyw\xf6rd')))
+
+        self.assertItemsEqual(
+            [u'1', u'1', 'client1', 'no', 'subject', 'keyword', 'me', 'pick'],
+            index_data_for(mail).get('SearchableText'))
+
+
+class TestMailIndexersMock(MockTestCase):
 
     def setUp(self):
-        super(TestMailIndexers, self).setUp()
+        super(TestMailIndexersMock, self).setUp()
         grok('opengever.mail.indexer')
 
     def test_checked_out(self):
         self.assertEqual(checked_out(None)(), '')
 
     def test_reference_number(self):
-        mail = self.providing_stub([IMail, ])
+        mail = self.providing_stub([IMail, IDocumentMetadata])
+
+        self.expect(mail.keywords).result([])
 
         ref_adapter = self.mocker.mock()
         self.expect(ref_adapter(mail)).result(ref_adapter)

--- a/opengever/mail/tests/test_mail.py
+++ b/opengever/mail/tests/test_mail.py
@@ -1,0 +1,26 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestMail(FunctionalTestCase):
+
+    @browsing
+    def test_regular_user_can_add_new_keywords_in_mail(self, browser):
+        dossier = create(Builder('dossier'))
+        mail = create(Builder('mail').within(dossier))
+
+        self.grant('Reader', 'Contributor', 'Editor')
+
+        browser.login().visit(mail, view='@@edit')
+
+        keywords = browser.find_field_by_text(u'Keywords')
+        new = browser.css('#' + keywords.attrib['id'] + '_new').first
+        new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
+        browser.find_button_by_label('Save').click()
+
+        browser.visit(mail, view='edit')
+        keywords = browser.find_field_by_text(u'Keywords')
+        self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
+                              tuple(keywords.value))

--- a/opengever/meeting/tests/test_indexers.py
+++ b/opengever/meeting/tests/test_indexers.py
@@ -1,0 +1,37 @@
+from collective.dexteritytextindexer.interfaces import IDynamicTextIndexExtender
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.mail.mail import IMail
+from ftw.testing import MockTestCase
+from grokcore.component.testing import grok
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import ISequenceNumber
+from opengever.mail.indexer import checked_out
+from opengever.testing import FunctionalTestCase
+from opengever.testing import index_data_for
+from zope.component import getAdapter
+from zope.component import getAdapters
+from zope.interface import Interface
+
+
+class TestSablonTemplateIndexers(FunctionalTestCase):
+
+    def test_keywords_field_is_indexed_in_Subject_index(self):
+        catalog = self.portal.portal_catalog
+
+        create(Builder("sablontemplate")
+               .having(keywords=(u'Keyword 1', u'Keyword with \xf6')))
+
+        self.assertTrue(len(catalog(Subject=u'Keyword 1')),
+                        'Expect one item with Keyword 1')
+        self.assertTrue(len(catalog(Subject=u'Keyword with \xf6')),
+                        u'Expect one item with Keyword with \xf6')
+
+    def test_searchable_text_contains_keywords(self):
+        sablon_template = create(
+            Builder("sablontemplate")
+            .having(keywords=(u'Pick me!', u'Keyw\xf6rd')))
+
+        self.assertItemsEqual(
+            [u'1', u'1', 'client1', 'testdokumant', 'keyword', 'me', 'pick'],
+            index_data_for(sablon_template).get('SearchableText'))

--- a/opengever/meeting/tests/test_sablon_template.py
+++ b/opengever/meeting/tests/test_sablon_template.py
@@ -25,3 +25,19 @@ class TestSablonTemplateView(FunctionalTestCase):
 
         self.assertEqual(browser.headers['content-type'], MIME_DOCX)
         self.assertIsNotNone(browser.contents)
+
+    @browsing
+    def test_regular_user_can_add_new_keywords_in_sablon(self, browser):
+        self.grant('Reader', 'Contributor', 'Editor')
+
+        browser.login().visit(self.sablon_template, view='@@edit')
+
+        keywords = browser.find_field_by_text(u'Keywords')
+        new = browser.css('#' + keywords.attrib['id'] + '_new').first
+        new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
+        browser.find_button_by_label('Save').click()
+
+        browser.visit(self.sablon_template, view='edit')
+        keywords = browser.find_field_by_text(u'Keywords')
+        self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
+                              tuple(keywords.value))


### PR DESCRIPTION
This PR enables the keywordwidget for the IDocumentMetadata behavior.

It concerns the following portal-types:

- Document
- Mail
- SablonTemplate

![screen1](https://cloud.githubusercontent.com/assets/557005/24144672/6ab534d6-0e2e-11e7-9598-4fa61e898183.gif)

close #2600 