### PR TITLE
Move ftw.testbrowser pinning to opengever/develop.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -18,8 +18,3 @@ zptlint = 0.2.4
 # which causes test isolation problems with PloneTestCase layers
 # which are not isolating properly.
 zope.testrunner = 4.4.4
-
-# Downgrade testbrowser because tests are failing due to some bugs
-# in ftw.testbrowser 1.21.0. This pinning should be removed as soon
-# as the ftw.testbrowser is fixed.
-ftw.testbrowser = 1.20.0


### PR DESCRIPTION
Remove the ftw.testbrowser from the versions.cfg since it was added to opengever/develop.
https://github.com/4teamwork/kgs/pull/100
Lets only have it pinned once.