### PR TITLE
Task listing PDF: Use AdminUnit abbreviation instead of title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Task listing PDF: Use AdminUnit abbreviation instead of title in order to
+  avoid nasty overflows caused by long admin unit titles.
+  [lgraf]
+
 - Get rid of unnecessary column label in extract attachments view.
   [lgraf]
 

--- a/opengever/latex/tasklisting.py
+++ b/opengever/latex/tasklisting.py
@@ -61,7 +61,7 @@ class TaskListingLaTeXView(grok.MultiAdapter, MakoLaTeXView):
         return rows
 
     def get_data_for_item(self, item):
-        admin_unit = item.get_admin_unit().title
+        admin_unit = item.get_admin_unit().abbreviation
         task_type = task_type_helper(item, item.task_type)
         sequence_number = unicode(item.sequence_number).encode('utf-8')
         deadline = helper.readable_date(item, item.deadline)


### PR DESCRIPTION
Task listing PDF: Use AdminUnit abbreviation instead of title in order to avoid nasty overflows caused by long admin unit titles.

**Before:**

![tasklisting_before](https://cloud.githubusercontent.com/assets/405124/24150579/5f14c8a4-0e46-11e7-8f03-2874688eedab.png)


**After:**

![tasklisting_after](https://cloud.githubusercontent.com/assets/405124/24150586/62ad1f34-0e46-11e7-9326-5e79f2321f3d.png)
