### PR TITLE
Disbale swfobject.js - no longer load Flash fallback for multiuploads.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix "leave GEVER" on logout overlay. [mathias.leimgruber]
+- Disbale swfobject.js - no longer load Flash Fallback for multiuploads. [mathias.leimgruber]
 - Add missing contacts only sources, used by customer special dossiers. [phgross]
 - Fix task assign form: Only users and the inbox of the current user is selectable. [mathias.leimgruber]
 - Fix for OGIP 15: no longer make a deepcopy of the payload. [mathias.leimgruber]

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -412,4 +412,9 @@
       inline="False"
       />
 
+  <javascript
+      id="++resource++quickupload_static/swfobject.js"
+      enabled="False"
+      />
+
 </object>

--- a/opengever/core/upgrades/20170615114951_disable_swfobject_js_from_c_quickupload/jsregistry.xml
+++ b/opengever/core/upgrades/20170615114951_disable_swfobject_js_from_c_quickupload/jsregistry.xml
@@ -1,0 +1,8 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      id="++resource++quickupload_static/swfobject.js"
+      enabled="False"
+      />
+
+</object>

--- a/opengever/core/upgrades/20170615114951_disable_swfobject_js_from_c_quickupload/upgrade.py
+++ b/opengever/core/upgrades/20170615114951_disable_swfobject_js_from_c_quickupload/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DisableSwfobjectJsFromCQuickupload(UpgradeStep):
+    """Disable swfobject.js from c.quickupload.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
I was no able to recognise any negative effects after disabling the swfobjects.js

There's no JS error in the console of IE11, FF, Chrome.

To completely remove Flash from GEVER, this PR https://github.com/4teamwork/collective.js.extjs/pull/3 is also needed.