### PR TITLE
Fix translation for the "Open as PDF" action.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]
 - Fix string type in bundle loader [buchi]
+- Fix translation for the Open as PDF action. [phgross]
 - Fix addable types constrain for repository folders in API calls [buchi]
 - Cache addable types constrains for repository folders per request [buchi]
 - Fix typo in dossier SearchableTextExtender, which results in a empty SearchableText if IFilingNumber behavior was activated. [mathias.leimgruber]

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -112,7 +112,6 @@
                     tal:define="link view/overlay/get_open_as_pdf_url; target python: '_blank' if view.overlay.should_open_in_new_window() else None"
                     tal:condition="nocall: link">
                     <a tal:attributes="href link; target target | nothing; class string:function-pdf-preview"
-                        i18n:domain="opengever.bumblebee"
                         i18n:translate="label_open_document_as_pdf">
                         Open as PDF
                     </a>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-05-17 11:42+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -42,13 +42,13 @@ msgstr "Dokument eingecheckt: ${title}"
 msgid "Checked out: ${title}"
 msgstr "Dokument ausgecheckt: ${title}"
 
-#: ./opengever/document/browser/templates/macros.pt:65
+#: ./opengever/document/browser/templates/macros.pt:66
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin with comment"
 msgstr "Mit Kommentar einchecken"
 
-#: ./opengever/document/browser/templates/macros.pt:62
+#: ./opengever/document/browser/templates/macros.pt:63
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
@@ -88,7 +88,7 @@ msgstr "Report konnte nicht generiert werden"
 msgid "Create Task"
 msgstr "Aufgabe erstellen"
 
-#: ./opengever/document/browser/overview.py:208
+#: ./opengever/document/browser/overview.py:209
 msgid "Current version: ${version}"
 msgstr "Aktuelle Version: ${version}"
 
@@ -114,10 +114,6 @@ msgstr "GEVER verlassen"
 msgid "Reverted file to version ${version_id}."
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
 
-#: ./opengever/document/forms.py:65
-msgid "Save"
-msgstr "Speichern"
-
 #. Default: "Send as email"
 #: ./opengever/document/profiles/default/actions.xml
 msgid "Send as email"
@@ -128,15 +124,15 @@ msgstr "Als E-Mail versenden"
 msgid "Submit additional documents"
 msgstr "Zusätzliche Anhänge einreichen"
 
-#: ./opengever/document/browser/overview.py:204
+#: ./opengever/document/browser/overview.py:205
 msgid "Submitted version: ${version}"
 msgstr "Eingereichte Version: ${version}"
 
-#: ./opengever/document/browser/overview.py:173
+#: ./opengever/document/browser/overview.py:174
 msgid "Submitted with"
 msgstr "Eingereicht bei"
 
-#: ./opengever/document/browser/download.py:39
+#: ./opengever/document/browser/download.py:40
 #: ./opengever/document/browser/edit.py:81
 msgid "The Document ${title} has no File."
 msgstr "Das Dokument ${title} enthält keine Datei."
@@ -195,7 +191,7 @@ msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:97
+#: ./opengever/document/document.py:98
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
 
@@ -205,7 +201,7 @@ msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:74
+#: ./opengever/document/document.py:75
 msgid "error_title_or_file_required"
 msgstr "Ein Titel oder eine Datei muss angegeben werden."
 
@@ -217,7 +213,7 @@ msgstr "Archiv Datei"
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:41
 #: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:50
+#: ./opengever/document/document.py:51
 msgid "fieldset_common"
 msgstr "Allgemein"
 
@@ -265,7 +261,7 @@ msgid "help_document_date"
 msgstr "Datum des Dokuments"
 
 #. Default: ""
-#: ./opengever/document/document.py:67
+#: ./opengever/document/document.py:68
 msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
@@ -298,13 +294,13 @@ msgid "initial_document_version_change_note"
 msgstr "Dokument erstellt (Initialversion)"
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:279
+#: ./opengever/document/browser/versions_tab.py:281
 msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "Archival File"
 #: ./opengever/document/behaviors/metadata.py:147
