### PR TITLE
Update to latests plone 4.3 version - 4.3.14

### DIFF
--- a/opengever/base/behaviors/configure.zcml
+++ b/opengever/base/behaviors/configure.zcml
@@ -73,7 +73,6 @@
       title="SequenceNumber"
       description="Adds the sequence number indexer"
       provides=".sequence.ISequenceNumberBehavior"
-      for="plone.dexterity.interfaces.IDexterityContent"
       />
 
   <plone:behavior

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -73,20 +73,17 @@ class OGQuickUploadCapableFileFactory(grok.Adapter):
     def __init__(self, context):
         self.context = aq_inner(context)
 
-    def __call__(self,
-                 filename,
-                 title,
-                 description,
-                 content_type,
+    def __call__(self, filename, title, description, content_type,
                  data, portal_type):
-
+        """Quickupload description inputs are hidden in gever
+        therefore we skip the description.
+        """
         if self.is_email_upload(filename):
             command = CreateEmailCommand(
-                self.context, filename, data, description=description,
+                self.context, filename, data,
                 message_source=MESSAGE_SOURCE_DRAG_DROP_UPLOAD)
         else:
-            command = CreateDocumentCommand(
-                self.context, filename, data, description=description)
+            command = CreateDocumentCommand(self.context, filename, data)
 
         try:
             obj = command.execute()

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -77,7 +77,7 @@ class XLSReporter(object):
         workbook = Workbook()
         sheet = workbook.active
         sheet.title = self.sheet_title
-        sheet.header_footer.center_footer.text = self.footer
+        sheet.oddFooter.center.text = self.footer
 
         self.insert_label_row(sheet)
         self.insert_value_rows(sheet)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -378,7 +378,6 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
 
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
-        expected['description'] = None
 
         self.assertDictEqual(expected, persisted_values)
 
@@ -554,7 +553,6 @@ class TestDocumentDefaults(TestDefaultsBase):
 
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
-        expected['description'] = None
 
         self.assertDictEqual(expected, persisted_values)
 
@@ -659,7 +657,6 @@ class TestMailDefaults(TestDefaultsBase):
 
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
-        expected['description'] = None
 
         self.assertDictEqual(expected, persisted_values)
 
@@ -788,8 +785,5 @@ class TestContactDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(contact)
         expected = self.get_z3c_form_defaults()
-
-        # XXX: Don't know why this happens
-        expected['description'] = None
 
         self.assertDictEqual(expected, persisted_values)

--- a/opengever/base/tests/test_quickupload.py
+++ b/opengever/base/tests/test_quickupload.py
@@ -33,7 +33,7 @@ class TestOGQuickupload(FunctionalTestCase):
 
         self.assertEquals('document', content.Title())
         self.assertEquals('text', content.file.data)
-        self.assertIsNone(content.description)
+        self.assertEquals(u'', content.description)
 
     def test_expect_one_journal_entry_after_upload(self):
         content = create(Builder('quickuploaded_document')

--- a/opengever/base/tests/test_reporter.py
+++ b/opengever/base/tests/test_reporter.py
@@ -60,20 +60,22 @@ class TestReporter(MockTestCase):
         workbook = self.get_workbook(reporter())
         self.assertEquals(
             [u'Title', None, u'Start', u'Responsible', u'Review state'],
-            [cell.value for cell in workbook.active.rows[0]])
+            [cell.value for cell in list(workbook.active.rows)[0]])
 
     def test_value_rows(self):
         reporter = XLSReporter(self.request, self.test_attributes, self.brains)
         workbook = self.get_workbook(reporter())
+
+        rows = list(workbook.active.rows)
         self.assertEquals(
             [u'Objekt 0', None, datetime(2012, 2, 25),
              u'test_user_0 (test_user_0)', u'dossier-state-active'],
-            [cell.value for cell in workbook.active.rows[1]])
+            [cell.value for cell in rows[1]])
 
         self.assertEquals(
             [u'Objekt 1', None, datetime(2012, 2, 26),
              u'test_user_1 (test_user_1)', 'dossier-state-active'],
-            [cell.value for cell in workbook.active.rows[2]])
+            [cell.value for cell in rows[2]])
 
     def test_set_sheet_title_for_active_workbook_sheet(self):
         title = 'Aufgaben\xc3\xbcbersicht'.decode('utf-8')

