### PR TITLE
Dossierdetails PDF: Fix indentation of dossier metadata table.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]
 - OGGBundle import: Make sure persistent changes that re-enable LDAP are
   always committed. [lgraf]
 - Meeting: add new "Proposal Template" FTI. [jone]

--- a/opengever/latex/layouts/default.py
+++ b/opengever/latex/layouts/default.py
@@ -30,6 +30,7 @@ class DefaultLayout(CustomizableLayout, grok.MultiAdapter):
         self.use_package('ae,aecompl')
         self.use_package('babel', 'ngerman', append_options=False)
         self.use_package('fancyhdr')
+        self.use_package('calc')
 
         self.use_package_geometry()
 

--- a/opengever/latex/templates/dossierdetails.tex
+++ b/opengever/latex/templates/dossierdetails.tex
@@ -10,10 +10,12 @@
 \small
 \noindent
 
-\begin{supertabular*}{150mm}{lp{130mm}}
+\setlength\tabcolsep{0pt}
+
+\begin{tabular}{p{40mm}p{\linewidth-40mm}}
 \shrinkheight{60mm}
 ${dossier_metadata} \\ \hline
-\end{supertabular*}
+\end{tabular}
 
 \begin{landscape}
   \setlength\extrarowheight{1pt}

--- a/opengever/latex/tests/test_default_layout.py
+++ b/opengever/latex/tests/test_default_layout.py
@@ -65,6 +65,7 @@ class TestDefaultLayout(MockTestCase):
                 r'\usepackage{ae,aecompl}',
                 r'\usepackage[ngerman]{babel}',
                 r'\usepackage{fancyhdr}',
+                r'\usepackage{calc}',
                 r'\usepackage[left=35mm, right=10mm, top=55mm, ' + \
                     r'bottom=10.5mm]{geometry}',
                 r'\usepackage{graphicx}',


### PR DESCRIPTION
Dossierdetails PDF: Fix indentation of dossier metadata table (make it left aligned with heading and the rest of the document).

---

![dossierdetails_indent](https://cloud.githubusercontent.com/assets/405124/25372836/66c97592-2997-11e7-9ef5-c41482126478.png)

---

[dossierdetails_before.pdf](https://github.com/4teamwork/opengever.core/files/954146/dossierdetails_before.pdf)

[dossierdetails_after.pdf](https://github.com/4teamwork/opengever.core/files/954147/dossierdetails_after.pdf)
