### PR TITLE
Add missing icon to download copy link for mails.

### DIFF
--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -226,11 +226,13 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
             self.context.absolute_url(),
             self.context.restrictedTraverse('@@authenticator').token())
 
-        return u"<a href={}>{}</a>".format(href, translate(
-            'label_download_copy',
-            default="Download copy",
-            domain='opengever.document',
-            context=self.request))
+        return u'<a href="{}" class="{}">{}</a>'.format(
+            href,
+            'function-download-copy',
+            translate('label_download_copy',
+                      default="Download copy",
+                      domain='opengever.document',
+                      context=self.request))
 
     def get_file(self):
         if not hasattr(self, '_file'):


### PR DESCRIPTION
![screen shot 2017-03-24 at 14 36 52](https://cloud.githubusercontent.com/assets/736583/24296426/60829d00-109f-11e7-9e12-c1a1d84e5e63.png)
