### PR TITLE
Do not sync task workflow changes to forwarding predecessors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Improve view permissions (ported from 4.15.5). [jone]
+- Do not sync task workflow changes to forwarding predecessors. [phgross]
 - Tests: Manage monkey patching of PDFCONVERTER_AVAILABLE through a context manager. [lgraf]
 - Remove no longer used ftw.treeview dependency. [phgross]
 - Improve help text for task responsible selection. [lgraf]

--- a/opengever/task/response_syncer/workflow.py
+++ b/opengever/task/response_syncer/workflow.py
@@ -15,7 +15,14 @@ class WorkflowResponseSyncerSender(BaseResponseSyncerSender):
     def get_related_tasks_to_sync(self, transition):
         if not self._is_synced_transition(transition):
             return []
-        return super(WorkflowResponseSyncerSender, self).get_related_tasks_to_sync(transition)
+
+        tasks = super(WorkflowResponseSyncerSender, self).get_related_tasks_to_sync(
+            transition)
+
+        # Skip forwardings. Workflow state changes should never be
+        # synced to the successor forwarding, because a forwarding predecessor
+        # is allways closed and stored in the yearfolder.
+        return [task for task in tasks if not task.is_forwarding]
 
     def raise_sync_exception(self, task, transition, text, **kwargs):
         raise ResponseSyncerSenderException(


### PR DESCRIPTION
Workflow changes should never be synced to a forwarding predecessor, because a forwarding predecessor is always closed and stored in a yearfolder. The forwarding has been already ignored by syncing, but the special handling has been removed by mistake during the rework PR #2828.

This fixes an `Forbidden` exception when trying to reassign a task, which has been created while assigning a forwarding to a dossier.

Closes #2912 