### PR TITLE
Cleanup changelog after bugfix release and bump version for next release

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-2017.3.1 (unreleased)
+2017.4.0 (unreleased)
 ---------------------
 
 - Add version of downloaded file to journal's entry. [tarnap]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,11 +7,7 @@ Changelog
 
 - Add version of downloaded file to journal's entry. [tarnap]
 - Allow to copy-paste single documents. [tarnap]
-- Expand current subdossier in subdossier tree. [Kevin Bieri]
 - Always download MSG file if avaiable. [mathias.leimgruber]
-- Do not sync comments to a predecessor forwarding. [phgross]
-- Ignore LocalRolesModified events in repositoryfolder ModifiedEvent subscribers. [phgross]
-- Fixed translation for portal message type, when adding a DX object. [phgross]
 - Remove dossier inheritance of templatefolder [elioschmutz]
 - Move data for most text-fields of Proposal (SQL) to their corresponding plone-objects Proposal/SubmittedProposal. [deiferni]
 - Introduce versioning for Proposal/SubmittedProposal. [deiferni]
@@ -19,6 +15,15 @@ Changelog
 - Use OGMail original_message-file for bumblebee-conversion if available. [elioschmutz]
 - Amend the OfficeConnector javascript to refresh the page based on the lock status. [Rotonen]
 - Add the document lock status to the document status end point. [Rotonen]
+
+
+2017.3.1 (2017-07-18)
+---------------------
+
+- Expand current subdossier in subdossier tree. [Kevin Bieri]
+- Ignore LocalRolesModified events in repositoryfolder ModifiedEvent subscribers. [phgross]
+- Do not sync comments to a predecessor forwarding. [phgross]
+- Fixed translation for portal message type, when adding a DX object. [phgross]
 
 
 2017.3.0 (2017-07-12)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2017.3.1.dev0'
+version = '2017.4.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
- Cleanup changelog after bugfix release 2017.3.1 (Release has been created via `2017.3-stable` branch)
- Bump next version to 2017.4.0.

