### PR TITLE
Implement and use a safe_call decorator for all remote endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Replace changed_security with elevated_privileges. [deiferni]
+- Implement safe_call decorator for better errorhandling/debugging remote requests. [mathias.leimgruber]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Replace changed_security with elevated_privileges. [deiferni]
 - Implement safe_call decorator for better errorhandling/debugging remote requests. [mathias.leimgruber]
+- Implement safe_call decorator for better errhandling/debugging remove requests. [mathias.leimgruber]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,7 @@ Changelog
 ---------------------
 
 - Replace changed_security with elevated_privileges. [deiferni]
-- Implement safe_call decorator for better errorhandling/debugging remote requests. [mathias.leimgruber]
+- Implement tracebackify decorator for better errorhandling/debugging remote requests. [mathias.leimgruber]
 - Implement safe_call decorator for better errhandling/debugging remove requests. [mathias.leimgruber]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -2,6 +2,8 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser">
 
+  <include package=".wizard" />
+
   <browser:page
       name="list_groupmembers"
       for="*"

--- a/opengever/base/browser/wizard/configure.zcml
+++ b/opengever/base/browser/wizard/configure.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      name="receive-wizard-data-set"
+      for="*"
+      class=".storage.ReceiveWizardDataSet"
+      permission="zope2.View"
+      />
+
+</configure>

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from five import grok
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.base.utils import ok_response
 from persistent.dict import PersistentDict
 from zope.annotation.interfaces import IAnnotations
@@ -94,6 +95,7 @@ class WizardDataStorage(grok.GlobalUtility):
                             admin_unit_id))
 
 
+@safe_call
 class ReceiveWizardDataSet(grok.View):
     """Receives a IWizardDataStorage data set from a remote client and stores
     it on the target client.

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from five import grok
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.utils import ok_response
 from persistent.dict import PersistentDict
 from Products.Five.browser import BrowserView
@@ -95,7 +95,7 @@ class WizardDataStorage(grok.GlobalUtility):
                             admin_unit_id))
 
 
-@safe_call
+@tracebackify
 class ReceiveWizardDataSet(BrowserView):
     """Receives a IWizardDataStorage data set from a remote client and stores
     it on the target client.

--- a/opengever/base/browser/wizard/storage.py
+++ b/opengever/base/browser/wizard/storage.py
@@ -8,10 +8,10 @@ from opengever.base.request import dispatch_request
 from opengever.base.request import safe_call
 from opengever.base.utils import ok_response
 from persistent.dict import PersistentDict
+from Products.Five.browser import BrowserView
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.component.hooks import getSite
-from zope.interface import Interface
 import json
 
 
@@ -96,16 +96,12 @@ class WizardDataStorage(grok.GlobalUtility):
 
 
 @safe_call
-class ReceiveWizardDataSet(grok.View):
+class ReceiveWizardDataSet(BrowserView):
     """Receives a IWizardDataStorage data set from a remote client and stores
     it on the target client.
     """
 
-    grok.context(Interface)
-    grok.name('receive-wizard-data-set')
-    grok.require('zope2.View')
-
-    def render(self):
+    def __call__(self):
         jsondata = self.request.get('data-set')
         key = self.request.get('key')
         data = json.loads(jsondata)

--- a/opengever/base/request.py
+++ b/opengever/base/request.py
@@ -159,7 +159,7 @@ def _remote_request(target_admin_unit_id, viewname, path, data, headers):
     response = opener.open(request)
     content = response.read().strip()
 
-    if response.headers.type == 'text/traceback':
+    if response.headers.type == 'text/x.traceback':
         raise RemoteRequestFailed(url, content)
     else:
         return StringIO(content)
@@ -189,7 +189,7 @@ def tracebackify(*args, **kwargs):
                     raise
                 except Exception:
                     self.request.response.setHeader("Content-type",
-                                                    "text/traceback")
+                                                    "text/x.traceback")
                     e_type, e_value, tb = sys.exc_info()
 
                     if HAS_RAVEN:

