### PR TITLE
We have no actual need to pin QA tools

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -10,7 +10,6 @@ collective.recipe.omelette = 0.16
 collective.z3cinspector = 1.1
 i18ndude = 3.4.0
 mr.developer = 1.33
-pyflakes = 0.9.1
 z3c.dependencychecker = 1.11
 zptlint = 0.2.4
 


### PR DESCRIPTION
This is the first baby step taken in eventually bringing the QA tools into developer buildouts with a repo level (and thus also team level) shared config file (all the QA tools already respect setup.cfg by common convention).

Unpinning pyflakes enables me more convenience for local development - I'm currently having a local buildout file and mucking around with the recipes to make editor/IDE linter compatible buildout wrappers for common QA tools. These would down the line live in the shared buildout config snippets and developers can choose to include them in their local buildouts or not - but if anyone uses a QA tool we'd still have a shared config we can tweak and discuss about over time.