### PR TITLE
Fix datetime converter when input is empty.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Fix datetime converter when input is empty. [deiferni]
 - Make sure that remote task state changes are synced to globalindex. [phgross]
 - Expand just the selected item in the subdossier tree. [Kevin Bieri]
 - Added missing cancel button for the manual journal entry form. [phgross]

--- a/opengever/base/schema.py
+++ b/opengever/base/schema.py
@@ -24,6 +24,8 @@ class UTCDatetimeDataConverter(DateTimeDataConverter):
     """
     def toFieldValue(self, value):
         value = super(UTCDatetimeDataConverter, self).toFieldValue(value)
+        if value is None:
+            return value
 
         try:
             local_dt = get_localzone().localize(value)

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -64,6 +64,23 @@ class TestMeeting(FunctionalTestCase):
         self.assertEqual(u'C\xf6mmunity meeting', link.text)
 
     @browsing
+    def test_regression_add_meeting_without_end_date_does_not_fail(self, browser):
+        # create meeting
+        browser.login().open(self.committee, view='add-meeting')
+        browser.fill({
+            'Start': '01.01.2010 10:00',
+            'End': '',
+            'Location': u'B\xe4rn',
+        }).submit()
+        # create dossier
+        browser.find('Save').click()
+
+        committee_model = self.committee.load_model()
+        self.assertEqual(1, len(committee_model.meetings))
+        meeting = committee_model.meetings[0]
+        self.assertIsNone(meeting.end)
+
+    @browsing
     def test_add_meeting_and_dossier(self, browser):
         # create meeting
         browser.login().open(self.committee, view='add-meeting')


### PR DESCRIPTION
This PR fixes an issue when creating meetings that don't have an end date.

Fixes #3102.