### PR TITLE
Make sure checkout link on document tooltip is only displayed for editable documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Make sure checkout link on document tooltip is only displayed for editable
+  documents (e.g., not on documents in resolved dossiers).
+  [lgraf]
+
 - Disposition overview: Differs beetween singular/plural on the dossier(s) label.
   [phgross]
 

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -235,17 +235,7 @@ class Overview(DisplayForm, GeverTabMixin):
         return False
 
     def is_checkout_and_edit_available(self):
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-
-        if manager.get_checked_out_by():
-            if manager.get_checked_out_by() == \
-                    getSecurityManager().getUser().getId():
-                return True
-            else:
-                return False
-
-        return manager.is_checkout_allowed()
+        return self.context.is_checkout_and_edit_available()
 
     def is_download_copy_available(self):
         """Disable copy link when the document is checked

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -21,7 +21,9 @@ class TooltipView(BrowserView):
         return not self.document.is_trashed
 
     def checkout_and_edit_link_available(self):
-        return self.document.is_document
+        if not self.document.is_document:
+            return False
+        return self.document.getObject().is_checkout_and_edit_available()
 
     def checkout_and_edit_link(self):
         return addTokenToUrl('{}/editing_document'.format(self.get_url()))


### PR DESCRIPTION
Make sure checkout link on document tooltip is only displayed for editable documents (e.g., not on documents in resolved dossiers).

Done by moving the `is_checkout_and_edit_available()` method to the `Document` class.