### PR TITLE
Fix checkout behavior of already checked out document.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Implement safe_call decorator for better errhandling/debugging remove requests. [mathias.leimgruber]
 - Refactor SQL models, move Query classes to query module. [deiferni]
 - Link keywords on dossier overview. [mathias.leimgruber]
+- Fix checkout behavior of already checked out documents. [Kevin Bieri]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2955

Because the user is able to just edit a checked out document the loader has to behave different.
So first check if the document is already checked out. If so just display the loader 5 seconds
to close the waiting time for opening the office connector.