### PR TITLE
OGGBundle: Do not initialize the mail title for mails with a title given.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Keep *.msg file after conversion and store message source for mails. [deiferni]
 - Fix string type in bundle loader [buchi]
 - Fix translation for the Open as PDF action. [phgross]
+- OGGBundle: Do not initialize the mail title for mails with a title given. [phgross]
 - Fix addable types constrain for repository folders in API calls [buchi]
 - Cache addable types constrains for repository folders per request [buchi]
 - Fix typo in dossier SearchableTextExtender, which results in a empty SearchableText if IFilingNumber behavior was activated. [mathias.leimgruber]

--- a/opengever/bundle/sections/fileloader.py
+++ b/opengever/bundle/sections/fileloader.py
@@ -10,6 +10,7 @@ from opengever.document.subscribers import set_digitally_available
 from opengever.document.subscribers import sync_title_and_filename_handler
 from opengever.mail.mail import initalize_title
 from opengever.mail.mail import initialize_metadata
+from opengever.mail.mail import NO_SUBJECT_TITLE_FALLBACK
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import classProvides
 from zope.interface import implements
@@ -176,9 +177,11 @@ class FileLoaderSection(object):
                 # too early before (when the file contents weren't loaded yet)
                 if self.is_mail(item):
                     initialize_metadata(obj, None)
-                    # Reset the [No Subject] placeholder
-                    obj.title = None
-                    initalize_title(obj, None)
+
+                    if obj.title == NO_SUBJECT_TITLE_FALLBACK:
+                        # Reset the [No Subject] placeholder
+                        obj.title = None
+                        initalize_title(obj, None)
                 else:
                     sync_title_and_filename_handler(obj, None)
                     set_digitally_available(obj, None)

--- a/opengever/bundle/tests/assets/basic.oggbundle/documents.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/documents.json
@@ -32,6 +32,12 @@
     "review_state": "document-state-draft",
     "title": "Ein Mail"
   },  {
+    "guid": "0970e3800a78407ea2558d718739961d",
+    "parent_guid": "659645aec58d48a9b9663399ea2ec069",
+    "filepath": "files/sample.eml",
+    "review_state": "document-state-draft",
+    "title": ""
+  },  {
     "guid": "7363583a8a78407ea2558d718774e8d2",
     "parent_guid": "659645aec58d48a9b9663399ea2ec069",
     "filepath": "\\\\host\\mount\\subdir\\wordfile.docx",

--- a/opengever/bundle/tests/test_bundle_loader.py
+++ b/opengever/bundle/tests/test_bundle_loader.py
@@ -30,7 +30,7 @@ class TestBundleLoader(TestCase):
 
     def test_loads_correct_number_of_items(self):
         bundle = self.load_bundle()
-        self.assertEqual(10, len(list(bundle)))
+        self.assertEqual(11, len(list(bundle)))
 
     def test_loads_items_in_correct_order(self):
         bundle = self.load_bundle()
@@ -44,6 +44,7 @@ class TestBundleLoader(TestCase):
              ('document', 'Bewerbung Hanspeter M\xc3\xbcller'),
              ('document', 'Entlassung Hanspeter M\xc3\xbcller'),
              ('mail', 'Ein Mail'),
+             ('mail', ''),
              ('document', 'Document referenced via UNC-Path')],
             [(get_portal_type(i), get_title(i)) for i in list(bundle)])
 
@@ -69,6 +70,7 @@ class TestBundleLoader(TestCase):
             ('document', 'Bewerbung Hanspeter M\xc3\xbcller'),
             ('document', 'Document referenced via UNC-Path'),
             ('document', 'Entlassung Hanspeter M\xc3\xbcller'),
+            ('mail', ''),
             ('mail', 'Ein Mail'),
             ('repositoryfolder', 'Organigramm, Prozesse'),
             ('repositoryfolder', 'Organisation'),

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -344,8 +344,9 @@ class TestOggBundlePipeline(FunctionalTestCase):
     def assert_documents_created(self, parent):
         self.assert_document_1_created(parent)
         self.assert_document_2_created(parent)
-        self.assert_mail_created(parent)
-        self.assert_document_4_created(parent)
+        self.assert_mail_1_created(parent)
+        self.assert_mail_2_created(parent)
+        self.assert_document_5_created(parent)
 
     def assert_document_1_created(self, parent):
         document_1 = parent.get('document-1')
@@ -423,21 +424,21 @@ class TestOggBundlePipeline(FunctionalTestCase):
         history = repo_tool.getHistoryMetadata(document_2)
         self.assertEqual(1, len(history))
 
-    def assert_document_4_created(self, parent):
-        document_4 = parent.get('document-4')
+    def assert_document_5_created(self, parent):
+        document_5 = parent.get('document-5')
 
