### PR TITLE
Added missing cancel button for the manual journal entry form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Added missing cancel button for the manual journal entry form. [phgross]
 - XSS: Escape html for manual journal entries' comment. [tarnap]
 - Allow move items in the documents tab within the templatefolder. [elioschmutz]
 - XSS: Escape html for Dossier title on task listing. [mathias.leimgruber]

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -83,6 +83,10 @@ class ManualJournalEntryAddForm(AddForm):
         return self.request.RESPONSE.redirect(
             '{}#journal'.format(self.context.absolute_url()))
 
+    def updateActions(self):
+        super(ManualJournalEntryAddForm, self).updateActions()
+        self.actions['add'].addClass("context")
+
     def createAndAdd(self, data):
         contacts, users = self.split_contacts_and_users(data.get('contacts'))
         entry = ManualJournalEntry(self.context,

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -4,9 +4,12 @@ from opengever.contact.sources import ContactsSourceBinder
 from opengever.journal import _
 from opengever.journal.entry import ManualJournalEntry
 from plone.autoform.widgets import ParameterizedWidget
+from plone.dexterity.i18n import MessageFactory as pd_mf
 from plone.directives import form
+from z3c.form import button
 from z3c.form.field import Fields
 from z3c.form.form import AddForm
+from z3c.form.i18n import MessageFactory as z3c_mf
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
@@ -63,6 +66,22 @@ class ManualJournalEntryAddForm(AddForm):
         KeywordWidget,
         async=True
     )
+
+    @button.buttonAndHandler(z3c_mf('Add'), name='add')
+    def handleAdd(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+        obj = self.createAndAdd(data)
+        if obj is not None:
+            # mark only as finished if we get the new object
+            self._finishedAdd = True
+
+    @button.buttonAndHandler(pd_mf(u'Cancel'), name='cancel')
+    def handleCancel(self, action):
+        return self.request.RESPONSE.redirect(
+            '{}#journal'.format(self.context.absolute_url()))
 
     def createAndAdd(self, data):
         contacts, users = self.split_contacts_and_users(data.get('contacts'))

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -158,3 +158,11 @@ class TestManualJournalEntry(FunctionalTestCase):
         self.assertEquals(
             ['Test A'],
             browser.css('#form-widgets-related_documents-autocomplete .option').text)
+
+    @browsing
+    def test_cancel_the_form_redirects_back_to_journal_tab(self, browser):
+        browser.login().open(self.dossier, view='add-journal-entry')
+        browser.css('#form-buttons-cancel').first.click()
+
+        self.assertEquals(
+            '{}#journal'.format(self.dossier.absolute_url()), browser.url)


### PR DESCRIPTION
Because z3c.form could not handle the inherited add and the new cancel button, also the add button hat do be defined by the `ManualJournalEntryAddForm` itself.

Besides that I've also fixed the styling of the add button.