--- a/opengever/base/tests/test_security.py
+++ b/opengever/base/tests/test_security.py
@@ -11,13 +11,13 @@ class TestSecurity(FunctionalTestCase):
         self.test_user = api.user.get(userid=TEST_USER_ID)
 
     def test_elevated_privileges_sets_priviledged_user_and_restores_old(self):
-        self.assertEqual(self.test_user, api.user.get_current())
+        self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
         self.assertNotIn('manage', api.user.get_current().getRoles())
 
         with elevated_privileges():
             current_user = api.user.get_current()
-            self.assertEqual(self.test_user, current_user)
+            self.assertEqual(TEST_USER_ID, current_user.getId())
             self.assertIn('manage', current_user.getRoles())
 
         self.assertNotIn('manage', api.user.get_current().getRoles())
-        self.assertEqual(self.test_user, api.user.get_current())
+        self.assertEqual(TEST_USER_ID, current_user.getId())

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -11,8 +11,8 @@ from opengever.bundle.sections.map_local_roles import NAME_ROLE_MAPPING
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.ogds.base.utils import get_current_admin_unit
 from openpyxl import Workbook
-from openpyxl.cell import get_column_letter
 from openpyxl.styles import Font
+from openpyxl.utils import get_column_letter
 from os.path import basename
 from plone import api
 from zope.annotation import IAnnotations

--- a/opengever/contact/contact.py
+++ b/opengever/contact/contact.py
@@ -144,6 +144,7 @@ class IContact(form.Schema):
     description = schema.Text(
         title=_(u'label_description', default=u'Description'),
         required=False,
+        missing_value=u'',
         )
 
     address1 = schema.TextLine(

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -249,7 +249,11 @@ class Disposition(Container):
                 obj=relation.to_object, transition='dossier-transition-archive')
 
     def destroy_dossiers(self):
+        if not self.dossiers:
+            return
+
         alsoProvides(getRequest(), IDuringDossierDestruction)
+
         dossiers = [relation.to_object for relation in self.dossiers]
         self.set_destroyed_dossiers(dossiers)
         self.check_destroy_permission(dossiers)

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -51,7 +51,7 @@ class TestDispositionExcelExport(FunctionalTestCase):
                 [u'Reference Number', u'title', u'Opening Date',
                  u'Closing Date', u'Public Trial', u'Archival value',
                  u'archivalValueAnnotation', u'Appraisal'],
-                [cell.value for cell in workbook.active.rows[0]])
+                [cell.value for cell in list(workbook.active.rows)[0]])
             self.assertTrue(workbook.active.cell('A1').font.bold)
 
     @browsing
@@ -64,15 +64,17 @@ class TestDispositionExcelExport(FunctionalTestCase):
             tmpfile.flush()
             workbook = load_workbook(tmpfile.name)
 
+            rows = list(workbook.active.rows)
+
             self.assertEquals(
                 [u'Client1 1 / 1', u'Dossier A', datetime(2016, 1, 19, 0, 0),
                  datetime(2016, 3, 19, 0, 0), u'limited-public',
                  u'archival worthy', None, u'archival worthy'],
-                [cell.value for cell in workbook.active.rows[1]])
+                [cell.value for cell in rows[1]])
 
             self.assertEquals(
                 [u'Client1 1 / 2', u'Dossier B', datetime(2015, 1, 19, 0, 0),
                  datetime(2015, 3, 19, 0, 0), u'limited-public',
                  u'not archival worthy', u'In Absprache mit ARCH.',
                  u'not archival worthy'],
-                [cell.value for cell in workbook.active.rows[2]])
+                [cell.value for cell in rows[2]])

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -65,6 +65,7 @@ class IDocumentMetadata(form.Schema):
     description = schema.Text(
         title=_(u'label_description', default=u'Description'),
         required=False,
+        missing_value=u'',
         )
 
     form.widget('keywords', KeywordFieldWidget, new_terms_as_unicode=True)

--- a/opengever/document/browser/templates/archiv_file.pt
+++ b/opengever/document/browser/templates/archiv_file.pt
@@ -8,7 +8,6 @@
         <span class="filename" tal:content="filename">Filename</span>
         <span class="discreet">
           &mdash; <span tal:define="sizekb view/w/IDocumentMetadata.archival_file/file_size" tal:replace="sizekb">100</span>
