### PR TITLE
Update ftw.testbrowser to newest version

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.2.2 (unreleased)
 ---------------------
 
+- Handle require_login error where came_from_did not exist. [jone]
 - Word meeting: replace proposal textfields with a document. [jone]
 
 

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -6,8 +6,6 @@ from opengever.activity.browser import resolve_notification_url
 from opengever.base.oguid import Oguid
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
-from zExceptions import NotFound
-from zExceptions import Unauthorized
 
 
 class TestResolveNotificationView(FunctionalTestCase):
@@ -23,12 +21,12 @@ class TestResolveNotificationView(FunctionalTestCase):
 
     @browsing
     def test_raises_notfound_when_notification_id_is_missing(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.portal, view='resolve_notification')
 
     @browsing
     def test_raises_notfound_when_notification_id_is_invalid(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.portal, view='resolve_notification',
                                  data={'notification_id': '123'})
 
@@ -42,10 +40,11 @@ class TestResolveNotificationView(FunctionalTestCase):
         notification = create(Builder('notification')
                               .having(activity=activity, userid='hugo.boss'))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(
-                self.portal, view='resolve_notification',
-                data={'notification_id': notification.notification_id})
+                self.portal,
+                view='resolve_notification?notification_id={}'.format(
+                    notification.notification_id))
 
     @browsing
     def test_mark_notification_as_read(self, browser):
@@ -96,7 +95,7 @@ class TestResolveNotificationView(FunctionalTestCase):
         # raise an NotFound exception,  because the view redirects to the
         # foreign admin_unit. But we can't setup a second plone site
         # in this test.
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(
                 self.portal, view='resolve_notification',
                 data={'notification_id': notification.notification_id})

--- a/opengever/activity/tests/test_views.py
+++ b/opengever/activity/tests/test_views.py
@@ -82,7 +82,7 @@ class TestMarkAsRead(FunctionalTestCase):
 
     @browsing
     def test_read_raise_exception_when_parameter_is_missing(self, browser):
-        with self.assertRaises(Exception):
+        with browser.expect_http_error():
             browser.login().open(self.portal, view='notifications/read')
 
 

--- a/opengever/base/skins/opengever.base_scripts/require_login.py
+++ b/opengever/base/skins/opengever.base_scripts/require_login.py
@@ -9,6 +9,7 @@
 ##
 
 from AccessControl import Unauthorized
+from zExceptions import NotFound
 
 portal = context.portal_url.getPortalObject()
 portal_url = portal.absolute_url().rstrip('/') + '/'
@@ -49,6 +50,9 @@ try:
 except Unauthorized:
     # This is expected to be the standard use case, where the user
     # actually has insufficient privileges.
+    return portal.restrictedTraverse('insufficient_privileges')()
+except (KeyError, AttributeError, NotFound):
+    # The content could not be found.
     return portal.restrictedTraverse('insufficient_privileges')()
 else:
     # We've had an Unauthorized exception on the previous resource although

--- a/opengever/base/tests/test_anonymous.py
+++ b/opengever/base/tests/test_anonymous.py
@@ -1,4 +1,3 @@
-from AccessControl import Unauthorized
 from ftw.testbrowser import browsing
 from opengever.testing import FunctionalTestCase
 
@@ -7,7 +6,7 @@ class TestAnonymousAccess(FunctionalTestCase):
 
     @browsing
     def test_anonymous_cannot_access_search(self, browser):
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.visit(self.portal, view='search')
 
     @browsing

--- a/opengever/base/tests/test_edit_public_trial_form.py
+++ b/opengever/base/tests/test_edit_public_trial_form.py
@@ -3,7 +3,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.browser import edit_public_trial
 from opengever.testing import FunctionalTestCase
-from zExceptions import Unauthorized
 from opengever.base.behaviors.classification import PUBLIC_TRIAL_PRIVATE
 
 
@@ -78,7 +77,7 @@ class TestEditPublicTrialForm(FunctionalTestCase):
     def test_raise_aunauthorized_if_the_user_CANNOT_modify(self, browser):
         user = create(Builder('user').with_roles('Contributor'))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login(user.getId()).visit(self.document,
                                               view='edit_public_trial')
 

