### PR TITLE
Tests: Add debugging output to debug flaky tests on Jenkins.

### DIFF
--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -20,6 +20,23 @@ class TestOverview(FunctionalTestCase):
         mail = create(Builder("mail").with_message(MAIL_DATA))
         browser.login().visit(mail, view='tabbedview_view-overview')
 
+        view = mail.restrictedTraverse('tabbedview_view-overview')
+        if not view.is_preview_supported():
+            # Unexpected preconditions, print debug output for CI tests
+            print "view.is_preview_supported() is unexpectedly False!"
+
+            from opengever.base.pdfconverter import is_pdfconverter_enabled
+            print "is_pdfconverter_enabled(): %r" % is_pdfconverter_enabled()
+
+            import pkg_resources
+            dist = pkg_resources.get_distribution('opengever.pdfconverter')
+            print("pkg_resources.get_distribution"
+                  "('opengever.pdfconverter'): %r" % dist)
+
+            from opengever.bumblebee import is_bumblebee_feature_enabled
+            print ("is_bumblebee_feature_enabled(): "
+                   "%r" % is_bumblebee_feature_enabled())
+
         expect = [['Document Date', date_format_helper(get_header_date(mail))],
                   ['Document Type', ''],
                   ['Author', get_author_by_email(mail)],


### PR DESCRIPTION
If preconditions for the `test_mail_overview_tab` test are different than what we expect them to be, we print this debugging output which should end up in the Jenkins build log:

```
view.is_preview_supported() is unexpectedly False!
is_pdfconverter_enabled(): True
pkg_resources.get_distribution('opengever.pdfconverter'): opengever.pdfconverter 1.5.0 (/Users/lukasgraf/Plone/eggs/opengever.pdfconverter-1.5.0-py2.7.egg)
is_bumblebee_feature_enabled(): False
```