### PR TITLE
Fix "leave GEVER" on logout overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Fix "leave GEVER" on logout overlay. [mathias.leimgruber]
 - Add missing contacts only sources, used by customer special dossiers. [phgross]
 - Fix task assign form: Only users and the inbox of the current user is selectable. [mathias.leimgruber]
 - Fix for OGIP 15: no longer make a deepcopy of the payload. [mathias.leimgruber]

--- a/opengever/document/browser/templates/logout_overlay.pt
+++ b/opengever/document/browser/templates/logout_overlay.pt
@@ -16,6 +16,6 @@
       </ul>
       <input type="hidden" class="logout_overlay_redirect" name="form.redirect.url"
              tal:attributes="value view/redirect_url" />
-      <input type="submit" class="logout_overlay_submit" name="form.submitted"
-             value="Logout" class="destructive" i18n:attributes="value"/>
+      <input type="submit" name="form.submitted"
+             value="Logout" class=" logout_overlay_submit destructive" i18n:attributes="value"/>
 </form>


### PR DESCRIPTION
The `class` attribute was defined twice in the template, which lead the Chameleon engine to just drop this attribute.

![logout](https://user-images.githubusercontent.com/437933/27172358-39534be2-51b5-11e7-973b-66c7c6bc93d2.gif)


Fixes #2964 
