### PR TITLE
Check is_pasting_allowed view when pasting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.2.2 (unreleased)
 ---------------------
 
+- Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]
 - Fix addable types constrain for repository folders in API calls [buchi]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -37,6 +37,13 @@
       />
 
   <browser:page
+      name="paste_clipboard"
+      for="*"
+      class=".paste.PasteClipboardView"
+      permission="zope2.View"
+      />
+
+  <browser:page
       name="confirm-action"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       template="confirm.pt"

--- a/opengever/base/browser/paste.py
+++ b/opengever/base/browser/paste.py
@@ -29,9 +29,17 @@ class PasteClipboardView(BrowserView):
             return self.redirect()
 
         if not self.is_pasting_objects_allowed(objs):
-            msg = _(u"msg_pasting_not_allowed",
+            msg = _(u"msg_pasting_type_not_allowed",
                     default=u"Can't paste items, it's not allowed to add "
                     "objects of this type.")
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+            return self.redirect()
+
+        if not self.is_pasting_on_context_allowed():
+            msg = _(u"msg_pasting_not_allowed",
+                    default=u"Can't paste items, the context does not allow "
+                    "pasting items.")
             api.portal.show_message(
                 message=msg, request=self.request, type='error')
             return self.redirect()
@@ -42,6 +50,16 @@ class PasteClipboardView(BrowserView):
                 default=u"Objects from clipboard successfully pasted.")
         api.portal.show_message(message=msg, request=self.request, type='info')
         return self.redirect()
+
+    def is_pasting_on_context_allowed(self):
+        is_pasting_allowed_view = self.context.restrictedTraverse(
+            '@@is_pasting_allowed')
+
+        if not is_pasting_allowed_view:
+            # the is_pasting_allowed_view should always be available, but if
+            # not we probably cannot paste
+            return False
+        return is_pasting_allowed_view()
 
     def is_pasting_objects_allowed(self, objs):
         allowed_content_types = [

--- a/opengever/base/browser/paste.py
+++ b/opengever/base/browser/paste.py
@@ -1,7 +1,7 @@
-from five import grok
 from opengever.base import _
 from opengever.base.clipboard import Clipboard
 from plone import api
+from Products.Five import BrowserView
 from zope.container.interfaces import INameChooser
 from zope.interface import alsoProvides
 from zope.interface import Interface
@@ -9,21 +9,17 @@ from zope.interface import Interface
 
 class ICopyPasteRequestLayer(Interface):
     """This request layer is activiated during the copy & paste process.
-    This allow us to skip automatic renames etc. in the journal."""
+    This allow us to skip automatic renames etc. in the journal.
+    """
 
 
-class PasteClipboardView(grok.View):
+class PasteClipboardView(BrowserView):
     """A view that pastes objects from our own clipboard to the current context.
     It replaces the default Plone `objectPaste.cpy`. This allows us to use
     our own ID format for pasted objects instead of the default Plone
     (`copy_of_dossier-19`).
     """
-
-    grok.name('paste_clipboard')
-    grok.context(Interface)
-    grok.require('zope2.View')
-
-    def render(self):
+    def __call__(self):
         objs = Clipboard(self.request).get_objs()
         if not objs:
             msg = _(u"msg_empty_clipboard",

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:20+0000\n"
+"POT-Creation-Date: 2017-05-17 15:37+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -303,9 +303,14 @@ msgstr "Es können keine Objekte eingefügt werden, die Zwischenablage ist leer.
 msgid "msg_no_items_available"
 msgstr "Es sind keine Elemente verfügbar."
 
+#. Default: "Can't paste items, the context does not allow pasting items."
+#: ./opengever/base/browser/paste.py:40
+msgid "msg_pasting_not_allowed"
+msgstr "Es ist nicht erlaubt die Objekte an diesem Ort einzufügen."
+
 #. Default: "Can't paste items, it's not allowed to add objects of this type."
 #: ./opengever/base/browser/paste.py:36
-msgid "msg_pasting_not_allowed"
+msgid "msg_pasting_type_not_allowed"
 msgstr "Es ist nicht erlaubt Objekte dieses Typs einzufügen."
 
 #. Default: "Selected objects successfully copied."

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:20+0000\n"
+"POT-Creation-Date: 2017-05-17 15:37+0000\n"
 "PO-Revision-Date: 2016-08-10 05:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -302,9 +302,14 @@ msgstr "Aucun objet ne peut être ajouté, le presse-papier est vide."
 msgid "msg_no_items_available"
 msgstr ""
 
+#. Default: "Can't paste items, the context does not allow pasting items."
+#: ./opengever/base/browser/paste.py:40
+msgid "msg_pasting_not_allowed"
+msgstr ""
+
 #. Default: "Can't paste items, it's not allowed to add objects of this type."
 #: ./opengever/base/browser/paste.py:36
-msgid "msg_pasting_not_allowed"
+msgid "msg_pasting_type_not_allowed"
 msgstr ""
 
 #. Default: "Selected objects successfully copied."

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:20+0000\n"
+"POT-Creation-Date: 2017-05-17 15:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -299,9 +299,14 @@ msgstr ""
 msgid "msg_no_items_available"
 msgstr ""
 
+#. Default: "Can't paste items, the context does not allow pasting items."
+#: ./opengever/base/browser/paste.py:40
+msgid "msg_pasting_not_allowed"
+msgstr ""
+
 #. Default: "Can't paste items, it's not allowed to add objects of this type."
 #: ./opengever/base/browser/paste.py:36
-msgid "msg_pasting_not_allowed"
+msgid "msg_pasting_type_not_allowed"
 msgstr ""
 
 #. Default: "Selected objects successfully copied."

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -177,3 +177,19 @@ class TestCopyPaste(FunctionalTestCase):
             ["Can't paste items, it's not allowed to add objects of this type."],
             error_messages())
         self.assertEqual(branch_node.absolute_url(), browser.url)
+
+    @browsing
+    def test_copy_document_from_repository_into_private_folder_fails(self, browser):  # noqa
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+        private_dossier = create(Builder('private_dossier'))
+
+        browser.login().open(
+            dossier, view="copy_items",
+            data={'paths:list': ['/'.join(document.getPhysicalPath())]})
+        browser.css('#contentActionMenus a#paste').first.click()
+
+        browser.open(private_dossier, view='paste_clipboard')
+        self.assertEqual(
+            ["Can't paste items, the context does not allow pasting items."],
+            error_messages())


### PR DESCRIPTION
We have an `is_pasting_allowed` view that returns whether pasting is allowed. We should also check that one when pasting to prevent url-crafting by the user.

Closes #1159.