### PR TITLE
Replaced disposition tabbedview with a simple browserview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Replaced disposition tabbedview with a simple browserview. [phgross]
 - Fix translation for the journal pdf title. [phgross]
 - Add the document title to the OC attach payloads. [Rotonen]
 - Skip comment for Document Sent entries in the dossiers journal pdf representation. [phgross]

--- a/opengever/disposition/browser/configure.zcml
+++ b/opengever/disposition/browser/configure.zcml
@@ -34,7 +34,7 @@
   <browser:page
       class=".overview.DispositionOverview"
       for="opengever.disposition.interfaces.IDisposition"
-      name="tabbedview_view-overview"
+      name="overview"
       permission="zope2.View"
       template="templates/overview.pt"
       />

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -2,7 +2,6 @@ from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition import _
 from opengever.disposition.interfaces import IHistoryStorage
-from opengever.tabbedview import GeverTabMixin
 from plone import api
 from plone.protect.utils import addTokenToUrl
 from Products.CMFPlone.CatalogTool import num_sort_regex
@@ -16,10 +15,7 @@ def sort_on_sortable_title(item):
     return num_sort_regex.sub(zero_fill, item[0].Title())
 
 
-class DispositionOverview(BrowserView, GeverTabMixin):
-
-    show_searchform = False
-
+class DispositionOverview(BrowserView):
 
     def __call__(self):
         self.init_dossiers()

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -1,227 +1,253 @@
-<div id="disposition_overview" i18n:domain="opengever.disposition"
-     tal:attributes="data-appraisal_update_url view/get_update_appraisal_url">
+<metal:page define-macro="master">
+  <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+        xmlns:tal="http://xml.zope.org/namespaces/tal"
+        xmlns:metal="http://xml.zope.org/namespaces/metal"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        lang="en"
+        metal:use-macro="context/main_template/macros/master"
+        i18n:domain="ftw.tabbedview">
 
-  <div>
-    <!-- <h3><span i18n:domain="plone" i18n:translate="State">State</span>:</h3> -->
-    <div class="workflow_wizard">
-      <ul class="wizard_steps" tal:define="current_state view/get_current_state" >
-        <li tal:repeat="state view/get_states"
-            tal:content="state"
-            tal:attributes="class python: 'selected' if state == current_state else ''"
-            i18n:domain="plone" i18n:translate="">
-        </li>
-      </ul>
-    </div>
-  </div>
+    <body>
+      <div metal:fill-slot="main">
+        <metal:main-macro define-macro="main">
+          <div id="disposition_overview" i18n:domain="opengever.disposition"
+               tal:attributes="data-appraisal_update_url view/get_update_appraisal_url">
 
-  <ul class="list-group" tal:repeat="dossier_list view/get_dossier_lists">
-    <tal:define tal:define="label python: dossier_list[0];
-                            mappings python: dossier_list[1]"
-                tal:condition="mappings">
+            <!-- necessary for correct display of the watermark-icon -->
+            <div id="tabbedview-header">
+              <div tal:replace="structure provider:plone.abovecontenttitle" />
 