-          KB
         </span>
       </span>
 

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -32,7 +32,7 @@ class TestDocumentIntegration(FunctionalTestCase):
         browser.login().open(self.document, view='edit')
 
         self.assertEqual(
-            u'document1.doc \u2014 0 KB',
+            u'document1.doc \u2014 1 KB',
             browser.css('.named-file-widget.namedblobfile-field').first.text)
 
         # edit should not be posssible

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -307,7 +307,7 @@ class TestDocumentOverview(FunctionalTestCase):
                           archival_file_row.css('th').first.text)
         self.assertEquals('icon-pdf',
                           archival_file_row.css('td span')[0].get('class'))
-        self.assertEquals(u'test.pdf \u2014 0 KB',
+        self.assertEquals(u'test.pdf \u2014 1 KB',
                           archival_file_row.css('td span')[1].text)
 
 

--- a/opengever/document/tests/test_reporter.py
+++ b/opengever/document/tests/test_reporter.py
@@ -67,4 +67,4 @@ class TestDocumentReporter(FunctionalTestCase):
              u'unchecked',
              u'Dossier A',
              ],
-            [cell.value for cell in workbook.active.rows[1]])
+            [cell.value for cell in list(workbook.active.rows)[1]])

--- a/opengever/document/widgets/no_download_display.pt
+++ b/opengever/document/widgets/no_download_display.pt
@@ -22,7 +22,7 @@
             tal:condition="python: exists and fieldname">
         <span tal:attributes="class context/css_class"></span>
         <span tal:content="filename">Filename</span>
-        <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB</span>
+        <span class="discreet"> &mdash; <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span></span>
     </span>
     <span tal:condition="not:exists" class="discreet" i18n:translate="no_file">
         No file

--- a/opengever/document/widgets/no_download_input.pt
+++ b/opengever/document/widgets/no_download_input.pt
@@ -29,7 +29,7 @@
         <span tal:attributes="class context/css_class"></span>
         <a class="link-overlay modal" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
         <span class="discreet"> &mdash;
-            <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span> KB
+            <span tal:define="sizekb view/file_size" tal:replace="sizekb">100</span>
         </span>
     </span>
     <div tal:condition="allow_nochange" style="padding-top: 1em;">

--- a/opengever/dossier/behaviors.zcml
+++ b/opengever/dossier/behaviors.zcml
@@ -64,7 +64,6 @@
       title="Restrict addable dossier templates"
       description="Adds addable dossiertemplate field for repositoryfolders"
       provides=".dossiertemplate.behaviors.IRestrictAddableDossierTemplates"
-      for="plone.dexterity.interfaces.IDexterityContent"
       />
 
   <!-- Restricted dossier behavior -->
@@ -73,7 +72,6 @@
       description="A restricted dossier is not addable by default in the
                    repository folder."
       provides="opengever.dossier.behaviors.restricteddossier.IRestrictedDossier"
-      for="opengever.dossier.behaviors.dossier.IDossierMarker"
       />
 
   <!-- filingnumber support -->

--- a/opengever/dossier/tests/test_reporter.py
+++ b/opengever/dossier/tests/test_reporter.py
@@ -56,7 +56,7 @@ class TestDossierReporterWithFilingNumberSupport(FunctionalTestCase):
              u'Client1-Leitung-2012-1',
              u'active',
              u'Client1 / 1'],
-            [cell.value for cell in workbook.active.rows[1]])
+            [cell.value for cell in list(workbook.active.rows)[1]])
 
 
 class TestDossierReporter(FunctionalTestCase):
@@ -93,6 +93,8 @@ class TestDossierReporter(FunctionalTestCase):
             tmpfile.flush()
             workbook = load_workbook(tmpfile.name)
 
