### PR TITLE
Include missing permission definitions from Products.CMFCore.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Include missing permission definitions from Products.CMFCore. [phgross]
 - Fix PrivateFolders Title encoding. [phgross]
 - Fix "leave GEVER" on logout overlay. [mathias.leimgruber]
 - Disbale swfobject.js - no longer load Flash Fallback for multiuploads. [mathias.leimgruber]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -13,6 +13,8 @@
 
   <meta:provides feature="opengever" />
 
+  <include package="Products.CMFCore" file="permissions.zcml" />
+
   <include package="plone.app.workflow" />
   <include package="plone.behavior" file="meta.zcml" />
   <include package="plone.directives.form" />


### PR DESCRIPTION
This allow us to include opengever.core zcmls from a policy packages, which has to be loaded before opengever.core so that customized translations works correctly.