### PR TITLE
Bundle import: Don't commit "before post-processing"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Bundle import: Don't commit "before post-processing". [lgraf]
 - Make sure GEVER specific customizations works during bundle import. [phgross]
 - Replaced disposition tabbedview with a simple browserview. [phgross]
 - Refactor: Use ZCML for registering reference number adapters for consistency. [jone]

--- a/opengever/bundle/sections/post_processing.py
+++ b/opengever/bundle/sections/post_processing.py
@@ -38,9 +38,6 @@ class PostProcessingSection(object):
         self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
 
     def __iter__(self):
-        log.info("Committing transaction...")
-        self.commit_and_log("Committed transaction before post-processing.")
-
         # Yield all items and collect them, so we can apply post-processing
         # steps *after* all the other sections have been executed
         items_to_post_process = []


### PR DESCRIPTION
This commit was triggered was too early (at the very beginning of the pipeline, because of how Transmogrifier works), and may have been related to sporadic conflict errors, among other things.