-        self.assertTrue(document_4.digitally_available)
-        self.assertIsNotNone(document_4.file)
-        self.assertEqual(24390, len(document_4.file.data))
+        self.assertTrue(document_5.digitally_available)
+        self.assertIsNotNone(document_5.file)
+        self.assertEqual(24390, len(document_5.file.data))
 
         self.assertEqual(
             'document-state-draft',
-            api.content.get_state(document_4))
+            api.content.get_state(document_5))
         self.assertEqual(
             u'Document referenced via UNC-Path',
-            document_4.title)
+            document_5.title)
 
-    def assert_mail_created(self, parent):
+    def assert_mail_1_created(self, parent):
         mail = parent.get('document-3')
 
         self.assertTrue(mail.digitally_available)
@@ -472,12 +473,19 @@ class TestOggBundlePipeline(FunctionalTestCase):
             api.content.get_state(mail))
 
         self.assertEqual(
-            u'Lorem Ipsum',
+            u'Ein Mail',
             mail.title)
 
         repo_tool = api.portal.get_tool('portal_repository')
         history = repo_tool.getHistoryMetadata(mail)
         self.assertEqual(0, len(history))
+
+    def assert_mail_2_created(self, parent):
+        mail = parent.get('document-4')
+
+        self.assertIsNotNone(mail.message)
+        self.assertEqual(920, len(mail.message.data))
+        self.assertEqual(u'Lorem Ipsum', mail.title)
 
     def assert_report_data_collected(self, bundle):
         report_data = bundle.report_data
@@ -502,4 +510,4 @@ class TestOggBundlePipeline(FunctionalTestCase):
         self.assertEqual(3, len(repofolders))
         self.assertEqual(2, len(dossiers))
         self.assertEqual(3, len(documents))
-        self.assertEqual(1, len(mails))
+        self.assertEqual(2, len(mails))

--- a/opengever/bundle/tests/test_section_bundlesource.py
+++ b/opengever/bundle/tests/test_section_bundlesource.py
@@ -34,7 +34,7 @@ class TestBundleSource(FunctionalTestCase):
 
     def test_yields_items_from_bundle(self):
         source = self.setup_source({})
-        self.assertEqual(10, len(list(source)))
+        self.assertEqual(11, len(list(source)))
 
     def test_raises_if_bundle_path_missing(self):
         transmogrifier = MockTransmogrifier()

--- a/opengever/bundle/tests/test_section_fileloader.py
+++ b/opengever/bundle/tests/test_section_fileloader.py
@@ -140,3 +140,17 @@ class TestFileLoader(FunctionalTestCase):
         self.assertEqual('message/rfc822', mail.message.contentType)
         self.assertEqual('lorem-ipsum.eml', mail.message.filename)
         self.assertEqual(True, mail.digitally_available)
+
+    def test_uses_subject_as_title_only_when_no_title_is_given(self):
+        mail2 = create(Builder('mail').titled(u'Test Mail'))
+        item = {
+            u"guid": u"12345",
+            u"_type": u"ftw.mail.mail",
+            u"_path": '/'.join(mail2.getPhysicalPath()[2:]),
+            u"filepath": u"files/sample.eml",
+            u"_object": mail2,
+            u"title": 'Test Mail',
+        }
+        section = self.setup_section(previous=[item])
+        list(section)
+        self.assertEqual(u'Test Mail', mail2.title)

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -58,6 +58,7 @@ else:
 
 MESSAGE_SOURCE_DRAG_DROP_UPLOAD = 'upload'
 MESSAGE_SOURCE_MAILIN = 'mailin'
+NO_SUBJECT_TITLE_FALLBACK = '[No Subject]'
 
 
 IMail.setTaggedValue(FIELDSETS_KEY, [
@@ -370,7 +371,8 @@ def initalize_title(mail, event):
             value = subject.decode('utf8')
         else:
             value = translate(
-                ftw_mf(u'no_subject', default=u'[No Subject]'),
+                ftw_mf(u'no_subject',
+                       default=NO_SUBJECT_TITLE_FALLBACK.decode('utf-8')),
                 context=getSite().REQUEST)
 
         IOGMail(mail).title = value

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.document.interfaces import IDocumentSettings
 from opengever.mail.mail import IOGMailMarker
+from opengever.mail.mail import NO_SUBJECT_TITLE_FALLBACK
 from opengever.mail.tests import MAIL_DATA
 from opengever.testing import FunctionalTestCase
 from plone import api
@@ -49,8 +50,8 @@ class TestOGMailAddition(FunctionalTestCase):
 
     def test_title_accessor(self):
         mail = create(Builder("mail"))
-        self.assertEquals(u'[No Subject]', mail.title)
-        self.assertEquals('[No Subject]', mail.Title())
+        self.assertEquals(NO_SUBJECT_TITLE_FALLBACK, mail.title)
+        self.assertEquals(NO_SUBJECT_TITLE_FALLBACK, mail.Title())
 
         mail = create(Builder("mail").with_message(MAIL_DATA))
 


### PR DESCRIPTION
The fileloader had a special handling for initializing the mail title (use the subject as title) after attaching the message to the object. Those handling hasn't checked for an already existing title.

Fixes #2942 