### PR TITLE
Fix some common i18n issues

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,15 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Fix some common i18n issues:
+
+  - Homogenize full stops at the end of sentences.
+  - Remove trailing spaces
+  - Remove trailing colons appearing only in source or translation
+  - Homogenize use of punctuation marks in french translations (no space before colon / question marks)
+
+  [lgraf]
+
 - Meeting: add proposal template tab to templates folder. [jone]
 - Support simple css colornames in the colorization viewlet. [phgross]
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -33,7 +33,7 @@ msgstr "Pas de contenu"
 
 #: ./opengever/base/viewlets/download.py:22
 msgid "No file in in this version"
-msgstr "Pas de fichier pour cette version "
+msgstr "Pas de fichier pour cette version"
 
 #: ./opengever/base/profiles/default/actions.xml
 msgid "Properties"
@@ -46,7 +46,7 @@ msgstr "Sauvegarder"
 
 #: ./opengever/base/browser/list_groupmembers.pt:14
 msgid "There are no members in this group."
-msgstr "Ce groupe n'a aucun utilisateur"
+msgstr "Ce groupe n'a aucun utilisateur."
 
 #: ./opengever/base/browser/list_groupmembers.pt:3
 msgid "Users of group:"
@@ -113,7 +113,7 @@ msgstr "Valeur archivistique"
 
 #: ./opengever/base/behaviors/classification.py:72
 msgid "help_classification"
-msgstr "Classification permettant la protection des documents contre la consultation non-autorisée "
+msgstr "Classification permettant la protection des documents contre la consultation non-autorisée"
 
 #: ./opengever/base/behaviors/lifecycle.py:74
 msgid "help_custody_period"
@@ -355,7 +355,7 @@ msgstr "Public"
 #. Default: "Did you not find what you were looking for? Try the ${advanced_search} to refine your search."
 #: ./opengever/base/browser/search.pt:63
 msgid "search_results_advanced"
-msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search} vous offre des possibilités de recherche précises"
+msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search} vous offre des possibilités de recherche précises."
 
 #. Default: "Advanced Search"
 #: ./opengever/base/browser/search.pt:64

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -48,34 +48,34 @@ msgid "Delegate task"
 msgstr "Déléguer"
 
 msgid "Document state changed to document-state-checked_out"
-msgstr "Etat du document modifié : checkout"
+msgstr "Etat du document modifié: checkout"
 
 msgid "Document state changed to document-state-draft"
-msgstr "Etat du document modifié : ouvert"
+msgstr "Etat du document modifié: ouvert"
 
 msgid "Document state changed to document-state-pending"
-msgstr "Etat du document modifié : en suspend"
+msgstr "Etat du document modifié: en suspend"
 
 msgid "Document state changed to document-state-reject"
-msgstr "Etat du document modifié : rejeté"
+msgstr "Etat du document modifié: rejeté"
 
 msgid "Document state changed to document-state-working_copy"
-msgstr "Etat du document modifié : copie de travail"
+msgstr "Etat du document modifié: copie de travail"
 
 msgid "Dossier state changed to dossier-state-active"
-msgstr "Etat du dossier modifié : En cours de traitement"
+msgstr "Etat du dossier modifié: En cours de traitement"
 
 msgid "Dossier state changed to dossier-state-archived"
-msgstr "Etat du dossier modifié : Archivé"
+msgstr "Etat du dossier modifié: Archivé"
 
 msgid "Dossier state changed to dossier-state-inactive"
-msgstr "Etat du dossier modifié : Annulé"
+msgstr "Etat du dossier modifié: Annulé"
 
 msgid "Dossier state changed to dossier-state-offered"
 msgstr ""
 
 msgid "Dossier state changed to dossier-state-resolved"
-msgstr "Etat du dossier modifié : Fermé"
+msgstr "Etat du dossier modifié: Fermé"
 
 msgid "Dossier with template"
 msgstr ""

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -461,10 +461,10 @@ msgstr "Für diesen Kontakt existiert bereits eine Beteiligung."
 msgid "personal"
 msgstr "Persönliche Angaben"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/contact/no_selection_amount.pt:3
 msgid "tab_matches"
-msgstr "${amount} Treffer."
+msgstr "${amount} Treffer"
 
 #. Default: "Telefon"
 #: ./opengever/contact/contact.py:44

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -463,7 +463,7 @@ msgstr ""
 msgid "personal"
 msgstr "Coordonnées"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/contact/no_selection_amount.pt:3
 msgid "tab_matches"
 msgstr "Résultat(s): ${amount}"

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -464,7 +464,7 @@ msgstr ""
 msgid "personal"
 msgstr ""
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/contact/no_selection_amount.pt:3
 msgid "tab_matches"
 msgstr ""

--- a/opengever/contact/no_selection_amount.pt
+++ b/opengever/contact/no_selection_amount.pt
@@ -1,4 +1,4 @@
 <div i18n:domain="opengever.contact"
      i18n:translate="tab_matches">
-    <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
+    <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches
 </div>

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -37,7 +37,7 @@ class DocumentishDownload(Download):
             named_file = self._getFile()
         except NotFound:
             msg = _(
-                u'The Document ${title} has no File',
+                u'The Document ${title} has no File.',
                 mapping={'title': self.context.Title().decode('utf-8')})
             api.portal.show_message(msg, self.request, type='error')
             return self.request.RESPONSE.redirect(
@@ -74,7 +74,7 @@ class DownloadConfirmation(BrowserView):
         return self.context.file is not None
 
     def msg_no_file_available(self):
-        return _(u'The Document ${title} has no File',
+        return _(u'The Document ${title} has no File.',
                  mapping={'title': self.context.Title().decode('utf-8')})
 
 

--- a/opengever/document/browser/edit.py
+++ b/opengever/document/browser/edit.py
@@ -57,7 +57,7 @@ class EditCheckerView(grok.View):
                 '%s/edit' % (self.context.absolute_url()))
         else:
             msg = _(
-                u'You are not authorized to edit the document ${title}',
+                u'You are not authorized to edit the document ${title}.',
                 mapping={'title': self.context.Title().decode('utf-8')})
 
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
@@ -79,7 +79,7 @@ class EditingDocument(grok.View):
         # have the document a file
         if not self.context.file:
             msg = _(
-                u'The Document ${title} has no File',
+                u'The Document ${title} has no File.',
                 mapping={'title': self.context.Title().decode('utf-8')})
 
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
@@ -110,7 +110,7 @@ class EditingDocument(grok.View):
                     get_redirect_url(self.context))
 
         elif manager.get_checked_out_by() is not None:
-            msg = _(u"The Document is allready checked out by: ${userid}",
+            msg = _(u"The Document is already checked out by: ${userid}",
                     mapping={'userid':
                              Actor.lookup(manager.get_checked_out_by()).get_label()})
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
@@ -119,7 +119,7 @@ class EditingDocument(grok.View):
 
         elif not manager.is_checkout_allowed():
             msg = _(
-                u'Could not check out document ${title}',
+                u'Could not check out document ${title}.',
                 mapping={'title': self.context.Title().decode('utf-8')})
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
             return self.request.RESPONSE.redirect(

--- a/opengever/document/checkout/cancel.py
+++ b/opengever/document/checkout/cancel.py
@@ -25,7 +25,7 @@ class CancelDocuments(grok.View):
 
         # using "paths" is mandantory on any objects except for a document
         if not paths and not IDocumentSchema.providedBy(self.context):
-            msg = _(u'You have not selected any documents')
+            msg = _(u'You have not selected any documents.')
             api.portal.show_message(
                 message=msg, request=self.request, type='error')
 
@@ -78,7 +78,7 @@ class CancelDocuments(grok.View):
 
         # is cancel allowed for this document?
         if not manager.is_cancel_allowed():
-            msg = _(u'Could not cancel checkout on document ${title}',
+            msg = _(u'Could not cancel checkout on document ${title}.',
                     mapping=dict(title=obj.Title().decode('utf-8')))
             api.portal.show_message(
                 message=msg, request=self.request, type='error')

--- a/opengever/document/checkout/checkin.py
+++ b/opengever/document/checkout/checkin.py
@@ -194,7 +194,7 @@ class CheckinDocuments(layout.FormWrapper, grok.View):
         try:
             return layout.FormWrapper.__call__(self, *args, **kwargs)
         except NoItemsSelected:
-            msg = _(u'You have not selected any documents')
+            msg = _(u'You have not selected any documents.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 
@@ -230,7 +230,7 @@ class CheckinDocumentsWithoutComment(CheckinDocumentWithoutComment):
         try:
             self.checkin_controller.checkin_documents(self.request.get('paths'))
         except NoItemsSelected:
-            msg = _(u'You have not selected any documents')
+            msg = _(u'You have not selected any documents.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 

--- a/opengever/document/checkout/checkout.py
+++ b/opengever/document/checkout/checkout.py
@@ -31,7 +31,7 @@ class CheckoutDocuments(grok.View):
 
         # using "paths" is mandantory on any objects except for a document
         if not paths and not IDocumentSchema.providedBy(self.context):
-            msg = _(u'You have not selected any documents')
+            msg = _(u'You have not selected any documents.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 
@@ -59,7 +59,7 @@ class CheckoutDocuments(grok.View):
                 # notify the user. we have a no-checkoutable object
                 msg = _(
                     u'Could not check out object: ${title}, '
-                    'it is not a document',
+                    'it is not a document.',
                     mapping={'title': obj.Title().decode('utf-8')})
                 IStatusMessage(
                     self.request).addStatusMessage(msg, type='error')
@@ -99,7 +99,7 @@ class CheckoutDocuments(grok.View):
 
         # is checkout allowed for this document?
         if not manager.is_checkout_allowed():
-            msg = _(u'Could not check out document ${title}',
+            msg = _(u'Could not check out document ${title}.',
                     mapping={'title': obj.Title().decode('utf-8')})
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
 

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -285,7 +285,7 @@ class CheckinCheckoutManager(grok.MultiAdapter):
 
         if create_version:
             # let's create a version
-            msg = _(u'Reverted file to version ${version_id}',
+            msg = _(u'Reverted file to version ${version_id}.',
                     mapping=dict(version_id=version_id))
             comment = translate(msg, context=self.request)
             self.repository.save(obj=self.context, comment=comment)

--- a/opengever/document/checkout/revert.py
+++ b/opengever/document/checkout/revert.py
@@ -23,7 +23,7 @@ class RevertFileToVersion(grok.View):
         manager.revert_to_version(version_id)
 
         # create a status message
-        msg = _(u'Reverted file to version ${version_id}',
+        msg = _(u'Reverted file to version ${version_id}.',
                 mapping=dict(version_id=version_id))
         IStatusMessage(self.request).addStatusMessage(msg, type='info')
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -60,7 +60,7 @@ msgid "Checkout"
 msgstr "Auschecken"
 
 #: ./opengever/document/checkout/cancel.py:81
-msgid "Could not cancel checkout on document ${title}"
+msgid "Could not cancel checkout on document ${title}."
 msgstr "Das Auschecken des Dokuments ${title} konnte nicht widerrufen werden."
 
 #: ./opengever/document/checkout/checkin.py:73
@@ -73,11 +73,11 @@ msgstr "Konnte Dokument nicht einchecken: ${title}"
 
 #: ./opengever/document/browser/edit.py:121
 #: ./opengever/document/checkout/checkout.py:102
-msgid "Could not check out document ${title}"
+msgid "Could not check out document ${title}."
 msgstr "Es ist nicht erlaubt, das Dokument ${title} auszuchecken."
 
 #: ./opengever/document/checkout/checkout.py:60
-msgid "Could not check out object: ${title}, it is not a document"
+msgid "Could not check out object: ${title}, it is not a document."
 msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
 
 #: ./opengever/document/browser/report.py:81
@@ -111,7 +111,7 @@ msgstr "GEVER verlassen"
 
 #: ./opengever/document/checkout/manager.py:288
 #: ./opengever/document/checkout/revert.py:26
-msgid "Reverted file to version ${version_id}"
+msgid "Reverted file to version ${version_id}."
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
 
 #: ./opengever/document/forms.py:65
@@ -138,11 +138,11 @@ msgstr "Eingereicht bei"
 
 #: ./opengever/document/browser/download.py:39
 #: ./opengever/document/browser/edit.py:81
-msgid "The Document ${title} has no File"
+msgid "The Document ${title} has no File."
 msgstr "Das Dokument ${title} enthält keine Datei."
 
 #: ./opengever/document/browser/edit.py:113
-msgid "The Document is allready checked out by: ${userid}"
+msgid "The Document is already checked out by: ${userid}"
 msgstr "Das Dokument ist bereits von ${userid} ausgecheckt."
 
 #: ./opengever/document/browser/templates/submitted_with.pt:18
@@ -150,13 +150,13 @@ msgid "Update document in proposal"
 msgstr "Eingereichte Version aktualisieren"
 
 #: ./opengever/document/browser/edit.py:59
-msgid "You are not authorized to edit the document ${title}"
+msgid "You are not authorized to edit the document ${title}."
 msgstr "Sie sind nicht berechtigt, das Dokument ${title} zu bearbeiten."
 
 #: ./opengever/document/checkout/cancel.py:28
 #: ./opengever/document/checkout/checkin.py:197
 #: ./opengever/document/checkout/checkout.py:34
-msgid "You have not selected any documents"
+msgid "You have not selected any documents."
 msgstr "Sie haben keine Dokumente ausgewählt."
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
@@ -249,7 +249,7 @@ msgstr "Archivtaugliche Version der Originaldatei"
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
 #: ./opengever/document/behaviors/metadata.py:124
 msgid "help_author"
-msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachname Vorname aufgelöst)."
+msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachname Vorname aufgelöst)"
 
 #. Default: "Describe, why you checkin the selected documents"
 #: ./opengever/document/checkout/checkin.py:86
@@ -418,7 +418,7 @@ msgstr "Dokumenttyp"
 
 #: ./opengever/document/browser/report.py:51
 msgid "label_dossier_title"
-msgstr "Dossier Titel"
+msgstr "Dossier-Titel"
 
 #: ./opengever/document/browser/templates/downloadconfirmation.pt:25
 msgid "label_download"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -60,12 +60,12 @@ msgid "Checkout"
 msgstr "Checkout"
 
 #: ./opengever/document/checkout/cancel.py:81
-msgid "Could not cancel checkout on document ${title}"
-msgstr "Checkout du document ${title} inabouti"
+msgid "Could not cancel checkout on document ${title}."
+msgstr "Checkout du document ${title} inabouti."
 
 #: ./opengever/document/checkout/checkin.py:73
 msgid "Could not check in ${title}, it is not a document."
-msgstr "${title} n'est pas un document, par consequent checkin n'a pas abouti"
+msgstr "${title} n'est pas un document, par consequent checkin n'a pas abouti."
 
 #: ./opengever/document/checkout/checkin.py:55
 msgid "Could not check in document ${title}"
@@ -73,12 +73,12 @@ msgstr "Checkin de ${title} n'a pas abouti"
 
 #: ./opengever/document/browser/edit.py:121
 #: ./opengever/document/checkout/checkout.py:102
-msgid "Could not check out document ${title}"
-msgstr "Checkout de ${title} n'a pas abouti"
+msgid "Could not check out document ${title}."
+msgstr "Checkout de ${title} n'a pas abouti."
 
 #: ./opengever/document/checkout/checkout.py:60
-msgid "Could not check out object: ${title}, it is not a document"
-msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti"
+msgid "Could not check out object: ${title}, it is not a document."
+msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti."
 
 #: ./opengever/document/browser/report.py:81
 msgid "Could not generate the report"
@@ -111,8 +111,8 @@ msgstr "Quitter GEVER"
 
 #: ./opengever/document/checkout/manager.py:288
 #: ./opengever/document/checkout/revert.py:26
-msgid "Reverted file to version ${version_id}"
-msgstr "Retour à la version ${version_id}  du document"
+msgid "Reverted file to version ${version_id}."
+msgstr "Retour à la version ${version_id} du document."
 
 #: ./opengever/document/forms.py:65
 msgid "Save"
@@ -137,31 +137,31 @@ msgstr "Soumis par"
 
 #: ./opengever/document/browser/download.py:39
 #: ./opengever/document/browser/edit.py:81
-msgid "The Document ${title} has no File"
-msgstr "Le dodument  ${title} ne contient pas de fichier"
+msgid "The Document ${title} has no File."
+msgstr "Le dodument  ${title} ne contient pas de fichier."
 
 #: ./opengever/document/browser/edit.py:113
-msgid "The Document is allready checked out by: ${userid}"
-msgstr "Le document a déjà un checkout par  ${userid}"
+msgid "The Document is already checked out by: ${userid}"
+msgstr "Le document a déjà un checkout par ${userid}."
 
 #: ./opengever/document/browser/templates/submitted_with.pt:18
 msgid "Update document in proposal"
 msgstr "Actualiser la version soumise"
 
 #: ./opengever/document/browser/edit.py:59
-msgid "You are not authorized to edit the document ${title}"
-msgstr "Vous n'avez pas les droits de modifier le document ${title}"
+msgid "You are not authorized to edit the document ${title}."
+msgstr "Vous n'avez pas les droits de modifier le document ${title}."
 
 #: ./opengever/document/checkout/cancel.py:28
 #: ./opengever/document/checkout/checkin.py:197
 #: ./opengever/document/checkout/checkout.py:34
-msgid "You have not selected any documents"
+msgid "You have not selected any documents."
 msgstr "Vous n'avez  sélectionné aucun document"
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
 #: ./opengever/document/browser/templates/logout_overlay.pt:3
 msgid "alert_not_checked_in_documents"
-msgstr "Vous avez encore des documents en checkout! Voulez-vous quand même quitter Gever ?"
+msgstr "Vous avez encore des documents en checkout! Voulez-vous quand même quitter GEVER?"
 
 #. Default: "Cancel"
 #: ./opengever/document/checkout/checkin.py:112
@@ -238,7 +238,7 @@ msgstr "Remplacer par un nouveau fichier"
 #. Default: "Checkin Documents"
 #: ./opengever/document/checkout/checkin.py:97
 msgid "heading_checkin_comment_form"
-msgstr "Faire le checkin des documents."
+msgstr "Faire le checkin des documents"
 
 #: ./opengever/document/behaviors/metadata.py:148
 msgid "help_archival_file"
@@ -252,7 +252,7 @@ msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d
 #. Default: "Describe, why you checkin the selected documents"
 #: ./opengever/document/checkout/checkin.py:86
 msgid "help_checkin_journal_comment"
-msgstr "Modification(s) faite(s) dans le document ?"
+msgstr "Modification(s) faite(s) dans le document?"
 
 #: ./opengever/document/behaviors/metadata.py:109
 msgid "help_delivery_date"
@@ -544,7 +544,7 @@ msgstr "Oui"
 #. Default: "This item is being checked out by ${creator}."
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:9
 msgid "message_checkout_info"
-msgstr "Ce document a un checkout de ${creator}"
+msgstr "Ce document a un checkout de ${creator}."
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
 #: ./opengever/document/checkout/cancel.py:67

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -61,7 +61,7 @@ msgid "Checkout"
 msgstr ""
 
 #: ./opengever/document/checkout/cancel.py:81
-msgid "Could not cancel checkout on document ${title}"
+msgid "Could not cancel checkout on document ${title}."
 msgstr ""
 
 #: ./opengever/document/checkout/checkin.py:73
@@ -74,11 +74,11 @@ msgstr ""
 
 #: ./opengever/document/browser/edit.py:121
 #: ./opengever/document/checkout/checkout.py:102
-msgid "Could not check out document ${title}"
+msgid "Could not check out document ${title}."
 msgstr ""
 
 #: ./opengever/document/checkout/checkout.py:60
-msgid "Could not check out object: ${title}, it is not a document"
+msgid "Could not check out object: ${title}, it is not a document."
 msgstr ""
 
 #: ./opengever/document/browser/report.py:81
@@ -112,7 +112,7 @@ msgstr ""
 
 #: ./opengever/document/checkout/manager.py:288
 #: ./opengever/document/checkout/revert.py:26
-msgid "Reverted file to version ${version_id}"
+msgid "Reverted file to version ${version_id}."
 msgstr ""
 
 #: ./opengever/document/forms.py:65
@@ -138,11 +138,11 @@ msgstr ""
 
 #: ./opengever/document/browser/download.py:39
 #: ./opengever/document/browser/edit.py:81
-msgid "The Document ${title} has no File"
+msgid "The Document ${title} has no File."
 msgstr ""
 
 #: ./opengever/document/browser/edit.py:113
-msgid "The Document is allready checked out by: ${userid}"
+msgid "The Document is already checked out by: ${userid}"
 msgstr ""
 
 #: ./opengever/document/browser/templates/submitted_with.pt:18
@@ -150,13 +150,13 @@ msgid "Update document in proposal"
 msgstr ""
 
 #: ./opengever/document/browser/edit.py:59
-msgid "You are not authorized to edit the document ${title}"
+msgid "You are not authorized to edit the document ${title}."
 msgstr ""
 
 #: ./opengever/document/checkout/cancel.py:28
 #: ./opengever/document/checkout/checkin.py:197
 #: ./opengever/document/checkout/checkout.py:34
-msgid "You have not selected any documents"
+msgid "You have not selected any documents."
 msgstr ""
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"

--- a/opengever/document/tests/test_cancel.py
+++ b/opengever/document/tests/test_cancel.py
@@ -27,7 +27,7 @@ class TestCancelDocuments(FunctionalTestCase):
     @browsing
     def test_shows_message_if_view_is_called_on_a_dossier_without_passing_paths(self, browser):
         browser.login().open(self.dossier, view='cancel_document_checkouts')
-        self.assertEquals(['You have not selected any documents'],
+        self.assertEquals(['You have not selected any documents.'],
                           error_messages())
 
     @browsing
@@ -87,7 +87,7 @@ class TestCancelDocuments(FunctionalTestCase):
                              view='cancel_document_checkouts', )
 
         self.assertEquals(
-            [u'Could not cancel checkout on document Testdokum\xe4nt'],
+            [u'Could not cancel checkout on document Testdokum\xe4nt.'],
             error_messages())
 
     @browsing

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -108,7 +108,7 @@ class TestReverting(FunctionalTestCase):
 
         self.assertEquals(4, len(repo_tool.getHistory(self.document)))
         self.assertEqual(self.document.file.data, version2.object.file.data)
-        self.assertEquals(u'Reverted file to version 2',
+        self.assertEquals(u'Reverted file to version 2.',
                           repo_tool.retrieve(self.document, 3).comment)
 
     def test_creates_a_new_blob_instance(self):
@@ -162,7 +162,7 @@ class TestReverting(FunctionalTestCase):
         revert_link = second_row.css('td a')[-1]
         revert_link.click()
 
-        self.assertEquals(['Reverted file to version 1'], info_messages())
+        self.assertEquals(['Reverted file to version 1.'], info_messages())
         self.assertEquals('VERSION 1 DATA', self.document.file.data)
 
     @browsing
@@ -438,7 +438,7 @@ class TestCheckinViews(FunctionalTestCase):
                   'checkin_without_comment:method': 1,
                   '_authenticator': createToken()})
 
-        self.assertEquals(['You have not selected any documents'],
+        self.assertEquals(['You have not selected any documents.'],
                           error_messages())
         self.assertEquals(
             'http://nohost/plone/dossier-1#documents', browser.url)
@@ -450,7 +450,7 @@ class TestCheckinViews(FunctionalTestCase):
                   '_authenticator': createToken()})
         browser.click_on('Checkin')
 
-        self.assertEquals(['You have not selected any documents'],
+        self.assertEquals(['You have not selected any documents.'],
                           error_messages())
         self.assertEquals(
             'http://nohost/plone/dossier-1#documents', browser.url)

--- a/opengever/document/tests/test_download.py
+++ b/opengever/document/tests/test_download.py
@@ -94,7 +94,7 @@ class TestDocumentDownloadConfirmation(FunctionalTestCase):
         transaction.commit()
 
         browser.login().open(self.document, view='file_download_confirmation')
-        self.assertEqual(['The Document A letter for you has no File'],
+        self.assertEqual(['The Document A letter for you has no File.'],
                          warning_messages())
 
     @browsing
@@ -128,5 +128,5 @@ class TestDocumentDownloadConfirmation(FunctionalTestCase):
         document = create(Builder('document').titled('No Document'))
 
         browser.login().open(document, view='download')
-        self.assertEqual(['The Document No Document has no File'],
+        self.assertEqual(['The Document No Document has no File.'],
                          error_messages())

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -374,7 +374,7 @@ class TestOverviewMeetingFeatures(FunctionalTestCase):
 
         self.assertEqual(
             [u'A new submitted version of document'
-             u' Testdokum\xe4nt has been created'],
+             u' Testdokum\xe4nt has been created.'],
             info_messages())
         self.assertSubmittedDocumentCreated(
             self.proposal, self.document, submitted_version=1)

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -53,7 +53,7 @@ FILLING_NO_PATTERN = r'(.*)-(.*)-([0-9]*)-([0-9]*)'
 
 class MissingValue(Invalid):
     """ The Missing value was defined Exception."""
-    __doc__ = _(u"Not all required fields are filled")
+    __doc__ = _(u"Not all required fields are filled.")
 
 
 class EnddateValidator(validator.SimpleFieldValidator):
@@ -88,7 +88,7 @@ def valid_filing_year(value):
         if 1900 < int(value) < 3000:
             if str(int(value)) == value:
                 return True
-    raise Invalid(_(u'The given value is not a valid Year'))
+    raise Invalid(_(u'The given value is not a valid Year.'))
 
 
 @grok.provider(IContextSourceBinder)
@@ -256,7 +256,7 @@ class ArchiveForm(directives_form.Form):
             # allready resolved only give a filing number
             IDossierArchiver(self.context).archive(filing_prefix, filing_year)
             self.ptool.addPortalMessage(
-                _("The filing number has been given"), type="info")
+                _("The filing number has been given."), type="info")
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 
         # archiving must passed to the resolving view

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -159,7 +159,7 @@ class ParticipationAddForm(z3c.form.form.Form):
             phandler.append_participiation(part)
             status = IStatusMessage(self.request)
             msg = _(u'info_participation_create',
-                    u'Participation created')
+                    u'Participation created.')
             status.addStatusMessage(msg, type='info')
             return self._redirect_to_participants_tab()
 
@@ -204,7 +204,7 @@ class DeleteParticipants(grok.View):
             phandler.remove_participation(obj)
         status = IStatusMessage(self.request)
         msg = _(u'info_removed_participations',
-                'Removed participations')
+                'Removed participations.')
         status.addStatusMessage(msg, type='info')
         return self.request.RESPONSE.redirect(self.redirect_url)
 

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -57,7 +57,7 @@ class DossierReporter(grok.View):
 
         if not self.request.get('paths'):
             msg = _(
-                u'error_no_items', default=u'You have not selected any Items')
+                u'error_no_items', default=u'You have not selected any items.')
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
             return_temp = self.request.get(
                 'orig_template', self.context.absolute_url())
@@ -72,7 +72,7 @@ class DossierReporter(grok.View):
 
         data = reporter()
         if not data:
-            msg = _(u'Could not generate the report')
+            msg = _(u'Could not generate the report.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
             return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -47,7 +47,7 @@ msgid "Can only move objects from open dossiers!"
 msgstr "Es können nur Objekte aus aktiven Dossiers verschoben werden!"
 
 #: ./opengever/dossier/browser/report.py:75
-msgid "Could not generate the report"
+msgid "Could not generate the report."
 msgstr "Report konnte nicht generiert werden."
 
 #: ./opengever/dossier/profiles/default/actions.xml
@@ -94,8 +94,8 @@ msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr "Die folgenden Objekte konnten nicht kopiert werden: ${failed_objects}. Sie sind via WebDAV gesperrt."
 
 #: ./opengever/dossier/move_items.py:212
-msgid "It isn't allowed to add such items there"
-msgstr "Sie dürfen dieses Objekt nicht an den Zielort verschieben"
+msgid "It isn't allowed to add such items there."
+msgstr "Sie dürfen dieses Objekt nicht an den Zielort verschieben."
 
 #: ./opengever/dossier/resolve.py:94
 msgid "It isn't possible to reactivate a sub dossier."
@@ -118,7 +118,7 @@ msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
 
 #: ./opengever/dossier/archive.py:56
-msgid "Not all required fields are filled"
+msgid "Not all required fields are filled."
 msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -201,11 +201,11 @@ msgid "The dossier contains active proposals."
 msgstr "Das Dossier enthält aktive Anträge."
 
 #: ./opengever/dossier/resolve.py:70
-msgid "The dossier has been succesfully resolved"
+msgid "The dossier has been succesfully resolved."
 msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 
 #: ./opengever/dossier/archive.py:259
-msgid "The filing number has been given"
+msgid "The filing number has been given."
 msgstr "Die Ablagenummer wurde vergeben."
 
 #: ./opengever/dossier/archive.py:71
@@ -213,7 +213,7 @@ msgid "The given end date is not valid, it needs to be younger or               
 msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date})."
 
 #: ./opengever/dossier/archive.py:91
-msgid "The given value is not a valid Year"
+msgid "The given value is not a valid Year."
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
 #: ./opengever/dossier/move_items.py:89
@@ -229,7 +229,7 @@ msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
 #: ./opengever/dossier/resolve.py:66
-msgid "The subdossier has been succesfully resolved"
+msgid "The subdossier has been succesfully resolved."
 msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 
 #: ./opengever/dossier/activate.py:28
@@ -322,7 +322,7 @@ msgstr "Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in de
 msgid "error_enddate"
 msgstr "Enddatum erforderlich"
 
-#. Default: "You have not selected any Items"
+#. Default: "You have not selected any items."
 #: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
@@ -445,12 +445,12 @@ msgstr "Kommentar anzeigen."
 msgid "help_title_help"
 msgstr "Empfehlung für Titel. Wird beim Erstellen eines Dossiers ab Vorlage als Hilfetext dargestellt"
 
-#. Default: "Participation created"
+#. Default: "Participation created."
 #: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
 msgstr "Die Beteiligung wurde gespeichert."
 
-#. Default: "Removed participations"
+#. Default: "Removed participations."
 #: ./opengever/dossier/behaviors/participation.py:206
 msgid "info_removed_participations"
 msgstr "Die Beteiligungen wurde entfernt."
@@ -805,7 +805,7 @@ msgid "msg_main_dossier_not_found"
 msgstr "Das Object `${title}` ist nicht in einem Dossier abgelegt."
 
 #: ./opengever/dossier/resolve.py:19
-msgid "not all documents and tasks are stored in a subdossier"
+msgid "not all documents and tasks are stored in a subdossier."
 msgstr "Es sind nicht alle Dokumente und Aufgaben in Subdossiers abgelegt."
 
 #: ./opengever/dossier/resolve.py:21

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -45,8 +45,8 @@ msgid "Can only move objects from open dossiers!"
 msgstr "Seuls les objets de dossiers actifs peuvent être déplacés!"
 
 #: ./opengever/dossier/browser/report.py:75
-msgid "Could not generate the report"
-msgstr "Impossible de générer l'affichage"
+msgid "Could not generate the report."
+msgstr "Impossible de générer l'affichage."
 
 #: ./opengever/dossier/profiles/default/actions.xml
 msgid "Delete"
@@ -71,7 +71,7 @@ msgstr ""
 
 #: ./opengever/dossier/resolve.py:89
 msgid "Dossiers successfully reactivated."
-msgstr "Le dossier a été à nouveau ouvert avec succès"
+msgstr "Le dossier a été à nouveau ouvert avec succès."
 
 #: ./opengever/dossier/behaviors/dossier.py:257
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
@@ -92,7 +92,7 @@ msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr "Les objets suivants ne peuvent pas être copiés: ${failed_objects}. Ils sont verrouillés par WebDAV."
 
 #: ./opengever/dossier/move_items.py:212
-msgid "It isn't allowed to add such items there"
+msgid "It isn't allowed to add such items there."
 msgstr "Cet élément ne peut être déplacé ici."
 
 #: ./opengever/dossier/resolve.py:94
@@ -116,8 +116,8 @@ msgid "No Subdossiers"
 msgstr "Aucun sous-dossier"
 
 #: ./opengever/dossier/archive.py:56
-msgid "Not all required fields are filled"
-msgstr "Manque des champs obligatoires"
+msgid "Not all required fields are filled."
+msgstr "Manque des champs obligatoires."
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
 msgid "Participant"
@@ -170,7 +170,7 @@ msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches qui
 
 #: ./opengever/dossier/deactivate.py:52
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
-msgstr "Ce dossier ne peut pas être annulé, il contient encore des documents avec le statut checkout"
+msgstr "Ce dossier ne peut pas être annulé, il contient encore des documents avec le statut checkout."
 
 #: ./opengever/dossier/deactivate.py:66
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
@@ -197,20 +197,20 @@ msgid "The dossier contains active proposals."
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:70
-msgid "The dossier has been succesfully resolved"
-msgstr "Le dossier a été fermé avec succès"
+msgid "The dossier has been succesfully resolved."
+msgstr "Le dossier a été fermé avec succès."
 
 #: ./opengever/dossier/archive.py:259
-msgid "The filing number has been given"
-msgstr "Le numéro d'inventaire va être attribué"
+msgid "The filing number has been given."
+msgstr "Le numéro d'inventaire va être attribué."
 
 #: ./opengever/dossier/archive.py:71
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou égale à la date la plus récente de l'objet contenu."
 
 #: ./opengever/dossier/archive.py:91
-msgid "The given value is not a valid Year"
-msgstr "L'année de dépôt attribuée n'est pas valable"
+msgid "The given value is not a valid Year."
+msgstr "L'année de dépôt attribuée n'est pas valable."
 
 #: ./opengever/dossier/move_items.py:89
 msgid "The selected objects can't be found, please try it again."
@@ -225,8 +225,8 @@ msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
 #: ./opengever/dossier/resolve.py:66
-msgid "The subdossier has been succesfully resolved"
-msgstr "Le sous-dossier a été fermé avec succès"
+msgid "The subdossier has been succesfully resolved."
+msgstr "Le sous-dossier a été fermé avec succès."
 
 #: ./opengever/dossier/activate.py:28
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
@@ -234,7 +234,7 @@ msgstr "Ce sous-dossier ne peut pas être réactivé parce que le dossier prinic
 
 #: ./opengever/dossier/archive.py:215
 msgid "When the Action give filing number is selected,                         all fields are required."
-msgstr "Pour l'attribution de numéro d'inventaire, tous les champs sont obligatoires"
+msgstr "Pour l'attribution de numéro d'inventaire, tous les champs sont obligatoires."
 
 #: ./opengever/dossier/move_items.py:195
 msgid "You have not selected any items"
@@ -311,14 +311,14 @@ msgstr "Documents"
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
 #: ./opengever/dossier/move_items.py:243
 msgid "error_NotInContentTypes ${failed_objects}"
-msgstr "Pas d'objet déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi : ${failed_objects}"
+msgstr "Pas d'objet déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi: ${failed_objects}"
 
 #. Default: "The enddate is required."
 #: ./opengever/dossier/archive.py:66
 msgid "error_enddate"
 msgstr "Date de clôture obligatoire"
 
-#. Default: "You have not selected any Items"
+#. Default: "You have not selected any items."
 #: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun objet."
@@ -411,7 +411,7 @@ msgstr "Recherche en direct: Recherche de ce client"
 
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
-msgstr "Saisir le numéro d'inventaire complet"
+msgstr "Saisir le numéro d'inventaire complet."
 
 #: ./opengever/dossier/behaviors/dossier.py:62
 msgid "help_keywords"
@@ -441,15 +441,15 @@ msgstr ""
 msgid "help_title_help"
 msgstr ""
 
-#. Default: "Participation created"
+#. Default: "Participation created."
 #: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
-msgstr "Participation enregistrée"
+msgstr "Participation enregistrée."
 
-#. Default: "Removed participations"
+#. Default: "Removed participations."
 #: ./opengever/dossier/behaviors/participation.py:206
 msgid "info_removed_participations"
-msgstr "Participations enlevées"
+msgstr "Participations enlevées."
 
 #. Default: "Add Note"
 #: ./opengever/dossier/viewlets/templates/note.pt:22
@@ -555,7 +555,7 @@ msgstr "Email"
 #: ./opengever/dossier/behaviors/dossier.py:82
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
-msgstr "Date de fin :"
+msgstr "Date de fin"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
@@ -801,8 +801,8 @@ msgid "msg_main_dossier_not_found"
 msgstr "L'objet `${title}`n'est déposé dans aucun dossier."
 
 #: ./opengever/dossier/resolve.py:19
-msgid "not all documents and tasks are stored in a subdossier"
-msgstr "Pas de document ni de tâche classés dans le sous-dossier"
+msgid "not all documents and tasks are stored in a subdossier."
+msgstr "Pas de document ni de tâche classés dans le sous-dossier."
 
 #: ./opengever/dossier/resolve.py:21
 msgid "not all documents are checked in"
@@ -857,7 +857,7 @@ msgstr ""
 
 #: ./opengever/dossier/resolve.py:23
 msgid "the dossier start date is missing."
-msgstr "Aucune date de début n'a été saisie"
+msgstr "Aucune date de début n'a été saisie."
 
 #. Default: "expired"
 #: ./opengever/dossier/project_templates/byline.pt:47
@@ -872,5 +872,5 @@ msgstr ""
 #. Default: "You didn't select any participants."
 #: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
-msgstr "Vous n'avez sélectionné aucune participation"
+msgstr "Vous n'avez sélectionné aucune participation."
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -46,7 +46,7 @@ msgid "Can only move objects from open dossiers!"
 msgstr ""
 
 #: ./opengever/dossier/browser/report.py:75
-msgid "Could not generate the report"
+msgid "Could not generate the report."
 msgstr ""
 
 #: ./opengever/dossier/profiles/default/actions.xml
@@ -93,7 +93,7 @@ msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr ""
 
 #: ./opengever/dossier/move_items.py:212
-msgid "It isn't allowed to add such items there"
+msgid "It isn't allowed to add such items there."
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:94
@@ -117,7 +117,7 @@ msgid "No Subdossiers"
 msgstr ""
 
 #: ./opengever/dossier/archive.py:56
-msgid "Not all required fields are filled"
+msgid "Not all required fields are filled."
 msgstr ""
 
 #: ./opengever/dossier/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -198,11 +198,11 @@ msgid "The dossier contains active proposals."
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:70
-msgid "The dossier has been succesfully resolved"
+msgid "The dossier has been succesfully resolved."
 msgstr ""
 
 #: ./opengever/dossier/archive.py:259
-msgid "The filing number has been given"
+msgid "The filing number has been given."
 msgstr ""
 
 #: ./opengever/dossier/archive.py:71
@@ -210,7 +210,7 @@ msgid "The given end date is not valid, it needs to be younger or               
 msgstr ""
 
 #: ./opengever/dossier/archive.py:91
-msgid "The given value is not a valid Year"
+msgid "The given value is not a valid Year."
 msgstr ""
 
 #: ./opengever/dossier/move_items.py:89
@@ -226,7 +226,7 @@ msgid "The start or end date is invalid"
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:66
-msgid "The subdossier has been succesfully resolved"
+msgid "The subdossier has been succesfully resolved."
 msgstr ""
 
 #: ./opengever/dossier/activate.py:28
@@ -319,7 +319,7 @@ msgstr ""
 msgid "error_enddate"
 msgstr ""
 
-#. Default: "You have not selected any Items"
+#. Default: "You have not selected any items."
 #: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
 msgstr ""
@@ -442,12 +442,12 @@ msgstr ""
 msgid "help_title_help"
 msgstr ""
 
-#. Default: "Participation created"
+#. Default: "Participation created."
 #: ./opengever/dossier/behaviors/participation.py:161
 msgid "info_participation_create"
 msgstr ""
 
-#. Default: "Removed participations"
+#. Default: "Removed participations."
 #: ./opengever/dossier/behaviors/participation.py:206
 msgid "info_removed_participations"
 msgstr ""
@@ -802,7 +802,7 @@ msgid "msg_main_dossier_not_found"
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:19
-msgid "not all documents and tasks are stored in a subdossier"
+msgid "not all documents and tasks are stored in a subdossier."
 msgstr ""
 
 #: ./opengever/dossier/resolve.py:21

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -209,7 +209,7 @@ class MoveItemsFormView(layout.FormWrapper, grok.View):
 
 
 class NotInContentTypes(Invalid):
-    __doc__ = _(u"It isn't allowed to add such items there")
+    __doc__ = _(u"It isn't allowed to add such items there.")
 
 
 class DestinationValidator(validator.SimpleFieldValidator):

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -17,7 +17,7 @@ from zope.i18n import translate
 
 
 NOT_SUPPLIED_OBJECTS = _(
-    "not all documents and tasks are stored in a subdossier")
+    "not all documents and tasks are stored in a subdossier.")
 NOT_CHECKED_IN_DOCS = _("not all documents are checked in")
 NOT_CLOSED_TASKS = _("not all task are closed")
 NO_START_DATE = _("the dossier start date is missing.")
@@ -63,11 +63,11 @@ class DossierResolveView(grok.View):
             resolver.resolve()
             if self.context.is_subdossier():
                 ptool.addPortalMessage(
-                    _('The subdossier has been succesfully resolved'),
+                    _('The subdossier has been succesfully resolved.'),
                     type='info')
             else:
                 ptool.addPortalMessage(
-                    _('The dossier has been succesfully resolved'),
+                    _('The dossier has been succesfully resolved.'),
                     type='info')
 
             self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -37,7 +37,7 @@ class TestResolvingDossiers(FunctionalTestCase):
                              view='transition-resolve')
 
         self.assertEquals(dossier.absolute_url(), browser.url)