--- a/opengever/base/request.py
+++ b/opengever/base/request.py
@@ -3,13 +3,38 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from Products.CMFCore.utils import getToolByName
 from StringIO import StringIO
+from ZODB.POSException import ConflictError
 from zope.component.hooks import getSite
 from zope.component.hooks import setSite
 from zope.globalrequest import getRequest
 import json
 import os.path
+import pkg_resources
+import sys
+import traceback
 import urllib
 import urllib2
+
+
+try:
+    pkg_resources.get_distribution('ftw.raven')
+    from ftw.raven.reporter import maybe_report_exception
+except pkg_resources.DistributionNotFound:
+    HAS_RAVEN = False
+else:
+    HAS_RAVEN = True
+
+
+class RemoteRequestFailed(Exception):
+    """Exception class for remote requests"""
+
+    def __init__(self, url, tb):
+        self.url = url
+        self.tb = tb
+
+    def __str__(self):
+        return 'Remote request to "{url}": Traceback: {tb}'.format(
+            **{'url': self.url, 'tb': self.tb})
 
 
 def dispatch_json_request(target_admin_unit_id, viewname, path='',
@@ -120,7 +145,8 @@ def _remote_request(target_admin_unit_id, viewname, path, data, headers):
     handler = urllib2.ProxyHandler({})
     opener = urllib2.build_opener(handler)
 
-    viewname = viewname if viewname.startswith('@@') else '@@{}'.format(viewname)
+    viewname = viewname if viewname.startswith(
+        '@@') else '@@{}'.format(viewname)
     if path:
         url = os.path.join(target_unit.site_url, path, viewname)
     else:
@@ -129,4 +155,64 @@ def _remote_request(target_admin_unit_id, viewname, path, data, headers):
     request = urllib2.Request(url,
                               urllib.urlencode(data),
                               headers)
-    return opener.open(request)
+
+    response = opener.open(request)
+    content = response.read().strip()
+    response.seek(0)
+
+    try:
+        json.loads(content)
+    except ValueError:
+        is_json = False
+    else:
+        is_json = True
+
+    if content == 'OK' or is_json:
+        return response
+    else:
+        # Otherwise expect a traceback as response from the remote server
+        raise RemoteRequestFailed(url, response)
+
+
+def safe_call(*args, **kwargs):
+    """Decorator for remote endpoints
+    The decorator safely calls the View and returns the traceback as string.
+    Plus: Also try to report the traceback to sentry, so the original
+    traceback from the remote view is reported too"""
+
+    to_re_raise = kwargs.pop('to_re_raise', None)
+
+    if not isinstance(to_re_raise, list):
+        to_re_raise = [to_re_raise]
+
+    def wrapper(Cls):
+
+        class SafeCall(Cls):
+            def __call__(self, *args, **kwargs):
+
+                try:
+                    return super(SafeCall, self).__call__(*args, **kwargs)
+                except (ConflictError, KeyboardInterrupt):
+                    raise
+                except tuple(to_re_raise):
+                    raise
+                except Exception as exc:
+                    self.request.response.setHeader("Content-type",
+                                                    "text/plain")
+                    e_type, e_value, tb = sys.exc_info()
+
+                    if HAS_RAVEN:
+                        maybe_report_exception(self.context, self.request,
+                                               e_type, e_value, tb)
+
+                    return ''.join(traceback.format_exception(e_type, e_value,
+                                                              tb))
+        return SafeCall
+
+    if args:
+        Cls = args[0]
+        return wrapper(Cls)
+    else:
+        def decorator(Cls):
+            return wrapper(Cls)
+        return decorator

--- a/opengever/base/tests/test_safe_call_decorator.py
+++ b/opengever/base/tests/test_safe_call_decorator.py
@@ -1,41 +1,41 @@
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from Products.Five.browser import BrowserView
 from unittest2 import TestCase
 from ZODB.POSException import ConflictError
 from zope.publisher.browser import TestRequest
 
 
-@safe_call
+@tracebackify
 class ValidView(BrowserView):
     def __call__(self):
         return 'OK'
 
 
-@safe_call
+@tracebackify
 class RaiseErrorView(BrowserView):
     def __call__(self):
         raise
 
 
-@safe_call
+@tracebackify
 class RaiseConflictErrorErrorView(BrowserView):
     def __call__(self):
         raise ConflictError
 
 
-@safe_call
+@tracebackify
 class RaiseKeyboardInterruptErrorView(BrowserView):
     def __call__(self):
         raise KeyboardInterrupt
 
 
-@safe_call(to_re_raise=ValueError)
+@tracebackify(to_re_raise=ValueError)
 class RaiseValueErrorErrorView(BrowserView):
     def __call__(self):
         raise ValueError
 
 
-@safe_call(to_re_raise=[ValueError, KeyError])
+@tracebackify(to_re_raise=[ValueError, KeyError])
 class RaiseMultipleErrorView(BrowserView):
     def __call__(self, keyerror):
         if keyerror:

--- a/opengever/base/tests/test_safe_call_decorator.py
+++ b/opengever/base/tests/test_safe_call_decorator.py
@@ -1,0 +1,76 @@
+from opengever.base.request import safe_call
+from Products.Five.browser import BrowserView
+from unittest2 import TestCase
+from ZODB.POSException import ConflictError
+from zope.publisher.browser import TestRequest
+
+
+@safe_call
+class ValidView(BrowserView):
+    def __call__(self):
+        return 'OK'
+
+
+@safe_call
+class RaiseErrorView(BrowserView):
+    def __call__(self):
+        raise
+
+
+@safe_call
+class RaiseConflictErrorErrorView(BrowserView):
+    def __call__(self):
+        raise ConflictError
+
+
+@safe_call
+class RaiseKeyboardInterruptErrorView(BrowserView):
+    def __call__(self):
+        raise KeyboardInterrupt
+
+
+@safe_call(to_re_raise=ValueError)
+class RaiseValueErrorErrorView(BrowserView):
+    def __call__(self):
+        raise ValueError
+
+
+@safe_call(to_re_raise=[ValueError, KeyError])
+class RaiseMultipleErrorView(BrowserView):
+    def __call__(self, keyerror):
+        if keyerror:
+            raise KeyError
+        else:
+            raise ValueError
+
+
+class TestSafeCallDecorator(TestCase):
+
+    def test_return_subclass(self):
+        self.assertTrue(issubclass(ValidView, BrowserView))
+
+    def test_decorated_view_is_now_a_SafeCall_view(self):
+        self.assertEquals('SafeCall', ValidView.__name__)
+
+    def test_exceptions_gets_catched_and_returned(self):
+        view = RaiseErrorView(object(), TestRequest())
+        self.assertTrue(view().startswith('Traceback (most recent call last)'))
+
+    def test_conflicterror_raises(self):
+        with self.assertRaises(ConflictError):
+            RaiseConflictErrorErrorView(object(), TestRequest())()
+
+    def test_keyboardinterrupt_raises(self):
+        with self.assertRaises(KeyboardInterrupt):
+            RaiseKeyboardInterruptErrorView(object(), TestRequest())()
+
+    def test_raise_single_additional_exceptions(self):
+        with self.assertRaises(ValueError):
+            RaiseValueErrorErrorView(object(), TestRequest())()
+
+    def test_raise_multiple_additional_exceptions(self):
+        with self.assertRaises(ValueError):
+            RaiseMultipleErrorView(object(), TestRequest())(keyerror=False)
+
+        with self.assertRaises(KeyError):
+            RaiseMultipleErrorView(object(), TestRequest())(keyerror=True)

--- a/opengever/meeting/browser/rejectproposal.py
+++ b/opengever/meeting/browser/rejectproposal.py
@@ -1,7 +1,9 @@
+from opengever.base.request import safe_call
 from plone import api
 from Products.Five import BrowserView
 
 
+@safe_call
 class RejectProposal(BrowserView):
 
     def __call__(self):

--- a/opengever/meeting/browser/rejectproposal.py
+++ b/opengever/meeting/browser/rejectproposal.py
@@ -1,9 +1,9 @@
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from plone import api
 from Products.Five import BrowserView
 
 
-@safe_call
+@tracebackify
 class RejectProposal(BrowserView):
 
     def __call__(self):

--- a/opengever/ogds/base/configure.zcml
+++ b/opengever/ogds/base/configure.zcml
@@ -13,6 +13,7 @@
 
   <include package=".browser" />
   <include package=".viewlets" />
+  <include package=".sync" />
 
   <grok:grok package="." />
 

--- a/opengever/ogds/base/sync/configure.zcml
+++ b/opengever/ogds/base/sync/configure.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      name="update_sync_stamp"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      class=".import_stamp.UpdateSyncStamp"
+      permission="zope2.View"
+      />
+
+</configure>

--- a/opengever/ogds/base/sync/import_stamp.py
+++ b/opengever/ogds/base/sync/import_stamp.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from five import grok
 from opengever.base.protect import unprotected_write
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.core import dictstorage
 from opengever.ogds.base.interfaces import ISyncStamp
 from opengever.ogds.base.utils import ogds_service
@@ -83,7 +83,7 @@ class SyncStampUtility(grok.GlobalUtility):
         logger.info("Stored sync_stamp %s in annotations" % stamp)
 
 
-@safe_call
+@tracebackify
 class UpdateSyncStamp(BrowserView):
     """View wich is called from the ogds, after the LDAP Synchronisation"""
 

--- a/opengever/ogds/base/sync/import_stamp.py
+++ b/opengever/ogds/base/sync/import_stamp.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from five import grok
 from opengever.base.protect import unprotected_write
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.core import dictstorage
 from opengever.ogds.base.interfaces import ISyncStamp
 from opengever.ogds.base.utils import ogds_service
@@ -81,6 +82,7 @@ class SyncStampUtility(grok.GlobalUtility):
         logger.info("Stored sync_stamp %s in annotations" % stamp)
 
 
+@safe_call
 class UpdateSyncStamp(grok.View):
     """View wich is called from the ogds, after the LDAP Synchronisation"""
 

--- a/opengever/ogds/base/sync/import_stamp.py
+++ b/opengever/ogds/base/sync/import_stamp.py
@@ -8,6 +8,7 @@ from opengever.ogds.base.interfaces import ISyncStamp
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.Five.browser import BrowserView
 from urllib2 import URLError
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
@@ -83,16 +84,12 @@ class SyncStampUtility(grok.GlobalUtility):
 
 
 @safe_call
-class UpdateSyncStamp(grok.View):
+class UpdateSyncStamp(BrowserView):
     """View wich is called from the ogds, after the LDAP Synchronisation"""
-
-    grok.context(IPloneSiteRoot)
-    grok.name('update_sync_stamp')
-    grok.require('zope2.View')
 
     INTERN_SYNC_KEY = 'ldap_sync_key'
 
-    def render(self):
+    def __call__(self):
         """read the actual timestamp(isoformat) and save it into a annotation.
         """
 

--- a/opengever/task/browser/accept/configure.zcml
+++ b/opengever/task/browser/accept/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      name="accept_task_workflow_transition"
+      for="opengever.task.task.ITask"
+      class=".utils.AcceptTaskWorkflowTransitionView"
+      permission="cmf.AddPortalContent"
+      />
+
+
+</configure>

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -1,4 +1,3 @@
-from five import grok
 from opengever.activity import notification_center
 from opengever.base.oguid import Oguid
 from opengever.base.request import dispatch_request
@@ -21,6 +20,7 @@ from opengever.task.transporter import IResponseTransporter
 from opengever.task.util import change_task_workflow_state
 from opengever.task.util import CustomInitialVersionMessage
 from plone.dexterity.utils import createContentInContainer
+from Products.Five.browser import BrowserView
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 import AccessControl
@@ -299,7 +299,7 @@ def accept_task_with_successor(dossier, predecessor_oguid, response_text):
 
 
 @safe_call
-class AcceptTaskWorkflowTransitionView(grok.View):
+class AcceptTaskWorkflowTransitionView(BrowserView):
     """A remote request view called by another adminunit, to accept a task,
     during the SuccessorTask creation process.
 
@@ -308,11 +308,7 @@ class AcceptTaskWorkflowTransitionView(grok.View):
     the task will watch the successor.
     """
 
-    grok.context(ITask)
-    grok.name('accept_task_workflow_transition')
-    grok.require('cmf.AddPortalContent')
-
-    def render(self):
+    def __call__(self):
         if self.is_already_accepted():
             return ok_response()
 

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -1,7 +1,7 @@
 from opengever.activity import notification_center
 from opengever.base.oguid import Oguid
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
 from opengever.globalindex.model.task import Task
@@ -298,7 +298,7 @@ def accept_task_with_successor(dossier, predecessor_oguid, response_text):
     return successor
 
 
-@safe_call
+@tracebackify
 class AcceptTaskWorkflowTransitionView(BrowserView):
     """A remote request view called by another adminunit, to accept a task,
     during the SuccessorTask creation process.

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -2,6 +2,7 @@ from five import grok
 from opengever.activity import notification_center
 from opengever.base.oguid import Oguid
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
 from opengever.globalindex.model.task import Task
@@ -297,6 +298,7 @@ def accept_task_with_successor(dossier, predecessor_oguid, response_text):
     return successor
 
 
+@safe_call
 class AcceptTaskWorkflowTransitionView(grok.View):
     """A remote request view called by another adminunit, to accept a task,
     during the SuccessorTask creation process.

--- a/opengever/task/browser/close.py
+++ b/opengever/task/browser/close.py
@@ -7,7 +7,7 @@ from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.base.utils import ok_response
 from opengever.dossier.base import DOSSIER_STATES_OPEN
@@ -293,7 +293,7 @@ class ChooseDosserStepRedirecter(grok.View):
         return self.request.RESPONSE.redirect(url)
 
 
-@safe_call
+@tracebackify
 class CloseTaskView(BrowserView):
     """This view closes the task. It is either called directly, if no
     documents are selected to be copied or after choosing the target dossier

--- a/opengever/task/browser/close.py
+++ b/opengever/task/browser/close.py
@@ -7,6 +7,7 @@ from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.base.utils import ok_response
 from opengever.dossier.base import DOSSIER_STATES_OPEN
@@ -291,6 +292,7 @@ class ChooseDosserStepRedirecter(grok.View):
         return self.request.RESPONSE.redirect(url)
 
 
+@safe_call
 class CloseTaskView(grok.View):
     """This view closes the task. It is either called directly, if no
     documents are selected to be copied or after choosing the target dossier

--- a/opengever/task/browser/close.py
+++ b/opengever/task/browser/close.py
@@ -25,6 +25,7 @@ from plone.directives.form import Schema
 from plone.z3cform.layout import FormWrapper
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.button import buttonAndHandler
@@ -293,20 +294,16 @@ class ChooseDosserStepRedirecter(grok.View):
 
 
 @safe_call
-class CloseTaskView(grok.View):
+class CloseTaskView(BrowserView):
     """This view closes the task. It is either called directly, if no
     documents are selected to be copied or after choosing the target dossier
     and copying the documents.
     It is not context sensitive.
     """
 
-    grok.context(ITask)
-    grok.name('close-task-wizard-remote_close')
-    grok.require('zope2.View')
-
     transition = 'task-transition-open-tested-and-closed'
 
-    def render(self):
+    def __call__(self):
         text = self.request.get('text')
         if self.is_already_done():
             return ok_response(self.request)

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -9,6 +9,7 @@ from five import grok
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
 from opengever.globalindex.model.task import Task
@@ -253,6 +254,7 @@ class CompleteSuccessorTask(FormWrapper, grok.View):
         grok.View.__init__(self, *args, **kwargs)
 
 
+@safe_call
 class CompleteSuccessorTaskReceiveDelivery(grok.View):
     """This view is called by the complete-sucessor-task form while
     completeing the task. It is called on the client of the predecessor and

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -9,7 +9,7 @@ from five import grok
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
 from opengever.globalindex.model.task import Task
@@ -255,7 +255,7 @@ class CompleteSuccessorTask(FormWrapper, grok.View):
         grok.View.__init__(self, *args, **kwargs)
 
 
-@safe_call
+@tracebackify
 class CompleteSuccessorTaskReceiveDelivery(BrowserView):
     """This view is called by the complete-sucessor-task form while
     completeing the task. It is called on the client of the predecessor and

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -25,6 +25,7 @@ from persistent.list import PersistentList
 from plone.directives.form import Schema
 from plone.z3cform.layout import FormWrapper
 from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form import validator
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
@@ -255,7 +256,7 @@ class CompleteSuccessorTask(FormWrapper, grok.View):
 
 
 @safe_call
-class CompleteSuccessorTaskReceiveDelivery(grok.View):
+class CompleteSuccessorTaskReceiveDelivery(BrowserView):
     """This view is called by the complete-sucessor-task form while
     completeing the task. It is called on the client of the predecessor and
     makes the necessary changes regarding the predecessor task:
@@ -266,11 +267,7 @@ class CompleteSuccessorTaskReceiveDelivery(grok.View):
     documents and containing the entered response text.
     """
 
-    grok.context(ITask)
-    grok.name('complete_successor_task-receive_delivery')
-    grok.require('zope2.View')
-
-    def render(self):
+    def __call__(self):
         data = self.request.get('data', None)
         assert data is not None, 'Bad request: no delivery data found'
         data = json.loads(data)

--- a/opengever/task/browser/configure.zcml
+++ b/opengever/task/browser/configure.zcml
@@ -3,12 +3,35 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="opengever.task">
 
+  <include package=".accept" />
+
   <browser:page
       name="task_transition_controller"
       for="opengever.task.task.ITask"
       class=".transitioncontroller.TaskTransitionController"
       permission="zope2.View"
       allowed_interface=".transitioncontroller.ITaskTransitionController"
+      />
+
+  <browser:page
+      name="store_forwarding_in_yearfolder"
+      for="opengever.task.task.ITask"
+      class=".store.StoreForwardingInYearfolderView"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      name="close-task-wizard-remote_close"
+      for="opengever.task.task.ITask"
+      class=".close.CloseTaskView"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      name="complete_successor_task-receive_delivery"
+      for="opengever.task.task.ITask"
+      class=".complete.CompleteSuccessorTaskReceiveDelivery"
+      permission="zope2.View"
       />
 
 </configure>

--- a/opengever/task/browser/store.py
+++ b/opengever/task/browser/store.py
@@ -1,22 +1,18 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from five import grok
 from opengever.base.request import safe_call
 from opengever.base.utils import ok_response
 from opengever.task.interfaces import IYearfolderStorer
-from opengever.task.task import ITask
 from opengever.task.util import change_task_workflow_state
 from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
 from zExceptions import Unauthorized
 
 
 @safe_call
-class StoreForwardingInYearfolderView(grok.View):
-    grok.name('store_forwarding_in_yearfolder')
-    grok.context(ITask)
-    grok.require('zope2.View')
+class StoreForwardingInYearfolderView(BrowserView):
 
-    def render(self):
+    def __call__(self):
         if self.is_already_done():
             return ok_response()
 
@@ -32,9 +28,9 @@ class StoreForwardingInYearfolderView(grok.View):
 
         if transition:
             change_task_workflow_state(self.context,
-                                      transition,
-                                      text=response_text,
-                                      successor_oguid=successor_oguid)
+                                       transition,
+                                       text=response_text,
+                                       successor_oguid=successor_oguid)
 
         IYearfolderStorer(self.context).store_in_yearfolder()
 

