### PR TITLE
Reworked portlet initialization when setting up GEVER

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 
   [lgraf]
 
+- Reworked portlet initialization during setup. [phgross]
 - Meeting: add proposal template tab to templates folder. [jone]
 - Support simple css colornames in the colorization viewlet. [phgross]
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -10,11 +10,6 @@ from opengever.examplecontent.contacts import ExampleContactCreator
 from opengever.private import enable_opengever_private
 from opengever.testing import builders  # keep!
 from plone import api
-from plone.portlets.constants import CONTEXT_CATEGORY
-from plone.portlets.interfaces import ILocalPortletAssignmentManager
-from plone.portlets.interfaces import IPortletManager
-from zope.component import getMultiAdapter
-from zope.component import getUtility
 import pytz
 
 PROPOSED_ACTION_1 = u'''Der Rat stellt der Versammlung den Antrag, der Anstellung von Hans Baumann als Sachbearbeiter mit einem Bescha\u0308ftigungsgrad von 90%, Amtsantritt 01.05.2015, zuzustimmen.'''

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -8,7 +8,6 @@ from ftw.builder import session
 from opengever.base.model import create_session
 from opengever.examplecontent.contacts import ExampleContactCreator
 from opengever.private import enable_opengever_private
-from opengever.setup.hooks import block_context_portlets
 from opengever.testing import builders  # keep!
 from plone import api
 from plone.portlets.constants import CONTEXT_CATEGORY
@@ -206,10 +205,6 @@ class MeetingExampleContentCreator(object):
         self.meeting.schedule_proposal(proposal4.load_model())
 
 
-def block_portlets_for_meetings(site):
-    block_context_portlets(site, 'sitzungen')
-
-
 def municipality_content_profile_installed(site):
     creator = MeetingExampleContentCreator(site)
     creator.create_content()
@@ -217,5 +212,4 @@ def municipality_content_profile_installed(site):
     creator = ExampleContactCreator()
     creator.create()
 
-    block_portlets_for_meetings(site)
     enable_opengever_private()

--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
@@ -8,7 +8,13 @@
         "excerpt_template": "resolvePath::/vorlagen/sablon-template-2",
         "agendaitem_list_template": "resolvePath::/vorlagen/sablon-template-3",
         "toc_template": "resolvePath::/vorlagen/sablon-template-4",
-
+        "_portlets": {
+          "plone.leftcolumn": {
+            "blacklist_status": {
+              "context": "block"
+            }
+          }
+        },
         "_children": [
             {
                 "_id": "committee-1",

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/hooks.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/hooks.py.bob
@@ -1,19 +1,7 @@
-from opengever.setup.hooks import assign_default_navigation_portlet
 {{% if setup.enable_private_folder %}}
 from opengever.private import enable_opengever_private
-{{% endif %}}
-{{% if setup.enable_meeting_feature %}}
-from opengever.setup.hooks import block_context_portlets
-{{% endif %}}
 
 
 def default_content_installed(site):
-    assign_default_navigation_portlet(site, 'eingangskorb')
-    assign_default_navigation_portlet(site, 'vorlagen')
-    assign_default_navigation_portlet(site, 'kontakte')
-{{% if setup.enable_meeting_feature %}}
-    block_context_portlets(site, 'sitzungen')
-{{% endif %}}
-{{% if setup.enable_private_folder %}}
     enable_opengever_private()
 {{% endif %}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/01-initial-structure.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/01-initial-structure.json.bob
@@ -10,6 +10,21 @@
             "Editor",
             "Contributor"
           ]
+        },
+        "_portlets": {
+          "plone.leftcolumn": {
+            "blacklist_status": {
+              "context": "block"
+            },
+            "assignments": [
+              {"id": "navigation",
+               "portlet_type": "portlets.Navigation",
+               "bottomLevel": 0,
+               "currentFolderOnly": false,
+               "includeTop": false,
+               "topLevel": 1}
+            ]
+          }
         }
     },
     {
@@ -25,6 +40,21 @@
                 "Editor",
                 "Reader"
             ]
+        },
+        "_portlets": {
+          "plone.leftcolumn": {
+            "blacklist_status": {
+              "context": "block"
+            },
+            "assignments": [
+              {"id": "navigation",
+               "portlet_type": "portlets.Navigation",
+               "bottomLevel": 0,
+               "currentFolderOnly": false,
+               "includeTop": false,
+               "topLevel": 1}
+            ]
+          }
         }
     },
     {
@@ -41,6 +71,22 @@
                 "Editor",
                 "Reader"
             ]
+        },
+      "_portlets": {
+        "plone.leftcolumn": {
+          "blacklist_status": {
+            "context": "block"
+          },
+          "assignments": [
+            {"id": "navigation",
+             "portlet_type": "portlets.Navigation",
+             "bottomLevel": 0,
+             "currentFolderOnly": false,
+             "includeTop": false,
+             "topLevel": 1}
+          ]
         }
+      }
+        
     }
 ]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/03_committees.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/03_committees.json.bob
@@ -11,6 +11,13 @@
                 "Editor",
                 "Reader"
             ]
+        },
+        "_portlets": {
+          "plone.leftcolumn": {
+            "blacklist_status": {
+              "context": "block"
+            }
+          }
         }
     }
 ]

