### PR TITLE
Also create journal entries on dossier level when attaching.

### DIFF
--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-03-14 17:26+0000\n"
+"POT-Creation-Date: 2017-04-13 15:05+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -31,7 +31,7 @@ msgid "label_add_journal_entry"
 msgstr "Journaleintrag hinzufügen"
 
 #. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py:324
+#: ./opengever/journal/handlers.py:337
 msgid "label_attachments_deleted"
 msgstr "Attachments gelöscht: ${filenames}"
 
@@ -57,97 +57,102 @@ msgid "label_contacts"
 msgstr "Kontakte"
 
 #. Default: "DocProperties updated."
-#: ./opengever/journal/handlers.py:313
+#: ./opengever/journal/handlers.py:326
 msgid "label_doc_properties_updated"
 msgstr "DocProperties aktualisiert"
 
 #. Default: "Document added: ${title}"
-#: ./opengever/journal/handlers.py:339
+#: ./opengever/journal/handlers.py:352
 msgid "label_document_added"
 msgstr "Dokument hinzugefügt: ${title}"
 
 #. Default: "Document attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:790
+#: ./opengever/journal/handlers.py:807
 msgid "label_document_attached"
 msgstr "Dokument mit Mailprogramm versendet"
 
 #. Default: "Document checked in"
-#: ./opengever/journal/handlers.py:454
+#: ./opengever/journal/handlers.py:467
 msgid "label_document_checkin"
 msgstr "Dokument eingecheckt"
 
 #. Default: "Document checked out"
-#: ./opengever/journal/handlers.py:441
+#: ./opengever/journal/handlers.py:454
 msgid "label_document_checkout"
 msgstr "Dokument ausgecheckt"
 
 #. Default: "Canceled document checkout"
-#: ./opengever/journal/handlers.py:466
+#: ./opengever/journal/handlers.py:479
 msgid "label_document_checkout_cancel"
 msgstr "Änderungen an der Datei widerrufen"
 
 #. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py:391
+#: ./opengever/journal/handlers.py:404
 msgid "label_document_file_and_metadata_modified"
 msgstr "Datei und Metadaten bearbeitet"
 
 #. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py:394
+#: ./opengever/journal/handlers.py:407
 msgid "label_document_file_and_metadata_modified__parent"
 msgstr "Datei und Metadaten des Dokuments «${title}» bearbeitet"
 
 #. Default: "Changed file"
-#: ./opengever/journal/handlers.py:403
+#: ./opengever/journal/handlers.py:416
 msgid "label_document_file_modified"
 msgstr "Datei bearbeitet"
 
 #. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py:405
+#: ./opengever/journal/handlers.py:418
 msgid "label_document_file_modified__parent"
 msgstr "Datei des Dokuments «${title}» bearbeitet"
 
 #. Default: "Reverte document file to version ${version_id}"
-#: ./opengever/journal/handlers.py:484
+#: ./opengever/journal/handlers.py:497
 msgid "label_document_file_reverted"
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt"
 
+#. Default: "Document in dossier attached to email via OfficeConnector"
+#: ./opengever/journal/handlers.py:813
+msgid "label_document_in_dossier_attached"
+msgstr "Dokument im Dossier mit Mailprogramm versendet"
+
 #. Default: "Changed metadata"
-#: ./opengever/journal/handlers.py:413
+#: ./opengever/journal/handlers.py:426
 msgid "label_document_metadata_modified"
 msgstr "Metadaten bearbeitet"
 
 #. Default: "Changed metadata of document ${title}"
-#: ./opengever/journal/handlers.py:415
+#: ./opengever/journal/handlers.py:428
 msgid "label_document_metadata_modified__parent"
 msgstr "Metadaten des Dokuments «${title}» bearbeitet"
 
 #. Default: "Public trial changed to \"${public_trial}\"."
-#: ./opengever/journal/handlers.py:428
+#: ./opengever/journal/handlers.py:441
 msgid "label_document_public_trial_modified"
 msgstr "Öffentlichkeitsstatus geändert nach «${public_trial}»."
 
 #. Default: "Document ${title} removed."
