### PR TITLE
Include psc configuration in sources.cfg

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -1,6 +1,9 @@
 [buildout]
-extends = http://kgs.4teamwork.ch/sources.cfg
-extensions = mr.developer
+extends =
+    http://kgs.4teamwork.ch/sources.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
+
+extensions += mr.developer
 
 development-packages =
   opengever.maintenance

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -6,10 +6,6 @@ extends =
 
 package-name = opengever.core
 package-namespace = opengever
-
-find-links +=
-    http://psc.4teamwork.ch/simple
-
 test-egg = opengever.core[api, tests]
 
 [test]


### PR DESCRIPTION
Update sources.cfg to extend from 4teamwork-psc.cfg, configuring our PSC as source in find-links and adding the authentication extensions.
In order for this to work, each host must have a `~/.pypirc` with the necessary credentials configured.