### PR TITLE
Make sure qtip tooltips are destroyed on hide.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2017.1.0 (unreleased)
 -------------------
 
+- Make sure qtip tooltips are destroyed on hide.
+  [Rotonen]
+
 - Make sure checkout link on document tooltip is only displayed for editable
   documents (e.g., not on documents in resolved dossiers).
   [lgraf]

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -29,7 +29,8 @@
       fixed: true // Make sure the tooltip gets not hidden if mouse is over the tooltip
     },
     events: {
-      show: closeTooltips
+      show: closeTooltips,
+      hide: destroyTooltips,
     }
   };
 
@@ -51,6 +52,8 @@
   function initTooltips(event) { $(event.currentTarget).qtip(settings, event); }
 
   function closeTooltips(event, api) { $(event.originalEvent.target).on("click", function() { api.hide(); }); }
+
+  function destroyTooltips(event, api) { api.destroy(true); }
 
   $(document).on("mouseover", ".tooltip-trigger", initTooltips);
 


### PR DESCRIPTION
* Make sure qtip tooltips are removed from the DOM on hide on IE11.

Fixes #2786