### PR TITLE
Make sure keywords are unicode consistently.

### DIFF
--- a/opengever/base/upgrades/20170207162749_enable_ftw_keywordwidget_and_index_keywords_of_dossiers/upgrade.py
+++ b/opengever/base/upgrades/20170207162749_enable_ftw_keywordwidget_and_index_keywords_of_dossiers/upgrade.py
@@ -11,7 +11,8 @@ class EnableFtwKeywordwidgetAndIndexKeywordsOfDossiers(UpgradeStep):
         self.setup_install_profile('profile-ftw.keywordwidget:default')
         self.setup_install_profile('profile-ftw.keywordwidget:select2js')
 
-        query = {'object_provides': [IDossierTemplateMarker.__identifier__,
-                                     IDossierMarker.__identifier__]}
-        self.catalog_reindex_objects(query, idxs=['Subject', ])
+        # will be reindexed in 20170411113233
+        # query = {'object_provides': [IDossierTemplateMarker.__identifier__,
+        #                              IDossierMarker.__identifier__]}
+        # self.catalog_reindex_objects(query, idxs=['Subject', ])
         self.install_upgrade_profile()

--- a/opengever/base/upgrades/20170411113233_fix_subject_index__use_unicode_consistently/upgrade.py
+++ b/opengever/base/upgrades/20170411113233_fix_subject_index__use_unicode_consistently/upgrade.py
@@ -1,0 +1,42 @@
+from ftw.upgrade import UpgradeStep
+from opengever.document.behaviors.metadata import IDocumentMetadata
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+from plone import api
+from Products.CMFPlone.utils import safe_unicode
+
+
+class FixSubjectIndex_useUnicodeConsistently(UpgradeStep):
+    """Fix Subject index, use unicode consistently."""
+
+    def __call__(self):
+        self.clear_subject_index()
+        self.make_document_keywords_unicode()
+        self.make_dossier_keywords_unicode()
+        self.recalculate_subject_index()
+
+    def clear_subject_index(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        catalog.clearIndex('Subject')
+
+    def make_document_keywords_unicode(self):
+        query = {'object_provides': [IDocumentMetadata.__identifier__]}
+        for obj in self.objects(query, 'Ensure document keywords are unicode'):
+            doc = IDocumentMetadata(obj)
+            doc.keywords = tuple(
+                safe_unicode(keyword) for keyword in doc.keywords)
+
+    def make_dossier_keywords_unicode(self):
+        query = {'object_provides': [IDossierTemplateMarker.__identifier__,
+                                     IDossierMarker.__identifier__, ]}
+        for obj in self.objects(query, 'Ensure dossier keywords are unicode'):
+            dossier = IDossier(obj)
+            dossier.keywords = tuple(
+                safe_unicode(keyword) for keyword in dossier.keywords)
+
+    def recalculate_subject_index(self):
+        query = {'object_provides': [IDocumentMetadata.__identifier__,
+                                     IDossierTemplateMarker.__identifier__,
+                                     IDossierMarker.__identifier__, ]}
+        self.catalog_reindex_objects(query, idxs=['Subject', ])

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -67,7 +67,7 @@ class IDocumentMetadata(form.Schema):
         required=False,
         )
 
-    form.widget(keywords=KeywordFieldWidget)
+    form.widget('keywords', KeywordFieldWidget, new_terms_as_unicode=True)
     keywords = schema.Tuple(
         title=_(u'label_keywords', default=u'Keywords'),
         description=_(u'help_keywords', default=u''),

--- a/opengever/document/upgrades/20170321120536_enable_ftw_keywordwidget_for_document_metadata_behavior/upgrade.py
+++ b/opengever/document/upgrades/20170321120536_enable_ftw_keywordwidget_for_document_metadata_behavior/upgrade.py
@@ -11,8 +11,9 @@ class EnableFtwKeywordwidgetForDocumentMetadataBehavior(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.ensure_utf_8_keywords()
-        self.catalog_reindex_objects(self.query, idxs=['Subject', ])
+        # will be reindexed in 20170411113233
+        # self.ensure_utf_8_keywords()
+        # self.catalog_reindex_objects(self.query, idxs=['Subject', ])
 
     def ensure_utf_8_keywords(self):
         for obj in self.objects(self.query, 'Ensure keywords are utf-8'):

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -56,7 +56,7 @@ class IDossier(form.Schema):
         ],
     )
 
-    form.widget(keywords=KeywordFieldWidget)
+    form.widget('keywords', KeywordFieldWidget, new_terms_as_unicode=True)
     keywords = schema.Tuple(
         title=_(u'label_keywords', default=u'Keywords'),
         description=_(u'help_keywords', default=u''),

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,6 +7,7 @@ development-packages =
   plonetheme.teamraum
   collective.js.timeago
   plonetheme.teamraum
+  ftw.keywordwidget
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
This PR makes sure that keywords use unicode consistenlty.

When switching from `LinesWidget` to `KeywordWidget` we also changed how the values are stored on the field, the first one stored it as `unicode` whereas `ftw.keywordwidget` always persited the field values as `utf-8`. After some discussion we've decided to make `unicode`/`utf-8` terms customizable in `ftw.keywordwidget`, this has been implemented in https://github.com/4teamwork/ftw.keywordwidget/pull/13. That PR also contains a detailed description of our discussion/decisions.

This PR now makes sure that keywords are always stored as unicode, in objects and in the catalog. This purposefully breaks Plone's convention of usually `utf-8` catalog values.

Fixes #2823.