--- a/opengever/base/tests/test_require_login.py
+++ b/opengever/base/tests/test_require_login.py
@@ -45,11 +45,10 @@ class TestRequireLoginScript(FunctionalTestCase):
 
     @browsing
     def test_unauthorized_visible_when_raised_in_traversal(self, browser):
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(view='test-traversal-unauthorized')
 
     @browsing
     def test_unauthorized_visible_when_raised_in_publishing(self, browser):
-        browser.replace_request_header('X-zope-handle-errors', 'True')
         browser.login().open(view='test-publishing-unauthorized')
         self.assertEquals('Insufficient Privileges', plone.first_heading())

--- a/opengever/base/tests/test_require_login.py
+++ b/opengever/base/tests/test_require_login.py
@@ -52,3 +52,12 @@ class TestRequireLoginScript(FunctionalTestCase):
     def test_unauthorized_visible_when_raised_in_publishing(self, browser):
         browser.login().open(view='test-publishing-unauthorized')
         self.assertEquals('Insufficient Privileges', plone.first_heading())
+
+    @browsing
+    def test_unauthorized_when_came_from_does_not_exist(self, browser):
+        # When the came_from URL does not exist, we want the regular unauthorized
+        # page to appear when logged in.
+        url = ('{0}/acl_users/credentials_cookie_auth/require_login'
+               '?came_from={0}/does/not/exist').format(self.portal.absolute_url())
+        browser.login().open(url)
+        self.assertEquals('Insufficient Privileges', plone.first_heading())

--- a/opengever/base/tests/test_resolve_oguid.py
+++ b/opengever/base/tests/test_resolve_oguid.py
@@ -4,7 +4,6 @@ from ftw.testbrowser import browsing
 from opengever.base.browser.resolveoguid import ResolveOGUIDView
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import logout
-from zExceptions import Unauthorized
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
@@ -29,7 +28,7 @@ class TestResolveOGUIDView(FunctionalTestCase):
         logout()
         url = ResolveOGUIDView.url_for('client1:{}'.format(self.task_id),
                                        self.admin_unit)
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.open(url)
 
     @browsing

--- a/opengever/bumblebee/tests/test_download.py
+++ b/opengever/bumblebee/tests/test_download.py
@@ -5,15 +5,12 @@ from ftw.bumblebee.interfaces import IBumblebeeDocument
 from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.bumblebee.tests.helpers import download_token_for
-from ftw.bumblebee.tests.helpers import set_file
 from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
 from plone.namedfile.file import NamedBlobFile
 from plone.uuid.interfaces import IUUID
 from Products.Archetypes.event import ObjectEditedEvent
-from zExceptions import BadRequest
-from zExceptions import NotFound
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 import transaction
@@ -80,11 +77,8 @@ class TestBumblebeeDownloadView(FunctionalTestCase):
 
     @browsing
     def test_parameters_required(self, browser):
-        with self.assertRaises(BadRequest) as cm:
+        with browser.expect_http_error(reason='Bad Request'):
             browser.open(view='bumblebee_download')
-
-        self.assertEquals('missing params: checksum, token, uuid',
-                          str(cm.exception))
 
     @browsing
     def test_download_version_after_a_change(self, browser):
@@ -121,10 +115,8 @@ class TestBumblebeeDownloadView(FunctionalTestCase):
                      .attach_file_containing(u'The Content', name=u'file.pdf')
                      .within(self.dossier))
 
-        with self.assertRaises(NotFound) as cm:
+        with browser.expect_http_error(reason='Not Found'):
             browser.open(view='bumblebee_download',
                          data={'token': download_token_for(doc),
                                'uuid': IUUID(doc),
                                'checksum': 'wrong-checksum'})
-
-        self.assertEquals('Version not found by checksum.', str(cm.exception))

--- a/opengever/contact/tests/test_mail_addresses_view.py
+++ b/opengever/contact/tests/test_mail_addresses_view.py
@@ -6,7 +6,6 @@ from opengever.contact.browser.mail import IMailAddressesActions
 from opengever.contact.browser.mail import MailAddressesView
 from opengever.contact.models.mailaddress import MailAddress
 from opengever.testing import FunctionalTestCase
-from zExceptions import NotFound
 from zope.interface.verify import verifyClass
 
 