-      <li class="list-group-item label">
-        <div class="list-group-cell data-cell">
-          <h3 tal:content="label" i18n:translate="" />
-        </div>
-        <div class="list-group-cell action-cell">
-          <h3 i18n:translate="label_archive">Archive</h3>
-        </div>
-      </li>
-
-      <li tal:repeat="item mappings"
-          class="repository-list-item collapsible">
-
-        <tal:define tal:define="repository python: item[0]; dossiers python: item[1];">
-
-          <div class="repository_cell">
-            <div class="repository_title" tal:condition="not: context/is_closed">
-              <h3 tal:content="repository/Title" />
-              <div class="meta" i18n:domain="opengever.base" >
-                <span i18n:translate="label_archival_value">Archival value</span>:
-                <span tal:content="repository/get_archival_value" i18n:translate=""/>
-              </div>
-              <div class="collapsible-header dossier-header">
-                <span tal:define="number_of_dossiers python: len(dossiers)">
-                  <span tal:content="number_of_dossiers" />
-                  <span tal:condition="python: number_of_dossiers > 1" i18n:translate="label_dossiers">Dossiers</span>
-                  <span tal:condition="python: number_of_dossiers == 1" i18n:translate="label_dossier">Dossier</span>
-                </span>
-              </div>
-            </div>
-            <div class="repository_title" tal:condition="context/is_closed">
-              <h3 tal:condition="context/is_closed" tal:content="repository" />
-              <div class="collapsible-header dossier-header">
-                <span tal:define="number_of_dossiers python: len(dossiers)">
-                  <span tal:content="number_of_dossiers" />
-                  <span tal:condition="python: number_of_dossiers > 1" i18n:translate="label_dossiers">Dossiers</span>
-                  <span tal:condition="python: number_of_dossiers == 1" i18n:translate="label_dossier">Dossier</span>
-                </span>
-              </div>
+              <metal:title define-slot="title">
+                <h1 class="documentFirstHeading" tal:content="context/Title" />
+              </metal:title>
+              <div tal:replace="structure provider:plone.belowcontenttitle" />
             </div>
 
