### PR TITLE
Fix UnicodeEncodeError in task listings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix datetime converter when input is empty. [deiferni]
+- Fix UnicodeEncodeError in task listings. [phgross]
 - Make sure that remote task state changes are synced to globalindex. [phgross]
 - Expand just the selected item in the subdossier tree. [Kevin Bieri]
 - Added missing cancel button for the manual journal entry form. [phgross]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -12,6 +12,7 @@ from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.types import UnicodeCoercingText
 from plone import api
+from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import Date
@@ -163,13 +164,15 @@ class Task(Base):
         self.is_subtask = plone_task.get_is_subtask()
         self.sequence_number = plone_task.get_sequence_number()
         self.reference_number = plone_task.get_reference_number()
-        self.containing_dossier = plone_task.get_containing_dossier_title()
+        self.containing_dossier = safe_unicode(
+            plone_task.get_containing_dossier_title())
         self.dossier_sequence_number = plone_task.get_dossier_sequence_number()
         self.assigned_org_unit = plone_task.responsible_client
         self.principals = plone_task.get_principals()
         self.predecessor = self.query_predecessor(
             *plone_task.get_predecessor_ids())
-        self.containing_subdossier = plone_task.get_containing_subdossier()
+        self.containing_subdossier = safe_unicode(
+            plone_task.get_containing_subdossier())
 
     # XXX move me to task query
     def query_predecessor(self, admin_unit_id, pred_init_id):

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -10,6 +10,7 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import ram
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.interfaces._tools import IMemberData
+from Products.CMFPlone.utils import safe_unicode
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
 from Products.ZCatalog.interfaces import ICatalogBrain
 from zope.component import getUtility
@@ -102,27 +103,27 @@ def linked_containing_subdossier(item, value):
     if not subdossier_title:
         return ''
 
-    title = escape_html(subdossier_title)
+    title = safe_unicode(escape_html(subdossier_title))
 
     url = get_url(item)
     if not url:
         return title
 
-    redirect_url = "{}/redirect_to_parent_dossier".format(get_url(item))
-    link = '<a href="{}" title="{}" class="subdossierLink">{}</a>'.format(
+    redirect_url = u"{}/redirect_to_parent_dossier".format(safe_unicode(url))
+    link = u'<a href="{}" title="{}" class="subdossierLink">{}</a>'.format(
         redirect_url, title, title)
     return link
 
 
 def linked_containing_maindossier(item, value):
-    title = escape_html(item.containing_dossier)
+    title = safe_unicode(escape_html(item.containing_dossier))
 
     url = get_url(item)
     if not url:
         return title
 
-    redirect_url = "{}/redirect_to_main_dossier".format(get_url(item))
-    link = '<a href="{}" title="{}" class="maindossierLink">{}</a>'.format(
+    redirect_url = u"{}/redirect_to_main_dossier".format(safe_unicode(get_url(item)))
+    link = u'<a href="{}" title="{}" class="maindossierLink">{}</a>'.format(
         redirect_url, title, title)
     return link
 

--- a/opengever/tabbedview/tests/test_tasklisting.py
+++ b/opengever/tabbedview/tests/test_tasklisting.py
@@ -10,7 +10,10 @@ class TestTaskListing(FunctionalTestCase):
         super(TestTaskListing, self).setUp()
 
         self.dossier = create(Builder('dossier')
-                              .titled(u'<b>Bold title</b>'))
+                              .titled(u'<b>B\xf6ld title</b>'))
+        self.subdossier = create(Builder('dossier')
+                                 .within(self.dossier)
+                                 .titled(u'S\xfcb'))
         self.task1 = create(Builder('task')
                             .within(self.dossier)
                             .in_state('task-state-open')
@@ -20,7 +23,7 @@ class TestTaskListing(FunctionalTestCase):
                             .in_state('task-state-tested-and-closed')
                             .titled('Task 2'))
         self.task3 = create(Builder('task')
-                            .within(self.dossier)
+                            .within(self.subdossier)
                             .in_state('task-state-in-progress')
                             .titled('Task 3'))
 
@@ -49,6 +52,7 @@ class TestTaskListing(FunctionalTestCase):
             self.dossier, view='tabbedview_view-tasks')
         table = browser.css('.listing').first
         second_row_dossier_cell = table.rows[1].css('td:nth-child(10) .maindossierLink').first
+
         self.assertEquals(
-            '&lt;b&gt;Bold title&lt;/b&gt;',
+            u'&lt;b&gt;B\xf6ld title&lt;/b&gt;',
             second_row_dossier_cell.innerHTML.strip().strip('\n'))


### PR DESCRIPTION
For tasks inside a dossier/subdossier with umlauts in the title the task listing rendering has failed with the following traceback:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module ftw.tabbedview.browser.tabbed, line 167, in listing
  Module ftw.tabbedview.browser.listing, line 124, in __call__
  Module ftw.tabbedview.browser.listing, line 274, in render_listing
  Module ftw.table.utils, line 102, in generate
  Module ftw.table.utils, line 213, in get_value
  Module opengever.tabbedview.helper, line 126, in linked_containing_maindossier
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 5: ordinal not in range(128)
```

@elioschmutz  💰 -> 🐷 ,  please!

---

Besides that I've discovered a "bug" in the Globalindex task-synchronisation. Both values `containing_dossier` and `containing_subdossier` are not inserted as unicode. If changed that behavior, to avoid the following message:
`UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  return x == y`