### PR TITLE
Ensure test versions are used correctly.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -3,7 +3,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     versions.cfg
     sources.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 
 package-name = opengever.core
 package-namespace = opengever

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -21,7 +21,3 @@ eggs +=
 
 [test-jenkins]
 test-command = bin/mtest $@
-
-[versions]
-opengever.core =
-ftw.testing =

--- a/test-xml-convention.cfg
+++ b/test-xml-convention.cfg
@@ -1,4 +1,7 @@
 [buildout]
-extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-xmls-formatted.cfg
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-xmls-formatted.cfg
+    versions.cfg
+
 package-name = opengever.core
 package-namespace = opengever


### PR DESCRIPTION
It is important that we pin all versions in order to have a reproducable state. The `versions.cfg` is the master and all testing jobs should extend from it. This will make it easier to branch off of an old release and the tests will have a higher chance to still pass.

- plone tests
  - remove un-pinnings from `test-plone-4.3.x.cfg`
  - no longer use [ftw-buildout's `test-versions.cfg`](https://github.com/4teamwork/ftw-buildouts/blob/master/test-versions.cfg)
    - it is already included in [ftw-buildout's `test-plone-4.3.x.cfg`](https://github.com/4teamwork/ftw-buildouts/blob/master/test-plone-4.3.x.cfg#L6)
    - we want to be in charge of our versions in the `versions.cfg`
- xml convention test: use `versions.cfg`

The docs-tests seem to require the newest versions of Sphinx; do we want to include the versions in the test-cfgs?