### PR TITLE
No longer separately include ruby-gems.cfg.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ and the `ruby-build <https://github.com/sstephenson/ruby-build>`_ plugin:
     gem install bundler
 
 The installation of the ``Sablon`` gem can then be performed by buildout (by
-extending from `ruby-gems.cfg <http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg>`_).
+extending from `ruby-gems.cfg <https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg>`_).
 
 
 LDAP credentials

--- a/development.cfg
+++ b/development.cfg
@@ -3,7 +3,6 @@ extends =
     test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-dev.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
-    http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
     sphinx.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml.cfg
 

--- a/development.cfg
+++ b/development.cfg
@@ -25,7 +25,6 @@ eggs +=
     ${buildout:instance-eggs}
 
 environment-vars +=
-    SABLON_BIN ${buildout:sablon-executable}
     BUMBLEBEE_APP_ID gever_dev
     BUMBLEBEE_INTERNAL_PLONE_URL http://localhost:${instance:http-address}/fd
     BUMBLEBEE_PUBLIC_URL http://localhost:3000/

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
@@ -7,10 +7,3 @@ extends =
 {{% endif %}}
 
 ogds-db-name = opengever{{{package.name}}}
-
-
-{{% if setup.enable_meeting_feature %}}
-[instance]
-environment-vars +=
-    SABLON_BIN ${buildout:sablon-executable}
-{{% endif %}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/development.cfg.bob
@@ -5,9 +5,6 @@ extends =
 {{% if setup.enable_bumblebee_feature %}}
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
 {{% endif %}}
-{{% if setup.enable_meeting_feature %}}
-  http://buildout-proxy.4teamwork.ch/4teamwork/opengever-buildouts/master/ruby-gems.cfg
-{{% endif %}}
 
 ogds-db-name = opengever{{{package.name}}}
 


### PR DESCRIPTION
It is now included by https://github.com/4teamwork/gever-buildouts/blob/master/standard-dev.cfg