### PR TITLE
Remove no longer used ftw.treeview dependency.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Tests: Manage monkey patching of PDFCONVERTER_AVAILABLE through a context manager. [lgraf]
+- Remove no longer used ftw.treeview dependency. [phgross]
 - Improve help text for task responsible selection. [lgraf]
 - Fix mail downloads by demanding a context to be passed into DC helpers. [Rotonen]
 - Make OC multiattach behave more gracefully for long URLs:

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,6 @@ setup(name='opengever.core',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-        # Remove ftw.treeview when uninstall upgrade installed.
-        'ftw.treeview',
-
         'alembic >= 0.7.0',
         'collective.autopermission',
         'collective.blueprint.jsonmigrator',


### PR DESCRIPTION
The use of ftw.treeview has been dropped during the portlet rework in #476, and this change is deployed on every productive deployment. So the ftw.treeview dependency can be dropped completely.

Closes #2452 