### PR TITLE
Keep *.msg file after conversion and store message source for mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Remove an unused creator behaviour from the codebase. [Rotonen]
+- Keep *.msg file after conversion and store message source for mails. [deiferni]
 - Fix addable types constrain for repository folders in API calls [buchi]
 - Cache addable types constrains for repository folders per request [buchi]
 - Fix typo in dossier SearchableTextExtender, which results in a empty SearchableText if IFilingNumber behavior was activated. [mathias.leimgruber]

--- a/opengever/base/command.py
+++ b/opengever/base/command.py
@@ -64,7 +64,10 @@ class CreateEmailCommand(CreateDocumentCommand):
         self.transform = transform or Msg2MimeTransform()
 
         if self.is_msg_upload(filename):
-                filename, data = self.convert_to_mime(filename, data)
+            kwargs['original_message'] = NamedBlobFile(
+                data=data, filename=safe_unicode(filename),
+                contentType=content_type)
+            filename, data = self.convert_to_mime(filename, data)
 
         super(CreateEmailCommand, self).__init__(
             context, filename, data, title, content_type, **kwargs)

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -8,6 +8,7 @@ from five import grok
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.command import CreateEmailCommand
+from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
 from opengever.quota.exceptions import ForbiddenByQuota
 from plone.protect import createToken
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -81,7 +82,8 @@ class OGQuickUploadCapableFileFactory(grok.Adapter):
 
         if self.is_email_upload(filename):
             command = CreateEmailCommand(
-                self.context, filename, data, description=description)
+                self.context, filename, data, description=description,
+                message_source=MESSAGE_SOURCE_DRAG_DROP_UPLOAD)
         else:
             command = CreateDocumentCommand(
                 self.context, filename, data, description=description)

--- a/opengever/base/tests/test_command.py
+++ b/opengever/base/tests/test_command.py
@@ -25,3 +25,6 @@ class TestCreateEmailCommand(FunctionalTestCase):
 
         self.assertEqual('message/rfc822', mail.message.contentType)
         self.assertEqual('no-subject.eml', mail.message.filename)
+
+        self.assertEqual(u'testm\xe4il.msg', mail.original_message.filename)
+        self.assertEqual('mock-msg-body', mail.original_message.data)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -30,6 +30,9 @@ OMITTED_FORM_FIELDS = [
     'thumbnail', 'former_reference_number', 'reference_number',
     'temporary_former_reference_number'
 ]
+DISPLAY_MODE_FORM_FIELDS = [
+    'message_source', 'original_message',
+]
 
 REPOROOT_REQUIREDS = {
     'title_de': DEFAULT_TITLE,
@@ -264,6 +267,9 @@ class TestDefaultsBase(FunctionalTestCase):
         defaults.update(self.requireds)
 
         for key in OMITTED_FORM_FIELDS:
+            defaults.pop(key, None)
+
+        for key in DISPLAY_MODE_FORM_FIELDS:
             defaults.pop(key, None)
 
         return defaults

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -163,7 +163,8 @@ MAIL_MISSING_VALUES = {
     'document_type': None,
     'foreign_reference': None,
     'preview': None,
-    'thumbnail': None
+    'thumbnail': None,
+    'original_message': None,
 }
 
 

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -165,6 +165,7 @@ MAIL_MISSING_VALUES = {
     'preview': None,
     'thumbnail': None,
     'original_message': None,
+    'message_source': None,
 }
 
 

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -10,6 +10,7 @@ from opengever.document.browser.overview import FieldRow
 from opengever.document.browser.overview import Overview
 from opengever.document.browser.overview import TemplateRow
 from opengever.mail import _
+from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import instance
 from Products.CMFCore.utils import getToolByName
@@ -79,7 +80,7 @@ class OverviewTab(MailAttachmentsMixin, Overview):
     attachments_template = ViewPageTemplateFile('templates/attachments.pt')
 
     def get_metadata_config(self):
-        return [
+        rows = [
             FieldRow('title'),
             FieldRow('IDocumentMetadata.document_date'),
             FieldRow('IDocumentMetadata.document_type'),
@@ -106,3 +107,8 @@ class OverviewTab(MailAttachmentsMixin, Overview):
                                     default='Public Trial')),
             FieldRow('IClassification.public_trial_statement'),
         ]
