### PR TITLE
List only documents as related_documents in the documents overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.0 (unreleased)
 ---------------------
 
+- List only documents as related_documents in the documents overview. [phgross]
 - Disable the displaymenu-item in contentmenu for all types. [phgross]
 - Fix datetime converter when input is empty. [deiferni]
 - Fix UnicodeEncodeError in task listings. [phgross]

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -208,7 +208,7 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
             'title': obj.Title(),
             'url': obj.absolute_url(),
         } for obj in sorted(
-            self.context.related_items(bidirectional=True),
+            self.context.related_items(bidirectional=True, documents_only=True),
             key=lambda obj: obj.Title()
         )]
 

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -36,15 +36,26 @@ class TestDocumentOverview(FunctionalTestCase):
         super(TestDocumentOverview, self).tearDown()
 
     @browsing
-    def test_overview_displays_related_documents(self, browser):
+    def test_overview_displays_related_documents_but_only_documents(self, browser):
         self.doc_a = create(Builder('document')
+                            .within(self.dossier)
                             .having(title=u'A\xf6'))
         self.doc_b = create(Builder('document')
+                            .within(self.dossier)
                             .having(title=u'B\xf6')
                             .relate_to(self.doc_a))
         self.doc_c = create(Builder('document')
+                            .within(self.dossier)
                             .having(title=u'C\xf6')
                             .relate_to(self.doc_b))
+        self.task = create(Builder('task')
+                           .within(self.dossier)
+                           .having(title=u'C\xf6')
+                           .relate_to(self.doc_b))
+        self.proposal = create(Builder('proposal')
+                               .within(self.dossier)
+                               .having(title=u'C\xf6')
+                               .relate_to(self.doc_b))
 
         browser.login().open(self.doc_b, view='tabbedview_view-overview')
 


### PR DESCRIPTION
Skip proposal and task from the back relations list. Closes #3112.

A more specific relation catalog query is not possible, because the relation field on the task and the proposal schema have the same name than the one in the `IRelatedDocuments` behavior. Therefore we have to filter the list afterwards.