### PR TITLE
Disable the displaymenu-item in contentmenu for all types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- Disable the displaymenu-item in contentmenu for all types. [phgross]
 - Fix datetime converter when input is empty. [deiferni]
 - Fix UnicodeEncodeError in task listings. [phgross]
 - Make sure that remote task state changes are synced to globalindex. [phgross]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -110,4 +110,12 @@
       permission="zope2.View"
       />
 
+  <adapter
+      for="*
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      name="plone.contentmenu.display"
+      factory=".menu.OGDisplaySubMenuItem"
+      provides="plone.app.contentmenu.interfaces.IContentMenuItem"
+      />
+
 </configure>

--- a/opengever/base/menu.py
+++ b/opengever/base/menu.py
@@ -2,7 +2,10 @@ from five import grok
 from ftw.contentmenu.interfaces import IContentmenuPostFactoryMenu
 from ftw.contentmenu.menu import CombinedActionsWorkflowMenu
 from opengever.meeting import is_meeting_feature_enabled
+from plone.app.contentmenu.interfaces import IDisplaySubMenuItem
+from plone.app.contentmenu.menu import DisplaySubMenuItem
 from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.interface import implements
 from zope.interface import Interface
 
 
@@ -101,3 +104,14 @@ class OGCombinedActionsWorkflowMenu(CombinedActionsWorkflowMenu):
                   .getWorkflowMenuItems(context, request))
         return filter(lambda item: (item.get('extra', {})
                                     .get('id', None) != 'advanced'), result)
+
+
+class OGDisplaySubMenuItem(DisplaySubMenuItem):
+    """Disable display sub menu item for GEVER in general.
+    It should never be possible to change the layout property in the UI.
+    """
+
+    implements(IDisplaySubMenuItem)
+
+    def available(self):
+        return False


### PR DESCRIPTION
Nobody, not even a Manager, should change the "layout" property via the UI (contentmenu), therefore it makes sense to completely disable this menu-item.

![bildschirmfoto_2017-07-11_um_16_35_31](https://user-images.githubusercontent.com/485755/28073756-ff98db40-6656-11e7-8594-0088ee677c0e.png)


This fixes #3101.