### PR TITLE
Add opengever.ogds.models to development-packages.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -13,6 +13,7 @@ development-packages =
   Products.LDAPMultiPlugins
   ftw.tabbedview
   ftw.testbrowser
+  opengever.ogds.models
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
To include a fix which has been made for oracle backends, see https://github.com/4teamwork/opengever.ogds.models/pull/46.