### PR TITLE
Add api_group deployment configuration option.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Add api_group deployment configuration option. [deiferni]
 - Merge Generic Setup profiles into a new opengever.core:default profile. [phgross]
 - Fix Subject link on dossier overview. [mathias.leimgruber]
 - Fix tasktemplate view by adding a missing </table> tag. [mathias.leimgruber]

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -163,6 +163,8 @@ class GeverDeployment(object):
                                   'archivist_group', 'Archivist')
         self.assign_group_to_role(self.site, self.config,
                                   'records_manager_group', 'Records Manager')
+        self.assign_group_to_role(self.site, self.config,
+                                  'api_group', 'APIUser')
 
         # REALLY set the language - the plone4 addPloneSite is really
         # buggy with languages.

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -85,6 +85,11 @@ class IDeploymentDirective(Interface):
         required=False,
         max_length=GROUP_ID_LENGTH)
 
+    api_group = TextLine(
+        title=u'API group',
+        required=False,
+        max_length=GROUP_ID_LENGTH)
+
 
 def register_ldap(context, **kwargs):
     title = kwargs.get('title')


### PR DESCRIPTION
Only possibility to configure this so fare is TTW. This PR adds a configuration option to also set the group on a per deployment configuration basis.