### PR TITLE
Rename repository to repofolder in fixtures.

### DIFF
--- a/opengever/core/tests/test_fixture.py
+++ b/opengever/core/tests/test_fixture.py
@@ -25,21 +25,21 @@ class TestTestingFixture(IntegrationTestCase):
         browser.login(self.administrator).open(self.repository_root)
         self.assertEquals('Ordnungssystem', plone.first_heading())
 
-    def test_leaf_repository_has_no_subrepositories(self):
+    def test_leaf_repofolder_has_no_subrepositories(self):
         self.assertFalse(
             filter(IRepositoryFolder.providedBy,
-                   self.leaf_repository.objectValues()),
+                   self.leaf_repofolder.objectValues()),
             'The "leaf repository" {!r} should not have sub'
             ' repositories as it wouldnt be a "leaf" anymore.'.format(
-                self.leaf_repository))
+                self.leaf_repofolder))
 
-    def test_branch_repository_has_subrepositories(self):
+    def test_branch_repofolder_has_subrepositories(self):
         self.assertTrue(
             filter(IRepositoryFolder.providedBy,
-                   self.branch_repository.objectValues()),
-            'The "branch repository" {!r} must have sub'
+                   self.branch_repofolder.objectValues()),
+            'The "branch repository folder" {!r} must have sub'
             ' repositories as it wouldnt be a "branch" anymore.'.format(
-                self.branch_repository))
+                self.branch_repofolder))
 
     def test_dossiers(self):
         """This test makes sure that the objects are not acceidentally

--- a/opengever/repository/tests/test_deletion.py
+++ b/opengever/repository/tests/test_deletion.py
@@ -14,25 +14,25 @@ class TestRepositoryDeleter(IntegrationTestCase):
 
     def test_deletion_is_not_allowed_when_repository_is_not_empty(self):
         self.login(self.administrator)
-        self.assertTrue(self.branch_repository.objectIds(),
+        self.assertTrue(self.branch_repofolder.objectIds(),
                         'Precondition: Assumed repofolder to have children.')
-        self.assertFalse(RepositoryDeleter(self.branch_repository)
+        self.assertFalse(RepositoryDeleter(self.branch_repofolder)
                          .is_deletion_allowed())
 
     def test_deletion_is_allowed_when_repository_is_empty(self):
         self.login(self.administrator)
-        self.assertFalse(self.empty_repository.objectIds(),
+        self.assertFalse(self.empty_repofolder.objectIds(),
                          'Precondition: Assumed repofolder to have no children.')
-        self.assertTrue(RepositoryDeleter(self.empty_repository)
+        self.assertTrue(RepositoryDeleter(self.empty_repofolder)
                         .is_deletion_allowed())
 
     def test_repository_deletion(self):
         self.login(self.administrator)
-        parent = aq_parent(aq_inner(self.empty_repository))
-        repo_id = self.empty_repository.getId()
+        parent = aq_parent(aq_inner(self.empty_repofolder))
+        repo_id = self.empty_repofolder.getId()
 
         self.assertIn(repo_id, parent.objectIds())
-        RepositoryDeleter(self.empty_repository).delete()
+        RepositoryDeleter(self.empty_repofolder).delete()
         self.assertNotIn(repo_id, parent.objectIds())
 
     def test_deletion_denied_without_admin_or_manager_role(self):
@@ -44,26 +44,26 @@ class TestRepositoryDeleter(IntegrationTestCase):
         user = create(Builder('user').with_roles(*valid_roles))
         self.login(user)
         with self.assertRaises(Unauthorized):
-            api.content.delete(obj=self.empty_repository)
+            api.content.delete(obj=self.empty_repofolder)
 
     @browsing
     def test_delete_action_is_only_available_when_preconditions_satisfied(
             self, browser):
         self.login(self.administrator, browser)
 
-        browser.open(self.empty_repository)
+        browser.open(self.empty_repofolder)
         self.assertIn(
             'Delete',
             browser.css('#plone-contentmenu-actions .actionMenuContent a').text,
             'Expected "Delete" action to be visible on {!r}.'.format(
-                self.empty_repository))
+                self.empty_repofolder))
 
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         self.assertNotIn(
             'Delete',
             browser.css('#plone-contentmenu-actions .actionMenuContent a').text,
             'Expected "Delete" action to be invisible on {!r}.'.format(
-                self.branch_repository))
+                self.branch_repofolder))
 
     @browsing
     def test_raise_unauthorized_when_preconditions_not_satisfied(self, browser):
@@ -73,19 +73,19 @@ class TestRepositoryDeleter(IntegrationTestCase):
         # Unauthorized exception and end the infinite loop.
         browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
-            browser.open(self.branch_repository, view='delete_repository')
+            browser.open(self.branch_repofolder, view='delete_repository')
 
     @browsing
     def test_cancel_redirects_back_to_repository(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.empty_repository, view='delete_repository')
+        browser.open(self.empty_repofolder, view='delete_repository')
         browser.click_on('Cancel')
-        self.assertEquals(self.empty_repository, browser.context)
+        self.assertEquals(self.empty_repofolder, browser.context)
 
     @browsing
     def test_submit_redirects_to_parent(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.empty_repository, view='delete_repository')
+        browser.open(self.empty_repofolder, view='delete_repository')
         browser.click_on('Delete')
         statusmessages.assert_message(
             'The repository have been successfully deleted.')
@@ -95,7 +95,7 @@ class TestRepositoryDeleter(IntegrationTestCase):
     def test_form_is_csrf_safe(self, browser):
         self.login(self.administrator, browser)
         url = '{}/delete_repository?form.buttons.delete=true'.format(
-            self.empty_repository.absolute_url())
+            self.empty_repofolder.absolute_url())
 
         with browser.expect_unauthorized():
             browser.open(url)

--- a/opengever/repository/tests/test_menu.py
+++ b/opengever/repository/tests/test_menu.py
@@ -8,12 +8,12 @@ class TestRepositoryFolderFactoryMenu(IntegrationTestCase):
     @browsing
     def test_businesscase_dossier_is_addable_by_default(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.leaf_repository)
+        browser.open(self.leaf_repofolder)
         self.assertIn('Business Case Dossier', factoriesmenu.addable_types())
 
     @browsing
     def test_businesscase_dossier_is_not_addable_when_disallowed(self, browser):
         self.login(self.regular_user, browser)
-        self.leaf_repository.allow_add_businesscase_dossier = False
-        browser.open(self.leaf_repository)
+        self.leaf_repofolder.allow_add_businesscase_dossier = False
+        browser.open(self.leaf_repofolder)
         self.assertNotIn('Business Case Dossier', factoriesmenu.addable_types())

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -14,13 +14,13 @@ class TestReferenceBehavior(IntegrationTestCase):
 
     def test_repositories_provide_marker_interface(self):
         self.assertTrue(IReferenceNumberPrefixMarker.providedBy(
-            self.leaf_repository))
-        verifyObject(IReferenceNumberPrefixMarker, self.leaf_repository)
+            self.leaf_repofolder))
+        verifyObject(IReferenceNumberPrefixMarker, self.leaf_repofolder)
 
     @browsing
     def test_set_next_reference_number_as_default_value(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         factoriesmenu.add('RepositoryFolder')
         self.assertEquals('2', browser.find('Reference Prefix').value)
 

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -12,13 +12,13 @@ class TestReferencePrefixManager(IntegrationTestCase):
     def setUp(self):
         super(TestReferencePrefixManager, self).setUp()
         # move repo1 to prefix 3 which leaves prefix 1 unused
-        manager = ReferenceNumberPrefixAdpater(self.branch_repository)
-        manager.set_number(self.leaf_repository, 3)
+        manager = ReferenceNumberPrefixAdpater(self.branch_repofolder)
+        manager.set_number(self.leaf_repofolder, 3)
 
     @browsing
     def test_list_and_unlock_unused_prefixes(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.branch_repository, view='referenceprefix_manager')
+        browser.open(self.branch_repofolder, view='referenceprefix_manager')
         self.assertEquals(
             [['1', u'Vertr\xe4ge und Vereinbarungen', 'Unlock'],
              ['3', u'Vertr\xe4ge und Vereinbarungen', 'In use']],
@@ -32,15 +32,15 @@ class TestReferencePrefixManager(IntegrationTestCase):
             browser.css('#reference_prefix_manager_table').first.lists())
 
     def test_manager_throws_error_when_delete_request_for_used_prefix_occurs(self):
-        manager = ReferenceNumberPrefixAdpater(self.branch_repository)
+        manager = ReferenceNumberPrefixAdpater(self.branch_repofolder)
         with self.assertRaises(Exception):
             manager.free_number(19)
 
     @browsing
     def test_manager_handles_deleted_repositories_correctly(self, browser):
         self.login(self.administrator, browser)
-        api.content.delete(obj=self.leaf_repository)
-        browser.open(self.branch_repository, view='referenceprefix_manager')
+        api.content.delete(obj=self.leaf_repofolder)
+        browser.open(self.branch_repofolder, view='referenceprefix_manager')
         self.assertEquals(
             [['1', '-- Already removed object --', 'Unlock'],
              ['3', '-- Already removed object --', 'Unlock']],
@@ -49,7 +49,7 @@ class TestReferencePrefixManager(IntegrationTestCase):
     @browsing
     def test_manager_shows_default_message_when_no_repository_available(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.leaf_repository, view='referenceprefix_manager')
+        browser.open(self.leaf_repofolder, view='referenceprefix_manager')
 
         self.assertEquals(
             'No nested repositorys available.',
@@ -59,12 +59,12 @@ class TestReferencePrefixManager(IntegrationTestCase):
     def test_manager_is_hidden_from_users_without_permission(self, browser):
         self.login(self.regular_user, browser)
         with browser.expect_unauthorized():
-            browser.open(self.branch_repository, view='referenceprefix_manager')
+            browser.open(self.branch_repofolder, view='referenceprefix_manager')
 
     @browsing
     def test_unlock_actions_are_journalized(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.branch_repository, view='referenceprefix_manager')
+        browser.open(self.branch_repofolder, view='referenceprefix_manager')
         browser.click_on('Unlock')
         statusmessages.assert_no_error_messages()
 
@@ -77,7 +77,7 @@ class TestReferencePrefixManager(IntegrationTestCase):
     @browsing
     def test_error_while_unlock_shows_statusmessage(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.branch_repository,
+        browser.open(self.branch_repofolder,
                      view='referenceprefix_manager?prefix=3')
         statusmessages.assert_message(
             'The reference you try to unlock is still in use.')

--- a/opengever/repository/tests/test_repository_workflow.py
+++ b/opengever/repository/tests/test_repository_workflow.py
@@ -6,15 +6,15 @@ from plone.app.testing import SITE_OWNER_NAME
 class TestRepositoryWorkflow(IntegrationTestCase):
 
     @browsing
-    def test_list_folder_contents_on_repository_is_not_available_for_adminstrators(self, browser):
+    def test_list_folder_contents_on_repofolder_is_not_available_for_adminstrators(self, browser):
         self.login(self.administrator, browser)
         with browser.expect_unauthorized():
-            browser.open(self.branch_repository, view='folder_contents')
+            browser.open(self.branch_repofolder, view='folder_contents')
 
     @browsing
-    def test_list_folder_contents_on_repository_is_available_for_managers(self, browser):
+    def test_list_folder_contents_on_repofolder_is_available_for_managers(self, browser):
         self.login(SITE_OWNER_NAME, browser)
-        browser.open(self.branch_repository, view='folder_contents')
+        browser.open(self.branch_repofolder, view='folder_contents')
 
     @browsing
     def test_list_folder_contents_on_repositoryroot_is_not_available_for_adminstrators(self, browser):

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -20,36 +20,36 @@ class TestRepositoryFolder(IntegrationTestCase):
 
     def test_Title_is_prefixed_with_reference_number(self):
         self.assertEquals('1.1. Vertr\xc3\xa4ge und Vereinbarungen',
-                          self.leaf_repository.Title())
+                          self.leaf_repofolder.Title())
 
     def test_Title_accessor_use_reference_formatters_seperator(self):
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IReferenceNumberSettings)
         proxy.formatter = 'grouped_by_three'
         self.assertEquals('11 Vertr\xc3\xa4ge und Vereinbarungen',
-                          self.leaf_repository.Title())
+                          self.leaf_repofolder.Title())
 
     def test_Title_returns_title_in_current_language(self):
         set_preferred_language(self.portal.REQUEST, 'fr-ch')
-        self.assertEquals('1.1. Contrats et accords', self.leaf_repository.Title())
+        self.assertEquals('1.1. Contrats et accords', self.leaf_repofolder.Title())
 
         set_preferred_language(self.portal.REQUEST, 'de-ch')
         self.assertEquals('1.1. Vertr\xc3\xa4ge und Vereinbarungen',
-                          self.leaf_repository.Title())
+                          self.leaf_repofolder.Title())
 
     def test_title_indexes(self):
-        brain = obj2brain(self.leaf_repository)
+        brain = obj2brain(self.leaf_repofolder)
         self.assertEquals(u'1.1. Contrats et accords', brain.title_fr)
         self.assertEquals(u'1.1. Vertr\xe4ge und Vereinbarungen', brain.title_de)
 
     def test_get_archival_value(self):
         self.assertEquals(ARCHIVAL_VALUE_UNCHECKED,
-                          self.leaf_repository.get_archival_value())
+                          self.leaf_repofolder.get_archival_value())
 
     @browsing
     def test_create_repository_folder(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         factoriesmenu.add('RepositoryFolder')
         browser.fill({'Title': 'Custody'}).save()
         statusmessages.assert_no_error_messages()
@@ -75,28 +75,28 @@ class TestRepositoryFolder(IntegrationTestCase):
                   u'a new leafnode afterwards.'
 
         self.assertTrue(any(filter(IDossierMarker.providedBy,
-                                   self.leaf_repository.objectValues())),
-                        'Expected at least one dossier within leaf_repository.')
-        browser.open(self.leaf_repository)
+                                   self.leaf_repofolder.objectValues())),
+                        'Expected at least one dossier within leaf_repofolder.')
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('RepositoryFolder')
         statusmessages.assert_message(warning)
 
         self.assertFalse(any(filter(IDossierMarker.providedBy,
-                                    self.branch_repository.objectValues())),
-                         'Expected no dossiers within branch_repository.')
-        browser.open(self.branch_repository)
+                                    self.branch_repofolder.objectValues())),
+                         'Expected no dossiers within branch_repofolder.')
+        browser.open(self.branch_repofolder)
         factoriesmenu.add('RepositoryFolder')
         statusmessages.assert_no_messages()
 
         self.assertFalse(any(filter(IDossierMarker.providedBy,
-                                    self.empty_repository.objectValues())),
-                         'Expected no dossiers within empty_repository.')
-        browser.open(self.empty_repository)
+                                    self.empty_repofolder.objectValues())),
+                         'Expected no dossiers within empty_repofolder.')
+        browser.open(self.empty_repofolder)
         factoriesmenu.add('RepositoryFolder')
         statusmessages.assert_no_messages()
 
     @browsing
-    def test_only_repository_addable_when_already_contains_repositories(self, browser):
+    def test_only_repofolder_addable_when_already_contains_repositories(self, browser):
         """A repository folder should not contain other repository folders AND
         dossiers at the same time.
         Therefore dossiers should not be addable in branch repository folders.