+
+        if api.user.has_permission('cmf.ManagePortal'):
+            rows.append(FieldRow('IOGMail.original_message'))
+
+        return rows

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -110,5 +110,6 @@ class OverviewTab(MailAttachmentsMixin, Overview):
 
         if api.user.has_permission('cmf.ManagePortal'):
             rows.append(FieldRow('IOGMail.original_message'))
+            rows.append(FieldRow('IOGMail.message_source'))
 
         return rows

--- a/opengever/mail/create.py
+++ b/opengever/mail/create.py
@@ -1,5 +1,6 @@
 from ftw.mail.create import CreateMailInContainer
 from opengever.base.command import CreateEmailCommand
+from opengever.mail.mail import MESSAGE_SOURCE_MAILIN
 
 
 class OGCreateMailInContainer(CreateMailInContainer):
@@ -15,5 +16,6 @@ class OGCreateMailInContainer(CreateMailInContainer):
         self.check_permission()
         self.check_addable_types()
 
-        command = CreateEmailCommand(self.context, 'message.eml', message)
+        command = CreateEmailCommand(self.context, 'message.eml', message,
+                                     message_source=MESSAGE_SOURCE_MAILIN)
         return command.execute()

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-16 08:24+0000\n"
+"POT-Creation-Date: 2017-05-16 15:00+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -20,7 +20,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ./opengever/mail/browser/send_document.py:54
+#: ./opengever/mail/browser/send_document.py:56
 msgid "No Mail Address"
 msgstr "Keine E-Mail Adresse"
 
@@ -28,7 +28,7 @@ msgstr "Keine E-Mail Adresse"
 msgid "Save attachments"
 msgstr "Anhänge speichern"
 
-#: ./opengever/mail/browser/send_document.py:336
+#: ./opengever/mail/browser/send_document.py:338
 msgid "Sent mail filed as '${title}'."
 msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 
@@ -36,17 +36,17 @@ msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 msgid "The files you selected are larger than the maximum size"
 msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maximalgrösse."
 
-#: ./opengever/mail/browser/send_document.py:128
+#: ./opengever/mail/browser/send_document.py:130
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:195
+#: ./opengever/mail/browser/send_document.py:197
 msgid "button_send"
 msgstr "Senden"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:253
+#: ./opengever/mail/browser/send_document.py:255
 msgid "cancel_back"
 msgstr "Abbrechen"
 
@@ -76,17 +76,17 @@ msgid "error_no_attachments_to_extract"
 msgstr "Diese E-Mail hat keine Anhänge, die extrahiert werden könnten."
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:74
+#: ./opengever/mail/browser/send_document.py:76
 msgid "extern_receiver"
 msgstr "Externer Empfänger"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:185
+#: ./opengever/mail/browser/send_document.py:187
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(nur für aktive Dossiers möglich)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:160
+#: ./opengever/mail/browser/send_document.py:162
 msgid "heading_send_as_email"
 msgstr "Dokumente als E-Mail versenden"
 
@@ -101,12 +101,12 @@ msgid "help_delete_action"
 msgstr "Wählen Sie aus, ob und welche Anhänge aus dieser E-Mail gelöscht werden sollen."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:75
+#: ./opengever/mail/browser/send_document.py:77
 msgid "help_extern_receiver"
 msgstr "E-Mail Adressen der externen Empfänger manuell eintragen. Pro Zeile eine Adresse eingeben."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py:64
 msgid "help_intern_receiver"
 msgstr "Live Search: Nachname/Vorname der internen Mitarbeiter oder Kontakte eingeben. Mehrauswahl möglich."
 
@@ -116,12 +116,12 @@ msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:243
+#: ./opengever/mail/browser/send_document.py:245
 msgid "info_mail_sent"
 msgstr "E-Mail wurde versendet."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:61
+#: ./opengever/mail/browser/send_document.py:63
 msgid "intern_receiver"
 msgstr "Interne Empfänger"
 
