### PR TITLE
Fix policy tests

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -217,6 +217,9 @@ MEMORY_DB_LAYER = sqlite_testing.StandaloneMemoryDBLayer(
 OPENGEVER_FIXTURE_SQLITE = OpengeverFixture(
     sqlite_testing.SQLITE_MEMORY_FIXTURE)
 
+# OPENGEVER_FIXTURE is the default fixture used in policy tests.
+OPENGEVER_FIXTURE = OPENGEVER_FIXTURE_SQLITE
+
 OPENGEVER_INTEGRATION_TESTING = IntegrationTesting(
     bases=(OPENGEVER_FIXTURE_SQLITE,
            set_builder_session_factory(integration_session_factory)),


### PR DESCRIPTION
The policies base the tests on the `OPENGEVER_FIXTURE`.
Renaming it to `OPENGEVER_FIXTURE_SQLITE` caused policy tests to fail.
For new we just redefine `OPENGEVER_FIXTURE` and use the sqlite version (as there is no other yet).
We may refactor this later.