### PR TITLE
Clump OC document attach dossier journal entries per dossier per event

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Add an aggregated per dossier attach to email event on OC attach actions. [Rotonen]
 - Fix some common i18n issues:
 
   - Homogenize full stops at the end of sentences.

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -5,7 +5,6 @@ from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
 from opengever.document.interfaces import NO_DOWNLOAD_INPUT_MODE
 from plone.dexterity.browser.edit import DefaultEditForm
 from plone.dexterity.events import EditFinishedEvent
-from plone.dexterity.i18n import MessageFactory as _
 from plone.directives import form
 from plone.z3cform import layout
 from z3c.form import button
@@ -62,7 +61,7 @@ class DocumentFileUploadForm(DefaultEditForm):
     additionalSchemata = ()
     render_form = True
 
-    @button.buttonAndHandler(_(u'Save'), name='save')
+    @button.buttonAndHandler(u'oc-file-upload', name='upload')
     def handleApply(self, action):
         data, errors = self.extractData()
         if errors:

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -12,6 +12,7 @@ import transaction
 
 
 class TestDocumentIntegration(FunctionalTestCase):
+    """Test document forms."""
 
     def setUp(self):
         super(TestDocumentIntegration, self).setUp()
@@ -54,12 +55,15 @@ class TestDocumentIntegration(FunctionalTestCase):
         browser.login().open(self.document, view='edit')
 
         self.assertEqual(
-            '{}/file_download_confirmation'.format(self.document.absolute_url()),
+            '{}/file_download_confirmation'
+            .format(self.document.absolute_url()),
             browser.css('#form-widgets-file a.link-overlay').first.get('href'))
 
         # edit should be posssible
         self.assertEqual(
-            ['Keep existing file', 'Remove existing file', 'Replace with new file'],
+            ['Keep existing file',
+             'Remove existing file',
+             'Replace with new file'],
             browser.css('#form-widgets-file label').text)
 
         manager.cancel()
@@ -93,6 +97,7 @@ class TestDocumentIntegration(FunctionalTestCase):
 
 
 class TestDocumentFileUploadForm(FunctionalTestCase):
+    """Test document file upload forms."""
 
     def setUp(self):
         super(TestDocumentFileUploadForm, self).setUp()

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -140,7 +140,7 @@ class TestDocumentFileUploadForm(FunctionalTestCase):
             'File': ('New file data', 'file.txt', 'text/plain'),
             'form.widgets.file.action': 'replace',
             })
-        browser.find('Save').click()
+        browser.find('oc-file-upload').click()
         self.assertEqual('New file data', self.document.file.data)
 
     @browsing
@@ -151,5 +151,5 @@ class TestDocumentFileUploadForm(FunctionalTestCase):
             'form.widgets.file.action': 'replace',
             })
         with self.assertRaises(HTTPError) as cm:
-            browser.find('Save').click()
+            browser.find('oc-file-upload').click()
         self.assertEqual(412, cm.exception.getcode())

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -4,10 +4,11 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.widgets.file import DexterityFileWidget
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
+from plone.app.testing import TEST_USER_NAME
 from urllib2 import HTTPError
 from zope.component import queryMultiAdapter
+
 import transaction
 
 

--- a/opengever/dossier/events.py
+++ b/opengever/dossier/events.py
@@ -24,3 +24,13 @@ class ParticipationRemoved(ObjectEvent):
     def __init__(self, obj, participant):
         self.object = obj
         self.participant = participant
+
+
+class DossierAttachedToEmailEvent(ObjectEvent):
+    """The file was attached to an email by OfficeConnector."""
+
+    implements(interfaces.IDossierAttachedToEmailEvent)
+
+    def __init__(self, obj, documents=None):
+        self.object = obj
+        self.documents = documents

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -35,7 +35,7 @@ class IDossierContainerTypes(Interface):
 
 
 class IConstrainTypeDecider(Interface):