@@ -104,15 +104,15 @@ class TestRepositoryFolder(IntegrationTestCase):
         self.login(self.administrator, browser)
 
         self.assertTrue(any(filter(IRepositoryFolder.providedBy,
-                                   self.branch_repository.objectValues())),
-                        'Expected repositories within branch_repository.')
-        browser.open(self.branch_repository)
+                                   self.branch_repofolder.objectValues())),
+                        'Expected repositories within branch_repofolder.')
+        browser.open(self.branch_repofolder)
         self.assertEquals(
             ['RepositoryFolder'],
             factoriesmenu.addable_types())
 
     @browsing
-    def test_dossiers_addable_in_empty_repository_folder(self, browser):
+    def test_dossiers_addable_in_empty_repofolder_folder(self, browser):
         """A repository folder should not contain other repository folders AND
         dossiers at the same time.
         Therefore dossiers should be addable in empty repository folders.
@@ -120,9 +120,9 @@ class TestRepositoryFolder(IntegrationTestCase):
         self.login(self.administrator, browser)
 
         self.assertFalse(any(filter(IRepositoryFolder.providedBy,
-                                    self.empty_repository.objectValues())),
-                         'Expected no repositories within empty_repository.')
-        browser.open(self.empty_repository)
+                                    self.empty_repofolder.objectValues())),
+                         'Expected no repositories within empty_repofolder.')
+        browser.open(self.empty_repofolder)
         self.assertEquals(
             ['Business Case Dossier', 'RepositoryFolder'],
             factoriesmenu.addable_types())
@@ -131,7 +131,7 @@ class TestRepositoryFolder(IntegrationTestCase):
     def test_max_depth_causes_repositories_to_not_be_addable(self, browser):
         self.login(self.administrator, browser)
 
-        browser.open(self.leaf_repository)
+        browser.open(self.leaf_repofolder)
         self.assertIn('RepositoryFolder', factoriesmenu.addable_types())
 
         api.portal.set_registry_record(
@@ -152,11 +152,11 @@ class TestDossierTemplateFactoryMenu(IntegrationTestCase):
     @browsing
     def test_adding_from_template_allowed_on_leaf_nodes(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.leaf_repository)
+        browser.open(self.leaf_repofolder)
         self.assertIn(self.factory_label, factoriesmenu.addable_types())
 
     @browsing
     def test_adding_from_template_not_allowed_on_branch_nodes(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         self.assertNotIn(self.factory_label, factoriesmenu.addable_types())

--- a/opengever/repository/tests/test_repositoryfolder_byline.py
+++ b/opengever/repository/tests/test_repositoryfolder_byline.py
@@ -8,7 +8,7 @@ class TestRepositoryfolderByline(IntegrationTestCase):
     @browsing
     def test_privacy_layer_is_shown(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         # XXX The English transalation of the values are missing.
         self.assertDictContainsSubset(
             {'Privacy layer:': 'privacy_layer_no'},
@@ -17,7 +17,7 @@ class TestRepositoryfolderByline(IntegrationTestCase):
     @browsing
     def test_archival_value_is_shown(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         self.assertDictContainsSubset(
             {'Archival value:': 'unchecked'},
             byline.text_dict())
@@ -25,7 +25,7 @@ class TestRepositoryfolderByline(IntegrationTestCase):
     @browsing
     def test_public_trial_is_not_present(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.branch_repository)
+        browser.open(self.branch_repofolder)
         self.assertNotIn(
             'Public Trial:', byline.text_dict(),
             "Public trial must NOT be part of repository byline any more")
@@ -33,9 +33,9 @@ class TestRepositoryfolderByline(IntegrationTestCase):
     @browsing
     def test_description_is_shown_when_exists(self, browser):
         self.login(self.regular_user, browser)
-        self.assertTrue(self.branch_repository.Description(),
-                        'Expected branch_repository to have a description.')
-        browser.open(self.branch_repository)
+        self.assertTrue(self.branch_repofolder.Description(),
+                        'Expected branch_repofolder to have a description.')
+        browser.open(self.branch_repofolder)
         self.assertEquals(
             [u'Alles zum Thema F\xfchrung.'],
             browser.css('.documentByLine .description').text)
@@ -43,7 +43,7 @@ class TestRepositoryfolderByline(IntegrationTestCase):
     @browsing
     def test_description_is_not_shown_when_there_is_none(self, browser):
         self.login(self.regular_user, browser)
-        self.assertFalse(self.leaf_repository.Description(),
-                        'Expected leaf_repository to have no description.')
-        browser.open(self.leaf_repository)
+        self.assertFalse(self.leaf_repofolder.Description(),
+                        'Expected leaf_repofolder to have no description.')
+        browser.open(self.leaf_repofolder)
         self.assertFalse(browser.css('.documentByLine .description'))

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -10,21 +10,21 @@ class TestReferencePrefixUpdating(IntegrationTestCase):
     @browsing
     def test_reference_number_is_updated_in_catalog(self, browser):
         self.login(self.administrator, browser)
-        self.assertEquals('Client1 1.1', obj2brain(self.leaf_repository).reference)
+        self.assertEquals('Client1 1.1', obj2brain(self.leaf_repofolder).reference)
 
-        browser.open(self.leaf_repository, view='edit')
+        browser.open(self.leaf_repofolder, view='edit')
         browser.fill({'Reference Prefix': u'7'}).save()
-        self.assertEquals('Client1 1.7', obj2brain(self.leaf_repository).reference)
+        self.assertEquals('Client1 1.7', obj2brain(self.leaf_repofolder).reference)
 
     @browsing
     def test_reference_number_of_children_is_updated_in_catalog(self, browser):
         self.login(self.administrator, browser)
         self.assertEqual(
-            self.leaf_repository,
+            self.leaf_repofolder,
             aq_parent(aq_inner(self.dossier)),
-            'Fixture: expected self.dossier to be within self.leaf_repository')
+            'Fixture: expected self.dossier to be within self.leaf_repofolder')
         self.assertEquals('Client1 1.1 / 1', obj2brain(self.dossier).reference)
 
-        browser.open(self.leaf_repository, view='edit')
+        browser.open(self.leaf_repofolder, view='edit')
         browser.fill({'Reference Prefix': u'7'}).save()
         self.assertEquals('Client1 1.7 / 1', obj2brain(self.dossier).reference)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -76,18 +76,18 @@ class OpengeverContentFixture(object):
                                        ('Reader', 'Contributor', 'Editor'))
         self.root.reindexObjectSecurity()
 
-        self.repo0 = self.register('branch_repository', create(
+        self.repofolder0 = self.register('branch_repofolder', create(
             Builder('repository').within(self.root)
             .having(title_de=u'F\xfchrung',
                     title_fr=u'Direction',
                     description=u'Alles zum Thema F\xfchrung.')))
 
-        self.repo00 = self.register('leaf_repository', create(
-            Builder('repository').within(self.repo0)
+        self.repofolder00 = self.register('leaf_repofolder', create(
+            Builder('repository').within(self.repofolder0)
             .having(title_de=u'Vertr\xe4ge und Vereinbarungen',
                     title_fr=u'Contrats et accords')))
 
-        self.repo1 = self.register('empty_repository', create(
+        self.repofolder1 = self.register('empty_repofolder', create(
             Builder('repository').within(self.root)
             .having(title_de=u'Rechnungspr\xfcfungskommission',
                     title_fr=u'Commission de v\xe9rification')))
@@ -114,14 +114,14 @@ class OpengeverContentFixture(object):
 
         self.register('committee', self.create_committee(
             title=u'Rechnungspr\xfcfungskommission',
-            repository_folder=self.repo1,
+            repository_folder=self.repofolder1,
             group_id='committee_rpk_group',
             members=[self.administrator]))
 
     @staticuid()
     def create_treaty_dossiers(self):
         dossier = self.register('dossier', create(
-            Builder('dossier').within(self.repo00)
+            Builder('dossier').within(self.repofolder00)
             .titled(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung')
             .having(description=u'Alle aktuellen Vertr\xe4ge mit der'
                     u' kantonalen Finanzverwaltung sind hier abzulegen.'
@@ -133,7 +133,7 @@ class OpengeverContentFixture(object):
                       create(Builder('dossier').within(dossier).titled(u'2016')))
 
         self.register('archive_dossier', create(
-            Builder('dossier').within(self.repo00)
+            Builder('dossier').within(self.repofolder00)
             .titled(u'Archiv Vertr\xe4ge')
             .having(description=u'Archiv der Vertr\xe4ge vor 2016.',
                     keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),


### PR DESCRIPTION
"repository" refers more to the whole tree, including the root. Therefore the term "repository folder" or short "repofolder" is more accurate.