### PR TITLE
Add bumblebee gallery view for related documents tab on tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Change Member fullname to `Lastname Firstname` instead of `Firstname Lastname` to be consistent with Actor/Contact et cetera. [deiferni]
 - Sort meeting participants alphabetically. [deiferni]
 - Use officeconnector to edit a newly created document from template. [tarnap]
+- Add bumblebee gallery view for related-documents tab on tasks. [elioschmutz]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/de/LC_MESSAGES/ftw.tabbedview.po
@@ -188,6 +188,9 @@ msgstr "Verwande Dokumente"
 msgid "relateddocuments"
 msgstr "Dokumente"
 
+msgid "relateddocuments-proxy"
+msgstr "Dokumente"
+
 msgid "reports"
 msgstr "Arbeitsrapporte"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -188,6 +188,9 @@ msgstr "Documents liés"
 msgid "relateddocuments"
 msgstr "Documents"
 
+msgid "relateddocuments-proxy"
+msgstr "Documents"
+
 msgid "reports"
 msgstr "Rapports de travail"
 

--- a/opengever/base/locales/ftw.tabbedview.pot
+++ b/opengever/base/locales/ftw.tabbedview.pot
@@ -197,6 +197,9 @@ msgstr ""
 msgid "related_documents"
 msgstr ""
 
+msgid "relateddocuments-proxy"
+msgstr ""
+
 msgid "relateddocuments"
 msgstr ""
 

--- a/opengever/core/profiles/default/types/opengever.inbox.forwarding.xml
+++ b/opengever/core/profiles/default/types/opengever.inbox.forwarding.xml
@@ -82,7 +82,7 @@
   <action
       i18n:domain="opengever.core"
       title="Related Documents"
-      action_id="relateddocuments"
+      action_id="relateddocuments-proxy"
       category="tabbedview-tabs"
       condition_expr=""
       url_expr="string:#"

--- a/opengever/core/profiles/default/types/opengever.task.task.xml
+++ b/opengever/core/profiles/default/types/opengever.task.task.xml
@@ -84,7 +84,7 @@
   <action
       i18n:domain="opengever.core"
       title="Related Documents"
-      action_id="relateddocuments"
+      action_id="relateddocuments-proxy"
       category="tabbedview-tabs"
       condition_expr=""
       url_expr="string:#"

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -65,8 +65,8 @@ class BumblebeeGalleryMixin(object):
         self.table_source.config.filter_text = self.request.get(
             'searchable_text', '')
 
