### PR TITLE
Fix Subject link on dossier overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Fix Subject link on dossier overview. [mathias.leimgruber]
 - Fix get_retention_expiration_date on dossier. retention_period may be a unicode. [mathias.leimgruber]
 - Install ftw.copymovepatches for better move performance. [mathias.leimgruber]
 - Use latest ftw.datepicker for all datetime widgets. [mathias.leimgruber]

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -20,6 +20,7 @@ from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import desc
+from urllib import quote_plus
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
@@ -210,7 +211,8 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
         linked_keywords = []
         for keyword in IDossier(self.context).keywords:
             url = u'{}/@@search?Subject={}'.format(
-                api.portal.get().absolute_url(), safe_unicode(keyword))
+                api.portal.get().absolute_url(),
+                quote_plus(safe_unicode(keyword).encode('utf-8')))
             linked_keywords.append(
                 {
                     'getURL': url,


### PR DESCRIPTION
The Subject needs be url quoted. Don't know why this lead us to a problem in customer integration, but not in gever itself. 

To quote the querystring values is anyway a good practice.