### PR TITLE
Add integration testing layer with fixture.

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -4,6 +4,7 @@ from ftw.builder import session
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import set_builder_session_factory
 from ftw.bumblebee.tests.helpers import BumblebeeTestTaskQueue
+from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
 from ftw.testing import ComponentRegistryLayer
 from ftw.testing import TransactionInterceptor
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
@@ -493,5 +494,5 @@ class GEVERIntegrationTesting(IntegrationTesting):
 OPENGEVER_INTEGRATION_TESTING = GEVERIntegrationTesting(
     # Warning: do not try to base other layers on ContentFixtureLayer.
     # See docstring of ContentFixtureLayer.
-    bases=(ContentFixtureLayer(), ),
+    bases=(ContentFixtureLayer(), TRAVERSAL_BROWSER_FIXTURE),
     name="opengever.core:integration")

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -439,7 +439,7 @@ class ContentFixtureLayer(OpengeverFixture):
         # Avoid circular imports:
         from opengever.testing.fixtures import OpengeverContentFixture
         setRequest(portal.REQUEST)
-        OpengeverContentFixture()()
+        self['fixture_lookup_table'] = OpengeverContentFixture()()
         setRequest(None)
 
     def tearDown(self):

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -401,15 +401,15 @@ class ContentFixtureLayer(OpengeverFixture):
     Builder session:
     ftw.builder provides testing layers and functions for using builders within
     tests.
-    It does not provide infrastructure for setting up buliders in layer setup.
+    It does not provide infrastructure for setting up builders in layer setup.
     Therefore we cannot reuse ftw.builder's testing layers but configure the
     builder manually in a non-committing integration testing mode.
 
     Warning:
     Do not create another fixture layer based on this fixture layer.
     It won't work without fixing transactionality issues.
-    The current setup works because the fixture state is commited to the database.
-    Commited state cannot be rolled back.
+    The current setup works because the fixture state is committed to the database.
+    Committed state cannot be rolled back.
     Uncommitted state will get lost when IntegrationTesting.testSetUp begins
     a new transaction.
     """
@@ -449,7 +449,7 @@ class ContentFixtureLayer(OpengeverFixture):
 
     def allowAllTypes(self, portal):
         """In the fixture layer, the fixture objects should be used and
-        we want them to be at the correct place hirearchically.
+        we want them to be at the correct place hierarchically.
         When additional objects need to be created anyway, they can be placed
         in the correct spot easily by using the fixture objects as parents.
         Therefore we do not allow to create objects at the portal.
@@ -460,7 +460,7 @@ class ContentFixtureLayer(OpengeverFixture):
 class GEVERIntegrationTesting(IntegrationTesting):
     """Custom integration testing extension:
     1. Make savepoint at test begin and rollback after the test.
-    2. Prevent all interaction with transactions, primarely in order to avoid
+    2. Prevent all interaction with transactions, primarily in order to avoid
        having data committed which can then not be rolled back anymore.
     """
 

--- a/opengever/core/tests/test_fixture.py
+++ b/opengever/core/tests/test_fixture.py
@@ -1,0 +1,14 @@
+from DateTime import DateTime
+from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
+
+
+class TestTestingFixture(IntegrationTestCase):
+
+    def test_ordnungssystem_has_static_creation_date(self):
+        self.assertEquals(DateTime('2016/08/31 09:01:33 GMT+2'),
+                          self.repository_root.created())
+
+    def test_ordnungssystem_has_static_uuid(self):
+        self.assertEquals('repotree000000000000000000000001',
+                          IUUID(self.repository_root))

--- a/opengever/core/tests/test_fixture.py
+++ b/opengever/core/tests/test_fixture.py
@@ -1,14 +1,54 @@
 from DateTime import DateTime
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
+from opengever.repository.interfaces import IRepositoryFolder
 from opengever.testing import IntegrationTestCase
 from plone.uuid.interfaces import IUUID
 
 
 class TestTestingFixture(IntegrationTestCase):
 
