### PR TITLE
Also whitelist 'customlogoright' for unauthenticated access

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Replaced disposition tabbedview with a simple browserview. [phgross]
 - Refactor: Use ZCML for registering reference number adapters for consistency. [jone]
+- Also whitelist 'customlogoright' for unauthenticated access. [lgraf]
 - Fix translation for the journal pdf title. [phgross]
 - Add the document title to the OC attach payloads. [Rotonen]
 - Skip comment for Document Sent entries in the dossiers journal pdf representation. [phgross]

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -24,6 +24,7 @@ ALLOWED_ENDPOINTS = set([
     'POST_application_json_@logout',
     'POST_application_json_@login-renew',
     'customlogo',
+    'customlogo_right',
     'favicon',
     'list-open-dossiers-json',
     'logged_out',


### PR DESCRIPTION
Also whitelist 'customlogoright' for unauthenticated access (introduced in 4teamwork/plonetheme.teamraum#535.)

/cc @bierik 