--- a/opengever/task/browser/store.py
+++ b/opengever/task/browser/store.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from five import grok
+from opengever.base.request import safe_call
 from opengever.base.utils import ok_response
 from opengever.task.interfaces import IYearfolderStorer
 from opengever.task.task import ITask
@@ -9,6 +10,7 @@ from Products.CMFCore.utils import getToolByName
 from zExceptions import Unauthorized
 
 
+@safe_call
 class StoreForwardingInYearfolderView(grok.View):
     grok.name('store_forwarding_in_yearfolder')
     grok.context(ITask)

--- a/opengever/task/browser/store.py
+++ b/opengever/task/browser/store.py
@@ -1,6 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.utils import ok_response
 from opengever.task.interfaces import IYearfolderStorer
 from opengever.task.util import change_task_workflow_state
@@ -9,7 +9,7 @@ from Products.Five.browser import BrowserView
 from zExceptions import Unauthorized
 
 
-@safe_call
+@tracebackify
 class StoreForwardingInYearfolderView(BrowserView):
 
     def __call__(self):

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -47,6 +47,20 @@
       />
 
   <browser:page
+      name="task-responses-extract"
+      for="opengever.task.task.ITask"
+      permission="zope2.View"
+      class=".transporter.ExtractResponses"
+      />
+
+  <browser:page
+      name="task-responses-receive"
+      for="opengever.task.task.ITask"
+      permission="zope2.View"
+      class=".transporter.ReceiveResponses"
+      />
+
+  <browser:page
       name="plone_layout"
       for="opengever.task.task.ITask"
       permission="zope.Public"