+        rows = list(workbook.active.rows)
+
         self.assertSequenceEqual(
             [u'Export1 Dossier',
              datetime(2012, 1, 1),
@@ -100,7 +102,7 @@ class TestDossierReporter(FunctionalTestCase):
              u'Test User (test_user_1_)',
              u'active',
              u'Client1 / 1'],
-            [cell.value for cell in workbook.active.rows[1]])
+            [cell.value for cell in rows[1]])
         self.assertSequenceEqual(
             [u'Foo Dossier',
              datetime(2012, 1, 1),
@@ -108,7 +110,7 @@ class TestDossierReporter(FunctionalTestCase):
              u'Test User (test_user_1_)',
              u'active',
              u'Client1 / 2'],
-            [cell.value for cell in workbook.active.rows[2]])
+            [cell.value for cell in rows[2]])
 
     def test_filing_no_year(self):
         self.assertEquals(

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -79,6 +79,7 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
         self.templatefolder = create(Builder('templatefolder'))
         self.template_a = create(Builder('document')
                                  .titled('Template A')
+                                 .with_dummy_content()
                                  .within(self.templatefolder)
                                  .with_modification_date(self.modification_date))
         self.template_b = create(Builder('document')
@@ -833,7 +834,7 @@ class TestTemplateDocumentTabs(FunctionalTestCase):
 
         browser.open(self.template, view=INFO_TAB)
         self.assertEquals([['Logged-in users', False, False, False],
-                           [TEST_USER_ID, True, True, True]],
+                           ['test-user (test_user_1_)', True, True, True]],
                           sharing_tab_data())
 
 

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -40,4 +40,4 @@ class TestTaskReporter(FunctionalTestCase):
              u'To comment',
              u'client1',
              1L],
-            [cell.value for cell in workbook.active.rows[1]])
+            [cell.value for cell in list(workbook.active.rows)[1]])

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -192,8 +192,8 @@ class SendDocumentForm(form.Form):
                   default='(only possible for open dossiers)'),
                 context=self.request)
 
+            file_copy_widget.value = []
             checkbox = file_copy_widget.items[0]
-            checkbox['checked'] = False
             checkbox['label'] = u'{} {}'.format(
                 checkbox['label'], disabled_hint_text)
             file_copy_widget.disabled = 'disabled'

--- a/opengever/mail/browser/templates/file.pt
+++ b/opengever/mail/browser/templates/file.pt
@@ -7,7 +7,6 @@
       <span class="filename" tal:content="filename">Filename</span>
       <span class="discreet">
         &mdash; <span tal:define="sizekb view/w/message/file_size" tal:replace="sizekb">100</span>
-        KB
       </span>
     </span>
   </tal:file>

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -58,6 +58,7 @@ else:
 
 MESSAGE_SOURCE_DRAG_DROP_UPLOAD = 'upload'
 MESSAGE_SOURCE_MAILIN = 'mailin'
+NO_SUBJECT_FALLBACK_ID = 'no_subject'
 NO_SUBJECT_TITLE_FALLBACK = '[No Subject]'
 
 
@@ -361,8 +362,8 @@ class OGMailBase(metadata.MetadataBase):
 @grok.subscribe(IOGMailMarker, IObjectCreatedEvent)
 @grok.subscribe(IOGMailMarker, IObjectModifiedEvent)
 def initalize_title(mail, event):
-
-    if not IOGMail(mail).title:
+    title = IOGMail(mail).title
+    if not title or title == NO_SUBJECT_FALLBACK_ID:
         subject = utils.get_header(mail.msg, 'Subject')
         if subject:
             # long headers may contain line breaks with tabs.
