### PR TITLE
Do not sync comments to a predecessor forwarding.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.1 (unreleased)
 ---------------------
 
+- Do not sync comments to a predecessor forwarding. [phgross]
 - Fixed translation for portal message type, when adding a DX object. [phgross]
 - Remove dossier inheritance of templatefolder [elioschmutz]
 - Move data for most text-fields of Proposal (SQL) to their corresponding plone-objects Proposal/SubmittedProposal. [deiferni]

--- a/opengever/task/response_syncer/comment.py
+++ b/opengever/task/response_syncer/comment.py
@@ -13,6 +13,15 @@ class CommentResponseSyncerSender(BaseResponseSyncerSender):
                 task.admin_unit_id,
                 task.physical_path))
 
+    def get_related_tasks_to_sync(self, transition):
+        tasks = super(CommentResponseSyncerSender, self).get_related_tasks_to_sync(
+            transition)
+
+        # Skip forwardings. Comments should never be synced to the
+        # successor forwarding, because a forwarding predecessor
+        # is allways closed and stored in the yearfolder.
+        return [task for task in tasks if not task.is_forwarding]
+
 
 class CommentResponseSyncerReceiver(BaseResponseSyncerReceiver):
     """This view receives a sync-task-comment-response request from another

--- a/opengever/task/tests/test_comment_response.py
+++ b/opengever/task/tests/test_comment_response.py
@@ -57,6 +57,19 @@ class TestCommentResponseHandler(FunctionalTestCase):
         ICommentResponseHandler(predecessor).add_response("My response")
         self.assertEqual(1, len(response_container))
 
+    def test_comment_is_not_synced_to_forwarding_predecessor(self):
+        predecessor = create(Builder('forwarding'))
+        successor = create(Builder('task').successor_from(predecessor))
+
+        activate_request_layer(self.portal.REQUEST,
+                               IInternalOpengeverRequestLayer)
+
+        response_container = IResponseContainer(predecessor)
+
+        self.assertEqual(0, len(response_container))
+        ICommentResponseHandler(successor).add_response("My response")
+        self.assertEqual(0, len(response_container))
+
     def test_a_Member_can_not_add_task_comment_on_open_dossier(self):
         create(Builder('user')
                .having(firstname='Hugo', lastname='Boss')


### PR DESCRIPTION
Because a forwarding predecessor is always closed and stored in the yearfolder, comments made on the task should not be synced to the "predecessor".

Closes #3133 