-        self.assertEquals(['The dossier has been succesfully resolved'],
+        self.assertEquals(['The dossier has been succesfully resolved.'],
                           info_messages())
 
     @browsing
@@ -53,7 +53,7 @@ class TestResolvingDossiers(FunctionalTestCase):
                              view='transition-resolve')
 
         self.assertEquals(subdossier.absolute_url(), browser.url)
-        self.assertEquals(['The subdossier has been succesfully resolved'],
+        self.assertEquals(['The subdossier has been succesfully resolved.'],
                           info_messages())
 
 
@@ -254,7 +254,7 @@ class TestResolveConditions(FunctionalTestCase):
 
         self.assertEquals(dossier.absolute_url(), browser.url)
         self.assertEquals(
-            ['not all documents and tasks are stored in a subdossier',
+            ['not all documents and tasks are stored in a subdossier.',
              'not all documents are checked in'], error_messages())
 
     @browsing
@@ -326,7 +326,7 @@ class TestResolveConditions(FunctionalTestCase):
                              view='transition-resolve')
 
         self.assertEquals(dossier.absolute_url(), browser.url)
-        self.assertEquals(['The dossier has been succesfully resolved'],
+        self.assertEquals(['The dossier has been succesfully resolved.'],
                           info_messages())
 
 

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -47,7 +47,7 @@ class TaskReporter(grok.View):
 
         if not tasks:
             msg = _(
-                u'error_no_items', default=u'You have not selected any Items')
+                u'error_no_items', default=u'You have not selected any items.')
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
             if self.request.get('orig_template'):
                 return self.request.RESPONSE.redirect(
@@ -91,7 +91,7 @@ class TaskReporter(grok.View):
 
         data = reporter()
         if not data:
-            msg = _(u'Could not generate the report')
+            msg = _(u'Could not generate the report.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
             return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -17,7 +17,7 @@ msgstr ""
 "X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/globalindex/browser/report.py:94
-msgid "Could not generate the report"
+msgid "Could not generate the report."
 msgstr "Aufgaben Export konnte nicht erstellt werden."
 
 #: ./opengever/globalindex/profiles/default/actions.xml
@@ -25,7 +25,7 @@ msgstr "Aufgaben Export konnte nicht erstellt werden."
 msgid "Export selection"
 msgstr "Auswahl exportieren"
 
-#. Default: "You have not selected any Items"
+#. Default: "You have not selected any items."
 #: ./opengever/globalindex/browser/report.py:49
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
@@ -49,7 +49,7 @@ msgstr "Frist"
 
 #: ./opengever/globalindex/browser/report.py:68
 msgid "label_dossier_title"
-msgstr "Dossier Titel"
+msgstr "Dossier-Titel"
 
 #: ./opengever/globalindex/browser/report.py:69
 msgid "label_issuer"

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -17,18 +17,18 @@ msgstr ""
 "X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/globalindex/browser/report.py:94
-msgid "Could not generate the report"
-msgstr "Impossible de générer l'export de tâches"
+msgid "Could not generate the report."
+msgstr "Impossible de générer l'export de tâches."
 
 #: ./opengever/globalindex/profiles/default/actions.xml
 #: ./opengever/globalindex/upgrades/profiles/2601/actions.xml
 msgid "Export selection"
 msgstr "Exporter choix"
 
-#. Default: "You have not selected any Items"
+#. Default: "You have not selected any items."
 #: ./opengever/globalindex/browser/report.py:49
 msgid "error_no_items"
-msgstr "Aucun élément sélectionné"
+msgstr "Aucun élément sélectionné."
 
 #. Default: "Forwarding"
 #: ./opengever/globalindex/browser/report.py:23

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.globalindex\n"
 
 #: ./opengever/globalindex/browser/report.py:94
-msgid "Could not generate the report"
+msgid "Could not generate the report."
 msgstr ""
 
 #: ./opengever/globalindex/profiles/default/actions.xml
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Export selection"
 msgstr ""
 
-#. Default: "You have not selected any Items"
+#. Default: "You have not selected any items."
 #: ./opengever/globalindex/browser/report.py:49
 msgid "error_no_items"
 msgstr ""

--- a/opengever/inbox/browser/view.py
+++ b/opengever/inbox/browser/view.py
@@ -14,7 +14,7 @@ class InboxContainerView(OGDefaultView):
         else:
             msg = _(
                 u'current_inbox_not_available',
-                u'Your not allowed to access the inbox of ${current_org_unit}',
+                u'Your not allowed to access the inbox of ${current_org_unit}.',
                 mapping={'current_org_unit': get_current_org_unit().label()})
 
             IStatusMessage(self.request).addStatusMessage(msg, type='warning')

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -114,7 +114,7 @@ class ForwardingAddForm(AddForm):
             # autocomplete-search request!
             IStatusMessage(self.request).addStatusMessage(
                 _(u'error_no_document_selected',
-                  u'Error: Please select at least one document to forward'),
+                  u'Error: Please select at least one document to forward.'),
                 type='error')
             redir_url = self.request.get('orig_template',
                                          self.context.absolute_url())

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -45,15 +45,15 @@ msgstr "Jahresordner"
 msgid "close"
 msgstr "Abschliessen"
 
-#. Default: "Your not allowed to access the inbox of ${current_org_unit}"
+#. Default: "Your not allowed to access the inbox of ${current_org_unit}."
 #: ./opengever/inbox/browser/view.py:15
 msgid "current_inbox_not_available"
 msgstr "Sie sind nicht dazu berechtigt auf den Eingangskorb der/des ${current_org_unit} zuzugreifen."
 
-#. Default: "Error: Please select at least one document to forward"
+#. Default: "Error: Please select at least one document to forward."
 #: ./opengever/inbox/forwarding.py:116
 msgid "error_no_document_selected"
-msgstr "Fehler: Bitte wählen Sie mindestens ein Dokument aus das weitergeleitet werden soll"
+msgstr "Fehler: Bitte wählen Sie mindestens ein Dokument aus das weitergeleitet werden soll."
 
 #. Default: "Common"
 #: ./opengever/inbox/inbox.py:20

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -47,12 +47,12 @@ msgstr "Classeur pour l'année"
 msgid "close"
 msgstr "Fermer"
 
-#. Default: "Your not allowed to access the inbox of ${current_org_unit}"
+#. Default: "Your not allowed to access the inbox of ${current_org_unit}."
 #: ./opengever/inbox/browser/view.py:15
 msgid "current_inbox_not_available"
-msgstr "Vous n'avez pas accès à la boîte de réception de ${current_org_unit}"
+msgstr "Vous n'avez pas accès à la boîte de réception de ${current_org_unit}."
 
-#. Default: "Error: Please select at least one document to forward"
+#. Default: "Error: Please select at least one document to forward."
 #: ./opengever/inbox/forwarding.py:116
 msgid "error_no_document_selected"
 msgstr "Erreur: Choisissez au minimum un document à transmettre."

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -48,12 +48,12 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#. Default: "Your not allowed to access the inbox of ${current_org_unit}"
+#. Default: "Your not allowed to access the inbox of ${current_org_unit}."
 #: ./opengever/inbox/browser/view.py:15
 msgid "current_inbox_not_available"
 msgstr ""
 
-#. Default: "Error: Please select at least one document to forward"
+#. Default: "Error: Please select at least one document to forward."
 #: ./opengever/inbox/forwarding.py:116
 msgid "error_no_document_selected"
 msgstr ""

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -25,7 +25,7 @@ class TestForwarding(FunctionalTestCase):
 
         messages = statusmessages.messages()
         self.assertEqual(
-            ['Error: Please select at least one document to forward'],
+            ['Error: Please select at least one document to forward.'],
             messages.get('error'))
 
     @browsing

--- a/opengever/inbox/tests/test_inbox_container.py
+++ b/opengever/inbox/tests/test_inbox_container.py
@@ -66,7 +66,7 @@ class TestInboxView(FunctionalTestCase):
         browser.login().open(self.container)
         self.assertEqual(self.container.absolute_url(), browser.url)
         self.assertEquals(
-            ['Your not allowed to access the inbox of Client1'],
+            ['Your not allowed to access the inbox of Client1.'],
             statusmessages.messages().get('warning'))
 
     @browsing

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -630,7 +630,7 @@ OBJECT_RESTORE = 'Object restore'
 def document_untrashed(context, event):
     title = _(
         u'label_restore',
-        default=u'Object restore: ${title}',
+        default=u'Object restored: ${title}',
         mapping={
             'title': context.title_or_id(),
             })

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -256,10 +256,10 @@ msgstr "Referenzen"
 msgid "label_related_documents"
 msgstr "Dokumentverweise"
 
-#. Default: "Object restore: ${title}"
+#. Default: "Object restored: ${title}"
 #: ./opengever/journal/handlers.py:631
 msgid "label_restore"
-msgstr "Dokument ${title} reaktiviert."
+msgstr "Dokument ${title} reaktiviert"
 
 #. Default: "Task added: ${title}"
 #: ./opengever/journal/handlers.py:573
@@ -284,15 +284,15 @@ msgstr "Titel"
 #. Default: "Object moved to trash: ${title}"
 #: ./opengever/journal/handlers.py:613
 msgid "label_to_trash"
-msgstr "Dokument ${title} in den Papierkorb verschoben."
+msgstr "Dokument ${title} in den Papierkorb verschoben"
 
 #. Default: "Journal"
 #: ./opengever/journal/templates/journalhistory.pt:17
 msgid "summary_journal"
 msgstr "Journal"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
-msgstr "${amount} Treffer."
+msgstr "${amount} Treffer"
 

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -131,17 +131,17 @@ msgstr "Méta-données du document ${title} modifiées"
 #. Default: "Public trial changed to \"${public_trial}\"."
 #: ./opengever/journal/handlers.py:441
 msgid "label_document_public_trial_modified"
-msgstr "Statut public modifié en «${public_trial}»"
+msgstr "Statut public modifié en «${public_trial}»."
 
 #. Default: "Document ${title} removed."
 #: ./opengever/journal/handlers.py:648
 msgid "label_document_removed"
-msgstr "Document ${title} effacé"
+msgstr "Document ${title} effacé."
 
 #. Default: "Document ${title} restored."
 #: ./opengever/journal/handlers.py:665
 msgid "label_document_restored"
-msgstr "Document restoré"
+msgstr "Document restoré."
 
 #. Default: "Document sent by Mail: ${subject}"
 #: ./opengever/journal/handlers.py:549
@@ -186,7 +186,7 @@ msgstr "Télécharger une copie"
 #. Default: "Local roles aquistion activated."
 #: ./opengever/journal/handlers.py:297
 msgid "label_local_roles_acquisition_activated"
-msgstr "Héritage des droits d'accès activé"
+msgstr "Héritage des droits d'accès activé."
 
 #. Default: "Local roles aquistion activated at ${repository}."
 #: ./opengever/journal/handlers.py:190
@@ -196,7 +196,7 @@ msgstr "Héritage des droits d'accès activé pour  ${repository}."
 #. Default: "Local roles aquistion blocked."
 #: ./opengever/journal/handlers.py:282
 msgid "label_local_roles_acquisition_blocked"
-msgstr "Héritage des droits d'accès désactivé"
+msgstr "Héritage des droits d'accès désactivé."
 
 #. Default: "Local roles aquistion blocked at ${repository}."
 #: ./opengever/journal/handlers.py:172
@@ -206,12 +206,12 @@ msgstr "Héritage des droits d'accès désactivé pour  ${repository}."
 #. Default: "Local roles modified."
 #: ./opengever/journal/handlers.py:312
 msgid "label_local_roles_modified"
-msgstr "Rôles à l'intérne modifiés"
+msgstr "Rôles à l'intérne modifiés."
 
 #. Default: "Local roles modified at ${repository}."
 #: ./opengever/journal/handlers.py:208
 msgid "label_local_roles_modified_at"
-msgstr "Rôles à l'intérne pour ${repository} modifiés"
+msgstr "Rôles à l'intérne pour ${repository} modifiés."
 
 #. Default: "Manual entry: ${category}"
 #: ./opengever/journal/entry.py:81
@@ -221,12 +221,12 @@ msgstr ""
 #. Default: "Object cut: ${title}"
 #: ./opengever/journal/handlers.py:754
 msgid "label_object_cut"
-msgstr "Objet coupé : ${title}"
+msgstr "Objet coupé: ${title}"
 
 #. Default: "Object moved: ${title}"
 #: ./opengever/journal/handlers.py:732
 msgid "label_object_moved"
-msgstr "Objet collé : ${title}"
+msgstr "Objet collé: ${title}"
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
 #: ./opengever/journal/handlers.py:688
@@ -258,20 +258,20 @@ msgstr ""
 msgid "label_related_documents"
 msgstr ""
 
-#. Default: "Object restore: ${title}"
+#. Default: "Object restored: ${title}"
 #: ./opengever/journal/handlers.py:631
 msgid "label_restore"
-msgstr "Objet restauré : ${title}"
+msgstr "Objet restauré: ${title}"
 
 #. Default: "Task added: ${title}"
 #: ./opengever/journal/handlers.py:573
 msgid "label_task_added"
-msgstr "Tâche ajoutée : ${title}"
+msgstr "Tâche ajoutée: ${title}"
 
 #. Default: "Task modified: ${title}"
 #: ./opengever/journal/handlers.py:590
 msgid "label_task_modified"
-msgstr "Tâche modifiée : ${title}"
+msgstr "Tâche modifiée: ${title}"
 
 #. Default: "Time"
 #: ./opengever/journal/tab.py:67
@@ -286,15 +286,15 @@ msgstr "Titre"
 #. Default: "Object moved to trash: ${title}"
 #: ./opengever/journal/handlers.py:613
 msgid "label_to_trash"
-msgstr "Objet effacé : ${title}"
+msgstr "Objet effacé: ${title}"
 
 #. Default: "Journal"
 #: ./opengever/journal/templates/journalhistory.pt:17
 msgid "summary_journal"
 msgstr "Historique"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
-msgstr "Résultat(s) : ${amount}"
+msgstr "Résultat(s): ${amount}"
 

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -259,7 +259,7 @@ msgstr ""
 msgid "label_related_documents"
 msgstr ""
 
-#. Default: "Object restore: ${title}"
+#. Default: "Object restored: ${title}"
 #: ./opengever/journal/handlers.py:631
 msgid "label_restore"
 msgstr ""
@@ -294,7 +294,7 @@ msgstr ""
 msgid "summary_journal"
 msgstr ""
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
 msgstr ""

--- a/opengever/journal/templates/journal_selection.pt
+++ b/opengever/journal/templates/journal_selection.pt
@@ -6,5 +6,5 @@
 </div>
 
 <div i18n:domain="opengever.journal" i18n:translate="tab_matches">
-  <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
+  <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches
 </div>

--- a/opengever/journal/tests/test_integration.py
+++ b/opengever/journal/tests/test_integration.py
@@ -285,12 +285,12 @@ class TestOpengeverJournalGeneral(unittest.TestCase):
         self.check_annotation(
             document,
             action_type='Object restore',
-            action_title='Object restore: %s' % (
+            action_title='Object restored: %s' % (
                 document.title_or_id()), )
         self.check_annotation(
             dossier,
             action_type='Object restore',
-            action_title='Object restore: %s' % (
+            action_title='Object restored: %s' % (
                 document.title_or_id()), )
 
     def test_integration_participation_events(self):

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -91,7 +91,7 @@ msgstr "Ordnungsposition"
 #. Default: "Repositoryfolder"
 #: ./opengever/latex/listing.py:157
 msgid "label_repository_title"
-msgstr "Ordnungspos."
+msgstr "Ordnungsposition"
 
 #. Default: "Responsible"
 #: ./opengever/latex/dossierdetails.py:122

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -158,7 +158,7 @@ msgstr "Anhänge"
 #. Default: "Send documents only als links"
 #: ./opengever/mail/browser/send_document.py:112
 msgid "label_documents_as_link"
-msgstr "Dokumente nur als Link versenden."
+msgstr "Dokumente nur als Link versenden"
 
 #. Default: "File a copy of the sent mail in dossier"
 #: ./opengever/mail/browser/send_document.py:118

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -30,7 +30,7 @@ msgstr "Extraire documents"
 
 #: ./opengever/mail/browser/send_document.py:336
 msgid "Sent mail filed as '${title}'."
-msgstr "Email envoyé classé sous '${title}'"
+msgstr "Email envoyé classé sous '${title}'."
 
 #: ./opengever/mail/validators.py:20
 msgid "The files you selected are larger than the maximum size"
@@ -38,7 +38,7 @@ msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permis
 
 #: ./opengever/mail/browser/send_document.py:129
 msgid "You have to select a intern                             or enter a extern mail-addres"
-msgstr "Sélectionner au minimum une adresse Email interne ou externe"
+msgstr "Sélectionner au minimum une adresse Email interne ou externe."
 
 #. Default: "Send"
 #: ./opengever/mail/browser/send_document.py:199
@@ -73,7 +73,7 @@ msgstr "Vous n'avez sélectionné aucune annexe."
 #. Default: "This mail has no attachments to extract."
 #: ./opengever/mail/browser/extract_attachments.py:117
 msgid "error_no_attachments_to_extract"
-msgstr "Cet Email n'a pas d'annexe à extraire"
+msgstr "Cet Email n'a pas d'annexe à extraire."
 
 #. Default: "Extern receiver"
 #: ./opengever/mail/browser/send_document.py:74
@@ -108,12 +108,12 @@ msgstr "Ajouter les adresses email des destinataires externes. Une adresse par l
 #. Default: "Live Search: search for users and contacts"
 #: ./opengever/mail/browser/send_document.py:62
 msgid "help_intern_receiver"
-msgstr "Recherche en direct : Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible. "
+msgstr "Recherche en direct: Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible."
 
 #. Default: "Created document ${title}"
 #: ./opengever/mail/browser/extract_attachments.py:149
 msgid "info_extracted_document"
-msgstr "Document créé : ${title}"
+msgstr "Document créé: ${title}"
 
 #. Default: "E-mail has been sent."
 #: ./opengever/mail/browser/send_document.py:246
@@ -133,7 +133,7 @@ msgstr "Fichiers attachés"
 #. Default: "Delete attachments"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:64
 msgid "label_delete_action"
-msgstr "Effacer les fichiers attachés."
+msgstr "Effacer les fichiers attachés"
 
 #. Default: "Delete all attachments"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:86
@@ -143,7 +143,7 @@ msgstr "Effacer tous les fichiers attachés de cet email"
 #. Default: "Delete nothing"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:77
 msgid "label_delete_action_nothing"
-msgstr "N'effacer aucun fichier attaché."
+msgstr "N'effacer aucun fichier attaché"
 
 #. Default: "Delete all selected attachments"
 #: ./opengever/mail/browser/extract_attachments_templates/extract_attachments.pt:95

--- a/opengever/meeting/browser/memberships.py
+++ b/opengever/meeting/browser/memberships.py
@@ -51,7 +51,7 @@ class AddMembership(ModelAddForm):
 
         if overlapping:
             msg = _("Can't add membership, it overlaps an existing membership "
-                    "from ${date_from} to ${date_to}",
+                    "from ${date_from} to ${date_to}.",
                     mapping=dict(date_from=overlapping.format_date_from(),
                                  date_to=overlapping.format_date_to()))
 
@@ -85,7 +85,7 @@ class EditMembership(ModelEditForm):
 
         if overlapping:
             msg = _("Can't change membership, it overlaps an existing membership "
-                    "from ${date_from} to ${date_to}",
+                    "from ${date_from} to ${date_to}.",
                     mapping=dict(date_from=overlapping.format_date_from(),
                                  date_to=overlapping.format_date_to()))
 

--- a/opengever/meeting/browser/templates/no_selection.pt
+++ b/opengever/meeting/browser/templates/no_selection.pt
@@ -1,3 +1,3 @@
 <div i18n:domain="opengever.meeting" i18n:translate="tab_matches">
-  <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
+  <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches
 </div>

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -46,12 +46,12 @@ class ProtocolOperations(object):
 
     def get_generated_message(self, meeting):
         return _(u'Protocol for meeting ${title} has been generated '
-                 'successfully',
+                 'successfully.',
                  mapping=dict(title=meeting.get_title()))
 
     def get_updated_message(self, meeting):
         return _(u'Protocol for meeting ${title} has been updated '
-                 'successfully',
+                 'successfully.',
                  mapping=dict(title=meeting.get_title()))
 
     def get_title(self, meeting):
@@ -324,7 +324,7 @@ class NullUpdateSubmittedDocumentCommand(object):
     def show_message(self):
         portal = api.portal.get()
         api.portal.show_message(
-            _(u'Document ${title} has already been submitted in that version',
+            _(u'Document ${title} has already been submitted in that version.',
               mapping=dict(title=self.document.title)),
             portal.REQUEST,
             type='warning')
@@ -361,7 +361,7 @@ class UpdateSubmittedDocumentCommand(object):
     def show_message(self):
         portal = api.portal.get()
         api.portal.show_message(
-            _(u'A new submitted version of document ${title} has been created',
+            _(u'A new submitted version of document ${title} has been created.',
               mapping=dict(title=self.document.title)),
             portal.REQUEST)
 
@@ -395,7 +395,7 @@ class CopyProposalDocumentCommand(object):
     def show_message(self):
         portal = api.portal.get()
         api.portal.show_message(
-            _(u'Additional document ${title} has been submitted successfully',
+            _(u'Additional document ${title} has been submitted successfully.',
               mapping=dict(title=self.document.title)),
             portal.REQUEST)
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: ./opengever/meeting/command.py:364
-msgid "A new submitted version of document ${title} has been created"
+msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:293
@@ -58,7 +58,7 @@ msgid "Add period"
 msgstr "Periode hinzufügen"
 
 #: ./opengever/meeting/command.py:398
-msgid "Additional document ${title} has been submitted successfully"
+msgid "Additional document ${title} has been submitted successfully."
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
@@ -79,11 +79,11 @@ msgid "Are you sure you want to decide this agendaitem?"
 msgstr "Sind Sie sicher das Sie dieses Traktandum beschliessen möchten?"
 
 #: ./opengever/meeting/browser/memberships.py:53
-msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
+msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Die Mitgliedschaft kann nicht erstellt werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis ${date_to} überschneidet."
 
 #: ./opengever/meeting/browser/memberships.py:87
-msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}"
+msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis zum ${date_to} überschneidet."
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
@@ -123,8 +123,8 @@ msgid "Discard"
 msgstr "Verwerfen"
 
 #: ./opengever/meeting/command.py:327
-msgid "Document ${title} has already been submitted in that version"
-msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht"
+msgid "Document ${title} has already been submitted in that version."
+msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
 msgid "Documents"
@@ -285,11 +285,11 @@ msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
 #: ./opengever/meeting/command.py:48
-msgid "Protocol for meeting ${title} has been generated successfully"
+msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 
 #: ./opengever/meeting/command.py:53
-msgid "Protocol for meeting ${title} has been updated successfully"
+msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
 #: ./opengever/meeting/committee.py:49
@@ -1371,7 +1371,7 @@ msgstr "Eingereicht"
 msgid "submittedproposals"
 msgstr "Anträge"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/meeting/browser/templates/no_selection.pt:2
 msgid "tab_matches"
 msgstr "${amount} Treffer"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -20,8 +20,8 @@ msgstr ""
 "X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/meeting/command.py:364
-msgid "A new submitted version of document ${title} has been created"
-msgstr "Une nouvelle version soumis du document ${title} a été créeé"
+msgid "A new submitted version of document ${title} has been created."
+msgstr "Une nouvelle version soumis du document ${title} a été créeé."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:293
 msgid "Actions"
@@ -60,8 +60,8 @@ msgid "Add period"
 msgstr ""
 
 #: ./opengever/meeting/command.py:398
-msgid "Additional document ${title} has been submitted successfully"
-msgstr "Le document supplémentaire ${title} a été soumis avec succès"
+msgid "Additional document ${title} has been submitted successfully."
+msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
 msgid "Agenda Items"
@@ -81,11 +81,11 @@ msgid "Are you sure you want to decide this agendaitem?"
 msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
-msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
-msgstr "Impossible d'ajouter une affiliation, elle se chevauche avec une affiliation existante du ${date_from} jusqu'au ${date_to}"
+msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
+msgstr "Impossible d'ajouter une affiliation, elle se chevauche avec une affiliation existante du ${date_from} jusqu'au ${date_to}."
 
 #: ./opengever/meeting/browser/memberships.py:87
-msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}"
+msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
@@ -125,7 +125,7 @@ msgid "Discard"
 msgstr ""
 
 #: ./opengever/meeting/command.py:327
-msgid "Document ${title} has already been submitted in that version"
+msgid "Document ${title} has already been submitted in that version."
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
@@ -287,11 +287,11 @@ msgid "Protocol Excerpt"
 msgstr ""
 
 #: ./opengever/meeting/command.py:48
-msgid "Protocol for meeting ${title} has been generated successfully"
+msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Procès-verbal pour la séance ${title} a été créé avec succès"
 
 #: ./opengever/meeting/command.py:53
-msgid "Protocol for meeting ${title} has been updated successfully"
+msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Procès-verbal pour la séance ${title} a été actualisé avec succès."
 
 #: ./opengever/meeting/committee.py:49
@@ -352,7 +352,7 @@ msgstr ""
 
 #: ./opengever/meeting/browser/submitdocuments.py:201
 msgid "Updated with a newer docment version from proposal's dossier."
-msgstr "Le document a été écrasé par une version plus récente du dossier proposé"
+msgstr "Le document a été écrasé par une version plus récente du dossier proposé."
 
 #: ./opengever/meeting/browser/excerpt.py:44
 msgid "Updated with a newer excerpt version."
@@ -1373,7 +1373,7 @@ msgstr "Soumis"
 msgid "submittedproposals"
 msgstr "Propositions"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/meeting/browser/templates/no_selection.pt:2
 msgid "tab_matches"
 msgstr "${amount} résultats"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.meeting\n"
 
 #: ./opengever/meeting/command.py:364
-msgid "A new submitted version of document ${title} has been created"
+msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:293
@@ -57,7 +57,7 @@ msgid "Add period"
 msgstr ""
 
 #: ./opengever/meeting/command.py:398
-msgid "Additional document ${title} has been submitted successfully"
+msgid "Additional document ${title} has been submitted successfully."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:247
@@ -78,11 +78,11 @@ msgid "Are you sure you want to decide this agendaitem?"
 msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:53
-msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}"
+msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
 #: ./opengever/meeting/browser/memberships.py:87
-msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}"
+msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
@@ -122,7 +122,7 @@ msgid "Discard"
 msgstr ""
 
 #: ./opengever/meeting/command.py:327
-msgid "Document ${title} has already been submitted in that version"
+msgid "Document ${title} has already been submitted in that version."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
@@ -284,11 +284,11 @@ msgid "Protocol Excerpt"
 msgstr ""
 
 #: ./opengever/meeting/command.py:48
-msgid "Protocol for meeting ${title} has been generated successfully"
+msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr ""
 
 #: ./opengever/meeting/command.py:53
-msgid "Protocol for meeting ${title} has been updated successfully"
+msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr ""
 
 #: ./opengever/meeting/committee.py:49
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "submittedproposals"
 msgstr ""
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/meeting/browser/templates/no_selection.pt:2
 msgid "tab_matches"
 msgstr ""

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -70,7 +70,7 @@ class TestMemberships(FunctionalTestCase):
         # form field error
         self.assertEqual(
             ["Can't add membership, it overlaps an existing membership from "
-             "Jan 01, 2010 to Dec 31, 2010"],
+             "Jan 01, 2010 to Dec 31, 2010."],
             browser.css('div#content-core div.error').text)
 
     @browsing
@@ -122,7 +122,7 @@ class TestMemberships(FunctionalTestCase):
         self.assertEqual(['There were some errors.'], error_messages())
         self.assertEqual(
             ["Can't change membership, it overlaps an existing membership from "
-             "Jan 01, 2003 to Jan 01, 2007"],
+             "Jan 01, 2003 to Jan 01, 2007."],
             browser.css('div#content-core div.error').text)
 
     def test_not_started_membership_is_inactive(self):

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -368,7 +368,7 @@ class TestProtocol(FunctionalTestCase):
 
         self.assertEquals(
             ['Protocol for meeting My meeting '
-             'has been generated successfully'],
+             'has been generated successfully.'],
             info_messages())
 
         meeting = Meeting.get(self.meeting.meeting_id)  # refresh meeting

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -119,7 +119,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
-            ['Additional document A Document has been submitted successfully'],
+            ['Additional document A Document has been submitted successfully.'],
             info_messages())
 
     @browsing