-#: ./opengever/journal/handlers.py:635
+#: ./opengever/journal/handlers.py:648
 msgid "label_document_removed"
 msgstr "Dokument ${title} gelöscht."
 
 #. Default: "Document ${title} restored."
-#: ./opengever/journal/handlers.py:652
+#: ./opengever/journal/handlers.py:665
 msgid "label_document_restored"
 msgstr "Dokument ${title} wiederhergestellt."
 
 #. Default: "Document sent by Mail: ${subject}"
-#: ./opengever/journal/handlers.py:536
+#: ./opengever/journal/handlers.py:549
 msgid "label_document_sent"
 msgstr "Dokumentversand per E-Mail: ${subject}"
 
 #. Default: "Attachments: ${documents} | Receivers: ${receiver} | Message: ${message}"
-#: ./opengever/journal/handlers.py:541
+#: ./opengever/journal/handlers.py:554
 msgid "label_document_sent_comment"
 msgstr "Anhänge: ${documents} | Empfänger: ${receiver} | Nachricht: ${message}"
 
 #. Default: "Document included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:770
+#: ./opengever/journal/handlers.py:783
 msgid "label_document_zipped"
 msgstr "Dokument in ZIP-Export aufgenommen: ${title}"
 
@@ -157,52 +162,52 @@ msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Dossier added: ${title}"
-#: ./opengever/journal/handlers.py:215
+#: ./opengever/journal/handlers.py:228
 msgid "label_dossier_added"
 msgstr "Dossier hinzugefügt: ${title}"
 
 #. Default: "Dossier modified: ${title}"
-#: ./opengever/journal/handlers.py:228
+#: ./opengever/journal/handlers.py:241
 msgid "label_dossier_modified"
 msgstr "Dossier modifiziert: ${title}"
 
 #. Default: "Dossier included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:757
+#: ./opengever/journal/handlers.py:770
 msgid "label_dossier_zipped"
 msgstr "Dossier in ZIP-Export aufgenommen: ${title}"
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:495
+#: ./opengever/journal/handlers.py:508
 msgid "label_file_copy_downloaded"
 msgstr "Download Kopie"
 
 #. Default: "Local roles aquistion activated."
-#: ./opengever/journal/handlers.py:284
+#: ./opengever/journal/handlers.py:297
 msgid "label_local_roles_acquisition_activated"
 msgstr "Vererbung der Berechtigungen aktiviert."
 
 #. Default: "Local roles aquistion activated at ${repository}."
-#: ./opengever/journal/handlers.py:177
+#: ./opengever/journal/handlers.py:190
 msgid "label_local_roles_acquisition_activated_at"
 msgstr "Vererbung der Berechtigungen aktiviert für ${repository}."
 
 #. Default: "Local roles aquistion blocked."
-#: ./opengever/journal/handlers.py:269
+#: ./opengever/journal/handlers.py:282
 msgid "label_local_roles_acquisition_blocked"
 msgstr "Vererbung der Berechtigungen unterbrochen."
 
 #. Default: "Local roles aquistion blocked at ${repository}."
-#: ./opengever/journal/handlers.py:159
+#: ./opengever/journal/handlers.py:172
 msgid "label_local_roles_acquisition_blocked_at"
 msgstr "Vererbung der Berechtigungen für ${repository} unterbrochen."
 
 #. Default: "Local roles modified."
-#: ./opengever/journal/handlers.py:299
+#: ./opengever/journal/handlers.py:312
 msgid "label_local_roles_modified"
 msgstr "Lokale Rollen modifiziert."
 
 #. Default: "Local roles modified at ${repository}."
-#: ./opengever/journal/handlers.py:195
+#: ./opengever/journal/handlers.py:208
 msgid "label_local_roles_modified_at"
 msgstr "Lokale Rollen von ${repository} modifziert."
 
@@ -212,32 +217,32 @@ msgid "label_manual_journal_entry"
 msgstr "Manueller Eintrag: ${category}"
 
 #. Default: "Object cut: ${title}"
-#: ./opengever/journal/handlers.py:741
+#: ./opengever/journal/handlers.py:754
 msgid "label_object_cut"
 msgstr "Objekt ausgeschnitten: ${title}"
 
 #. Default: "Object moved: ${title}"
