### PR TITLE
Update testing documentation in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ src/
 var/
 snakefood/
 /format_all_xmls.log
+/README.html

--- a/README.rst
+++ b/README.rst
@@ -353,6 +353,9 @@ Once a new policy has been generated the following things need to be added manua
 Tests
 -----
 
+Parallelisation
+~~~~~~~~~~~~~~~
+
 Use ``bin/mtest`` for running all test in multiple processes. Alternatively ``bin/test`` runs the tests in sequence.
 The multi process script distributes the packages (e.g. ``opengever.task``, ``opengever.base``, etc) into multiple processes,
 trying to balance the amount of test suites, so that it speeds up the test run.

--- a/README.rst
+++ b/README.rst
@@ -395,38 +395,6 @@ Then you can use the ``Builder`` function in your test cases:
 Note that when using the ``OPENGEVER_FUNCTIONAL_TESTING`` Layer the ``Builder`` will automatically do a ``transaction.commit()`` when ``create()`` is called.
 
 
-Browser API
-~~~~~~~~~~~
-
-The center of the `Browser API` is the ``OGBrowser`` class. It's a
-simple subclass of ``plone.testing.z2.Browser`` and the easiest way to
-use it is to extend ``opengever.testing.FunctionalTestCase``:
-
-.. code:: python
-
-    from opengever.testing import FunctionalTestCase
-
-
-    class TestExample(FunctionalTestCase):
-        use_browser = True
-
-        def test_first_example(self):
-          self.browser # => instance of OGBrowser
-
-Now you can use the ``self.browser`` instance:
-
-.. code:: python
-
-    self.browser.fill({'Title': "My first Dossier",
-                       'Description': "This is my first Dossier"})
-    self.browser.click('Save')
-    self.browser.assert_url("http://nohost/plone/dossier-1")
-
-Have a look at the `opengever.testing.browser module
-<https://github.com/4teamwork/opengever.core/blob/master/opengever/testing/browser.py>`_
-to see the complete API.
-
-
 Testing Inbound Mail
 --------------------
 


### PR DESCRIPTION
I have updated the testing documentation in the README:

- Remove the old gever-testbrowser documentation; `ftw.testbrowser` shall be used.
- Add a section about functional and integration testing.
- Add an example integration test case.
- Add some best practices.

@4teamwork/gever please have a look.