### PR TITLE
Avoid unauthorized redirect loops

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 
   [Rotonen]
 
+- Avoid unauthorized redirect loops. [jone]
 - Add an aggregated per dossier attach to email event on OC attach actions. [Rotonen]
 - Fix some common i18n issues:
 

--- a/opengever/base/skins/opengever.base_scripts/require_login.py
+++ b/opengever/base/skins/opengever.base_scripts/require_login.py
@@ -8,21 +8,51 @@
 ##title=Login
 ##
 
-login = 'login'
+from AccessControl import Unauthorized
 
 portal = context.portal_url.getPortalObject()
-# if cookie crumbler did a traverse instead of a redirect,
-# this would be the way to get the value of came_from
-#url = portal.getCurrentUrl()
-#context.REQUEST.set('came_from', url)
+portal_url = portal.absolute_url().rstrip('/') + '/'
+request = context.REQUEST
 
 if context.portal_membership.isAnonymousUser():
-    return portal.restrictedTraverse(login)()
+    return portal.restrictedTraverse('login')()
+
+if request.method != 'GET':
+    # We should not try to redirect when we have a POST payload,
+    # because we cannot take along the payload.
+    return portal.restrictedTraverse('insufficient_privileges')()
+
+
+came_from_url = request.get('came_from')
+if 'require_login_avoid_loop=' in came_from_url.split('?')[-1]:
+    # We already sent the user back to the came_from url,
+    # but it looks that we have a redirect loop due to an Unauthorized
+    # exception while publishing the traversable endpoint.
+    return portal.restrictedTraverse('insufficient_privileges')()
 else:
-    expected_location = context.REQUEST.get('came_from')
-    try:
-        #XXX Attempt a traverse to the given path
-        portal.restrictedTraverse(expected_location.replace(portal.absolute_url()+'/',''))
-        container.REQUEST.RESPONSE.redirect(expected_location)
-    except:
-        return portal.restrictedTraverse('insufficient_privileges')()
+    # Attach a marker so that we can detect redirect loops.
+    if '?' in came_from_url:
+        came_from_url += '&require_login_avoid_loop=true'
+    else:
+        came_from_url += '?require_login_avoid_loop=true'
+
+
+if not came_from_url.startswith(portal_url):
+    raise ValueError('URL {!r} not in portal {!r}'.format(
+        came_from_url, portal_url))
+
+
+came_from_path = came_from_url[len(portal_url):].split('?')[0].split('#')[0]
+try:
+    # Probe for an actual Unauthorized exception while traversing.
+    portal.restrictedTraverse(came_from_path)
+except Unauthorized:
+    # This is expected to be the standard use case, where the user
+    # actually has insufficient privileges.
+    return portal.restrictedTraverse('insufficient_privileges')()
+else:
+    # We've had an Unauthorized exception on the previous resource although
+    # the current user has enough privileges.
+    # This usually because of an MS Office probe without cookies beforehand.
+    # We simply redirect the user back to came_from for a retry.
+    return request.RESPONSE.redirect(came_from_url)

--- a/opengever/base/tests/test_require_login.py
+++ b/opengever/base/tests/test_require_login.py
@@ -1,9 +1,12 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
+from zExceptions import Unauthorized
+import urllib
 
 
 class TestRequireLoginScript(FunctionalTestCase):
@@ -22,17 +25,31 @@ class TestRequireLoginScript(FunctionalTestCase):
     @browsing
     def test_require_login_redirects_to_came_from_if_already_logged_in(self, browser):
         browser.login().open(
-            view='require_login',
-            data={'came_from': self.document.absolute_url()})
-        self.assertEqual(browser.url, self.document.absolute_url())
+            view='require_login?came_from={}'.format(
+                urllib.quote(self.document.absolute_url())))
+        self.assertEqual(self.document.absolute_url(),
+                         browser.url.split('?')[0])
 
     @browsing
     def test_require_login_displays_login_form_and_redirecs_upon_login(self, browser):
         browser.open(
-            view='require_login',
-            data={'came_from': self.document.absolute_url()})
-        self.assertEqual('http://nohost/plone/require_login', browser.url)
+            view='require_login?came_from={}'.format(
+                urllib.quote(self.document.absolute_url())))
+        self.assertTrue(
+            browser.url.startswith('http://nohost/plone/require_login'),
+            'Unexpected URL {}'.format(browser.url))
 
         browser.fill({'Login Name': TEST_USER_NAME,
                       'Password': TEST_USER_PASSWORD}).submit()
-        self.assertEqual(browser.url, self.document.absolute_url())
+        self.assertEqual(self.document.absolute_url(), browser.url)
+
+    @browsing
+    def test_unauthorized_visible_when_raised_in_traversal(self, browser):
+        with self.assertRaises(Unauthorized):
+            browser.login().open(view='test-traversal-unauthorized')
+
+    @browsing
+    def test_unauthorized_visible_when_raised_in_publishing(self, browser):
+        browser.replace_request_header('X-zope-handle-errors', 'True')
+        browser.login().open(view='test-publishing-unauthorized')
+        self.assertEquals('Insufficient Privileges', plone.first_heading())

--- a/opengever/base/tests/views/configure.zcml
+++ b/opengever/base/tests/views/configure.zcml
@@ -11,4 +11,18 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:page
+      name="test-traversal-unauthorized"
+      class=".unauthorized.TraversalUnauthorized"
+      for="*"
+      permission="zope2.Public"
+      />
+
+  <browser:page
+      name="test-publishing-unauthorized"
+      class=".unauthorized.PublishingUnauthorized"
+      for="*"
+      permission="zope2.Public"
+      />
+
 </configure>

--- a/opengever/base/tests/views/unauthorized.py
+++ b/opengever/base/tests/views/unauthorized.py
@@ -1,0 +1,14 @@
+from Products.Five import BrowserView
+from zExceptions import Unauthorized
+
+
+class TraversalUnauthorized(BrowserView):
+
+    def __init__(self, context, request):
+        raise Unauthorized()
+
+
+class PublishingUnauthorized(BrowserView):
+
+    def __call__(self):
+        raise Unauthorized()


### PR DESCRIPTION
The require_login script was customized in order to support MS Office
probing, which happens without the session (cookies).

The old implementation had issues:
- When the request had a payload, such as a POST request, the payload
  did not survive the redirect. When a ++add++ could be rendered but not
  posted, this caused the form to reload empty without an error.
- When the unauthorized exception did not happen during traversal but
  during publishing a redirect loop was created.

In order to fix this issues I rewrote the require_login script to be
more robust.
- No longer redirect when the request method is not GET.
- When redirecting, add a marker GET parameter for detecting loopbacks
  and breaking redirect loops.
- No longer catch all exceptions; catch only the Unauthorized exception.
- Remove GET-Params when converting to a path when probing.
- Crash on purpose when came_from is not within our site root.

---

Besides fixing a bunch of actual redirect loops in the application this change allows us to move on to a newer ftw.testbrowser later, without downgrading the HTTP error handling.