-#: ./opengever/journal/handlers.py:719
+#: ./opengever/journal/handlers.py:732
 msgid "label_object_moved"
 msgstr "Objekt eingefügt: ${title}"
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
-#: ./opengever/journal/handlers.py:675
+#: ./opengever/journal/handlers.py:688
 msgid "label_participant_added"
 msgstr "Beteiligung hinzugefügt für ${contact} als ${roles}"
 
 #. Default: "Participant removed: ${contact}"
-#: ./opengever/journal/handlers.py:690
+#: ./opengever/journal/handlers.py:703
 msgid "label_participant_removed"
 msgstr "Beteiligung von ${contact} entfernt"
 
 #. Default: "PDF downloaded"
-#: ./opengever/journal/handlers.py:505
+#: ./opengever/journal/handlers.py:518
 msgid "label_pdf_downloaded"
 msgstr "PDF heruntergeladen"
 
 #. Default: "Unlocked prefix ${prefix} in ${repository}."
-#: ./opengever/journal/handlers.py:143
+#: ./opengever/journal/handlers.py:156
 msgid "label_prefix_unlocked"
 msgstr "Aktenzeichen ${prefix} in ${repository} wurde freigegeben."
 
@@ -252,17 +257,17 @@ msgid "label_related_documents"
 msgstr "Dokumentverweise"
 
 #. Default: "Object restore: ${title}"
-#: ./opengever/journal/handlers.py:618
+#: ./opengever/journal/handlers.py:631
 msgid "label_restore"
 msgstr "Dokument ${title} reaktiviert."
 
 #. Default: "Task added: ${title}"
-#: ./opengever/journal/handlers.py:560
+#: ./opengever/journal/handlers.py:573
 msgid "label_task_added"
 msgstr "Aufgabe hinzugefügt: ${title}"
 
 #. Default: "Task modified: ${title}"
-#: ./opengever/journal/handlers.py:577
+#: ./opengever/journal/handlers.py:590
 msgid "label_task_modified"
 msgstr "Aufgabe modifiziert: ${title}"
 
@@ -277,7 +282,7 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Object moved to trash: ${title}"
-#: ./opengever/journal/handlers.py:600
+#: ./opengever/journal/handlers.py:613
 msgid "label_to_trash"
 msgstr "Dokument ${title} in den Papierkorb verschoben."
 
@@ -290,3 +295,4 @@ msgstr "Journal"
 #: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
 msgstr "${amount} Treffer."
+

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-14 17:26+0000\n"
+"POT-Creation-Date: 2017-04-13 15:05+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
@@ -33,7 +33,7 @@ msgid "label_add_journal_entry"
 msgstr ""
 
 #. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py:324
+#: ./opengever/journal/handlers.py:337
 msgid "label_attachments_deleted"
 msgstr "Fichiers attachés effacés: ${filenames}"
 
@@ -59,97 +59,102 @@ msgid "label_contacts"
 msgstr ""
 
 #. Default: "DocProperties updated."
-#: ./opengever/journal/handlers.py:313
+#: ./opengever/journal/handlers.py:326
 msgid "label_doc_properties_updated"
 msgstr "DocProperties actualisé"
 
 #. Default: "Document added: ${title}"
-#: ./opengever/journal/handlers.py:339
+#: ./opengever/journal/handlers.py:352
 msgid "label_document_added"
 msgstr "Document ajouté: ${title}"
 
 #. Default: "Document attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:790
+#: ./opengever/journal/handlers.py:807
 msgid "label_document_attached"
 msgstr ""
 
 #. Default: "Document checked in"
-#: ./opengever/journal/handlers.py:454
+#: ./opengever/journal/handlers.py:467
 msgid "label_document_checkin"
 msgstr "Document avec checkin"
 
 #. Default: "Document checked out"
-#: ./opengever/journal/handlers.py:441
+#: ./opengever/journal/handlers.py:454
 msgid "label_document_checkout"
 msgstr "Document avec checkout"
 
 #. Default: "Canceled document checkout"
-#: ./opengever/journal/handlers.py:466
+#: ./opengever/journal/handlers.py:479
 msgid "label_document_checkout_cancel"
 msgstr "Annuler les modification du fichier"
 
 #. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py:391
