### PR TITLE
Display attachments on mail overviews

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.2.2 (unreleased)
 ---------------------
 
+- Display attachments on mail overviews. [Rotonen]
 - Use CreatEmailCommand to create email upon mail-in. [deiferni]
 - Fix typo in method name: resolve_sumitted_proposal -> resolve_submitted_proposal. [mathias.leimgruber]
 - Handle require_login error where came_from_did not exist. [jone]

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -1,8 +1,8 @@
 from Acquisition import aq_inner
 from five import grok
 from ftw.mail import utils
-from ftw.mail.mail import View as ftwView
 from ftw.mail.mail import IMail
+from ftw.mail.mail import View
 from opengever.base import _ as ogbmf
 from opengever.document import _ as ogdmf
 from opengever.document.browser.overview import CustomRow
@@ -17,33 +17,29 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getUtility
 
 
-class PreviewTab(ftwView):
-    """Render a preview of a mail."""
-
-    template = ViewPageTemplateFile('templates/previewtab.pt')
-
-    def __call__(self):
-        self.normalizer = getUtility(IIDNormalizer)
-        self.mtr = getToolByName(self.context, 'mimetypes_registry')
-        return super(PreviewTab, self).__call__()
+class MailAttachmentsMixin(object):
+    """List the attachments of a mailitem."""
 
     def lookup_mimetype_registry(self, attachment):
+        mtr = getToolByName(self.context, 'mimetypes_registry')
         if attachment.get('content-type') == 'application/octet-stream':
-            lookup = self.mtr.globFilename(attachment.get('filename'))
+            lookup = mtr.globFilename(attachment.get('filename'))
         else:
-            lookup = self.mtr.lookup(attachment['content-type'])
+            lookup = mtr.lookup(attachment['content-type'])
 
         if lookup and (isinstance(lookup, list) or isinstance(lookup, tuple)):
             lookup = lookup[0]
 
         return lookup
 
-    def get_css_class(self, lookup):
+    def get_attachment_css_class(self, lookup):
         # copied from opengever.base.browser.utils.get_css_class, should be
         # removed when the sprite problematic is solved complety for opengever
+        # also duplicated under a different name to sidestep MRO
         icon_path = lookup.icon_path
         filetype = icon_path[:icon_path.rfind('.')].replace('icon_', '')
-        css_class = 'icon-%s' % self.normalizer.normalize(filetype)
+        normalizer = getUtility(IIDNormalizer)
+        css_class = 'icon-{}'.format(normalizer.normalize(filetype))
         return css_class
 
     @instance.memoize
@@ -53,7 +49,7 @@ class PreviewTab(ftwView):
         for attachment in attachments:
             lookup = self.lookup_mimetype_registry(attachment)
             if lookup:
-                attachment['class'] = self.get_css_class(lookup)
+                attachment['class'] = self.get_attachment_css_class(lookup)
                 attachment['type-name'] = lookup.name()
             else:
                 attachment['class'] = ''
@@ -62,7 +58,17 @@ class PreviewTab(ftwView):
         return attachments
 
 
-class OverviewTab(Overview):
+class PreviewTab(MailAttachmentsMixin, View):
+    """Render a preview of a mail.
+
+    We need to be mindful of the MRO C3 here as we need the mixin to override
+    methods of the ftw.mail.mail.View.
+    """
+
+    template = ViewPageTemplateFile('templates/previewtab.pt')
+
+
+class OverviewTab(MailAttachmentsMixin, Overview):
     """Render an overview of the mailitem."""
 
     grok.context(IMail)
@@ -70,6 +76,7 @@ class OverviewTab(Overview):
 
     # override template lookup, its realive to this file
     file_template = ViewPageTemplateFile('templates/file.pt')