--- a/opengever/task/response_syncer/__init__.py
+++ b/opengever/task/response_syncer/__init__.py
@@ -1,4 +1,5 @@
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.base.utils import ok_response
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.task.adapters import IResponseContainer
@@ -92,6 +93,7 @@ class BaseResponseSyncerSender(object):
         return dispatch_request(target_admin_unit_id, viewname, path, data)
 
 
+@safe_call
 class BaseResponseSyncerReceiver(BrowserView):
     """Abstract ResponseSyncerReceiver view for receiving requests from a
     ResponseSyncerSender and updates the current task with the received data

--- a/opengever/task/response_syncer/__init__.py
+++ b/opengever/task/response_syncer/__init__.py
@@ -93,7 +93,7 @@ class BaseResponseSyncerSender(object):
         return dispatch_request(target_admin_unit_id, viewname, path, data)
 
 
-@safe_call
+@safe_call(to_re_raise=Forbidden)
 class BaseResponseSyncerReceiver(BrowserView):
     """Abstract ResponseSyncerReceiver view for receiving requests from a
     ResponseSyncerSender and updates the current task with the received data

--- a/opengever/task/response_syncer/__init__.py
+++ b/opengever/task/response_syncer/__init__.py
@@ -1,5 +1,5 @@
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.utils import ok_response
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.task.adapters import IResponseContainer
@@ -93,7 +93,7 @@ class BaseResponseSyncerSender(object):
         return dispatch_request(target_admin_unit_id, viewname, path, data)
 
 
