### PR TITLE
Remove opengever.core version pinning.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -142,7 +142,6 @@ odict = 1.6.1
 ooxml-docprops = 1.3.0
 ooxml_docprops = 1.3.0
 opengever.async = 1.2
-opengever.core = 2017.3.0
 opengever.devtheme = 2.2
 opengever.docucomposer = 2.2.1
 opengever.mysqlconfig = 1.1.2


### PR DESCRIPTION
opengever.core was added to the versions.cfg while releasing 2017.3.0 in
order to let it appear in the versions.cfg of the tag for use in
buildout extends.
It was not removed after the release.  

@phgross 💣 🐷 😏 