### PR TITLE
Don't create initial versions for mails (or other content)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Limit creating initial versions to documents.
+  [deiferni]
+
 - Protect dispose transition with a guard, that checks if any of the dossier
   has to be archived.
   [phgross]

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -3,8 +3,6 @@ from AccessControl.SecurityManagement import getSecurityManager
 from Acquisition import aq_parent
 from five import grok
 from ftw.tabbedview.browser.tabbed import TabbedView
-from OFS.interfaces import IObjectClonedEvent
-from opengever.base import _
 from plone.app.lockingbehavior.behaviors import ILocking
 from plone.app.relationfield.event import extract_relations
 from plone.dexterity.interfaces import IDexterityContent
@@ -14,9 +12,6 @@ from Products.CMFCore.interfaces import ISiteRoot
 from Products.PluggableAuthService.interfaces.events import IUserLoggedOutEvent
 from z3c.relationfield.event import _setRelation
 from zope.annotation import IAnnotations
-from zope.component.hooks import getSite
-from zope.globalrequest import getRequest
-from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import Interface
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
@@ -50,23 +45,6 @@ ALLOWED_ENDPOINTS = set([
     'bumblebee_download',
     'health-check',
 ])
-
-
-@grok.subscribe(IDexterityContent, IObjectClonedEvent)
-def create_initial_version(obj, event):
-    """When a object was copied, create an initial version.
-    """
-    portal = getSite()
-    pr = portal.portal_repository
-    history = pr.getHistory(obj)
-
-    if history is not None and not len(history) > 0:
-        comment = translate(_(u'label_initial_version_copied',
-                            default="Initial version (document copied)"),
-                            context=getRequest())
-        # Create an initial version
-        pr._recursiveSave(obj, {}, pr._prepareSysMetadata(comment),
-            autoapply=pr.autoapply)
 
 
 @grok.subscribe(ILocking, IEditBegunEvent)

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -15,7 +15,7 @@ log.setLevel(logging.INFO)
 
 
 INTERMEDIATE_COMMIT_INTERVAL = 200
-VERSIONABLE_TYPES = ('opengever.document.document', 'ftw.mail.mail')
+VERSIONABLE_TYPES = ('opengever.document.document',)
 
 
 class PostProcessingSection(object):

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -475,6 +475,10 @@ class TestOggBundlePipeline(FunctionalTestCase):
             u'Lorem Ipsum',
             mail.title)
 
+        repo_tool = api.portal.get_tool('portal_repository')
+        history = repo_tool.getHistoryMetadata(mail)
+        self.assertEqual(0, len(history))
+
     def assert_report_data_collected(self, bundle):
         report_data = bundle.report_data
         metadata = report_data['metadata']

--- a/opengever/document/subscribers.py
+++ b/opengever/document/subscribers.py
@@ -1,10 +1,12 @@
 from five import grok
+from OFS.interfaces import IObjectClonedEvent
 from opengever.document import _
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import IDocumentSchema
 from opengever.ogds.base.utils import ogds_service
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from zope.component import getUtility
+from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
@@ -12,6 +14,23 @@ from zope.lifecycleevent.interfaces import IObjectCopiedEvent
 from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 import os.path
+
+
+@grok.subscribe(IDocumentSchema, IObjectClonedEvent)
+def create_initial_version(obj, event):
+    """When a object was copied, create an initial version.
+    """
+    portal = getSite()
+    pr = portal.portal_repository
+    history = pr.getHistory(obj)
+
+    if history is not None and not len(history) > 0:
+        comment = translate(_(u'label_initial_version_copied',
+                            default="Initial version (document copied)"),
+                            context=getRequest())
+        # Create an initial version
+        pr._recursiveSave(obj, {}, pr._prepareSysMetadata(comment),
+            autoapply=pr.autoapply)
 
 
 @grok.subscribe(IDocumentSchema, IObjectAddedEvent)

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -132,6 +132,18 @@ class TestDocument(FunctionalTestCase):
         copy = api.content.copy(source=mail, target=dossier_b)
         self.assertEquals(u'copy of Testmail', copy.title)
 
+    def test_copying_a_mail_does_not_create_versions(self):
+        self.grant('Reader', 'Contributor', 'Editor')
+        dossier_a = create(Builder('dossier').titled(u'Dossier A'))
+        dossier_b = create(Builder('dossier').titled(u'Dossier B'))
+        mail = create(Builder('mail')
+                      .within(dossier_a)
+                      .titled('Testmail'))
+
+        copy = api.content.copy(source=mail, target=dossier_b)
+        new_history = self.portal.portal_repository.getHistory(copy)
+        self.assertEquals(len(new_history), 0)
+
     def test_copying_a_document_does_not_copy_its_versions(self):
         orig_doc = create(Builder("document").having(preserved_as_paper=False))
 


### PR DESCRIPTION
Currently initial versions are created when:
- any dexterity content is copied/pasted (strangely also for e.g. dossiers that don't have the `IVersionable` behavior)
- mails are loaded from the ogg-bundle pipeline

This PR limits creating initial versions to documents only since afaik that was the way it is intended and exposed in theUI.

Open questions: what happens to data in `portal_repository`. should we attempt to cleanup version data stored there for non-dossiers.