### PR TITLE
Make (all) PDF views customizable by having them dynamically provide request layers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Make (all) PDF views customizable by having them dynamically provide their
+  request layers instead of hardcoding them. [lgraf]
 - Meeting: add a "Word implementation" feature flag. [jone]
 - Fix scrollbar of tree view portlet. [Kevin Bieri]
 - Add state filters to user listings. [deiferni]

--- a/opengever/latex/dossiercover.py
+++ b/opengever/latex/dossiercover.py
@@ -25,8 +25,10 @@ class DossierCoverPDFView(grok.View, ExportPDFView):
     grok.context(IDossierMarker)
     grok.require('zope2.View')
 
+    request_layer = IDossierCoverLayer
+
     def render(self):
-        provide_request_layer(self.request, IDossierCoverLayer)
+        provide_request_layer(self.request, self.request_layer)
 
         return ExportPDFView.__call__(self)
 

--- a/opengever/latex/opentaskreport.py
+++ b/opengever/latex/opentaskreport.py
@@ -40,11 +40,13 @@ class OpenTaskReportPDFView(grok.View, ExportPDFView):
     grok.context(Interface)
     grok.require('zope2.View')
 
+    request_layer = IOpenTaskReportLayer
+
     def render(self):
         if not is_open_task_report_allowed():
             raise Unauthorized()
 
-        provide_request_layer(self.request, IOpenTaskReportLayer)
+        provide_request_layer(self.request, self.request_layer)
         return ExportPDFView.__call__(self)
 
 

--- a/opengever/latex/tasklisting.py
+++ b/opengever/latex/tasklisting.py
@@ -29,9 +29,11 @@ class TaskListingPDFView(grok.View, ExportPDFView):
 
     index = ViewPageTemplateFile('templates/export_pdf.pt')
 
+    request_layer = ITaskListingLayer
+
     def render(self):
         # let the request provide ITaskListingLayer
-        provide_request_layer(self.request, ITaskListingLayer)
+        provide_request_layer(self.request, self.request_layer)
 
         return ExportPDFView.__call__(self)
 


### PR DESCRIPTION
Make (all) PDF views customizable by having them dynamically provide their request layers instead of hardcoding them. That way, `self.request_layer` can be overridden in subclasses and the customized view can provide a more specific request layer interface.