### PR TITLE
Refactor SQL model classes, put Query* classes into own module.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Replace changed_security with elevated_privileges. [deiferni]
 - Implement tracebackify decorator for better errorhandling/debugging remote requests. [mathias.leimgruber]
 - Implement safe_call decorator for better errhandling/debugging remove requests. [mathias.leimgruber]
+- Refactor SQL models, move Query classes to query module. [deiferni]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -5,7 +5,6 @@ from opengever.base.model import DEFAULT_LOCALE
 from opengever.base.model import SUPPORTED_LOCALES
 from opengever.base.model import UTCDateTime
 from opengever.ogds.models import USER_ID_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -17,13 +16,7 @@ from sqlalchemy_i18n import Translatable
 from sqlalchemy_i18n import translation_base
 
 
-class ActivityQuery(BaseQuery):
-    pass
-
-
 class Activity(Base, Translatable):
-
-    query_cls = ActivityQuery
 
     __tablename__ = 'activities'
     __translatable__ = {'locales': SUPPORTED_LOCALES,

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -1,7 +1,5 @@
-from opengever.activity.model.subscription import Subscription
 from opengever.base.model import Base
 from opengever.ogds.models import USER_ID_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -11,25 +9,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 
 
-class NotificationQuery(BaseQuery):
-
-    def by_user(self, userid):
-        return self.filter_by(userid=userid)
-
-    def by_subscription_roles(self, roles, activity):
-        subscriptions = Subscription.query.by_resource_and_role(
-            activity.resource, roles)
-        user_ids = []
-        for subscription in subscriptions:
-            user_ids += subscription.watcher.get_user_ids()
-
-        return self.filter_by(activity_id=activity.id).filter(
-            Notification.userid.in_(user_ids))
-
-
 class Notification(Base):
-
-    query_cls = NotificationQuery
 
     __tablename__ = 'notifications'
 

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -1,8 +1,28 @@
-from opengever.ogds.models.query import BaseQuery
 from opengever.activity.model import Activity
+from opengever.activity.model import Notification
+from opengever.activity.model.subscription import Subscription
+from opengever.ogds.models.query import BaseQuery
 
 
 class ActivityQuery(BaseQuery):
     pass
 
 Activity.query_cls = ActivityQuery
+
+
+class NotificationQuery(BaseQuery):
+
+    def by_user(self, userid):
+        return self.filter_by(userid=userid)
+
+    def by_subscription_roles(self, roles, activity):
+        subscriptions = Subscription.query.by_resource_and_role(
+            activity.resource, roles)
+        user_ids = []
+        for subscription in subscriptions:
+            user_ids += subscription.watcher.get_user_ids()
+
+        return self.filter_by(activity_id=activity.id).filter(
+            Notification.userid.in_(user_ids))
+
+Notification.query_cls = NotificationQuery

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -1,5 +1,6 @@
 from opengever.activity.model import Activity
 from opengever.activity.model import Notification
+from opengever.activity.model import NotificationDefault
 from opengever.activity.model import Resource
 from opengever.activity.model.subscription import Subscription
 from opengever.ogds.models.query import BaseQuery
@@ -35,3 +36,18 @@ class ResourceQuery(BaseQuery):
         return self.filter_by(oguid=oguid).first()
 
 Resource.query_cls = ResourceQuery
+
+
+class NotificationDefaultQuery(BaseQuery):
+
+    def is_dispatch_needed(self, dispatch_setting, kind):
+        setting = self.filter_by(kind=kind).first()
+        if not setting:
+            return False
+
+        return getattr(setting, dispatch_setting, False)
+
+    def by_kind(self, kind):
+        return self.filter_by(kind=kind)
+
+NotificationDefault.query_cls = NotificationDefaultQuery

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -1,0 +1,8 @@
+from opengever.ogds.models.query import BaseQuery
+from opengever.activity.model import Activity
+
+
+class ActivityQuery(BaseQuery):
+    pass
+
+Activity.query_cls = ActivityQuery

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -3,6 +3,7 @@ from opengever.activity.model import Notification
 from opengever.activity.model import NotificationDefault
 from opengever.activity.model import Resource
 from opengever.activity.model import Subscription
+from opengever.activity.model import Watcher
 from opengever.ogds.models.query import BaseQuery
 
 
@@ -67,3 +68,11 @@ class SubscriptionQuery(BaseQuery):
             Subscription.role.in_(roles))
 
 Subscription.query_cls = SubscriptionQuery
