### PR TITLE
Escape html of content on the task listing tab

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,8 @@ Changelog
 ---------------------
 
 - Allow move items in the documents tab within the templatefolder. [elioschmutz]
-- CSRF: Escape html for the breadcrumbs part for get_link on tasks. [mathias.leimgruber]
+- XSS: Escape html for Dossier title on task listing. [mathias.leimgruber]
+- XSS: Escape html for the breadcrumbs part for get_link on tasks. [mathias.leimgruber]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Allow move items in the documents tab within the templatefolder. [elioschmutz]
+- CSRF: Escape html for the breadcrumbs part for get_link on tasks. [mathias.leimgruber]
 - Implement and enable redirector etag adapter. [phgross]
 - Add reference column to document listings. [tarnap]
 - Do not display templates without an assigned file in the CreateDocumentFromTemplate form. [tarnap]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -292,7 +292,8 @@ class Task(Base):
 
         url = '/'.join((admin_unit.public_url, self.physical_path))
         breadcrumb_titles = u"[{}] > {}".format(
-            admin_unit.title, self.breadcrumb_title)
+            admin_unit.title, escape_html(self.breadcrumb_title))
+
         responsible_info = u' <span class="discreet">({})</span>'.format(
             self.get_responsible_label(linked=False))
         link_content = u'<span class="{}">{}</span>'.format(

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -145,6 +145,20 @@ class TestTaskLinkGeneration(FunctionalTestCase):
             '<span class="contenttype-opengever-task-task">Foo &lt;b onmouseover=alert(\'Wufff!\')&gt;click me!&lt;/b&gt;</span>',
             tostring(link_tag))
 
+    def test_link_breadcrumb_part_is_xss_safe(self):
+        link = self.add_task_and_get_link(
+            breadcrumb_title='0 Allg. > <b>4tw</b> > Task')
+
+        link_tag = link.xpath(css_to_xpath('a'))[0]
+
+        #INFO: link_tag.attr['titles'] automatically decodes html entities
+        self.assertEquals(
+            '<a href="http://example.com/qux/dossier-1/task-2" '
+            'title="[Client1] &gt; 0 Allg. &gt; &lt;b&gt;4tw&lt;/b&gt; &gt; '
+            'Task"><span class="contenttype-opengever-task-task">Do it!</span>'
+            '</a>  ',
+            tostring(link_tag))
+
     def test_handles_non_ascii_characters_correctly(self):
         link = self.add_task_and_get_link(title=u'D\xfc it')
         span_tag = link.xpath(css_to_xpath('a span'))[0]

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -12,6 +12,7 @@ from opengever.tabbedview.filters import Filter
 from opengever.tabbedview.filters import FilterList
 from opengever.tabbedview.filters import PendingTasksFilter
 from opengever.tabbedview.helper import display_org_unit_title_condition
+from opengever.tabbedview.helper import escape_html_transform
 from opengever.tabbedview.helper import org_unit_title_helper
 from opengever.tabbedview.helper import readable_date_set_invisibles
 from opengever.tabbedview.helper import readable_ogds_author
@@ -105,7 +106,8 @@ class GlobalTaskListingTab(BaseListingTab):
          'transform': helper.readable_date},
 
         {'column': 'containing_dossier',
-         'column_title': _('containing_dossier', 'Dossier'), },
+         'column_title': _('containing_dossier', 'Dossier'),
+         'transform': escape_html_transform},
 
         {'column': 'issuing_org_unit',
          'column_title': _('column_issuing_org_unit',

--- a/opengever/tabbedview/tests/test_tasklisting.py
+++ b/opengever/tabbedview/tests/test_tasklisting.py
@@ -9,7 +9,8 @@ class TestTaskListing(FunctionalTestCase):
     def setUp(self):
         super(TestTaskListing, self).setUp()
 
-        self.dossier = create(Builder('dossier'))
+        self.dossier = create(Builder('dossier')
+                              .titled(u'<b>Bold title</b>'))
         self.task1 = create(Builder('task')
                             .within(self.dossier)
                             .in_state('task-state-open')
@@ -32,7 +33,6 @@ class TestTaskListing(FunctionalTestCase):
         self.assertEquals(['Task 1', 'Task 3'],
                           [row.get('Title') for row in table.dicts()])
 
-
     @browsing
     def test_list_every_dossiers_with_the_all_filter(self, browser):
         browser.login().open(
@@ -42,3 +42,13 @@ class TestTaskListing(FunctionalTestCase):
         table = browser.css('.listing').first
         self.assertEquals(['Task 1', 'Task 2', 'Task 3'],
                           [row.get('Title') for row in table.dicts()])
+
+    @browsing
+    def test_escape_dossier_title_to_prevent_xss(self, browser):
+        browser.login().open(
+            self.dossier, view='tabbedview_view-tasks')
+        table = browser.css('.listing').first
+        second_row_dossier_cell = table.rows[1].css('td:nth-child(10)').first
+        self.assertEquals(
+            '&lt;b&gt;Bold title&lt;/b&gt;',
+            second_row_dossier_cell.innerHTML.strip().strip('\n'))


### PR DESCRIPTION
This PR fixes two issue:
- breadcrumb part of the title
- containing dossier title