-@safe_call(to_re_raise=Forbidden)
+@tracebackify(to_re_raise=Forbidden)
 class BaseResponseSyncerReceiver(BrowserView):
     """Abstract ResponseSyncerReceiver view for receiving requests from a
     ResponseSyncerSender and updates the current task with the received data

--- a/opengever/task/transporter.py
+++ b/opengever/task/transporter.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from five import grok
 from opengever.base.request import dispatch_json_request
 from opengever.base.request import dispatch_request
-from opengever.base.request import safe_call
+from opengever.base.request import tracebackify
 from opengever.base.transport import ORIGINAL_INTID_ANNOTATION_KEY
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
@@ -201,7 +201,7 @@ class ResponseTransporter(grok.Adapter):
         return val
 
 
-@safe_call
+@tracebackify
 class ReceiveResponses(BrowserView):
     """Receives a json request cotnaining one or more responses to
     add to the context task.
@@ -227,7 +227,7 @@ class ReceiveResponses(BrowserView):
         return ok_response(self.request)
 
 
-@safe_call
+@tracebackify
 class ExtractResponses(BrowserView):
 
     def __call__(self):

--- a/opengever/task/transporter.py
+++ b/opengever/task/transporter.py
@@ -16,6 +16,7 @@ from opengever.task.task import ITask
 from opengever.task.util import get_documents_of_task
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
+from Products.Five.browser import BrowserView
 from z3c.relationfield import RelationValue
 from zope.annotation.interfaces import IAnnotations
 from zope.app.intid.interfaces import IIntIds
