### PR TITLE
OGGBundle import: Make sure persistent changes that re-enable LDAP are always committed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- OGGBundle import: Make sure persistent changes that re-enable LDAP are
+  always committed. [lgraf]
 - Meeting: add new "Proposal Template" FTI. [jone]
 - OGGBundle import: Don't use a separate ZODB connection to issue sequence
   numbers in order to avoid conflict errors. [lgraf]

--- a/opengever/bundle/ldap.py
+++ b/opengever/bundle/ldap.py
@@ -1,6 +1,8 @@
 from persistent.mapping import PersistentMapping
 from plone import api
 import logging
+import transaction
+
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -20,7 +22,15 @@ class DisabledLDAP(object):
         disable_ldap(self.portal)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is not None:
+            # Exception happened, make sure transaction is rolled back
+            transaction.abort()
+            transaction.begin()
+
         enable_ldap(self.portal)
+
+        # Make sure persistent changes that re-enable LDAP are committed
+        transaction.commit()
 
 
 def disable_ldap(portal):

--- a/opengever/bundle/ldap.py
+++ b/opengever/bundle/ldap.py
@@ -1,3 +1,4 @@
+from persistent.mapping import PersistentMapping
 from plone import api
 import logging
 
@@ -38,7 +39,7 @@ def disable_ldap(portal):
             ldap_plugins.append(plugin.getId())
 
     original_plugins = plugin_registry._plugins
-    plugins_without_ldap = {}
+    plugins_without_ldap = PersistentMapping()
     for interface, plugins in original_plugins.items():
         actives = tuple([p for p in plugins if p not in ldap_plugins])
         plugins_without_ldap[interface] = actives


### PR DESCRIPTION
Make sure persistent changes that re-enable LDAP are always committed, so we don't end up with a broken plugin registry.