@@ -208,17 +207,17 @@ class TestMailAddressesView(FunctionalTestCase):
 
     @browsing
     def test_raise_not_found_if_not_an_api_function_and_not_a_number(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().visit(self.contactfolder, view='contact-1/mails/bad_name')
 
     @browsing
     def test_raise_not_found_if_mail_address_id_is_already_set_on_view(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().visit(self.contactfolder, view='contact-1/mails/10/100')
 
     @browsing
     def test_raise_not_found_if_no_mailaddress_with_the_given_id_exists(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().visit(self.contactfolder, view='contact-1/mails/10')
 
     @browsing
@@ -230,7 +229,7 @@ class TestMailAddressesView(FunctionalTestCase):
                        .labeled(u'Home')
                        .having(address=u'peter@example.com'))
 
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().visit(
                 self.contactfolder,
                 view='contact-1/mails/{}'.format(email.mailaddress_id))

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -12,7 +12,6 @@ from opengever.core.testing import toggle_feature
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import get_contacts_token
 from plone import api
-from zExceptions import Unauthorized
 
 
 class TestDossierParticipation(FunctionalTestCase):
@@ -118,7 +117,7 @@ class TestParticipationWrapper(FunctionalTestCase):
     @browsing
     def test_cross_injection_raises_unauthorized(self, browser):
         dossier2 = create(Builder('dossier'))
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open('{}/participation-1/edit'.format(
                 dossier2.absolute_url()))
 
@@ -263,7 +262,7 @@ class TestAddForm(FunctionalTestCase):
     @browsing
     def test_raises_unathorized_when_user_is_not_allowed_to_add_content(self, browser):
         self.grant('Reader')
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.dossier,
                                  view='add-sql-participation')
 

--- a/opengever/disposition/tests/test_workflow.py
+++ b/opengever/disposition/tests/test_workflow.py
@@ -203,7 +203,6 @@ class TestDispositionWorkflow(FunctionalTestCase):
 
         with self.assertRaises(FormFieldNotFound):
             browser.fill({'Transfer number': 'AB 123'})
-            browser.click_on('Save')
 
         self.grant('Archivist')
         browser.login().open(self.disposition, view='edit')

--- a/opengever/document/tests/test_archival_file_form.py
+++ b/opengever/document/tests/test_archival_file_form.py
@@ -5,7 +5,6 @@ from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.browser.archival_file_form import can_access_archival_file_form
 from opengever.testing import FunctionalTestCase
 from plone.namedfile.file import NamedBlobFile
-from zExceptions import Unauthorized
 
 
 class TestEditArchivalFormAccess(FunctionalTestCase):
@@ -77,7 +76,7 @@ class TestArchivalFileForm(FunctionalTestCase):
     def test_raise_unauthorized_if_the_user_CANNOT_modify(self, browser):
         user = create(Builder('user').with_roles('Contributor'))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login(user.getId()).visit(self.document,
                                               view='edit_archival_file')
 

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -178,10 +178,11 @@ class TestReverting(FunctionalTestCase):
         self.manager.checkout()
         transaction.commit()
 
-        with self.assertRaises(Unauthorized):
-            browser.login().open(self.document, view='revert-file-to-version',
-                                 data={'version_id': 2,
-                                       '_authenticator': createToken()})
+        with browser.expect_unauthorized():
+            browser.login().open(
+                self.document,
+                view='revert-file-to-version?version_id=2&_authenticator={}'
+                .format(createToken()))
 
 
 class TestManagerHelpers(FunctionalTestCase):

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -6,9 +6,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import login
 from plone.app.testing import TEST_USER_NAME
-from urllib2 import HTTPError
 from zope.component import queryMultiAdapter
-
 import transaction
 
 
@@ -150,6 +148,5 @@ class TestDocumentFileUploadForm(FunctionalTestCase):
             'File': ('New file data', 'file.txt', 'text/plain'),
             'form.widgets.file.action': 'replace',
             })
-        with self.assertRaises(HTTPError) as cm:
+        with browser.expect_http_error(code=412):
             browser.find('oc-file-upload').click()
-        self.assertEqual(412, cm.exception.getcode())

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -114,7 +114,12 @@ class TestDossier(FunctionalTestCase):
         branch_node = create(Builder('repository'))
         create(Builder('repository').within(branch_node))
 
