### PR TITLE
Add related documents method to document overview

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Sort meeting participants alphabetically. [deiferni]
 - Use officeconnector to edit a newly created document from template. [tarnap]
 - Add bumblebee gallery view for related-documents tab on tasks. [elioschmutz]
+- List bidirectionally related documents in the document's overview. [tarnap]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -1,5 +1,4 @@
 from AccessControl import getSecurityManager
-from Acquisition import aq_inner
 from five import grok
 from ftw import bumblebee
 from opengever.base import _ as ogbmf
@@ -24,11 +23,9 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.common import MimeTypeException
 from z3c.form.browser.checkbox import SingleCheckBoxWidget
-from zc.relation.interfaces import ICatalog
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
-from zope.intid.interfaces import IIntIds
 
 
 class BaseRow(object):
@@ -201,19 +198,15 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
 
     def linked_documents(self):
         """Returns a list documents related to the context document."""
-        catalog = getUtility(ICatalog)
-        doc_id = getUtility(IIntIds).getId(aq_inner(self.context))
-        related_objects = self.context.related_items() + [
-            r.from_object
-            for r in catalog.findRelations(
-                {'to_id': doc_id, 'from_attribute': 'relatedItems'}
-            )
-        ]
+
         return [{
             'class': self.get_css_class(obj),
             'title': obj.Title(),
             'url': obj.absolute_url(),
-        } for obj in sorted(related_objects, key=lambda obj: obj.Title())]
+        } for obj in sorted(
+            self.context.related_items(bidirectional=True),
+            key=lambda obj: obj.Title()
+        )]
 
     def is_outdated(self, submitted_document):
         return not submitted_document.is_up_to_date(self.context)

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -1,4 +1,5 @@
 from AccessControl import getSecurityManager
+from Acquisition import aq_inner
 from five import grok
 from ftw import bumblebee
 from opengever.base import _ as ogbmf
@@ -23,9 +24,11 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.common import MimeTypeException
 from z3c.form.browser.checkbox import SingleCheckBoxWidget
+from zc.relation.interfaces import ICatalog
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
+from zope.intid.interfaces import IIntIds
 
 
 class BaseRow(object):
@@ -133,6 +136,8 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
     show_searchform = False
 
     file_template = ViewPageTemplateFile('templates/file.pt')
+    related_documents_template = ViewPageTemplateFile(
+        'templates/related_documents.pt')
     archival_file_template = ViewPageTemplateFile('templates/archiv_file.pt')
     public_trial_template = ViewPageTemplateFile('templates/public_trial.pt')
     submitted_with_template = ViewPageTemplateFile('templates/submitted_with.pt')  # noqa
@@ -155,7 +160,8 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
             FieldRow('IDocumentMetadata.preserved_as_paper'),
             FieldRow('IDocumentMetadata.receipt_date'),
             FieldRow('IDocumentMetadata.delivery_date'),
-            FieldRow('IRelatedDocuments.relatedItems'),
+            TemplateRow(self.related_documents_template, label=_(
+                u'label_related_documents', default=u'Related Documents')),
             FieldRow('IClassification.classification'),
             FieldRow('IClassification.privacy_layer'),
             TemplateRow(self.public_trial_template,
@@ -193,6 +199,22 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
                     submitted_document.document_id
                     )
 
+    def linked_documents(self):
+        """Returns a list documents related to the context document."""
+        catalog = getUtility(ICatalog)
+        doc_id = getUtility(IIntIds).getId(aq_inner(self.context))
+        related_objects = self.context.related_items() + [
+            r.from_object
+            for r in catalog.findRelations(
+                {'to_id': doc_id, 'from_attribute': 'relatedItems'}
+            )
+        ]
+        return [{
+            'class': self.get_css_class(obj),
+            'title': obj.Title(),
+            'url': obj.absolute_url(),
+        } for obj in sorted(related_objects, key=lambda obj: obj.Title())]
+
     def is_outdated(self, submitted_document):
         return not submitted_document.is_up_to_date(self.context)
 
@@ -220,8 +242,8 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
             return Actor.user(manager.get_checked_out_by()).get_link()
         return ''
 
-    def get_css_class(self):
-        return get_css_class(self.context)
+    def get_css_class(self, context=None):
+        return get_css_class(context or self.context)
 
     def show_modfiy_public_trial_link(self):
         try:

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -29,7 +29,8 @@ from zope.component import queryMultiAdapter
 
 
 class BaseRow(object):
-    """Base class for metadata row configurations."""
+    """Base class for metadata row configurations.
+    """
 
     def __init__(self):
         self._view = None
@@ -45,7 +46,8 @@ class BaseRow(object):
 
 
 class FieldRow(BaseRow):
-    """A metadata row type that gets its information from schema fields."""
+    """A metadata row type that gets its information from schema fields.
+    """
 
     def __init__(self, field, label=None):
         super(FieldRow, self).__init__()
@@ -120,7 +122,8 @@ class TemplateRow(CustomRow):
 
 
 class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
-    """File details overview."""
+    """File details overview.
+    """
 
     is_on_detail_view = True
     is_overview_tab = True
@@ -197,7 +200,8 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
                     )
 
     def linked_documents(self):
-        """Returns a list documents related to the context document."""
+        """Returns a list documents related to the context document.
+        """
 
         return [{
             'class': self.get_css_class(obj),

--- a/opengever/document/browser/templates/related_documents.pt
+++ b/opengever/document/browser/templates/related_documents.pt
@@ -1,0 +1,12 @@
+<tal:block xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="opengever.document">
+
+    <ul class="related_documents">
+        <li tal:repeat="doc view/linked_documents">
+            <span tal:attributes="class doc/class" />
+            <a tal:attributes="href doc/url"
+               tal:content="doc/title"/>
+        </li>
+    </ul>
+
+</tal:block>

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -36,6 +36,24 @@ class TestDocumentOverview(FunctionalTestCase):
         super(TestDocumentOverview, self).tearDown()
 
     @browsing
+    def test_overview_displays_related_documents(self, browser):
+        self.doc_a = create(Builder('document')
+                            .having(title=u'A\xf6'))
+        self.doc_b = create(Builder('document')
+                            .having(title=u'B\xf6')
+                            .relate_to(self.doc_a))
+        self.doc_c = create(Builder('document')
+                            .having(title=u'C\xf6')
+                            .relate_to(self.doc_b))
+
+        browser.login().open(self.doc_b, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            [self.doc_a.title, self.doc_c.title],
+            browser.css('ul.related_documents a').text
+        )
+
+    @browsing
     def test_overview_has_edit_link(self, browser):
         browser.login().open(self.document, view='tabbedview_view-overview')
         self.assertEquals('Checkout and edit',


### PR DESCRIPTION
... also improve overview's `get_css_class` method.

When adding / editing a document (let's say A), related documents
(sat B and C) can be selected. These are listed under "related
documents" in the document overview (A lists B and C)..
Those related objects should list the documents which are related to
them as well (B and C should display A as well).

![related documents](https://user-images.githubusercontent.com/194114/27496481-6a9860b4-5856-11e7-921b-2a8899774916.gif)

TODO: Add CSS assets to style the list of documents

Resolves: #1498 
See also: https://github.com/4teamwork/plonetheme.teamraum/pull/559