-            <div class="repo-appraisal-button-group action-cell"
-                 tal:condition="view/appraisal_buttons_available"
-                 tal:attributes="data-intids python:[dossier.intid for dossier in dossiers]">
-              <a href="#" title="Archive all" class="icon_button archive_all"
-                 data-archive="true" i18n:attributes="title label_archive_all" />
-
-              <a href="#" title="Do not archive all" class="icon_button not_archive_all"
-                 data-archive="false" i18n:attributes="title label_dont_archive_all" />
-            </div>
-          </div>
-
-          <ul class="dossiers">
-            <li tal:repeat="dossier dossiers" class="dispositions list-group-item">
-
-              <div class="list-group-cell data-cell">
-
-                <h3 class="title">
-                  <span class="reference_number" tal:content="dossier/reference_number"/>
-
-                  <a href="#" tal:condition="dossier/url"
-                     tal:attributes="href dossier/url" tal:content="dossier/title" />
-
-                  <span tal:condition="not: dossier/url" tal:content="dossier/title" />
-                </h3>
-
-                <div class="meta" tal:condition="dossier/additional_metadata_available">
-                  <span class="meta-value date_period">
-                    <span i18n:translate="period">Period</span>:
-                    <span tal:content="python: view.get_localized_time(dossier.start)"/>
-                    -
-                    <span tal:content="python: view.get_localized_time(dossier.end)"/>
-                  </span>
-                  <span class="meta-value public_trial">
-                    <span i18n:domain="opengever.base" i18n:translate="label_public_trial">Public Trial</span>:
-                    <span i18n:domain="opengever.base" i18n:translate="" tal:content="dossier/public_trial"/>
-                  </span>
-                  <span class="meta-value archival_value">
-                    <span i18n:domain="opengever.base" i18n:translate="label_archival_value">Archival value</span>:
-                    <span i18n:domain="opengever.base" i18n:translate=""
-                          tal:content="dossier/archival_value"/>
-
-                    <span tal:condition="dossier/archival_value_annotation">
-                      (
-                      <span i18n:domain="opengever.base"
-                            tal:content="dossier/archival_value_annotation"/>
-                      )
-                    </span>
-                  </span>
-                </div>
-
-              </div>
-
-              <div class="list-group-cell action-cell">
-                <div class="button-group appraisal-button-group"
-                     tal:condition="view/appraisal_buttons_available">
-
-                  <a href="#"
-                     class="button"
-                     title="Archive"
-                     i18n:attributes="title label_archive"
-                     tal:attributes="class python: 'icon_button archive active' if dossier.appraisal else 'icon_button archive';
-                                     data-intid dossier/intid;
-                                     data-archive string:true">
-                  </a>
-                  <a href="#"
-                     title="Don't archive"
-                     i18n:attributes="title label_dont_archive"
-                     tal:attributes="class python: 'not_archive icon_button active' if dossier.appraisal==False else 'not_archive icon_button';
-                                     data-intid dossier/intid;
-                                     data-archive string:false">
-                  </a>
-
-                </div>
-
-                <div class="button-group appraisal-button-group"
-                     tal:condition="not: view/appraisal_buttons_available">
-
-                  <span tal:condition="dossier/appraisal"
-                        class="icon_button archive active"
-                        title="Archive"
-                        i18n:attributes="title label_archive" />
-                  <span
-                      tal:condition="not: dossier/appraisal"
-                      class="icon_button not_archive active"
-                      title="Don't archive"
-                      i18n:attributes="title label_dont_archive" />
-
-                </div>
-
-              </li>
-            </ul>
-          </tal:define>
-        </li>
-      </tal:define>
-  </ul>
-
-  <div class="actionButtons clearfix">
-    <ul class="transitions">
-      <li tal:repeat="transition view/get_transitions" >
-        <a tal:condition="transition/url"
-           tal:attributes="href transition/url;
-                           title transition/title;
-                           id transition/id | nothing;
-                           class string: ${transition/id} "
-           i18n:domain="plone"
-           i18n:attributes="title">
-          <span tal:content="transition/title" class="transition actionText"
-                i18n:translate="" i18n:domain="plone">
-          </span>
-        </a>
-      </li>
-    </ul>
-    <ul class="actions">
-      <tal:repeat tal:repeat="action view/get_actions">
-        <li tal:condition="action/visible">
-          <a tal:attributes="href action/url;
-                             title action/label;
-                             class python: action.get('class');
-                             id action/id | nothing;"
-             i18n:attributes="title">
-            <span tal:content="action/label" class="actionText"
-                  i18n:translate="" i18n:domain="plone">
-            </span>
-          </a>
-        </li>
-      </tal:repeat>
-    </ul>
-  </div>
-
-  <div class="progress">
-    <h3 i18n:translate="progress">Progress</h3>
-
-    <div class="answers">
-      <tal:repeat tal:repeat="entry view/get_history">
-        <div class="answer" tal:attributes="class string:answer ${entry/css_class}">
-          <div class="answerType">&nbsp;</div>
-          <div class="answerBody">
-            <div class="date" tal:content="entry/date" />
-            <h3 tal:content="structure entry/msg" i18n:translate="">
-              History Transition
-            </h3>
-            <div class="details collapsible">
-              <div class="collapsible-header">
-                <span i18n:translate="label_details">Details:</span>
-              </div>
-              <div class="collapsible-content">
-                <ul>
-                  <li tal:repeat="detail entry/details">
-                    <span class="reference_number" tal:content="detail/reference_number" />
-                    <span class="title" tal:content="detail/title" />
-                    <span class="appraisal" tal:condition="detail/appraisal"
-                          i18n:translate="label_archive">Archive</span>
-                    <span class="appraisal" tal:condition="not: detail/appraisal"
-                          i18n:translate="label_dont_archive">Don't archive</span>
+            <div>
+              <div class="workflow_wizard">
+                <ul class="wizard_steps" tal:define="current_state view/get_current_state" >
+                  <li tal:repeat="state view/get_states"
+                      tal:content="state"
+                      tal:attributes="class python: 'selected' if state == current_state else ''"
+                      i18n:domain="plone" i18n:translate="">
                   </li>
                 </ul>
               </div>
             </div>
-          </div>
-        </div>
-        <div style="clear:both"><!-- --></div>
-      </tal:repeat>
-    </div>
-  </div>
 