+        # XXX This causes an infinite redirection loop between ++add++ and
+        # reqiure_login. By enabling exception_bubbling we can catch the
+        # Unauthorized exception and end the infinite loop.
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
+        # with browser.expect_unauthorized():
             browser.login().open(
                 branch_node, view='++add++{}'.format(self.portal_type))
 

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -255,6 +255,7 @@ class TestOverview(FunctionalTestCase):
         dossier_data = IDossier(self.dossier)
         self.assertEquals("New comment", dossier_data.comments)
 
+        browser.exception_bubbling = True
         with self.assertRaises(KeyError):
             payload = '{"invalidkey": "New comment"}'
             browser.login().visit(self.dossier,

--- a/opengever/latex/tests/test_opentaskreport.py
+++ b/opengever/latex/tests/test_opentaskreport.py
@@ -128,7 +128,13 @@ class TestOpenTaskReport(FunctionalTestCase):
 
     @browsing
     def test_open_task_report_view_not_allowed_raises_unauthorized(self, browser):
+        # XXX This causes an infinite redirection loop between
+        # pdf-open-task-report and reqiure_login.
+        # By enabling exception_bubbling we can catch the
+        # Unauthorized exception and end the infinite loop.
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
+        # with browser.expect_unauthorized():
             browser.login('hans.meier').open(view='pdf-open-task-report')
 
     def test_task_report_is_only_available_for_current_inbox_users(self):

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -13,8 +13,6 @@ from plone import api
 from plone.locking.interfaces import ILockable
 from plone.protect import createToken
 from z3c.relationfield.relation import RelationValue
-from zExceptions import NotFound
-from zExceptions import Unauthorized
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 import json
@@ -193,7 +191,7 @@ class TestAgendaItemEdit(TestAgendaItem):
 
     @browsing
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/12345/edit')
 
@@ -204,7 +202,7 @@ class TestAgendaItemEdit(TestAgendaItem):
 
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/edit'.format(item.agenda_item_id),
@@ -230,7 +228,7 @@ class TestAgendaItemDelete(TestAgendaItem):
 
     @browsing
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/12345/delete')
 
@@ -246,7 +244,7 @@ class TestAgendaItemDelete(TestAgendaItem):
         other_item = create(Builder('agenda_item').having(
             title=u'foo', meeting=other_meeting))
 
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/delete'.format(other_item.agenda_item_id))
@@ -258,7 +256,7 @@ class TestAgendaItemDelete(TestAgendaItem):
 
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/delete'.format(item.agenda_item_id))
@@ -382,7 +380,7 @@ class TestAgendaItemDecide(TestAgendaItem):
 
     @browsing
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/12345/decide')
 
@@ -393,7 +391,7 @@ class TestAgendaItemDecide(TestAgendaItem):
 
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/decide'.format(item.agenda_item_id))
@@ -426,7 +424,7 @@ class TestAgendaItemDecide(TestAgendaItem):
 
         self.login(user_id=u'hugo.boss')
         browser.login(username=u'hugo.boss')
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.open(self.dossier)
 
 
@@ -463,7 +461,7 @@ class TestAgendaItemReopen(TestAgendaItem):
 
     @browsing
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/12345/reopen')
 
@@ -475,7 +473,7 @@ class TestAgendaItemReopen(TestAgendaItem):
 
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/reopen'.format(item.agenda_item_id))
@@ -538,7 +536,7 @@ class TestAgendaItemRevise(TestAgendaItem):
 
     @browsing
     def test_raises_not_found_for_invalid_agenda_item_id(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/12345/revise')
 
@@ -550,7 +548,7 @@ class TestAgendaItemRevise(TestAgendaItem):
 
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/revise'.format(item.agenda_item_id))
@@ -588,7 +586,7 @@ class TestAgendaItemUpdateOrder(TestAgendaItem):
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/update_order')
 
@@ -611,7 +609,7 @@ class TestScheduleParagraph(TestAgendaItem):
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/schedule_paragraph')
 
@@ -634,6 +632,6 @@ class TestScheduleText(TestAgendaItem):
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/schedule_paragraph')

--- a/opengever/meeting/tests/test_locking.py
+++ b/opengever/meeting/tests/test_locking.py
@@ -8,7 +8,6 @@ from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 from plone.locking.interfaces import ILockable
 from plone.protect import createToken
-from zExceptions import Redirect
 
 
 class TestMeetingLocking(FunctionalTestCase):
@@ -105,12 +104,12 @@ class TestMeetingLocking(FunctionalTestCase):
                       .in_groups('client1_users'))
         browser.login(username='hugo.boss').open(self.meeting.get_url(view='protocol'))
 
-        with self.assertRaises(Redirect) as cm:
-            browser.login().open(self.meeting.get_url(view='protocol'))
+        browser.login().open(self.meeting.get_url(view='protocol'))
 
         self.assertEquals(
             'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1',
-            str(cm.exception))
+            browser.url,
+            'Expected redirect')
 
     @browsing
     def test_meeting_view_shows_information_when_is_locked(self, browser):

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -9,7 +9,6 @@ from opengever.meeting.model import SubmittedDocument
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.testing import FunctionalTestCase
 from plone import api
