### PR TITLE
Fix filetree scroll position of current item.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Added missing cancel button for the manual journal entry form. [phgross]
 - XSS: Escape html for manual journal entries' comment. [tarnap]
+- Fix filetree scroll position of current item. [Kevin Bieri]
 - Allow move items in the documents tab within the templatefolder. [elioschmutz]
 - XSS: Escape html for Dossier title on task listing. [mathias.leimgruber]
 - XSS: Escape html for the breadcrumbs part for get_link on tasks. [mathias.leimgruber]

--- a/opengever/portlets/tree/resources/init_tree.js
+++ b/opengever/portlets/tree/resources/init_tree.js
@@ -6,7 +6,6 @@ $(function() {
 
   $(document).bind('tree:rendered', function() {
     limit_treeportlet_height();
-    scroll_to_selected_item(portlet.find('.portlet-tabs > .tab'));
   });
 
 
@@ -41,6 +40,7 @@ $(function() {
           navtree.render(tree_node);
           navtree.selectCurrent(find_parent_node_for_url(
               navtree, portlet.data('context-url')));
+          scroll_to_selected_item();
         });
   });
 
@@ -139,11 +139,12 @@ $(function() {
     tabs.css('max-height', 'calc(100vh - ' + offset + 'px');
   }
 
-  function scroll_to_selected_item(tree) {
-    var position = tree.find('a.current').position();
-    if (position) {
-      $('.portletTreePortlet dd.portletItem').scrollTop(position.top - 60);
-    }
+  function scroll_to_selected_item() {
+    var tree = $("#tree-complete");
+    var portletHeader = $(".portlet-header-tabs");
+    var current = tree.find("a.current");
+    if(!current.length) { return; }
+    tree.scrollTop(tree.scrollTop() + current.position().top - portletHeader.height());
   }
 
   function sort_by_text(list_of_nodes) {


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/3014

![file_tree_autoscrolling](https://user-images.githubusercontent.com/1637820/27641666-d1b0e7ac-5c1c-11e7-9e8c-e974820547c6.gif)
