### PR TITLE
Move the attach to email action to second position, after the copy action

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]
+- Move the attach to email action to second position, after the copy action. [elioschmutz]
 - OGGBundle import: Make sure persistent changes that re-enable LDAP are
   always committed. [lgraf]
 - Meeting: add new "Proposal Template" FTI. [jone]

--- a/opengever/document/profiles/default/actions.xml
+++ b/opengever/document/profiles/default/actions.xml
@@ -14,6 +14,18 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="attach_documents" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Attach selection</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:javascript:officeConnectorMultiAttach('$portal_url/officeconnector_attach_url');</property>
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="checkout" meta_type="CMF Action" i18n:domain="opengever.document">
       <property name="title" i18n:translate="">Checkout</property>
       <property name="description" i18n:translate="" />
@@ -90,18 +102,6 @@
       <property name="title" i18n:translate="">Export selection</property>
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:@@document_report:method</property>
-      <property name="icon_expr" />
-      <property name="available_expr" />
-      <property name="permissions">
-        <element value="View" />
-      </property>
-      <property name="visible">True</property>
-    </object>
-
-    <object name="attach_documents" meta_type="CMF Action" i18n:domain="opengever.document">
-      <property name="title" i18n:translate="">Attach selection</property>
-      <property name="description" i18n:translate="" />
-      <property name="url_expr">string:javascript:officeConnectorMultiAttach('$portal_url/officeconnector_attach_url');</property>
       <property name="icon_expr" />
       <property name="available_expr" />
       <property name="permissions">

--- a/opengever/document/upgrades/20170424163920_adjust_sort_order_of_actions/actions.xml
+++ b/opengever/document/upgrades/20170424163920_adjust_sort_order_of_actions/actions.xml
@@ -1,0 +1,19 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+  <object name="folder_buttons" meta_type="CMF Action Category">
+
+    <object name="attach_documents" remove="True"></object>
+
+    <object name="attach_documents" meta_type="CMF Action" i18n:domain="opengever.document" insert-after="send_as_email">
+      <property name="title" i18n:translate="">Attach selection</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:javascript:officeConnectorMultiAttach('$portal_url/officeconnector_attach_url');</property>
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+</object>

--- a/opengever/document/upgrades/20170424163920_adjust_sort_order_of_actions/upgrade.py
+++ b/opengever/document/upgrades/20170424163920_adjust_sort_order_of_actions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AdjustSortOrderOfActions(UpgradeStep):
+    """Adjust sort order of actions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/officeconnector/tests/test_templates.py
+++ b/opengever/officeconnector/tests/test_templates.py
@@ -217,12 +217,12 @@ class TestOCTemplatesDossierOpenWithoutFile(FunctionalTestCase):
         self.assertEqual(['Create Task',
                           u'More actions \u25bc',
                           'Copy Items',
+                          'Attach selection',
                           'Checkout',
                           'Cancel',
                           'Checkin with comment',
                           'Checkin without comment',
                           'Export selection',
-                          'Attach selection',
                           'Move Items',
                           'trashed',
                           'Export as Zip'],
@@ -272,12 +272,12 @@ class TestOCTemplatesDossierOpenWithoutFile(FunctionalTestCase):
         self.assertEqual(['Create Task',
                           u'More actions \u25bc',
                           'Copy Items',
+                          'Attach selection',
                           'Checkout',
                           'Cancel',
                           'Checkin with comment',
                           'Checkin without comment',
                           'Export selection',
-                          'Attach selection',
                           'Move Items',
                           'trashed',
                           'Export as Zip'],
@@ -482,8 +482,8 @@ class TestOCTemplatesDossierInactiveWithoutFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -525,8 +525,8 @@ class TestOCTemplatesDossierInactiveWithoutFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -730,8 +730,8 @@ class TestOCTemplatesDossierResolvedWithoutFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -773,8 +773,8 @@ class TestOCTemplatesDossierResolvedWithoutFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -1186,12 +1186,12 @@ class TestOCTemplatesDossierOpenWithFile(FunctionalTestCase):
         self.assertEqual(['Create Task',
                           u'More actions \u25bc',
                           'Copy Items',
+                          'Attach selection',
                           'Checkout',
                           'Cancel',
                           'Checkin with comment',
                           'Checkin without comment',
                           'Export selection',
-                          'Attach selection',
                           'Move Items',
                           'trashed',
                           'Export as Zip'],
@@ -1241,12 +1241,12 @@ class TestOCTemplatesDossierOpenWithFile(FunctionalTestCase):
         self.assertEqual(['Create Task',
                           u'More actions \u25bc',
                           'Copy Items',
+                          'Attach selection',
                           'Checkout',
                           'Cancel',
                           'Checkin with comment',
                           'Checkin without comment',
                           'Export selection',
-                          'Attach selection',
                           'Move Items',
                           'trashed',
                           'Export as Zip'],
@@ -1596,8 +1596,8 @@ class TestOCTemplatesDossierInactiveWithFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -1639,8 +1639,8 @@ class TestOCTemplatesDossierInactiveWithFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -1918,8 +1918,8 @@ class TestOCTemplatesDossierResolvedWithFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)
@@ -1961,8 +1961,8 @@ class TestOCTemplatesDossierResolvedWithFile(FunctionalTestCase):
 
         self.assertEqual([u'More actions \u25bc',
                           'Copy Items',
-                          'Export selection',
                           'Attach selection',
+                          'Export selection',
                           'Move Items',
                           'Export as Zip'],
                          browser.css('.tabbedview-action-list a').text)


### PR DESCRIPTION
Before:
<img width="380" alt="972c569e-25de-11e7-8661-11e07b63cb72" src="https://cloud.githubusercontent.com/assets/557005/25343442/5c82759e-290f-11e7-9cd9-b58d2c65237a.png">

After:
![bildschirmfoto 2017-04-24 um 16 53 53](https://cloud.githubusercontent.com/assets/557005/25343407/40090ed2-290f-11e7-9687-888379bb6207.png)

closes #2864 