+#: ./opengever/journal/handlers.py:404
 msgid "label_document_file_and_metadata_modified"
 msgstr "Fichier et méta-données modifiés"
 
 #. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py:394
+#: ./opengever/journal/handlers.py:407
 msgid "label_document_file_and_metadata_modified__parent"
 msgstr "Fichier et méta-données du document «${title}» modifiés"
 
 #. Default: "Changed file"
-#: ./opengever/journal/handlers.py:403
+#: ./opengever/journal/handlers.py:416
 msgid "label_document_file_modified"
 msgstr "Fichier modifié"
 
 #. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py:405
+#: ./opengever/journal/handlers.py:418
 msgid "label_document_file_modified__parent"
 msgstr "Fichier du document «${title}» modifié"
 
 #. Default: "Reverte document file to version ${version_id}"
-#: ./opengever/journal/handlers.py:484
+#: ./opengever/journal/handlers.py:497
 msgid "label_document_file_reverted"
 msgstr "Fichier du document remis à la version ${version_id}"
 
+#. Default: "Document in dossier attached to email via OfficeConnector"
+#: ./opengever/journal/handlers.py:813
+msgid "label_document_in_dossier_attached"
+msgstr ""
+
 #. Default: "Changed metadata"
-#: ./opengever/journal/handlers.py:413
+#: ./opengever/journal/handlers.py:426
 msgid "label_document_metadata_modified"
 msgstr "Méta-données modifiées"
 
 #. Default: "Changed metadata of document ${title}"
-#: ./opengever/journal/handlers.py:415
+#: ./opengever/journal/handlers.py:428
 msgid "label_document_metadata_modified__parent"
 msgstr "Méta-données du document ${title} modifiées"
 
 #. Default: "Public trial changed to \"${public_trial}\"."
-#: ./opengever/journal/handlers.py:428
+#: ./opengever/journal/handlers.py:441
 msgid "label_document_public_trial_modified"
 msgstr "Statut public modifié en «${public_trial}»"
 
 #. Default: "Document ${title} removed."
-#: ./opengever/journal/handlers.py:635
+#: ./opengever/journal/handlers.py:648
 msgid "label_document_removed"
 msgstr "Document ${title} effacé"
 
 #. Default: "Document ${title} restored."
-#: ./opengever/journal/handlers.py:652
+#: ./opengever/journal/handlers.py:665
 msgid "label_document_restored"
 msgstr "Document restoré"
 
 #. Default: "Document sent by Mail: ${subject}"
-#: ./opengever/journal/handlers.py:536
+#: ./opengever/journal/handlers.py:549
 msgid "label_document_sent"
 msgstr "Envoi de document par Email: ${subject}"
 
 #. Default: "Attachments: ${documents} | Receivers: ${receiver} | Message: ${message}"
-#: ./opengever/journal/handlers.py:541
+#: ./opengever/journal/handlers.py:554
 msgid "label_document_sent_comment"
 msgstr "Annexes:  ${documents} | Récepteur ${receiver} | Message ${message}"
 
 #. Default: "Document included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:770
+#: ./opengever/journal/handlers.py:783
 msgid "label_document_zipped"
 msgstr ""
 
@@ -159,52 +164,52 @@ msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossier added: ${title}"
-#: ./opengever/journal/handlers.py:215
+#: ./opengever/journal/handlers.py:228
 msgid "label_dossier_added"
 msgstr "Dossier ajouté: ${title}"
 
 #. Default: "Dossier modified: ${title}"
-#: ./opengever/journal/handlers.py:228
+#: ./opengever/journal/handlers.py:241
 msgid "label_dossier_modified"
 msgstr "Dossier modifié: ${title}"
 
 #. Default: "Dossier included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:757
+#: ./opengever/journal/handlers.py:770
 msgid "label_dossier_zipped"
 msgstr ""
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:495
+#: ./opengever/journal/handlers.py:508
 msgid "label_file_copy_downloaded"
 msgstr "Télécharger une copie"
 
 #. Default: "Local roles aquistion activated."
-#: ./opengever/journal/handlers.py:284
+#: ./opengever/journal/handlers.py:297
 msgid "label_local_roles_acquisition_activated"
 msgstr "Héritage des droits d'accès activé"
 
 #. Default: "Local roles aquistion activated at ${repository}."