@@ -152,18 +152,18 @@ msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Attachments"
 #: ./opengever/mail/browser/mail.py:95
-#: ./opengever/mail/browser/send_document.py:93
+#: ./opengever/mail/browser/send_document.py:95
 #: ./opengever/mail/browser/templates/previewtab.pt:48
 msgid "label_documents"
 msgstr "Anhänge"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:112
+#: ./opengever/mail/browser/send_document.py:114
 msgid "label_documents_as_link"
 msgstr "Dokumente nur als Link versenden"
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:118
+#: ./opengever/mail/browser/send_document.py:120
 msgid "label_file_copy_in_dossier"
 msgstr "Kopie des versandten Mails in Dossier ablegen"
 
@@ -173,7 +173,7 @@ msgid "label_journal_initialized"
 msgstr "Dokument migriert"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:88
+#: ./opengever/mail/browser/send_document.py:90
 msgid "label_message"
 msgstr "Mitteilung"
 
@@ -182,26 +182,26 @@ msgstr "Mitteilung"
 msgid "label_org_message"
 msgstr "Originalnachricht"
 
+#. Default: "Raw *.msg message before conversion"
+#: ./opengever/mail/mail.py:89
+msgid "label_original_message"
+msgstr "Quelldatei im *.msg Format vor der Konvertierung"
+
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:301
+#: ./opengever/mail/browser/send_document.py:303
 msgid "label_see_attachment"
 msgstr "siehe Anhänge"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:83
+#: ./opengever/mail/browser/send_document.py:85
 msgid "label_subject"
 msgstr "Betreff"
 
-#. Default: "Title"
-#: ./opengever/mail/mail.py:80
-msgid "label_title"
-msgstr "Titel"
-
-#: ./opengever/mail/browser/send_document.py:66
+#: ./opengever/mail/browser/send_document.py:68
 msgid "mails"
 msgstr "E-Mails"
 
-#: ./opengever/mail/browser/send_document.py:78
+#: ./opengever/mail/browser/send_document.py:80
 msgid "receiver"
 msgstr "Empfänger"
 

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-16 15:00+0000\n"
+"POT-Creation-Date: 2017-05-17 09:46+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -151,7 +151,7 @@ msgid "label_delete_action_selected"
 msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Attachments"
-#: ./opengever/mail/browser/mail.py:95
+#: ./opengever/mail/browser/mail.py:96
 #: ./opengever/mail/browser/send_document.py:95
 #: ./opengever/mail/browser/templates/previewtab.pt:48
 msgid "label_documents"
@@ -177,13 +177,28 @@ msgstr "Dokument migriert"
 msgid "label_message"
 msgstr "Mitteilung"
 
+#. Default: "Message source"
+#: ./opengever/mail/mail.py:116
+msgid "label_message_source"
+msgstr "Quelle Originalnachricht"
+
+#. Default: "Drag and drop upload"
+#: ./opengever/mail/mail.py:80
+msgid "label_message_source_d_n_d_upload"
+msgstr "Drag & Drop Upload"
+
+#. Default: "Mail-in"
+#: ./opengever/mail/mail.py:77
+msgid "label_message_source_mailin"
+msgstr "Mail-In"
+
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:92
+#: ./opengever/mail/browser/mail.py:93
 msgid "label_org_message"
 msgstr "Originalnachricht"
 
 #. Default: "Raw *.msg message before conversion"
-#: ./opengever/mail/mail.py:89
+#: ./opengever/mail/mail.py:107
 msgid "label_original_message"
 msgstr "Quelldatei im *.msg Format vor der Konvertierung"
 

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-16 15:00+0000\n"
+"POT-Creation-Date: 2017-05-17 09:46+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
@@ -151,7 +151,7 @@ msgid "label_delete_action_selected"
 msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Attachments"
-#: ./opengever/mail/browser/mail.py:95
+#: ./opengever/mail/browser/mail.py:96
 #: ./opengever/mail/browser/send_document.py:95
 #: ./opengever/mail/browser/templates/previewtab.pt:48
 #, fuzzy
