### PR TITLE
Enable secure flag for cookies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Define cookie path when setting the current orgunit id in the cookie. [phgross]
 - Add version of downloaded file to journal's entry. [tarnap]
 - Allow to copy-paste single documents. [tarnap]
+- Enable secure flag for cookies. [phgross]
 - Always download MSG file if avaiable. [mathias.leimgruber]
 - Remove dossier inheritance of templatefolder [elioschmutz]
 - Move data for most text-fields of Proposal (SQL) to their corresponding plone-objects Proposal/SubmittedProposal. [deiferni]

--- a/opengever/base/tests/test_require_login.py
+++ b/opengever/base/tests/test_require_login.py
@@ -5,7 +5,7 @@ from ftw.testbrowser.pages import plone
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
-from zExceptions import Unauthorized
+import transaction
 import urllib
 
 
@@ -32,6 +32,11 @@ class TestRequireLoginScript(FunctionalTestCase):
 
     @browsing
     def test_require_login_displays_login_form_and_redirecs_upon_login(self, browser):
+        # Disable the `cookie only over https flag, activated
+        # by `opengever.core.hooks.installed`.
+        self.portal.acl_users.session.secure = False
+        transaction.commit()
+
         browser.open(
             view='require_login?came_from={}'.format(
                 urllib.quote(self.document.absolute_url())))

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -79,6 +79,7 @@ def should_prevent_duplicate_installation(profile):
 
 def installed(site):
     trigger_subpackage_hooks(site)
+    enable_secure_flag_for_cookies(site)
 
 
 def trigger_subpackage_hooks(site):
@@ -97,3 +98,8 @@ def trigger_subpackage_hooks(site):
     opengever.activity.hooks.insert_notification_defaults(site)
     opengever.private.hooks.configure_members_area(site)
     opengever.quota.hooks.policy_installed(site)
+
+
+def enable_secure_flag_for_cookies(context):
+    session_plugin = context.acl_users.session
+    session_plugin.secure = True

--- a/opengever/core/upgrades/20170717182153_enable_secure_flag_for_cookies/upgrade.py
+++ b/opengever/core/upgrades/20170717182153_enable_secure_flag_for_cookies/upgrade.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.hooks import enable_secure_flag_for_cookies
+
+
+class EnableSecureFlagForCookies(UpgradeStep):
+    """Enable secure flag for cookies.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        enable_secure_flag_for_cookies(self.portal)


### PR DESCRIPTION
Activate option `Only Send Cookie Over HTTPS` in the acl_users session plugin.

Closes https://github.com/4teamwork/opengever.ftw/issues/37