@@ -133,7 +133,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
-            ['Additional document A Document has been submitted successfully'],
+            ['Additional document A Document has been submitted successfully.'],
             info_messages())
 
     @browsing
@@ -154,7 +154,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         self.assertSubmittedDocumentCreated(
             proposal, self.document, submitted_version=2)
         self.assertSequenceEqual(
-            ['A new submitted version of document A Document has been created'],
+            ['A new submitted version of document A Document has been created.'],
             info_messages())
 
     @browsing
@@ -170,7 +170,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
-            ['Additional document A Document has been submitted successfully'],
+            ['Additional document A Document has been submitted successfully.'],
             info_messages(),
             "The document was preselected by the request parameter and should "
             "have been updated without selecting it again.")
@@ -189,7 +189,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         browser.find('Submit Attachments').click()
 
         self.assertSequenceEqual(
-            ['A new submitted version of document A Document has been created'],
+            ['A new submitted version of document A Document has been created.'],
             info_messages())
 
     @browsing
@@ -252,7 +252,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         self.assertSubmittedDocumentCreated(proposal, self.document)
         self.assertSequenceEqual(
-            ['Additional document A Document has been submitted successfully'],
+            ['Additional document A Document has been submitted successfully.'],
             info_messages())
 
     @browsing
@@ -269,5 +269,5 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
         browser.find('Submit Attachments').click()
 
         self.assertSequenceEqual(
-            ['A new submitted version of document A Document has been created'],
+            ['A new submitted version of document A Document has been created.'],
             info_messages())