@@ -178,13 +178,28 @@ msgstr "Document migré"
 msgid "label_message"
 msgstr "Message"
 
+#. Default: "Message source"
+#: ./opengever/mail/mail.py:116
+msgid "label_message_source"
+msgstr ""
+
+#. Default: "Drag and drop upload"
+#: ./opengever/mail/mail.py:80
+msgid "label_message_source_d_n_d_upload"
+msgstr ""
+
+#. Default: "Mail-in"
+#: ./opengever/mail/mail.py:77
+msgid "label_message_source_mailin"
+msgstr ""
+
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:92
+#: ./opengever/mail/browser/mail.py:93
 msgid "label_org_message"
 msgstr "Message original"
 
 #. Default: "Raw *.msg message before conversion"
-#: ./opengever/mail/mail.py:89
+#: ./opengever/mail/mail.py:107
 msgid "label_original_message"
 msgstr ""
 

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-16 08:24+0000\n"
+"POT-Creation-Date: 2017-05-16 15:00+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
@@ -20,7 +20,7 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ./opengever/mail/browser/send_document.py:54
+#: ./opengever/mail/browser/send_document.py:56
 msgid "No Mail Address"
 msgstr "Pas d'adresse Email"
 
@@ -28,7 +28,7 @@ msgstr "Pas d'adresse Email"
 msgid "Save attachments"
 msgstr "Extraire documents"
 
-#: ./opengever/mail/browser/send_document.py:336
+#: ./opengever/mail/browser/send_document.py:338
 msgid "Sent mail filed as '${title}'."
 msgstr "Email envoyé classé sous '${title}'."
 
@@ -36,17 +36,17 @@ msgstr "Email envoyé classé sous '${title}'."
 msgid "The files you selected are larger than the maximum size"
 msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permise."
 
-#: ./opengever/mail/browser/send_document.py:128
+#: ./opengever/mail/browser/send_document.py:130
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse Email interne ou externe."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:195
+#: ./opengever/mail/browser/send_document.py:197
 msgid "button_send"
 msgstr "Envoyer"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:253
+#: ./opengever/mail/browser/send_document.py:255
 msgid "cancel_back"
 msgstr "Annuler"
 
@@ -76,17 +76,17 @@ msgid "error_no_attachments_to_extract"
 msgstr "Cet Email n'a pas d'annexe à extraire."
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:74
+#: ./opengever/mail/browser/send_document.py:76
 msgid "extern_receiver"
 msgstr "Destinataire externe"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:185
+#: ./opengever/mail/browser/send_document.py:187
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(possible uniquement pour les dossiers ouverts)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:160
+#: ./opengever/mail/browser/send_document.py:162
 msgid "heading_send_as_email"
 msgstr "Envoyer les documents comme Email"
 
@@ -101,12 +101,12 @@ msgid "help_delete_action"
 msgstr "Sélectionnez les annexes à effacer."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:75
+#: ./opengever/mail/browser/send_document.py:77
 msgid "help_extern_receiver"
 msgstr "Ajouter les adresses email des destinataires externes. Une adresse par ligne."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py:64
 msgid "help_intern_receiver"
 msgstr "Recherche en direct: Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible."
 
@@ -116,12 +116,12 @@ msgid "info_extracted_document"
 msgstr "Document créé: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:243
+#: ./opengever/mail/browser/send_document.py:245
 msgid "info_mail_sent"
 msgstr "Email envoyé."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:61
+#: ./opengever/mail/browser/send_document.py:63
 msgid "intern_receiver"
 msgstr "Destinataires internes"
 
@@ -152,19 +152,19 @@ msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Attachments"
 #: ./opengever/mail/browser/mail.py:95
-#: ./opengever/mail/browser/send_document.py:93
+#: ./opengever/mail/browser/send_document.py:95
 #: ./opengever/mail/browser/templates/previewtab.pt:48
 #, fuzzy
 msgid "label_documents"
 msgstr "Fichiers attachés"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:112
