### PR TITLE
Integration testing: start tests anonymously.

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -23,6 +23,7 @@ from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
+from plone.app.testing import logout
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -487,6 +488,7 @@ class GEVERIntegrationTesting(IntegrationTesting):
         self.interceptor.intercept(self.interceptor.BEGIN
                                    | self.interceptor.COMMIT
                                    | self.interceptor.ABORT)
+        logout()
 
     def testTearDown(self):
         self.savepoint.rollback()

--- a/opengever/core/tests/test_integration_testing_setup.py
+++ b/opengever/core/tests/test_integration_testing_setup.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.ogds.base.utils import ogds_service
 from opengever.testing import IntegrationTestCase
+from plone import api
 import transaction
 
 
@@ -58,3 +59,6 @@ class TestIntegrationTestSetup(IntegrationTestCase):
         self.assertFalse(
             ogds_service().fetch_user(args['userid']),
             'Could not rollback SQL properly.')
+
+    def test_serverside_default_user_is_anonymous(self):
+        self.assertTrue(api.user.is_anonymous())

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -13,6 +13,7 @@ from zope.interface.verify import verifyObject
 class TestReferenceBehavior(IntegrationTestCase):
 
     def test_repositories_provide_marker_interface(self):
+        self.login(self.regular_user)
         self.assertTrue(IReferenceNumberPrefixMarker.providedBy(
             self.leaf_repofolder))
         verifyObject(IReferenceNumberPrefixMarker, self.leaf_repofolder)

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -11,9 +11,10 @@ class TestReferencePrefixManager(IntegrationTestCase):
 
     def setUp(self):
         super(TestReferencePrefixManager, self).setUp()
-        # move repo1 to prefix 3 which leaves prefix 1 unused
-        manager = ReferenceNumberPrefixAdpater(self.branch_repofolder)
-        manager.set_number(self.leaf_repofolder, 3)
+        with self.login(self.administrator):
+            # move repo1 to prefix 3 which leaves prefix 1 unused
+            manager = ReferenceNumberPrefixAdpater(self.branch_repofolder)
+            manager.set_number(self.leaf_repofolder, 3)
 
     @browsing
     def test_list_and_unlock_unused_prefixes(self, browser):
@@ -32,6 +33,7 @@ class TestReferencePrefixManager(IntegrationTestCase):
             browser.css('#reference_prefix_manager_table').first.lists())
 
     def test_manager_throws_error_when_delete_request_for_used_prefix_occurs(self):
+        self.login(self.administrator)
         manager = ReferenceNumberPrefixAdpater(self.branch_repofolder)
         with self.assertRaises(Exception):
             manager.free_number(19)

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -19,10 +19,12 @@ from zope.component import getUtility
 class TestRepositoryFolder(IntegrationTestCase):
 
     def test_Title_is_prefixed_with_reference_number(self):
+        self.login(self.regular_user)
         self.assertEquals('1.1. Vertr\xc3\xa4ge und Vereinbarungen',
                           self.leaf_repofolder.Title())
 
     def test_Title_accessor_use_reference_formatters_seperator(self):
+        self.login(self.regular_user)
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IReferenceNumberSettings)
         proxy.formatter = 'grouped_by_three'
@@ -30,6 +32,7 @@ class TestRepositoryFolder(IntegrationTestCase):
                           self.leaf_repofolder.Title())
 
     def test_Title_returns_title_in_current_language(self):
+        self.login(self.regular_user)
         set_preferred_language(self.portal.REQUEST, 'fr-ch')
         self.assertEquals('1.1. Contrats et accords', self.leaf_repofolder.Title())
 
@@ -38,11 +41,13 @@ class TestRepositoryFolder(IntegrationTestCase):
                           self.leaf_repofolder.Title())
 
     def test_title_indexes(self):
+        self.login(self.regular_user)
         brain = obj2brain(self.leaf_repofolder)
         self.assertEquals(u'1.1. Contrats et accords', brain.title_fr)
         self.assertEquals(u'1.1. Vertr\xe4ge und Vereinbarungen', brain.title_de)
 
     def test_get_archival_value(self):
+        self.login(self.regular_user)
         self.assertEquals(ARCHIVAL_VALUE_UNCHECKED,
                           self.leaf_repofolder.get_archival_value())
 

