### PR TITLE
Switch og.ogds.models back to master

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -14,8 +14,3 @@ auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
-
-
-[branches]
-# https://github.com/4teamwork/opengever.ogds.models/pull/45
-opengever.ogds.models = jone-sql-builder-commit


### PR DESCRIPTION
Switch `opengever.ogds.models` back to master after merging 4teamwork/opengever.ogds.models#45.