-from zExceptions import Unauthorized
 import transaction
 
 
@@ -53,7 +52,7 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
                              roles=['Contributor', 'Editor', 'Reader'])
         transaction.commit()
         browser.login(username='hugo.boss')
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.open(self.committee)
 
     def test_cannot_submit_new_document_versions_outside_proposals(self):

--- a/opengever/meeting/tests/test_unscheduled_proposals.py
+++ b/opengever/meeting/tests/test_unscheduled_proposals.py
@@ -5,8 +5,6 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Meeting
 from opengever.meeting.wrapper import MeetingWrapper
 from opengever.testing import FunctionalTestCase
-from zExceptions import NotFound
-from zExceptions import Unauthorized
 
 
 class TestUnscheduledProposals(FunctionalTestCase):
@@ -113,11 +111,11 @@ class TestScheduleProposal(TestUnscheduledProposals):
         self.meeting.workflow_state = 'closed'
 
         view = 'unscheduled_proposals/1/schedule'
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.meeting_wrapper, view=view)
 
     @browsing
     def test_raise_notfound_with_invalid_proposal_id(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.meeting_wrapper,
                                  view='unscheduled_proposals/123/schedule')

--- a/opengever/officeatwork/tests/test_create_with_officeatwork.py
+++ b/opengever/officeatwork/tests/test_create_with_officeatwork.py
@@ -18,7 +18,12 @@ class TestCreateWithOfficeatworkFeatureDisabled(FunctionalTestCase):
         document = create(Builder('document')
                           .within(self.dossier)
                           .as_shadow_document())
+        # XXX This causes an infinite redirection loop between ++add++ and
+        # reqiure_login. By enabling exception_bubbling we can catch the
+        # Unauthorized exception and end the infinite loop.
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
+        # with browser.expect_unauthorized():
             browser.login().open(document, view='create_with_officeatwork')
 
 
@@ -62,5 +67,10 @@ class TestCreateWithOfficeatwork(FunctionalTestCase):
     @browsing
     def test_document_in_non_shadow_state_raises_unauthorized(self, browser):
         document = create(Builder('document').within(self.dossier))
+        # XXX This causes an infinite redirection loop between ++add++ and
+        # reqiure_login. By enabling exception_bubbling we can catch the
+        # Unauthorized exception and end the infinite loop.
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
+        # with browser.expect_unauthorized():
             browser.login().open(document, view='create_with_officeatwork')

--- a/opengever/officeatwork/tests/test_shadow_state.py
+++ b/opengever/officeatwork/tests/test_shadow_state.py
@@ -3,7 +3,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_OFFICEATWORK_LAYER
 from opengever.testing import FunctionalTestCase
-from zExceptions import Unauthorized
 
 
 class TestShadowState(FunctionalTestCase):
@@ -27,5 +26,5 @@ class TestShadowState(FunctionalTestCase):
         user = create(Builder('user').with_roles(
             'Reader', 'Contributor', 'Editor', 'Reviewer', 'Publisher'))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login(user.getId()).visit(self.document)

--- a/opengever/officeatwork/tests/test_webdav_unlock.py
+++ b/opengever/officeatwork/tests/test_webdav_unlock.py
@@ -5,6 +5,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
 from opengever.testing import FunctionalTestCase
 from opengever.testing.officeconnector import TestOfficeConnector
 from plone import api
+import transaction
 
 
 class TestWebDAVUnlock(FunctionalTestCase):
@@ -27,6 +28,7 @@ class TestWebDAVUnlock(FunctionalTestCase):
         connector.unlock()
 
         browser.open(self.document)
