### PR TITLE
Fix repository folder in examplecontent committees.

### DIFF
--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/04_committees.json
@@ -14,14 +14,14 @@
                 "_id": "committee-1",
                 "_type": "opengever.meeting.committee",
                 "title": "Kommission für Rechtsfragen",
-                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/kommission-fuer-rechtsfragen",
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/kommission-fuer-rechtsfragen/sitzungen",
                 "group_id": "og_demo-ftw_users"
             },
             {
                 "_id": "committee-2",
                 "_type": "opengever.meeting.committee",
                 "title": "Rechnungsprüfungskommission",
-                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/rechnungspruefungskommission",
+                "repository_folder": "resolvePath::/ordnungssystem/fuehrung/kommissionen-mit-selbstaendigen-verwaltungsbefugnissen/rechnungspruefungskommission/sitzungen",
                 "group_id": "og_demo-ftw_users"
             },
             {


### PR DESCRIPTION
The configured repository folder in a committee is used for storing meeting content in dossiers. Since the meeting module creates dossiers in this folder, the configured folder must be a leaf-node.
This change updates the examplecontent from using branch-nodes to leaf-nodes, so that it is possible to create a meeting in a those committees.