### PR TITLE
Improve UX for office connector interactions.

### DIFF
--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -32,8 +32,9 @@
             <tal:checkout_and_edit_enabled tal:condition="checkout_and_edit_available">
 
                 <tal:oc_checkout tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
-                    <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;"
-                        class="function-edit"
+                    <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+                                       data-document-url context/absolute_url"
+                        class="function-edit oc-checkout"
                         href="#"
                         i18n:translate="label_checkout_and_edit">
                         Checkout and edit

--- a/opengever/document/static/officeconnector.js
+++ b/opengever/document/static/officeconnector.js
@@ -1,3 +1,71 @@
+(function($) {
+
+    "use strict";
+
+    function poll(fn, options) {
+
+        options = $.extend({
+            interval: 2000,
+            timeout: 15 * 1000
+        }, options);
+
+        var promise = $.Deferred();
+        var endTime = new Date().getTime() + options.timeout;
+
+        function checkCondition() {
+            $.when(fn()).done(function(proceed) {
+                if(proceed) {
+                    promise.resolve();
+                } else if(new Date().getTime() < endTime) {
+                    setTimeout(checkCondition, options.interval);
+                } else {
+                    promise.reject(new Error("Polling timed out using timeout of: " + options.timeout + "ms"));
+                }
+            });
+        }
+
+        checkCondition();
+
+        return promise;
+    }
+
+    function requestJSON(url) {
+        return $.ajax(url, {
+            headers: {
+                Accept: "application/json",
+            }
+        });
+    }
+
+    function isDocumentCheckedOut(documentURL) {
+        return requestJSON(documentURL + "/status").pipe(function(data) {
+            return JSON.parse(data)["checked_out"];
+        });
+    }
+
+    function checkout(trigger, documentURL) {
+        if(trigger.hasClass("oc-loading")) {
+            return false;
+        }
+        trigger.addClass("oc-loading");
+        return poll(function() {
+            return isDocumentCheckedOut(documentURL)
+        });
+    }
+
+    $(document).on("click", ".oc-checkout", function(event) {
+        var checkoutButton = $(event.currentTarget);
+        var documentURL = checkoutButton.data("document-url");
+        var checkoutRequest = checkout(checkoutButton, documentURL);
+        checkoutRequest.done(function() {
+            location.reload();
+        }).always(function() {
+            checkoutButton.removeClass("oc-loading");
+        });
+    });
+
+})(window.jQuery);
+
 function openOfficeconnector(data) {
     // URLs the browser does not handle get passed onto the OS
     window.location = data['url'];


### PR DESCRIPTION
Depends on https://github.com/4teamwork/plonetheme.teamraum/pull/549

Closes https://github.com/4teamwork/opengever.core/issues/2876

In order to give the user a feedback poll the document state to determine
if the office connector has completely loaded.

![gever-officeconnector-autoreload](https://cloud.githubusercontent.com/assets/1637820/25663572/5928b088-3018-11e7-8875-e0fc67f7798e.gif)