+    attachments_template = ViewPageTemplateFile('templates/attachments.pt')
 
     def get_metadata_config(self):
         return [
@@ -84,6 +91,9 @@ class OverviewTab(Overview):
             TemplateRow(self.file_template,
                         label=_('label_org_message',
                                 default='Original message')),
+            TemplateRow(self.attachments_template,
+                        label=_('label_documents',
+                                default='Attachments')),
             FieldRow('IDocumentMetadata.digitally_available'),
             FieldRow('IDocumentMetadata.preserved_as_paper'),
             FieldRow('IDocumentMetadata.receipt_date'),

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -1,8 +1,8 @@
 from Acquisition import aq_inner
 from five import grok
 from ftw.mail import utils
-from ftw.mail.mail import IMail
 from ftw.mail.mail import View as ftwView
+from ftw.mail.mail import IMail
 from opengever.base import _ as ogbmf
 from opengever.document import _ as ogdmf
 from opengever.document.browser.overview import CustomRow

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -18,6 +18,7 @@ from zope.component import getUtility
 
 
 class PreviewTab(ftwView):
+    """Render a preview of a mail."""
 
     template = ViewPageTemplateFile('templates/previewtab.pt')
 
@@ -62,6 +63,8 @@ class PreviewTab(ftwView):
 
 
 class OverviewTab(Overview):
+    """Render an overview of the mailitem."""
+
     grok.context(IMail)
     grok.require('zope2.View')
 

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -92,7 +92,7 @@ class ISendDocumentSchema(Interface):
         )
 
     documents = RelationList(
-        title=_(u'label_documents', default=u'Documents'),
+        title=_(u'label_documents', default=u'Attachments'),
         default=[],
         missing_value=[],
         value_type=RelationChoice(
@@ -276,7 +276,7 @@ class SendDocumentForm(form.Form):
         # iterate over object list (which can include documents and mails),
         # create attachement parts for them and prepare docs_links
         docs_links = '%s:\r\n' % (translate(
-                _('label_documents', default=u'Documents'),
+                _('label_documents', default=u'Attachments'),
                 context=self.request))
 
         for obj in objs:

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -49,12 +49,15 @@ CHARSET = 'utf-8'
 
 
 class NoMail(Invalid):
-    """ The No Mail was defined Exception."""
+    """This is a dummy class to raise an exception in the lack of a mail
+    address.
+    """
+
     __doc__ = _(u"No Mail Address")
 
 
 class ISendDocumentSchema(Interface):
-    """ The Send Document Form Schema."""
+    """The Send Document Form Schema."""
 
     intern_receiver = schema.Tuple(
         title=_('intern_receiver', default="Intern receiver"),
@@ -72,8 +75,8 @@ class ISendDocumentSchema(Interface):
     extern_receiver = schema.List(
         title=_('extern_receiver', default="Extern receiver"),
         description=_('help_extern_receiver',
-                      default="email addresses of the receivers. " +
-                          "Enter manually the addresses, one per each line."),
+                      default="email addresses of the receivers. "
+                      "Enter manually the addresses, one per each line."),
         value_type=schema.TextLine(title=_('receiver'), ),
         required=False,
         )
@@ -120,10 +123,9 @@ class ISendDocumentSchema(Interface):
         default=True,
         )
 
-
     @invariant
     def validateHasEmail(self):
-        """ check if minium one e-mail-address is given."""
+        """Check if minium one e-mail-address is given."""
         if len(self.intern_receiver) == 0 and not self.extern_receiver:
             raise NoMail(_(u'You have to select a intern \
                             or enter a extern mail-addres'))
@@ -132,7 +134,6 @@ class ISendDocumentSchema(Interface):
 @default_value(field=ISendDocumentSchema['documents_as_links'])
 def default_documents_as_links(data):
     """Set the client specific default (configured in the registry)."""
-
     registry = getUtility(IRegistry)
     proxy = registry.forInterface(ISendDocumentConf)
     return proxy.documents_as_links_default
@@ -154,7 +155,7 @@ provideAdapter(AddressValidator)
 
 
 class SendDocumentForm(form.Form):
-    """ The Send Documents per Mail Formular """
+    """A form to send documents over mail with."""
 
     fields = field.Fields(ISendDocumentSchema)
     ignoreContext = True
@@ -168,10 +169,8 @@ class SendDocumentForm(form.Form):
         = SingleCheckBoxFieldWidget
 
     def update(self):
-        """ put default value for documents field, into the request,
-
+        """Put default value for documents field, into the request,
         because this view would call from the document tab in the dossier view
-
         """
         paths = self.request.get('paths', [])
         if paths:
@@ -197,7 +196,7 @@ class SendDocumentForm(form.Form):
 
     @button.buttonAndHandler(_(u'button_send', default=u'Send'))
     def send_button_handler(self, action):
-        """ create and Send the Email """
+        """Create and Send the Email."""
         data, errors = self.extractData()
 
         if len(errors) == 0:
@@ -238,7 +237,8 @@ class SendDocumentForm(form.Form):
             mh.send(msg, mfrom=mfrom, mto=','.join(addresses))
 
             # Store a copy of the sent mail in dossier
-            if data.get('file_copy_in_dossier', False) and self._allow_save_file_copy_in_context():
+            if (data.get('file_copy_in_dossier', False)
+                    and self._allow_save_file_copy_in_context()):
                 self.file_sent_mail_in_dossier(msg)
 
             # let the user know that the mail was sent
@@ -264,8 +264,11 @@ class SendDocumentForm(form.Form):
         return self.request.RESPONSE.redirect(url)
 
     def create_mail(self, text='', objs=[], only_links=''):
-        """Create the mail and attach the the files. For object without a file
-        it include a Link to the Object in to the message"""
+        """Create the mail and attach the the files.
+
+        For object without a file it include a Link to the Object in to the
+        message.
+        """
         attachment_parts = []
         msg = MIMEMultipart()
         msg['Date'] = formatdate(localtime=True)
@@ -347,10 +350,9 @@ class SendDocumentForm(form.Form):
 
 
 class SendDocumentFormView(layout.FormWrapper, grok.View):
-    """ The View wich display the SendDocument-Form.
+    """The View wich display the SendDocument-Form.
 
     For sending documents with per mail.
-
     """
 
     grok.context(ISendableDocsContainer)

--- a/opengever/mail/browser/templates/attachments.pt
+++ b/opengever/mail/browser/templates/attachments.pt
@@ -1,0 +1,17 @@
+<tal:block xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="opengever.mail">
+
+    <tal:attachments tal:condition="view/attachments">
+        <tal:attachment tal:repeat="attachment view/attachments">
+            <div class="mailAttachment">
+                <a href=""
+                    tal:define="position python:attachment['position']"
+                    tal:attributes="href string:${here/absolute_url}/get_attachment?position=${position};
+                    class attachment/class">
+                    <span tal:content="python:attachment['filename']">filename</span>
+                </a>
+                <span tal:content="python:context.getObjSize(size=attachment['size'])">0Kb</span>
+        </tal:attachment>
+    </tal:attachments>
+
+</tal:block>

--- a/opengever/mail/browser/templates/previewtab.pt
+++ b/opengever/mail/browser/templates/previewtab.pt
@@ -45,7 +45,7 @@
         <div tal:replace="structure view/html_safe_body">Body</div>
 
         <tal:attachments condition="view/attachments">
-        <h2 i18n:translate="">Attachments</h2>
+        <h2 i18n:domain="opengever.mail" i18n:translate="label_documents">Attachments</h2>
         <tal:items tal:repeat="item view/attachments">
             <div class="mailAttachment">
                 <a href=""

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-05-16 08:24+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -36,17 +36,17 @@ msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 msgid "The files you selected are larger than the maximum size"
 msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maximalgrösse."
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py:128
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:199
+#: ./opengever/mail/browser/send_document.py:195
 msgid "button_send"
 msgstr "Senden"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py:253
 msgid "cancel_back"
 msgstr "Abbrechen"
 
@@ -81,12 +81,12 @@ msgid "extern_receiver"
 msgstr "Externer Empfänger"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:189
+#: ./opengever/mail/browser/send_document.py:185
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(nur für aktive Dossiers möglich)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:160
 msgid "heading_send_as_email"
 msgstr "Dokumente als E-Mail versenden"
 
@@ -116,7 +116,7 @@ msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py:243
 msgid "info_mail_sent"
 msgstr "E-Mail wurde versendet."
 
@@ -150,8 +150,10 @@ msgstr "Keine Anhänge löschen"
 msgid "label_delete_action_selected"
 msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
-#. Default: "Documents"
+#. Default: "Attachments"
+#: ./opengever/mail/browser/mail.py:95
 #: ./opengever/mail/browser/send_document.py:93
+#: ./opengever/mail/browser/templates/previewtab.pt:48
 msgid "label_documents"
 msgstr "Anhänge"
 
@@ -176,7 +178,7 @@ msgid "label_message"
 msgstr "Mitteilung"
 
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:81
+#: ./opengever/mail/browser/mail.py:92
 msgid "label_org_message"
 msgstr "Originalnachricht"
 

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-05-16 08:24+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
@@ -36,17 +36,17 @@ msgstr "Email envoyé classé sous '${title}'."
 msgid "The files you selected are larger than the maximum size"
 msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permise."
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py:128
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse Email interne ou externe."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:199
+#: ./opengever/mail/browser/send_document.py:195
 msgid "button_send"
 msgstr "Envoyer"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py:253
 msgid "cancel_back"
 msgstr "Annuler"
 
@@ -81,12 +81,12 @@ msgid "extern_receiver"
 msgstr "Destinataire externe"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:189
+#: ./opengever/mail/browser/send_document.py:185
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(possible uniquement pour les dossiers ouverts)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:160
 msgid "heading_send_as_email"
 msgstr "Envoyer les documents comme Email"
 
@@ -116,7 +116,7 @@ msgid "info_extracted_document"
 msgstr "Document créé: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py:243
 msgid "info_mail_sent"
 msgstr "Email envoyé."
 
@@ -150,8 +150,11 @@ msgstr "N'effacer aucun fichier attaché"
 msgid "label_delete_action_selected"
 msgstr "Effacer tous les fichiers attachés séléctionnés"
 
-#. Default: "Documents"
+#. Default: "Attachments"
+#: ./opengever/mail/browser/mail.py:95
 #: ./opengever/mail/browser/send_document.py:93
+#: ./opengever/mail/browser/templates/previewtab.pt:48
+#, fuzzy
 msgid "label_documents"
 msgstr "Fichiers attachés"
 
@@ -176,7 +179,7 @@ msgid "label_message"
 msgstr "Message"
 
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:81
+#: ./opengever/mail/browser/mail.py:92
 msgid "label_org_message"
 msgstr "Message original"
 

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-05-16 08:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,17 +37,17 @@ msgstr ""
 msgid "The files you selected are larger than the maximum size"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py:128
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr ""
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:199
+#: ./opengever/mail/browser/send_document.py:195
 msgid "button_send"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py:253
 msgid "cancel_back"
 msgstr ""
 
@@ -82,12 +82,12 @@ msgid "extern_receiver"
 msgstr ""
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:189
+#: ./opengever/mail/browser/send_document.py:185
 msgid "file_copy_widget_disabled_hint_text"
 msgstr ""
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:162
+#: ./opengever/mail/browser/send_document.py:160
 msgid "heading_send_as_email"
 msgstr ""
 
@@ -117,7 +117,7 @@ msgid "info_extracted_document"
 msgstr ""
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py:243
 msgid "info_mail_sent"
 msgstr ""
 
@@ -151,8 +151,10 @@ msgstr ""
 msgid "label_delete_action_selected"
 msgstr ""
 
-#. Default: "Documents"
+#. Default: "Attachments"
+#: ./opengever/mail/browser/mail.py:95
 #: ./opengever/mail/browser/send_document.py:93
+#: ./opengever/mail/browser/templates/previewtab.pt:48
 msgid "label_documents"
 msgstr ""
 
@@ -177,7 +179,7 @@ msgid "label_message"
 msgstr ""
 
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:81
+#: ./opengever/mail/browser/mail.py:92
 msgid "label_org_message"
 msgstr ""
 

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -14,10 +14,14 @@ def date_format_helper(dateobj):
 
 
 class TestOverview(FunctionalTestCase):
+    """Test the overview view of uploaded emails."""
 
     @browsing
     def test_mail_overview_tab(self, browser):
-        mail = create(Builder("mail").with_message(MAIL_DATA))
+        mail = create(Builder('mail')
+                      .with_message(MAIL_DATA)
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
         browser.login().visit(mail, view='tabbedview_view-overview')
 
         view = mail.restrictedTraverse('tabbedview_view-overview')
@@ -44,8 +48,12 @@ class TestOverview(FunctionalTestCase):
                   ['Description', ''],
                   ['Foreign Reference', ''],
                   ['Original message',
-                   u'die-burgschaft.eml \u2014 1 KB Checkout and edit '
-                   u'Download copy PDF Preview'],
+                   u'mehrere-anhange.eml \u2014 32 KB '
+                   u'Checkout and edit Download copy PDF Preview'],
+                  ['Attachments',
+                   'Inneres Testma?il ohne Attachments.eml 1 KB '
+                   'word_document.docx 22.4 KB '
+                   'Text.txt 1 KB'],
                   ['Digital Available', 'yes'],
                   ['Preserved as paper', 'yes'],
                   ['Date of receipt', date_format_helper(date.today())],

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -34,6 +34,7 @@ w6TDtsOcCg==
 
 
 class TestOGMailAddition(FunctionalTestCase):
+    """Test mail uploads."""
 
     def setUp(self):
         super(TestOGMailAddition, self).setUp()
@@ -131,7 +132,7 @@ class TestOGMailAddition(FunctionalTestCase):
         },)
         self.assertEqual(expected_description, mail.get_attachments())
 
