### PR TITLE
Replace changed_security with elevated_privileges.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.2.2 (unreleased)
 ---------------------
 
+- Replace changed_security with elevated_privileges. [deiferni]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]

--- a/opengever/base/security.py
+++ b/opengever/base/security.py
@@ -1,21 +1,10 @@
 from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import setSecurityManager
-from AccessControl.SecurityManagement import SpecialUsers
 from AccessControl.User import UnrestrictedUser as BaseUnrestrictedUser
 from contextlib import contextmanager
 from plone import api
 from zope.globalrequest import getRequest
-
-
-@contextmanager
-def changed_security(user=SpecialUsers.system):
-    old_manager = getSecurityManager()
-    newSecurityManager(getRequest(), user)
-
-    yield
-
-    setSecurityManager(old_manager)
 
 
 class UnrestrictedUser(BaseUnrestrictedUser):

--- a/opengever/base/tests/test_security.py
+++ b/opengever/base/tests/test_security.py
@@ -1,5 +1,3 @@
-from AccessControl.SecurityManagement import SpecialUsers
-from opengever.base.security import changed_security
 from opengever.base.security import elevated_privileges
 from opengever.testing import FunctionalTestCase
 from plone import api
@@ -11,14 +9,6 @@ class TestSecurity(FunctionalTestCase):
     def setUp(self):
         super(TestSecurity, self).setUp()
         self.test_user = api.user.get(userid=TEST_USER_ID)
-
-    def test_changed_security_sets_priviledged_user_and_restores_old(self):
-        self.assertEqual(self.test_user, api.user.get_current())
-        with changed_security():
-            self.assertEqual(
-                SpecialUsers.system.getUserName(),
-                api.user.get_current().getUserName())
-        self.assertEqual(self.test_user, api.user.get_current())
 
     def test_elevated_privileges_sets_priviledged_user_and_restores_old(self):
         self.assertEqual(self.test_user, api.user.get_current())

--- a/opengever/inbox/yearfolder.py
+++ b/opengever/inbox/yearfolder.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from opengever.base.security import changed_security
+from opengever.base.security import elevated_privileges
 from opengever.inbox import _
 from opengever.inbox.utils import get_current_inbox
 from plone.dexterity.utils import createContentInContainer
@@ -32,7 +32,7 @@ def get_current_yearfolder(context=None, inbox=None):
 def _create_yearfolder(inbox, year):
     """creates the yearfolder for the given year"""
 
-    with changed_security():
+    with elevated_privileges():
         # for creating the folder, we need to be a superuser since
         # normal user should not be able to add year folders.
         # --- help i18ndude ---

--- a/opengever/task/yearfolderstorer.py
+++ b/opengever/task/yearfolderstorer.py
@@ -1,7 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from five import grok
-from opengever.base.security import changed_security
+from opengever.base.security import elevated_privileges
 from opengever.document.handlers import DISABLE_DOCPROPERTY_UPDATE_FLAG
 from opengever.task.browser.accept.utils import get_current_yearfolder
 from opengever.task.interfaces import IYearfolderStorer
@@ -20,6 +20,6 @@ class YearfolderStorer(grok.Adapter):
 
         self.context.REQUEST.set(DISABLE_DOCPROPERTY_UPDATE_FLAG, True)
 
-        with changed_security():
+        with elevated_privileges():
             clipboard = inbox.manage_cutObjects((self.context.getId(),))
             yearfolder.manage_pasteObjects(clipboard)


### PR DESCRIPTION
The function `elevated_privileges` supersedes `changed_security` because it retains the current user name instead of using SpecialUsers.system which does not have an username since it corresponds to no real user.

Also tested manually with yearfolders.

Closes #1410.