### PR TITLE
Catch up tests with ftw.testbrowser bugfix.

### DIFF
--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -158,13 +158,12 @@ class TestProtocol(FunctionalTestCase):
     def test_protocol_is_generated_when_closing_meetings(self, browser):
         self.setup_protocol(browser)
 
-        self.assertFalse(browser.context.model.has_protocol_document())
+        self.assertFalse(self.meeting.has_protocol_document())
 
         browser.find('Close meeting').click()
 
-        browser.open(self.meeting.get_url())
-
-        self.assertTrue(browser.context.model.has_protocol_document())
+        meeting = Meeting.query.get(self.meeting.meeting_id)
+        self.assertTrue(meeting.has_protocol_document())
 
     @browsing
     def test_protocol_shows_validation_errors(self, browser):


### PR DESCRIPTION
In https://github.com/4teamwork/ftw.testbrowser/pull/55 a bug has been fixed where the view would be exposed as `browser.context`. Unfortunately a test actually relied on that behaviour 😂 . This PR rewrites the test to only test against the model.

_CL should not be required i'd say_