-#: ./opengever/document/browser/overview.py:168
+#: ./opengever/document/browser/overview.py:169
 msgid "label_archival_file"
 msgstr "Archivdatei"
 
@@ -314,7 +310,7 @@ msgid "label_archival_file_state"
 msgstr "Status Archivdatei"
 
 #. Default: "Attach to email"
-#: ./opengever/document/browser/templates/macros.pt:84
+#: ./opengever/document/browser/templates/macros.pt:85
 msgid "label_attach_to_email"
 msgstr "Mit Mailprogramm versenden"
 
@@ -340,7 +336,7 @@ msgid "label_change_archival_file"
 msgstr "Archivdatei ändern"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:150
+#: ./opengever/document/browser/overview.py:151
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr "Ausgecheckt"
@@ -356,17 +352,17 @@ msgid "label_checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:287
+#: ./opengever/document/browser/versions_tab.py:289
 msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:146
+#: ./opengever/document/browser/overview.py:147
 msgid "label_creator"
 msgstr "Ersteller"
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:283
+#: ./opengever/document/browser/versions_tab.py:285
 msgid "label_date"
 msgstr "Datum"
 
@@ -425,15 +421,15 @@ msgid "label_download"
 msgstr "Herunterladen"
 
 #. Default: "Download copy"
-#: ./opengever/document/browser/download.py:135
+#: ./opengever/document/browser/download.py:140
 #: ./opengever/document/browser/templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/templates/macros.pt:75
+#: ./opengever/document/browser/templates/macros.pt:76
 msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:152
-#: ./opengever/document/document.py:66
+#: ./opengever/document/browser/overview.py:153
+#: ./opengever/document/document.py:67
 msgid "label_file"
 msgstr "Datei"
 
@@ -466,13 +462,18 @@ msgstr "OK"
 msgid "label_open_detail_view"
 msgstr "Detailansicht öffnen"
 
+#. Default: "Open as PDF"
+#: ./opengever/document/browser/templates/macros.pt:114
+msgid "label_open_document_as_pdf"
+msgstr "Dokument als PDF öffnen"
+
 #. Default: "Open document preview"
 #: ./opengever/document/widgets/tooltip.pt:15
 msgid "label_open_document_preview"
 msgstr "Dokumentvorschau öffnen"
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/templates/macros.pt:102
+#: ./opengever/document/browser/templates/macros.pt:103
 msgid "label_pdf_preview"
 msgstr "PDF Vorschau"
 
@@ -483,7 +484,7 @@ msgstr "In Papierform aufbewahrt"
 
 #. Default: "Preview"
 #: ./opengever/document/behaviors/metadata.py:166
-#: ./opengever/document/browser/versions_tab.py:305
+#: ./opengever/document/browser/versions_tab.py:307
 msgid "label_preview"
 msgstr "Vorschau"
 
@@ -512,7 +513,7 @@ msgid "label_reset"
 msgstr "Zurücksetzen"
 
 #. Default: "Revert"
-#: ./opengever/document/browser/versions_tab.py:300
+#: ./opengever/document/browser/versions_tab.py:302
 msgid "label_revert"
 msgstr "Zurücksetzen"
 
@@ -533,12 +534,12 @@ msgstr "Kurzbild"
 
 #. Default: "Title"
 #: ./opengever/document/browser/report.py:30
-#: ./opengever/document/document.py:60
+#: ./opengever/document/document.py:61
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:275
+#: ./opengever/document/browser/versions_tab.py:277
 msgid "label_version"
 msgstr "Version"
 
@@ -582,4 +583,3 @@ msgstr "Mit Kommentar"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Ohne Kommentar"
-

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-05-17 11:42+0000\n"
 "PO-Revision-Date: 2017-05-01 15:48+0000\n"
 "Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-document/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.7-dev\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.7-dev\n"
 
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/20170322142153_add_office_connector_multi_attach_action_to_documents/actions.xml
@@ -44,13 +43,13 @@ msgstr "Checkin du document:  ${title}"
 msgid "Checked out: ${title}"
 msgstr "Checkout du document:  ${title}"
 
-#: ./opengever/document/browser/templates/macros.pt:65
+#: ./opengever/document/browser/templates/macros.pt:66
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin with comment"
 msgstr "Checkin avec commentaire"
 
