### PR TITLE
Ensure unicode in proposal SQL.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix: remove ftw.showroom CSS on fresh installations too. [jone]
 - Define cookie path when setting the current orgunit id in the cookie. [phgross]
+- Make sure unicode is stored in proposal sql. [jone]
 - Add version of downloaded file to journal's entry. [tarnap]
 - Allow to copy-paste single documents. [tarnap]
 - Always download MSG file if avaiable. [mathias.leimgruber]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -29,6 +29,7 @@ from plone.app.uuid.utils import uuidToObject
 from plone.directives import form
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
+from Products.CMFPlone.utils import safe_unicode
 from z3c.relationfield.relation import RelationValue
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -505,8 +506,8 @@ class Proposal(ProposalBase):
             context.get_main_dossier()).get_number()
 
         language = data.get('language')
-        repository_folder_title = aq_wrapped_self.get_repository_folder_title(
-            language)
+        repository_folder_title = safe_unicode(
+            aq_wrapped_self.get_repository_folder_title(language))
 
         data.update(dict(workflow_state=workflow_state,
                          physical_path=aq_wrapped_self.get_physical_path(),


### PR DESCRIPTION
The repository folder title should be stored as unicode into the proposal SQL in order to prevent encoding issues when testing with sqlite.

This change is similar to what #3109 changed in the task globalindex.

I could only reproduce the problem with an sqlite database. The postgres driver seems to handle enconding in this case. I want this to be fixed so that we can use non-ASCII strings in tests, such as it will be introduced with the integration testing fixture.

The error I fix is:
```python
Traceback (most recent call last):
  File "/Users/jone/projects/python/cache/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 400, in run_layer
    setup_layer(options, layer, setup_layers)
  File "/Users/jone/projects/python/cache/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 708, in setup_layer
    setup_layer(options, base, setup_layers)
  File "/Users/jone/projects/python/cache/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 713, in setup_layer
    layer.setUp()
  File "/Users/jone/projects/python/cache/eggs/plone.app.testing-4.2.5-py2.7.egg/plone/app/testing/helpers.py", line 343, in setUp
    self.setUpPloneSite(portal)
  File "/Users/jone/projects/packages/opengever.core/opengever/core/testing.py", line 452, in setUpPloneSite
    self['fixture_lookup_table'] = OpengeverContentFixture()()
  File "/Users/jone/projects/packages/opengever.core/opengever/testing/fixtures.py", line 41, in __call__
    self.create_treaty_dossiers()
  File "/Users/jone/projects/packages/opengever.core/src/ftw.testing/ftw/testing/staticuids.py", line 17, in wrapper
    return func(*args, **kwargs)
  File "/Users/jone/projects/packages/opengever.core/opengever/testing/fixtures.py", line 179, in create_treaty_dossiers
    .relate_to(document)))
  File "/Users/jone/projects/packages/opengever.core/opengever/base/monkey/patches/default_values.py", line 281, in create
    result = original_create(*args, **kwargs)
  File "/Users/jone/projects/python/cache/eggs/ftw.builder-1.11.0-py2.7.egg/ftw/builder/builder.py", line 11, in create
    return CREATOR_CHAIN[0](builder, **kwargs)
  File "/Users/jone/projects/python/cache/eggs/ftw.builder-1.11.0-py2.7.egg/ftw/builder/builder.py", line 40, in __call__
    return self.parent_create(*args, **kwargs)
  File "/Users/jone/projects/python/cache/eggs/ftw.builder-1.11.0-py2.7.egg/ftw/builder/builder.py", line 59, in original_create
    return builder.create(**kwargs)
  File "/Users/jone/projects/packages/opengever.core/opengever/testing/builders/dx.py", line 353, in create
    proposal = super(ProposalBuilder, self).create()
  File "/Users/jone/projects/python/cache/eggs/ftw.builder-1.11.0-py2.7.egg/ftw/builder/dexterity.py", line 57, in create
    self.after_create(obj)
  File "/Users/jone/projects/packages/opengever.core/opengever/testing/builders/dx.py", line 338, in after_create
    obj.create_model(self.model_arguments, self.container)
  File "/Users/jone/projects/packages/opengever.core/opengever/meeting/container.py", line 53, in create_model
    session.flush()  # required to create an autoincremented id
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/session.py", line 2171, in flush
    self._flush(objects)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/session.py", line 2291, in _flush
    transaction.rollback(_capture_exception=True)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/util/langhelpers.py", line 66, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/session.py", line 2255, in _flush
    flush_context.execute()
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/unitofwork.py", line 389, in execute
    rec.execute(self)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/unitofwork.py", line 548, in execute
    uow
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/persistence.py", line 181, in save_obj
    mapper, table, insert)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/orm/persistence.py", line 835, in _emit_insert_statements
    execute(statement, params)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/engine/base.py", line 1053, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/engine/base.py", line 1402, in _handle_dbapi_exception
    exc_info
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/Users/jone/projects/python/cache/eggs/SQLAlchemy-1.1.10-py2.7-macosx-10.4-x86_64.egg/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
ProgrammingError: (sqlite3.ProgrammingError) You must not use 8-bit bytestrings unless you use a text_factory that can interpret 8-bit bytestrings (like text_factory = str). It is highly recommended that you instead just switch your application to Unicode strings. [SQL: u'INSERT INTO proposals (admin_unit_id, int_id, physical_path, creator, submitted_admin_unit_id, submitted_int_id, submitted_physical_path, excerpt_document_id, submitted_excerpt_document_id, workflow_state, committee_id, dossier_reference_number, repository_folder_title, language) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'] [parameters: (u'plone', 576287022, 'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/proposal-1', 'robert.ziegler', None, None, None, None, None, 'pending', 1, 'Client1 1.1 / 1', 'Vertr\xc3\xa4ge und Vereinbarungen', 'de')]
```