### PR TITLE
i18n: Use some existing translations for message strings that can use the same translation.

### DIFF
--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -2,19 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-04-27 11:21+0000\n"
-"PO-Revision-Date: 2016-09-20 21:24+0000\n"
-"Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
+"PO-Revision-Date: 2017-05-01 15:55+0000\n"
+"Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
+"gever/opengever-contact/fr/>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-"Language: fr\n"
-"X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "Add Person"
 #: ./opengever/contact/browser/person.py:123
@@ -87,7 +88,7 @@ msgstr ""
 #. Default: "Firstname"
 #: ./opengever/contact/browser/person_listing.py:40
 msgid "column_firstname"
-msgstr ""
+msgstr "Prénom"
 
 #. Default: "Former contact id"
 #: ./opengever/contact/browser/organization_listing.py:41
@@ -98,7 +99,7 @@ msgstr ""
 #. Default: "Lastname"
 #: ./opengever/contact/browser/person_listing.py:44
 msgid "column_lastname"
-msgstr ""
+msgstr "Nom"
 
 #. Default: "Name"
 #: ./opengever/contact/browser/organization_listing.py:33
@@ -221,7 +222,7 @@ msgstr ""
 #: ./opengever/contact/browser/participation_forms.py:136
 #: ./opengever/contact/browser/templates/person_edit.pt:28
 msgid "label_cancel"
-msgstr ""
+msgstr "Annuler"
 
 #. Default: "City"
 #: ./opengever/contact/contact.py:165
@@ -403,7 +404,7 @@ msgstr ""
 #. Default: "Roles"
 #: ./opengever/contact/browser/participation_forms.py:30
 msgid "label_roles"
-msgstr ""
+msgstr "Rôles"
 
 #. Default: "Salutation"
 #: ./opengever/contact/browser/person.py:92
@@ -472,4 +473,3 @@ msgstr "Résultat(s): ${amount}"
 #: ./opengever/contact/contact.py:44
 msgid "telefon"
 msgstr "Téléphone"
-

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -2,19 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-04-27 11:21+0000\n"
-"PO-Revision-Date: 2016-09-20 21:24+0000\n"
-"Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
+"PO-Revision-Date: 2017-05-01 15:48+0000\n"
+"Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
+"gever/opengever-document/fr/>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-"Language: fr\n"
-"X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/20170322142153_add_office_connector_multi_attach_action_to_documents/actions.xml
@@ -201,7 +202,7 @@ msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire
 #. Default: "You have not selected any Items"
 #: ./opengever/document/browser/report.py:65
 msgid "error_no_items"
-msgstr ""
+msgstr "Aucun élément sélectionné."
 
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py:74
@@ -412,7 +413,7 @@ msgstr "Type de document"
 
 #: ./opengever/document/browser/report.py:51
 msgid "label_dossier_title"
-msgstr ""
+msgstr "Titre du dossier"
 
 #: ./opengever/document/browser/templates/downloadconfirmation.pt:25
 msgid "label_download"
@@ -483,7 +484,7 @@ msgstr "Aperçu"
 
 #: ./opengever/document/browser/report.py:47
 msgid "label_public_trial"
-msgstr ""
+msgstr "Statut public"
 
 #. Default: "Date of receipt"
 #: ./opengever/document/behaviors/metadata.py:100
@@ -576,4 +577,3 @@ msgstr "Avec commentaire"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Sans commentaire"
-

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -2,19 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-04-27 11:21+0000\n"
-"PO-Revision-Date: 2016-09-20 21:24+0000\n"
-"Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
+"PO-Revision-Date: 2017-05-01 15:56+0000\n"
+"Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
+"gever/opengever-dossier/fr/>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-"Language: fr\n"
-"X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/dossier/move_items.py:149
 msgid "${copied_items} Elements were moved successfully"
@@ -321,7 +322,7 @@ msgstr "Date de clôture obligatoire"
 #. Default: "You have not selected any items."
 #: ./opengever/dossier/browser/report.py:59
 msgid "error_no_items"
-msgstr "Vous n'avez sélectionné aucun objet."
+msgstr "Aucun élément sélectionné."
 
 #. Default: "Common"
 #: ./opengever/dossier/behaviors/dossier.py:48
@@ -464,7 +465,7 @@ msgstr ""
 #. Default: "Address"
 #: ./opengever/dossier/templatefolder/form.py:272
 msgid "label_address"
-msgstr ""
+msgstr "Adresse"
 
 #. Default: "by ${author}"
 #: ./opengever/dossier/project_templates/byline.pt:10