-#: ./opengever/journal/handlers.py:177
+#: ./opengever/journal/handlers.py:190
 msgid "label_local_roles_acquisition_activated_at"
 msgstr "Héritage des droits d'accès activé pour  ${repository}."
 
 #. Default: "Local roles aquistion blocked."
-#: ./opengever/journal/handlers.py:269
+#: ./opengever/journal/handlers.py:282
 msgid "label_local_roles_acquisition_blocked"
 msgstr "Héritage des droits d'accès désactivé"
 
 #. Default: "Local roles aquistion blocked at ${repository}."
-#: ./opengever/journal/handlers.py:159
+#: ./opengever/journal/handlers.py:172
 msgid "label_local_roles_acquisition_blocked_at"
 msgstr "Héritage des droits d'accès désactivé pour  ${repository}."
 
 #. Default: "Local roles modified."
-#: ./opengever/journal/handlers.py:299
+#: ./opengever/journal/handlers.py:312
 msgid "label_local_roles_modified"
 msgstr "Rôles à l'intérne modifiés"
 
 #. Default: "Local roles modified at ${repository}."
-#: ./opengever/journal/handlers.py:195
+#: ./opengever/journal/handlers.py:208
 msgid "label_local_roles_modified_at"
 msgstr "Rôles à l'intérne pour ${repository} modifiés"
 
@@ -214,32 +219,32 @@ msgid "label_manual_journal_entry"
 msgstr ""
 
 #. Default: "Object cut: ${title}"
-#: ./opengever/journal/handlers.py:741
+#: ./opengever/journal/handlers.py:754
 msgid "label_object_cut"
 msgstr "Objet coupé : ${title}"
 
 #. Default: "Object moved: ${title}"
-#: ./opengever/journal/handlers.py:719
+#: ./opengever/journal/handlers.py:732
 msgid "label_object_moved"
 msgstr "Objet collé : ${title}"
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
-#: ./opengever/journal/handlers.py:675
+#: ./opengever/journal/handlers.py:688
 msgid "label_participant_added"
 msgstr "Participation ajoutée pour ${contact} comme ${roles}"
 
 #. Default: "Participant removed: ${contact}"
-#: ./opengever/journal/handlers.py:690
+#: ./opengever/journal/handlers.py:703
 msgid "label_participant_removed"
 msgstr "Participation de ${contact} enlevée"
 
 #. Default: "PDF downloaded"
-#: ./opengever/journal/handlers.py:505
+#: ./opengever/journal/handlers.py:518
 msgid "label_pdf_downloaded"
 msgstr "Télécharger le PDF"
 
 #. Default: "Unlocked prefix ${prefix} in ${repository}."
-#: ./opengever/journal/handlers.py:143
+#: ./opengever/journal/handlers.py:156
 msgid "label_prefix_unlocked"
 msgstr "Référence ${prefix} dans ${repository} a été débloqué."
 
@@ -254,17 +259,17 @@ msgid "label_related_documents"
 msgstr ""
 
 #. Default: "Object restore: ${title}"
-#: ./opengever/journal/handlers.py:618
+#: ./opengever/journal/handlers.py:631
 msgid "label_restore"
 msgstr "Objet restauré : ${title}"
 
 #. Default: "Task added: ${title}"
-#: ./opengever/journal/handlers.py:560
+#: ./opengever/journal/handlers.py:573
 msgid "label_task_added"
 msgstr "Tâche ajoutée : ${title}"
 
 #. Default: "Task modified: ${title}"
-#: ./opengever/journal/handlers.py:577
+#: ./opengever/journal/handlers.py:590
 msgid "label_task_modified"
 msgstr "Tâche modifiée : ${title}"
 
@@ -279,7 +284,7 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Object moved to trash: ${title}"
-#: ./opengever/journal/handlers.py:600
+#: ./opengever/journal/handlers.py:613
 msgid "label_to_trash"
 msgstr "Objet effacé : ${title}"
 

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-03-14 17:26+0000\n"
+"POT-Creation-Date: 2017-04-13 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,7 +34,7 @@ msgid "label_add_journal_entry"
 msgstr ""
 
 #. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py:324
