### PR TITLE
Handle unknown asynchronous tooltip response.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 
 2017.4.1 (unreleased)
 ---------------------
+- Handle unknown asynchronous tooltip response. [Kevin Bieri]
 - Update ftw.keyowordwidget to 1.3.3, to fix a problem while select/search new keywords. [mathias.leimgruber]
 - Upgrade ftw.zopemaster which uses the new ftw.slacker for slack notifications. [elioschmutz]
 - Refactor the function: earliest_possible_end_date. [elioschmutz]

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -12,10 +12,10 @@
       my: "center left",
       adjust: {
         mouse: false, // Do not track the mouse
-        x: 20, // Slighly shift the location in x direction
-        y: 20 // Slighly shift the location in y direction
+        x: 20, // Slightly shift the location in x direction
+        y: 20 // Slightly shift the location in y direction
       },
-      effect: false // Do not animate the tooltip loaction changes
+      effect: false // Do not animate the tooltip location changes
     },
     show: {
       solo: true, // Make sure that only one tooltip is visible

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -35,16 +35,24 @@
 
   function spinner() { return '<img src="' + $("head > base").attr("href") + '/spinner.gif" class="spinner"/>'; }
 
-  function failure(status, error) { return status + ": " + error; }
+  function isTooltipResponse(data, status, jqXHR) {
+    if(jqXHR.getResponseHeader('X-Tooltip-Response') !== "True") {
+      return $.Deferred().reject(jqXHR, "error");
+    }
+    return $.Deferred().resolve(data, status, jqXHR);
+  }
 
   function tooltipContent(event, api) {
     $.get($(event.currentTarget).data("tooltip-url"))
+      .pipe(isTooltipResponse)
       .done(function(data) {
         api.set("content.text", data);
         $(document).trigger("tooltip.show", [api]);
         $(".showroom-reference").on("click", function() { api.hide(); });
       })
-      .fail(function(xhr, status, error) { api.set("content.text", failure(status, error)); });
+      .fail(function() {
+        location.reload();
+      });
     return spinner();
   }
 

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -8,3 +8,4 @@ class TooltipView(ActionButtonRendererMixin):
     def __init__(self, context, request):
         super(TooltipView, self).__init__(context, request)
         self.document = IContentListingObject(self.context)
+        self.request.response.setHeader('X-Tooltip-Response', True)


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2825

The tooltip may call the content with a logged out user. This leads
to an unwanted rendering of the whole login page in the tooltip.

So add a response header to make sure the response is a true tooltip response
and redirect the user to the login page with a simple reload.