+        transaction.begin()
         self.assertFalse(browser.context.is_shadow_document())
         self.assertEqual('document-state-draft',
                          api.content.get_state(browser.context))

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -1,7 +1,6 @@
 from opengever.testing import FunctionalTestCase
 from ftw.testbrowser import browsing
 from opengever.testing import create_ogds_user
-from zExceptions import NotFound
 
 
 class TestUserDetails(FunctionalTestCase):
@@ -20,5 +19,5 @@ class TestUserDetails(FunctionalTestCase):
 
     @browsing
     def test_user_details_return_not_found_for_not_exisiting_user(self, browser):
-        with self.assertRaises(NotFound):
+        with browser.expect_http_error(reason='Not Found'):
             browser.login().open(self.portal, view='@@user-details/hugo.boss')

--- a/opengever/private/tests/test_root.py
+++ b/opengever/private/tests/test_root.py
@@ -22,11 +22,13 @@ class TestPrivateRoot(FunctionalTestCase):
 
     @browsing
     def test_is_only_addable_by_manager(self, browser):
+        browser.login().open(
+            self.portal, view='++add++opengever.private.root')
+        browser.fill({'Title (German)': u'Meine Ablage',
+                      'Title (French)': u'Mon d\xe9p\xf4t'})
+
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
-            browser.login().open(
-                self.portal, view='++add++opengever.private.root')
-            browser.fill({'Title (German)': u'Meine Ablage',
-                          'Title (French)': u'Mon d\xe9p\xf4t'})
             browser.click_on('Save')
 
     @browsing

--- a/opengever/private/tests/test_workflows.py
+++ b/opengever/private/tests/test_workflows.py
@@ -5,7 +5,6 @@ from ftw.testbrowser.pages import factoriesmenu
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.private.tests import create_members_folder
 from opengever.testing import FunctionalTestCase
-from zExceptions import Unauthorized
 
 
 class TestPrivateFolderWorkflow(FunctionalTestCase):
@@ -28,7 +27,7 @@ class TestPrivateFolderWorkflow(FunctionalTestCase):
     def test_only_owner_and_admin_can_see_private_folder(self, browser):
         browser.login().open(self.folder)
         browser.login(self.admin).open(self.folder)
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login(self.hugo).open(self.folder)
 
     @browsing
@@ -58,7 +57,7 @@ class TestPrivateFolderWorkflow(FunctionalTestCase):
 
         browser.login().visit(dossier)
         browser.login(self.admin).visit(dossier)
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login(self.hugo).visit(dossier)
 
     @browsing
@@ -73,7 +72,7 @@ class TestPrivateFolderWorkflow(FunctionalTestCase):
 
         browser.login().visit(document)
         browser.login(self.admin).visit(document)
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login(self.hugo).visit(document)
 
     def test_make_sure_private_root_has_no_additional_local_roles(self):

--- a/opengever/quota/tests/test_quota_container.py
+++ b/opengever/quota/tests/test_quota_container.py
@@ -133,10 +133,8 @@ class TestSizeQuota(FunctionalTestCase):
 
         user_folder = create_members_folder(create(Builder('private_root')))
         user_dossier = create(Builder('dossier').within(user_folder))
-        browser.login().get_mechbrowser().addheaders.remove((
-            'X-zope-handle-errors', 'False'))
 
-        browser.open(user_dossier)
+        browser.login().open(user_dossier)
         factoriesmenu.add('Document')
         browser.fill({'File': ('Some data', 'file.txt', 'text/plain')}).save()
         statusmessages.assert_no_error_messages()

--- a/opengever/repository/tests/test_deletion.py
+++ b/opengever/repository/tests/test_deletion.py
@@ -89,7 +89,12 @@ class TestRepositoryDeletion(FunctionalTestCase):
     @browsing
     def test_raise_unauthorized_when_preconditions_not_satisfied(self, browser):
         create(Builder('dossier').within(self.repository))
+        # XXX This causes an infinite redirection loop between ++add++ and
+        # reqiure_login. By enabling exception_bubbling we can catch the
+        # Unauthorized exception and end the infinite loop.
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
+        # with browser.expect_unauthorized():
             browser.login().open(self.repository, view='delete_repository')
 
     @browsing
