### PR TITLE
Optimize journal queries

### DIFF
--- a/opengever/journal/browser.py
+++ b/opengever/journal/browser.py
@@ -1,11 +1,13 @@
 
 from Acquisition import aq_inner
+from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
+from ftw.journal.interfaces import IAnnotationsJournalizable
+from ftw.journal.interfaces import IWorkflowHistoryJournalizable
 from Products.Five.browser import BrowserView
-from zope.annotation.interfaces import IAnnotations, IAnnotatable
+from zope.annotation.interfaces import IAnnotatable
+from zope.annotation.interfaces import IAnnotations
 from zope.interface import alsoProvides
 
-from ftw.journal.interfaces import IAnnotationsJournalizable, IWorkflowHistoryJournalizable
-from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 
 class JournalHistory(BrowserView):
     """ BrowserView listing the journal history

--- a/opengever/journal/browser.py
+++ b/opengever/journal/browser.py
@@ -10,8 +10,7 @@ from zope.interface import alsoProvides
 
 
 class JournalHistory(BrowserView):
-    """ BrowserView listing the journal history
-    """
+    """BrowserView listing the journal history."""
 
     def __init__(self, context, *args, **kwargs):
         self.context = aq_inner(context)
@@ -19,9 +18,6 @@ class JournalHistory(BrowserView):
         super(JournalHistory, self).__init__(context, *args, **kwargs)
 
     def data(self):
-        """
-        """
-
         if IAnnotationsJournalizable.providedBy(self.context):
             annotations = IAnnotations(self.context)
             return annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, [])

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -11,6 +11,7 @@ from zope import schema
 
 
 class IManualJournalEntry(form.Schema):
+    """Provide a z3c.form.Schema to enter a manual journal entry."""
 
     category = schema.Choice(
         title=_(u'label_category', default=u'Category'),
@@ -51,6 +52,8 @@ class IManualJournalEntry(form.Schema):
 
 
 class ManualJournalEntryAddForm(AddForm):
+    """Provide a z3c.form to enter a manual journal entry."""
+
     label = _(u'label_add_journal_entry', default=u'Add journal entry')
     fields = Fields(IManualJournalEntry)
 

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -1,5 +1,4 @@
 from BeautifulSoup import BeautifulSoup
-from copy import deepcopy
 from five import grok
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.journal.interfaces import IAnnotationsJournalizable
@@ -21,6 +20,8 @@ from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
+
+import cPickle
 
 
 def tooltip_helper(item, value):
@@ -139,6 +140,8 @@ class JournalTableSource(GeverTableSource):
               'title': title_column_sorter,
               'actor': actor_column_sorter}
 
+    batching_enabled = True
+
     def validate_base_query(self, query):
         context = self.config.context
         if IAnnotationsJournalizable.providedBy(context):
@@ -147,7 +150,9 @@ class JournalTableSource(GeverTableSource):
         elif IWorkflowHistoryJournalizable.providedBy(context):
             raise NotImplemented
 
-        data = deepcopy(data)
+        # XXX - a performance hack to replace deepcopy(data)
+        # This only works as persistent objects are guaranteed to be picklable
+        data = cPickle.loads(cPickle.dumps(data))
         return data
 
     def extend_query_with_ordering(self, results):

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -6,7 +6,8 @@ from ftw.journal.interfaces import IAnnotationsJournalizable
 from ftw.journal.interfaces import IJournalizable
 from ftw.journal.interfaces import IWorkflowHistoryJournalizable
 from ftw.table import helper
-from ftw.table.interfaces import ITableSourceConfig, ITableSource
+from ftw.table.interfaces import ITableSource
+from ftw.table.interfaces import ITableSourceConfig
 from opengever.contact.utils import get_contactfolder_url
 from opengever.journal import _
 from opengever.tabbedview import BaseListingTab
@@ -18,7 +19,8 @@ from zope.annotation.interfaces import IAnnotations
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-from zope.interface import implements, Interface
+from zope.interface import implements
+from zope.interface import Interface
 
 
 def tooltip_helper(item, value):

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -24,13 +24,17 @@ from zope.interface import Interface
 
 
 def tooltip_helper(item, value):
-    text = ''.join(BeautifulSoup(value, fromEncoding='utf8').findAll(text=True))
+    text = ''.join(
+        BeautifulSoup(value, fromEncoding='utf8').findAll(text=True))
     return '<span title="%s">%s</span>' % (text.encode('utf-8'), value)
 
 
 def title_helper(item, value):
-    return translate(item['action'].get('title'),
-                    context=getRequest())
+    return translate(item['action'].get('title'), context=getRequest())
+
+
+def empty_template_helper(self, *args, **kwargs):
+    return ''
 
 
 class IJournalSourceConfig(ITableSourceConfig):
@@ -44,14 +48,15 @@ class JournalTab(BaseListingTab):
 
     implements(IJournalSourceConfig)
 
-    reference_template = ViewPageTemplateFile('templates/journal_references.pt')
+    reference_template = ViewPageTemplateFile(
+        'templates/journal_references.pt')
 
     grok.name('tabbedview_view-journal')
     grok.require('zope2.View')
     grok.context(IJournalizable)
 
-    # do not select
-    select_all_template = lambda *a, **kw: ''
+    # This is a bound method on purpose so it can be called down the line
+    select_all_template = empty_template_helper
 
     sort_on = 'time'
     sort_reverse = True
@@ -125,6 +130,7 @@ def actor_column_sorter(a, b):
 
 
 class JournalTableSource(GeverTableSource):
+    """Generate a table to display in the journal tab view."""
 
     grok.implements(ITableSource)
     grok.adapts(IJournalSourceConfig, Interface)


### PR DESCRIPTION
The actual root cause of #1244 was tackled in the lack of actual understanding of how to build the whole thing properly up from `ftw.table` -> `ftw.tabbedview` -> `opengever.core`. This is doable, but not within the time frame of the sprint now. Our current implementation is a hack which goes against the grain of how one should use these tools.

The actual end result query should eventually end up relying on `plone.batching`.

In the course of mucking around a technique to optimize the slowest part, the deepcopy within the abusely-built-query, was discovered. It turned out pickling and unpickling the objects with cPickle is faster than making a deepcopy. This is a hack, but a valid one at least partially addressing the issue at hand?

I've locally metrified a gain in the journal of a dossier, but further testing by others on this metric is most welcome as this seems to be a bit hardware dependent. If we can find a situation this ends up being slower for this particular query, we should not proceed as this essentially trades a bit of RAM (the serialization overhead vs. the deepcopy object in-memroy) for less CPU cycles.

`/fd/ordnungssystem/ressourcen-und-support/finanzen/planung/finanzplanung/dossier-5#journal`

```
Entry count: 7
Deepcopy took 0.0014500617981s
cPickle took 0.000730037689209s
cPickle / Deepcopy = 0.503452811575
Deepcopy / cPickle = 1.98628347485
```

```
Entry count: 107
Deepcopy took 0.0270109176636s
cPickle took 0.0104432106018s
cPickle / Deepcopy = 0.386629241253
Deepcopy / cPickle = 2.5864572394
```

```
Entry count: 1107
Deepcopy took 0.623929023743s
cPickle took 0.126353025436s
cPickle / Deepcopy = 0.202511857324
Deepcopy / cPickle = 4.93798246293
```

```
Entry count: 11107
Deepcopy took 6.77266812325s
cPickle took 2.10805010796s
cPickle / Deepcopy = 0.311258439007
Deepcopy / cPickle = 3.21276429706
```

```
Entry count: 111107
Deepcopy took 85.6392359734s
cPickle took 28.9555430412s
cPickle / Deepcopy = 0.338110711897
Deepcopy / cPickle = 2.95761111617
```

The results above are averages of 5 runs each wherein discarding the best and worst results as outliers. I had no patience for more runs of the 100k set. No hard guarantees, but better than nothing.

One can also easily get in-situ in-context metrification (or journal entry generation) going on in a pdb session when one pops into a local context proper interpreter via `!import code; code.interact(local=vars())`.

Where to loop to generate entries:
https://github.com/4teamwork/opengever.core/blob/60b6df7c4079b14c34d75e02d0043031853ce3d9/opengever/journal/form.py#L67

```
for x in xrange(n):
    if x % 100 == 0:
        print x
    entry.save()
```

Where to metrify the gains:
https://github.com/4teamwork/opengever.core/blob/60b6df7c4079b14c34d75e02d0043031853ce3d9/opengever/journal/tab.py#L142

```
from copy import deepcopy
from timeit import default_timer

import cPickle

print "Entry count: {}".format(len(data))

begin = default_timer()
deepcopy(data)
end = default_timer()
dcresult = end - begin

print "Deepcopy took {}s".format(dcresult)

begin = default_timer()
cPickle.loads(cPickle.dumps(data))
end = default_timer()
cpresult = end - begin

print "cPickle took {}s".format(cpresult)

print "cPickle / Deepcopy = {}".format(cpresult / dcresult)
print "Deepcopy / cPickle = {}".format(dcresult / cpresult)
```