### PR TITLE
Fixes get-prefill after the Products.PloneHotfix20160830 for CompleteSuccessorTaskForm.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bundle import: Don't commit "before post-processing". [lgraf]
+- Allow get prefills for the CompleteSuccessorTaskForm. [elioschmutz]
 - Make sure GEVER specific customizations works during bundle import. [phgross]
 - Replaced disposition tabbedview with a simple browserview. [phgross]
 - Refactor: Use ZCML for registering reference number adapters for consistency. [jone]

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -114,6 +114,8 @@ class CompleteSuccessorTaskForm(Form):
     fields = Fields(ICompleteSuccessorTaskSchema)
     fields['documents'].widgetFactory = CheckBoxFieldWidget
 
+    allow_prefill_from_GET_request = True  # XXX
+
     label = _(u'title_complete_task', u'Complete task')
     ignoreContext = True
 


### PR DESCRIPTION
This PR fixes get-prefill after the Products.PloneHotfix20160830 for CompleteSuccessorTaskForm.

closes #2857 