+
+
+class WatcherQuery(BaseQuery):
+
+    def get_by_actorid(self, actorid):
+        return self.filter_by(actorid=actorid).first()
+
+Watcher.query_cls = WatcherQuery

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -2,7 +2,7 @@ from opengever.activity.model import Activity
 from opengever.activity.model import Notification
 from opengever.activity.model import NotificationDefault
 from opengever.activity.model import Resource
-from opengever.activity.model.subscription import Subscription
+from opengever.activity.model import Subscription
 from opengever.ogds.models.query import BaseQuery
 
 
@@ -51,3 +51,19 @@ class NotificationDefaultQuery(BaseQuery):
         return self.filter_by(kind=kind)
 
 NotificationDefault.query_cls = NotificationDefaultQuery
+
+
+class SubscriptionQuery(BaseQuery):
+
+    def fetch(self, resource, watcher, role):
+        return self.filter_by(
+            resource=resource, watcher=watcher, role=role).first()
+
+    def get_by_watcher_resource(self, resource, watcher):
+        return self.filter_by(resource=resource, watcher=watcher).first()
+
+    def by_resource_and_role(self, resource, roles):
+        return self.filter_by(resource=resource).filter(
+            Subscription.role.in_(roles))
+
+Subscription.query_cls = SubscriptionQuery

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -1,5 +1,6 @@
 from opengever.activity.model import Activity
 from opengever.activity.model import Notification
+from opengever.activity.model import Resource
 from opengever.activity.model.subscription import Subscription
 from opengever.ogds.models.query import BaseQuery
 
@@ -26,3 +27,11 @@ class NotificationQuery(BaseQuery):
             Notification.userid.in_(user_ids))
 
 Notification.query_cls = NotificationQuery
+
+
+class ResourceQuery(BaseQuery):
+
+    def get_by_oguid(self, oguid):
+        return self.filter_by(oguid=oguid).first()
+
+Resource.query_cls = ResourceQuery

--- a/opengever/activity/model/resource.py
+++ b/opengever/activity/model/resource.py
@@ -4,7 +4,6 @@ from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.ogds.models import UNIT_ID_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -14,15 +13,7 @@ from sqlalchemy.orm import composite
 from sqlalchemy.schema import Sequence
 
 
-class ResourceQuery(BaseQuery):
-
-    def get_by_oguid(self, oguid):
-        return self.filter_by(oguid=oguid).first()
-
-
 class Resource(Base):
-
-    query_cls = ResourceQuery
 
     __tablename__ = 'resources'
     __table_args__ = (UniqueConstraint('admin_unit_id', 'int_id'), {})

--- a/opengever/activity/model/settings.py
+++ b/opengever/activity/model/settings.py
@@ -1,5 +1,4 @@
 from opengever.base.model import Base
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -9,22 +8,7 @@ from sqlalchemy.schema import Sequence
 import json
 
 
-class NotificationDefaultQuery(BaseQuery):
-
-    def is_dispatch_needed(self, dispatch_setting, kind):
-        setting = self.filter_by(kind=kind).first()
-        if not setting:
-            return False
-
-        return getattr(setting, dispatch_setting, False)
-
-    def by_kind(self, kind):
-        return self.filter_by(kind=kind)
-
-
 class NotificationDefault(Base):
-
-    query_cls = NotificationDefaultQuery
 
     __tablename__ = 'notification_defaults'
 

--- a/opengever/activity/model/subscription.py
+++ b/opengever/activity/model/subscription.py
@@ -1,5 +1,4 @@
 from opengever.base.model import Base
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
@@ -15,22 +14,7 @@ DISPOSITION_ARCHIVIST_ROLE = 'archivist'
 WATCHER_ROLE = 'regular_watcher'
 
 
-class SubscriptionQuery(BaseQuery):
-
-    def fetch(self, resource, watcher, role):
-        return self.filter_by(
-            resource=resource, watcher=watcher, role=role).first()
-
-    def get_by_watcher_resource(self, resource, watcher):
-        return self.filter_by(resource=resource, watcher=watcher).first()
-
-    def by_resource_and_role(self, resource, roles):
-        return self.filter_by(resource=resource).filter(
-            Subscription.role.in_(roles))
-
-
 class Subscription(Base):
