### PR TITLE
Fix PrivateFolders Title encoding.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Fix PrivateFolders Title encoding. [phgross]
 - Fix "leave GEVER" on logout overlay. [mathias.leimgruber]
 - Add missing contacts only sources, used by customer special dossiers. [phgross]
 - Fix task assign form: Only users and the inbox of the current user is selectable. [mathias.leimgruber]

--- a/opengever/core/upgrades/20170616071527_make_private_folders_title_a_string/upgrade.py
+++ b/opengever/core/upgrades/20170616071527_make_private_folders_title_a_string/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.upgrade import UpgradeStep
+from opengever.private.folder import IPrivateFolder
+
+
+class MakePrivateFoldersTitleAString(UpgradeStep):
+    """Make PrivateFolders Title a string.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        query = {'object_provides': IPrivateFolder.__identifier__}
+        for obj in self.objects(query, 'Reindex PrivateFolders title'):
+            obj.reindexObject(idxs=['Title', 'sortable_title'])

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -21,7 +21,7 @@ class PrivateFolder(Container):
     """
 
     def Title(self):
-        return Actor.lookup(self.id).get_label(self)
+        return Actor.lookup(self.id).get_label(self).encode('utf-8')
 
     def notifyMemberAreaCreated(self):
         """Add additional local_roles to the members folder.

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -29,8 +29,11 @@ class TestPrivateFolder(FunctionalTestCase):
     def test_object_id_is_userid(self):
         self.assertEquals(TEST_USER_ID, self.folder.getId())
 
-    def test_title_is_corresponding_users_label(self):
+    def test_Title_is_corresponding_users_label(self):
         self.assertEquals('Test User (test_user_1_)', self.folder.Title())
+
+    def test_Title_returns_string(self):
+        self.assertTrue(isinstance(self.folder.Title(), str))
 
     def test_uses_userid_as_reference_number_part(self):
         self.assertEquals('Client1 test_user_1_',


### PR DESCRIPTION
The Title accessor needs to return bytestring not unicode. The users label is always unicode.

Needs backport to: 2017.2-stable


🐷  already filled 😉 