### PR TITLE
Meeting: Tab für Antragsvorlagen in Vorlageordner

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Meeting: add proposal template tab to templates folder. [jone]
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]
 - Move the attach to email action to second position, after the copy action. [elioschmutz]
 - OGGBundle import: Make sure persistent changes that re-enable LDAP are

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -2,6 +2,7 @@ from opengever.contact import is_contact_feature_enabled
 from opengever.dossier import _
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
+from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.tabbedview import GeverTabbedView
 
 
@@ -102,6 +103,14 @@ class TemplateFolderTabbedView(GeverTabbedView):
                     }
 
     @property
+    def proposal_templates_tab(self):
+        if is_word_meeting_implementation_enabled():
+            return {'id': 'proposaltemplates',
+                    'title': _(u'label_proposal_templates',
+                               default=u'Proposal Templates'),
+                    }
+
+    @property
     def dossiertemplate_tab(self):
         if is_dossier_template_feature_enabled():
             return {'id': 'dossiertemplates',
@@ -114,6 +123,7 @@ class TemplateFolderTabbedView(GeverTabbedView):
             self.template_tab,
             self.dossiertemplate_tab,
             self.sablon_tab,
+            self.proposal_templates_tab,
             self.tasktemplate_folders_tab
         ]
 

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -42,43 +42,41 @@ class DossierTabbedView(GeverTabbedView):
     def subdossiers_tab(self):
         if self.context.show_subdossier:
             return {'id': 'subdossiers',
-                    'title': _(u'label_subdossiers', default=u'Subdossiers'),
-                    }
-
-        return None
+                    'title': _(u'label_subdossiers', default=u'Subdossiers')}
+        else:
+            return None
 
     @property
     def proposals_tab(self):
         if is_meeting_feature_enabled():
             return {'id': 'proposals',
-                    'title': _(u'label_proposals', default=u'Proposals'),
-                    }
-
-        return None
+                    'title': _(u'label_proposals', default=u'Proposals')}
+        else:
+            return None
 
     @property
     def participations_tab(self):
         if is_contact_feature_enabled():
             return {
                 'id': 'participations',
-                'title': _(u'label_participations', default=u'Participations'),
-                }
-
-        return {
-            'id': 'participants',
-            'title': _(u'label_participants', default=u'Participants'),
-            }
+                'title': _(u'label_participations', default=u'Participations')}
+        else:
+            return {
+                'id': 'participants',
+                'title': _(u'label_participants', default=u'Participants')}
 
     def _get_tabs(self):
-        return [self.overview_tab,
-                self.subdossiers_tab,
-                self.documents_tab,
-                self.tasks_tab,
-                self.proposals_tab,
-                self.participations_tab,
-                self.trash_tab,
-                self.journal_tab,
-                self.info_tab]
+        return filter(None, [
+            self.overview_tab,
+            self.subdossiers_tab,
+            self.documents_tab,
+            self.tasks_tab,
+            self.proposals_tab,
+            self.participations_tab,
+            self.trash_tab,
+            self.journal_tab,
+            self.info_tab,
+        ])
 
 
 class TemplateFolderTabbedView(GeverTabbedView):
@@ -99,40 +97,43 @@ class TemplateFolderTabbedView(GeverTabbedView):
         if is_meeting_feature_enabled():
             return {'id': 'sablontemplates',
                     'title': _(u'label_sablon_templates',
-                               default=u'Sablon Templates'),
-                    }
+                               default=u'Sablon Templates')}
+        else:
+            return None
 
     @property
     def proposal_templates_tab(self):
         if is_word_meeting_implementation_enabled():
             return {'id': 'proposaltemplates',
                     'title': _(u'label_proposal_templates',
-                               default=u'Proposal Templates'),
-                    }
+                               default=u'Proposal Templates')}
+        else:
+            return None
 
     @property
     def dossiertemplate_tab(self):
         if is_dossier_template_feature_enabled():
             return {'id': 'dossiertemplates',
                     'title': _(u'label_dossier_templates',
-                               default=u'Dossier templates'),
-                    }
+                               default=u'Dossier templates')}
+        else:
+            return None
 
     def _get_tabs(self):
-        return [
+        return filter(None, [
             self.template_tab,
             self.dossiertemplate_tab,
             self.sablon_tab,
             self.proposal_templates_tab,
-            self.tasktemplate_folders_tab
-        ]
+            self.tasktemplate_folders_tab,
+        ])
 
 
 class DossierTemplateTabbedView(DossierTabbedView):
 
     def _get_tabs(self):