@@ -112,5 +117,5 @@ class TestRepositoryDeletion(FunctionalTestCase):
         url = '{}/delete_repository?form.buttons.delete=true'.format(
             self.repository.absolute_url())
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(url)

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -6,7 +6,6 @@ from opengever.base.adapters import ReferenceNumberPrefixAdpater
 from opengever.journal.tests.utils import get_journal_entry
 from opengever.testing import FunctionalTestCase
 from plone import api
-from zExceptions import Unauthorized
 from zope.i18n import translate
 import transaction
 
@@ -96,7 +95,7 @@ class TestReferencePrefixManager(FunctionalTestCase):
     def test_manager_is_hidden_from_user_without_permission(self, browser):
         self.grant('Contributor')
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.repo1, view='referenceprefix_manager')
 
     @browsing

--- a/opengever/repository/tests/test_workflow.py
+++ b/opengever/repository/tests/test_workflow.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import FunctionalTestCase
-from zExceptions import Unauthorized
 
 
 class TestRepositoryWorkflow(FunctionalTestCase):
@@ -17,7 +16,7 @@ class TestRepositoryWorkflow(FunctionalTestCase):
     def test_list_folder_contents_on_repository_is_not_available_for_adminstrators(self, browser):
         self.grant('Administrator')
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.repository, view='folder_contents')
 
     @browsing
@@ -30,7 +29,7 @@ class TestRepositoryWorkflow(FunctionalTestCase):
     def test_list_folder_contents_on_repositoryroot_is_not_available_for_adminstrators(self, browser):
         self.grant('Administrator')
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(self.repository_root, view='folder_contents')
 
     @browsing

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -2,7 +2,6 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.tabbedview.helper import linked
@@ -152,12 +151,14 @@ class TestDossierListing(FunctionalTestCase):
         self.assertEquals(['label_tabbedview_filter_all', 'Active'],
                           browser.css('.state_filters a').text)
 
-    def test_linked_helper_adds_uid_data_attribute_using_obj(self):
+    @browsing
+    def test_linked_helper_adds_uid_data_attribute_using_obj(self, browser):
         browser.open_html(linked(self.dossier_c, 'Title'))
         self.assertEquals(browser.css('a').first.attrib['data-uid'],
                           IUUID(self.dossier_c))
 
-    def test_linked_helper_adds_uid_data_attribute_using_brain(self):
+    @browsing
+    def test_linked_helper_adds_uid_data_attribute_using_brain(self, browser):
         uid = IUUID(self.dossier_c)
         brain = self.portal.portal_catalog(UID=uid)[0]
 

--- a/opengever/task/tests/test_response.py
+++ b/opengever/task/tests/test_response.py
@@ -3,8 +3,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.testing import FunctionalTestCase
-from zExceptions import Unauthorized
-from zope.component import getMultiAdapter
 
 
 class TestTaskCommentResponseAddFormView(FunctionalTestCase):
@@ -137,7 +135,7 @@ class TestTaskCommentResponseAddFormView(FunctionalTestCase):
 
         task = create(Builder('task').titled('Task 1').within(dossier))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(task, view='addcommentresponse')
 
     @browsing
@@ -148,7 +146,7 @@ class TestTaskCommentResponseAddFormView(FunctionalTestCase):
 
         task = create(Builder('task').titled('Task 1').within(dossier))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(task, view='addcommentresponse')
 
     @browsing
@@ -159,7 +157,7 @@ class TestTaskCommentResponseAddFormView(FunctionalTestCase):
 
         task = create(Builder('task').titled('Task 1').within(dossier))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(task, view='addcommentresponse')
 
     @browsing
@@ -170,7 +168,7 @@ class TestTaskCommentResponseAddFormView(FunctionalTestCase):
 
         task = create(Builder('task').titled('Task 1').within(dossier))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(task, view='addcommentresponse')
 
     @browsing
@@ -181,7 +179,7 @@ class TestTaskCommentResponseAddFormView(FunctionalTestCase):
 
         task = create(Builder('task').titled('Task 1').within(dossier))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(task, view='addcommentresponse')
 
     def get_latest_answer(self, browser):

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -14,7 +14,6 @@ from plone.app.testing import TEST_USER_ID
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.registry.interfaces import IRegistry
 from z3c.relationfield.relation import RelationValue
