### PR TITLE
Tests: Manage monkey patching of PDFCONVERTER_AVAILABLE through a context manager

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.1.2 (unreleased)
 ---------------------
 
+- Tests: Manage monkey patching of PDFCONVERTER_AVAILABLE through a context manager. [lgraf]
 - Improve help text for task responsible selection. [lgraf]
 - Fix mail downloads by demanding a context to be passed into DC helpers. [Rotonen]
 - Make OC multiattach behave more gracefully for long URLs:

--- a/opengever/base/pdfconverter.py
+++ b/opengever/base/pdfconverter.py
@@ -1,5 +1,6 @@
-import pkg_resources
 from opengever.bumblebee import is_bumblebee_feature_enabled
+import pkg_resources
+import threading
 
 
 try:
@@ -8,6 +9,11 @@ except pkg_resources.DistributionNotFound:
     PDFCONVERTER_AVAILABLE = False
 else:
     PDFCONVERTER_AVAILABLE = True
+
+
+# Lock used by context manager in og.core.testing to manage safe monkey
+# patching of PDFCONVERTER_AVAILABLE flag
+pdfconverter_available_lock = threading.Lock()
 
 
 def is_pdfconverter_enabled():


### PR DESCRIPTION
Previously, the `PDFCONVERTER_AVAILABLE` flag was being monkey patched in tests without being reset properly.

In one case, it was being "reset" to `False` in a hardcoded way. This was the default until we added `opengever.pdfconverter` as a test dependency. From that point on, the flag was being reset to an incorrect default value. However, this only started to flare up in tests once we shuffled around their execution order with parallelization improvements to `bin/mtest`.
