### PR TITLE
Amend the OfficeConnector JS to only refresh after a LOCK is acquired

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Introduce versioning for Proposal/SubmittedProposal. [deiferni]
 - Cleanup rolemap, don't redefine plone roles. [deiferni]
 - Use OGMail original_message-file for bumblebee-conversion if available. [elioschmutz]
+- Amend the OfficeConnector javascript to refresh the page based on the lock status. [Rotonen]
 - Add the document lock status to the document status end point. [Rotonen]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Introduce versioning for Proposal/SubmittedProposal. [deiferni]
 - Cleanup rolemap, don't redefine plone roles. [deiferni]
 - Use OGMail original_message-file for bumblebee-conversion if available. [elioschmutz]
+- Add the document lock status to the document status end point. [Rotonen]
 
 
 2017.3.0 (2017-07-12)

--- a/opengever/base/service.py
+++ b/opengever/base/service.py
@@ -1,6 +1,7 @@
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone.rest import Service
 from zope.app.intid.interfaces import IIntIds
+from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 
@@ -14,10 +15,18 @@ class DocumentStatus(Service):
         checkout_manager = queryMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
 
+        lock_manager = getMultiAdapter(
+            (self.context, self.request), name='plone_lock_info')
+
         payload = {}
         payload['int_id'] = getUtility(IIntIds).getId(self.context)
         payload['title'] = self.context.title_or_id()
         payload['checked_out'] = self.context.is_checked_out()
         payload['checked_out_by'] = checkout_manager.get_checked_out_by()
+        payload['locked'] = lock_manager.is_locked()
+        if lock_manager.lock_info():
+            payload['locked_by'] = lock_manager.lock_info()['creator']
+        else:
+            payload['locked_by'] = None
 
         return json.dumps(payload)

--- a/opengever/document/static/officeconnector.js
+++ b/opengever/document/static/officeconnector.js
@@ -39,15 +39,15 @@
         });
     }
 
-    function isDocumentCheckedOut(documentURL) {
+    function isDocumentLocked(documentURL) {
         return requestJSON(documentURL + "/status").pipe(function(data) {
-            return JSON.parse(data)["checked_out"];
+            return JSON.parse(data)["locked"];
         });
     }
 
     function checkout(documentURL) {
         return poll(function() {
-            return isDocumentCheckedOut(documentURL)
+            return isDocumentLocked(documentURL)
         });
     }
 
@@ -66,7 +66,7 @@
             return false;
         }
         checkoutButton.addClass("oc-loading");
-        isDocumentCheckedOut(documentURL).pipe(function(status) {
+        isDocumentLocked(documentURL).pipe(function(status) {
             if(status) {
                 return edit();
             } else {


### PR DESCRIPTION
Now that OfficeConnector (since 1.2.1) also does a WebDAV LOCK , change the javascript to check for that instead.

The document status JSON endpoint now also includes the document lock status.