-    query_cls = SubscriptionQuery
     __tablename__ = 'subscriptions'
 
     resource_id = Column(Integer, ForeignKey('resources.id'), primary_key=True)

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -1,6 +1,5 @@
 from opengever.base.model import Base
 from opengever.ogds.models import USER_ID_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from opengever.ogds.models.service import OGDSService
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -9,16 +8,8 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.schema import Sequence
 
 
-class WatcherQuery(BaseQuery):
-
-    def get_by_actorid(self, actorid):
-        return self.filter_by(actorid=actorid).first()
-
-
 class Watcher(Base):
-    """A user
-    """
-    query_cls = WatcherQuery
+    """Associates a user with a resource that he is watching."""
 
     __tablename__ = 'watchers'
 

--- a/opengever/contact/models/organization.py
+++ b/opengever/contact/models/organization.py
@@ -3,20 +3,11 @@ from opengever.contact.docprops import OrganizationDocPropertProvider
 from opengever.contact.models.contact import Contact
 from opengever.contact.utils import get_contactfolder_url
 from opengever.contact.wrapper import OrganizationWrapper
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
-
-
-class OrganizationQuery(BaseQuery):
-
-    searchable_fields = ['name']
-
-    def get_by_former_contact_id(self, former_contact_id):
-        return self.filter_by(former_contact_id=former_contact_id).first()
 
 
 class Organization(Contact):
@@ -53,5 +44,3 @@ class Organization(Contact):
 
     def get_doc_property_provider(self, prefix):
         return OrganizationDocPropertProvider(self, prefix)
-
-Organization.query_cls = OrganizationQuery

--- a/opengever/contact/models/participation.py
+++ b/opengever/contact/models/participation.py
@@ -9,65 +9,18 @@ from opengever.contact.ogdsuser import OgdsUserToContactAdapter
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
-from sqlalchemy import or_
 from sqlalchemy import String
 from sqlalchemy.orm import composite
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 
 
-class ParticipationQuery(BaseQuery):
-
-    def by_dossier(self, dossier):
-        return self.filter_by(dossier_oguid=Oguid.for_object(dossier))
-
-    def by_organization(self, organization):
-        """Returns both ContactParticapations and OrgRoleParticipation
-        of the given organization.
-        """
-        return self._org_role_join().filter(
-            or_(OrgRole.organization == organization,
-                ContactParticipation.contact == organization))
-
-    def by_person(self, person):
-        """Returns both ContactParticapations and OrgRoleParticipation
-        of the given person.
-        """
-        return self._org_role_join().filter(
-            or_(OrgRole.person == person,
-                ContactParticipation.contact == person))
-
-    def _org_role_join(self):
-        return self.outerjoin(
-            OrgRole, OrgRoleParticipation.org_role_id == OrgRole.org_role_id)
-
-
-class ContactParticipationQuery(ParticipationQuery):
-
-    def by_participant(self, contact):
-        return self.filter_by(contact=contact)
-
-
-class OrgRoleParticipationQuery(ParticipationQuery):
-
-    def by_participant(self, org_role):
-        return self.filter_by(org_role=org_role)
-
-
-class OgdsUserParticipationQuery(ParticipationQuery):
-
-    def by_participant(self, ogds_user):
-        return self.filter_by(ogds_userid=ogds_user.id)
-
-
 class Participation(Base, SQLFormSupport):
     """Base class for participations.
     """