@@ -371,7 +372,7 @@ def initalize_title(mail, event):
             value = subject.decode('utf8')
         else:
             value = translate(
-                ftw_mf(u'no_subject',
+                ftw_mf(NO_SUBJECT_FALLBACK_ID,
                        default=NO_SUBJECT_TITLE_FALLBACK.decode('utf-8')),
                 context=getSite().REQUEST)
 

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -42,8 +42,7 @@ class TestMailMetadataWithBuilder(FunctionalTestCase):
 
     def test_fill_metadata_of_new_mail(self):
         mail = self.create_mail()
-        self.assertIsNone(mail.description,
-                          'Description should have no value')
+        self.assertEquals(u'', mail.description)
 
         self.assertEquals((), mail.keywords, 'Expected no keywords')
 

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -226,23 +226,8 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
         browser.login().open(dossier, view="send_documents")
 
         field = browser.find('File a copy of the sent mail in dossier')
-        self.assertIsNone(field, "The field should not be visible")
-
-        fields = browser.css('input[id="form-widgets-{}-0"]'.format(fieldname))
-        self.assertEqual(
-            1, len(fields),
-            "The field should be available but not be visible. "
-            "The browser wasn't able to find the field. "
-            "Available fields are: {}".format(
-                browser.css('input[name^="form.widgets"]'))
-            )
-
-        field = fields.first
-        self.assertEqual(
-            'disabled', field.get('disabled', None),
-            "The field {} is not disabled. "
-            "See the field: {}".format(
-                fieldname, field))
+        self.assertEquals('disabled', field.get('disabled'))
+        self.assertIsNone(field.get('checked'))
 
     @browsing
     def test_file_copy_field_not_shown_if_not_on_dossier(self, browser):
@@ -251,7 +236,8 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
         browser.login().open(inbox, view="send_documents")
 
         field = browser.find('File a copy of the sent mail in dossier')
-        self.assertIsNone(field, "The field should not be visible")
+        self.assertEquals('disabled', field.get('disabled'))
+        self.assertIsNone(field.get('checked'))
 
     def send_documents(self, container, documents, browser=default_browser, **kwargs):
         documents = ['/'.join(doc.getPhysicalPath()) for doc in documents]

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -28,7 +28,9 @@ class TestProposalViewsDisabled(FunctionalTestCase):
     def setUp(self):
         super(TestProposalViewsDisabled, self).setUp()
         self.repo, self.repo_folder = create(Builder('repository_tree'))
-        self.dossier = create(Builder('dossier').within(self.repo_folder))
+        self.dossier = create(Builder('dossier')
+                              .titled(u'Dossier A')
+                              .within(self.repo_folder))
 
     @browsing
     def test_add_form_is_disabled(self, browser):
@@ -439,7 +441,9 @@ class TestProposal(FunctionalTestCase):
     @browsing
     def test_proposal_stores_reference_number_of_main_dossier(self, browser):
         committee = create(Builder('committee_model'))
-        subdossier = create(Builder('dossier').within(self.dossier))
+        subdossier = create(Builder('dossier')
+                            .titled(u'Sub A')
+                            .within(self.dossier))
         document = create(Builder('document')
                           .within(subdossier)
                           .titled('A Document'))

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -40,7 +40,7 @@ class TestPrivateFolder(FunctionalTestCase):
                           IReferenceNumber(self.folder).get_number())
 
     def test_adds_additonal_roles_after_creation(self):
-        self.assertEquals(
+        self.assertItemsEqual(
             ['Publisher', 'Authenticated', 'Owner', 'Editor', 'Reader',
              'Contributor', 'Reviewer'],
             api.user.get_roles(username=TEST_USER_ID, obj=self.folder))

--- a/opengever/quota/configure.zcml
+++ b/opengever/quota/configure.zcml
@@ -25,7 +25,6 @@
       title="Primary field quota subject"
       description="Subject to quota by counting the primary field blob size."
       provides="opengever.quota.primary.IPrimaryBlobFieldQuota"
-      for="plone.dexterity.interfaces.IDexterityItem"
       />
 
   <subscriber

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -40,6 +40,7 @@ class IRepositoryFolderSchema(form.Schema):
             u'help_description',
             default=u'A short summary of the content.'),
         required=False,
+        missing_value=u'',
         )
 
     valid_from = schema.Date(

--- a/opengever/sharing/configure.zcml
+++ b/opengever/sharing/configure.zcml
@@ -32,14 +32,12 @@
       title="OpenGever Standard Sharing"
       description="Adds OpenGever Standard Sharing View"
       provides=".behaviors.IStandard"
-      for="plone.dexterity.interfaces.IDexterityContent"
       />
 
   <plone:behavior
       title="OpenGever Dossier Sharing"
       description="Adds OpenGever Dossier Sharing View"
       provides=".behaviors.IDossier"
-      for="plone.dexterity.interfaces.IDexterityContent"
       />
 
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -12,6 +12,7 @@ development-packages =
   Products.LDAPUserFolder
   Products.LDAPMultiPlugins
   ftw.tabbedview
+  ftw.testbrowser
 
 auto-checkout = ${buildout:development-packages}
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -11,6 +11,7 @@ development-packages =
   ftw.showroom
   Products.LDAPUserFolder
   Products.LDAPMultiPlugins
+  ftw.tabbedview
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
⚠️  The PR currently contains a separate develop-versions.cfg, I'll remove that and copy it to opengever/develop kgs, as soon the PR is approved.   

The following adjustments had to be made (more informations in the commit messages):
 - Added missing value for our own description `schema.Text` fields, so we have the same behavior than the IBasic behavior from opengever.base and plone.app.dexterity.
 - Also handler default fallback title `no_subject` in the OGMail title initalization.
 - Adjust XLS Reporter to let it work with newest `openpyxl` version (Footer, imports)
 - Remove doubled KB in file widgets. The newer version of plone.formwidget.namedfile the method file_size already returns the size with indication of size.
 - Some additional adjustments on tests, without any change on the functionality.

Closes #3030 