### PR TITLE
Inter-Admin-Unit Requests: Extract response body into the local namespace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,8 @@ Changelog
 - Fix typo in method name: resolve_sumitted_proposal -> resolve_submitted_proposal. [mathias.leimgruber]
 - Use chameleon as the templating engine for better performance. [Rotonen]
 - Handle require_login error where came_from_did not exist. [jone]
+- Inter-Admin-Unit Requests: Extract response body into the local namespace so
+  Sentry can log it as a local in case of failure. [lgraf]
 - Word meeting: replace proposal textfields with a document. [jone]
 
 

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -88,7 +88,8 @@ class WizardDataStorage(grok.GlobalUtility):
                                     '@@receive-wizard-data-set',
                                     data=req_data)
 
-        if response.read().strip() != 'OK':
+        response_body = response.read()
+        if response_body.strip() != 'OK':
             raise Exception('Could not push session data to admin_unit %s' % (
                             admin_unit_id))
 

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -335,7 +335,9 @@ class RejectProposalCommand(object):
             model.admin_unit_id,
             '@@reject-proposal',
             path=model.physical_path)
-        if response.read() != 'OK':
+
+        response_body = response.read()
+        if response_body != 'OK':
             raise ValueError(
                 'Unexpected response {!r} when rejecting proposal.'.format(
                     response))

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -154,7 +154,8 @@ def accept_forwarding_with_successor(
                                 path=predecessor.physical_path,
                                 data=request_data)
 
-    if response.read().strip() != 'OK':
+    response_body = response.read()
+    if response_body.strip() != 'OK':
         raise TaskRemoteRequestError(
             'Adding the response and changing the workflow state on the '
             'predecessor forwarding failed.')
@@ -283,7 +284,8 @@ def accept_task_with_successor(dossier, predecessor_oguid, response_text):
                                 path=predecessor.physical_path,
                                 data=request_data)
 
-    if response.read().strip() != 'OK':
+    response_body = response.read()
+    if response_body.strip() != 'OK':
         raise TaskRemoteRequestError(
             'Adding the response and changing the workflow state on the '
             'predecessor task failed.')

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -235,7 +235,8 @@ class CompleteSuccessorTaskForm(Form):
             predecessor.physical_path,
             data=request_data)
 
-        if response.read().strip() != 'OK':
+        response_body = response.read()
+        if response_body.strip() != 'OK':
             raise Exception('Delivering documents and updating task failed '
                             'on remote client %s.' % predecessor.admin_unit_id)
 


### PR DESCRIPTION
Inter-Admin-Unit Requests: Extract response body into the local namespace so Sentry can log it as a local in case of failure.

Example Sentry Event:
https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3129/events/88432/

(See `response_body` in locals below code, above traceback ("Show more"))

This partly helps with #1541 (still some things left to do though)