### PR TITLE
Skip comment for Document Sent entries in the dossiers journal pdf representation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add the document title to the OC attach payloads. [Rotonen]
+- Skip comment for Document Sent entries in the dossiers journal pdf representation. [phgross]
 - Make (all) PDF views customizable by having them dynamically provide their
   request layers instead of hardcoding them. [lgraf]
 - Meeting: add a "Word implementation" feature flag. [jone]

--- a/opengever/latex/dossierjournal.py
+++ b/opengever/latex/dossierjournal.py
@@ -57,7 +57,7 @@ class DossierListingLaTeXView(grok.MultiAdapter, MakoLaTeXView):
     def get_render_arguments(self):
         self.layout.show_organisation = True
 
-        dossier_listing = getMultiAdapter((self.context, self.request, self),
+        journal_listing = getMultiAdapter((self.context, self.request, self),
                                           ILaTexListing, name='journal')
 
         return {
@@ -67,7 +67,7 @@ class DossierListingLaTeXView(grok.MultiAdapter, MakoLaTeXView):
                   mapping={'title': self.context.title,
                            'reference_number': self.context.get_reference_number()}),
                 context=self.request),
-            'listing': dossier_listing.get_listing(self.get_journal_data())}
+            'listing': journal_listing.get_listing(self.get_journal_data())}
 
     def get_journal_data(self):
         if IAnnotationsJournalizable.providedBy(self.context):

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -299,12 +299,12 @@ class JournalLaTeXListing(LaTexListing):
             Column('time',
                    journal_mf('label_time', default=u'Time'),
                    '10%',
-                   lambda brain: helper.readable_date_time(brain, brain.get('time'))),
+                   lambda item: helper.readable_date_time(item, item.get('time'))),
 
             Column('title',
                    journal_mf('label_title', default=u'Title'),
                    '45%',
-                   lambda brain: title_helper(brain, brain['action'].get('title'))),
+                   lambda item: title_helper(item, item['action'].get('title'))),
 
             Column('actor',
                    journal_mf('label_actor', default=u'Changed by'),

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from five import grok
 from ftw.table import helper
 from opengever.journal import _ as journal_mf
+from opengever.journal.handlers import DOCUMENT_SENT
 from opengever.journal.tab import title_helper
 from opengever.latex import _
 from opengever.latex.utils import get_issuer_of_task
@@ -275,7 +276,6 @@ class TasksLaTeXListing(DossiersLaTeXListing):
         ]
 
 
-
 class JournalLaTeXListing(LaTexListing):
     grok.provides(ILaTexListing)
     grok.adapts(Interface, Interface, Interface)
@@ -285,6 +285,14 @@ class JournalLaTeXListing(LaTexListing):
 
     def get_actor_label(self, item):
         return Actor.lookup(item.get('actor')).get_label()
+
+    def get_journal_comment(self, item):
+        """Skip comment for document sent entries.
+        """
+        if item.get('action', {}).get('type') == DOCUMENT_SENT:
+            return
+
+        return item.get('comments')
 
     def get_columns(self):
         return [
@@ -306,5 +314,5 @@ class JournalLaTeXListing(LaTexListing):
             Column('comments',
                    journal_mf('label_comments', default='Comments'),
                    '30%',
-                   lambda brain: brain.get('comments'))
+                   self.get_journal_comment)
         ]

--- a/opengever/latex/tests/test_dossierjournal.py
+++ b/opengever/latex/tests/test_dossierjournal.py
@@ -46,7 +46,7 @@ class TestDossierJournalPDFView(MockTestCase):
             dossierjournal.IDossierJournalLayer.providedBy(request))
 
 
-class TestDossierListingLaTeXView(FunctionalTestCase):
+class TestJournalListingLaTeXView(FunctionalTestCase):
 
     @browsing
     def test_journal_label(self, browser):

--- a/opengever/latex/tests/test_listing.py
+++ b/opengever/latex/tests/test_listing.py
@@ -308,6 +308,19 @@ class TestJournalListings(BaseLatexListingTest):
          'comments': '',
          'actor': 'peter.mueller',
          'time': DateTime(2016, 4, 25, 10, 0)},
+        {'action': {'visible': False,
+                    'type': 'Dossier modified',
+                    'title': u'label_dossier_modified'},
+         'comments': 'Lorem ipsum',
+         'actor': 'peter.mueller',
+         'time': DateTime(2016, 4, 25, 10, 0)},
+
+        {'action': {'visible': True,
+                    'type': 'Document Sent',
+                    'title': u'label_document_sent'},
+         'actor': 'test_user_1_',
+         'comments': 'Attachments: sample ...',
+         'time': DateTime('2016/04/12 11:35:00 GMT+2')}
     ]
 
     def setUp(self):
@@ -351,3 +364,21 @@ class TestJournalListings(BaseLatexListingTest):
                           rows[0].xpath(CSSSelector('td').path)[0].text)
         self.assertEquals('12.04.2016 12:10',
                           rows[1].xpath(CSSSelector('td').path)[0].text)
+
+    def test_comment_is_included(self):
+        table = lxml.html.fromstring(self.listing.template())
+        rows = table.xpath(CSSSelector('tbody tr').path)
+
+        self.assertEquals('Lorem ipsum',
+                          rows[3].xpath(CSSSelector('td').path)[3].text)
+
+    def test_document_sent_comments_are_skipped(self):
+        table = lxml.html.fromstring(self.listing.template())
+        rows = table.xpath(CSSSelector('tbody tr').path)
+
+        document_sent_row = rows[4]
+        self.assertEquals(
+            'label_document_sent',
+            document_sent_row.xpath(CSSSelector('td').path)[1].text)
+        self.assertIsNone(
+            document_sent_row.xpath(CSSSelector('td').path)[3].text)


### PR DESCRIPTION
The comment of an `Document Sent` entry contains the attachment links in HTML and the complete mail text which makes no sense to include in the pdf journal listing.
 
Fixes #2839

Sentry: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/2871