### PR TITLE
Fixed attaching mails via document listing to oc.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - OGGBundle import: Make sure persistent changes that re-enable LDAP are
   always committed. [lgraf]
+- Handle oc-attaching of mails. [phgross]
 - Meeting: add new "Proposal Template" FTI. [jone]
 - OGGBundle import: Don't use a separate ZODB connection to issue sequence
   numbers in order to avoid conflict errors. [lgraf]

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -22,7 +22,7 @@
 
   <plone:service
       method="GET"
-      for="opengever.document.document.IDocumentSchema"
+      for="opengever.document.behaviors.IBaseDocument"
       accept="application/json"
       factory=".service.OfficeConnectorAttachURL"
       name="officeconnector_attach_url"
@@ -37,7 +37,6 @@
       name="officeconnector_attach_url"
       permission="zope2.View"
       />
-
 
   <plone:service
       method="GET"

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -1,4 +1,4 @@
-from opengever.document.document import IDocumentSchema
+from opengever.document.behaviors import IBaseDocument
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from plone import api
 from Products.CMFCore.utils import getToolByName
@@ -24,10 +24,10 @@ def parse_documents(request, context):
 
     if request['REQUEST_METHOD'] == 'GET':
         # Feature enabled for the wrong content type
-        if not IDocumentSchema.providedBy(context):
+        if not IBaseDocument.providedBy(context):
             raise NotFound
 
-        if not context.file:
+        if not context.has_file():
             raise NotFound
 
         documents.append(context)

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -37,7 +37,7 @@ def parse_documents(request, context):
         for path in paths:
             # Restricted traversal does not handle unicode paths
             document = api.content.get(path=str(path))
-            if document.file:
+            if document.has_file():
                 documents.append(document)
 
     return documents

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -88,11 +88,12 @@ class OfficeConnectorPayload(Service):
         # Do not 404 if we do not have a normal user
         if api.user.is_anonymous():
             raise Forbidden
+
         self.document = api.content.get(UID=self.uuid)
-        if not self.document or not self.document.file:
+        if not self.document or not self.document.has_file():
             raise NotFound
         return {
-            'content-type': self.document.file.contentType,
+            'content-type': self.document.get_file().contentType,
             'csrf-token': createToken(),
             'document-url': self.document.absolute_url(),
             'download': 'download',

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -69,6 +69,11 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
                                             .attach_file_containing(
                                                 self.original_file_content))
 
+        self.mail_with_file_wf_open = create(Builder('mail')
+                                            .titled(u'Mail 2')
+                                            .within(self.open_dossier)
+                                            .with_dummy_message())
+
         self.doc_with_file_wf_open_second = create(Builder('document')
                                                    .titled(u'docu-3')
                                                    .within(self.open_dossier)
@@ -337,7 +342,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
             self.open_dossier, view='tabbedview_view-documents')
 
         document_checkboxes = browser.css("input[type='checkbox']")
-        self.assertEquals(3, len(document_checkboxes))
+        self.assertEquals(4, len(document_checkboxes))
 
         document_paths = []
         for checkbox in document_checkboxes:
@@ -355,7 +360,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
 
         payload = jwt.decode(token['url'].split(':')[-1], verify=False)
 
-        self.assertEquals(2, len(payload['documents']))
+        self.assertEquals(3, len(payload['documents']))
 
         for document in payload['documents']:
             # Test we can actually fetch an action payload based on the URL JWT


### PR DESCRIPTION
Currently attaching mails failed because the attach functionality directly accessed the file with `document.file` but the mail file attribute is named `message`. To solve this issues I consequently used the `get_file`, `has_file` methods  from the `BaseDocumentMixin` and register the services for the IBaseDocument interface.