### PR TITLE
Ignore LocalRolesModified events in repositoryfolder ModifiedEvent subscribers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Do not sync comments to a predecessor forwarding. [phgross]
+- Ignore LocalRolesModified events in repositoryfolder ModifiedEvent subscribers. [phgross]
 - Fixed translation for portal message type, when adding a DX object. [phgross]
 - Remove dossier inheritance of templatefolder [elioschmutz]
 - Move data for most text-fields of Proposal (SQL) to their corresponding plone-objects Proposal/SubmittedProposal. [deiferni]

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -6,6 +6,7 @@ from opengever.base.restricted_vocab import RestrictedVocabularyFactory
 from opengever.base.utils import language_cache_key
 from plone import api
 from plone.app.dexterity.behaviors import metadata
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
 from plone.memoize import ram
@@ -120,6 +121,9 @@ class IClassificationSettings(Interface):
 
 @grok.subscribe(IClassificationMarker, IObjectModifiedEvent)
 def propagate_vocab_restrictions_to_children(container, event):
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
+
     restricted_fields = [
         IClassification['classification'],
         IClassification['privacy_layer']]

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -6,6 +6,7 @@ from opengever.base.interfaces import IBaseCustodyPeriods
 from opengever.base.interfaces import IRetentionPeriodRegister
 from opengever.base.restricted_vocab import propagate_vocab_restrictions
 from opengever.base.restricted_vocab import RestrictedVocabularyFactory
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from plone.autoform.directives import write_permission
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.directives import form
@@ -96,6 +97,9 @@ alsoProvides(ILifeCycle, IFormFieldProvider)
 
 @grok.subscribe(ILifeCycleMarker, IObjectModifiedEvent)
 def propagate_vocab_restrictions_to_children(container, event):
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
+
     restricted_fields = [
         ILifeCycle['retention_period'],
         ILifeCycle['archival_value'],

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -11,6 +11,7 @@ from opengever.dossier.resolve import get_resolver
 from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from plone import api
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from Products.CMFCore.interfaces import IActionSucceededEvent
 from zope.component import getAdapter
 from zope.lifecycleevent import IObjectRemovedEvent
@@ -94,6 +95,9 @@ def reindex_contained_objects(dossier, event):
     show an outdated title in the ``subdossier`` column
     """
 
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
+
     catalog = api.portal.get_tool('portal_catalog')
     parent = aq_parent(aq_inner(dossier))
     is_subdossier = IDossierMarker.providedBy(parent)
@@ -110,6 +114,10 @@ def reindex_contained_objects(dossier, event):
 def reindex_containing_dossier(dossier, event):
     """Reindex the containging_dossier index for all the contained obects,
     when the title has changed."""
+
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
+
     if not IDossierMarker.providedBy(aq_parent(aq_inner(dossier))):
         for descr in event.descriptions:
             for attr in descr.attributes:

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -39,6 +39,7 @@ from opengever.trash.trash import IUntrashedEvent
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone.app.versioningbehavior.utils import get_change_note
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFCore.interfaces import IActionSucceededEvent
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
@@ -239,6 +240,9 @@ DOSSIER_MODIIFED_ACTION = 'Dossier modified'
 
 @grok.subscribe(IDossierMarker, IObjectModifiedEvent)
 def dossier_modified(context, event):
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
+
     title = _(
         u'label_dossier_modified',
         default=u'Dossier modified: ${title}',

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -1,6 +1,7 @@
 from five import grok
 from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
@@ -17,6 +18,8 @@ def update_reference_prefixes(obj, event):
     """A eventhandler which reindex all contained objects, if the
     reference prefix has been changed.
     """
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
 
     if is_reference_number_prefix_changed(event.descriptions):
         catalog = api.portal.get_tool('portal_catalog')

--- a/opengever/repository/tests/test_sharing.py
+++ b/opengever/repository/tests/test_sharing.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.testing import FunctionalTestCase
+
+
+class TestSharingOnRepositoryFolders(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestSharingOnRepositoryFolders, self).setUp()
+        self.grant('Administrator')
+        self.repo_folder = create(Builder('repository'))
+
+    @browsing
+    def test_add_local_roles_to_user(self, browser):
+        # search for test user
+        browser.login().open(self.repo_folder, view='sharing')
+        browser.fill({'search_term': 'test'})
+        browser.css('#sharing-save-button').first.click()
+
+        # change local roles and save
+        browser.fill({'entries.role_Reviewer:records': True})
+        browser.click_on('Save')
+
+        self.assertEquals(['Changes saved.'], info_messages())
+        self.assertEquals(
+            (('test_user_1_', ('Owner', u'Reviewer')),),
+            self.repo_folder.get_local_roles())
+
+    @browsing
+    def test_break_permission_inheritance(self, browser):
+        browser.login().open(self.repo_folder, view='sharing')
+        browser.fill({'Inherit permissions from higher levels': False})
+        browser.click_on('Save')
+
+        self.assertEquals(['Changes saved.'], info_messages())
+        self.assertTrue(self.repo_folder.__ac_local_roles_block__)


### PR DESCRIPTION
Since the new plone version, a LocalRolesModified event is fired when changing local roles on a object (see https://github.com/plone/plone.app.workflow/commit/cc75f6d96584462d8a74017769b6225e46b34384). Because the `LocalRolesModified` inherits from `ObjectModifiedEvent`, all IObjectModifiedEvent subscribers, wich assumes that the event.descriptions provides an list `attributes`, are called as well and are failing. Closes #3119.

