### PR TITLE
Fix unicode error in committee group vocabulary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Fix: remove ftw.showroom CSS on fresh installations too. [jone]
 - Define cookie path when setting the current orgunit id in the cookie. [phgross]
 - Make sure unicode is stored in proposal sql. [jone]
+- Fix unicode error in committee group vocabulary. [jone]
 - Add version of downloaded file to journal's entry. [tarnap]
 - Allow to copy-paste single documents. [tarnap]
 - Enable secure flag for cookies. [phgross]

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -16,11 +16,14 @@ from opengever.meeting.wrapper import PeriodWrapper
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.directives import form
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 from z3c.form.validator import WidgetValidatorDiscriminators
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
+from zope.component import getUtility
 from zope.interface import Interface
 from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 
@@ -28,6 +31,7 @@ from zope.schema.vocabulary import SimpleVocabulary
 def get_group_vocabulary(context):
     service = ogds_service()
     userid = api.user.get_current().getId()
+    normalize = getUtility(IIDNormalizer).normalize
     terms = []
 
     if api.user.has_permission('cmf.ManagePortal', obj=context):
@@ -36,8 +40,10 @@ def get_group_vocabulary(context):
         groups = service.assigned_groups(userid)
 
     for group in groups:
-        terms.append(SimpleVocabulary.createTerm(
-            group.groupid, group.groupid, group.title))
+        terms.append(SimpleTerm(
+            group.groupid,
+            token=normalize(group.groupid),
+            title=group.title or group.groupid))
     return SimpleVocabulary(terms)
 
 


### PR DESCRIPTION
The token of a vocabulary term must be a bytestring because it will be sent over HTTP. The VocabularyTerm class casts tokens to bytestring in it's __init__, which will throw an encoding error when the token is a unicode containing non-ASCII characters.

Simply encoding the unicode as utf-8-bytestring will not work because the z3cform validation will fail and not allow to select the term.

A good token does only contain ASCII characters while beeing reproducable and hopefully not conflicting with other terms. Therefore I changed the token to be a normalized string generated from the group ID.

It seems that groups usually have no title. We should not fallback to the normalized string then but to the original group id.

---

Without this fix, the encoding problem can be produced by editing a any comittee with a `Manager`-user on an environment where the OGDS group table contains groups with non-ASCII characters.
This is the case with a default local development installation, as `zopemaster`, at http://localhost:8080/fd/sitzungen/committee-3/edit .