-        return [
+        return filter(None, [
             self.overview_tab,
             self.subdossiers_tab,
             self.documents_tab,
-            ]
+        ])

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-04-12 05:08+0000\n"
+"POT-Creation-Date: 2017-04-26 12:38+0000\n"
 "PO-Revision-Date: 2016-07-22 15:24+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -514,7 +514,7 @@ msgstr "Erstellt von"
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:239
-#: ./opengever/dossier/templatefolder/tabs.py:111
+#: ./opengever/dossier/templatefolder/tabs.py:141
 msgid "label_description"
 msgstr "Beschreibung"
 
@@ -525,7 +525,7 @@ msgstr "Zielposition / Zieldossier"
 
 #. Default: "Documents"
 #: ./opengever/dossier/browser/overview.py:231
-#: ./opengever/dossier/browser/tabbed.py:17
+#: ./opengever/dossier/browser/tabbed.py:18
 msgid "label_documents"
 msgstr "Dokumente"
 
@@ -535,7 +535,7 @@ msgid "label_dossier_note_placeholder"
 msgstr "Kommentar erfassen"
 
 #. Default: "Dossier templates"
-#: ./opengever/dossier/browser/tabbed.py:108
+#: ./opengever/dossier/browser/tabbed.py:117
 msgid "label_dossier_templates"
 msgstr "Dossiervorlagen"
 
@@ -583,12 +583,12 @@ msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:37
+#: ./opengever/dossier/browser/tabbed.py:38
 msgid "label_info"
 msgstr "Info"
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:32
+#: ./opengever/dossier/browser/tabbed.py:33
 msgid "label_journal"
 msgstr "Journal"
 
@@ -630,12 +630,12 @@ msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:12
+#: ./opengever/dossier/browser/tabbed.py:13
 msgid "label_overview"
 msgstr "Übersicht"
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:68
+#: ./opengever/dossier/browser/tabbed.py:66
 msgid "label_participants"
 msgstr "Beteiligungen"
 
@@ -645,7 +645,7 @@ msgid "label_participation"
 msgstr "Beteiligung"
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:63
+#: ./opengever/dossier/browser/tabbed.py:62
 msgid "label_participations"
 msgstr "Beteiligungen"
 
@@ -658,6 +658,11 @@ msgstr "Telefonnummer"
 #: ./opengever/dossier/dossiertemplate/behaviors.py:44
 msgid "label_predefined_keywords"
 msgstr "Schlagworte vorausfüllen"
+
+#. Default: "Proposal Templates"
+#: ./opengever/dossier/browser/tabbed.py:108
+msgid "label_proposal_templates"
+msgstr "Antragsvorlagen"
 
 #. Default: "Proposals"
 #: ./opengever/dossier/browser/tabbed.py:53
@@ -704,7 +709,7 @@ msgid "label_roles"
 msgstr "Rollen"
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:100
+#: ./opengever/dossier/browser/tabbed.py:99
 msgid "label_sablon_templates"
 msgstr "Sablon Vorlagen"
 
@@ -736,17 +741,17 @@ msgid "label_start_byline"
 msgstr "Beginn"
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:44
+#: ./opengever/dossier/browser/tabbed.py:45
 msgid "label_subdossiers"
 msgstr "Subdossiers"
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:22
+#: ./opengever/dossier/browser/tabbed.py:23
 msgid "label_tasks"
 msgstr "Aufgaben"
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:92
+#: ./opengever/dossier/browser/tabbed.py:91
 msgid "label_tasktemplate_folders"
 msgstr "Standardabläufe"
 
@@ -769,7 +774,7 @@ msgid "label_title_help"
 msgstr "Titelhilfe"
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:27
+#: ./opengever/dossier/browser/tabbed.py:28
 msgid "label_trash"
 msgstr "Papierkorb"
 
@@ -864,7 +869,7 @@ msgid "time_expired"
 msgstr "abgelaufen"
 
 #. Default: "Journal of dossier ${title}, ${timestamp}"
-#: ./opengever/dossier/resolve.py:192
+#: ./opengever/dossier/resolve.py:190
 msgid "title_dossier_journal"
 msgstr "Dossier Journal ${title}, ${timestamp}"
 
@@ -872,3 +877,4 @@ msgstr "Dossier Journal ${title}, ${timestamp}"
 #: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
+

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-12 05:08+0000\n"
+"POT-Creation-Date: 2017-04-26 12:38+0000\n"
 "PO-Revision-Date: 2016-09-20 21:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -510,7 +510,7 @@ msgstr "Créé par"
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:239
-#: ./opengever/dossier/templatefolder/tabs.py:111
+#: ./opengever/dossier/templatefolder/tabs.py:141
 msgid "label_description"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr "Destination"
 
 #. Default: "Documents"
 #: ./opengever/dossier/browser/overview.py:231
