### PR TITLE
Allow move items in the documents tab within the templatefolder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Allow move items in the documents tab within the templatefolder. [elioschmutz]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/opengever/dossier/templatefolder/tabs.py
+++ b/opengever/dossier/templatefolder/tabs.py
@@ -43,7 +43,6 @@ class TemplateFolderDocuments(Documents):
         'checkin',
         'checkout',
         'create_task',
-        'move_items',
         'send_as_email',
         'submit_additional_documents',
     ]

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -282,6 +282,19 @@ class TestMoveItemsWithTestbrowser(FunctionalTestCase):
         self.assertIn(task, self.target_dossier.objectValues())
 
     @browsing
+    def test_move_items_within_templatefolder_is_possible(self, browser):
+        templatefolder = create(Builder('templatefolder'))
+        subtemplatefolder = create(Builder('templatefolder').within(templatefolder))
+
+        document = create(Builder('document').within(templatefolder))
+
+        self.move_items(
+            browser, src=templatefolder,
+            obj=document, target=subtemplatefolder)
+
+        self.assertIn(document, subtemplatefolder.objectValues())
+
+    @browsing
     def test_paste_action_not_visible_for_closed_dossiers(self, browser):
         resolved_dossier = create(Builder('dossier')
                                   .in_state('dossier-state-resolved'))

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -740,7 +740,7 @@ class TestTemplateFolderListings(FunctionalTestCase):
 
         self.assertItemsEqual(
             ['Copy Items', 'Checkin with comment', 'Checkin without comment',
-             'Export selection', 'trashed', 'Export as Zip'],
+             'Export selection', 'Move Items', 'trashed', 'Export as Zip'],
             browser.css('.actionMenuContent li').text)
 
     @browsing


### PR DESCRIPTION
This PR allows move items in the documents tab within the templatefolder.

![screen2](https://cloud.githubusercontent.com/assets/557005/25336410/a4f053ae-28f7-11e7-815c-c4855839d76f.gif)

closes #2401 