-#: ./opengever/document/browser/templates/macros.pt:62
+#: ./opengever/document/browser/templates/macros.pt:63
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
@@ -89,7 +88,7 @@ msgstr ""
 msgid "Create Task"
 msgstr "Créer une tâche"
 
-#: ./opengever/document/browser/overview.py:208
+#: ./opengever/document/browser/overview.py:209
 msgid "Current version: ${version}"
 msgstr "Version actuelle: ${version}"
 
@@ -115,10 +114,6 @@ msgstr "Quitter GEVER"
 msgid "Reverted file to version ${version_id}."
 msgstr "Retour à la version ${version_id} du document."
 
-#: ./opengever/document/forms.py:65
-msgid "Save"
-msgstr "Sauvegarder"
-
 #: ./opengever/document/profiles/default/actions.xml
 msgid "Send as email"
 msgstr "Envoyer par E-Mail"
@@ -128,15 +123,15 @@ msgstr "Envoyer par E-Mail"
 msgid "Submit additional documents"
 msgstr "Soumettre des documents additionnels"
 
-#: ./opengever/document/browser/overview.py:204
+#: ./opengever/document/browser/overview.py:205
 msgid "Submitted version: ${version}"
 msgstr "Version soumise: ${version}"
 
-#: ./opengever/document/browser/overview.py:173
+#: ./opengever/document/browser/overview.py:174
 msgid "Submitted with"
 msgstr "Soumis par"
 
-#: ./opengever/document/browser/download.py:39
+#: ./opengever/document/browser/download.py:40
 #: ./opengever/document/browser/edit.py:81
 msgid "The Document ${title} has no File."
 msgstr "Le dodument  ${title} ne contient pas de fichier."
@@ -195,7 +190,7 @@ msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:97
+#: ./opengever/document/document.py:98
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
 
@@ -205,7 +200,7 @@ msgid "error_no_items"
 msgstr "Aucun élément sélectionné."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:74
+#: ./opengever/document/document.py:75
 msgid "error_title_or_file_required"
 msgstr "Un titre ou un fichier est requis."
 
@@ -217,7 +212,7 @@ msgstr ""
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:41
 #: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:50
+#: ./opengever/document/document.py:51
 msgid "fieldset_common"
 msgstr "En général"
 
@@ -263,7 +258,7 @@ msgstr "Date, à laquelle le document a été envoyé par écrit"
 msgid "help_document_date"
 msgstr "Date de création du document"
 
-#: ./opengever/document/document.py:67
+#: ./opengever/document/document.py:68
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
@@ -293,13 +288,13 @@ msgid "initial_document_version_change_note"
 msgstr "Document créé (version initiale)"
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:279
+#: ./opengever/document/browser/versions_tab.py:281
 msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "Archival File"
 #: ./opengever/document/behaviors/metadata.py:147
-#: ./opengever/document/browser/overview.py:168
+#: ./opengever/document/browser/overview.py:169
 msgid "label_archival_file"
 msgstr "Fichier archivé"
 
@@ -309,7 +304,7 @@ msgid "label_archival_file_state"
 msgstr ""
 
 #. Default: "Attach to email"
-#: ./opengever/document/browser/templates/macros.pt:84
+#: ./opengever/document/browser/templates/macros.pt:85
 msgid "label_attach_to_email"
 msgstr ""
 
@@ -335,7 +330,7 @@ msgid "label_change_archival_file"
 msgstr ""
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:150
+#: ./opengever/document/browser/overview.py:151
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr "Avec checkout"
@@ -351,17 +346,17 @@ msgid "label_checkout_and_edit"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:287
+#: ./opengever/document/browser/versions_tab.py:289
 msgid "label_comment"
 msgstr "commentaire"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:146
+#: ./opengever/document/browser/overview.py:147
 msgid "label_creator"
 msgstr "Créateur"
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:283
+#: ./opengever/document/browser/versions_tab.py:285
 msgid "label_date"
 msgstr "Date"
 
@@ -420,15 +415,15 @@ msgid "label_download"
 msgstr "Télécharger"
 
 #. Default: "Download copy"