-        catalog = getToolByName(self.context, 'portal_catalog')
-        return catalog(self.table_source.build_query())
+        query = self.table_source.build_query()
+        return self.table_source.search_results(query)
 
     def fetch(self):
         """Action for retrieving more events (based on `next_event_id` in
@@ -163,16 +163,6 @@ class RelatedDocumentsGallery(BumblebeeGalleryMixin, RelatedDocuments):
     @property
     def list_view_name(self):
         return "relateddocuments"
-
-    @memoize
-    def get_brains(self):
-        # The build_query of the RelatedDocuments-View returns the brains instead
-        # a query object. So we have to override the get_brains-function to
-        # handle this exception
-        self.table_source.config.filter_text = self.request.get(
-            'searchable_text', '')
-
-        return self.table_source.build_query()
 
 
 class RelatedDocumentsGalleryFetch(RelatedDocumentsGallery):

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -9,6 +9,7 @@ from opengever.tabbedview.browser.personal_overview import MyDocuments
 from opengever.tabbedview.browser.tabs import Documents
 from opengever.tabbedview.browser.tabs import Trash
 from opengever.task.browser.related_documents import RelatedDocuments
+from plone.memoize.view import memoize
 from zExceptions import NotFound
 
 
@@ -59,14 +60,13 @@ class BumblebeeGalleryMixin(object):
                 'mime_type_css_class': get_css_class(brain),
             }
 
+    @memoize
     def get_brains(self):
         self.table_source.config.filter_text = self.request.get(
             'searchable_text', '')
 
-        if not hasattr(self, '_brains'):
-            catalog = getToolByName(self.context, 'portal_catalog')
-            setattr(self, '_brains', catalog(self.table_source.build_query()))
-        return getattr(self, '_brains')
+        catalog = getToolByName(self.context, 'portal_catalog')
+        return catalog(self.table_source.build_query())
 
     def fetch(self):
         """Action for retrieving more events (based on `next_event_id` in
@@ -164,6 +164,7 @@ class RelatedDocumentsGallery(BumblebeeGalleryMixin, RelatedDocuments):
     def list_view_name(self):
         return "relateddocuments"
 
+    @memoize
     def get_brains(self):
         # The build_query of the RelatedDocuments-View returns the brains instead
         # a query object. So we have to override the get_brains-function to
@@ -171,9 +172,7 @@ class RelatedDocumentsGallery(BumblebeeGalleryMixin, RelatedDocuments):
         self.table_source.config.filter_text = self.request.get(
             'searchable_text', '')
 
-        if not hasattr(self, '_brains'):
-            setattr(self, '_brains', self.table_source.build_query())
-        return getattr(self, '_brains')
+        return self.table_source.build_query()
 
 
 class RelatedDocumentsGalleryFetch(RelatedDocumentsGallery):

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -8,6 +8,7 @@ from opengever.bumblebee import set_preferred_listing_view
 from opengever.tabbedview.browser.personal_overview import MyDocuments
 from opengever.tabbedview.browser.tabs import Documents
 from opengever.tabbedview.browser.tabs import Trash
+from opengever.task.browser.related_documents import RelatedDocuments
 from zExceptions import NotFound
 
 
@@ -151,6 +152,41 @@ class TrashGalleryFetch(TrashGallery):
     soon as the parent views are registered as Zope 3 BrowserViews.
     """
     grok.name('tabbedview_view-trash-gallery-fetch')
+
+    def __call__(self):
+        return self.fetch()
+
+
+class RelatedDocumentsGallery(BumblebeeGalleryMixin, RelatedDocuments):
+    grok.name('tabbedview_view-relateddocuments-gallery')
+
+    @property
+    def list_view_name(self):
+        return "relateddocuments"
+
+    def get_brains(self):
+        # The build_query of the RelatedDocuments-View returns the brains instead
+        # a query object. So we have to override the get_brains-function to
+        # handle this exception
+        self.table_source.config.filter_text = self.request.get(
+            'searchable_text', '')
+
+        if not hasattr(self, '_brains'):
+            setattr(self, '_brains', self.table_source.build_query())
+        return getattr(self, '_brains')
+
+
+class RelatedDocumentsGalleryFetch(RelatedDocumentsGallery):
+    """Returns the next gallery-items.
+
+    Unfortunately it's not possible to use a traversable method with
+    five.grok-views. Therefore we have to register an own browserview
+    to fetch the next gallery-items.
+
+    This browserview can be removed and implemented with allowed-attributes as
+    soon as the parent views are registered as Zope 3 BrowserViews.
+    """
+    grok.name('tabbedview_view-relateddocuments-gallery-fetch')
 
     def __call__(self):
         return self.fetch()

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -478,6 +478,14 @@ class TestProxyViewsWithDeactivatedFeature(FunctionalTestCase):
         browser.login().visit(dossier, view="tabbedview_view-trash-proxy")
         self.assertIsNone(browser.cookies.get(BUMBLEBEE_VIEW_COOKIE_NAME))
 
+    @browsing
+    def test_do_not_set_cookie_on_related_documents_tab(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').within(dossier))
+
+        browser.login().visit(task, view="tabbedview_view-relateddocuments-proxy")
+        self.assertIsNone(browser.cookies.get(BUMBLEBEE_VIEW_COOKIE_NAME))
+
 
 class TestProxyViewsWithActivatedFeature(FunctionalTestCase):
 
@@ -555,6 +563,26 @@ class TestProxyViewsWithActivatedFeature(FunctionalTestCase):
         browser.login().visit(dossier, view="tabbedview_view-trash-gallery")
 
         browser.login().visit(dossier, view="tabbedview_view-trash-proxy")
+
+        self.assertEqual(
+            'Gallery',
+            browser.css('.ViewChooser .active').first.text)
+
+    @browsing
+    def test_relateddocuments_proxy_tab(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').within(dossier))
+
+        browser.login().visit(task, view="tabbedview_view-relateddocuments-proxy")
+
+        self.assertEqual(
+            'List',
+            browser.css('.ViewChooser .active').first.text)
+
+        # Set cookie for gallery-view
+        browser.login().visit(task, view="tabbedview_view-relateddocuments-gallery")
+
+        browser.login().visit(task, view="tabbedview_view-relateddocuments-proxy")
 
         self.assertEqual(
             'Gallery',

--- a/opengever/task/browser/related_documents.py
+++ b/opengever/task/browser/related_documents.py
@@ -3,6 +3,7 @@ from ftw.table.catalog_source import default_custom_sort
 from ftw.table.interfaces import ICatalogTableSourceConfig
 from ftw.table.interfaces import ITableSource
 from opengever.tabbedview import GeverCatalogTableSource
+from opengever.tabbedview.browser.tabs import BaseTabProxy
 from opengever.tabbedview.browser.tabs import Documents
 from opengever.task.task import ITask
 from operator import attrgetter
@@ -214,6 +215,13 @@ class RelatedDocumentsCatalogTableSource(GeverCatalogTableSource):
                 return column
 
         return {}
+
+
+class RelatedDocumentsProxy(BaseTabProxy):
+    """This proxyview is looking for the last used documents
+    view (list or gallery) and reopens this view.
+    """
+    grok.name('tabbedview_view-relateddocuments-proxy')
 
 
 class RelatedDocuments(Documents):

--- a/opengever/task/upgrades/20170627091144_use_task_related_documents_proxy_view/upgrade.py
+++ b/opengever/task/upgrades/20170627091144_use_task_related_documents_proxy_view/upgrade.py
@@ -1,0 +1,32 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class UseRelatedDocumentsProxyView(UpgradeStep):
+    """Use related documents proxy view.
+    """
+
+    old_action_id = 'relateddocuments'
+    new_action_id = 'relateddocuments-proxy'
+
+    type_names = ['opengever.task.task']
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.change_relateddocuments_tab_to_relateddocuments_proxy_tab()
+
+    def change_relateddocuments_tab_to_relateddocuments_proxy_tab(self):
+        """To choose which template the user has selected before (list or gallery)
+        with activated bumblebeefeature, we have to add a proxy view.
+
+        The tabs are stored in actions. So we have to update them to the new
+        proxy-view.
+        """
+        ttool = api.portal.get_tool('portal_types')
+        for type_name in self.type_names:
+            fti = ttool[type_name]
+            for action in fti._actions:
+                if not action.id == self.old_action_id:
+                    continue
+
+                action.id = self.new_action_id

--- a/opengever/task/upgrades/20170627091144_use_task_related_documents_proxy_view/upgrade.py
+++ b/opengever/task/upgrades/20170627091144_use_task_related_documents_proxy_view/upgrade.py
@@ -9,7 +9,8 @@ class UseRelatedDocumentsProxyView(UpgradeStep):
     old_action_id = 'relateddocuments'
     new_action_id = 'relateddocuments-proxy'
 
-    type_names = ['opengever.task.task']
+    type_names = ['opengever.task.task',
+                  'opengever.inbox.forwarding']
 
     def __call__(self):
         self.install_upgrade_profile()


### PR DESCRIPTION
This PR adds the bumblebee-gallery view for the relateddocuments-tab which will be used by `opengever.task.task` and `opengever.inbox.forwarding`.

closes #3043 