+#: ./opengever/mail/browser/send_document.py:114
 msgid "label_documents_as_link"
 msgstr "Envoyer seulement le lien du document"
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:118
+#: ./opengever/mail/browser/send_document.py:120
 msgid "label_file_copy_in_dossier"
 msgstr "Classer une copie de l'email envoyé dans le dossier"
 
@@ -174,7 +174,7 @@ msgid "label_journal_initialized"
 msgstr "Document migré"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:88
+#: ./opengever/mail/browser/send_document.py:90
 msgid "label_message"
 msgstr "Message"
 
@@ -183,26 +183,26 @@ msgstr "Message"
 msgid "label_org_message"
 msgstr "Message original"
 
+#. Default: "Raw *.msg message before conversion"
+#: ./opengever/mail/mail.py:89
+msgid "label_original_message"
+msgstr ""
+
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:301
+#: ./opengever/mail/browser/send_document.py:303
 msgid "label_see_attachment"
 msgstr "Voir  fichiers attachés"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:83
+#: ./opengever/mail/browser/send_document.py:85
 msgid "label_subject"
 msgstr "Objet"
 
-#. Default: "Title"
-#: ./opengever/mail/mail.py:80
-msgid "label_title"
-msgstr "Titre"
-
-#: ./opengever/mail/browser/send_document.py:66
+#: ./opengever/mail/browser/send_document.py:68
 msgid "mails"
 msgstr "Email"
 
-#: ./opengever/mail/browser/send_document.py:78
+#: ./opengever/mail/browser/send_document.py:80
 msgid "receiver"
 msgstr "Destinataire"
 

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-16 15:00+0000\n"
+"POT-Creation-Date: 2017-05-17 09:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -152,7 +152,7 @@ msgid "label_delete_action_selected"
 msgstr ""
 
 #. Default: "Attachments"
-#: ./opengever/mail/browser/mail.py:95
+#: ./opengever/mail/browser/mail.py:96
 #: ./opengever/mail/browser/send_document.py:95
 #: ./opengever/mail/browser/templates/previewtab.pt:48
 msgid "label_documents"
@@ -178,13 +178,28 @@ msgstr ""
 msgid "label_message"
 msgstr ""
 
+#. Default: "Message source"
+#: ./opengever/mail/mail.py:116
+msgid "label_message_source"
+msgstr ""
+
+#. Default: "Drag and drop upload"
+#: ./opengever/mail/mail.py:80
+msgid "label_message_source_d_n_d_upload"
+msgstr ""
+
+#. Default: "Mail-in"
+#: ./opengever/mail/mail.py:77
+msgid "label_message_source_mailin"
+msgstr ""
+
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:92
+#: ./opengever/mail/browser/mail.py:93
 msgid "label_org_message"
 msgstr ""
 
 #. Default: "Raw *.msg message before conversion"
-#: ./opengever/mail/mail.py:89
+#: ./opengever/mail/mail.py:107
 msgid "label_original_message"
 msgstr ""
 

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-16 08:24+0000\n"
+"POT-Creation-Date: 2017-05-16 15:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:54
+#: ./opengever/mail/browser/send_document.py:56
 msgid "No Mail Address"
 msgstr ""
 
@@ -29,7 +29,7 @@ msgstr ""
 msgid "Save attachments"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:336
+#: ./opengever/mail/browser/send_document.py:338
 msgid "Sent mail filed as '${title}'."
 msgstr ""
 
@@ -37,17 +37,17 @@ msgstr ""
 msgid "The files you selected are larger than the maximum size"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:128
+#: ./opengever/mail/browser/send_document.py:130
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr ""
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:195
+#: ./opengever/mail/browser/send_document.py:197
 msgid "button_send"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:253
+#: ./opengever/mail/browser/send_document.py:255
 msgid "cancel_back"
 msgstr ""
 
@@ -77,17 +77,17 @@ msgid "error_no_attachments_to_extract"
 msgstr ""
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:74
+#: ./opengever/mail/browser/send_document.py:76
 msgid "extern_receiver"
 msgstr ""
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:185
+#: ./opengever/mail/browser/send_document.py:187
 msgid "file_copy_widget_disabled_hint_text"
 msgstr ""
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:160
+#: ./opengever/mail/browser/send_document.py:162
 msgid "heading_send_as_email"
 msgstr ""
 
