### PR TITLE
Fix schema migration EnlargeProfileidInMigrationTrackingTable for oracle backend.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Show userid instead of E-Mail address on all sources (except EMailSource). [mathias.leimgruber]
 - Fix "leave GEVER" on logout overlay. [mathias.leimgruber]
 - Disbale swfobject.js - no longer load Flash Fallback for multiuploads. [mathias.leimgruber]
+- Fix schema migration EnlargeProfileidInMigrationTrackingTable for oracle backend. [phgross]
 - Add missing contacts only sources, used by customer special dossiers. [phgross]
 - Reset journal after copy a document. [mathias.leimgruber]
 - Switch back to the orginal plone.formwidget.autocomplete package from our fork. [phgross]

--- a/opengever/ogds/base/upgrades/20160211150813_enlarge_profileid_in_migration_tracking_table/upgrade.py
+++ b/opengever/ogds/base/upgrades/20160211150813_enlarge_profileid_in_migration_tracking_table/upgrade.py
@@ -1,5 +1,12 @@
 from opengever.core.upgrade import SchemaMigration
 from sqlalchemy import BigInteger
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+TRACKING_TABLE_NAME = 'opengever_upgrade_version'
 
 
 class EnlargeProfileidInMigrationTrackingTable(SchemaMigration):
@@ -12,9 +19,68 @@ class EnlargeProfileidInMigrationTrackingTable(SchemaMigration):
     """
 
     def migrate(self):
+        if self.is_oracle:
+            self.migrate_oracle()
+
+        else:
+            self.op.alter_column(
+                table_name=TRACKING_TABLE_NAME,
+                column_name='upgradeid',
+                existing_nullable=False,
+                type_=BigInteger,
+            )
+
+    def migrate_oracle(self):
+        """Because oracle can't handle an Number increase of a column which
+        contains data, so we have to rename the column, copy the data over and
+        then drop the original column.
+
+        See `ORA-01440' for more details.
+        """
+
+        self.rename_original_column()
+        self.add_new_column()
+
+        self.migrate_data()
+
+        self.make_upgradeid_non_nullable()
+        self.drop_tmp_column()
+
+    def rename_original_column(self):
         self.op.alter_column(
-            table_name='opengever_upgrade_version',
+            table_name=TRACKING_TABLE_NAME,
             column_name='upgradeid',
+            new_column_name='old_upgradeid',
             existing_nullable=False,
-            type_=BigInteger,
+            type_=Integer,
         )
+
+    def add_new_column(self):
+        self.op.add_column(
+            TRACKING_TABLE_NAME,
+            Column('upgradeid', BigInteger, nullable=True)
+        )
+
+    def migrate_data(self):
+        tracking_table = table(
+            TRACKING_TABLE_NAME,
+            column("profileid"),
+            column("upgradeid"),
+            column("old_upgradeid")
+        )
+
+        profiles = self.connection.execute(tracking_table.select()).fetchall()
+
+        for profile in profiles:
+            self.execute(
+                tracking_table.update()
+                .values(upgradeid=profile.old_upgradeid)
+                .where(tracking_table.columns.profileid == profile.profileid)
+            )
+
+    def make_upgradeid_non_nullable(self):
+        self.op.alter_column(TRACKING_TABLE_NAME, 'upgradeid',
+                             existing_type=BigInteger, nullable=False)
+
+    def drop_tmp_column(self):
+        self.op.drop_column(TRACKING_TABLE_NAME, 'old_upgradeid')


### PR DESCRIPTION
Because Oracle is not able to change a Integer column to a BigInteger, when it contains data. I've add a separate implementation for oracle backends to  the `EnlargeProfileidInMigrationTrackingTable` upgradestep. Instead of changing the column type, it now renames the column, add the new one, copies the data and drops the old_column.