### PR TITLE
testing builders: make reindexing more efficient.

### DIFF
--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -110,7 +110,7 @@ class DocumentBuilder(DexterityBuilder):
     def after_create(self, obj):
         if self._checked_out:
             IAnnotations(obj)[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = self._checked_out
-            obj.reindexObject()
+            obj.reindexObject(idxs=['checked_out'])
 
         if self._trashed:
             trasher = ITrashable(obj)


### PR DESCRIPTION
When the checked out state of a document is switched, the checked_out index must be updated.
But it is not necessary to update all indexes.