### PR TITLE
Fix manipulating the tag config of the keywordwidget in the dossier template form

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 
   [lgraf]
 
+- Fix manipulating the tag config of the keywordwidget in the dossier template form. [mathias.leimgruber]
 - Meeting: add proposal template tab to templates folder. [jone]
 - Support simple css colornames in the colorization viewlet. [phgross]
 - Dossierdetails PDF: Fix indentation of dossier metadata table. [lgraf]

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -220,11 +220,11 @@ class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
                     # possible to manipulate the add_permission directly.
                     # Changing other values like something on a field may
                     # lead to unexpected behavior.
-                    # This is the insecure options - but it feeds for this
+                    # This is the insecure option - but it fits for this
                     # usecase
-                    js_config = json.loads(widget.js_config)
-                    js_config['tags'] = False
-                    widget.js_config = json.dumps(js_config)
+                    select2_config = json.loads(widget.config_json)
+                    select2_config['tags'] = False
+                    widget.config_json = json.dumps(select2_config)
 
                     # The vocabular should only contain the terms from
                     # the template.

--- a/sources.cfg
+++ b/sources.cfg
@@ -7,6 +7,7 @@ development-packages =
   plonetheme.teamraum
   collective.js.timeago
   plonetheme.teamraum
+  ftw.keywordwidget
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
Issue:
By running the `update` method on the widget, the content of variable `js_config` was converted from a dict to a JSON string. 
This behavior is IMHO bad, since the update method should not change the type of the value.

This was fixed with the latest change in ftw.keywordwidget.
`config_json` now always holds JSON. and `js_config` is always a dict.


This reimplements support for the latest ftw.keywordwidget.

Fixes #2886
