### PR TITLE
Fix UnicodeDecodeError if uploading a .msg email with an umlaut in the filename to a dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 ---------------------
 
 - Add state filters to user listings. [deiferni]
+- Fix UnicodeDecodeError if uploading a .msg email with an umlaut in the filename
+  to a dossier. [elioschmutz]
 - Add api-link to footer viewlet. [elioschmutz]
 - Adjust title and label of dossiers journal PDF representation. [phgross]
 - Improve title and TeX template for removal protocol. [phgross]

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -2,6 +2,7 @@ from opengever.base.transforms.msg2mime import Msg2MimeTransform
 from os.path import splitext
 from plone.dexterity.utils import createContentInContainer
 from plone.namedfile.file import NamedBlobFile
+from Products.CMFPlone.utils import safe_unicode
 
 
 class BaseObjectCreatorCommand(object):
@@ -75,6 +76,7 @@ class CreateEmailCommand(CreateDocumentCommand):
 
     def convert_to_mime(self, filename, data):
         data = self.transform.transform(data)
+        filename = safe_unicode(filename)
         base_filename, ext = splitext(filename)
         filename = u'{}.eml'.format(base_filename)
         return filename, data

--- a/opengever/base/tests/test_command.py
+++ b/opengever/base/tests/test_command.py
@@ -19,7 +19,7 @@ class TestCreateEmailCommand(FunctionalTestCase):
 
     def test_converted_msg_is_created_correctly(self):
         command = CreateEmailCommand(
-            self.dossier, 'testmail.msg', 'mock-msg-body',
+            self.dossier, 'testm\xc3\xa4il.msg', 'mock-msg-body',
             transform=MockMsg2MimeTransform())
         mail = command.execute()
 


### PR DESCRIPTION
This PR fixes an UnicodeDecodeError while uploading a .msg file with an umlaut in the filename to a dossier.

closes #2775 