@@ -474,7 +475,7 @@ msgstr "Responsable: ${author}"
 #. Default: "Cancel"
 #: ./opengever/dossier/viewlets/templates/note.pt:55
 msgid "label_cancel"
-msgstr ""
+msgstr "Annuler"
 
 #. Default: "Close"
 #: ./opengever/dossier/viewlets/templates/note.pt:61
@@ -512,7 +513,7 @@ msgstr "Créé par"
 #: ./opengever/dossier/browser/overview.py:239
 #: ./opengever/dossier/templatefolder/tabs.py:141
 msgid "label_description"
-msgstr ""
+msgstr "Description"
 
 #. Default: "Destination"
 #: ./opengever/dossier/move_items.py:26
@@ -777,7 +778,7 @@ msgstr "Corbeille"
 #. Default: "URL"
 #: ./opengever/dossier/templatefolder/form.py:306
 msgid "label_url"
-msgstr ""
+msgstr "Adresse URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
@@ -873,4 +874,3 @@ msgstr ""
 #: ./opengever/dossier/behaviors/participation.py:196
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation."
-

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -2,19 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-04-27 11:21+0000\n"
-"PO-Revision-Date: 2016-08-10 05:15+0000\n"
-"Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
+"PO-Revision-Date: 2017-05-01 15:51+0000\n"
+"Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
+"gever/opengever-journal/fr/>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-"Language: fr\n"
-"X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "Journal"
 #: ./opengever/journal/templates/journalhistory.pt:15
@@ -24,7 +25,7 @@ msgstr "Historique"
 #. Default: "Changed by"
 #: ./opengever/journal/tab.py:75
 msgid "label_actor"
-msgstr "Modifier le"
+msgstr "Modifier par"
 
 #. Default: "Add journal entry"
 #: ./opengever/journal/form.py:54
@@ -45,7 +46,7 @@ msgstr ""
 #. Default: "Comment"
 #: ./opengever/journal/form.py:22
 msgid "label_comment"
-msgstr ""
+msgstr "commentaire"
 
 #. Default: "Comments"
 #: ./opengever/journal/tab.py:79
@@ -161,7 +162,7 @@ msgstr ""
 #. Default: "Documents"
 #: ./opengever/journal/templates/journal_references.pt:17
 msgid "label_documents"
-msgstr ""
+msgstr "Documents"
 
 #. Default: "Dossier added: ${title}"
 #: ./opengever/journal/handlers.py:228
@@ -297,4 +298,3 @@ msgstr "Historique"
 #: ./opengever/journal/templates/journal_selection.pt:9
 msgid "tab_matches"
 msgstr "Résultat(s): ${amount}"
-

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -5,19 +5,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-04-27 11:21+0000\n"
-"PO-Revision-Date: 2016-08-10 05:19+0000\n"
-"Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
+"PO-Revision-Date: 2017-05-01 15:57+0000\n"
+"Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
+"gever/opengever-meeting/fr/>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-"Language: fr\n"
-"X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/meeting/command.py:364
 msgid "A new submitted version of document ${title} has been created."
@@ -130,11 +131,11 @@ msgstr "Le document ${title} a déjà été soumis dans cette version."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:292
 msgid "Documents"
-msgstr ""
+msgstr "Documents"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:98
 msgid "Edit"
-msgstr ""
+msgstr "Modifier"
 
 #: ./opengever/meeting/command.py:101
 msgid "Excerpt for agenda item ${title} has been generated successfully"
@@ -336,7 +337,7 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:291
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:47
 msgid "Unschedule"
@@ -669,7 +670,7 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/excerpt.py:153
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:36
 msgid "label_cancel"
-msgstr ""
+msgstr "Annuler"
 
 #. Default: "Close"
 #: ./opengever/meeting/browser/meetings/protocol.py:239
@@ -862,7 +863,7 @@ msgstr ""
 #. Default: "File"
 #: ./opengever/meeting/proposaltemplate.py:19
 msgid "label_file"
-msgstr ""
+msgstr "Fichier"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt:274
@@ -1217,7 +1218,7 @@ msgstr "Nouvelles propositions soumises"
 #. Default: "Overview"
 #: ./opengever/meeting/browser/tabbed.py:10
 msgid "overview"
-msgstr ""
+msgstr "Sommaire"
 
 #. Default: "Paragraph successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py:281
@@ -1391,4 +1392,3 @@ msgstr ""
 #: ./opengever/meeting/model/proposal.py:163
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
-


### PR DESCRIPTION
These translations have already been used for message strings in other domains with the exact same ID, and they should be generic enough not to be context dependent.