-    def test_get_attachments_returns_empty_list_for_mails_without_attachments(self):
+    def test_get_attachments_returns_empty_list_for_mails_without_attachments(self):  # noqa
         mail = create(Builder('mail')
                       .within(self.dossier)
                       .with_message(MAIL_DATA))
@@ -153,7 +154,8 @@ class TestOGMailAddition(FunctionalTestCase):
     def test_delete_all_attachments(self):
         mail = create(Builder('mail')
                       .within(self.dossier)
-                      .with_asset_message('mail_with_multiple_attachments.eml'))
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
 
         mail.delete_all_attachments()
         self.assertFalse(mail.has_attachments())
@@ -161,7 +163,8 @@ class TestOGMailAddition(FunctionalTestCase):
     def test_delete_one_attachment(self):
         mail = create(Builder('mail')
                       .within(self.dossier)
-                      .with_asset_message('mail_with_multiple_attachments.eml'))
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
 
         self.assertEqual(3, len(mail.get_attachments()))
         mail.delete_attachments([2])
@@ -176,6 +179,7 @@ class TestOGMailAddition(FunctionalTestCase):
 
 
 class TestExtractMailInDossier(FunctionalTestCase):
+    """Test the conversion of emails into OG data types."""
 
     def setUp(self):
         super(TestExtractMailInDossier, self).setUp()
