### PR TITLE
Fix sortorder of repository favorites in the treeportlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
   numbers in order to avoid conflict errors. [lgraf]
 - Bundle import: Don't commit "before post-processing". [lgraf]
 - Allow get prefills for the CompleteSuccessorTaskForm. [elioschmutz]
+- Fix sortorder of repository favorites in the treeportlet.
 - Make sure GEVER specific customizations works during bundle import. [phgross]
 - Unify file action button logic. [Rotonen]
 - Replaced disposition tabbedview with a simple browserview. [phgross]

--- a/opengever/portlets/tree/resources/init_tree.js
+++ b/opengever/portlets/tree/resources/init_tree.js
@@ -149,17 +149,10 @@ $(function() {
   function sort_by_text(list_of_nodes) {
     /* Sorts a list of nodes by text in-place. */
     function compare_text(first, second) {
-      var a = first.text;
-      var b = second.text;
-      if (a < b) {
-        return -1;
-      }
-      else if (a > b) {
-        return 1;
-      }
-      else {
-        return 0;
-      }
+      // We do a localeCompare with a numeric strings comparsion.
+      // With this configuration, 1.3 will be sorted before 1.10
+      // To do a language independent comparsion we don't set the language.
+      return first.text.localeCompare(second.text, undefined, {numeric: true});
     }
     list_of_nodes.sort(compare_text);
   }


### PR DESCRIPTION
Before:

![bildschirmfoto 2017-04-20 um 12 16 50](https://cloud.githubusercontent.com/assets/557005/25225878/51925676-25c3-11e7-97ae-822d4afda897.png)

After: 

![bildschirmfoto 2017-04-20 um 12 14 54](https://cloud.githubusercontent.com/assets/557005/25225868/4b46a114-25c3-11e7-8b6a-8cd6658fbed5.png)

closes #2853 