### PR TITLE
 Respect `maximum_dossier_depth` registry record in DefaultConstrainTypeDecider

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Use CreatEmailCommand to create email upon mail-in. [deiferni]
 - Fix typo in method name: resolve_sumitted_proposal -> resolve_submitted_proposal. [mathias.leimgruber]
 - Use chameleon as the templating engine for better performance. [Rotonen]
+- Respect `maximum_dossier_depth` registry record in DefaultConstrainTypeDecider [mathias.leimgruber]
 - Handle require_login error where came_from_did not exist. [jone]
 - Word meeting: replace proposal textfields with a document. [jone]
 

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -259,7 +259,7 @@ class DossierContainer(Container):
             'review_state': [
                 'dossier-state-active',
                 'dossier-state-resolved', ],
-            })
+        })
 
         end_dates = []
         # main dossier
@@ -370,24 +370,23 @@ class DefaultConstrainTypeDecider(grok.MultiAdapter):
     grok.adapts(Interface, IDossierMarker, IDexterityFTI)
     grok.name('')
 
-    CONSTRAIN_CONFIGURATION = {
-        'opengever.dossier.businesscasedossier': {
-            'opengever.dossier.businesscasedossier': 2,
-            'opengever.dossier.projectdossier': 1,
-            },
-        'opengever.private.dossier': {
-            'opengever.private.dossier': 2
-        },
-        'opengever.dossier.projectdossier': {
-            'opengever.dossier.projectdossier': 1,
-            'opengever.dossier.businesscasedossier': 1,
-            },
-        }
-
     def __init__(self, request, context, fti):
         self.context = context
         self.request = request
         self.fti = fti
+
+        max_dossier_depth = api.portal.get_registry_record(
+            'maximum_dossier_depth',
+            interface=IDossierContainerTypes) + 1
+
+        self.constrain_configuration = {
+            'opengever.dossier.businesscasedossier': {
+                'opengever.dossier.businesscasedossier': max_dossier_depth,
+            },
+            'opengever.private.dossier': {
+                'opengever.private.dossier': max_dossier_depth
+            },
+        }
 
     def addable(self, depth):
         container_type = self.context.portal_type
@@ -411,7 +410,7 @@ class DefaultConstrainTypeDecider(grok.MultiAdapter):
 
     @property
     def constrain_type_mapping(self):
-        conf = self.CONSTRAIN_CONFIGURATION
+        conf = self.constrain_configuration
         for container_type, type_constr in conf.items():
             for factory_type, max_depth in type_constr.items():
                 yield container_type, max_depth, factory_type

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -4,8 +4,11 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testing import freeze
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.testing import FunctionalTestCase
 from plone import api
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 
 class TestDossierContainer(FunctionalTestCase):
@@ -76,6 +79,19 @@ class TestDossierContainer(FunctionalTestCase):
 
         self.assertNotIn('opengever.dossier.businesscasedossier',
                          [fti.id for fti in subdossier.allowedContentTypes()])
+
+    def test_get_subdossier_depth_from_registry(self):
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IDossierContainerTypes)
+        proxy.maximum_dossier_depth = 2
+
+        dossier = create(Builder('dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+        subsubdossier = create(Builder('dossier').within(subdossier))
+
+        self.assertNotIn(
+            'opengever.dossier.businesscasedossier',
+            [fti.id for fti in subsubdossier.allowedContentTypes()])
 
     def test_get_subdossiers_returns_subsubdossiers_as_well(self):
         dossier = create(Builder('dossier'))


### PR DESCRIPTION
Changing `maximum_dossier_depth` is now implemented in the `DefaultConstrainTypeDecider`. 
The value is used for:
- opengever.dossier.businesscasedossier
- opengever.private.dossier

I slightly change the signature of the  adapter. CONSTRAIN_CONFIGURATION is no longer a `constant`, since it now depends on a configurable value. This may break customer integration of this adapter.

I also had to change the default value of `maximum_dossier_depth` from 1 to 2, since most of the tests depend on 2 levels.

Closes #955 