@@ -201,16 +202,12 @@ class ResponseTransporter(grok.Adapter):
 
 
 @safe_call
-class ReceiveResponses(grok.View):
+class ReceiveResponses(BrowserView):
     """Receives a json request cotnaining one or more responses to
     add to the context task.
     """
 
-    grok.context(ITask)
-    grok.name('task-responses-receive')
-    grok.require('zope2.View')
-
-    def render(self):
+    def __call__(self):
         rawdata = self.request.get('responses')
         data = json.loads(rawdata)
 
@@ -231,14 +228,11 @@ class ReceiveResponses(grok.View):
 
 
 @safe_call
-class ExtractResponses(grok.View):
-    grok.context(ITask)
-    grok.name('task-responses-extract')
-    grok.require('zope2.View')
+class ExtractResponses(BrowserView):
 
-    def render(self):
+    def __call__(self):
         intids_mapping = json.loads(self.request.get(
-                'intids_mapping', '{}'))
+            'intids_mapping', '{}'))
 
         # json converts dict-keys to strings - but we need
         # keys and values as int

--- a/opengever/task/transporter.py
+++ b/opengever/task/transporter.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from five import grok
 from opengever.base.request import dispatch_json_request
 from opengever.base.request import dispatch_request
+from opengever.base.request import safe_call
 from opengever.base.transport import ORIGINAL_INTID_ANNOTATION_KEY
 from opengever.base.transport import Transporter
 from opengever.base.utils import ok_response
