### PR TITLE
Cleanup rolemap, don't redefine plone roles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Move data for most text-fields of Proposal (SQL) to their corresponding plone-objects Proposal/SubmittedProposal. [deiferni]
 - Introduce versioning for Proposal/SubmittedProposal. [deiferni]
+- Cleanup rolemap, don't redefine plone roles. [deiferni]
 
 
 2017.3.0 (2017-07-12)

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -1,32 +1,12 @@
 <rolemap>
   <roles>
-
-    <!--migrated from opengever/sharing/profiles/default/rolemap.xml-->
     <role name="Administrator" />
-    <role name="Anonymous" />
-    <role name="Authenticated" />
-    <role name="Contributor" />
-    <role name="Editor" />
-    <role name="Manager" />
-    <role name="Member" />
-    <role name="Owner" />
-    <role name="Reader" />
-    <role name="Reviewer" />
-    <role name="Publisher" />
-    <role name="Role Manager" />
-
-
-    <!--migrated from opengever/meeting/profiles/default/rolemap.xml-->
-    <role name="CommitteeGroupMember" />
-
-
-    <!--migrated from opengever/disposition/profiles/default/rolemap.xml-->
-    <role name="Records Manager" />
-    <role name="Archivist" />
-
-
-    <!--migrated from opengever/policy/base/profiles/default/rolemap.xml-->
     <role name="APIUser" />
+    <role name="Archivist" />
+    <role name="CommitteeGroupMember" />
+    <role name="Publisher" />
+    <role name="Records Manager" />
+    <role name="Role Manager" />
   </roles>
   <permissions>
 


### PR DESCRIPTION
It is not necessary to refedine roles alredy defined by plone.
Also remove comments from profile-merge to allow sorting the roles alphabetically.