### PR TITLE
submitted proposal edit form: fix wrong class.

### DIFF
--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -38,7 +38,7 @@ class SubmittedProposalEditForm(ModelProxyEditForm, dexterity.EditForm):
 
     grok.context(ISubmittedProposal)
     fields = field.Fields(SubmittedProposal.model_schema, ignoreContext=True)
-    content_type = Proposal
+    content_type = SubmittedProposal
 
     fields['legal_basis'].widgetFactory = TrixFieldWidget
     fields['initial_position'].widgetFactory = TrixFieldWidget


### PR DESCRIPTION
I believe the submited propsal edit form should have the content type class `SubmittedProposal`, not `Proposal`.
⚠️ I have no idea if this is on purpose or by accident, nor can I asses the impact of this ching. It just struck me as odd.