### PR TITLE
Sanitize 2017.2-stable branch.

### DIFF
--- a/opengever/core/sqlite_testing.py
+++ b/opengever/core/sqlite_testing.py
@@ -1,3 +1,4 @@
+from ftw.dictstorage.sql import DictStorageModel
 from opengever.base import model
 from opengever.base.model import create_session
 from opengever.ogds.base.setup import create_sql_tables
@@ -91,8 +92,11 @@ def create_tables():
 def truncate_tables():
     """Truncate existing tables in an sqlite way.
     """
-    tables = BASE.metadata.tables.values() + \
-             model.Base.metadata.tables.values()
+    tables = (
+        BASE.metadata.tables.values() +
+        model.Base.metadata.tables.values() +
+        DictStorageModel.metadata.tables.values()
+    )
 
     session = create_session()
     for table in tables:

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    http://kgs.4teamwork.ch/release/opengever/2017.2.1
+    http://kgs.4teamwork.ch/release/opengever/2017.2.2
 
 versions = versions
 


### PR DESCRIPTION
Backport a fix for a flaky test. Will help to avoid failing tests should another backport be necessary. Not necessary to release separately, though.

Also extend from the correct release version.