### PR TITLE
Fix get_retention_expiration_date on dossier. retention_period may be a unicode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Fix get_retention_expiration_date on dossier. retention_period may be a unicode. [mathias.leimgruber]
 - Use latest ftw.datepicker for all datetime widgets. [mathias.leimgruber]
 - Make `resolving` a dossier customizable and provide two implementations (strict and lenient). [deiferni]
 - Replace changed_security with elevated_privileges. [deiferni]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -321,7 +321,8 @@ class DossierContainer(Container):
         retention period.
         """
         if IDossier(self).end:
-            year = IDossier(self).end.year + ILifeCycle(self).retention_period
+            year = IDossier(self).end.year + \
+                int(ILifeCycle(self).retention_period)
             return date(year + 1, 1, 1)
 
         return None

--- a/opengever/dossier/tests/test_retention_expiration.py
+++ b/opengever/dossier/tests/test_retention_expiration.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
@@ -75,3 +76,8 @@ class TestRetentionExpirationDate(FunctionalTestCase):
     def test_is_not_expired_when_its_later_than_today(self):
         with freeze(datetime(2030, 2, 18)):
             self.assertFalse(self.dossier.is_retention_period_expired())
+
+    def test_get_retention_expiration_date_if_retention_period_is_unicode(self):
+        ILifeCycle(self.dossier).retention_period = u'10'
+        self.assertEquals(date(2021, 1, 1),
+                          self.dossier.get_retention_expiration_date())


### PR DESCRIPTION

The default values in the interface are:

```
        default=[u'5',
                u'10',
                u'15',
                u'20',
                u'25'],

``` 

The default value of the field is `5` (as Int)

This means after changing the `retention_period` of a dossier, it was no longer possible to get the `get_retention_expiration_date`. 

This currently may break an upgrade to onegovgever 2017.2.2.

