### PR TITLE
fix invalid exception catching in meeting feature.

### DIFF
--- a/opengever/meeting/__init__.py
+++ b/opengever/meeting/__init__.py
@@ -12,5 +12,5 @@ def is_meeting_feature_enabled():
         registry = getUtility(IRegistry)
         return registry.forInterface(IMeetingSettings).is_feature_enabled
 
-    except KeyError, AttributeError:
+    except (KeyError, AttributeError):
         return  False


### PR DESCRIPTION
When catching two exceptions, they must be in a tuple, otherwise the second is the variable name holding the exception of the first type.