@@ -199,6 +200,7 @@ class ResponseTransporter(grok.Adapter):
         return val
 
 
+@safe_call
 class ReceiveResponses(grok.View):
     """Receives a json request cotnaining one or more responses to
     add to the context task.
@@ -228,6 +230,7 @@ class ReceiveResponses(grok.View):
         return ok_response(self.request)
 
 
+@safe_call
 class ExtractResponses(grok.View):
     grok.context(ITask)
     grok.name('task-responses-extract')


### PR DESCRIPTION
The goal is to improve the error handling and debugging ability for requests to other gever sites.
See #1541 for more details.

This PR implements:
- A `safe_call` decorator, which wraps the `__call__` method of an endpoint in a try/except. In case of an exception the traceback is returned as string.
- The safe_call decorator also tries to notify sentry if possible, to not swallow the exception silently.
- On the client site the `dispatch_request` method is now able to  report the traceback of the failed remote call as exception message.
- ConflictError and KeyBoardInterrupt are not catched.
- The parameter to_raise allows you to add more Exceptions, which should not be handled.

**The result:**
If a remote call fails there are 2 entries in sentry. https://sentry.4teamwork.ch/sentry/exceptiontest/
one from the client (actually raised to the user) and one from the remote site (manually send to sentry).

<img width="1919" alt="screen shot 2017-05-18 at 09 09 51" src="https://cloud.githubusercontent.com/assets/437933/26191813/a98896ea-3baf-11e7-9bda-9d5d09746fa3.png">