--- a/opengever/portlets/tree/locales/fr/LC_MESSAGES/opengever.portlets.tree.po
+++ b/opengever/portlets/tree/locales/fr/LC_MESSAGES/opengever.portlets.tree.po
@@ -44,7 +44,7 @@ msgstr "En survolant les numéros de classement dans le plan de classement avec 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
 #: ./opengever/portlets/tree/treeportlet.pt:53
 msgid "tree_favorites_help_marked"
-msgstr "Vos numéros de classement choisis comme favoris sont épinglés dans l'onglet du plan de classement avec le symbole correspondant (${icon})"
+msgstr "Vos numéros de classement choisis comme favoris sont épinglés dans l'onglet du plan de classement avec le symbole correspondant (${icon})."
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
 #: ./opengever/portlets/tree/treeportlet.pt:60
@@ -54,5 +54,5 @@ msgstr "Pour effacer un favori, retournez sur l'onglet \"Plan de classement\" et
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
 #: ./opengever/portlets/tree/treeportlet.pt:39
 msgid "tree_favorites_help_summary"
-msgstr "L'ajout ou la suppression des favoris se fait dans l'onglet plan de classement"
+msgstr "L'ajout ou la suppression des favoris se fait dans l'onglet plan de classement."
 

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -207,7 +207,7 @@ class TestPrivateDossierWorkflow(FunctionalTestCase):
         browser.login().open(self.dossier,
                              {'_authenticator': createToken()},
                              view='transition-resolve')
