### PR TITLE
Fix site setup after introducing INoSeparateConnectionForSequenceNumbers

### DIFF
--- a/opengever/base/sequence.py
+++ b/opengever/base/sequence.py
@@ -91,7 +91,7 @@ class SequenceNumberIncrementer(object):
             return self._increment_number(portal, sequence_number_key)
 
         if any([IDuringSetup.providedBy(request),
-                INoSeparateConnectionForSequenceNumbers(request)]):
+                INoSeparateConnectionForSequenceNumbers.providedBy(request)]):
             # During setup, the Plone site will just have been created in that
             # very transaction. That means it's not available for us to fetch
             # from a separate ZODB connection during setup. So no separate


### PR DESCRIPTION
Fix site setup after introducing `INoSeparateConnectionForSequenceNumbers` request interface:

Request interface needs to be checked with `iface.providedBy()`, not by attempting to adapt the request.