### PR TITLE
Ensure plone.rest directives are loaded.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.2.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Make sure `plone.rest` directives are loaded when used. [deiferni]
 
 
 2017.2.0 (2017-05-11)

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -18,6 +18,7 @@
   <include package="plone.directives.form" />
   <include package="plone.directives.form" file="meta.zcml" />
   <include package="plone.formwidget.namedfile" />
+  <include package="plone.rest" file="meta.zcml" />
   <include package="ftw.profilehook" />
 
   <include package=".behaviors" />


### PR DESCRIPTION
Currently it seems to work only by coincidence, now we make sure that `plone.rest` `service` directive is loaded when it is being used.