### PR TITLE
Implement and enable the org unit selector etag adapter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Implement and enable the org unit selector etag adapter. [phgross]
 - Add api_group deployment configuration option. [deiferni]
 - Merge Generic Setup profiles into a new opengever.core:default profile. [phgross]
 - Replace the AutocompleteField(Multi)Widget with the KeywordWidget. This makes the AutocompleteWidget obsolete. [mathias.leimgruber]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -130,6 +130,7 @@
     <value purge="False">
       <element>tabbedview</element>
       <element>quotawarning</element>
+      <element>ouselector</element>
     </value>
   </record>
 
@@ -137,6 +138,7 @@
     <value purge="False">
       <element>tabbedview</element>
       <element>quotawarning</element>
+      <element>ouselector</element>
     </value>
   </record>
 

--- a/opengever/core/upgrades/20170606112029_include_orgunit_selector_e_tag_to_cache_rules/registry.xml
+++ b/opengever/core/upgrades/20170606112029_include_orgunit_selector_e_tag_to_cache_rules/registry.xml
@@ -1,0 +1,15 @@
+<registry>
+
+  <record name="plone.app.caching.weakCaching.plone.content.itemView.etags">
+    <value purge="False">
+      <element>ouselector</element>
+    </value>
+  </record>
+
+  <record name="plone.app.caching.weakCaching.plone.content.folderView.etags">
+    <value purge="False">
+      <element>ouselector</element>
+    </value>
+  </record>
+
+</registry>

--- a/opengever/core/upgrades/20170606112029_include_orgunit_selector_e_tag_to_cache_rules/upgrade.py
+++ b/opengever/core/upgrades/20170606112029_include_orgunit_selector_e_tag_to_cache_rules/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class IncludeOrgunitSelectorETagToCacheRules(UpgradeStep):
+    """Include orgunit selector eTag to cache rules.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/ogds/base/tests/test_viewlet_ou_selector.py
+++ b/opengever/ogds/base/tests/test_viewlet_ou_selector.py
@@ -2,7 +2,9 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import FunctionalTestCase
+from plone.app.caching.interfaces import IETagValue
 from plone.app.testing import TEST_USER_ID
+from zope.component import getMultiAdapter
 
 
 class TestOrgUnitSelectorViewletIsAvailable(FunctionalTestCase):
@@ -142,3 +144,19 @@ class TestOrgUnitSelectorViewlet(FunctionalTestCase):
         active_unit = browser.css('.orgunitMenu dt a')
         self.assertEquals(
             ['Client 4'], active_unit.text)
+
+    def test_etag_value_returns_current_org_unit_id(self):
+        view = self.repo_root.unrestrictedTraverse('@@view')
+        self.assertEquals('client1', self.get_etag_value_for(view))
+
+        self.portal.REQUEST['unit_id'] = 'client4'
+        self.portal.unrestrictedTraverse('change_org_unit')()
+
+        view = self.repo_root.unrestrictedTraverse('@@view')
+        self.assertEquals('client4', self.get_etag_value_for(view))
+
+    def get_etag_value_for(self, view):
+        adapter = getMultiAdapter((view, self.request),
+                                  IETagValue,
+                                  name='ouselector')
+        return adapter()

--- a/opengever/ogds/base/viewlets/configure.zcml
+++ b/opengever/ogds/base/viewlets/configure.zcml
@@ -9,4 +9,9 @@
       permission="zope2.View"
       />
 
+  <adapter
+      factory=".ou_selector_viewlet.OrgUnitSelectorETagValue"
+      name="ouselector"
+      />
+
 </configure>

--- a/opengever/ogds/base/viewlets/ou_selector_viewlet.py
+++ b/opengever/ogds/base/viewlets/ou_selector_viewlet.py
@@ -1,9 +1,12 @@
 from five import grok
 from opengever.ogds.base.utils import get_ou_selector
 from opengever.ogds.base.utils import ogds_service
+from plone.app.caching.interfaces import IETagValue
 from plone.app.layout.viewlets import common
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from sqlalchemy.exc import OperationalError
+from zope.component import adapts
+from zope.interface import implements
 from zope.interface import Interface
 import logging
 
@@ -47,3 +50,15 @@ class ChangeOrgUnitView(grok.View):
             get_ou_selector().set_current_unit(unit_id)
 
         return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+
+class OrgUnitSelectorETagValue(object):
+    implements(IETagValue)
+    adapts(Interface, Interface)
+
+    def __init__(self, published, request):
+        self.published = published
+        self.request = request
+
+    def __call__(self):
+        return get_ou_selector().get_current_unit().id()


### PR DESCRIPTION
This changes includes the current orgunit id to the plone.app.caching etags, to make sure the site is only served by cache when the current org_unit has not been changed.