### PR TITLE
Add missing contacts source

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Add missing contacts only sources, used by customer special dossiers. [phgross]
 - Fix task assign form: Only users and the inbox of the current user is selectable. [mathias.leimgruber]
 - Fix for OGIP 15: no longer make a deepcopy of the payload. [mathias.leimgruber]
 - Render subdossier tree collapsed initially. [Kevin Bieri]


### PR DESCRIPTION
This source is not used directly by opengever.core features but used in different customer special dossiers.

This change allow us to consequently use `ftw.keywordwidget` instead of the `plone.formwidget.autocomplete`.