### PR TITLE
Fix typo in dossier SearchableTextExtender, which results in a empty SearchableText if IFilingNumber behavior was activated.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix addable types constrain for repository folders in API calls [buchi]
+- Fix typo in dossier SearchableTextExtender, which results in a empty SearchableText if IFilingNumber behavior was activated. [mathias.leimgruber]
 - Display attachments on mail overviews. [Rotonen]
 - Use CreatEmailCommand to create email upon mail-in. [deiferni]
 - Fix typo in method name: resolve_sumitted_proposal -> resolve_submitted_proposal. [mathias.leimgruber]

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -163,7 +163,7 @@ class SearchableTextExtender(grok.Adapter):
 
         # filing_no
         if IFilingNumberMarker.providedBy(self.context):
-            filing_no = getattr(IFilingNumber(self.contxt), 'filing_no', None)
+            filing_no = getattr(IFilingNumber(self.context), 'filing_no', None)
             if filing_no:
                 searchable.append(filing_no.encode('utf-8'))
 

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -177,3 +177,15 @@ class TestFilingNumberIndexer(FunctionalTestCase):
                           index_data_for(dossier).get('filing_no'))
         self.assertEquals(['ska', 'arch', 'administration', '2012', '3'],
                           index_data_for(dossier).get('searchable_filing_no'))
+
+    def test_filing_no_is_also_in_searchable_text(self):
+        dossier = create(Builder("dossier")
+                         .having(filing_prefix='directorate',
+                                 filing_no='SKA ARCH-Administration-2012-3'))
+
+        searchable_text_data = index_data_for(dossier).get('SearchableText')
+        self.assertIn('ska', searchable_text_data)
+        self.assertIn('arch', searchable_text_data)
+        self.assertIn('administration', searchable_text_data)
+        self.assertIn('2012', searchable_text_data)
+        self.assertIn('3', searchable_text_data)


### PR DESCRIPTION
This will fix some customer policy tests too. 