### PR TITLE
Make sure GEVER customizations works during bundle import

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Make sure GEVER specific customizations works during bundle import. [phgross]
 - Replaced disposition tabbedview with a simple browserview. [phgross]
 - Refactor: Use ZCML for registering reference number adapters for consistency. [jone]
 - Also whitelist 'customlogoright' for unauthenticated access. [lgraf]

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,10 +1,12 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
+from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.bundle.ldap import DisabledLDAP
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
 from zope.annotation import IAnnotations
+from zope.interface import alsoProvides
 import logging
 import sys
 import transaction
@@ -22,6 +24,9 @@ def import_oggbundle(app, args):
     log.info("Importing OGGBundle %s" % bundle_path)
 
     plone = setup_plone(get_first_plone_site(app))
+
+    # mark request with GEVER layer
+    alsoProvides(plone.REQUEST, IOpengeverBaseLayer)
 
     transmogrifier = Transmogrifier(plone)
     IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = bundle_path


### PR DESCRIPTION
This change let the request during the bundle import provide the `IOpengeverBaseLayer`.

This is necessary because only the `GeverBumblebeeService` respects the bumblebee feature flag and does not trigger conversion requests, when the flag is disabled. The `GeverBumblebeeService` is a GEVER specific customization registered on the IOpengeverBaseLayer request layer, which is not be provided by default in an zope_ctl script.