### PR TITLE
Fix new installation to remove ftw.showroom css styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.3.1 (unreleased)
 ---------------------
 
+- Fix: remove ftw.showroom CSS on fresh installations too. [jone]
 - Add version of downloaded file to journal's entry. [tarnap]
 - Allow to copy-paste single documents. [tarnap]
 - Expand current subdossier in subdossier tree. [Kevin Bieri]

--- a/opengever/core/profiles/default/cssregistry.xml
+++ b/opengever/core/profiles/default/cssregistry.xml
@@ -5,4 +5,9 @@
       id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.css"
       />
 
+  <stylesheet
+      id="++resource++ftw.showroom/style.css"
+      remove="True"
+      />
+
 </object>


### PR DESCRIPTION
There is an opengever.core:default upgrade step removing the
ftw.showroom css from the registry because the stylings are part of the
teamraum theme.
This should also happen on a fresh installation.

See 043f7112e3bcba77315b5dc6f6ba5b29f9b23045