### PR TITLE
Also truncate dictstorage table during tests.

### DIFF
--- a/opengever/core/sqlite_testing.py
+++ b/opengever/core/sqlite_testing.py
@@ -1,3 +1,4 @@
+from ftw.dictstorage.sql import DictStorageModel
 from opengever.base import model
 from opengever.base.model import create_session
 from opengever.ogds.base.setup import create_sql_tables
@@ -91,8 +92,11 @@ def create_tables():
 def truncate_tables():
     """Truncate existing tables in an sqlite way.
     """
-    tables = BASE.metadata.tables.values() + \
-             model.Base.metadata.tables.values()
+    tables = (
+        BASE.metadata.tables.values() +
+        model.Base.metadata.tables.values() +
+        DictStorageModel.metadata.tables.values()
+    )
 
     session = create_session()
     for table in tables:


### PR DESCRIPTION
Prevent state bleeding between tests by also clearing the dictstorage table. It was created in `create_sql_tables` but never cleared. This led to `DownloadConfirmationHelper` state bleeding between tests.