-    def test_ordnungssystem_has_static_creation_date(self):
+    def test_administrator_user(self):
+        self.assertEquals('nicole.kohler', self.administrator.getId())
+        self.assertIn('Administrator', self.administrator.getRoles())
+
+    def test_repository_root_has_static_creation_date(self):
         self.assertEquals(DateTime('2016/08/31 09:01:33 GMT+2'),
                           self.repository_root.created())
 
-    def test_ordnungssystem_has_static_uuid(self):
-        self.assertEquals('repotree000000000000000000000001',
+    def test_repository_root_has_static_uuid(self):
+        self.assertEquals('createrepositorytree000000000001',
                           IUUID(self.repository_root))
+
+    @browsing
+    def test_repository_root_view_renders(self, browser):
+        browser.login(self.administrator).open(self.repository_root)
+        self.assertEquals('Ordnungssystem', plone.first_heading())
+
+    def test_leaf_repository_has_no_subrepositories(self):
+        self.assertFalse(
+            filter(IRepositoryFolder.providedBy,
+                   self.leaf_repository.objectValues()),
+            'The "leaf repository" {!r} should not have sub'
+            ' repositories as it wouldnt be a "leaf" anymore.'.format(
+                self.leaf_repository))
+
+    def test_branch_repository_has_subrepositories(self):
+        self.assertTrue(
+            filter(IRepositoryFolder.providedBy,
+                   self.branch_repository.objectValues()),
+            'The "branch repository" {!r} must have sub'
+            ' repositories as it wouldnt be a "branch" anymore.'.format(
+                self.branch_repository))
+
+    def test_dossiers(self):
+        """This test makes sure that the objects are not acceidentally
+        scrambled up when fiddling with the fixture.
+        It also tests that the content attributes are available on the
+        test case.
+        """
+        self.login(self.dossier_responsible)
+        self.assertEquals('Vertr\xc3\xa4ge mit der kantonalen Finanzverwaltung',
+                          self.dossier.Title())
+        self.assertEquals('2016', self.subdossier.Title())
+        self.assertEquals('Archiv Vertr\xc3\xa4ge', self.archive_dossier.Title())

--- a/opengever/core/tests/test_integration_testing_setup.py
+++ b/opengever/core/tests/test_integration_testing_setup.py
@@ -1,0 +1,51 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.ogds.base.utils import ogds_service
+from opengever.testing import IntegrationTestCase
+import transaction
+
+
+class TestIntegrationTestSetup(IntegrationTestCase):
+
+    def test_zodb_changes_are_isolated_1(self):
+        self.assertEquals(
+            'Repository Root', self.repository_root.Title(),
+            'ZODB changes seem not to be isolated between tests.')
+        self.repository_root.title_de = 'Changed Repository Root Title'
+        self.assertEquals('Changed Repository Root Title',
+                          self.repository_root.Title())
+
+    test_zodb_changes_are_isolated_2 = test_zodb_changes_are_isolated_1
+
+    def test_sql_changes_are_isolated_1(self):
+        args = {
+            'firstname': u'Leak',
+            'lastname': u'Officer',
+            'userid': 'leak.officer',
+            'email': 'leak@officer.local',
+        }
+        self.assertFalse(
+            ogds_service().fetch_user(args['userid']),
+            'SQL changes seem not to be isolated between tests.')
+        create(Builder('ogds_user').having(**args))
+        self.assertTrue(ogds_service().fetch_user(args['userid']))
+
+    test_sql_changes_are_isolated_2 = test_sql_changes_are_isolated_1
+
+    def test_rollback_nested_sql_savepoints(self):
+        args = {
+            'firstname': u'Transaction',
+            'lastname': u'Manager',
+            'userid': 'transaction.manager',
+        }
+        self.assertFalse(
+            ogds_service().fetch_user(args['userid']),
+            'Opps, there is already a user {!r}'.format(args['userid']))
+
+        savepoint = transaction.savepoint()
+        create(Builder('ogds_user').having(**args))
+        self.assertTrue(ogds_service().fetch_user(args['userid']))
+        savepoint.rollback()
+        self.assertFalse(
+            ogds_service().fetch_user(args['userid']),
+            'Could not rollback SQL properly.')

--- a/opengever/core/tests/test_integration_testing_setup.py
+++ b/opengever/core/tests/test_integration_testing_setup.py
@@ -8,8 +8,9 @@ import transaction
 class TestIntegrationTestSetup(IntegrationTestCase):
 
     def test_zodb_changes_are_isolated_1(self):
+        self.login(self.administrator)
         self.assertEquals(
-            'Repository Root', self.repository_root.Title(),
+            'Ordnungssystem', self.repository_root.Title(),
             'ZODB changes seem not to be isolated between tests.')
         self.repository_root.title_de = 'Changed Repository Root Title'
         self.assertEquals('Changed Repository Root Title',
@@ -21,6 +22,7 @@ class TestIntegrationTestSetup(IntegrationTestCase):
     test_zodb_changes_are_isolated_2 = test_zodb_changes_are_isolated_1
 
     def test_sql_changes_are_isolated_1(self):
+        self.login(self.administrator)
         args = {
             'firstname': u'Leak',
             'lastname': u'Officer',
@@ -39,6 +41,7 @@ class TestIntegrationTestSetup(IntegrationTestCase):
     test_sql_changes_are_isolated_2 = test_sql_changes_are_isolated_1
 
     def test_rollback_nested_sql_savepoints(self):
+        self.login(self.administrator)
         args = {
             'firstname': u'Transaction',
             'lastname': u'Manager',

--- a/opengever/core/tests/test_integration_testing_setup.py
+++ b/opengever/core/tests/test_integration_testing_setup.py
@@ -15,6 +15,9 @@ class TestIntegrationTestSetup(IntegrationTestCase):
         self.assertEquals('Changed Repository Root Title',
                           self.repository_root.Title())
 
+    # By duplicating the method pointer on the class this test will be
+    # executed twice. The test is built so that it detects leaks from
+    # a prior run when the isolation does not work.
     test_zodb_changes_are_isolated_2 = test_zodb_changes_are_isolated_1
 
     def test_sql_changes_are_isolated_1(self):
@@ -30,6 +33,9 @@ class TestIntegrationTestSetup(IntegrationTestCase):
         create(Builder('ogds_user').having(**args))
         self.assertTrue(ogds_service().fetch_user(args['userid']))
 
+    # By duplicating the method pointer on the class this test will be
+    # executed twice. The test is built so that it detects leaks from
+    # a prior run when the isolation does not work.
     test_sql_changes_are_isolated_2 = test_sql_changes_are_isolated_1
 
     def test_rollback_nested_sql_savepoints(self):

--- a/opengever/testing/__init__.py
+++ b/opengever/testing/__init__.py
@@ -20,6 +20,7 @@ else:
     from opengever.testing.sql import create_ogds_user
     from opengever.testing.sql import select_current_org_unit
     from opengever.testing.test_case import FunctionalTestCase
+    from opengever.testing.integration_test_case import IntegrationTestCase
     from opengever.testing.test_case import TestCase
     import opengever.testing.testbrowser_datetime_widget
     import opengever.testing.testbrowser_tablechoice_widget

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1,0 +1,43 @@
+from contextlib import contextmanager
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.builder import ticking_creator
+from ftw.testing import freeze
+from ftw.testing import staticuid
+
+
+class OpengeverContentFixture(object):
+
+    def __call__(self):
+        with self.freeze_at_hour(7):
+            self.create_users_and_units()
+
+        with self.freeze_at_hour(8):
+            self.create_repository_tree()
+
+    def create_users_and_units(self):
+        create(Builder('fixture').with_all_unit_setup())
+
+    @staticuid('repotree')
+    def create_repository_tree(self):
+        create(Builder('repository_root').titled('Repository Root'))
+
+    @contextmanager
+    def freeze_at_hour(self, hour):
+        """Freeze the time when creating content with builders, so that
+        we can rely on consistent creation times.
+        Since we can sort consistently when all objects have the exact same
+        creation times we need to move the clock forward whenevery things are
+        created, using ftw.builder's ticking creator in combination with a
+        freezed clock.
+
+        In order to be able to insert new objects in the fixture without
+        scrambling up all timestamps, we group the builders and let each group
+        start at a given hour, moving the clock two minutes for each builder.
+        We move it two minutes because the catalog rounds times sometimes to
+        minute precision and we want to be more precise.
+        """
+        with freeze(datetime(2016, 8, 31, hour, 1, 33)) as clock:
+            with ticking_creator(clock, minutes=2):
+                yield

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -28,12 +28,12 @@ class OpengeverContentFixture(object):
         """Freeze the time when creating content with builders, so that
         we can rely on consistent creation times.
         Since we can sort consistently when all objects have the exact same
-        creation times we need to move the clock forward whenevery things are
+        creation times we need to move the clock forward whenever things are
         created, using ftw.builder's ticking creator in combination with a
-        freezed clock.
+        frozen clock.
 
         In order to be able to insert new objects in the fixture without
-        scrambling up all timestamps, we group the builders and let each group
+        mixing up all timestamps, we group the builders and let each group
         start at a given hour, moving the clock two minutes for each builder.
         We move it two minutes because the catalog rounds times sometimes to
         minute precision and we want to be more precise.

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1,27 +1,109 @@
+from AccessControl.SecurityManagement import getSecurityManager
+from AccessControl.SecurityManagement import setSecurityManager
 from contextlib import contextmanager
+from datetime import date
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder import ticking_creator
 from ftw.testing import freeze
 from ftw.testing import staticuid
+from plone.app.testing import login
+from time import time
+from zope.component.hooks import getSite
 
 
 class OpengeverContentFixture(object):
 
     def __call__(self):
+        start = time()
+
+        with self.freeze_at_hour(6):
+            self.create_units()
+
         with self.freeze_at_hour(7):
-            self.create_users_and_units()
+            self.create_users()
 
         with self.freeze_at_hour(8):
-            self.create_repository_tree()
+            with self.login(self.administrator):
+                self.create_repository_tree()
 
-    def create_users_and_units(self):
-        create(Builder('fixture').with_all_unit_setup())
+        with self.freeze_at_hour(9):
+            with self.login(self.dossier_responsible):
+                self.create_treaty_dossiers()
 
-    @staticuid('repotree')
+        end = time()
+        print '(fixture setup in {}s) '.format(round(end-start, 3)),
+
+    def create_units(self):
+        self.admin_unit = create(
+            Builder('admin_unit')
+            .having(title=u'Hauptmandant',
+                    unit_id=u'plone',
+                    public_url='http://nohost/plone')
+            .as_current_admin_unit())
+
+        self.org_unit = create(
+            Builder('org_unit')
+            .id('fa')
+            .having(title=u'Finanzamt',
+                    admin_unit=self.admin_unit)
+            .with_default_groups()
+            .as_current_org_unit())
+
+    def create_users(self):
+        self.administrator = self.create_user(
+            u'Nicole', u'Kohler', ['Administrator'])
+        self.dossier_responsible = self.create_user(u'Robert', u'Ziegler')
+        self.regular_user = self.create_user(u'K\xe4thi', u'B\xe4rfuss')
+
+    @staticuid()
     def create_repository_tree(self):
-        create(Builder('repository_root').titled('Repository Root'))
+        self.root = create(
+            Builder('repository_root')
+            .having(title_de=u'Ordnungssystem',
+                    title_fr=u'Syst\xe8me de classement'))
+        self.root.manage_setLocalRoles(self.org_unit.users_group_id,
+                                       ('Reader', 'Contributor', 'Editor'))
+        self.root.reindexObjectSecurity()
+
+        self.repo0 = create(
+            Builder('repository').within(self.root)
+            .having(title_de=u'F\xfchrung',
+                    title_fr=u'Direction'))
+
+        self.repo00 = create(
+            Builder('repository').within(self.repo0)
+            .having(title_de=u'Vertr\xe4ge und Vereinbarungen',
+                    title_fr=u'Contrats et accords'))
+
+        self.repo1 = create(
+            Builder('repository').within(self.root)
+            .having(title_de=u'Bev\xf6lkerung und Sicherheit',
+                    title_fr=u'Population et de la s\xe9curit\xe9'))
+
+    @staticuid()
+    def create_treaty_dossiers(self):
+        dossier = create(
+            Builder('dossier').within(self.repo00)
+            .titled(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung')
+            .having(description=u'Alle aktuellen Vertr\xe4ge mit der'
+                    u' kantonalen Finanzverwaltung sind hier abzulegen.'
+                    u' Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                    keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
+                    start=date(2016, 1, 1),
+                    responsible='hugo.boss'))
+        create(Builder('dossier').within(dossier).titled(u'2016'))
+
+        create(
+            Builder('dossier').within(self.repo00)
+            .titled(u'Archiv Vertr\xe4ge')
+            .having(description=u'Archiv der Vertr\xe4ge vor 2016.',
+                    keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
+                    start=date(2000, 1, 1),
+                    end=date(2015, 12, 31),
+                    responsible='hugo.boss')
+            .in_state('dossier-state-resolved')).absolute_url()
 
     @contextmanager
     def freeze_at_hour(self, hour):
@@ -41,3 +123,31 @@ class OpengeverContentFixture(object):
         with freeze(datetime(2016, 8, 31, hour, 1, 33)) as clock:
             with ticking_creator(clock, minutes=2):
                 yield
+
+    def create_user(self, firstname, lastname, globalroles=()):
+        globalroles = ['Member'] + list(globalroles)
+        builder = (
+            Builder('user')
+            .named(firstname, lastname)
+            .with_roles(*globalroles)
+            .in_groups(self.org_unit.users_group_id))
+
+        builder.update_properties()  # updates builder.userid
+        email = '{}@gever.local'.format(builder.userid)
+        plone_user = create(builder.with_email(email))
+
+        create(Builder('ogds_user')
+               .id(plone_user.getId())
+               .having(firstname=firstname, lastname=lastname, email=email)
+               .assign_to_org_units([self.org_unit]))
+
+        return plone_user
+
+    @contextmanager
+    def login(self, user):
+        old_manager = getSecurityManager()
+        try:
+            login(getSite(), user.getId())
+            yield
+        finally:
+            setSecurityManager(old_manager)

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -89,3 +89,20 @@ def obj2paths(objs):
     """Returns a list of paths (string) for the given objects.
     """
     return ['/'.join(obj.getPhysicalPath()) for obj in objs]
+
+
+def flatten_content_lookup_table(input, path_prefix=None):
+    output = {}
+    for name, value in input.items():
+        if isinstance(value, tuple):
+            path, subtable = value
+        else:
+            path, subtable = value, None
+
+        if path_prefix is not None:
+            path = '/'.join((path_prefix, path))
+
+        output[name] = path
+        if subtable is not None:
+            output.update(flatten_content_lookup_table(subtable, path))
+    return output

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -89,20 +89,3 @@ def obj2paths(objs):
     """Returns a list of paths (string) for the given objects.
     """
     return ['/'.join(obj.getPhysicalPath()) for obj in objs]
-
-
-def flatten_content_lookup_table(input, path_prefix=None):
-    output = {}
-    for name, value in input.items():
-        if isinstance(value, tuple):
-            path, subtable = value
-        else:
-            path, subtable = value, None
-
-        if path_prefix is not None:
-            path = '/'.join((path_prefix, path))
-
-        output[name] = path
-        if subtable is not None:
-            output.update(flatten_content_lookup_table(subtable, path))
-    return output

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -1,5 +1,32 @@
+from AccessControl import getSecurityManager
 from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.testing.helpers import flatten_content_lookup_table
+from plone import api
+from plone.app.testing import login
 from unittest2 import TestCase
+
+
+"""The CONTENT_LOOKUP_TABLE is used for looking up objects when accessed as
+attribute in a test.
+In order to keep things organized and paths short, the lookup table is defined
+recursively.
+"""
+CONTENT_LOOKUP_TABLE = flatten_content_lookup_table({
+    'repository_root': 'ordnungssystem',
+    'branch_repository': 'ordnungssystem/fuhrung',
+
+    'leaf_repository': ('ordnungssystem/fuhrung/vertrage-und-vereinbarungen', {
+        'dossier':  ('dossier-1', {
+            'subdossier': 'dossier-2'}),
+        'archive_dossier': 'dossier-3'}),
+})
+
+
+USER_LOOKUP_TABLE = {
+    'administrator': 'nicole.kohler',
+    'dossier_responsible': 'robert.ziegler',
+    'regular_user': 'kathi.barfuss',
+}
 
 
 class IntegrationTestCase(TestCase):
@@ -7,7 +34,32 @@ class IntegrationTestCase(TestCase):
 
     def setUp(self):
         super(IntegrationTestCase, self).setUp()
-        self.portal = portal = self.layer['portal']
+        self.portal = self.layer['portal']
         self.request = self.layer['request']
 
-        self.repository_root = portal['repository-root']
+        self.login(self.regular_user)
+
+    def login(self, user):
+        """Login a user by passing in the user object.
+        Common users are available through the USER_LOOKUP_TABLE.
+
+        Example:
+        >>> self.login(self.dossier_responsible)
+        """
+        login(self.portal, user.getId())
+
+    def __getattr__(self, name):
+        """Make it possible to access objects from the content lookup table
+        directly with attribute access on the test case.
+        """
+        if name in CONTENT_LOOKUP_TABLE:
+            path = CONTENT_LOOKUP_TABLE[name]
+            locals()['__traceback_info__'] = {
+                'path': path,
+                'current user': getSecurityManager().getUser()}
+            return self.portal.restrictedTraverse(path)
+
+        if name in USER_LOOKUP_TABLE:
+            return api.user.get(USER_LOOKUP_TABLE[name])
+
+        return self.__getattribute__(name)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -1,0 +1,13 @@
+from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+from unittest2 import TestCase
+
+
+class IntegrationTestCase(TestCase):
+    layer = OPENGEVER_INTEGRATION_TESTING
+
+    def setUp(self):
+        super(IntegrationTestCase, self).setUp()
+        self.portal = portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        self.repository_root = portal['repository-root']

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -36,14 +36,20 @@ USER_LOOKUP_TABLE = {
 }
 
 
+FEATURE_FLAGS = {
+    'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
+}
+
+
 class IntegrationTestCase(TestCase):
     layer = OPENGEVER_INTEGRATION_TESTING
+    features = ()
 
     def setUp(self):
         super(IntegrationTestCase, self).setUp()
         self.portal = self.layer['portal']
         self.request = self.layer['request']
-
+        map(self.activate_feature, self.features)
         self.login(self.regular_user)
 
     def login(self, user):
@@ -54,6 +60,11 @@ class IntegrationTestCase(TestCase):
         >>> self.login(self.dossier_responsible)
         """
         login(self.portal, user.getId())
+
+    def activate_feature(self, feature):
+        """Activate a feature flag.
+        """
+        api.portal.set_registry_record(FEATURE_FLAGS[feature], True)
 
     def __getattr__(self, name):
         """Make it possible to access objects from the content lookup table

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -19,6 +19,13 @@ CONTENT_LOOKUP_TABLE = flatten_content_lookup_table({
         'dossier':  ('dossier-1', {
             'subdossier': 'dossier-2'}),
         'archive_dossier': 'dossier-3'}),
+
+    'committee': 'opengever-meeting-committeecontainer/committee-1',
+    'committee_container': 'opengever-meeting-committeecontainer',
+
+    'templates': ('vorlagen', {
+        'sablon_template': 'document-1',
+    }),
 })
 
 


### PR DESCRIPTION
The integration testing layer sets up a fixture with commonly used objects.
By setting up a fixture instead of creating all the objects in each test we want to speed up the test suite.

Since we cannot rollback commits in SQL, we use integration testing and avoid unwanted commits so that we can achieve isolation between tests by rolling back to savepoints.

This change provides the infrastructure for building the fixture and gradually switching tests to the new integration testing.

It is a conscious decision to call the new testing "integration testing" and the old testing "functional testing" in order to have a simple language to communicate between developers.