### PR TITLE
Prefill responsible user for templatefolders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Prefill responsible user for templatefolders.
+  [elioschmutz]
+
 - Task listing PDF: Use AdminUnit abbreviation instead of title in order to
   avoid nasty overflows caused by long admin unit titles.
   [lgraf]

--- a/opengever/dossier/templatefolder/templatefolder.py
+++ b/opengever/dossier/templatefolder/templatefolder.py
@@ -1,3 +1,4 @@
+from AccessControl import getSecurityManager
 from five import grok
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
@@ -8,6 +9,18 @@ from opengever.dossier.templatefolder import ITemplateFolder
 
 class TemplateFolderAddForm(TranslatedTitleAddForm):
     grok.name('opengever.dossier.templatefolder')
+
+    def update(self):
+        """Adds a default value for `responsible` to the request so the
+        field is prefilled with the current user, or the parent dossier's
+        responsible in the case of a subdossier.
+        """
+        responsible = getSecurityManager().getUser().getId()
+
+        if not self.request.get('form.widgets.IDossier.responsible', None):
+            self.request.set('form.widgets.IDossier.responsible',
+                             [responsible])
+        super(TemplateFolderAddForm, self).update()
 
 
 class TemplateFolderEditForm(TranslatedTitleEditForm):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -482,8 +482,7 @@ class TestTemplateFolder(FunctionalTestCase):
         browser.login().open(self.portal)
         factoriesmenu.add('Template Folder')
 
-        browser.fill({'Title': 'Templates',
-                      'Responsible': TEST_USER_ID}).save()
+        browser.fill({'Title': 'Templates'}).save()
 
         self.assertTrue(ITemplateFolder.providedBy(browser.context))
 
@@ -521,8 +520,7 @@ class TestTemplateFolder(FunctionalTestCase):
         self.grant('Manager')
         browser.login().open()
         factoriesmenu.add('Template Folder')
-        browser.fill({'Responsible': TEST_USER_ID,
-                      'Title (German)': u'Vorlagen',
+        browser.fill({'Title (German)': u'Vorlagen',
                       'Title (French)': u'mod\xe8le'})
         browser.find('Save').click()
 
@@ -539,6 +537,18 @@ class TestTemplateFolder(FunctionalTestCase):
         browser.login().visit(templatefolder)
 
         self.assertEqual(0, len(browser.css('.formTab #tab-dossiertemplates')))
+
+    @browsing
+    def test_prefill_responsible_user(self, browser):
+        self.grant('Manager')
+        add_languages(['de-ch'])
+        browser.login().open(self.portal)
+        factoriesmenu.add('Template Folder')
+
+        self.assertEqual(
+            'Test User (test_user_1_)',
+            browser.css('#formfield-form-widgets-IDossier-responsible span.label').first.text
+            )
 
 
 class TestTemplateFolderMeetingEnabled(FunctionalTestCase):


### PR DESCRIPTION
This PR prefills the responsible field with the current logged in user as it is already implemented in a dossier.

closes #2770 