--- a/opengever/setup/cfgs/gever_content.cfg
+++ b/opengever/setup/cfgs/gever_content.cfg
@@ -19,6 +19,7 @@ pipeline =
     workflowupdater
     placefulworkflowupdater
     propertiesupdater
+    portlets
     modelconstructor
     local_roles
     block_local_roles

--- a/opengever/setup/hooks.py
+++ b/opengever/setup/hooks.py
@@ -14,11 +14,6 @@ def default_installed(site):
     disable_site_syndication(site)
 
 
-def default_content_installed(site):
-    assign_default_navigation_portlet(site, 'eingangskorb')
-    assign_default_navigation_portlet(site, 'vorlagen')
-
-
 def set_global_roles(site):
     assign_roles(site, ['og_administratoren'])
 

--- a/opengever/setup/hooks.py
+++ b/opengever/setup/hooks.py
@@ -17,7 +17,6 @@ def default_installed(site):
 def default_content_installed(site):
     assign_default_navigation_portlet(site, 'eingangskorb')
     assign_default_navigation_portlet(site, 'vorlagen')
-    assign_default_navigation_portlet(site, 'kontakte')
 
 
 def set_global_roles(site):

--- a/opengever/setup/hooks.py
+++ b/opengever/setup/hooks.py
@@ -1,4 +1,3 @@
-from opengever.private import MEMBERSFOLDER_ID
 from plone.app.portlets.portlets import navigation
 from plone.portlets.constants import CONTEXT_CATEGORY
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
@@ -19,7 +18,6 @@ def default_content_installed(site):
     assign_default_navigation_portlet(site, 'eingangskorb')
     assign_default_navigation_portlet(site, 'vorlagen')
     assign_default_navigation_portlet(site, 'kontakte')
-    block_context_portlets(site, MEMBERSFOLDER_ID)
 
 
 def set_global_roles(site):

--- a/opengever/setup/profiles.zcml
+++ b/opengever/setup/profiles.zcml
@@ -29,11 +29,6 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
-  <profilehook:hook
-      profile="opengever.setup:default_content"
-      handler=".hooks.default_content_installed"
-      />
-
   <genericsetup:registerProfile
       name="casauth"
       title="opengever.setup: casauth"

--- a/opengever/setup/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/setup/profiles/default_content/content_creation/01_default_content.json
@@ -3,7 +3,14 @@
         "_path": "private",
         "_type": "opengever.private.root",
         "title_de": "Meine Ablage",
-        "title_fr": "Mon depot"
+        "title_fr": "Mon depot",
+        "_portlets": {
+            "plone.leftcolumn": {
+              "blacklist_status": {
+                "context": "block"
+              }
+            }
+        }
     },
     {
         "_path": "eingangskorb",

--- a/opengever/setup/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/setup/profiles/default_content/content_creation/01_default_content.json
@@ -17,14 +17,45 @@
         "_type": "opengever.inbox.inbox",
         "title_de": "Eingangskorb",
         "title_fr": "Boîte de réception",
-        "inbox_group": "og_mandant1_eingangskorb"
+        "inbox_group": "og_mandant1_eingangskorb",
+        "_portlets": {
+          "plone.leftcolumn": {
+            "blacklist_status": {
+              "context": "block"
+            },
+            "assignments": [
+              {"id": "navigation",
+               "portlet_type": "portlets.Navigation",
+               "bottomLevel": 0,
+               "currentFolderOnly": false,
+               "includeTop": false,
+               "topLevel": 1}
+            ]
+          }
+        }
+
     },
     {
         "_path": "vorlagen",
         "_type": "opengever.dossier.templatefolder",
         "title_de": "Vorlagen",
         "title_fr": "Modèles",
-        "responsible": "ogadmin"
+        "responsible": "ogadmin",
+        "_portlets": {
+          "plone.leftcolumn": {
+            "blacklist_status": {
+              "context": "block"
+            },
+            "assignments": [
+              {"id": "navigation",
+               "portlet_type": "portlets.Navigation",
+               "bottomLevel": 0,
+               "currentFolderOnly": false,
+               "includeTop": false,
+               "topLevel": 1}
+            ]
+          }
+        }
     },
     {
         "_path": "kontakte",

--- a/opengever/setup/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/setup/profiles/default_content/content_creation/01_default_content.json
@@ -31,6 +31,21 @@
         "_type": "opengever.contact.contactfolder",
         "title_de": "Kontakte",
         "title_fr": "Contacts",
-        "_transitions": "publish"
+      "_transitions": "publish",
+      "_portlets": {
+        "plone.leftcolumn": {
+          "blacklist_status": {
+            "context": "block"
+          },
+          "assignments": [
+            {"id": "navigation",
+             "portlet_type": "portlets.Navigation",
+             "bottomLevel": 0,
+             "currentFolderOnly": false,
+             "includeTop": false,
+             "topLevel": 1}
+          ]
+        }
+      }
     }
 ]

--- a/sources.cfg
+++ b/sources.cfg
@@ -6,7 +6,7 @@ development-packages =
   opengever.maintenance
   plonetheme.teamraum
   collective.js.timeago
-  plonetheme.teamraum
+  ftw.inflator
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
With the newly introduced `PortletUpdater` in ftw.inflator (https://github.com/4teamwork/ftw.inflator/pull/33), it's now possible to define portlet assignments in the content json files. I replaced the current implementation hook and moved the portlet definitions to the content json files.

Closes #1214 