@@ -102,12 +102,12 @@ msgid "help_delete_action"
 msgstr ""
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:75
+#: ./opengever/mail/browser/send_document.py:77
 msgid "help_extern_receiver"
 msgstr ""
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py:64
 msgid "help_intern_receiver"
 msgstr ""
 
@@ -117,12 +117,12 @@ msgid "info_extracted_document"
 msgstr ""
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:243
+#: ./opengever/mail/browser/send_document.py:245
 msgid "info_mail_sent"
 msgstr ""
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:61
+#: ./opengever/mail/browser/send_document.py:63
 msgid "intern_receiver"
 msgstr ""
 
@@ -153,18 +153,18 @@ msgstr ""
 
 #. Default: "Attachments"
 #: ./opengever/mail/browser/mail.py:95
-#: ./opengever/mail/browser/send_document.py:93
+#: ./opengever/mail/browser/send_document.py:95
 #: ./opengever/mail/browser/templates/previewtab.pt:48
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:112
+#: ./opengever/mail/browser/send_document.py:114
 msgid "label_documents_as_link"
 msgstr ""
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:118
+#: ./opengever/mail/browser/send_document.py:120
 msgid "label_file_copy_in_dossier"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgid "label_journal_initialized"
 msgstr ""
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:88
+#: ./opengever/mail/browser/send_document.py:90
 msgid "label_message"
 msgstr ""
 
@@ -183,26 +183,26 @@ msgstr ""
 msgid "label_org_message"
 msgstr ""
 
+#. Default: "Raw *.msg message before conversion"
+#: ./opengever/mail/mail.py:89
+msgid "label_original_message"
+msgstr ""
+
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:301
+#: ./opengever/mail/browser/send_document.py:303
 msgid "label_see_attachment"
 msgstr ""
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:83
+#: ./opengever/mail/browser/send_document.py:85
 msgid "label_subject"
 msgstr ""
 
-#. Default: "Title"
-#: ./opengever/mail/mail.py:80
-msgid "label_title"
-msgstr ""
-
-#: ./opengever/mail/browser/send_document.py:66
+#: ./opengever/mail/browser/send_document.py:68
 msgid "mails"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:78
+#: ./opengever/mail/browser/send_document.py:80
 msgid "receiver"
 msgstr ""
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -86,10 +86,11 @@ class IOGMail(form.Schema):
     form.read_permission(original_message='cmf.ManagePortal')
     form.write_permission(original_message='cmf.ManagePortal')
     original_message = field.NamedBlobFile(
-        title=_(u"label_original_message",
-               default=u"Raw *.msg message before conversion"),
+        title=_(u'label_original_message',
+                default=u'Raw *.msg message before conversion'),
         required=False,
     )
+
 
 alsoProvides(IOGMail, IFormFieldProvider)
 

--- a/opengever/mail/tests/test_inbound.py
+++ b/opengever/mail/tests/test_inbound.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail import inbound
 from ftw.mail.interfaces import IEmailAddress
+from opengever.mail.mail import MESSAGE_SOURCE_MAILIN
 from opengever.testing import FunctionalTestCase
 from plone import api
 
@@ -41,3 +42,4 @@ class TestMailInbound(FunctionalTestCase):
         obj = inbound.createMailInContainer(dossier, message)
         self.assertTrue(obj.preserved_as_paper)
         self.assertEqual(message, obj.message.data)
+        self.assertEqual(MESSAGE_SOURCE_MAILIN, obj.message_source)

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -6,6 +6,7 @@ from ftw.testbrowser import browser
 from opengever.document.interfaces import IDocumentSettings
 from opengever.mail.mail import extract_email
 from opengever.mail.mail import get_author_by_email
+from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
 from opengever.mail.tests import MAIL_DATA
 from opengever.mail.tests.utils import get_header_date
 from opengever.testing import FunctionalTestCase
@@ -124,6 +125,11 @@ class TestMailMetadataWithQuickupload(TestMailMetadataWithBuilder):
                       .within(dossier)
                       .with_message(MAIL_DATA))
         return mail
