### PR TITLE
Add `ftw.mobilenavigation` to development-packages,

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -14,6 +14,7 @@ development-packages =
   ftw.tabbedview
   ftw.testbrowser
   opengever.ogds.models
+  ftw.mobilenavigation
 
 auto-checkout = ${buildout:development-packages}
 


### PR DESCRIPTION
To include the latest fix https://github.com/4teamwork/ftw.mobilenavigation/pull/45 to include portal tabs. Closes #2993 