-#: ./opengever/document/browser/download.py:135
+#: ./opengever/document/browser/download.py:140
 #: ./opengever/document/browser/templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/templates/macros.pt:75
+#: ./opengever/document/browser/templates/macros.pt:76
 msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:152
-#: ./opengever/document/document.py:66
+#: ./opengever/document/browser/overview.py:153
+#: ./opengever/document/document.py:67
 msgid "label_file"
 msgstr "Fichier"
 
@@ -461,13 +456,18 @@ msgstr "Ok"
 msgid "label_open_detail_view"
 msgstr ""
 
+#. Default: "Open as PDF"
+#: ./opengever/document/browser/templates/macros.pt:114
+msgid "label_open_document_as_pdf"
+msgstr ""
+
 #. Default: "Open document preview"
 #: ./opengever/document/widgets/tooltip.pt:15
 msgid "label_open_document_preview"
 msgstr ""
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/templates/macros.pt:102
+#: ./opengever/document/browser/templates/macros.pt:103
 msgid "label_pdf_preview"
 msgstr ""
 
@@ -478,7 +478,7 @@ msgstr "Conserver sous forme papier"
 
 #. Default: "Preview"
 #: ./opengever/document/behaviors/metadata.py:166
-#: ./opengever/document/browser/versions_tab.py:305
+#: ./opengever/document/browser/versions_tab.py:307
 msgid "label_preview"
 msgstr "Aperçu"
 
@@ -507,7 +507,7 @@ msgid "label_reset"
 msgstr "Remettre"
 
 #. Default: "Revert"
-#: ./opengever/document/browser/versions_tab.py:300
+#: ./opengever/document/browser/versions_tab.py:302
 msgid "label_revert"
 msgstr "Reculer"
 
@@ -528,12 +528,12 @@ msgstr "Vignette"
 
 #. Default: "Title"
 #: ./opengever/document/browser/report.py:30
-#: ./opengever/document/document.py:60
+#: ./opengever/document/document.py:61
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:275
+#: ./opengever/document/browser/versions_tab.py:277
 msgid "label_version"
 msgstr "Version"
 
@@ -577,3 +577,4 @@ msgstr "Avec commentaire"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Sans commentaire"
+

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-05-17 11:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,13 +44,13 @@ msgstr ""
 msgid "Checked out: ${title}"
 msgstr ""
 
-#: ./opengever/document/browser/templates/macros.pt:65
+#: ./opengever/document/browser/templates/macros.pt:66
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin with comment"
 msgstr ""
 
-#: ./opengever/document/browser/templates/macros.pt:62
+#: ./opengever/document/browser/templates/macros.pt:63
 #: ./opengever/document/profiles/default/actions.xml
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Create Task"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:208
+#: ./opengever/document/browser/overview.py:209
 msgid "Current version: ${version}"
 msgstr ""
 
@@ -115,10 +115,6 @@ msgstr ""
 msgid "Reverted file to version ${version_id}."
 msgstr ""
 
-#: ./opengever/document/forms.py:65
-msgid "Save"
-msgstr ""
-
 #: ./opengever/document/profiles/default/actions.xml
 msgid "Send as email"
 msgstr ""
@@ -128,15 +124,15 @@ msgstr ""
 msgid "Submit additional documents"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:204
+#: ./opengever/document/browser/overview.py:205
 msgid "Submitted version: ${version}"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:173
+#: ./opengever/document/browser/overview.py:174
 msgid "Submitted with"
 msgstr ""
 
-#: ./opengever/document/browser/download.py:39
+#: ./opengever/document/browser/download.py:40
 #: ./opengever/document/browser/edit.py:81
 msgid "The Document ${title} has no File."
 msgstr ""
@@ -195,7 +191,7 @@ msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:97
+#: ./opengever/document/document.py:98
 msgid "error_mail_upload"
 msgstr ""
 
@@ -205,7 +201,7 @@ msgid "error_no_items"
 msgstr ""
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:74
+#: ./opengever/document/document.py:75
 msgid "error_title_or_file_required"
 msgstr ""
 
@@ -217,7 +213,7 @@ msgstr ""
 #. Default: "Common"
 #: ./opengever/document/behaviors/metadata.py:41
 #: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:50
