### PR TITLE
Fix string type in bundle loader

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]
+- Fix string type in bundle loader [buchi]
 - Fix addable types constrain for repository folders in API calls [buchi]
 - Cache addable types constrains for repository folders per request [buchi]
 - Fix typo in dossier SearchableTextExtender, which results in a empty SearchableText if IFilingNumber behavior was activated. [mathias.leimgruber]

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -1,3 +1,5 @@
+from collections import Iterable
+from collections import Mapping
 from collections import OrderedDict
 from datetime import datetime
 from jsonschema import FormatChecker
@@ -117,7 +119,7 @@ class BundleLoader(object):
     def _load_items(self):
         self._items = []
         for json_name, portal_type in BUNDLE_JSON_TYPES.items():
-            items = self._load_json(json_name)
+            items = unicode2bytes(self._load_json(json_name))
             if items is None:
                 continue
 
@@ -244,3 +246,17 @@ class IngestionSettingsReader(object):
             log.info('No ingestion settings found at %s' % settings_path)
             return {}
         return settings
+
+
+def unicode2bytes(data):
+    """Converts unicode strings to byte strings."""
+    if isinstance(data, unicode):
+        return data.encode('utf8')
+    elif isinstance(data, str):
+        return data
+    elif isinstance(data, Mapping):
+        return type(data)(map(unicode2bytes, data.iteritems()))
+    elif isinstance(data, Iterable):
+        return type(data)(map(unicode2bytes, data))
+    else:
+        return data

--- a/opengever/bundle/sections/fileloader.py
+++ b/opengever/bundle/sections/fileloader.py
@@ -123,6 +123,8 @@ class FileLoaderSection(object):
                     continue
 
                 filename = os.path.basename(abs_filepath)
+                if isinstance(filename, str):
+                    filename = filename.decode('utf8')
 
                 # TODO: Check for this in OGGBundle validation
                 if any(abs_filepath.lower().endswith(ext) for ext in INVALID_FILE_EXTENSIONS):  # noqa


### PR DESCRIPTION
With this fix all items injected into the transmogrifier pipeline contain utf8 encoded byte strings instead of unicode strings. This fixes an issue with unicode strings in local roles (#2927).

It may introduce new issues if something in the ogg bundle pipeline relies on unicode strings. But in general items in the transmogrifier pipeline should always contain byte strings. Various sections will break with unicode strings.

/cc @lukasgraf 