+#: ./opengever/journal/handlers.py:337
 msgid "label_attachments_deleted"
 msgstr ""
 
@@ -60,97 +60,102 @@ msgid "label_contacts"
 msgstr ""
 
 #. Default: "DocProperties updated."
-#: ./opengever/journal/handlers.py:313
+#: ./opengever/journal/handlers.py:326
 msgid "label_doc_properties_updated"
 msgstr ""
 
 #. Default: "Document added: ${title}"
-#: ./opengever/journal/handlers.py:339
+#: ./opengever/journal/handlers.py:352
 msgid "label_document_added"
 msgstr ""
 
 #. Default: "Document attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:790
+#: ./opengever/journal/handlers.py:807
 msgid "label_document_attached"
 msgstr ""
 
 #. Default: "Document checked in"
-#: ./opengever/journal/handlers.py:454
+#: ./opengever/journal/handlers.py:467
 msgid "label_document_checkin"
 msgstr ""
 
 #. Default: "Document checked out"
-#: ./opengever/journal/handlers.py:441
+#: ./opengever/journal/handlers.py:454
 msgid "label_document_checkout"
 msgstr ""
 
 #. Default: "Canceled document checkout"
-#: ./opengever/journal/handlers.py:466
+#: ./opengever/journal/handlers.py:479
 msgid "label_document_checkout_cancel"
 msgstr ""
 
 #. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py:391
+#: ./opengever/journal/handlers.py:404
 msgid "label_document_file_and_metadata_modified"
 msgstr ""
 
 #. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py:394
+#: ./opengever/journal/handlers.py:407
 msgid "label_document_file_and_metadata_modified__parent"
 msgstr ""
 
 #. Default: "Changed file"
-#: ./opengever/journal/handlers.py:403
+#: ./opengever/journal/handlers.py:416
 msgid "label_document_file_modified"
 msgstr ""
 
 #. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py:405
+#: ./opengever/journal/handlers.py:418
 msgid "label_document_file_modified__parent"
 msgstr ""
 
 #. Default: "Reverte document file to version ${version_id}"
-#: ./opengever/journal/handlers.py:484
+#: ./opengever/journal/handlers.py:497
 msgid "label_document_file_reverted"
 msgstr ""
 
+#. Default: "Document in dossier attached to email via OfficeConnector"
+#: ./opengever/journal/handlers.py:813
+msgid "label_document_in_dossier_attached"
+msgstr ""
+
 #. Default: "Changed metadata"
-#: ./opengever/journal/handlers.py:413
+#: ./opengever/journal/handlers.py:426
 msgid "label_document_metadata_modified"
 msgstr ""
 
 #. Default: "Changed metadata of document ${title}"
-#: ./opengever/journal/handlers.py:415
+#: ./opengever/journal/handlers.py:428
 msgid "label_document_metadata_modified__parent"
 msgstr ""
 
 #. Default: "Public trial changed to \"${public_trial}\"."
-#: ./opengever/journal/handlers.py:428
+#: ./opengever/journal/handlers.py:441
 msgid "label_document_public_trial_modified"
 msgstr ""
 
 #. Default: "Document ${title} removed."
-#: ./opengever/journal/handlers.py:635
+#: ./opengever/journal/handlers.py:648
 msgid "label_document_removed"
 msgstr ""
 
 #. Default: "Document ${title} restored."
-#: ./opengever/journal/handlers.py:652
+#: ./opengever/journal/handlers.py:665
 msgid "label_document_restored"
 msgstr ""
 
 #. Default: "Document sent by Mail: ${subject}"
-#: ./opengever/journal/handlers.py:536
+#: ./opengever/journal/handlers.py:549
 msgid "label_document_sent"
 msgstr ""
 
 #. Default: "Attachments: ${documents} | Receivers: ${receiver} | Message: ${message}"
-#: ./opengever/journal/handlers.py:541
+#: ./opengever/journal/handlers.py:554
 msgid "label_document_sent_comment"
 msgstr ""
 
 #. Default: "Document included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:770
+#: ./opengever/journal/handlers.py:783
 msgid "label_document_zipped"
 msgstr ""
 
