### PR TITLE
Create document from template using office connector

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix meeting TOC, correctly limit TOC to committee. [deiferni]
 - Change Member fullname to `Lastname Firstname` instead of `Firstname Lastname` to be consistent with Actor/Contact et cetera. [deiferni]
 - Sort meeting participants alphabetically. [deiferni]
+- Use officeconnector to edit a newly created document from template. [tarnap]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/opengever/document/checkout/checkout.py
+++ b/opengever/document/checkout/checkout.py
@@ -1,10 +1,7 @@
 from five import grok
-from opengever.base.interfaces import IRedirector
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
-from opengever.officeconnector.helpers import create_oc_url
-from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
@@ -70,21 +67,11 @@ class CheckoutDocuments(grok.View):
         # lets register a redirector for starting external
         # editor - if requested
         external_edit = self.request.get('mode') == 'external'
-        if len(objects) == 1 and external_edit:
-            redirector = IRedirector(self.request)
-            if not is_officeconnector_checkout_feature_enabled():
-                redirector.redirect(
-                    '%s/external_edit' % objects[0].absolute_url(),
-                    target='_self',
-                    timeout=1000)
-            else:
-                redirector.redirect(create_oc_url(
-                    self.request,
-                    self.context,
-                    dict(action='checkout'),
-                    ))
+
         # now lets redirect to an appropriate target..
         if len(objects) == 1:
+            if external_edit:
+                objects[0].setup_external_edit_redirect(self.request)
             return self.request.RESPONSE.redirect(
                 objects[0].absolute_url())
 

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -7,6 +7,7 @@ from collective import dexteritytextindexer
 from five import grok
 from ftw.mail.interfaces import IEmailAddress
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
+from opengever.base.interfaces import IRedirector
 from opengever.document import _
 from opengever.document.base import BaseDocumentMixin
 from opengever.document.behaviors.related_docs import IRelatedDocuments
@@ -14,6 +15,8 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
+from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from opengever.officeconnector.helpers import create_oc_url
 from opengever.task.task import ITask
 from plone import api
 from plone.autoform import directives as form_directives
@@ -258,3 +261,17 @@ class Document(Item, BaseDocumentMixin):
                 self, transition='document-transition-initialize')
 
         return response
+
+    def setup_external_edit_redirect(self, request):
+        redirector = IRedirector(request)
+        if is_officeconnector_checkout_feature_enabled():
+            redirector.redirect(create_oc_url(
+                request,
+                self,
+                dict(action='checkout'),
+            ))
+        else:
+            redirector.redirect(
+                '%s/external_edit' % self.absolute_url(),
+                target='_self',
+                timeout=1000)

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -13,6 +13,8 @@ from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.dossier import _
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.templatefolder import get_template_folder
+from opengever.officeconnector.helpers import create_oc_url
+from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
@@ -138,10 +140,18 @@ class CreateDocumentMixin(object):
         # Add redirect to the zem-file download,
         # in order to start editing with external editor.
         redirector = IRedirector(self.request)
-        redirector.redirect(
-            '%s/external_edit' % new_doc.absolute_url(),
-            target='_self',
-            timeout=1000)
+
+        if not is_officeconnector_checkout_feature_enabled():
+            redirector.redirect(
+                '%s/external_edit' % new_doc.absolute_url(),
+                target='_self',
+                timeout=1000)
+        else:
+            redirector.redirect(create_oc_url(
+                self.request,
+                new_doc,
+                dict(action='checkout'),
+            ))
 
     def create_document(self, data):
         """Create a new document based on a template."""

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -3,7 +3,6 @@ from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.table import helper
 from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
-from opengever.base.interfaces import IRedirector
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
@@ -13,8 +12,6 @@ from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.dossier import _
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.templatefolder import get_template_folder
-from opengever.officeconnector.helpers import create_oc_url
-from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
@@ -137,21 +134,7 @@ class CreateDocumentMixin(object):
         manager = self.context.restrictedTraverse('checkout_documents')
         manager.checkout(new_doc)
 
-        # Add redirect to the zem-file download,
-        # in order to start editing with external editor.
-        redirector = IRedirector(self.request)
-
-        if not is_officeconnector_checkout_feature_enabled():
-            redirector.redirect(
-                '%s/external_edit' % new_doc.absolute_url(),
-                target='_self',
-                timeout=1000)
-        else:
-            redirector.redirect(create_oc_url(
-                self.request,
-                new_doc,
-                dict(action='checkout'),
-            ))
+        new_doc.setup_external_edit_redirect(self.request)
 
     def create_document(self, data):
         """Create a new document based on a template."""

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -23,7 +23,8 @@ def is_officeconnector_checkout_feature_enabled():
 def parse_documents(request, context):
     documents = []
 
-    if request['REQUEST_METHOD'] == 'GET':
+    if (request['REQUEST_METHOD'] == 'GET' or
+            request['REQUEST_METHOD'] == 'POST' and 'BODY' not in request):
         # Feature enabled for the wrong content type
         if not IBaseDocument.providedBy(context):
             raise NotFound
@@ -33,7 +34,8 @@ def parse_documents(request, context):
 
         documents.append(context)
 
-    if request['REQUEST_METHOD'] == 'POST':
+    if request['REQUEST_METHOD'] == 'POST' and 'BODY' in request:
+
         paths = json.loads(request['BODY'])
         for path in paths:
             # Restricted traversal does not handle unicode paths


### PR DESCRIPTION
I'm not totally certain about the second commit, which refactors some code:

https://github.com/4teamwork/opengever.core/commit/b7fe2f1778eef5aeabedec660045eb4a5f898e8e#diff-f6f40726c157ab858647bea6cd2a2b37L77
https://github.com/4teamwork/opengever.core/commit/b7fe2f1778eef5aeabedec660045eb4a5f898e8e#diff-f6f40726c157ab858647bea6cd2a2b37L83
and
https://github.com/4teamwork/opengever.core/commit/b7fe2f1778eef5aeabedec660045eb4a5f898e8e#diff-f6f40726c157ab858647bea6cd2a2b37R74

I dislike the fact that we're using `objects[0]` and `self.context` first and use only `objects[0]` afterwards... is it the same object?
Maybe @Rotonen can explain what's going on there.

Resolves #3044