-#: ./opengever/dossier/browser/tabbed.py:17
+#: ./opengever/dossier/browser/tabbed.py:18
 msgid "label_documents"
 msgstr "Documents"
 
@@ -531,7 +531,7 @@ msgid "label_dossier_note_placeholder"
 msgstr ""
 
 #. Default: "Dossier templates"
-#: ./opengever/dossier/browser/tabbed.py:108
+#: ./opengever/dossier/browser/tabbed.py:117
 msgid "label_dossier_templates"
 msgstr ""
 
@@ -579,12 +579,12 @@ msgid "label_former_reference_number"
 msgstr "Ancienne numéro référence"
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:37
+#: ./opengever/dossier/browser/tabbed.py:38
 msgid "label_info"
 msgstr "Info"
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:32
+#: ./opengever/dossier/browser/tabbed.py:33
 msgid "label_journal"
 msgstr "Historique"
 
@@ -626,12 +626,12 @@ msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:12
+#: ./opengever/dossier/browser/tabbed.py:13
 msgid "label_overview"
 msgstr "Sommaire"
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:68
+#: ./opengever/dossier/browser/tabbed.py:66
 msgid "label_participants"
 msgstr "Participants"
 
@@ -641,7 +641,7 @@ msgid "label_participation"
 msgstr "Participation"
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:63
+#: ./opengever/dossier/browser/tabbed.py:62
 msgid "label_participations"
 msgstr "Participation"
 
@@ -653,6 +653,11 @@ msgstr ""
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py:44
 msgid "label_predefined_keywords"
+msgstr ""
+
+#. Default: "Proposal Templates"
+#: ./opengever/dossier/browser/tabbed.py:108
+msgid "label_proposal_templates"
 msgstr ""
 
 #. Default: "Proposals"
@@ -700,7 +705,7 @@ msgid "label_roles"
 msgstr "Rôles"
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:100
+#: ./opengever/dossier/browser/tabbed.py:99
 msgid "label_sablon_templates"
 msgstr "Sablon Modèles"
 
@@ -732,17 +737,17 @@ msgid "label_start_byline"
 msgstr "De"
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:44
+#: ./opengever/dossier/browser/tabbed.py:45
 msgid "label_subdossiers"
 msgstr "Sous-dossiers"
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:22
+#: ./opengever/dossier/browser/tabbed.py:23
 msgid "label_tasks"
 msgstr "Tâches"
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:92
+#: ./opengever/dossier/browser/tabbed.py:91
 msgid "label_tasktemplate_folders"
 msgstr "Déroulements standards"
 
@@ -765,7 +770,7 @@ msgid "label_title_help"
 msgstr ""
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:27
+#: ./opengever/dossier/browser/tabbed.py:28
 msgid "label_trash"
 msgstr "Corbeille"
 
@@ -860,7 +865,7 @@ msgid "time_expired"
 msgstr "Périmé"
 
 #. Default: "Journal of dossier ${title}, ${timestamp}"
-#: ./opengever/dossier/resolve.py:192
+#: ./opengever/dossier/resolve.py:190
 msgid "title_dossier_journal"
 msgstr ""
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-12 05:08+0000\n"
+"POT-Creation-Date: 2017-04-26 12:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -511,7 +511,7 @@ msgstr ""
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:239
-#: ./opengever/dossier/templatefolder/tabs.py:111
+#: ./opengever/dossier/templatefolder/tabs.py:141
 msgid "label_description"
 msgstr ""
 
@@ -522,7 +522,7 @@ msgstr ""
 
 #. Default: "Documents"
 #: ./opengever/dossier/browser/overview.py:231
-#: ./opengever/dossier/browser/tabbed.py:17
+#: ./opengever/dossier/browser/tabbed.py:18
 msgid "label_documents"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgid "label_dossier_note_placeholder"
 msgstr ""
 
 #. Default: "Dossier templates"
-#: ./opengever/dossier/browser/tabbed.py:108
+#: ./opengever/dossier/browser/tabbed.py:117
 msgid "label_dossier_templates"
 msgstr ""
 
@@ -580,12 +580,12 @@ msgid "label_former_reference_number"
 msgstr ""
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:37
+#: ./opengever/dossier/browser/tabbed.py:38
 msgid "label_info"
 msgstr ""
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:32
+#: ./opengever/dossier/browser/tabbed.py:33
 msgid "label_journal"
 msgstr ""
 
