### PR TITLE
Add trash-tab in template folder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -24,6 +24,7 @@ Changelog
   [lgraf]
 
 - Fix manipulating the tag config of the keywordwidget in the dossier template form. [mathias.leimgruber]
+- Add missing trash-tab in template folder. [elioschmutz]
 - Meeting: add proposal template tab to templates folder. [jone]
 - Support simple css colornames in the colorization viewlet. [phgross]
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -92,6 +92,11 @@ class TemplateFolderTabbedView(GeverTabbedView):
                    default=u'Tasktemplate Folders'),
         }
 
+    trash_tab = {
+        'id': 'trash',
+        'title': _(u'label_trash', default=u'Trash'),
+        }
+
     @property
     def sablon_tab(self):
         if is_meeting_feature_enabled():
@@ -126,6 +131,7 @@ class TemplateFolderTabbedView(GeverTabbedView):
             self.sablon_tab,
             self.proposal_templates_tab,
             self.tasktemplate_folders_tab,
+            self.trash_tab,
         ])
 
 


### PR DESCRIPTION
This PR adds the missing trash-tab in the template-folder:

![bildschirmfoto 2017-04-27 um 10 34 08](https://cloud.githubusercontent.com/assets/557005/25474876/12012c68-2b35-11e7-8217-4648e7ae0b1d.png)

closes #2881 
