### PR TITLE
Isolate component registry between tests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Replaced disposition tabbedview with a simple browserview. [phgross]
+- Refactor: Use ZCML for registering reference number adapters for consistency. [jone]
 - Fix translation for the journal pdf title. [phgross]
 - Add the document title to the OC attach payloads. [Rotonen]
 - Skip comment for Document Sent entries in the dossiers journal pdf representation. [phgross]

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -5,6 +5,7 @@ from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import set_builder_session_factory
 from ftw.bumblebee.tests.helpers import BumblebeeTestTaskQueue
 from ftw.testing import ComponentRegistryLayer
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from ftw.testing.quickinstaller import snapshots
 from opengever.activity.interfaces import IActivitySettings
 from opengever.base.model import create_session
@@ -18,7 +19,6 @@ from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -97,7 +97,7 @@ ANNOTATION_LAYER = AnnotationLayer()
 
 
 class OpengeverFixture(PloneSandboxLayer):
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
 
     def __init__(self, sql_layer):
         bases = self.defaultBases + (sql_layer, )

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -21,7 +21,7 @@ class TestOGDSUpdater(FunctionalTestCase):
         ldap_plugin = FakeLDAPPlugin(FAKE_LDAP_USERFOLDER)
         self.portal.acl_users._setObject('ldap', ldap_plugin)
 
-        provideAdapter(FakeLDAPSearchUtility)
+        self.portal.getSiteManager().registerAdapter(FakeLDAPSearchUtility)
 
     def test_imports_users(self):
         FAKE_LDAP_USERFOLDER.users = [

--- a/opengever/repository/behaviors/configure.zcml
+++ b/opengever/repository/behaviors/configure.zcml
@@ -13,6 +13,12 @@
       marker=".referenceprefix.IReferenceNumberPrefixMarker"
       />
 
+  <adapter factory=".referenceprefix.ReferenceNumberPrefixValidator" />
+  <adapter
+      factory=".referenceprefix.ReferenceNumberPrefixErrorMessage"
+      name="message"
+      />
+
   <plone:behavior
       title="ResponsibleOrgUnit"
       description="OpenGever ResponsibleOrgUnit Behavior"

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -6,7 +6,6 @@ from plone.directives import form
 from z3c.form import validator, error
 from z3c.form.interfaces import IAddForm
 from zope import schema
-from zope.component import provideAdapter
 from zope.interface import alsoProvides
 from zope.interface import Interface
 from zope.interface import provider
@@ -66,16 +65,12 @@ validator.WidgetValidatorDiscriminators(
     field=IReferenceNumberPrefix['reference_number_prefix'],
     )
 
-provideAdapter(ReferenceNumberPrefixValidator)
-
-provideAdapter(error.ErrorViewMessage(
-        _('error_sibling_reference_number_existing',
-          default=u'A Sibling with the same reference number is existing'),
-        error=schema.interfaces.ConstraintNotSatisfied,
-        field=IReferenceNumberPrefix['reference_number_prefix'],
-        ),
-        name='message'
-        )
+ReferenceNumberPrefixErrorMessage = error.ErrorViewMessage(
+    _('error_sibling_reference_number_existing',
+      default=u'A Sibling with the same reference number is existing'),
+    error=schema.interfaces.ConstraintNotSatisfied,
+    field=IReferenceNumberPrefix['reference_number_prefix'],
+)
 
 
 class IReferenceNumberPrefixMarker(Interface):

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -3,10 +3,8 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefixMarker
-from opengever.repository.behaviors.referenceprefix import ReferenceNumberPrefixValidator
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
-from zope.component import provideAdapter
 from ftw.testbrowser.pages import factoriesmenu
 
 
@@ -18,9 +16,6 @@ class TestReferenceBehavior(FunctionalTestCase):
 
     def setUp(self):
         super(TestReferenceBehavior, self).setUp()
-        # Since plone tests sucks, we need to re-register
-        # the reference number validator again.
-        provideAdapter(ReferenceNumberPrefixValidator)
 
         add_languages(['de-ch'])
         self.repo = create(Builder('repository'))
@@ -53,7 +48,7 @@ class TestReferenceBehavior(FunctionalTestCase):
         browser.click_on('Save')
 
         self.assertEquals(
-            ['Constraint not satisfied'],
+            ['A Sibling with the same reference number is existing'],
             browser.css('#formfield-form-widgets-IReferenceNumberPrefix'
                         '-reference_number_prefix .error').text)
 

--- a/opengever/testing/event_recorder.py
+++ b/opengever/testing/event_recorder.py
@@ -1,0 +1,50 @@
+from persistent.list import PersistentList
+from zope.component.hooks import getSite
+
+
+EVENT_RECORD_ATTRIBUTE_NAME = '_og_testing_events_record'
+EVENT_RECORD_SERIALIZERS = {}
+_marker = object()
+
+
+def register_event_recorder(*required):
+    """Register a generic event subscriber for recording certain events.
+
+    In order to be able to use the testbrowser, the transaction must be able to
+    synchronize the threads. The easiest way to do that is to store the infos
+    in the database. We do that by just attaching them to the Plone site.
+    """
+    getSite().getSiteManager().registerHandler(
+        recording_event_subscriber, list(required))
+
+
+def get_recorded_events():
+    """Return all recorded events as tuple of the event classname (string)
+    """
+    return getattr(getSite(), EVENT_RECORD_ATTRIBUTE_NAME, ())
+
+
+def get_last_recorded_event():
+    """Returns the tuple of the last recorded event.
+    The tuple contains the string of the event class name and the serialized
+    data of the event.
+    """
+    events = get_recorded_events()
+    if events:
+        return events[-1]
+    else:
+        return None
+
+
+def recording_event_subscriber(*args):
+    site = getSite()
+    if not hasattr(site, EVENT_RECORD_ATTRIBUTE_NAME):
+        events = PersistentList()
+        setattr(site, EVENT_RECORD_ATTRIBUTE_NAME, events)
+    else:
+        events = getattr(site, EVENT_RECORD_ATTRIBUTE_NAME)
+
+    if len(args) == 1:
+        events.append(args[0])
+    else:
+        events.append(args)


### PR DESCRIPTION
Use the component registry isolation layer as base layer.
This isolates the component registries between tests.

This allows us to just register new components (adapters, utilities, event subscribers) without unregistering them in tear down.

The layer also provides a `load_zcml_string` method, which can be used
for loading a chunk of ZCML in the test:

```python
    def test(self):
        self.layer['load_zcml_string']('<configure>...</configure>')
```

Layer documentation: https://github.com/4teamwork/ftw.testing#component-registry-isolation-layer
Layer implementation: https://github.com/4teamwork/ftw.testing/blob/fd0f2c4ffe25b9680cffab81a4fa8fc0b01aabcd/ftw/testing/layer.py#L70-L92

Argumentation:
- We can awoid that tests leak components into next tests.
- It makes it easy to run postgres and sqlite in the same test process one after the other.
- It provides an easy method for loading ZCML without having to know how it works (stacked configuration contexts and stacked global component registries).