### PR TITLE
Fix tasktemplate view by adding a missing </table> tag.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix Subject link on dossier overview. [mathias.leimgruber]
+- Fix tasktemplate view by adding a missing </table> tag. [mathias.leimgruber]
 - Install ftw.copymovepatches for better move performance. [mathias.leimgruber]
 - Use latest ftw.datepicker for all datetime widgets. [mathias.leimgruber]
 - Make `resolving` a dossier customizable and provide two implementations (strict and lenient). [deiferni]

--- a/opengever/tasktemplates/browser/tasktemplates_templates/view.pt
+++ b/opengever/tasktemplates/browser/tasktemplates_templates/view.pt
@@ -40,6 +40,7 @@
               </tal:block>
             </tr>
           </tal:rep>
+        </table>
 
         <div class="visualClear"><!----></div>
         <div class="visualClear"><!----></div>


### PR DESCRIPTION
Prev.
<img width="848" alt="screen shot 2017-05-31 at 10 06 06" src="https://cloud.githubusercontent.com/assets/437933/26621909/c5ea531c-45e8-11e7-9d74-3610794a6faf.png">


Now:
<img width="848" alt="screen shot 2017-05-31 at 10 04 43" src="https://cloud.githubusercontent.com/assets/437933/26621884/ab2eaea6-45e8-11e7-99af-a57f924c3ab8.png">


This was a regression because of the chameleon rendering.

Closes #2988