### PR TITLE
Link keywords on dossier overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Implement tracebackify decorator for better errorhandling/debugging remote requests. [mathias.leimgruber]
 - Implement safe_call decorator for better errhandling/debugging remove requests. [mathias.leimgruber]
 - Refactor SQL models, move Query classes to query module. [deiferni]
+- Link keywords on dossier overview. [mathias.leimgruber]
 - Make sure that pasting is allowed before pasting. [deiferni]
 - Remove an unused creator behaviour from the codebase. [Rotonen]
 - Keep *.msg file after conversion and store message source for mails. [deiferni]

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -6,6 +6,7 @@ from plone.app.search.browser import EVER
 from plone.app.search.browser import quote_chars
 from plone.app.search.browser import Search
 from Products.CMFPlone.browser.navtree import getNavigationRoot
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import getMultiAdapter
 
 
@@ -151,5 +152,11 @@ class OpengeverSearch(Search):
         # respect navigation root
         if 'path' not in query:
             query['path'] = getNavigationRoot(self.context)
+
+        # Special treatment for the Subject index
+        # The index only stores unicode values, so we have to search
+        # for unicode values.
+        if 'Subject' in query:
+            query['Subject'] = safe_unicode(query['Subject'])
 
         return query

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -18,6 +18,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.tabbedview import GeverTabMixin
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
+from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import desc
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
@@ -206,7 +207,18 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
         return [relation.from_id for relation in relations]
 
     def get_keywords(self):
-        return ', '.join(IDossier(self.context).keywords)
+        linked_keywords = []
+        for keyword in IDossier(self.context).keywords:
+            url = u'{}/@@search?Subject={}'.format(
+                api.portal.get().absolute_url(), safe_unicode(keyword))
+            linked_keywords.append(
+                {
+                    'getURL': url,
+                    'Title': keyword,
+                    'css_class': '',
+                }
+            )
+        return linked_keywords
 
     def make_keyword_box(self):
         return dict(id='keywords', content=self.get_keywords(),

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -670,10 +670,10 @@ class TestDossierTemplateOverview(FunctionalTestCase):
                          browser.css('#descriptionBox span').first.text)
 
     @browsing
-    def test_keywords_box_shows_keywords_joined_by_comma(self, browser):
+    def test_keywords_box_shows_keywords_as_list(self, browser):
         browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
-        self.assertEqual(u'chuck, james',
-                         browser.css('#keywordsBox span').first.text)
+        self.assertEqual([u'chuck', u'james'],
+                         browser.css('#keywordsBox li span').text)
 
     @browsing
     def test_comments_box_shows_comment(self, browser):

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -276,5 +276,5 @@ class TestOverview(FunctionalTestCase):
                                  keywords=(u'secret', u'special')))
 
         browser.login().visit(dossier, view='tabbedview_view-overview')
-        self.assertEquals(['secret, special'],
-                          browser.css('#keywordsBox span').text)
+        self.assertEquals([u'secret', u'special'],
+                          browser.css('#keywordsBox li span').text)


### PR DESCRIPTION
In order to make it possible to actually search for keywords containing non ascii characters, it's necessary to pass the `Subject` as unicode.

- The Subject Index only stores unicode values

Currently the default gever listing on the overview tab, shows them as list. 
Not that neat, but consistent. 
<img width="593" alt="screen shot 2017-05-23 at 11 59 20" src="https://cloud.githubusercontent.com/assets/437933/26349322/abd5b3d4-3faf-11e7-93a6-92a52b83e596.png">


Closes #2901 