### PR TITLE
Make rules when resolving a dossier customisable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.2.2 (unreleased)
 ---------------------
 
+- Make `resolving` a dossier customizable and provide two implementations (strict and lenient). [deiferni]
 - Replace changed_security with elevated_privileges. [deiferni]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -49,4 +49,9 @@
       factory=".statestorage.DossierGridStateStorageKeyGenerator"
       />
 
+  <utility
+      factory=".resolve.ValidResolverNamesVocabularyFactory"
+      name="opengever.dossier.ValidResolverNamesVocabulary"
+      />
+
 </configure>

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -7,7 +7,7 @@ from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.bundle.sections.constructor import IDontIssueDossierReferenceNumber
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.dossier.resolve import DossierResolver
+from opengever.dossier.resolve import get_resolver
 from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from plone import api
@@ -140,4 +140,4 @@ def run_cleanup_jobs(dossier, event):
     if event.action != 'dossier-transition-resolve':
         return
 
-    DossierResolver(dossier).after_resolve()
+    get_resolver(dossier).after_resolve()

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -216,3 +216,9 @@ class IDossierResolveProperties(Interface):
         description=u'Select if GEVER should trigger the archival file '
         'conversion for each document, when a dossier gets resolved.',
         default=False)
+
+    resolver_name = schema.Choice(
+        title=u"Dossier resolver name",
+        vocabulary=u'opengever.dossier.ValidResolverNamesVocabulary',
+        default='strict'
+    )

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -252,6 +252,17 @@ class StrictDossierResolver(grok.Adapter):
         Reactivator(self.context).reactivate_dossier()
 
 
+class LenientDossierResolver(StrictDossierResolver):
+    """The lenient dossier resolver does not enforce that documents and tasks
+    are filed in subdossiers if the main dossier has subdossiers.
+    """
+    grok.implements(IDossierResolver)
+    grok.context(IDossierMarker)
+    grok.name('lenient')
+
+    strict = False
+
+
 class Resolver(object):
 
     def __init__(self, context):

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -31,16 +31,14 @@ class DossierResolveView(grok.View):
     grok.require('zope2.View')
 
     def render(self):
-
-        ptool = getToolByName(self, 'plone_utils')
-
         resolver = IDossierResolver(self.context)
 
         # check preconditions
         errors = resolver.is_resolve_possible()
         if errors:
             for msg in errors:
-                ptool.addPortalMessage(msg, type="error")
+                api.portal.show_message(
+                    message=msg, request=self.request, type='error')
 
             return self.request.RESPONSE.redirect(
                 self.context.absolute_url())
@@ -49,10 +47,10 @@ class DossierResolveView(grok.View):
         invalid_dates = resolver.are_enddates_valid()
         if invalid_dates:
             for title in invalid_dates:
-                ptool.addPortalMessage(
-                    _("The dossier ${dossier} has a invalid end_date",
-                      mapping=dict(dossier=title,)),
-                    type="error")
+                msg = _("The dossier ${dossier} has a invalid end_date",
+                        mapping=dict(dossier=title,))
+                api.portal.show_message(
+                    message=msg, request=self.request, type='error')
 
             return self.request.RESPONSE.redirect(
                 self.context.absolute_url())
@@ -62,13 +60,13 @@ class DossierResolveView(grok.View):
         else:
             resolver.resolve()
             if self.context.is_subdossier():
-                ptool.addPortalMessage(
-                    _('The subdossier has been succesfully resolved.'),
-                    type='info')
+                api.portal.show_message(
+                    message=_('The subdossier has been succesfully resolved.'),
+                    request=self.request, type='info')
             else:
-                ptool.addPortalMessage(
-                    _('The dossier has been succesfully resolved.'),
-                    type='info')
+                api.portal.show_message(
+                    message=_('The dossier has been succesfully resolved.'),
+                    request=self.request, type='info')
 
             self.request.RESPONSE.redirect(self.context.absolute_url())
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -38,7 +38,7 @@ class TestResolverVocabulary(FunctionalTestCase):
     def test_resolver_vocabulary(self):
         vocabulary = get_resolver_vocabulary()
         self.assertItemsEqual(
-            [u'strict'],
+            [u'strict', u'lenient'],
             vocabulary.by_value.keys())
 
 
@@ -385,6 +385,31 @@ class TestResolving(FunctionalTestCase):
                           api.content.get_state(dossier))
         self.assertEquals('dossier-state-resolved',
                           api.content.get_state(subdossier))
+
+    @browsing
+    def test_lenient_resolver_skips_document_and_task_filing_check(self, browser):  # noqa
+        api.portal.set_registry_record(
+            'resolver_name', 'lenient', IDossierResolveProperties)
+
+        dossier = create(Builder('dossier'))
+        subdossier = create(Builder('dossier').within(dossier))
+        create(Builder('document').within(dossier))
+        create(Builder('mail').within(dossier))
+        create(Builder('task')
+               .within(dossier)
+               .in_state('task-state-tested-and-closed'))
+
+        browser.login().open(dossier,
+                             {'_authenticator': createToken()},
+                             view='transition-resolve')
+
+        self.assertEquals(dossier.absolute_url(), browser.url)
+        self.assertEquals('dossier-state-resolved',
+                          api.content.get_state(dossier))
+        self.assertEquals('dossier-state-resolved',
+                          api.content.get_state(subdossier))
+        self.assertEquals(
+            ['The dossier has been succesfully resolved.'], info_messages())
 
     @browsing
     def test_handles_already_resolved_subdossiers(self, browser):

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -21,7 +21,25 @@ from plone import api
 from plone.app.testing import applyProfile
 from plone.protect import createToken
 from plone.uuid.interfaces import IUUID
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
 import transaction
+
+
+def get_resolver_vocabulary():
+    voca_factory = getUtility(
+        IVocabularyFactory,
+        name='opengever.dossier.ValidResolverNamesVocabulary')
+    return voca_factory(api.portal.get())
+
+
+class TestResolverVocabulary(FunctionalTestCase):
+
+    def test_resolver_vocabulary(self):
+        vocabulary = get_resolver_vocabulary()
+        self.assertItemsEqual(
+            [u'strict'],
+            vocabulary.by_value.keys())
 
 
 class TestResolvingDossiers(FunctionalTestCase):

--- a/opengever/dossier/upgrades/20170519152516_add_resolver_name_to_i_dossier_resolve_properties/registry.xml
+++ b/opengever/dossier/upgrades/20170519152516_add_resolver_name_to_i_dossier_resolve_properties/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+    <records interface="opengever.dossier.interfaces.IDossierResolveProperties">
+      <value key="resolver_name">strict</value>
+    </records>
+</registry>

--- a/opengever/dossier/upgrades/20170519152516_add_resolver_name_to_i_dossier_resolve_properties/upgrade.py
+++ b/opengever/dossier/upgrades/20170519152516_add_resolver_name_to_i_dossier_resolve_properties/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddResolverNameToIDossierResolveProperties(UpgradeStep):
+    """Add resolver_name to IDossierResolveProperties.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
With this PR the checks when resolving a dossier become customisable. To achieve this goal the dossier-resolver is converted into a named adapter. The name of the adapter to use is read from the registry and used in the adapter lookup. Thus it becomes possible to easily add new adapters, theoretically also on a per customer level, should this be desired. 

We also provide two adapters:
- `strict` the default current behavior which enforces all checks
- `lenient` an implementation which does not enforce that all documents and tasks are to be filed in a subdossier (if the main dossier has subdossiers)

Closes #1871.