@@ -627,12 +627,12 @@ msgid "label_number_of_containers"
 msgstr ""
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:12
+#: ./opengever/dossier/browser/tabbed.py:13
 msgid "label_overview"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:68
+#: ./opengever/dossier/browser/tabbed.py:66
 msgid "label_participants"
 msgstr ""
 
@@ -642,7 +642,7 @@ msgid "label_participation"
 msgstr ""
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:63
+#: ./opengever/dossier/browser/tabbed.py:62
 msgid "label_participations"
 msgstr ""
 
@@ -654,6 +654,11 @@ msgstr ""
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py:44
 msgid "label_predefined_keywords"
+msgstr ""
+
+#. Default: "Proposal Templates"
+#: ./opengever/dossier/browser/tabbed.py:108
+msgid "label_proposal_templates"
 msgstr ""
 
 #. Default: "Proposals"
@@ -701,7 +706,7 @@ msgid "label_roles"
 msgstr ""
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:100
+#: ./opengever/dossier/browser/tabbed.py:99
 msgid "label_sablon_templates"
 msgstr ""
 
@@ -733,17 +738,17 @@ msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:44
+#: ./opengever/dossier/browser/tabbed.py:45
 msgid "label_subdossiers"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:22
+#: ./opengever/dossier/browser/tabbed.py:23
 msgid "label_tasks"
 msgstr ""
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:92
+#: ./opengever/dossier/browser/tabbed.py:91
 msgid "label_tasktemplate_folders"
 msgstr ""
 
@@ -766,7 +771,7 @@ msgid "label_title_help"
 msgstr ""
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:27
+#: ./opengever/dossier/browser/tabbed.py:28
 msgid "label_trash"
 msgstr ""
 
@@ -861,7 +866,7 @@ msgid "time_expired"
 msgstr ""
 
 #. Default: "Journal of dossier ${title}, ${timestamp}"
-#: ./opengever/dossier/resolve.py:192
+#: ./opengever/dossier/resolve.py:190
 msgid "title_dossier_journal"
 msgstr ""
 

--- a/opengever/dossier/templatefolder/tabs.py
+++ b/opengever/dossier/templatefolder/tabs.py
@@ -79,6 +79,36 @@ class TemplateFolderSablonTemplates(Documents):
     ]
 
 
+class TemplateFolderProposalTemplates(Documents):
+    grok.context(ITemplateFolder)
+    grok.name('tabbedview_view-proposaltemplates')
+
+    types = ['opengever.meeting.proposaltemplate']
+
+    depth = 1
+
+    @property
+    def columns(self):
+        return drop_columns(
+            super(TemplateFolderProposalTemplates, self).columns)
+
+    @property
+    def enabled_actions(self):
+        return filter(
+            lambda x: x not in self.disabled_actions,
+            super(TemplateFolderProposalTemplates, self).enabled_actions)
+
+    disabled_actions = [
+        'cancel',
+        'checkin',
+        'checkout',
+        'create_task',
+        'move_items',
+        'send_as_email',
+        'submit_additional_documents',
+    ]
+
+
 class TemplateFolderTrash(Trash):
     grok.context(ITemplateFolder)
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-20 12:15+0000\n"
+"POT-Creation-Date: 2017-04-20 12:19+0000\n"
 "PO-Revision-Date: 2015-04-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-20 12:15+0000\n"
+"POT-Creation-Date: 2017-04-20 12:19+0000\n"
 "PO-Revision-Date: 2016-08-10 05:19+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-20 12:15+0000\n"
+"POT-Creation-Date: 2017-04-20 12:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -455,3 +455,10 @@ class DispositionBuilder(DexterityBuilder):
 
 
 builder_registry.register('disposition', DispositionBuilder)
+
+
+class ProposalTemplateBuilder(DocumentBuilder):
+
+    portal_type = 'opengever.meeting.proposaltemplate'
+
+builder_registry.register('proposaltemplate', ProposalTemplateBuilder)


### PR DESCRIPTION
Im Vorlageordner wird ein neues Tab "Antragsvorlagen" hinzugefügt, welches die Antragsvorlagen (#2834) in diesem Vorlageordner anzeigen.
Das Tab verhält sich genau gleich wie das Tab für Sablon-Vorlagen: gewisse Spalten und Aktionen des normalen Dokumente-Tabs stehen werden entfernt.

Dies ist Teil des Auftrags #2829.

![bildschirmfoto 2017-04-07 um 13 58 17](https://cloud.githubusercontent.com/assets/7469/24799611/709e2b16-1b9c-11e7-99c1-403c5464b2af.png)
