### PR TITLE
Integration testing support for plone.protects auto CSRF protection

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -488,9 +488,12 @@ class GEVERIntegrationTesting(IntegrationTesting):
         self.interceptor.intercept(self.interceptor.BEGIN
                                    | self.interceptor.COMMIT
                                    | self.interceptor.ABORT)
+        self.interceptor.begin_savepoint_simulation()
+        self.interceptor.begin()
         logout()
 
     def testTearDown(self):
+        self.interceptor.stop_savepoint_simulation()
         self.savepoint.rollback()
         self.savepoint = None
         self.interceptor.clear().intercept(self.interceptor.COMMIT)

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -29,13 +29,18 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.browserlayer.utils import unregister_layer
 from plone.dexterity.schema import SCHEMA_CACHE
+from plone.protect.auto import safeWrite
 from plone.testing import z2
+from plone.transformchain.interfaces import ITransform
 from Products.CMFCore.utils import getToolByName
 from Testing.ZopeTestCase.utils import setupCoreSessions
+from zope.component import getGlobalSiteManager
+from zope.component import getMultiAdapter
 from zope.component import getSiteManager
 from zope.configuration import xmlconfig
 from zope.globalrequest import setRequest
 from zope.sqlalchemy.datamanager import mark_changed
+from ZPublisher.interfaces import IPubAfterTraversal
 import logging
 import os
 import sys
@@ -474,6 +479,8 @@ class GEVERIntegrationTesting(IntegrationTesting):
         super(GEVERIntegrationTesting, self).setUp()
         transaction.commit()
         self.interceptor = TransactionInterceptor().install()
+        getGlobalSiteManager().registerHandler(
+            self.handlePubAfterTraversal, [IPubAfterTraversal])
 
     def tearDown(self):
         self.interceptor.uninstall()
@@ -498,6 +505,26 @@ class GEVERIntegrationTesting(IntegrationTesting):
         self.savepoint = None
         self.interceptor.clear().intercept(self.interceptor.COMMIT)
         super(GEVERIntegrationTesting, self).testTearDown()
+
+    def handlePubAfterTraversal(self, event):
+        """Support plone.protect's auto CSRF protection as good as possible.
+
+        The problem is that we use the same connection and transaction for
+        preparation as for performing a request with ftw.testbrowser.
+
+        This means that we may already have changed objects on the connection
+        but the change is not from within the request.
+
+        We fix that by marking all objects which are already marked as changed
+        on the current as safe for CSRF.
+        This also means that the auto protection does no longer trigger within
+        the test for the followed requests.
+        """
+        transform = getMultiAdapter((self['portal'], event.request),
+                                    ITransform,
+                                    name='plone.protect.autocsrf')
+        for obj in transform._registered_objects():
+            safeWrite(obj, event.request)
 
 
 OPENGEVER_INTEGRATION_TESTING = GEVERIntegrationTesting(

--- a/opengever/core/tests/test_integration_testing_setup.py
+++ b/opengever/core/tests/test_integration_testing_setup.py
@@ -1,5 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
 from opengever.ogds.base.utils import ogds_service
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -62,3 +64,10 @@ class TestIntegrationTestSetup(IntegrationTestCase):
 
     def test_serverside_default_user_is_anonymous(self):
         self.assertTrue(api.user.is_anonymous())
+
+    @browsing
+    def test_preparing_changes_do_not_trigger_csrf_protection(self, browser):
+        self.login(self.administrator, browser)
+        self.repository_root.title_de = 'New Repository Root Title'
+        browser.open(self.repository_root)
+        self.assertEquals('New Repository Root Title', plone.first_heading())


### PR DESCRIPTION
The problem is that we use the same connection / transaction for preparation as for performing a request with `ftw.testbrowser`.
This means that we may already have changed objects on the connection, but the change is not from within the request.

We fix that by marking all objects which are already marked as changed on the current as safe for CSRF. This also means that the auto protection does no longer trigger within the test for the followed requests.

This PR also activates the transaction interceptors savepoint simulation. This is necessary because `plone.protect` calls `transaction.abort()` when the CSRF validation fails. We want the state to be rollback to before the request in this state. The savepoint simulation does exactly that.

Based on https://github.com/4teamwork/ftw.testing/pull/28