### PR TITLE
Add german and french translation of the portalmessage "info success"…

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.1 (unreleased)
 ---------------------
 
+- Fixed translation for portal message type, when adding a DX object. [phgross]
 - Remove dossier inheritance of templatefolder [elioschmutz]
 - Move data for most text-fields of Proposal (SQL) to their corresponding plone-objects Proposal/SubmittedProposal. [deiferni]
 - Introduce versioning for Proposal/SubmittedProposal. [deiferni]

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -360,3 +360,5 @@ msgstr "Aktivieren"
 msgid "transition-add-document"
 msgstr "Dokument hinzugefügt"
 
+msgid "Info success"
+msgstr "Info"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -360,3 +360,5 @@ msgstr "Activer"
 msgid "transition-add-document"
 msgstr ""
 
+msgid "Info success"
+msgstr "Info"

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -371,3 +371,6 @@ msgstr ""
 
 msgid "disposition-transition-refuse"
 msgstr ""
+
+msgid "Info success"
+msgstr ""


### PR DESCRIPTION
type.

This portalmessage type was introduced in the newer version of plone.dexterity we currently use, but already dropped in the newest version (see https://github.com/plone/plone.dexterity/blob/master/plone/dexterity/browser/add.py#L114). Therefore it makes no sense to add a specific translation, "Info" is enough