-        self.assertEquals(['The dossier has been succesfully resolved'],
+        self.assertEquals(['The dossier has been succesfully resolved.'],
                           info_messages())
 
         self.assertEqual('dossier-state-resolved',

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -67,7 +67,7 @@ validator.WidgetValidatorDiscriminators(
 
 ReferenceNumberPrefixErrorMessage = error.ErrorViewMessage(
     _('error_sibling_reference_number_existing',
-      default=u'A Sibling with the same reference number is existing'),
+      default=u'A Sibling with the same reference number is existing.'),
     error=schema.interfaces.ConstraintNotSatisfied,
     field=IReferenceNumberPrefix['reference_number_prefix'],
 )

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -55,10 +55,10 @@ msgstr "Wählen Sie, ob es in dieser Ordnungsposition erlaubt ist, Geschäftsdos
 msgid "empty_repository"
 msgstr "Keine untergeordnete Ordnungspositionen verfügbar."
 
-#. Default: "A Sibling with the same reference number is existing"
+#. Default: "A Sibling with the same reference number is existing."
 #: ./opengever/repository/behaviors/referenceprefix.py:69
 msgid "error_sibling_reference_number_existing"
-msgstr "Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf gleicher Stufe"
+msgstr "Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf gleicher Stufe."
 
 #. Default: "Common"
 #: ./opengever/repository/behaviors/referenceprefix.py:32

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -34,7 +34,7 @@ msgstr "Système de classement"
 #: ./opengever/repository/profiles/default/actions.xml
 #: ./opengever/repository/upgrades/profiles/2601/actions.xml
 msgid "Unlock unused repository prefixes."
-msgstr "Déblocage de préfixes de référence inutilisés"
+msgstr "Déblocage de préfixes de référence inutilisés."
 
 #. Default: "Allow add businesscase dossier"
 #: ./opengever/repository/repositoryfolder.py:89
@@ -51,7 +51,7 @@ msgstr ""
 msgid "empty_repository"
 msgstr "Pas de numéros de classement disponible dans cette subdivison."
 
-#. Default: "A Sibling with the same reference number is existing"
+#. Default: "A Sibling with the same reference number is existing."
 #: ./opengever/repository/behaviors/referenceprefix.py:69
 msgid "error_sibling_reference_number_existing"
 msgstr "A ce niveau du classement ce numéro de référence existe déjà."
@@ -66,7 +66,7 @@ msgstr "En général"
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
 #: ./opengever/repository/repositoryfolder.py:81
 msgid "help_addable_dossier_types"
-msgstr "Sélectionnez les types de dossiers à ajouter pour cette position du classeur"
+msgstr "Sélectionnez les types de dossiers à ajouter pour cette position du classeur."
 
 #. Default: "A short summary of the content."
 #: ./opengever/repository/repositoryfolder.py:44
@@ -183,7 +183,7 @@ msgstr ""
 #. Default: "Reference prefix has been unlocked."
 #: ./opengever/repository/browser/referenceprefix_manager.py:32
 msgid "statmsg_prefix_unlocked"
-msgstr "Le préfixe de référence à été débloqué"
+msgstr "Le préfixe de référence à été débloqué."
 
 #. Default: "Documents:"
 #: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:16

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -54,7 +54,7 @@ msgstr ""
 msgid "empty_repository"
 msgstr ""
 
-#. Default: "A Sibling with the same reference number is existing"
+#. Default: "A Sibling with the same reference number is existing."
 #: ./opengever/repository/behaviors/referenceprefix.py:69
 msgid "error_sibling_reference_number_existing"
 msgstr ""

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -48,7 +48,7 @@ class TestReferenceBehavior(FunctionalTestCase):
         browser.click_on('Save')
 
         self.assertEquals(
-            ['A Sibling with the same reference number is existing'],
+            ['A Sibling with the same reference number is existing.'],
             browser.css('#formfield-form-widgets-IReferenceNumberPrefix'
                         '-reference_number_prefix .error').text)
 

--- a/opengever/tabbedview/browser/no_selection_amount.pt
+++ b/opengever/tabbedview/browser/no_selection_amount.pt
@@ -1,4 +1,4 @@
 <div i18n:domain="opengever.tabbedview"
      i18n:translate="tab_matches">
-    <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches.
+    <span i18n:name="amount" tal:replace="python:len(view.contents)" /> matches
 </div>

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -424,10 +424,10 @@ msgstr "Beginn"
 msgid "subdossiers"
 msgstr "Subdossiers"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/tabbedview/browser/no_selection_amount.pt:3
 msgid "tab_matches"
-msgstr "${amount} Treffer."
+msgstr "${amount} Treffer"
 
 #. Default: "Aufgaben"
 msgid "tasks"

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -409,10 +409,10 @@ msgstr "Début"
 msgid "subdossiers"
 msgstr "Sous-dossiers"
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/tabbedview/browser/no_selection_amount.pt:3
 msgid "tab_matches"
-msgstr "Résultat(s) : ${amount}"
+msgstr "Résultat(s): ${amount}"
 
 msgid "tasks"
 msgstr "Tâches"

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -408,7 +408,7 @@ msgstr ""
 msgid "subdossiers"
 msgstr ""
 
-#. Default: "${amount} matches."
+#. Default: "${amount} matches"
 #: ./opengever/tabbedview/browser/no_selection_amount.pt:3
 msgid "tab_matches"
 msgstr ""

--- a/opengever/task/browser/accept/main.py
+++ b/opengever/task/browser/accept/main.py
@@ -54,7 +54,7 @@ def method_vocabulary_factory(context):
                 SimpleTerm(
                     value=u'forwarding_participate',
                     title=_(u'accept_method_forwarding_participate',
-                            default=u"... store in ${client}'s inbox.",
+                            default=u"... store in ${client}'s inbox",
                             mapping={'client': org_unit.label()})),
 
                 SimpleTerm(

--- a/opengever/task/browser/accept/newdossier.py
+++ b/opengever/task/browser/accept/newdossier.py
@@ -211,7 +211,7 @@ class ISelectDossierTypeSchema(Schema):
     dossier_type = schema.Choice(
         title=_('label_accept_select_dossier_type', default=u'Dossier type'),
         description=_(u'help_accept_select_dossier_type',
-                      default=u'Select the type for the new dossier.'),
+                      default=u'Select the type for the new dossier'),
         source=allowed_dossier_types_vocabulary,
         required=True)
 

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -128,32 +128,32 @@ msgstr "In dem ausgewählten Dossier können Sie keine Aufgaben erstellen. Entwe
 #. Default: "file in existing dossier in ${client}"
 #: ./opengever/task/browser/accept/main.py:81
 msgid "accept_method_existing_dossier"
-msgstr "in einem bestehenden Dossier auf ${client} bearbeiten."
+msgstr "in einem bestehenden Dossier auf ${client} bearbeiten"
 
 #. Default: "... store in  ${client}'s inbox and process in an existing dossier on ${client}"
 #: ./opengever/task/browser/accept/main.py:62
 msgid "accept_method_forwarding_existing_dossier"
-msgstr "... im Eingangskorb von ${client} ablegen und in bestehendem Dossier auf ${client} bearbeiten."
+msgstr "... im Eingangskorb von ${client} ablegen und in bestehendem Dossier auf ${client} bearbeiten"
 
 #. Default: "... store in  ${client}'s inbox and process in a new dossier on ${client}"
 #: ./opengever/task/browser/accept/main.py:68
 msgid "accept_method_forwarding_new_dossier"
-msgstr "... im Eingangskorb von ${client} ablegen und in neuem Dossier auf ${client} bearbeiten."
+msgstr "... im Eingangskorb von ${client} ablegen und in neuem Dossier auf ${client} bearbeiten"
 
-#. Default: "... store in ${client}'s inbox."
+#. Default: "... store in ${client}'s inbox"
 #: ./opengever/task/browser/accept/main.py:56
 msgid "accept_method_forwarding_participate"
-msgstr "... im Eingangskorb von ${client} ablegen."
+msgstr "... im Eingangskorb von ${client} ablegen"
 
 #. Default: "file in new dossier in ${client}"
 #: ./opengever/task/browser/accept/main.py:87
 msgid "accept_method_new_dossier"
-msgstr "in einem neuen Dossier auf ${client} bearbeiten."
+msgstr "in einem neuen Dossier auf ${client} bearbeiten"
 
 #. Default: "process in issuer's dossier"
 #: ./opengever/task/browser/accept/main.py:76
 msgid "accept_method_participate"
-msgstr "direkt im Dossier des Auftraggebers bearbeiten."
+msgstr "direkt im Dossier des Auftraggebers bearbeiten"
 
 #. Default: "RE"
 #: ./opengever/task/browser/complete.py:309
@@ -218,7 +218,7 @@ msgstr "Die folgenden Dokumente (${title}) müssen noch eingecheckt werden."
 #. Default: "No changes: same responsible selected"
 #: ./opengever/task/browser/assign.py:84
 msgid "error_same_responsible"
-msgstr "Keine Änderung, da kein anderer Auftragnehmer ausgewählt wurde."
+msgstr "Keine Änderung, da kein anderer Auftragnehmer ausgewählt wurde"
 
 #. Default: "existing dossier"
 #: ./opengever/task/browser/assign_dossier.py:44
@@ -245,10 +245,10 @@ msgstr "Weiterleitung"
 msgid "help_accept_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem Sie die Aufgabe bearbeiten wollen."
 
-#. Default: "Select the type for the new dossier."
+#. Default: "Select the type for the new dossier"
 #: ./opengever/task/browser/accept/newdossier.py:213
 msgid "help_accept_select_dossier_type"
-msgstr "Wählen Sie den Typ des neuen Dossiers aus."
+msgstr "Wählen Sie den Typ des neuen Dossiers aus"
 
 #. Default: "Select the repository folder within the dossier should be created."
 #: ./opengever/task/browser/accept/newdossier.py:84

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -135,14 +135,14 @@ msgstr "modifier dans un dossier existant dans ${client}"
 #. Default: "... store in  ${client}'s inbox and process in an existing dossier on ${client}"
 #: ./opengever/task/browser/accept/main.py:62
 msgid "accept_method_forwarding_existing_dossier"
-msgstr "… déposer dans la boîte de réception de ${client} et modifier dans un dossier existant de ${client}."
+msgstr "… déposer dans la boîte de réception de ${client} et modifier dans un dossier existant de ${client}"
 
 #. Default: "... store in  ${client}'s inbox and process in a new dossier on ${client}"
 #: ./opengever/task/browser/accept/main.py:68
 msgid "accept_method_forwarding_new_dossier"
-msgstr "… déposer dans la boîte de réception de ${client} et modifier dans un nouveau dossier de ${client}."
+msgstr "… déposer dans la boîte de réception de ${client} et modifier dans un nouveau dossier de ${client}"
 
-#. Default: "... store in ${client}'s inbox."
+#. Default: "... store in ${client}'s inbox"
 #: ./opengever/task/browser/accept/main.py:56
 msgid "accept_method_forwarding_participate"
 msgstr "… déposer dans la boîte de réception de ${client}"
@@ -247,15 +247,15 @@ msgstr "Transmission"
 msgid "help_accept_select_dossier"
 msgstr "Choix du dossier dans lequel vous voulez modifier la tâche."
 
-#. Default: "Select the type for the new dossier."
+#. Default: "Select the type for the new dossier"
 #: ./opengever/task/browser/accept/newdossier.py:213
 msgid "help_accept_select_dossier_type"
-msgstr "Choix du type du nouveau dossier"
+msgstr "Choix du type du nouveau dossier."
 
 #. Default: "Select the repository folder within the dossier should be created."
 #: ./opengever/task/browser/accept/newdossier.py:84
 msgid "help_accept_select_repositoryfolder"
-msgstr "Choix du numéro de classement où le dossier doit être créé"
+msgstr "Choix du numéro de classement où le dossier doit être créé."
 
 #. Default: "Enter a answer text which will be shown as response when the task is accepted."
 #: ./opengever/task/browser/accept/main.py:102
@@ -320,12 +320,12 @@ msgstr "Durée effective en h"
 
 #: ./opengever/task/task.py:122
 msgid "help_responsible"
-msgstr "Choix de la personne responsable, membre du client mentionné ci-dessus"
+msgstr "Choix de la personne responsable, membre du client mentionné ci-dessus."
 
 #: ./opengever/task/browser/assign.py:38
 #: ./opengever/task/task.py:114
 msgid "help_responsible_client"
-msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire"
+msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire."
 
 #: ./opengever/task/browser/assign.py:45
 #: ./opengever/task/form.py:41
@@ -387,7 +387,7 @@ msgstr "Acheminement attribué à un/une.."
 #. Default: "by"
 #: ./opengever/task/viewlets/byline.py:28
 msgid "label_by_author"
-msgstr "Mandataire: "
+msgstr "Mandataire"
 
 #. Default: "Target dossier"
 #: ./opengever/task/browser/close.py:153

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -141,7 +141,7 @@ msgstr ""
 msgid "accept_method_forwarding_new_dossier"
 msgstr ""
 
-#. Default: "... store in ${client}'s inbox."
+#. Default: "... store in ${client}'s inbox"
 #: ./opengever/task/browser/accept/main.py:56
 msgid "accept_method_forwarding_participate"
 msgstr ""
@@ -246,7 +246,7 @@ msgstr ""
 msgid "help_accept_select_dossier"
 msgstr ""
 
-#. Default: "Select the type for the new dossier."
+#. Default: "Select the type for the new dossier"
 #: ./opengever/task/browser/accept/newdossier.py:213
 msgid "help_accept_select_dossier_type"
 msgstr ""

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -65,23 +65,23 @@ msgstr "En général"
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:74
 msgid "help_deadline"
-msgstr "Délai en jours à partir de la date de début de la tâche"
+msgstr "Délai en jours à partir de la date de début de la tâche."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:40
 msgid "help_issuer"
-msgstr "Choix du client. Vous pouvez aussi choisir les utilisateurs interactifs \"responsables\" ou \"collaborateurs\""
+msgstr "Choix du client. Vous pouvez aussi choisir les utilisateurs interactifs \"responsables\" ou \"collaborateurs\"."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:88
 msgid "help_preselected"
-msgstr "Ce modèle fait parti du choix standard des procédés standards"
+msgstr "Ce modèle fait parti du choix standard des procédés standards."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:67
 msgid "help_responsible"
-msgstr "Choix du mandataire. Si vous choisissez l'option \"utilisateur interactif\" dans le champ \"Client du mandataire\" vous pouvez aussi choisir \"responsable\"ou \"collaborateur\" dans ce champ "
+msgstr "Choix du mandataire. Si vous choisissez l'option \"utilisateur interactif\" dans le champ \"Client du mandataire\" vous pouvez aussi choisir \"responsable\"ou \"collaborateur\" dans ce champ."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:59
 msgid "help_responsible_client"
-msgstr "Choix du client du mandataire ou choisissez \"utilisateur interactif\""
+msgstr "Choix du client du mandataire ou choisissez \"utilisateur interactif\"."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:48
 msgid "help_task_type"
@@ -89,11 +89,11 @@ msgstr "Choix le type de tâche."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:81
 msgid "help_text"
-msgstr "Saisie d'une  instruction de travail détaillée ou d'un commentaire"
+msgstr "Saisie d'une  instruction de travail détaillée ou d'un commentaire."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py:33
 msgid "help_title"
-msgstr "Nom de la tâche"
+msgstr "Nom de la tâche."
 
 #. Default: "Current user"
 #: ./opengever/tasktemplates/vocabularies.py:23
@@ -219,7 +219,7 @@ msgstr "Vous n'avez sélectionné aucun modèle."
 #: ./opengever/tasktemplates/browser/form.py:307
 #: ./opengever/tasktemplates/browser/trigger.py:221
 msgid "message_tasks_created"
-msgstr "Toutes les tâches du procédé standard ont été créées"
+msgstr "Toutes les tâches du procédé standard ont été créées."
 
 #. Default: "Currently there are no active task template folders registered."
 #: ./opengever/tasktemplates/browser/form.py:144

--- a/opengever/trash/browser/remove_confirmation.py
+++ b/opengever/trash/browser/remove_confirmation.py
@@ -33,7 +33,7 @@ class RemoveConfirmation(grok.View):
 
         if not self.context.REQUEST.get('paths'):
             msg = _(u'error_no_documents_selected',
-                    default=u'You have not selected any items')
+                    default=u'You have not selected any items.')
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
             return self.redirect_back()
 

--- a/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
@@ -16,18 +16,18 @@ msgstr ""
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
 #: ./opengever/trash/trash.py:124
-msgid "You have not selected any items"
-msgstr "Sie haben keine Objekte ausgewählt"
+msgid "You have not selected any items."
+msgstr "Sie haben keine Objekte ausgewählt."
 
 #: ./opengever/trash/trash.py:99
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "Das Objekt ${obj} wurde bereits in den Papierkorb verschoben"
 
 #: ./opengever/trash/trash.py:108
-msgid "could not trash the object ${obj}, it is checked out"
+msgid "could not trash the object ${obj}, it is checked out."
 msgstr "Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist ausgecheckt."
 
-#. Default: "You have not selected any items"
+#. Default: "You have not selected any items."
 #: ./opengever/trash/browser/remove_confirmation.py:35
 msgid "error_no_documents_selected"
 msgstr "Sie haben keine Objekte ausgewählt."
@@ -85,7 +85,7 @@ msgstr "Das Dokument ist noch ausgecheckt."
 #. Default: "The document is not trashed."
 #: ./opengever/trash/remover.py:77
 msgid "msg_is_not_trashed"
-msgstr "Das Dokument ist noch nicht im Papierkorb"
+msgstr "Das Dokument ist noch nicht im Papierkorb."
 
 #: ./opengever/trash/profiles/default/actions.xml
 #: ./opengever/trash/upgrades/profiles/4100/actions.xml

--- a/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: ./opengever/trash/trash.py:124
-msgid "You have not selected any items"
+msgid "You have not selected any items."
 msgstr "Vous n'avez sélectionné aucun objet."
 
 #: ./opengever/trash/trash.py:99
@@ -23,10 +23,10 @@ msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "L'objet a été déplacé vers la corbeille"
 
 #: ./opengever/trash/trash.py:108
-msgid "could not trash the object ${obj}, it is checked out"
-msgstr "L'objet ${obj} a un checkout. Vous ne pouvez pas le supprimer"
+msgid "could not trash the object ${obj}, it is checked out."
+msgstr "L'objet ${obj} a un checkout. Vous ne pouvez pas le supprimer."
 
-#. Default: "You have not selected any items"
+#. Default: "You have not selected any items."
 #: ./opengever/trash/browser/remove_confirmation.py:35
 msgid "error_no_documents_selected"
 msgstr "Vous n'avez sélectionné aucun élément."
@@ -74,7 +74,7 @@ msgstr "Il existe encore une référence de document ${links} sur le document."
 #. Default: "The document contains relations."
 #: ./opengever/trash/remover.py:60
 msgid "msg_document_has_relations"
-msgstr "Le document fait réference à d'autres documents"
+msgstr "Le document fait réference à d'autres documents."
 
 #. Default: "The document is still checked out."
 #: ./opengever/trash/remover.py:52
@@ -93,7 +93,7 @@ msgstr "Effacer"
 
 #: ./opengever/trash/trash.py:118
 msgid "the object ${obj} trashed"
-msgstr "L'objet ${obj} a été déplacé dans la corbeille"
+msgstr "L'objet ${obj} a été déplacé dans la corbeille."
 
 #: ./opengever/trash/profiles/default/actions.xml
 msgid "trashed"

--- a/opengever/trash/locales/opengever.trash.pot
+++ b/opengever/trash/locales/opengever.trash.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.trash\n"
 
 #: ./opengever/trash/trash.py:124
-msgid "You have not selected any items"
+msgid "You have not selected any items."
 msgstr ""
 
 #: ./opengever/trash/trash.py:99
@@ -26,10 +26,10 @@ msgid "could not trash the object ${obj}, it is already trashed"
 msgstr ""
 
 #: ./opengever/trash/trash.py:108
-msgid "could not trash the object ${obj}, it is checked out"
+msgid "could not trash the object ${obj}, it is checked out."
 msgstr ""
 
-#. Default: "You have not selected any items"
+#. Default: "You have not selected any items."
 #: ./opengever/trash/browser/remove_confirmation.py:35
 msgid "error_no_documents_selected"
 msgstr ""

--- a/opengever/trash/tests/test_remove.py
+++ b/opengever/trash/tests/test_remove.py
@@ -87,7 +87,7 @@ class TestRemoveConfirmationView(FunctionalTestCase):
 
         self.assertEquals('{}#trash'.format(self.dossier.absolute_url()),
                           browser.url)
-        assert_message('You have not selected any items')
+        assert_message('You have not selected any items.')
 
     @browsing
     def test_submit_button_is_disabled_when_preconditions_are_not_satisfied(self, browser):

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -53,7 +53,7 @@ class TestTrash(FunctionalTestCase):
     def test_redirect_back_and_shows_message_when_no_items_is_selected(self, browser):
         browser.login().open(self.dossier, view="trashed")
 
-        self.assertEquals(['You have not selected any items'],
+        self.assertEquals(['You have not selected any items.'],
                           error_messages())
         self.assertEquals(
             'http://nohost/plone/dossier-1#documents', browser.url)
@@ -87,7 +87,7 @@ class TestTrash(FunctionalTestCase):
         browser.login().open(self.dossier, view="trashed", data=data)
 
         self.assertEquals(
-            [u'could not trash the object Dokum\xe4nt C, it is checked out'],
+            [u'could not trash the object Dokum\xe4nt C, it is checked out.'],
             error_messages())
         self.assertEquals(
             'http://nohost/plone/dossier-1#documents', browser.url)
@@ -103,7 +103,7 @@ class TestUntrash(FunctionalTestCase):
     def test_redirect_back_and_shows_message_when_no_items_is_selected(self, browser):
         browser.login().open(self.dossier, view="untrashed")
 
-        self.assertEquals(['You have not selected any items'],
+        self.assertEquals(['You have not selected any items.'],
                           error_messages())
         self.assertEquals('http://nohost/plone/dossier-1#trash', browser.url)
 

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -106,7 +106,7 @@ class TrashView(grok.View):
                 # check that the document isn't checked_out
                 if brains[0].checked_out:
                     msg = _(
-                        u'could not trash the object ${obj}, it is checked out',
+                        u'could not trash the object ${obj}, it is checked out.',
                         mapping={'obj': obj.Title().decode('utf-8')})
                     IStatusMessage(self.request).addStatusMessage(
                         msg, type='error')
@@ -121,7 +121,7 @@ class TrashView(grok.View):
                     msg, type='info')
 
         else:
-            msg = _(u'You have not selected any items')
+            msg = _(u'You have not selected any items.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 
@@ -149,7 +149,7 @@ class UntrashView(grok.View):
                 self.context.absolute_url()))
 
         else:
-            msg = _(u'You have not selected any items')
+            msg = _(u'You have not selected any items.')
             IStatusMessage(self.request).addStatusMessage(
                 msg, type='error')
 


### PR DESCRIPTION
Fix some common i18n issues:

- Homogenize full stops at the end of sentences.
- Remove trailing spaces
- Remove trailing colons appearing only in source or translation
- Homogenize use of punctuation marks in french translations (no space before colon / question marks)