### PR TITLE
Meeting: add a "Word implementation" feature flag.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Meeting: add a "Word implementation" feature flag. [jone]
 - Fix scrollbar of tree view portlet. [Kevin Bieri]
 - Add state filters to user listings. [deiferni]
 - Fix UnicodeDecodeError if uploading a .msg email with an umlaut in the filename

--- a/opengever/meeting/__init__.py
+++ b/opengever/meeting/__init__.py
@@ -1,4 +1,5 @@
 from opengever.meeting.interfaces import IMeetingSettings
+from plone import api
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
@@ -14,3 +15,25 @@ def is_meeting_feature_enabled():
 
     except (KeyError, AttributeError):
         return  False
+
+
+def is_word_meeting_implementation_enabled():
+    """The word implementation is a new implementation of parts of the meeting
+    feature.
+    It allows to do much more directly in Word instead of using structured
+    fields in GEVER.
+
+    This is a feature flag so that we can develop the new version in parallel
+    and switch it in production at a later point.
+    The feature flag only works when the base meeting feature is enabled.
+
+    Switching from old to new by activating this flag should only happen when
+    there are no meeting objects, since they are currently not migrated
+    automatically.
+    """
+    if not is_meeting_feature_enabled():
+        return False
+
+    return api.portal.get_registry_record('is_word_implementation_enabled',
+                                          interface=IMeetingSettings,
+                                          default=False)

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -11,6 +11,11 @@ class IMeetingSettings(Interface):
         description=u'Whether features from opengever.meeting are enabled',
         default=False)
 
+    is_word_implementation_enabled = schema.Bool(
+        title=u'Enable meeting Word implementation',
+        description=u'Whether meetings are using the Word implementation',
+        default=False)
+
 
 class IMeetingWrapper(ISQLObjectWrapper):
     """Marker interface for meeting object wrappers."""

--- a/opengever/meeting/upgrades/20170407092308_add_word_implementation_feature_flag/registry.xml
+++ b/opengever/meeting/upgrades/20170407092308_add_word_implementation_feature_flag/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+  <record name="opengever.meeting.interfaces.IMeetingSettings.is_word_implementation_enabled">
+    <field type="plone.registry.field.Bool" />
+    <value>False</value>
+  </record>
+</registry>

--- a/opengever/meeting/upgrades/20170407092308_add_word_implementation_feature_flag/upgrade.py
+++ b/opengever/meeting/upgrades/20170407092308_add_word_implementation_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddWordImplementationFeatureFlag(UpgradeStep):
+    """Add word implementation feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Part of #2829

The new feature flag "Word implementation" is used for switching the meeting implemetation to the new Word implementation.

The new word implementation allows to write protocols directly in word.
In order to develop it in parallel it needs to be feature flag.

When enabling the Word implementation feature flag no meeting objects
should exist, otherwise they migth lack a proper migration at this point.