### PR TITLE
Add state filters to ogds user listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Add state filters to user listings. [deiferni]
 - Add api-link to footer viewlet. [elioschmutz]
 - Adjust title and label of dossiers journal PDF representation. [phgross]
 - Improve title and TeX template for removal protocol. [phgross]

--- a/opengever/tabbedview/browser/users.py
+++ b/opengever/tabbedview/browser/users.py
@@ -6,9 +6,10 @@ from opengever.ogds.models.user import User
 from opengever.tabbedview import _
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import SqlTableSource
+from opengever.tabbedview.filters import Filter
+from opengever.tabbedview.filters import FilterList
 from opengever.tabbedview.helper import boolean_helper
 from opengever.tabbedview.helper import email_helper
-from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -27,6 +28,13 @@ class IUsersListingTableSourceConfig(ITableSourceConfig):
     """Marker interface for table source configuration using the OGDS users
     model as source.
     """
+
+
+class ActiveOnlyFilter(Filter):
+    """Filter to only display active users."""
+
+    def update_query(self, query):
+        return query.filter_by(active=True)
 
 
 class UsersListing(BaseListingTab):
@@ -50,7 +58,12 @@ class UsersListing(BaseListingTab):
     show_selects = False
     enabled_actions = []
     major_actions = []
-    selection = ViewPageTemplateFile("no_selection_amount.pt")
+
+    filterlist_name = 'user_state_filter'
+    filterlist_available = True
+    filterlist = FilterList(
+        Filter('filter_all', _('label_tabbedview_filter_all')),
+        ActiveOnlyFilter('filter_active', _('Active'), default=True))
 
     columns = (
         {'column': 'lastname',
@@ -79,12 +92,12 @@ class UsersListing(BaseListingTab):
 
         {'column': 'department',
          'column_title': _(u'label_department_user',
-                          default=u'Department')},
+                           default=u'Department')},
 
 
         {'column': 'directorate',
          'column_title': _(u'label_directorate_user',
-                         default=u'Directorate')},
+                           default=u'Directorate')},
 
         {'column': 'active',
          'column_title': _(u'label_active',

--- a/opengever/tabbedview/browser/users.py
+++ b/opengever/tabbedview/browser/users.py
@@ -50,14 +50,10 @@ class UsersListing(BaseListingTab):
 
     sort_on = 'lastname'
     sort_order = ''
-    # lazy must be false otherwise there will be no correct batching
-    lazy = False
 
     # the model attributes is used for a dynamic textfiltering functionality
     model = User
     show_selects = False
-    enabled_actions = []
-    major_actions = []
 
     filterlist_name = 'user_state_filter'
     filterlist_available = True

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-04-03 11:54+0000\n"
+"POT-Creation-Date: 2017-04-04 10:45+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -14,7 +14,8 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:265
+#: ./opengever/tabbedview/browser/tabs.py:278
+#: ./opengever/tabbedview/browser/users.py:62
 msgid "Active"
 msgstr "Aktiv"
 
@@ -52,10 +53,6 @@ msgstr "Akteur"
 
 msgid "additional_contact"
 msgstr "Zusätzliches"
-
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
-msgid "all"
-msgstr "Alle"
 
 msgid "all_contacts"
 msgstr "Alle Kontakte"
@@ -148,7 +145,7 @@ msgid "document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:137
+#: ./opengever/tabbedview/browser/tabs.py:139
 msgid "document_sequence_number"
 msgstr "Laufnummer"
 
@@ -187,7 +184,7 @@ msgstr "Ende"
 msgid "events"
 msgstr "Termine"
 
-#: ./opengever/tabbedview/browser/tabs.py:268
+#: ./opengever/tabbedview/browser/tabs.py:281
 msgid "expired"
 msgstr "Abgelaufen"
 
@@ -202,47 +199,47 @@ msgid "journal"
 msgstr "Journal"
 
 #. Default: "Active"
-#: ./opengever/tabbedview/browser/users.py:90
+#: ./opengever/tabbedview/browser/users.py:99
 msgid "label_active"
 msgstr "Aktiv"
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:164
+#: ./opengever/tabbedview/browser/tabs.py:166
 msgid "label_checked_out"
 msgstr "In Bearbeitung"
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:160
+#: ./opengever/tabbedview/browser/tabs.py:162
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Department"
-#: ./opengever/tabbedview/browser/users.py:81
+#: ./opengever/tabbedview/browser/users.py:90
 msgid "label_department_user"
 msgstr "Amt"
 
 #. Default: "Directorate"
-#: ./opengever/tabbedview/browser/users.py:86
+#: ./opengever/tabbedview/browser/users.py:95
 msgid "label_directorate_user"
 msgstr "Direktion"
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:147
+#: ./opengever/tabbedview/browser/tabs.py:149
 msgid "label_document_author"
 msgstr "Autor"
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:152
+#: ./opengever/tabbedview/browser/tabs.py:154
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:238
+#: ./opengever/tabbedview/browser/tabs.py:251
 msgid "label_dossier_responsible"
 msgstr "Federführung"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:247
+#: ./opengever/tabbedview/browser/tabs.py:260
 msgid "label_end"
 msgstr "Ende"
 
@@ -277,17 +274,17 @@ msgid "label_preview"
 msgstr "Vorschau"
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:172
+#: ./opengever/tabbedview/browser/tabs.py:174
 msgid "label_public_trial"
 msgstr "Öffentlichkeitsstatus"
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:156
+#: ./opengever/tabbedview/browser/tabs.py:158
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:226
+#: ./opengever/tabbedview/browser/tabs.py:239
 msgid "label_reference"
 msgstr "Aktenzeichen"
 
@@ -297,7 +294,7 @@ msgid "label_responsible_task"
 msgstr "Auftragnehmer"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:234
+#: ./opengever/tabbedview/browser/tabs.py:247
 msgid "label_review_state"
 msgstr "Status"
 
@@ -307,47 +304,48 @@ msgid "label_showroom_version_title"
 msgstr "Version ${version} vom ${timestamp}"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:243
+#: ./opengever/tabbedview/browser/tabs.py:256
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:168
+#: ./opengever/tabbedview/browser/tabs.py:170
 msgid "label_subdossier"
 msgstr "Subdossier"
 
-#: ./opengever/tabbedview/browser/tabs.py:263
+#: ./opengever/tabbedview/browser/tabs.py:276
 #: ./opengever/tabbedview/browser/tasklisting.py:63
+#: ./opengever/tabbedview/browser/users.py:61
 msgid "label_tabbedview_filter_all"
 msgstr "Alle"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:142
+#: ./opengever/tabbedview/browser/tabs.py:144
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Email"
-#: ./opengever/tabbedview/browser/users.py:72
+#: ./opengever/tabbedview/browser/users.py:81
 msgid "label_userstab_email"
 msgstr "E-Mail"
 
 #. Default: "Firstname"
-#: ./opengever/tabbedview/browser/users.py:62
+#: ./opengever/tabbedview/browser/users.py:71
 msgid "label_userstab_firstname"
 msgstr "Vorname"
 
 #. Default: "Lastname"
-#: ./opengever/tabbedview/browser/users.py:57
+#: ./opengever/tabbedview/browser/users.py:66
 msgid "label_userstab_lastname"
 msgstr "Nachname"
 
 #. Default: "Office Phone"
-#: ./opengever/tabbedview/browser/users.py:77
+#: ./opengever/tabbedview/browser/users.py:86
 msgid "label_userstab_phone_office"
 msgstr "Telefon Geschäft"
 
 #. Default: "Userid"
-#: ./opengever/tabbedview/browser/users.py:67
+#: ./opengever/tabbedview/browser/users.py:76
 msgid "label_userstab_userid"
 msgstr "Benutzerid"
 
@@ -445,3 +443,4 @@ msgstr "Titel"
 
 msgid "trash"
 msgstr "Papierkorb"
+

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,23 +1,23 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-07-21 14:08+0000\n"
+"POT-Creation-Date: 2017-04-04 10:45+0000\n"
 "PO-Revision-Date: 2016-09-20 21:23+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-tabbedview/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tabbedview/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:193
+#: ./opengever/tabbedview/browser/tabs.py:278
+#: ./opengever/tabbedview/browser/users.py:62
 msgid "Active"
 msgstr "Actif"
 
@@ -40,7 +40,7 @@ msgid "Show all in this Folder"
 msgstr "Tout afficher dans ce classeur"
 
 #: ./opengever/tabbedview/browser/generic_with_filters.pt:54
-#: ./opengever/tabbedview/browser/selection_with_filters.pt:21
+#: ./opengever/tabbedview/browser/selection_with_filters.pt:19
 msgid "State"
 msgstr "Etat"
 
@@ -52,11 +52,6 @@ msgstr "Acteur"
 
 msgid "additional_contact"
 msgstr "Additionnel"
-
-#: ./opengever/tabbedview/browser/tabs.py:190
-#: ./opengever/tabbedview/browser/tasklisting.py:64
-msgid "all"
-msgstr "Tous"
 
 msgid "all_contacts"
 msgstr "Tous les contacts"
@@ -148,7 +143,7 @@ msgid "document_date"
 msgstr "Date du document"
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:109
+#: ./opengever/tabbedview/browser/tabs.py:139
 msgid "document_sequence_number"
 msgstr "Numéro courant"
 
@@ -184,7 +179,7 @@ msgstr "Fin"
 msgid "events"
 msgstr "Rendez-vous"
 
-#: ./opengever/tabbedview/browser/tabs.py:158
+#: ./opengever/tabbedview/browser/tabs.py:281
 msgid "expired"
 msgstr ""
 
@@ -198,47 +193,47 @@ msgid "journal"
 msgstr "Historique"
 
 #. Default: "Active"
-#: ./opengever/tabbedview/browser/users.py:90
+#: ./opengever/tabbedview/browser/users.py:99
 msgid "label_active"
 msgstr "Actif"
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:136
+#: ./opengever/tabbedview/browser/tabs.py:166
 msgid "label_checked_out"
 msgstr "En traitement"
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:132
+#: ./opengever/tabbedview/browser/tabs.py:162
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Department"
-#: ./opengever/tabbedview/browser/users.py:81
+#: ./opengever/tabbedview/browser/users.py:90
 msgid "label_department_user"
 msgstr "Service"
 
 #. Default: "Directorate"
-#: ./opengever/tabbedview/browser/users.py:86
+#: ./opengever/tabbedview/browser/users.py:95
 msgid "label_directorate_user"
 msgstr "Direction"
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:119
+#: ./opengever/tabbedview/browser/tabs.py:149
 msgid "label_document_author"
 msgstr "Auteur"
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:124
+#: ./opengever/tabbedview/browser/tabs.py:154
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:221
+#: ./opengever/tabbedview/browser/tabs.py:251
 msgid "label_dossier_responsible"
 msgstr "Responsable"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:230
+#: ./opengever/tabbedview/browser/tabs.py:260
 msgid "label_end"
 msgstr "Fin"
 
@@ -248,7 +243,7 @@ msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "My notifications"
-#: ./opengever/tabbedview/browser/personal_overview.py:108
+#: ./opengever/tabbedview/browser/personal_overview.py:113
 msgid "label_my_notifications"
 msgstr "Mes notifications"
 
@@ -263,27 +258,27 @@ msgid "label_no_contents"
 msgstr "Aucun contenu"
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:66
+#: ./opengever/tabbedview/browser/tasklisting.py:65
 msgid "label_pending"
 msgstr "En suspens"
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:197
+#: ./opengever/tabbedview/helper.py:181
 msgid "label_preview"
 msgstr "Aperçu"
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:144
+#: ./opengever/tabbedview/browser/tabs.py:174
 msgid "label_public_trial"
 msgstr "Statut public"
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:128
+#: ./opengever/tabbedview/browser/tabs.py:158
 msgid "label_receipt_date"
 msgstr "Date de réception"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:209
+#: ./opengever/tabbedview/browser/tabs.py:239
 msgid "label_reference"
 msgstr "Numéro de référence"
 
@@ -293,52 +288,58 @@ msgid "label_responsible_task"
 msgstr "Mandataire"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:217
+#: ./opengever/tabbedview/browser/tabs.py:247
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:187
+#: ./opengever/tabbedview/helper.py:171
 msgid "label_showroom_version_title"
 msgstr "Version ${version} de ${timestamp}"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:226
+#: ./opengever/tabbedview/browser/tabs.py:256
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:140
+#: ./opengever/tabbedview/browser/tabs.py:170
 msgid "label_subdossier"
 msgstr "Sous-dossier"
 
+#: ./opengever/tabbedview/browser/tabs.py:276
+#: ./opengever/tabbedview/browser/tasklisting.py:63
+#: ./opengever/tabbedview/browser/users.py:61
+msgid "label_tabbedview_filter_all"
+msgstr ""
+
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:114
+#: ./opengever/tabbedview/browser/tabs.py:144
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Email"
-#: ./opengever/tabbedview/browser/users.py:72
+#: ./opengever/tabbedview/browser/users.py:81
 msgid "label_userstab_email"
 msgstr "Email"
 
 #. Default: "Firstname"
-#: ./opengever/tabbedview/browser/users.py:62
+#: ./opengever/tabbedview/browser/users.py:71
 msgid "label_userstab_firstname"
 msgstr "Prénom"
 
 #. Default: "Lastname"
-#: ./opengever/tabbedview/browser/users.py:57
+#: ./opengever/tabbedview/browser/users.py:66
 msgid "label_userstab_lastname"
 msgstr "Nom"
 
 #. Default: "Office Phone"
-#: ./opengever/tabbedview/browser/users.py:77
+#: ./opengever/tabbedview/browser/users.py:86
 msgid "label_userstab_phone_office"
 msgstr "Téléphone professionnel"
 
 #. Default: "Userid"
-#: ./opengever/tabbedview/browser/users.py:67
+#: ./opengever/tabbedview/browser/users.py:76
 msgid "label_userstab_userid"
 msgstr "N° d'utilisateur"
 
@@ -362,7 +363,7 @@ msgid "participants"
 msgstr "Participants"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:89
+#: ./opengever/tabbedview/browser/personal_overview.py:94
 msgid "personal_overview_title"
 msgstr "Vue d'ensemble personnelle: ${user_name}"
 
@@ -424,3 +425,4 @@ msgstr "Titre"
 
 msgid "trash"
 msgstr "Corbeille"
+

--- a/opengever/tabbedview/locales/opengever.tabbedview-manual.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview-manual.pot
@@ -170,10 +170,6 @@ msgstr ""
 msgid "Show all in this Folder"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
-msgid "all"
-msgstr ""
-
 #. Default: "More actions &#9660;"
 #: ./opengever/tabbedview/browser/tabs_templates/generic.pt:40
 msgid "button_more_actions"

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-04-03 11:54+0000\n"
+"POT-Creation-Date: 2017-04-04 10:45+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,7 +15,8 @@ msgstr ""
 "Domain: opengever.tabbedview\n"
 "X-Poedit-Language: German\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:265
+#: ./opengever/tabbedview/browser/tabs.py:278
+#: ./opengever/tabbedview/browser/users.py:62
 msgid "Active"
 msgstr ""
 
@@ -49,10 +50,6 @@ msgid "actor"
 msgstr ""
 
 msgid "additional_contact"
-msgstr ""
-
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
-msgid "all"
 msgstr ""
 
 msgid "all_contacts"
@@ -145,7 +142,7 @@ msgid "document_date"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:137
+#: ./opengever/tabbedview/browser/tabs.py:139
 msgid "document_sequence_number"
 msgstr ""
 
@@ -181,7 +178,7 @@ msgstr ""
 msgid "events"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:268
+#: ./opengever/tabbedview/browser/tabs.py:281
 msgid "expired"
 msgstr ""
 
@@ -195,47 +192,47 @@ msgid "journal"
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/tabbedview/browser/users.py:90
+#: ./opengever/tabbedview/browser/users.py:99
 msgid "label_active"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:164
+#: ./opengever/tabbedview/browser/tabs.py:166
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:160
+#: ./opengever/tabbedview/browser/tabs.py:162
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Department"
-#: ./opengever/tabbedview/browser/users.py:81
+#: ./opengever/tabbedview/browser/users.py:90
 msgid "label_department_user"
 msgstr ""
 
 #. Default: "Directorate"
-#: ./opengever/tabbedview/browser/users.py:86
+#: ./opengever/tabbedview/browser/users.py:95
 msgid "label_directorate_user"
 msgstr ""
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:147
+#: ./opengever/tabbedview/browser/tabs.py:149
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:152
+#: ./opengever/tabbedview/browser/tabs.py:154
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:238
+#: ./opengever/tabbedview/browser/tabs.py:251
 msgid "label_dossier_responsible"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:247
+#: ./opengever/tabbedview/browser/tabs.py:260
 msgid "label_end"
 msgstr ""
 
@@ -270,17 +267,17 @@ msgid "label_preview"
 msgstr ""
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:172
+#: ./opengever/tabbedview/browser/tabs.py:174
 msgid "label_public_trial"
 msgstr ""
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:156
+#: ./opengever/tabbedview/browser/tabs.py:158
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:226
+#: ./opengever/tabbedview/browser/tabs.py:239
 msgid "label_reference"
 msgstr ""
 
@@ -290,7 +287,7 @@ msgid "label_responsible_task"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:234
+#: ./opengever/tabbedview/browser/tabs.py:247
 msgid "label_review_state"
 msgstr ""
 
@@ -300,47 +297,48 @@ msgid "label_showroom_version_title"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:243
+#: ./opengever/tabbedview/browser/tabs.py:256
 msgid "label_start"
 msgstr ""
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:168
+#: ./opengever/tabbedview/browser/tabs.py:170
 msgid "label_subdossier"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:263
+#: ./opengever/tabbedview/browser/tabs.py:276
 #: ./opengever/tabbedview/browser/tasklisting.py:63
+#: ./opengever/tabbedview/browser/users.py:61
 msgid "label_tabbedview_filter_all"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:142
+#: ./opengever/tabbedview/browser/tabs.py:144
 msgid "label_title"
 msgstr ""
 
 #. Default: "Email"
-#: ./opengever/tabbedview/browser/users.py:72
+#: ./opengever/tabbedview/browser/users.py:81
 msgid "label_userstab_email"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/tabbedview/browser/users.py:62
+#: ./opengever/tabbedview/browser/users.py:71
 msgid "label_userstab_firstname"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/tabbedview/browser/users.py:57
+#: ./opengever/tabbedview/browser/users.py:66
 msgid "label_userstab_lastname"
 msgstr ""
 
 #. Default: "Office Phone"
-#: ./opengever/tabbedview/browser/users.py:77
+#: ./opengever/tabbedview/browser/users.py:86
 msgid "label_userstab_phone_office"
 msgstr ""
 
 #. Default: "Userid"
-#: ./opengever/tabbedview/browser/users.py:67
+#: ./opengever/tabbedview/browser/users.py:76
 msgid "label_userstab_userid"
 msgstr ""
 

--- a/opengever/tabbedview/tests/test_user_listing.py
+++ b/opengever/tabbedview/tests/test_user_listing.py
@@ -1,0 +1,66 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import FunctionalTestCase
+
+
+class TestUserListing(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestUserListing, self).setUp()
+
+        self.contactfolder = create(Builder('contactfolder')
+                                    .titled(u'Kontakte'))
+
+        create(Builder('ogds_user')
+               .having(userid=u'peter.mueller',
+                       firstname=u'Peter',
+                       lastname=u'M\xfcller'))
+        create(Builder('ogds_user')
+               .having(userid=u'hugo.boss',
+                       firstname=u'Hugo',
+                       lastname=u'B\xf6ss'))
+        create(Builder('ogds_user')
+               .having(userid=u'sandra.mustermann',
+                       firstname=u'Sandra',
+                       lastname=u'Mustermann',
+                       active=False))
+
+    def _get_user_data_listing(self, browser):
+        """Return the user listing displayed in the browser without header."""
+        return browser.css('.listing').first.lists()[1:]
+
+    @browsing
+    def test_display_only_active_users_by_default(self, browser):
+        browser.login().open(
+            self.contactfolder, view='tabbedview_view-users')
+
+        self.assertEquals([
+                [u'B\xf6ss', 'Hugo', 'hugo.boss', 'test@example.org',
+                 '', '', '', 'Yes'],
+                [u'M\xfcller', 'Peter', 'peter.mueller', 'test@example.org',
+                 '', '', '', 'Yes'],
+                ['Test', 'User', 'test_user_1_', 'test@example.org',
+                 '', '', '', 'Yes'],
+            ],
+            self._get_user_data_listing(browser)
+        )
+
+    @browsing
+    def test_display_all_users_when_all_filter_enabled(self, browser):
+        browser.login().open(
+            self.contactfolder, view='tabbedview_view-users',
+            data={'user_state_filter': 'filter_all'})
+
+        self.assertEquals([
+                [u'B\xf6ss', 'Hugo', 'hugo.boss', 'test@example.org',
+                 '', '', '', 'Yes'],
+                [u'Mustermann', 'Sandra', 'sandra.mustermann',
+                 'test@example.org', '', '', '', 'No'],
+                [u'M\xfcller', 'Peter', 'peter.mueller', 'test@example.org',
+                 '', '', '', 'Yes'],
+                ['Test', 'User', 'test_user_1_', 'test@example.org',
+                 '', '', '', 'Yes'],
+            ],
+            self._get_user_data_listing(browser)
+        )


### PR DESCRIPTION
Add an `active` and `all` filter to ogds user listings. `Active` is the default filter, it displays only users that are marked as `active` in ogds.

![screen shot 2017-04-04 at 11 50 49](https://cloud.githubusercontent.com/assets/736583/24652239/65a3240e-1931-11e7-8089-eeaa8f9e8a64.png)

Closes #2807.