### PR TITLE
Fix max-height of tree portlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Fix scrollbar of tree view portlet. [Kevin Bieri]
 - Add state filters to user listings. [deiferni]
 - Fix UnicodeDecodeError if uploading a .msg email with an umlaut in the filename
   to a dossier. [elioschmutz]

--- a/opengever/portlets/tree/resources/init_tree.js
+++ b/opengever/portlets/tree/resources/init_tree.js
@@ -5,7 +5,7 @@ $(function() {
   }
 
   $(document).bind('tree:rendered', function() {
-    resize_treeportlet_height();
+    limit_treeportlet_height();
     scroll_to_selected_item(portlet.find('.portlet-tabs > .tab'));
   });
 
@@ -133,12 +133,11 @@ $(function() {
     return find_parent_node_for_url(tree, url.slice(0, url.lastIndexOf('/')));
   }
 
-  function resize_treeportlet_height() {
+  function limit_treeportlet_height() {
     var tabs = $('dl.portlet.portletTreePortlet .portlet-tabs > .tab');
-    var max = $(window).height() - tabs.offset().top - 20;
-    tabs.css('max-height', max);
+    var offset = $('.portletTreePortlet').offset().top + 70;
+    tabs.css('max-height', 'calc(100vh - ' + offset + 'px');
   }
-  $(window).resize(resize_treeportlet_height);
 
   function scroll_to_selected_item(tree) {
     var position = tree.find('a.current').position();

--- a/sources.cfg
+++ b/sources.cfg
@@ -5,6 +5,7 @@ extensions = mr.developer
 development-packages =
   opengever.maintenance
   collective.js.timeago
+  plonetheme.teamraum
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2722

Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/525

The height calculation using javascript on every pageresize is very
expensive and buggy. So use the native CSS `calc` function and relative `vh` unit
to limit the height of the tree portlet.