-    query_cls = ParticipationQuery
     __tablename__ = 'participations'
 
     participation_id = Column('id', Integer, Sequence('participations_id_seq'),
@@ -173,7 +126,6 @@ class OgdsUserParticipation(Participation):
     include a foreign key to the ogds-user.
 
     """
-    query_cls = OgdsUserParticipationQuery
     __mapper_args__ = {'polymorphic_identity': 'ogds_user_participation'}
 
     ogds_userid = Column(String(USER_ID_LENGTH))
@@ -202,14 +154,12 @@ class OgdsUserParticipation(Participation):
         attributes['ogds_userid'] = self.ogds_userid
         return attributes
 
-
 OgdsUserToContactAdapter.participation_class = OgdsUserParticipation
 
 
 class ContactParticipation(Participation):
     """Let Contacts participate in dossiers with specified roles.
     """
-    query_cls = ContactParticipationQuery
     __mapper_args__ = {'polymorphic_identity': 'contact_participation'}
 
     contact_id = Column(Integer, ForeignKey('contacts.id'))
@@ -235,7 +185,6 @@ class ContactParticipation(Participation):
 class OrgRoleParticipation(Participation):
     """Let OrgRoles participate in dossiers with specified roles.
     """
-    query_cls = OrgRoleParticipationQuery
     __mapper_args__ = {'polymorphic_identity': 'org_role_participation'}
 
     org_role_id = Column(Integer, ForeignKey('org_roles.id'))

--- a/opengever/contact/models/person.py
+++ b/opengever/contact/models/person.py
@@ -5,20 +5,11 @@ from opengever.contact.utils import get_contactfolder_url
 from opengever.contact.wrapper import PersonWrapper
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import relationship
-
-
-class PersonQuery(BaseQuery):
-
-    searchable_fields = ['firstname', 'lastname']
-
-    def get_by_former_contact_id(self, former_contact_id):
-        return self.filter_by(former_contact_id=former_contact_id).first()
 
 
 class Person(Contact):
@@ -62,6 +53,3 @@ class Person(Contact):
 
     def get_doc_property_provider(self, prefix):
         return PersonDocPropertyProvider(self, prefix)
-
-
-Person.query_cls = PersonQuery

--- a/opengever/contact/models/query.py
+++ b/opengever/contact/models/query.py
@@ -1,7 +1,7 @@
 from opengever.contact.models import Contact
 from opengever.contact.models import Organization
 from opengever.contact.models import OrgRole
-from opengever.contact.models.person import Person
+from opengever.contact.models import Person
 from opengever.ogds.models.query import BaseQuery
 from opengever.ogds.models.query import extend_query_with_textfilter
 from sqlalchemy.orm import contains_eager
@@ -30,5 +30,14 @@ class ContactQuery(BaseQuery):
     def get_by_former_contact_id(self, former_contact_id):
         return self.filter_by(former_contact_id=former_contact_id).first()
 
-
 Contact.query_cls = ContactQuery
+
+
+class OrganizationQuery(BaseQuery):
+
+    searchable_fields = ['name']
+
+    def get_by_former_contact_id(self, former_contact_id):
+        return self.filter_by(former_contact_id=former_contact_id).first()
+
+Organization.query_cls = OrganizationQuery

--- a/opengever/contact/models/query.py
+++ b/opengever/contact/models/query.py
@@ -100,3 +100,13 @@ class OgdsUserParticipationQuery(ParticipationQuery):
         return self.filter_by(ogds_userid=ogds_user.id)
 
 OgdsUserParticipation.query_cls = OgdsUserParticipationQuery
+
+
+class PersonQuery(BaseQuery):
+
+    searchable_fields = ['firstname', 'lastname']
+
+    def get_by_former_contact_id(self, former_contact_id):
+        return self.filter_by(former_contact_id=former_contact_id).first()
+
+Person.query_cls = PersonQuery

--- a/opengever/contact/models/query.py
+++ b/opengever/contact/models/query.py
@@ -1,9 +1,15 @@
+from opengever.base.oguid import Oguid
 from opengever.contact.models import Contact
+from opengever.contact.models import ContactParticipation
+from opengever.contact.models import OgdsUserParticipation
 from opengever.contact.models import Organization
 from opengever.contact.models import OrgRole
+from opengever.contact.models import OrgRoleParticipation
+from opengever.contact.models import Participation
 from opengever.contact.models import Person
 from opengever.ogds.models.query import BaseQuery
 from opengever.ogds.models.query import extend_query_with_textfilter
+from sqlalchemy import or_
 from sqlalchemy.orm import contains_eager
 
 
@@ -41,3 +47,56 @@ class OrganizationQuery(BaseQuery):
         return self.filter_by(former_contact_id=former_contact_id).first()
 
 Organization.query_cls = OrganizationQuery
+
+
+class ParticipationQuery(BaseQuery):
+
+    def by_dossier(self, dossier):
+        return self.filter_by(dossier_oguid=Oguid.for_object(dossier))
+
+    def by_organization(self, organization):
+        """Returns both ContactParticapations and OrgRoleParticipation
+        of the given organization.
+        """
+        return self._org_role_join().filter(
+            or_(OrgRole.organization == organization,
+                ContactParticipation.contact == organization))
+
+    def by_person(self, person):
+        """Returns both ContactParticapations and OrgRoleParticipation
+        of the given person.
+        """
+        return self._org_role_join().filter(
+            or_(OrgRole.person == person,
+                ContactParticipation.contact == person))
+
+    def _org_role_join(self):
+        return self.outerjoin(
+            OrgRole, OrgRoleParticipation.org_role_id == OrgRole.org_role_id)
+
+
+Participation.query_cls = ParticipationQuery
+
+
+class ContactParticipationQuery(ParticipationQuery):
+
+    def by_participant(self, contact):
+        return self.filter_by(contact=contact)
+
+ContactParticipation.query_cls = ContactParticipationQuery
+
+
+class OrgRoleParticipationQuery(ParticipationQuery):
+
+    def by_participant(self, org_role):
+        return self.filter_by(org_role=org_role)
+
+OrgRoleParticipation.query_cls = OrgRoleParticipationQuery
+
+
+class OgdsUserParticipationQuery(ParticipationQuery):
+
+    def by_participant(self, ogds_user):
+        return self.filter_by(ogds_userid=ogds_user.id)
+
+OgdsUserParticipation.query_cls = OgdsUserParticipationQuery

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -85,5 +85,4 @@ class TaskQuery(BaseQuery):
     def in_pending_state(self):
         return self.filter(Task.review_state.in_(Task.PENDING_STATES))
 
-
 Task.query_cls = TaskQuery

--- a/opengever/locking/model/__init__.py
+++ b/opengever/locking/model/__init__.py
@@ -1,5 +1,5 @@
-from opengever.locking.model.locks import Lock
-
+from opengever.locking.model.locks import Lock  # noqa
+from opengever.locking.model import query  # noqa, keep, initializes query classes!
 
 tables = [
     'locks',

--- a/opengever/locking/model/locks.py
+++ b/opengever/locking/model/locks.py
@@ -3,7 +3,6 @@ from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import Base
 from opengever.base.model import UTCDateTime
 from opengever.ogds.models import USER_ID_LENGTH
-from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -18,23 +17,10 @@ def lowest_valid():
     return utcnow_tz_aware() - timedelta(seconds=DEFAULTTIMEOUT)
 
 
-class LockQuery(BaseQuery):
-
-    def valid_locks(self, object_type, object_id):
-        query = Lock.query.filter_by(object_type=object_type,
-                                     object_id=object_id)
-        return query.filter(Lock.time >= lowest_valid())
-
-    def invalid_locks(self):
-        return Lock.query.filter(Lock.time < lowest_valid())
-
-
 class Lock(Base):
 
     __tablename__ = 'locks'
     __table_args__ = (UniqueConstraint('object_id', 'object_type', 'lock_type'), {})
-
-    query_cls = LockQuery
 
     lock_id = Column("id", Integer, Sequence("locks_id_seq"), primary_key=True)
     object_id = Column(Integer)

--- a/opengever/locking/model/query.py
+++ b/opengever/locking/model/query.py
@@ -1,0 +1,17 @@
+from opengever.locking.model import Lock
+from opengever.locking.model.locks import lowest_valid
+from opengever.ogds.models.query import BaseQuery
+
+
+class LockQuery(BaseQuery):
+
+    def valid_locks(self, object_type, object_id):
+        query = Lock.query.filter_by(object_type=object_type,
+                                     object_id=object_id)
+        return query.filter(Lock.time >= lowest_valid())
+
+    def invalid_locks(self):
+        return Lock.query.filter(Lock.time < lowest_valid())
+
+
+Lock.query_cls = LockQuery


### PR DESCRIPTION
This decouples the `Query*` classes a bit from their corresponding model classes. This allows us to avoid possible cyclic imports when writing queries that connect multiple SQL-Models and it allows us to directly access class attributes when writing `filter` query methods.

Closes #1134