### PR TITLE
Ergänzung Unterkapitels "Einschränkung Metdaten"

### DIFF
--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -15,6 +15,7 @@ Inhalt:
    searching.rst
    workflow.rst
    content_types.rst
+   metadata.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/metadata.rst
+++ b/docs/public/dev-manual/api/metadata.rst
@@ -1,0 +1,57 @@
+.. _metadata:
+
+Einschränkung Metadaten
+=======================
+
+Mit Einschränkung sind Status gemeint, welche bei abnehmender Stufe (z.B.
+Ordnungsposition > Dossier > Dokument) nur noch eingeschränkt eingesetzt werden
+können. Dies ist bei nachfolgenden Status der Fall:
+
+Einschränkung Sichtbarkeit
+---------------------------
+
+Klassifikation
+~~~~~~~~~~~~~~
+
+- Level 1: nicht klassifiziert
+- Level 2: vertraulich
+- Level 3: geheim
+
+Datenschutzstufe
+~~~~~~~~~~~~~~~~
+
+- Level 1:  Keine Datenschutzstufe
+- Level 2: Enthält schützenswerte Personendaten
+
+Öffentlichkeitsstatus
+~~~~~~~~~~~~~~~~~~~~~
+
+Ist nicht einschränkend, enthält aber folgende Status:
+Nicht geprüft, Öffentlich, Eingeschränkt öffentlich, Privat
+
+Einschränkung Lebenszyklus
+--------------------------
+
+Aufbewahrungsdauer
+~~~~~~~~~~~~~~~~~~
+
+Ist einschränkbar (konfigurierbar), aber per Default nicht einschränkend
+Der Status enthält folgende Status:
+5, 10, 15, 20, 25
+
+Archivwürdigkeit
+~~~~~~~~~~~~~~~~
+
+- Level 1: Nicht geprüft
+- Level 2: Anbieten
+- Level 3: Archivwürdig, Nicht archivwürdig, Sampling
+
+Archivische Schutzfrist
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Level 1: 0
+- Level 2: 30
+- Level 3: 100
+- Level 4: 150
+
+.. disqus::


### PR DESCRIPTION
Ergänzung des Unterkapitels "Einschränkung Metadaten", in welchem kurz beschrieben wird, dass seit das Öffentlichkeitsgesetzt in Kraft getreten ist, gewisse Status bei Lebenszyklus und Sichtbarkeit nur eingeschränkt eingesetzt werden können. 