-    """ Adapter interface
+    """Adapter interface
     The constrain type decider decides, if a type is addable in the
     current dossier object. This decision depends on the current dossier
     type, the type to be added and the depth (distance to the next parent
@@ -52,14 +52,14 @@ class IConstrainTypeDecider(Interface):
         pass
 
     def addable(self, depth):
-        """ Returns True, if a object of type *fti* can be created in the
+        """Returns True, if a object of type *fti* can be created in the
         current *context*, depending on the *depth*
         """
         pass
 
 
 class IDossierParticipants(Interface):
-    """ Participants configuration (plone.registry)
+    """Participants configuration (plone.registry)
     """
 
     roles = schema.List(
@@ -75,7 +75,7 @@ class IDossierParticipants(Interface):
 
 
 class ITemplateFolderProperties(Interface):
-    """ Document properties configuration.
+    """Document properties configuration.
     """
 
     create_doc_properties = schema.Bool(
@@ -89,8 +89,8 @@ class ITemplateFolderProperties(Interface):
 class ITemplateDossierProperties(ITemplateFolderProperties):
     """XXX Legacy interface from rename TemplateFolder to TemplateDossier.
 
-    Do not remove this interface until each GEVER-installation is updated to the version
-    containing this changes.
+    Do not remove this interface until each GEVER-installation is updated to
+    the version containing this change.
     """
 
 
@@ -113,12 +113,13 @@ class IDisplayedInOverview(Interface):
 
 
 class IFilingNumberMaintenance(Interface):
+    """Allow access to filing number internals."""
 
     def print_mapping():
         """Return the actual filingnumber mapping"""
 
     def print_filing_numbers():
-        """Return a set of all filingnumbers the are used """
+        """Return a set of all filingnumbers the are used"""
 
     def print_filing_prefixes():
         """Reutrns all filing prefixes and their translations"""
@@ -126,7 +127,8 @@ class IFilingNumberMaintenance(Interface):
 
 class IDossierResolver(Interface):
     """Interface for the Dossier resolve, which provide all
-    functionality needed for resolving a dossier."""
+    functionality needed for resolving a dossier.
+    """
 
     def is_resolve_possible():
         """Check if all preconditions are fulfilled.
@@ -151,16 +153,19 @@ class IDossierArchiver(Interface):
 
     def generate_number(prefix, year):
         """Generate the complete filing number and
-        set the number and prefix on the dossier."""
+        set the number and prefix on the dossier.
+        """
 
     def archive(prefix, year, number=None):
         """Generate a correct filing number and
-        set it recursively on every subdossier."""
+        set it recursively on every subdossier.
+        """
 
     def get_indexer_value(searchable=False):
         """Return the filing value for the filing_no indexer.
         For Dossiers without a number and only a prefix it return the half
-        of the number."""
+        of the number.
+        """
 
     def update_prefix(prefix):
         """Update the filing prefix on the dossier and
@@ -180,6 +185,7 @@ class IDocProperties(Interface):
 class IDocPropertyProvider(Interface):
     """May adapt any object that can be a provider for DocProperties.
     """
+
     def get_properties():
         """Return a dictionary of DocProperties for the adapted object.
         """

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -104,6 +104,10 @@ class IParticipationRemoved(IObjectEvent):
     """
 
 
+class IDossierAttachedToEmailEvent(IObjectEvent):
+    """A file from this dossier was attached to an email."""
+
+
 class IDisplayedInOverviewMarker(IDossierMarker):
     """Marker Interface for additional dossier behaviors."""
 

--- a/opengever/journal/configure.zcml
+++ b/opengever/journal/configure.zcml
@@ -74,4 +74,10 @@
       handler=".handlers.document_attached_to_email"
       />
 
+  <subscriber
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
+           opengever.dossier.interfaces.IDossierAttachedToEmailEvent"
+      handler=".handlers.dossier_attached_to_email"
+      />
+
 </configure>

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -807,14 +807,16 @@ def document_attached_to_email(context, event):
                     default=u'Document attached to email via OfficeConnector')
     journal_entry_factory(document, DOCUMENT_ATTACHED, doc_journal)
 
-    parent_dossier = document.get_parent_dossier()
-    if parent_dossier:
-        dossier_journal = _(u'label_document_in_dossier_attached',
-                            default=u'Document in dossier attached to email '
-                                    u'via OfficeConnector')
+    return
 
-        journal_entry_factory(
-            parent_dossier, DOCUMENT_IN_DOSSIER_ATTACHED, dossier_journal,
-            visible=True, documents=[document])
+
+def dossier_attached_to_email(context, event):
+    dossier_journal = _(u'label_document_in_dossier_attached',
+                        default=u'Document in dossier attached to email '
+                                u'via OfficeConnector')
+
+    journal_entry_factory(
+        event.object, DOCUMENT_IN_DOSSIER_ATTACHED, dossier_journal,
+        visible=True, documents=event.documents)
 
     return

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -36,7 +36,6 @@ from opengever.task.task import ITask
 from opengever.trash.trash import ITrashedEvent
 from opengever.trash.trash import IUntrashedEvent
 from persistent.dict import PersistentDict
-from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone.app.versioningbehavior.utils import get_change_note
 from plone.dexterity.interfaces import IDexterityContent

--- a/opengever/journal/tests/test_attach_journal_entry.py
+++ b/opengever/journal/tests/test_attach_journal_entry.py
@@ -4,38 +4,103 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.journal.handlers import document_attached_to_email
+from opengever.journal.handlers import dossier_attached_to_email
 from opengever.testing import FunctionalTestCase
+
 import transaction
 
 
 class MockEvent(object):
+    """A convenience class to conform to a journal event."""
 
-    def __init__(self, obj):
+    def __init__(self, obj, documents=None):
         self.object = obj
+        self.documents = documents
 
 
 class TestAttachJournalEntry(FunctionalTestCase):
+    """Test journal entries from OC attach events."""
 
     @browsing
-    def test_attaching_document_creates_dossier_level_jounral_entry(self, browser):
+    def test_attaching_document_creates_dossier_level_jounral_entry(self, browser):  # noqa
         with freeze(datetime(2016, 12, 9, 9, 40)):
             self.dossier = create(Builder('dossier'))
-            self.document = create(Builder('document').within(self.dossier))
+            self.document = create(Builder('document')
+                                   .titled(u'docu-1')
+                                   .within(self.dossier))
             document_attached_to_email(self.document, MockEvent(self.document))
+            dossier_attached_to_email(
+                self.dossier, MockEvent(self.dossier, [self.document]))
             transaction.commit()
 
-        browser.login().open(self.dossier, view=u'tabbedview_view-journal')
+        browser.login()
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
         row = browser.css('.listing').first.rows[1]
 
         self.assertEquals(
             {'Changed by': 'Test User (test_user_1_)',
-             'Title': 'Document in dossier attached to email via OfficeConnector',
-             'References': u'Documents Testdokum\xe4nt',
+             'Title': 'Document in dossier attached to email via '
+             'OfficeConnector',
+             'References': u'Documents docu-1',
              'Comments': '',
              'Time': '09.12.2016 09:40'},
             row.dict())
 
-        self.assertEquals(u'Documents Testdokum\xe4nt',
+        self.assertEquals(u'Documents docu-1',
                           row.dict().get('References'))
-        browser.click_on(u'Testdokum\xe4nt')
+        browser.click_on(u'docu-1')
         self.assertEquals(self.document.absolute_url(), browser.url)
+
+        browser.open(self.document, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+
+        self.assertEquals(
+            {'Changed by': 'Test User (test_user_1_)',
+             'Title': 'Document attached to email via OfficeConnector',
+             'References': '',
+             'Comments': '',
+             'Time': '09.12.2016 09:40'},
+            row.dict())
+
+        # Second pass with 2 documents in a dossier
+        with freeze(datetime(2016, 12, 9, 9, 40)):
+            self.document_2 = create(Builder('document')
+                                     .titled(u'docu-2')
+                                     .within(self.dossier))
+            document_attached_to_email(self.document, MockEvent(self.document))
+            dossier_attached_to_email(
+                self.dossier, MockEvent(self.dossier, [
+                    self.document, self.document_2]))
+            transaction.commit()
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+
+        self.assertEquals(
+            {'Changed by': 'Test User (test_user_1_)',
+             'Title': 'Document in dossier attached to email via '
+             'OfficeConnector',
+             'References': u'Documents docu-1 docu-2',
+             'Comments': '',
+             'Time': '09.12.2016 09:40'},
+            row.dict())
+
+        self.assertEquals(u'Documents docu-1 docu-2',
+                          row.dict().get('References'))
+        browser.click_on(u'docu-1')
+        self.assertEquals(self.document.absolute_url(), browser.url)
+
+        browser.open(self.dossier, view=u'tabbedview_view-journal')
+        browser.click_on(u'docu-2')
+        self.assertEquals(self.document_2.absolute_url(), browser.url)
+
+        browser.open(self.document, view=u'tabbedview_view-journal')
+        row = browser.css('.listing').first.rows[1]
+
+        self.assertEquals(
+            {'Changed by': 'Test User (test_user_1_)',
+             'Title': 'Document attached to email via OfficeConnector',
+             'References': '',
+             'Comments': '',
+             'Time': '09.12.2016 09:40'},
+            row.dict())

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -48,7 +48,7 @@
       />
 
   <plone:service
-      method="GET"
+      method="POST"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       accept="application/json"
       factory=".service.OfficeConnectorAttachPayload"
@@ -57,7 +57,7 @@
       />
 
   <plone:service
-      method="GET"
+      method="POST"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       accept="application/json"
       factory=".service.OfficeConnectorCheckoutPayload"

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -90,13 +90,8 @@ def create_oc_url(request, context, payload):
     # Create a multi-document payload
     payload['documents'] = []
 
-    # Use plain locators for one document payloads - saves on char count
-    if len(documents) == 1:
-        payload['url'] += '/' + api.content.get_uuid(documents[0])
-        del payload['documents']
-    else:
-        for document in documents:
-            payload['documents'].append(api.content.get_uuid(document))
+    for document in documents:
+        payload['documents'].append(api.content.get_uuid(document))
 
     user_id = api.user.get_current().getId()
 

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -19,7 +19,7 @@ class OfficeConnectorURL(Service):
     """Create oc:<JWT> URLs for javascript to fetch and pass to the OS."""
 
     def create_officeconnector_url_json(self, payload):
-        self.request.response.setHeader('Content-type', 'application/json')
+        self.request.response.setHeader('Content-Type', 'application/json')
 
         url = create_oc_url(self.request, self.context, payload)
 
@@ -113,7 +113,9 @@ class OfficeConnectorAttachPayload(OfficeConnectorPayload):
     """
 
     def render(self):
-        self.request.response.setHeader('Content-type', 'application/json')
+        self.request.response.setHeader('Content-Type', 'application/json')
+
+        payloads = self.get_base_payloads()
 
         payload = self.get_base_payload()
 

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -1,5 +1,6 @@
 from ftw.mail.interfaces import IEmailAddress
 from opengever.document.events import FileAttachedToEmailEvent
+from opengever.dossier.events import DossierAttachedToEmailEvent
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
@@ -65,7 +66,6 @@ class OfficeConnectorCheckoutURL(OfficeConnectorURL):
 
 class OfficeConnectorPayload(Service):
     """Issue JSON instruction payloads for OfficeConnector."""
-
 
     def __init__(self, context, request):
         super(OfficeConnectorPayload, self).__init__(context, request)
@@ -138,6 +138,10 @@ class OfficeConnectorAttachPayload(OfficeConnectorPayload):
             payload['title'] = document.title_or_id()
             del payload['document']
             notify(FileAttachedToEmailEvent(document))
+
+        for uuid, documents in dossier_notifications.iteritems():
+            dossier = api.content.get(UID=uuid)
+            notify(DossierAttachedToEmailEvent(dossier, documents))
 
         return json.dumps(payloads)
 

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -70,9 +70,9 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
                                                 self.original_file_content))
 
         self.mail_with_file_wf_open = create(Builder('mail')
-                                            .titled(u'Mail 2')
-                                            .within(self.open_dossier)
-                                            .with_dummy_message())
+                                             .titled(u'Mail 2')
+                                             .within(self.open_dossier)
+                                             .with_dummy_message())
 
         self.doc_with_file_wf_open_second = create(Builder('document')
                                                    .titled(u'docu-3')

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -157,7 +157,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         self.api.headers.update({'Accept': 'text/html'})
         data = {
             'form.widgets.file.action': 'replace',
-            'form.buttons.save': 'Save',
+            'form.buttons.upload': 'oc-file-upload',
             '_authenticator': payload['csrf-token'],
             }
 


### PR DESCRIPTION
* Port OC payload fetches into POSTs to enable less requests per multiattach cycle
* Clump OC document attach dossier journal entries per dossier per event
* Amend the tests

Closes #2873 