@@ -184,7 +188,7 @@ class TestExtractMailInDossier(FunctionalTestCase):
     def setup_parent(self):
         return create(Builder('dossier'))
 
-    def test_extract_attachment_sets_default_values_correctly_on_document(self):
+    def test_extract_attachment_sets_default_values_correctly_on_document(self):  # noqa
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IDocumentSettings)
         proxy.preserved_as_paper_default = False
@@ -231,7 +235,8 @@ class TestExtractMailInDossier(FunctionalTestCase):
     def test_extract_multiple_attachments(self):
         mail = create(Builder('mail')
                       .within(self.parent)
-                      .with_asset_message('mail_with_multiple_attachments.eml'))
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
 
         positions = [attachment['position'] for attachment in
                      mail.get_attachments()]
@@ -257,12 +262,14 @@ class TestExtractMailInDossier(FunctionalTestCase):
 
 
 class TestExtractMailInInbox(TestExtractMailInDossier):
+    """Test email to OG conversion from the inbox."""
 
     def setup_parent(self):
         return create(Builder('inbox'))
 
 
 class TestExtractMailInTask(TestExtractMailInDossier):
+    """Test email to OG conversion from a task."""
 
     def setup_parent(self):
         self.dossier = create(Builder('dossier'))

--- a/opengever/mail/tests/test_subscribers.py
+++ b/opengever/mail/tests/test_subscribers.py
@@ -5,6 +5,7 @@ from opengever.testing import FunctionalTestCase
 
 
 class TestSubscribers(FunctionalTestCase):
+    """Test mail update events fire as designed."""
 
     def setUp(self):
         super(TestSubscribers, self).setUp()


### PR DESCRIPTION
* Minor cleanups on everything inspected during the process
* Added an extra row with an accompanying template to the mail overview
  * Broke out the attachments listing functionality into a mixin
* Amended the tests

<img width="1065" alt="screen shot 2017-05-16 at 14 14 18" src="https://cloud.githubusercontent.com/assets/935317/26105392/1236818a-3a42-11e7-933c-8539e5fc23b3.png">


Closes #437 