### PR TITLE
Provide option to initially render the jstree expanded.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Render subdossier tree collapsed initially. [Kevin Bieri]
 - Implement and enable the org unit selector etag adapter. [phgross]
 - Hard-code base profiles to be installed for every deployment. [deiferni]
 - Add api_group deployment configuration option. [deiferni]

--- a/opengever/dossier/resources/init_tree.js
+++ b/opengever/dossier/resources/init_tree.js
@@ -15,7 +15,8 @@ $(function() {
 
   function render_tree(tree_data) {
     var navtree = make_tree(tree_data, {
-      components: [new BusinessCaseDossierIconLinks()]
+      components: [new BusinessCaseDossierIconLinks()],
+      expanded: false
     });
     var tree_root = tree_container.find('>ul');
 

--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -10,7 +10,8 @@ function Tree(nodes, config) {
   configuration = $.extend(true, {
     'render_condition': function(){ return true; },
     'onclick': function(node, event){},
-    'components': []
+    'components': [],
+    expanded: true
   }, config);
   $(configuration['components']).each(function(_, component) {
     if(component !== null) {
@@ -68,7 +69,7 @@ function Tree(nodes, config) {
     this['link'] = $link;
     tree.render_children.apply(this);
 
-    if(this.parent) {
+    if(configuration.expanded && this.parent) {
       tree.expand(this.parent, true);
     }
   };


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2967

Render subdossier tree collapsed initially.