### PR TITLE
No longer display update gever warning in zmi.

### DIFF
--- a/opengever/setup/patches/addzmiopengeverclient.py
+++ b/opengever/setup/patches/addzmiopengeverclient.py
@@ -10,19 +10,6 @@ ADD_PLONE_SITE_HTML = '''
     <input type="submit" value="Install OneGov GEVER" />
   </form>
 </dtml-if>
-
-<dtml-if "this().meta_type == 'Plone Site'">
-  <!-- Warn if outdated -->
-  <dtml-if "this().portal_setup.listUpgrades('opengever.policy.base:default') != []">
-    <div style="background: #CC2A2A; padding: 10px; font-weight: bold; font-size: 125%;
-                margin-top: 1em;">
-      This OpenGever client's configuration is outdated and needs to be upgraded.
-      <a href="&dtml-URL1;/portal_setup/manage_upgrades?profile_id=opengever.policy.base:default" title="Go to the upgrade page">
-        Please continue with the upgrade.
-      </a>
-    </div>
-  </dtml-if>
-</dtml-if>
 '''
 
 main = ObjectManager.manage_main


### PR DESCRIPTION
With the profile merge it is now displayed incorrectly. This PR removes the hint:
![screen shot 2017-06-01 at 16 58 49](https://cloud.githubusercontent.com/assets/736583/26686047/22106ba0-46ec-11e7-9cac-37ba65a65bbd.png)
