### PR TITLE
Show userid instead of E-Mail address on responsible field of dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Include missing permission definitions from Products.CMFCore. [phgross]
 - Fix PrivateFolders Title encoding. [phgross]
+- Show userid instead of E-Mail address on all sources (except EMailSource). [mathias.leimgruber]
 - Fix "leave GEVER" on logout overlay. [mathias.leimgruber]
 - Disbale swfobject.js - no longer load Flash Fallback for multiuploads. [mathias.leimgruber]
 - Add missing contacts only sources, used by customer special dossiers. [phgross]

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -558,7 +558,7 @@ class TestTemplateFolder(FunctionalTestCase):
         factoriesmenu.add('Template Folder')
 
         self.assertEqual(
-            'Test User (test@example.org)',
+            'Test User (test_user_1_)',
             browser.css('#formfield-form-widgets-IDossier-responsible option[selected]').first.text
             )
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -97,7 +97,7 @@ class AllUsersAndInboxesSource(object):
         token = u'{}:{}'.format(orgunit_id, userid)
         title = u'{}: {} ({})'.format(orgunit.title,
                                       user.fullname(),
-                                      user.email)
+                                      user.userid)
         return SimpleTerm(value, token, title)
 
     def getTermByToken(self, token):
@@ -238,7 +238,7 @@ class UsersContactsInboxesSource(AllUsersAndInboxesSource):
 
         token = value
         title = u'{} ({})'.format(user.fullname(),
-                                  user.email)
+                                  user.userid)
         return SimpleTerm(value, token, title)
 
     def getTermByToken(self, token):
@@ -328,7 +328,7 @@ class AssignedUsersSource(AllUsersAndInboxesSource):
 
         token = value
         title = u'{} ({})'.format(user.fullname(),
-                                  user.email)
+                                  user.userid)
         return SimpleTerm(value, token, title)
 
     def search(self, query_string):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -53,7 +53,7 @@ class TestAllUsersAndInboxesSource(FunctionalTestCase):
     def test_get_term_by_token(self):
         term = self.source.getTermByToken(u'unit1:hans')
         self.assertTrue(isinstance(term, SimpleTerm))
-        self.assertEquals(u'Informatik: Peter Hans (test@example.org)',
+        self.assertEquals(u'Informatik: Peter Hans (hans)',
                           term.title)
 
     def test_get_term_by_token_raises_BadRequest_if_no_token(self):
@@ -73,7 +73,7 @@ class TestAllUsersAndInboxesSource(FunctionalTestCase):
         self.assertEqual(1, len(result), 'Expect one result. only John')
         self.assertEquals(u'unit1:john', result[0].token)
         self.assertEquals(u'unit1:john', result[0].value)
-        self.assertEquals(u'Informatik: Doe John (test@example.org)',
+        self.assertEquals(u'Informatik: Doe John (john)',
                           result[0].title)
 
     def test_users_in_result_are_ordered_by_user_lastname_and_firstname(self):
@@ -268,7 +268,7 @@ class TestUsersContactsInboxesSource(FunctionalTestCase):
         term = self.source.getTermByToken('hugo.boss')
         self.assertEquals('hugo.boss', term.token)
         self.assertEquals('hugo.boss', term.value)
-        self.assertEquals('Boss Hugo (test@example.org)', term.title)
+        self.assertEquals('Boss Hugo (hugo.boss)', term.title)
 
     def test_inboxes_are_valid(self):
         self.assertIn('inbox:client1', self.source)
@@ -343,7 +343,7 @@ class TestAssignedUsersSource(FunctionalTestCase):
     def test_get_term_by_token(self):
         term = self.source.getTermByToken(u'hugo.boss')
         self.assertTrue(isinstance(term, SimpleTerm))
-        self.assertEquals(u'User Test (test@example.org)', term.title)
+        self.assertEquals(u'User Test (hugo.boss)', term.title)
 
     def test_get_term_by_token_raises_BadReques_if_no_token(self):
         with self.assertRaises(LookupError):
@@ -358,7 +358,7 @@ class TestAssignedUsersSource(FunctionalTestCase):
         self.assertEqual(1, len(result), 'Expect one result. only Hugo')
         self.assertEquals(u'hugo.boss', result[0].token)
         self.assertEquals(u'hugo.boss', result[0].value)
-        self.assertEquals(u'User Test (test@example.org)', result[0].title)
+        self.assertEquals(u'User Test (hugo.boss)', result[0].title)
 
     def test_only_users_of_the_current_admin_unit_are_valid(self):
 


### PR DESCRIPTION
<img width="814" alt="screen shot 2017-06-16 at 08 45 28" src="https://user-images.githubusercontent.com/437933/27215185-5bdac0f8-5270-11e7-9149-141c5a9d3ce7.png">


Fixes #3022