-from zExceptions import BadRequest
 from zope.component import createObject
 from zope.component import getUtility
 from zope.component import queryUtility
@@ -131,7 +130,7 @@ class TestTaskIntegration(FunctionalTestCase):
     def test_addresponse_fails_without_transition(self, browser):
         dossier = create(Builder('dossier'))
         task = create(Builder('task').within(dossier).titled('some task'))
-        with self.assertRaises(BadRequest):
+        with browser.expect_http_error(reason='Bad Request'):
             browser.login().open(task, view='addresponse')
 
     def test_task_type_category(self):

--- a/opengever/task/tests/test_workflow.py
+++ b/opengever/task/tests/test_workflow.py
@@ -71,6 +71,9 @@ class TestTaskWorkflowAddingDocumentsAndMails(FunctionalTestCase):
 
         browser.visit(self.task, view='++add++opengever.document.document')
         form = browser.fill({'Title': 'foobar'})
+
+        # https://github.com/4teamwork/opengever.core/issues/2923
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized) as cm:
             form.save()
         self.assertEquals("Cannot create opengever.document.document",
@@ -85,6 +88,9 @@ class TestTaskWorkflowAddingDocumentsAndMails(FunctionalTestCase):
 
         browser.visit(self.task, view='++add++ftw.mail.mail')
         form = browser.fill({'Title': 'foobar'})
+
+        # https://github.com/4teamwork/opengever.core/issues/2923
+        browser.exception_bubbling = True
         with self.assertRaises(Unauthorized) as cm:
             form.save()
 
@@ -132,12 +138,8 @@ class TestTaskWorkflow(FunctionalTestCase):
         self.wf_tool.doActionFor(dossier, 'dossier-transition-resolve')
         transaction.commit()
 
-        with self.assertRaises(Unauthorized) as cm:
+        with browser.expect_unauthorized():
             browser.login().open(document, view='edit')
-
-        self.assertEquals(
-            'You are not authorized to access this resource.',
-            str(cm.exception))
 
     def test_deleting_task_is_only_allowed_for_managers(self):
         task = create(Builder('task'))

--- a/opengever/testing/officeconnector.py
+++ b/opengever/testing/officeconnector.py
@@ -1,3 +1,4 @@
+from ftw.testbrowser import LIB_REQUESTS
 from xml.etree import ElementTree
 
 WEBDAV_TIMEOUT = 'Infinite, Second-4100000000'
@@ -33,8 +34,9 @@ class TestOfficeConnector(object):
 
     def _request(self, method, body=None, headers=None):
         url = self.browser._normalize_url(self.context)
-        return self.browser.requests_session.request(
-            method, url, data=body, headers=headers)
+        driver = self.browser.get_driver(LIB_REQUESTS)
+        driver.make_request(method, url, data=body, headers=headers)
+        return driver.response
 
     def lock(self):
         """Issue a LOCK request for context.

--- a/opengever/trash/tests/test_remove.py
+++ b/opengever/trash/tests/test_remove.py
@@ -165,7 +165,7 @@ class TestRemoveConfirmationView(FunctionalTestCase):
             self.dossier.absolute_url(),
             '/'.join(self.doc1.getPhysicalPath()))
 
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().open(url)
 
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -18,3 +18,5 @@ zptlint = 0.2.4
 # which causes test isolation problems with PloneTestCase layers
 # which are not isolating properly.
 zope.testrunner = 4.4.4
+
+ftw.testbrowser =


### PR DESCRIPTION
Update ftw.testbrowser to the newest version where the HTTP error handling was changed.
Therefore the tests were updated so that we now use the new context managers:
```python
with browser.expect_http_error(reason='Not Found'):
    browser.open(..)

with browser.expect_unauthorized():
    browser.open(..)
```
See the testbrowser documentation for more infos: http://ftwtestbrowser.readthedocs.io/

While updating the tests I realized that the `require_login` script does not handle the case where `came_from` does not exist. I have included a change fixing this issue. This change is not testable with older ftw.testbrowser versions and some tests are not working on the new ftw.testbrowser version without this change, that's why I didn't submit the change separately.

⚠️ I have removed the `ftw.testbrowser` version pinning in the `versions.cfg` here. When merged, we should consider reverting this part and simply updating the `ftw.testbrowser` version in the `opengever/develop` KGS. This may impact the policies though.