### PR TITLE
Make contenttype fix more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.1.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Make conttenttype fix upgrade step more robust. [deiferni]
 
 
 2017.1.0 (2017-03-24)

--- a/opengever/document/upgrades/20170317095333_fix_contentypes_encoding_for_archival_files/upgrade.py
+++ b/opengever/document/upgrades/20170317095333_fix_contentypes_encoding_for_archival_files/upgrade.py
@@ -21,9 +21,12 @@ class FixContentypesEncodingForArchivalFiles(UpgradeStep):
             self.fix_contenttype_encoding(obj)
 
     def is_conversion_enabled(self):
-        return api.portal.get_registry_record(
-            'archival_file_conversion_enabled',
-            interface=IDossierResolveProperties)
+        try:
+            return api.portal.get_registry_record(
+                'archival_file_conversion_enabled',
+                interface=IDossierResolveProperties)
+        except KeyError:
+            return False
 
     def fix_contenttype_encoding(self, document):
         if not IDocumentMetadata(document).archival_file:


### PR DESCRIPTION
It may be run when the specified registry record is not available yet.