### PR TITLE
Make sure that remote task state changes are synced to globalindex

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Make sure that remote task state changes are synced to globalindex. [phgross]
 - Expand just the selected item in the subdossier tree. [Kevin Bieri]
 - Added missing cancel button for the manual journal entry form. [phgross]
 - XSS: Escape html for manual journal entries' comment. [tarnap]

--- a/opengever/task/response_syncer/workflow.py
+++ b/opengever/task/response_syncer/workflow.py
@@ -1,6 +1,6 @@
 from opengever.task import _
-from opengever.task.response_syncer import BaseResponseSyncerSender
 from opengever.task.response_syncer import BaseResponseSyncerReceiver
+from opengever.task.response_syncer import BaseResponseSyncerSender
 from opengever.task.response_syncer import ResponseSyncerSenderException
 from opengever.task.task import ITask
 from Products.CMFCore.utils import getToolByName
@@ -74,7 +74,5 @@ class WorkflowResponseSyncerReceiver(BaseResponseSyncerReceiver):
             ITask(self.context).responsible_client = responsible_client
             ITask(self.context).responsible = responsible
 
-            notify(ObjectModifiedEvent(self.context))
-
-        response.add_change('review_state', _(u'Issue state'),
-                            before, after)
+        notify(ObjectModifiedEvent(self.context))
+        response.add_change('review_state', _(u'Issue state'), before, after)

--- a/opengever/task/tests/test_response_syncer.py
+++ b/opengever/task/tests/test_response_syncer.py
@@ -485,6 +485,8 @@ class TestWorkflowSyncer(FunctionalTestCase):
 
         self.assertEquals('task-state-in-progress',
                           api.content.get_state(successor))
+        self.assertEquals('task-state-in-progress',
+                          successor.get_sql_object().review_state)
 
     def test_adds_corresponding_response(self):
         predecessor = create(Builder('task'))


### PR DESCRIPTION
Closes #3097. 

This problem has been "introduced" with the syncer refactoring (see #2828).