### PR TITLE
Replace our LDAP stack with our own forks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Improve visual search on customer request. [Kevin Bieri]
 - Merge Generic Setup profiles into a new opengever.core:default profile. [phgross]
 - Replace the AutocompleteField(Multi)Widget with the KeywordWidget. This makes the AutocompleteWidget obsolete. [mathias.leimgruber]
+- Respect lookup_groups_base during OGDS group sync. [phgross]
 - Use our own forks of Products.LDAPUserFolder and Products.LDAPMultiPlugins. [phgross]
 - Fix Subject link on dossier overview. [mathias.leimgruber]
 - Fix tasktemplate view by adding a missing </table> tag. [mathias.leimgruber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Improve visual search on customer request. [Kevin Bieri]
 - Merge Generic Setup profiles into a new opengever.core:default profile. [phgross]
 - Replace the AutocompleteField(Multi)Widget with the KeywordWidget. This makes the AutocompleteWidget obsolete. [mathias.leimgruber]
+- Use our own forks of Products.LDAPUserFolder and Products.LDAPMultiPlugins. [phgross]
 - Fix Subject link on dossier overview. [mathias.leimgruber]
 - Fix tasktemplate view by adding a missing </table> tag. [mathias.leimgruber]
 - Install ftw.copymovepatches for better move performance. [mathias.leimgruber]

--- a/sources.cfg
+++ b/sources.cfg
@@ -9,8 +9,13 @@ development-packages =
   plonetheme.teamraum
   ftw.keywordwidget
   ftw.showroom
+  Products.LDAPUserFolder
 
 auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
+Products.LDAPUserFolder = git git@github.com:4teamwork/Products.LDAPUserFolder.git  branch=${branches:Products.LDAPUserFolder}
+
+[branches]
+Products.LDAPUserFolder = ftw

--- a/sources.cfg
+++ b/sources.cfg
@@ -10,12 +10,15 @@ development-packages =
   ftw.keywordwidget
   ftw.showroom
   Products.LDAPUserFolder
+  Products.LDAPMultiPlugins
 
 auto-checkout = ${buildout:development-packages}
 
 [sources]
 plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
 Products.LDAPUserFolder = git git@github.com:4teamwork/Products.LDAPUserFolder.git  branch=${branches:Products.LDAPUserFolder}
+Products.LDAPMultiPlugins = git git@github.com:4teamwork/Products.LDAPMultiPlugins.git  branch=${branches:Products.LDAPMultiPlugins}
 
 [branches]
 Products.LDAPUserFolder = ftw
+Products.LDAPMultiPlugins = ftw


### PR DESCRIPTION
- Use our own [Products.LDAPUserFolder](https://github.com/4teamwork/Products.LDAPUserFolder) and [Products.LDAPUserFolder](https://github.com/4teamwork/Products.LDAPMultiPlugins) forks.
- Respect recently introduced `lookup_groups_base` during OGDS group synchronisation (see https://github.com/4teamwork/Products.LDAPMultiPlugins/pull/1)

⚠️  depends on https://github.com/4teamwork/Products.LDAPMultiPlugins/pull/1 
