### PR TITLE
Support simple css colornames in the colorization viewlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Meeting: add proposal template tab to templates folder. [jone]
+- Support simple css colornames in the colorization viewlet. [phgross]
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]
 - Move the attach to email action to second position, after the copy action. [elioschmutz]
 - OGGBundle import: Make sure persistent changes that re-enable LDAP are

--- a/opengever/base/viewlets/colorization.py
+++ b/opengever/base/viewlets/colorization.py
@@ -17,6 +17,7 @@ class ColorizationViewlet(ViewletBase):
 
     def css(self):
         colorname = os.environ.get(ENVIRONMENT_KEY, None)
-        if colorname is not None and colorname in COLORS:
-            return "div.contentWrapper {border: 5px solid %s;}" % COLORS[colorname]
+        if colorname is not None:
+            return "div.contentWrapper {border: 5px solid %s;}" % COLORS.get(
+                colorname, colorname)
         return None


### PR DESCRIPTION
This allows to use a different color, than on of the existing schema (red, yellow, green).

For example lab deployment: https://github.com/4teamwork/opengever.demo/blob/master/deployment-theta-17-lab.onegovgever.ch.cfg#L22