### PR TITLE
Always render a task link for administrators or managers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -24,6 +24,9 @@ Changelog
 - Remove no longer used ftw.treeview dependency. [phgross]
 - Improve help text for task responsible selection. [lgraf]
 - Fix mail downloads by demanding a context to be passed into DC helpers. [Rotonen]
+- Always render a task link for administrators or managers. [phgross]
+- Improve help text for task responsible selection. [lgraf]
+
 - Make OC multiattach behave more gracefully for long URLs:
 
   - Relax length limit from 500 to 2000 bytes for browsers other than IE11

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -274,6 +274,10 @@ class Task(Base):
         if not member:
             return False
 
+        roles = api.user.get_roles(user=member)
+        if 'Administrator' in roles or 'Manager' in roles:
+            return True
+
         principals = set(member.getGroups() + [member.getId()])
         allowed_principals = set(self.principals)
         return len(principals & allowed_principals) > 0

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -56,6 +56,24 @@ class TestTaskLinkGeneration(FunctionalTestCase):
         self.assertEquals('(Client1 / Test User (test_user_1_))',
                           link.xpath(css_to_xpath('span'))[2].text)
 
+    def test_task_is_always_linked_when_user_has_administrator_role(self):
+        self.grant('Administrator')
+        link = self.add_task_and_get_link(principals=[])
+        link_tag = link.xpath(css_to_xpath('a'))[0]
+
+        self.assertEquals(
+            'http://example.com/qux/dossier-1/task-2',
+            link_tag.get('href'))
+
+    def test_task_is_always_linked_when_user_has_manager_role(self):
+        self.grant('Manager')
+        link = self.add_task_and_get_link(principals=[])
+        link_tag = link.xpath(css_to_xpath('a'))[0]
+
+        self.assertEquals(
+            'http://example.com/qux/dossier-1/task-2',
+            link_tag.get('href'))
+
     def test_link_title_is_breadcrumb(self):
         link = self.add_task_and_get_link()
         link_tag = link.xpath(css_to_xpath('a'))[0]


### PR DESCRIPTION
Skip access test when the current user has Administrator or Manager role.

Closes #2838 