### PR TITLE
Fix an issue where creating a dossier from template ended in an exception.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Added missing cancel button for the manual journal entry form. [phgross]
 - XSS: Escape html for manual journal entries' comment. [tarnap]
 - Fix filetree scroll position of current item. [Kevin Bieri]
+- Fix an issue where creating a dossier from template ended in an exception. [elioschmutz]
 - Allow move items in the documents tab within the templatefolder. [elioschmutz]
 - XSS: Escape html for Dossier title on task listing. [mathias.leimgruber]
 - XSS: Escape html for the breadcrumbs part for get_link on tasks. [mathias.leimgruber]


### PR DESCRIPTION
While creating a dossier from a template, the user fills out fields on different wizard steps. Each step requires a new request. In the first step, the user chooses which dossiertemplate he wants to add, in the second step he fills out the dossier-fields prefilled from the choosen dossiertemplate and then he can save the dossier. We use an object-storage to retrive the dossietemplate in the next request. In some cases, this object looses its acquisitionwrapper which ends in an exception.

To fix this issue, we changed the implementation to use a path-storage and we retrieve the object in each request through traversing.

Issuer: https://extranet.4teamwork.ch/support/kunde-stadt-nidau/tracker/54
See related sentry issue: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3436/ 