### PR TITLE
CSRF: Update plone.protect to 3.0.20 and plone4.csrffixes to 1.1.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- CSRF: Update plone.protect to 3.0.20 and plone4.csrffixes to 1.1. [mathias.leimgruber]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,6 +13,9 @@ mr.developer = 1.33
 z3c.dependencychecker = 1.11
 zptlint = 0.2.4
 
+# Move to development kgs
+plone.protect = 3.0.20
+
 # zope.testrunner 4.4.5 has changed the testing layer ordering
 # which causes test isolation problems with PloneTestCase layers
 # which are not isolating properly.


### PR DESCRIPTION
Update CSRF related packages.

This PR updates plone.protect from 3.0.17 to 3.0.20 and plone4.csrffixes from 1.0.8 to 1.1.

**Notable changes in plone.protect:**
https://github.com/plone/plone.protect/compare/3.0.17...3.0.20

- Include protect.js -
  https://github.com/plone/plone.protect/commit/d6c220701e34a0dced721d7a7cf77cf7530ed8ed
  This makes the upgrade of `plone4.csrffixes` necessary. Otherwise both packages are trying to include the protect.js.
- Only try the confirm view for urls that are in the portal.
  https://github.com/plone/plone.protect/commit/062e1d17adbbc1dd31152db0a75cf07e21cc33c1
 

All other commits mostly apply some code cleanups and introduce more robust code.