-</div>
+            <ul class="list-group" tal:repeat="dossier_list view/get_dossier_lists">
+              <tal:define tal:define="label python: dossier_list[0];
+                                      mappings python: dossier_list[1]"
+                          tal:condition="mappings">
+
+                <li class="list-group-item label">
+                  <div class="list-group-cell data-cell">
+                    <h3 tal:content="label" i18n:translate="" />
+                  </div>
+                  <div class="list-group-cell action-cell">
+                    <h3 i18n:translate="label_archive">Archive</h3>
+                  </div>
+                </li>
+
+                <li tal:repeat="item mappings"
+                    class="repository-list-item collapsible">
+
+                  <tal:define tal:define="repository python: item[0]; dossiers python: item[1];">
+
+                    <div class="repository_cell">
+                      <div class="repository_title" tal:condition="not: context/is_closed">
+                        <h3 tal:content="repository/Title" />
+                        <div class="meta" i18n:domain="opengever.base" >
+                          <span i18n:translate="label_archival_value">Archival value</span>:
+                          <span tal:content="repository/get_archival_value" i18n:translate=""/>
+                        </div>
+                        <div class="collapsible-header dossier-header">
+                          <span tal:define="number_of_dossiers python: len(dossiers)">
+                            <span tal:content="number_of_dossiers" />
+                            <span tal:condition="python: number_of_dossiers > 1" i18n:translate="label_dossiers">Dossiers</span>
+                            <span tal:condition="python: number_of_dossiers == 1" i18n:translate="label_dossier">Dossier</span>
+                          </span>
+                        </div>
+                      </div>
+                      <div class="repository_title" tal:condition="context/is_closed">
+                        <h3 tal:condition="context/is_closed" tal:content="repository" />
+                        <div class="collapsible-header dossier-header">
+                          <span tal:define="number_of_dossiers python: len(dossiers)">
+                            <span tal:content="number_of_dossiers" />
+                            <span tal:condition="python: number_of_dossiers > 1" i18n:translate="label_dossiers">Dossiers</span>
+                            <span tal:condition="python: number_of_dossiers == 1" i18n:translate="label_dossier">Dossier</span>
+                          </span>
+                        </div>
+                      </div>
+
+                      <div class="repo-appraisal-button-group action-cell"
+                           tal:condition="view/appraisal_buttons_available"
+                           tal:attributes="data-intids python:[dossier.intid for dossier in dossiers]">
+                        <a href="#" title="Archive all" class="icon_button archive_all"
+                           data-archive="true" i18n:attributes="title label_archive_all" />
+
+                        <a href="#" title="Do not archive all" class="icon_button not_archive_all"
+                           data-archive="false" i18n:attributes="title label_dont_archive_all" />
+                      </div>
+                    </div>
+
+                    <ul class="dossiers">
+                      <li tal:repeat="dossier dossiers" class="dispositions list-group-item">
+
+                        <div class="list-group-cell data-cell">
+
+                          <h3 class="title">
+                            <span class="reference_number" tal:content="dossier/reference_number"/>
+
+                            <a href="#" tal:condition="dossier/url"
+                               tal:attributes="href dossier/url" tal:content="dossier/title" />
+
+                            <span tal:condition="not: dossier/url" tal:content="dossier/title" />
+                          </h3>
+
+                          <div class="meta" tal:condition="dossier/additional_metadata_available">
+                            <span class="meta-value date_period">
+                              <span i18n:translate="period">Period</span>:
+                              <span tal:content="python: view.get_localized_time(dossier.start)"/>
+                              -
+                              <span tal:content="python: view.get_localized_time(dossier.end)"/>
+                            </span>
+                            <span class="meta-value public_trial">
+                              <span i18n:domain="opengever.base" i18n:translate="label_public_trial">Public Trial</span>:
+                              <span i18n:domain="opengever.base" i18n:translate="" tal:content="dossier/public_trial"/>
+                            </span>
+                            <span class="meta-value archival_value">
+                              <span i18n:domain="opengever.base" i18n:translate="label_archival_value">Archival value</span>:
+                              <span i18n:domain="opengever.base" i18n:translate=""
+                                    tal:content="dossier/archival_value"/>
+
+                              <span tal:condition="dossier/archival_value_annotation">
+                                (
+                                <span i18n:domain="opengever.base"
+                                      tal:content="dossier/archival_value_annotation"/>
+                                )
+                              </span>
+                            </span>
+                          </div>
+
+                        </div>
+
+                        <div class="list-group-cell action-cell">
+                          <div class="button-group appraisal-button-group"
+                               tal:condition="view/appraisal_buttons_available">
+
+                            <a href="#"
+                               class="button"
+                               title="Archive"
+                               i18n:attributes="title label_archive"
+                               tal:attributes="class python: 'icon_button archive active' if dossier.appraisal else 'icon_button archive';
+                                               data-intid dossier/intid;
+                                               data-archive string:true">
+                            </a>
+                            <a href="#"
+                               title="Don't archive"
+                               i18n:attributes="title label_dont_archive"
+                               tal:attributes="class python: 'not_archive icon_button active' if dossier.appraisal==False else 'not_archive icon_button';
+                                               data-intid dossier/intid;
+                                               data-archive string:false">
+                            </a>
+
+                          </div>
+
+                          <div class="button-group appraisal-button-group"
+                               tal:condition="not: view/appraisal_buttons_available">
+
+                            <span tal:condition="dossier/appraisal"
+                                  class="icon_button archive active"
+                                  title="Archive"
+                                  i18n:attributes="title label_archive" />
+                            <span
+                                tal:condition="not: dossier/appraisal"
+                                class="icon_button not_archive active"
+                                title="Don't archive"
+                                i18n:attributes="title label_dont_archive" />
+
+                          </div>
+
+                        </li>
+                      </ul>
+                    </tal:define>
+                  </li>
+                </tal:define>
+              </ul>
+
+              <div class="actionButtons clearfix">
+                <ul class="transitions">
+                  <li tal:repeat="transition view/get_transitions" >
+                    <a tal:condition="transition/url"
+                       tal:attributes="href transition/url;
+                                       title transition/title;
+                                       id transition/id | nothing;
+                                       class string: ${transition/id} "
+                       i18n:domain="plone"
+                       i18n:attributes="title">
+                      <span tal:content="transition/title" class="transition actionText"
+                            i18n:translate="" i18n:domain="plone">
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+                <ul class="actions">
+                  <tal:repeat tal:repeat="action view/get_actions">
+                    <li tal:condition="action/visible">
+                      <a tal:attributes="href action/url;
+                                         title action/label;
+                                         class python: action.get('class');
+                                         id action/id | nothing;"
+                         i18n:attributes="title">
+                        <span tal:content="action/label" class="actionText"
+                              i18n:translate="" i18n:domain="plone">
+                        </span>
+                      </a>
+                    </li>
+                  </tal:repeat>
+                </ul>
+              </div>
+
+              <div class="progress">
+                <h3 i18n:translate="progress">Progress</h3>
+
+                <div class="answers">
+                  <tal:repeat tal:repeat="entry view/get_history">
+                    <div class="answer" tal:attributes="class string:answer ${entry/css_class}">
+                      <div class="answerType">&nbsp;</div>
+                      <div class="answerBody">
+                        <div class="date" tal:content="entry/date" />
+                        <h3 tal:content="structure entry/msg" i18n:translate="">
+                          History Transition
+                        </h3>
+                        <div class="details collapsible">
+                          <div class="collapsible-header">
+                            <span i18n:translate="label_details">Details:</span>
+                          </div>
+                          <div class="collapsible-content">
+                            <ul>
+                              <li tal:repeat="detail entry/details">
+                                <span class="reference_number" tal:content="detail/reference_number" />
+                                <span class="title" tal:content="detail/title" />
+                                <span class="appraisal" tal:condition="detail/appraisal"
+                                      i18n:translate="label_archive">Archive</span>
+                                <span class="appraisal" tal:condition="not: detail/appraisal"
+                                      i18n:translate="label_dont_archive">Don't archive</span>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div style="clear:both"><!-- --></div>
+                  </tal:repeat>
+                </div>
+              </div>
+
+            </div>
+          </metal:main-macro>
+        </div>
+      </body>
+    </html>
+  </metal:page>

