### PR TITLE
Add version number to journal's download entries

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.1 (unreleased)
 ---------------------
 
+- Add version of downloaded file to journal's entry. [tarnap]
 - Expand current subdossier in subdossier tree. [Kevin Bieri]
 - Always download MSG file if avaiable. [mathias.leimgruber]
 - Do not sync comments to a predecessor forwarding. [phgross]

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -160,5 +160,7 @@ class DocumentDownloadFileVersion(DownloadFileVersion):
 
         self._init_version_file()
         if self.version_file:
-            notify(FileCopyDownloadedEvent(self.context))
+            notify(FileCopyDownloadedEvent(
+                self.context,
+                getattr(self.request, 'version_id', None)))
         return super(DocumentDownloadFileVersion, self).render()

--- a/opengever/document/events.py
+++ b/opengever/document/events.py
@@ -66,6 +66,10 @@ class FileCopyDownloadedEvent(ObjectEvent):
 
     grok.implements(interfaces.IFileCopyDownloadedEvent)
 
+    def __init__(self, obj, version_id=None):
+        self.object = obj
+        self.version_id = version_id
+
 
 class FileAttachedToEmailEvent(ObjectEvent):
     """The file was attached to an email by OfficeConnector."""

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -12,6 +12,7 @@ from opengever.base.browser.paste import ICopyPasteRequestLayer
 from opengever.base.oguid import Oguid
 from opengever.bumblebee.interfaces import IPDFDownloadedEvent
 from opengever.document.behaviors import IBaseDocument
+from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import IFileCopyDownloadedEvent
 from opengever.document.interfaces import IObjectCheckedInEvent
 from opengever.document.interfaces import IObjectCheckedOutEvent
@@ -516,8 +517,29 @@ FILE_COPY_DOWNLOADED = 'File copy downloaded'
 
 @grok.subscribe(IBaseDocument, IFileCopyDownloadedEvent)
 def file_copy_downloaded(context, event):
-    title = _(u'label_file_copy_downloaded',
-              default=u'Download copy')
+
+    title_unversioned = _(u'label_file_copy_downloaded',
+                          default=u'Download copy')
+
+    if IDocumentSchema.providedBy(context):
+        version_id = getattr(event, 'version_id')
+
+        if version_id is not None:
+            version_string = _(u'label_file_copy_downloaded_version',
+                               default=u'version ${version_id}',
+                               mapping={'version_id': version_id})
+        else:
+            version_string = _(u'label_file_copy_downloaded_actual_version',
+                               default=u'current version (${version_id})',
+                               mapping={'version_id': context.version_id})
+
+        title = _(u'label_file_copy_downloaded_with_version',
+                  default=u'${title} ${version_string}',
+                  mapping={'title': title_unversioned,
+                           'version_string': version_string})
+    else:
+        title = title_unversioned
+
     journal_entry_factory(context, FILE_COPY_DOWNLOADED, title)
 
 

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-07-03 12:27+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -177,9 +177,24 @@ msgid "label_dossier_zipped"
 msgstr "Dossier in ZIP-Export aufgenommen: ${title}"
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:507
+#: ./opengever/journal/handlers.py:520
 msgid "label_file_copy_downloaded"
 msgstr "Download Kopie"
+
+#. Default: "current version (${version_id})"
+#: ./opengever/journal/handlers.py:513
+msgid "label_file_copy_downloaded_actual_version"
+msgstr "aktuelle Version (${version_id})"
+
+#. Default: "version ${version_id}"
+#: ./opengever/journal/handlers.py:516
+msgid "label_file_copy_downloaded_version"
+msgstr "Version ${version_id}"
+
+#. Default: "${title} ${version_string}"
+#: ./opengever/journal/handlers.py:525
+msgid "label_file_copy_downloaded_with_version"
+msgstr "${title} ${version_string}"
 
 #. Default: "Local roles aquistion activated."
 #: ./opengever/journal/handlers.py:296

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-07-03 12:27+0000\n"
 "PO-Revision-Date: 2017-06-04 12:59+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
@@ -179,9 +179,24 @@ msgid "label_dossier_zipped"
 msgstr "Dossier ajouté à l'export ZIP: ${title}"
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:507
+#: ./opengever/journal/handlers.py:520
 msgid "label_file_copy_downloaded"
 msgstr "Télécharger une copie"
+
+#. Default: "current version (${version_id})"
+#: ./opengever/journal/handlers.py:513
+msgid "label_file_copy_downloaded_actual_version"
+msgstr "version actuelle (${version_id})"
+
+#. Default: "version ${version_id}"
+#: ./opengever/journal/handlers.py:516
+msgid "label_file_copy_downloaded_version"
+msgstr "version ${version_id}"
+
+#. Default: "${title} ${version_string}"
+#: ./opengever/journal/handlers.py:525
+msgid "label_file_copy_downloaded_with_version"
+msgstr "${title} ${version_string}"
 
 #. Default: "Local roles aquistion activated."
 #: ./opengever/journal/handlers.py:296

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-07-03 12:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.journal\n"
+
+#: ./opengever/journal/handlers.py:513
+msgid "label_file_copy_downloaded"
+msgstr ""
 
 #. Default: "Journal"
 #: ./opengever/journal/templates/journalhistory.pt:15
@@ -179,9 +183,19 @@ msgstr ""
 msgid "label_dossier_zipped"
 msgstr ""
 
-#. Default: "Download copy"
-#: ./opengever/journal/handlers.py:507
+#. Default: "Download copy ${version_string}"
+#: ./opengever/journal/handlers.py:520
 msgid "label_file_copy_downloaded"
+msgstr ""
+
+#. Default: "current version (${version_id})"
+#: ./opengever/journal/handlers.py:513
+msgid "label_file_copy_downloaded_actual_version"
+msgstr ""
+
+#. Default: "version ${version_id}"
+#: ./opengever/journal/handlers.py:516
+msgid "label_file_copy_downloaded_version"
 msgstr ""
 
 #. Default: "Local roles aquistion activated."

--- a/opengever/journal/tests/test_integration.py
+++ b/opengever/journal/tests/test_integration.py
@@ -517,9 +517,11 @@ class TestOpengeverJournalGeneral(unittest.TestCase):
             )
 
     def check_document_copy_downloaded(self, obj):
+        title = u'Download copy current version ({version_id})'.format(
+            version_id=obj.version_id)
         self.check_annotation(
             obj,
             action_type='File copy downloaded',
-            action_title=u'Download copy',
+            action_title=title,
             actor=TEST_USER_ID,
             )

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -57,8 +57,7 @@ class TestMailDownloadCopy(FunctionalTestCase):
              'title': u'label_file_copy_downloaded'},
             action)
 
-        self.assertEquals(u'Download copy',
-                          translate(action['title']))
+        self.assertEquals(u'Download copy', translate(action['title']))
 
     @browsing
     def test_mail_download_converts_lf_to_crlf(self, browser):


### PR DESCRIPTION
It's not possible to determine which file version the user downloaded from the journal entries.
This is improved by adding the version number (or `current version` if the downloaded version was the working copy) to the title.

![version in journal](https://user-images.githubusercontent.com/194114/27737170-7200b6de-5da7-11e7-94cf-111acb15e433.gif)

Resolves: #3075