### PR TITLE
Fix upgrade step and make it run on mysql and psql.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -15,6 +15,13 @@ parts +=
 
 ogds-db-name = opengever
 
+# example mysql configuration
+#ogds-db-name = opengever
+#ogds-db-user = opengever
+#ogds-db-pw = opengever
+#ogds-dsn = mysql://${buildout:ogds-db-user}:${buildout:ogds-db-pw}@localhost/${buildout:ogds-db-name}?charset=utf8
+#ogds-db-driver = MySQL-python
+
 [upgrade]
 eggs += ftw.upgrade[colors]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Fix task-commented schema upgrade and make it both mysql and psql-compatible. [deiferni]
 - Fix Subject link on dossier overview. [mathias.leimgruber]
 - Fix get_retention_expiration_date on dossier. retention_period may be a unicode. [mathias.leimgruber]
 - Install ftw.copymovepatches for better move performance. [mathias.leimgruber]

--- a/opengever/activity/upgrades/20170328142858_add_task_commented_notification_setting/upgrade.py
+++ b/opengever/activity/upgrades/20170328142858_add_task_commented_notification_setting/upgrade.py
@@ -37,9 +37,11 @@ class AddTaskCommentedNotificationSetting(SchemaMigration):
                 # We don't want to reset already inserted settings
                 continue
 
-            self.execute(defaults_table
-                         .insert()
-                         .values(id=self.execute(seq),
-                                 kind=item['kind'],
-                                 mail_notification=item['mail_notification'],
-                                 mail_notification_roles=json.dumps(item['mail_notification_roles'])))
+            values = dict(kind=item['kind'],
+                          mail_notification=item['mail_notification'],
+                          mail_notification_roles=json.dumps(
+                                    item['mail_notification_roles']))
+            if self.supports_sequences:
+                values['id'] = self.execute(seq)
+
+            self.execute(defaults_table.insert().values(**values))

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -311,6 +311,10 @@ class SchemaMigration(SQLUpgradeStep):
         return foreign_keys.pop().name
 
     @property
+    def supports_sequences(self):
+        return self.op.impl.dialect.supports_sequences
+
+    @property
     def is_oracle(self):
         # Could be 'oracle' or 'oracle+cx_oracle'
         return 'oracle' in self.dialect_name


### PR DESCRIPTION
This PR fixes an issue when running upgrades on mysql which does not support sequences.

Only increment the sequence manually if the dialect actually supports sequences. The solution has been inspired by https://stackoverflow.com/questions/17196234/how-to-create-postgresqls-sequences-in-alembic.