--- a/opengever/testing/tests/test_fixtures.py
+++ b/opengever/testing/tests/test_fixtures.py
@@ -9,23 +9,28 @@ from plone.uuid.interfaces import IUUID
 class TestTestingFixture(IntegrationTestCase):
 
     def test_administrator_user(self):
+        self.login(self.regular_user)
         self.assertEquals('nicole.kohler', self.administrator.getId())
         self.assertIn('Administrator', self.administrator.getRoles())
 
     def test_repository_root_has_static_creation_date(self):
+        self.login(self.regular_user)
         self.assertEquals(DateTime('2016/08/31 09:01:33 GMT+2'),
                           self.repository_root.created())
 
     def test_repository_root_has_static_uuid(self):
+        self.login(self.regular_user)
         self.assertEquals('createrepositorytree000000000001',
                           IUUID(self.repository_root))
 
     @browsing
     def test_repository_root_view_renders(self, browser):
-        browser.login(self.administrator).open(self.repository_root)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.repository_root)
         self.assertEquals('Ordnungssystem', plone.first_heading())
 
     def test_leaf_repofolder_has_no_subrepositories(self):
+        self.login(self.regular_user)
         self.assertFalse(
             filter(IRepositoryFolder.providedBy,
                    self.leaf_repofolder.objectValues()),
@@ -34,6 +39,7 @@ class TestTestingFixture(IntegrationTestCase):
                 self.leaf_repofolder))
 
     def test_branch_repofolder_has_subrepositories(self):
+        self.login(self.regular_user)
         self.assertTrue(
             filter(IRepositoryFolder.providedBy,
                    self.branch_repofolder.objectValues()),

--- a/opengever/testing/tests/test_integration_test_case.py
+++ b/opengever/testing/tests/test_integration_test_case.py
@@ -1,0 +1,60 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestIntegrationTestCase(IntegrationTestCase):
+
+    def test_login(self):
+        self.assertTrue(api.user.is_anonymous())
+        self.login(self.regular_user)
+        self.assertFalse(api.user.is_anonymous())
+        self.assertEqual(self.regular_user, api.user.get_current())
+
+    @browsing
+    def test_login_browser(self, browser):
+        browser.open()
+        self.assertFalse(plone.logged_in())
+        self.login(self.regular_user, browser)
+        browser.open()
+        self.assertEquals(self.regular_user.getProperty('fullname'),
+                          plone.logged_in().encode('utf-8'))
+
+    def test_login_as_context_manager(self):
+        self.assertTrue(api.user.is_anonymous())
+
+        with self.login(self.regular_user):
+            self.assertFalse(api.user.is_anonymous())
+            self.assertEqual(self.regular_user, api.user.get_current())
+
+            with self.login(self.administrator):
+                self.assertFalse(api.user.is_anonymous())
+                self.assertEqual(self.administrator, api.user.get_current())
+
+            self.assertFalse(api.user.is_anonymous())
+            self.assertEqual(self.regular_user, api.user.get_current())
+
+        self.assertTrue(api.user.is_anonymous())
+
+    @browsing
+    def test_login_as_context_manager_in_browser(self, browser):
+        browser.open()
+        self.assertFalse(plone.logged_in())
+
+        with self.login(self.regular_user, browser):
+            browser.open()
+            self.assertEquals(self.regular_user.getProperty('fullname'),
+                              plone.logged_in().encode('utf-8'))
+
+            with self.login(self.administrator, browser):
+                browser.open()
+                self.assertEquals(self.administrator.getProperty('fullname'),
+                                  plone.logged_in().encode('utf-8'))
+
+            browser.open()
+            self.assertEquals(self.regular_user.getProperty('fullname'),
+                              plone.logged_in().encode('utf-8'))
+
+        browser.open()
+        self.assertFalse(plone.logged_in())


### PR DESCRIPTION
Tests should start anonymously by default, because:

- as a test reader, I want to see for each test with which user it runs  (as in BBD `As a dossier responsible, In order to .., I want to ..`)
- from a security / QA perspective I want to lead devopers to making an active decision for who this test should be
- as a developer I would like to have consistency between test-code and browser-code regarding who is the user under test.

``self.login`` is now also a context manager which resets to the prior security. This makes it easier to do authenticated preparations in the ``setUp`` method without the side effect the the user is now authorized in the test method.