### PR TITLE
Hard-code base profiles to be installed for every deployment.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Implement and enable the org unit selector etag adapter. [phgross]
+- Hard-code base profiles to be installed for every deployment. [deiferni]
 - Add api_group deployment configuration option. [deiferni]
 - Merge Generic Setup profiles into a new opengever.core:default profile. [phgross]
 - Replace the AutocompleteField(Multi)Widget with the KeywordWidget. This makes the AutocompleteWidget obsolete. [mathias.leimgruber]

--- a/opengever/core/configure.zcml
+++ b/opengever/core/configure.zcml
@@ -28,7 +28,7 @@
 
   <subscriber
       for="Products.GenericSetup.interfaces.IBeforeProfileImportEvent"
-      handler=".hooks.awoid_profile_reinstallation"
+      handler=".hooks.avoid_profile_reinstallation"
       />
 
 </configure>

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -60,13 +60,21 @@ def avoid_profile_reinstallation(event):
     if key not in annotations:
         annotations[key] = []
 
-    if profile.startswith('opengever.') or profile.startswith('ftw.'):
+    if should_prevent_duplicate_installation(profile):
         assert profile not in annotations[key], \
             'Profile {!r} should not be installed twice.'.format(profile)
     elif profile in annotations[key]:
         LOG.warning('{!r} installed twice'.format(profile))
 
     annotations[key].append(profile)
+
+
+def should_prevent_duplicate_installation(profile):
+    return (
+        profile.startswith('opengever.') or
+        profile.startswith('ftw.') or
+        profile.startswith('plonetheme.teamraum')
+    )
 
 
 def installed(site):

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -49,14 +49,14 @@ FORBIDDEN_PROFILES = (
     'opengever.policy.base:default')
 
 
-def awoid_profile_reinstallation(event):
+def avoid_profile_reinstallation(event):
     profile = re.sub('^profile-', '', event.profile_id)
     assert profile not in FORBIDDEN_PROFILES, \
         'It is not allowed to install the profile {!r}.'.format(profile)
 
     request = getSite().REQUEST
     annotations = IAnnotations(request)
-    key = 'opengever.core:awoid_profile_reinstallation'
+    key = 'opengever.core:avoid_profile_reinstallation'
     if key not in annotations:
         annotations[key] = []
 

--- a/opengever/examplecontent/profiles/default/metadata.xml
+++ b/opengever/examplecontent/profiles/default/metadata.xml
@@ -1,5 +1,2 @@
 <metadata>
-  <dependencies>
-    <dependency>profile-plonetheme.teamraum:gever</dependency>
-  </dependencies>
 </metadata>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/metadata.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/metadata.xml
@@ -1,6 +1,5 @@
 <metadata>
   <dependencies>
-    <dependency>profile-plonetheme.teamraum:gever</dependency>
     <dependency>profile-ftw.tika:default</dependency>
   </dependencies>
 </metadata>

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -30,8 +30,6 @@ BASE_PROFILES = (
     'opengever.policy.base:mimetype',
 )
 
-MIMETYPE_FIX_PROFILE = 'profile-opengever.policy.base:mimetype'
-
 
 class GeverDeployment(object):
 
@@ -145,8 +143,6 @@ class GeverDeployment(object):
         stool = getToolByName(self.site, 'portal_setup')
         stool.runAllImportStepsFromProfile(
             'profile-{}'.format(policy_profile))
-        # fix mime-type definitions by overriding temaraum-theme mimetypes
-        stool.runAllImportStepsFromProfile(MIMETYPE_FIX_PROFILE)
 
     def configure_plone_site(self):
         # configure mail settings

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -10,11 +10,12 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
 from Products.CMFPlone.factory import addPloneSite
 from Products.CMFPlone.utils import getToolByName
-from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin  # noqa
 from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from sqlalchemy import MetaData
 from zope.component import getAdapter
 from zope.component import getUtility
+
 
 # these profiles will be installed automatically
 EXTENSION_PROFILES = (
@@ -22,6 +23,12 @@ EXTENSION_PROFILES = (
     'plonetheme.sunburst:default',
 )
 
+# these profiles must always be installed in that order
+BASE_PROFILES = (
+    'opengever.core:default',
+    'plonetheme.teamraum:gever',
+    'opengever.policy.base:mimetype',
+)
 
 MIMETYPE_FIX_PROFILE = 'profile-opengever.policy.base:mimetype'
 
@@ -64,7 +71,7 @@ class GeverDeployment(object):
     def setup_plone_site(self):
         config = self.config
         ext_profiles = list(EXTENSION_PROFILES)
-        ext_profiles.append(config['base_profile'])
+        ext_profiles.extend(BASE_PROFILES)
 
         return addPloneSite(
             self.context,

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -20,11 +20,6 @@ class IDeploymentDirective(Interface):
         description=u'Displayed in deployment selection dropdown.',
         required=True)
 
-    base_profile = TextLine(
-        title=u'Base Profile',
-        default=u'opengever.core:default',
-        required=True)
-
     policy_profile = TextLine(
         title=u'Policy Profile',
         required=True)


### PR DESCRIPTION
The profiles

- `opengever.core:default`
- `plonetheme.teamraum:gever`
- `opengever.policy.base:mimetype`

must always be installed in that exact order and are always the first profiles that were listed in a policy's `metadata.xml`. This is an unnecessary duplication, so with this PR we hard-code the to be installed profiles. Also remove the option `base_profile` for the policy directives.

When this PR is merged it is no longer necessary to include the profiles manually in each policy. Also policies will most likely fail if they have incorrect dependencies sine https://github.com/4teamwork/opengever.core/pull/2570 introduced a check to avoid duplicate profile installation.