@@ -160,52 +165,52 @@ msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossier added: ${title}"
-#: ./opengever/journal/handlers.py:215
+#: ./opengever/journal/handlers.py:228
 msgid "label_dossier_added"
 msgstr ""
 
 #. Default: "Dossier modified: ${title}"
-#: ./opengever/journal/handlers.py:228
+#: ./opengever/journal/handlers.py:241
 msgid "label_dossier_modified"
 msgstr ""
 
 #. Default: "Dossier included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:757
+#: ./opengever/journal/handlers.py:770
 msgid "label_dossier_zipped"
 msgstr ""
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:495
+#: ./opengever/journal/handlers.py:508
 msgid "label_file_copy_downloaded"
 msgstr ""
 
 #. Default: "Local roles aquistion activated."
-#: ./opengever/journal/handlers.py:284
+#: ./opengever/journal/handlers.py:297
 msgid "label_local_roles_acquisition_activated"
 msgstr ""
 
 #. Default: "Local roles aquistion activated at ${repository}."
-#: ./opengever/journal/handlers.py:177
+#: ./opengever/journal/handlers.py:190
 msgid "label_local_roles_acquisition_activated_at"
 msgstr ""
 
 #. Default: "Local roles aquistion blocked."
-#: ./opengever/journal/handlers.py:269
+#: ./opengever/journal/handlers.py:282
 msgid "label_local_roles_acquisition_blocked"
 msgstr ""
 
 #. Default: "Local roles aquistion blocked at ${repository}."
-#: ./opengever/journal/handlers.py:159
+#: ./opengever/journal/handlers.py:172
 msgid "label_local_roles_acquisition_blocked_at"
 msgstr ""
 
 #. Default: "Local roles modified."
-#: ./opengever/journal/handlers.py:299
+#: ./opengever/journal/handlers.py:312
 msgid "label_local_roles_modified"
 msgstr ""
 
 #. Default: "Local roles modified at ${repository}."
-#: ./opengever/journal/handlers.py:195
+#: ./opengever/journal/handlers.py:208
 msgid "label_local_roles_modified_at"
 msgstr ""
 
@@ -215,32 +220,32 @@ msgid "label_manual_journal_entry"
 msgstr ""
 
 #. Default: "Object cut: ${title}"
-#: ./opengever/journal/handlers.py:741
+#: ./opengever/journal/handlers.py:754
 msgid "label_object_cut"
 msgstr ""
 
 #. Default: "Object moved: ${title}"
-#: ./opengever/journal/handlers.py:719
+#: ./opengever/journal/handlers.py:732
 msgid "label_object_moved"
 msgstr ""
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
-#: ./opengever/journal/handlers.py:675
+#: ./opengever/journal/handlers.py:688
 msgid "label_participant_added"
 msgstr ""
 
 #. Default: "Participant removed: ${contact}"
-#: ./opengever/journal/handlers.py:690
+#: ./opengever/journal/handlers.py:703
 msgid "label_participant_removed"
 msgstr ""
 
 #. Default: "PDF downloaded"
-#: ./opengever/journal/handlers.py:505
+#: ./opengever/journal/handlers.py:518
 msgid "label_pdf_downloaded"
 msgstr ""
 
 #. Default: "Unlocked prefix ${prefix} in ${repository}."
-#: ./opengever/journal/handlers.py:143
+#: ./opengever/journal/handlers.py:156
 msgid "label_prefix_unlocked"
 msgstr ""
 
@@ -255,17 +260,17 @@ msgid "label_related_documents"
 msgstr ""
 
 #. Default: "Object restore: ${title}"
-#: ./opengever/journal/handlers.py:618
+#: ./opengever/journal/handlers.py:631
 msgid "label_restore"
 msgstr ""
 
 #. Default: "Task added: ${title}"
-#: ./opengever/journal/handlers.py:560
+#: ./opengever/journal/handlers.py:573
 msgid "label_task_added"
 msgstr ""
 
 #. Default: "Task modified: ${title}"
-#: ./opengever/journal/handlers.py:577
+#: ./opengever/journal/handlers.py:590
 msgid "label_task_modified"
 msgstr ""
 
