### PR TITLE
Switch back to the original plone.formwidget.autocomplete package.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Disbale swfobject.js - no longer load Flash Fallback for multiuploads. [mathias.leimgruber]
 - Add missing contacts only sources, used by customer special dossiers. [phgross]
 - Reset journal after copy a document. [mathias.leimgruber]
+- Switch back to the orginal plone.formwidget.autocomplete package from our fork. [phgross]
 - Fix task assign form: Only users and the inbox of the current user is selectable. [mathias.leimgruber]
 - Fix for OGIP 15: no longer make a deepcopy of the payload. [mathias.leimgruber]
 - Render subdossier tree collapsed initially. [Kevin Bieri]

--- a/opengever/core/profiles/default/cssregistry.xml
+++ b/opengever/core/profiles/default/cssregistry.xml
@@ -1,0 +1,8 @@
+<object name="portal_css">
+
+  <stylesheet
+      remove="True"
+      id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.css"
+      />
+
+</object>

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -417,4 +417,14 @@
       enabled="False"
       />
 
+  <javascript
+      id="++resource++plone.formwidget.autocomplete/formwidget-autocomplete.js"
+      insert-after="collective.js.jqueryui.custom.min.js"
+      />
+
+  <javascript
+      id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.min.js"
+      insert-after="collective.js.jqueryui.custom.min.js"
+      />
+
 </object>

--- a/opengever/core/upgrades/20170608134918_change_to_original_plone_formwidget_autocomplete/cssregistry.xml
+++ b/opengever/core/upgrades/20170608134918_change_to_original_plone_formwidget_autocomplete/cssregistry.xml
@@ -1,0 +1,8 @@
+<object name="portal_css">
+
+  <stylesheet
+      remove="True"
+      id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.css"
+      />
+
+</object>

--- a/opengever/core/upgrades/20170608134918_change_to_original_plone_formwidget_autocomplete/jsregistry.xml
+++ b/opengever/core/upgrades/20170608134918_change_to_original_plone_formwidget_autocomplete/jsregistry.xml
@@ -1,0 +1,19 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      id="++resource++plone.formwidget.autocomplete/formwidget-autocomplete.js"
+      insert-after="collective.js.jqueryui.custom.min.js"
+      />
+
+  <javascript
+      id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.min.js"
+      insert-after="collective.js.jqueryui.custom.min.js"
+      />
+
+  <javascript
+      remove="True"
+      id="++resource++formwidget-autocomplete.js"
+      />
+
+
+</object>

--- a/opengever/core/upgrades/20170608134918_change_to_original_plone_formwidget_autocomplete/upgrade.py
+++ b/opengever/core/upgrades/20170608134918_change_to_original_plone_formwidget_autocomplete/upgrade.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ChangeToOriginalPloneFormwidgetAutocomplete(UpgradeStep):
+    """Change to original plone.formwidget.autocomplete.
+    """
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-plone.formwidget.autocomplete:default')
+        self.install_upgrade_profile()

--- a/sources.cfg
+++ b/sources.cfg
@@ -15,10 +15,12 @@ development-packages =
 auto-checkout = ${buildout:development-packages}
 
 [sources]
-plone.formwidget.autocomplete = git git@git.4teamwork.ch:opengever/plone.formwidget.autocomplete.git  branch=${branches:plone.formwidget.autocomplete}
 Products.LDAPUserFolder = git git@github.com:4teamwork/Products.LDAPUserFolder.git  branch=${branches:Products.LDAPUserFolder}
 Products.LDAPMultiPlugins = git git@github.com:4teamwork/Products.LDAPMultiPlugins.git  branch=${branches:Products.LDAPMultiPlugins}
 
 [branches]
 Products.LDAPUserFolder = ftw
 Products.LDAPMultiPlugins = ftw
+
+[versions]
+plone.formwidget.autocomplete = 1.2.5


### PR DESCRIPTION
Since the OGIP 15 task responsible rework, it's no longer necessary to dynamically change the data source on task responsible fields. Therefore our fork of the `plone.formwidget.autocomplete` is no longer necessary.

This change should allow us to switch to the latests plone 4.3.x release.

Styles: https://github.com/4teamwork/plonetheme.teamraum/pull/555

Closes #1152 