--- a/opengever/disposition/profiles/default/types/opengever.disposition.disposition.xml
+++ b/opengever/disposition/profiles/default/types/opengever.disposition.disposition.xml
@@ -22,19 +22,18 @@
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
-    <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
     <element value="opengever.disposition.behaviors.namefromtitle.IDispositionNameFromTitle" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
   </property>
 
   <!-- View information -->
-  <property name="immediate_view">tabbed_view</property>
-  <property name="default_view">tabbed_view</property>
+  <property name="immediate_view">overview</property>
+  <property name="default_view">overview</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
     <element value="view" />
-    <element value="tabbed_view" />
+    <element value="overview" />
   </property>
 
   <!-- Method aliases -->
@@ -62,18 +61,6 @@
       url_expr="string:${object_url}/edit"
       condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True">
     <permission value="Modify portal content" />
-  </action>
-
-  <!-- Tabbedview tabs-->
-  <action
-      i18n:domain="opengever.disposition"
-      title="Overview"
-      action_id="overview"
-      category="tabbedview-tabs"
-      condition_expr=""
-      url_expr="string:#"
-      visible="True">
-    <permission value="View" />
   </action>
 
 </object>

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -203,7 +203,7 @@ class TestHistoryListingInOverview(FunctionalTestCase):
 
     @browsing
     def test_is_sorted_chronological(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['Appraisal finalized by Test User (test_user_1_)',
@@ -212,7 +212,7 @@ class TestHistoryListingInOverview(FunctionalTestCase):
 
     @browsing
     def test_details_list_dossier_snapshot(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         appraise = browser.css('div.details ul')[0]
         add = browser.css('div.details ul')[1]
@@ -226,7 +226,7 @@ class TestHistoryListingInOverview(FunctionalTestCase):
 
     @browsing
     def test_is_marked_with_corresponding_css_class(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals('answer appraise',
                           browser.css('.progress .answer')[0].get('class'))

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -43,7 +43,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_list_only_all_disposition_dossiers(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         create(Builder('dossier').titled(u'Dossier C'))
 
@@ -53,7 +53,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_list_details_for_each_dossiers(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['Period: Jan 19, 2016 - Mar 19, 2016',
@@ -71,7 +71,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_archive_button_is_active_depending_on_the_appraisal(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             'Archive',
@@ -83,14 +83,14 @@ class TestDispositionOverview(FunctionalTestCase):
     @browsing
     def test_appraisal_buttons_are_only_links_in_progress_state(self, browser):
         self.grant('Archivist')
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['Archive', "Don't archive"],
             [link.get('title') for link in browser.css('.appraisal-button-group').first.css('a')])
         browser.find('disposition-transition-appraise').click()
 
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
         self.assertEquals(
             [],
             [link.get('title') for link in browser.css('.appraisal-button-group').first.css('a')])
@@ -103,7 +103,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_update_appraisal_displays_buttons_correctly(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['Archive', "Don't archive"],
@@ -116,7 +116,7 @@ class TestDispositionOverview(FunctionalTestCase):
                 'should_be_archived': button.get('data-archive')}
         browser.open(url, data)
 
-        browser.open(self.disposition, view='tabbedview_view-overview')
+        browser.open(self.disposition, view='overview')
         self.assertEquals(
             ['Archive', 'Archive'],
             [link.get('title') for link in browser.css('.appraisal-button-group .active')])
@@ -124,7 +124,7 @@ class TestDispositionOverview(FunctionalTestCase):
     @browsing
     def test_lists_possible_transitions_in_actionmenu_as_buttons(self, browser):
         self.grant('Archivist', 'Records Manager')
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(['disposition-transition-appraise',
                            'disposition-transition-refuse'],
@@ -133,25 +133,23 @@ class TestDispositionOverview(FunctionalTestCase):
         self.assertEquals('disposition-state-appraised',
                           api.content.get_state(self.disposition))
 
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
         self.assertEquals(['disposition-transition-dispose'],
                           browser.css('.transitions li').text)
 
     @browsing
     def test_sip_download_is_only_available_in_disposed_state(self, browser):
         self.grant('Archivist', 'Records Manager')
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
+
         self.assertEquals(['Export appraisal list as excel'],
                           browser.css('ul.actions li').text)
 
         browser.find('disposition-transition-appraise').click()
-        self.assertEquals([],
+        self.assertEquals(['Export appraisal list as excel'],
                           browser.css('ul.actions li').text)
 
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
         browser.find('disposition-transition-dispose').click()
-
-        browser.open(self.disposition, view='tabbedview_view-overview')
         self.assertEquals(['Export appraisal list as excel',
                            'Download disposition package'],
                           browser.css('ul.actions li').text)
@@ -162,7 +160,7 @@ class TestDispositionOverview(FunctionalTestCase):
     @browsing
     def test_appraisal_list_download_is_always_available(self, browser):
         self.grant('Records Manager')
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
         self.assertEquals(['Export appraisal list as excel'],
                           browser.css('ul.actions li').text)
         self.assertEquals(
@@ -173,7 +171,7 @@ class TestDispositionOverview(FunctionalTestCase):
     def test_removal_protocol_is_available_in_closed_state(self, browser):
         self.grant('Editor', 'Records Manager')
 
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
         self.assertEquals(['Export appraisal list as excel'],
                           browser.css('ul.actions li').text)
 
@@ -185,7 +183,7 @@ class TestDispositionOverview(FunctionalTestCase):
         disposition_2.set_destroyed_dossiers([dossier])
         transaction.commit()
 
-        browser.login().open(disposition_2, view='tabbedview_view-overview')
+        browser.login().open(disposition_2, view='overview')
 
         self.assertEquals(['Export appraisal list as excel',
                            'Download removal protocol'],
@@ -196,7 +194,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_states_are_displayed_in_a_wizard_in_the_process_order(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['disposition-state-in-progress',
@@ -208,7 +206,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_current_state_is_selected(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['disposition-state-in-progress'],
@@ -216,7 +214,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_displays_archival_value_for_repositories(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             'Archival value: archival worthy with sampling',
@@ -224,7 +222,7 @@ class TestDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_displays_active_and_inactive_dossiers_separately(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         resolved_list, inactive_list = browser.css('ul.list-group')
 
@@ -270,7 +268,7 @@ class TestDispositionOverview(FunctionalTestCase):
                                                     dossier_d,
                                                     dossier_e]))
 
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         repos = browser.css('.repository-list-item')
         self.assertEquals(
@@ -314,7 +312,7 @@ class TestClosedDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_dossier_title_is_not_linked(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals(
             ['Client1 1 / 1', 'Dossier A', 'Client1 1 / 2', 'Dossier B'],
@@ -324,6 +322,6 @@ class TestClosedDispositionOverview(FunctionalTestCase):
 
     @browsing
     def test_additional_metadata_is_not_displayed(self, browser):
-        browser.login().open(self.disposition, view='tabbedview_view-overview')
+        browser.login().open(self.disposition, view='overview')
 
         self.assertEquals([], browser.css('#disposition_overview div.meta'))

--- a/opengever/disposition/upgrades/20170405075741_replace_tabbedview_overview_with_simple_overview_view/types/opengever.disposition.disposition.xml
+++ b/opengever/disposition/upgrades/20170405075741_replace_tabbedview_overview_with_simple_overview_view/types/opengever.disposition.disposition.xml
@@ -1,0 +1,19 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.disposition.disposition" meta_type="Dexterity FTI" i18n:domain="opengever.disposition">
+
+  <!-- enabled behaviors -->
+  <property name="behaviors">
+    <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.disposition.behaviors.namefromtitle.IDispositionNameFromTitle" />
+    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+  </property>
+
+  <!-- View information -->
+  <property name="immediate_view">overview</property>
+  <property name="default_view">overview</property>
+  <property name="view_methods">
+    <element value="view" />
+    <element value="overview" />
+  </property>
+
+</object>

--- a/opengever/disposition/upgrades/20170405075741_replace_tabbedview_overview_with_simple_overview_view/upgrade.py
+++ b/opengever/disposition/upgrades/20170405075741_replace_tabbedview_overview_with_simple_overview_view/upgrade.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReplaceTabbedviewOverviewWithSimpleOverviewView(UpgradeStep):
+    """Replace tabbedview-overview with simple overview view.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.actions_remove_type_action(
+            'opengever.disposition.disposition', 'overview')


### PR DESCRIPTION
The disposition tabbedview has currently only one tab, the "overview" tab. Because there are no other tabs planned, it makes sense to drop the tabbedview and replace it with a simple browserview. The content of the overview is not changed.

Needs styling PR: https://github.com/4teamwork/plonetheme.teamraum/pull/538

Closes #2691