@@ -280,7 +285,7 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Object moved to trash: ${title}"
-#: ./opengever/journal/handlers.py:600
+#: ./opengever/journal/handlers.py:613
 msgid "label_to_trash"
 msgstr ""
 

--- a/opengever/journal/tests/test_attach_journal_entry.py
+++ b/opengever/journal/tests/test_attach_journal_entry.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.journal.handlers import document_attached_to_email
+from opengever.testing import FunctionalTestCase
+import transaction
+
+
+class MockEvent(object):
+
+    def __init__(self, obj):
+        self.object = obj
+
+
+class TestAttachJournalEntry(FunctionalTestCase):
+
+    @browsing
+    def test_attaching_document_creates_dossier_level_jounral_entry(self, browser):
+        with freeze(datetime(2016, 12, 9, 9, 40)):
+            self.dossier = create(Builder('dossier'))
+            self.document = create(Builder('document').within(self.dossier))
+            document_attached_to_email(self.document, MockEvent(self.document))
+            transaction.commit()
+
+        browser.login().open(self.dossier, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+
+        self.assertEquals(
+            {'Changed by': 'Test User (test_user_1_)',
+             'Title': 'Document in dossier attached to email via OfficeConnector',
+             'References': u'Documents Testdokum\xe4nt',
+             'Comments': '',
+             'Time': '09.12.2016 09:40'},
+            row.dict())
+
+        self.assertEquals(u'Documents Testdokum\xe4nt',
+                          row.dict().get('References'))
+        browser.click_on(u'Testdokum\xe4nt')
+        self.assertEquals(self.document.absolute_url(), browser.url)

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -242,6 +242,12 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         journal_entry = browser.css('.listing').first.lists()[1]
         self.assertEquals(journal_entry[1], 'Dokument mit Mailprogramm versendet')  # noqa
 
+        # Test there is also a journal entry in the dossier
+        browser.login()
+        browser.open(self.open_dossier, view='tabbedview_view-journal') # noqa
+        journal_entry = browser.css('.listing').first.lists()[1]
+        self.assertEquals(journal_entry[1], 'Dokument im Dossier mit Mailprogramm versendet')  # noqa
+
     @browsing
     def test_attach_to_outlook_payload_with_file_and_resolved_dossier(self, browser):  # noqa
         self.enable_attach_to_outlook()
@@ -267,6 +273,12 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         journal_entry = browser.css('.listing').first.lists()[1]
         self.assertEquals(journal_entry[1], 'Dokument mit Mailprogramm versendet')  # noqa
 
+        # Test there is also a journal entry in the dossier
+        browser.login()
+        browser.open(self.resolved_dossier, view='tabbedview_view-journal') # noqa
+        journal_entry = browser.css('.listing').first.lists()[1]
+        self.assertEquals(journal_entry[1], 'Dokument im Dossier mit Mailprogramm versendet')  # noqa
+
     @browsing
     def test_attach_to_outlook_payload_with_file_and_inactive_dossier(self, browser):  # noqa
         self.enable_attach_to_outlook()
@@ -291,6 +303,12 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         browser.open(self.doc_with_file_wf_inactive, view='tabbedview_view-journal') # noqa
         journal_entry = browser.css('.listing').first.lists()[1]
         self.assertEquals(journal_entry[1], 'Dokument mit Mailprogramm versendet')  # noqa
+
+        # Test there is also a journal entry in the dossier
+        browser.login()
+        browser.open(self.inactive_dossier, view='tabbedview_view-journal') # noqa
+        journal_entry = browser.css('.listing').first.lists()[1]
+        self.assertEquals(journal_entry[1], 'Dokument im Dossier mit Mailprogramm versendet')  # noqa
 
     def test_attach_to_outlook_get(self):
         self.enable_attach_to_outlook()


### PR DESCRIPTION
Add a journal entry to a document's dossier whenever attaching a document to a mail. Currently an individual entry will be created for each attached document since they will be downloaded separately (i.e. in separate requests) by OfficeConnector.

![screen shot 2017-04-20 at 11 52 28](https://cloud.githubusercontent.com/assets/736583/25224837/eb968c6e-25bf-11e7-8580-99da4b2e4c59.png)

Closes #2806.