+
+    def test_mail_message_source(self):
+        mail = self.create_mail()
+
+        self.assertEqual(MESSAGE_SOURCE_DRAG_DROP_UPLOAD, mail.message_source)
 
 
 class TestMailMetadataWithAddView(TestMailMetadataWithBuilder):

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -16,6 +16,8 @@ def date_format_helper(dateobj):
 class TestOverview(FunctionalTestCase):
     """Test the overview view of uploaded emails."""
 
+    expected_original_msg_label = 'Raw *.msg message before conversion'
+
     @browsing
     def test_mail_overview_tab(self, browser):
         mail = create(Builder('mail')
@@ -64,3 +66,26 @@ class TestOverview(FunctionalTestCase):
 
         self.assertEquals(expect,
                           browser.css('table').first.lists())
+
+    @browsing
+    def test_origial_message_info_is_omitted_for_non_managers(self, browser):
+        mail = create(Builder('mail')
+                      .with_message(MAIL_DATA)
+                      .with_dummy_message()
+                      .with_dummy_original_message())
+        browser.login().visit(mail, view='tabbedview_view-overview')
+
+        by_label = dict(browser.css('table').first.lists())
+        self.assertNotIn(self.expected_original_msg_label, by_label)
+
+    @browsing
+    def test_original_message_info_is_displayed_for_managers(self, browser):
+        self.grant('Manager')
+        mail = create(Builder('mail')
+                      .with_message(MAIL_DATA)
+                      .with_dummy_message()
+                      .with_dummy_original_message())
+
+        browser.login().visit(mail, view='tabbedview_view-overview')
+        by_label = dict(browser.css('table').first.lists())
+        self.assertIn(self.expected_original_msg_label, by_label)

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -19,7 +19,6 @@ class TestOverview(FunctionalTestCase):
     @browsing
     def test_mail_overview_tab(self, browser):
         mail = create(Builder('mail')
-                      .with_message(MAIL_DATA)
                       .with_asset_message(
                           'mail_with_multiple_attachments.eml'))
         browser.login().visit(mail, view='tabbedview_view-overview')

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -17,6 +17,7 @@ class TestOverview(FunctionalTestCase):
     """Test the overview view of uploaded emails."""
 
     expected_original_msg_label = 'Raw *.msg message before conversion'
+    expected_message_source_label = 'Message source'
 
     @browsing
     def test_mail_overview_tab(self, browser):
@@ -77,6 +78,7 @@ class TestOverview(FunctionalTestCase):
 
         by_label = dict(browser.css('table').first.lists())
         self.assertNotIn(self.expected_original_msg_label, by_label)
+        self.assertNotIn(self.expected_message_source_label, by_label)
 
     @browsing
     def test_original_message_info_is_displayed_for_managers(self, browser):
@@ -89,3 +91,4 @@ class TestOverview(FunctionalTestCase):
         browser.login().visit(mail, view='tabbedview_view-overview')
         by_label = dict(browser.css('table').first.lists())
         self.assertIn(self.expected_original_msg_label, by_label)
+        self.assertIn(self.expected_message_source_label, by_label)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -225,6 +225,11 @@ class MailBuilder(DexterityBuilder):
         self.arguments["message"] = file_
         return self
 
+    def with_dummy_original_message(self):
+        file_ = NamedBlobFile(data='dummy', filename=u'dummy.msg')
+        self.arguments["original_message"] = file_
+        return self
+
     def with_asset_message(self, filename):
         self.with_message(assets.load(filename), unicode(filename))
         return self


### PR DESCRIPTION
With this PR we will keep the original *.msg file after converting it to *.eml upon d&d upload. We will also store the source of a mail (mail-in or d&d-upload). The field is always rendered in display-mode and also shown on the mail-overview, but only for `Manager`:

 
![screen shot 2017-05-17 at 11 51 58](https://cloud.githubusercontent.com/assets/736583/26149039/10acddfc-3af9-11e7-9b6c-b56fbf33dadb.png)

Closes #1149.
