### PR TITLE
OGGBundle import: Don't use separate ZODB connection to issue sequence numbers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 ---------------------
 
 - Meeting: add new "Proposal Template" FTI. [jone]
+- OGGBundle import: Don't use a separate ZODB connection to issue sequence
+  numbers in order to avoid conflict errors. [lgraf]
 - Bundle import: Don't commit "before post-processing". [lgraf]
 - Allow get prefills for the CompleteSuccessorTaskForm. [elioschmutz]
 - Make sure GEVER specific customizations works during bundle import. [phgross]

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -23,6 +23,12 @@ class IDontIssueDossierReferenceNumber(Interface):
     """
 
 
+class INoSeparateConnectionForSequenceNumbers(Interface):
+    """Request layer to indicate no separate ZODB connection should be used
+    to issue sequence numbers.
+    """
+
+
 class IOpengeverCatalogBrain(ICatalogBrain):
     """Detailed Interface for opengever CatalogBrain.
     Used for add an opengever specific CatalogContentlisting Adapter.

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,4 +1,5 @@
 from collective.transmogrifier.transmogrifier import Transmogrifier
+from opengever.base.interfaces import INoSeparateConnectionForSequenceNumbers
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.bundle.ldap import DisabledLDAP
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
@@ -27,6 +28,10 @@ def import_oggbundle(app, args):
 
     # mark request with GEVER layer
     alsoProvides(plone.REQUEST, IOpengeverBaseLayer)
+
+    # Don't use a separate ZODB connection to issue sequence numbers in
+    # order to avoid conflict errors during OGGBundle import
+    alsoProvides(plone.REQUEST, INoSeparateConnectionForSequenceNumbers)
 
     transmogrifier = Transmogrifier(plone)
     IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = bundle_path


### PR DESCRIPTION
OGGBundle import: Don't use separate ZODB connection to issue sequence numbers  in order to avoid conflict errors (when writing to the Plone site root annotations).

I chose to introduce a new request interface `INoSeparateConnectionForSequenceNumbers` to specifically flag this behavior, instead of abusing the `IDuringSetup` one (since OGGBundle import isn't setup, and what happens as a cause of `IDuringSetup could change at any point).