### PR TITLE
Convert existing keywords to utf-8 first before upgrading.

### DIFF
--- a/opengever/document/upgrades/20170321120536_enable_ftw_keywordwidget_for_document_metadata_behavior/upgrade.py
+++ b/opengever/document/upgrades/20170321120536_enable_ftw_keywordwidget_for_document_metadata_behavior/upgrade.py
@@ -1,13 +1,22 @@
 from ftw.upgrade import UpgradeStep
 from opengever.document.behaviors.metadata import IDocumentMetadata
+from Products.CMFPlone.utils import safe_unicode
 
 
 class EnableFtwKeywordwidgetForDocumentMetadataBehavior(UpgradeStep):
     """Enable ftw keywordwidget for document metadata behavior.
     """
 
+    query = {'object_provides': [IDocumentMetadata.__identifier__]}
+
     def __call__(self):
         self.install_upgrade_profile()
-        self.catalog_reindex_objects(
-            {'object_provides': [IDocumentMetadata.__identifier__]},
-            idxs=['Subject', ])
+        self.ensure_utf_8_keywords()
+        self.catalog_reindex_objects(self.query, idxs=['Subject', ])
+
+    def ensure_utf_8_keywords(self):
+        for obj in self.objects(self.query, 'Ensure keywords are utf-8'):
+            doc = IDocumentMetadata(obj)
+            doc.keywords = tuple(
+                safe_unicode(keyword).encode('utf-8')
+                for keyword in doc.keywords)


### PR DESCRIPTION
This PR ensures that keywords are enocded as `utf-8` before being reindexed.

At the Moment `ftw.keywordwidget` stores the keywords as `utf-8`, this seems to be required by `plone.app.vocabularies.Keywords`. Previous document keywords are stored as `unicode`, however. They keywords-vocabulary is global and shared by documents and dossiers. Thus when executing this upgrade step there will be issues with already stored dossier keywords when reindexing as you cannot mix `utf-8` and `unicode` in a `KeywordIndex`.