+#: ./opengever/document/document.py:51
 msgid "fieldset_common"
 msgstr ""
 
@@ -263,7 +259,7 @@ msgstr ""
 msgid "help_document_date"
 msgstr ""
 
-#: ./opengever/document/document.py:67
+#: ./opengever/document/document.py:68
 msgid "help_file"
 msgstr ""
 
@@ -293,13 +289,13 @@ msgid "initial_document_version_change_note"
 msgstr ""
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:279
+#: ./opengever/document/browser/versions_tab.py:281
 msgid "label_actor"
 msgstr ""
 
 #. Default: "Archival File"
 #: ./opengever/document/behaviors/metadata.py:147
-#: ./opengever/document/browser/overview.py:168
+#: ./opengever/document/browser/overview.py:169
 msgid "label_archival_file"
 msgstr ""
 
@@ -309,7 +305,7 @@ msgid "label_archival_file_state"
 msgstr ""
 
 #. Default: "Attach to email"
-#: ./opengever/document/browser/templates/macros.pt:84
+#: ./opengever/document/browser/templates/macros.pt:85
 msgid "label_attach_to_email"
 msgstr ""
 
@@ -335,7 +331,7 @@ msgid "label_change_archival_file"
 msgstr ""
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:150
+#: ./opengever/document/browser/overview.py:151
 #: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
 msgid "label_checked_out"
 msgstr ""
@@ -351,17 +347,17 @@ msgid "label_checkout_and_edit"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:287
+#: ./opengever/document/browser/versions_tab.py:289
 msgid "label_comment"
 msgstr ""
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:146
+#: ./opengever/document/browser/overview.py:147
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:283
+#: ./opengever/document/browser/versions_tab.py:285
 msgid "label_date"
 msgstr ""
 
@@ -420,15 +416,15 @@ msgid "label_download"
 msgstr ""
 
 #. Default: "Download copy"
-#: ./opengever/document/browser/download.py:135
+#: ./opengever/document/browser/download.py:140
 #: ./opengever/document/browser/templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/templates/macros.pt:75
+#: ./opengever/document/browser/templates/macros.pt:76
 msgid "label_download_copy"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:152
-#: ./opengever/document/document.py:66
+#: ./opengever/document/browser/overview.py:153
+#: ./opengever/document/document.py:67
 msgid "label_file"
 msgstr ""
 
@@ -461,13 +457,18 @@ msgstr ""
 msgid "label_open_detail_view"
 msgstr ""
 
+#. Default: "Open as PDF"
+#: ./opengever/document/browser/templates/macros.pt:114
+msgid "label_open_document_as_pdf"
+msgstr ""
+
 #. Default: "Open document preview"
 #: ./opengever/document/widgets/tooltip.pt:15
 msgid "label_open_document_preview"
 msgstr ""
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/templates/macros.pt:102
+#: ./opengever/document/browser/templates/macros.pt:103
 msgid "label_pdf_preview"
 msgstr ""
 
@@ -478,7 +479,7 @@ msgstr ""
 
 #. Default: "Preview"
 #: ./opengever/document/behaviors/metadata.py:166
-#: ./opengever/document/browser/versions_tab.py:305
+#: ./opengever/document/browser/versions_tab.py:307
 msgid "label_preview"
 msgstr ""
 
@@ -507,7 +508,7 @@ msgid "label_reset"
 msgstr ""
 
 #. Default: "Revert"
-#: ./opengever/document/browser/versions_tab.py:300
+#: ./opengever/document/browser/versions_tab.py:302
 msgid "label_revert"
 msgstr ""
 
@@ -528,12 +529,12 @@ msgstr ""
 
 #. Default: "Title"
 #: ./opengever/document/browser/report.py:30
-#: ./opengever/document/document.py:60
+#: ./opengever/document/document.py:61
 msgid "label_title"
 msgstr ""
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:275
+#: ./opengever/document/browser/versions_tab.py:277
 msgid "label_version"
 msgstr ""
 


### PR DESCRIPTION
Fixes #2951 

Because the action is now part of the document subdirectory, i moved the translation to the og.document domain.

Backport to: 2017.2.x