### PR TITLE
SPV word: checkout proposal document after creating proposal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Format line breaks in task descriptions. [tarnap]
+- SPV word: checkout proposal document after creating proposal. [jone]
 
 
 2017.4.0 (2017-07-26)

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-04 06:48+0000\n"
-"PO-Revision-Date: 2015-04-10 09:01+0200\n"
+"POT-Creation-Date: 2017-07-18 14:53+0000\n"
+"PO-Revision-Date: 2017-07-18 16:49+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:394
+#: ./opengever/meeting/command.py:406
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
@@ -57,7 +57,7 @@ msgstr "Neue Periode hinzufügen"
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:428
+#: ./opengever/meeting/command.py:440
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
@@ -114,7 +114,7 @@ msgstr "Traktandum löschen"
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ./opengever/meeting/command.py:357
+#: ./opengever/meeting/command.py:369
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht."
 
@@ -126,19 +126,19 @@ msgstr "Dokumente"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/meeting/command.py:104
+#: ./opengever/meeting/command.py:107
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich generiert."
 
-#: ./opengever/meeting/command.py:109
+#: ./opengever/meeting/command.py:112
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/command.py:168
+#: ./opengever/meeting/command.py:175
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:173
+#: ./opengever/meeting/command.py:180
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -273,11 +273,11 @@ msgstr "Protokoll"
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
-#: ./opengever/meeting/command.py:51
+#: ./opengever/meeting/command.py:54
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:56
+#: ./opengever/meeting/command.py:59
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -340,7 +340,7 @@ msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier übe
 msgid "Updated with a newer excerpt version."
 msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
 
-#: ./opengever/meeting/command.py:262
+#: ./opengever/meeting/command.py:269
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
@@ -425,12 +425,12 @@ msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:168
+#: ./opengever/meeting/model/proposal.py:158
 msgid "cancel"
 msgstr "Stornieren"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:148
+#: ./opengever/meeting/model/proposal.py:138
 msgid "cancelled"
 msgstr "Storniert"
 
@@ -531,7 +531,7 @@ msgstr "Bis"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:166
+#: ./opengever/meeting/model/proposal.py:156
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -542,7 +542,7 @@ msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:31
-#: ./opengever/meeting/model/proposal.py:146
+#: ./opengever/meeting/model/proposal.py:136
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -648,7 +648,7 @@ msgstr "Vorlage Traktandenliste"
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
 #: ./opengever/meeting/browser/submitdocuments.py:36
-#: ./opengever/meeting/proposal.py:160
+#: ./opengever/meeting/proposal.py:123
 msgid "label_attachments"
 msgstr "Anhänge"
 
@@ -676,7 +676,7 @@ msgstr "Gremium erfolgreich reaktiviert."
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:53
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:60
+#: ./opengever/meeting/proposal.py:54
 msgid "label_committee"
 msgstr "Gremium"
 
@@ -687,18 +687,18 @@ msgstr "Das Protokoll wurde in der Zwischenzeit bearbeitet. Wenn Sie Ihre Änder
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:131
+#: ./opengever/meeting/proposal.py:146
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/protocol.py:150
-#: ./opengever/meeting/proposal.py:95
+#: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:114
+#: ./opengever/meeting/browser/proposalforms.py:117
 msgid "label_creator"
 msgstr "Ersteller"
 
@@ -743,17 +743,17 @@ msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:141
-#: ./opengever/meeting/proposal.py:241
+#: ./opengever/meeting/proposal.py:206
 msgid "label_decision"
 msgstr "Beschluss"
 
 #. Default: "Decision draft"
-#: ./opengever/meeting/proposal.py:80
+#: ./opengever/meeting/proposal.py:100
 msgid "label_decision_draft"
 msgstr "Beschlussentwurf"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:267
+#: ./opengever/meeting/proposal.py:232
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
@@ -769,23 +769,23 @@ msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py:147
-#: ./opengever/meeting/proposal.py:90
+#: ./opengever/meeting/proposal.py:112
 msgid "label_disclose_to"
 msgstr "\"Zu eröffnen\" an"
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:138
-#: ./opengever/meeting/proposal.py:412
+#: ./opengever/meeting/proposal.py:364
 msgid "label_discussion"
 msgstr "Diskussion"
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:392
+#: ./opengever/meeting/proposal.py:344
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:493
+#: ./opengever/meeting/proposal.py:445
 msgid "label_dossier_not_available"
 msgstr "Dossier nicht verfügbar"
 
@@ -813,6 +813,11 @@ msgstr "Bearbeiten"
 #: ./opengever/meeting/browser/meetings/meeting.py:369
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
+
+#. Default: "Edit after creation"
+#: ./opengever/meeting/browser/proposalforms.py:125
+msgid "label_edit_after_creation"
+msgstr "Nach dem Hinzufügen bearbeiten"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/meetings/meeting.py:367
@@ -874,7 +879,7 @@ msgstr "Gruppe"
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/protocol.py:129
-#: ./opengever/meeting/proposal.py:70
+#: ./opengever/meeting/proposal.py:88
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
@@ -896,7 +901,7 @@ msgstr "Nachname"
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/protocol.py:126
-#: ./opengever/meeting/proposal.py:65
+#: ./opengever/meeting/proposal.py:82
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
@@ -922,7 +927,7 @@ msgid "label_main_attributes"
 msgstr "Eigenschaften"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:205
+#: ./opengever/meeting/proposal.py:170
 msgid "label_meeting"
 msgstr "Sitzung"
 
@@ -932,7 +937,7 @@ msgid "label_member"
 msgstr "Mitglied"
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:117
+#: ./opengever/meeting/browser/proposalforms.py:120
 msgid "label_modified"
 msgstr "Zuletzt bearbeitet"
 
@@ -982,13 +987,13 @@ msgid "label_proposal_id"
 msgstr "Laufnummer"
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:105
+#: ./opengever/meeting/browser/proposalforms.py:108
 msgid "label_proposal_template"
 msgstr "Antragsvorlage"
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
-#: ./opengever/meeting/proposal.py:75
+#: ./opengever/meeting/proposal.py:94
 msgid "label_proposed_action"
 msgstr "Antrag"
 
@@ -999,7 +1004,7 @@ msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py:144
-#: ./opengever/meeting/proposal.py:85
+#: ./opengever/meeting/proposal.py:106
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
 
@@ -1100,7 +1105,7 @@ msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:263
+#: ./opengever/meeting/proposal.py:228
 msgid "label_workflow_state"
 msgstr "Status"
 
@@ -1109,7 +1114,7 @@ msgid "label_zip_download"
 msgstr "Zip-Datei herunterladen"
 
 #. Default: "Language"
-#: ./opengever/meeting/proposal.py:100
+#: ./opengever/meeting/proposal.py:59
 msgid "language"
 msgstr "Sprache"
 
@@ -1233,7 +1238,7 @@ msgstr "Teilnehmende"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:30
 #: ./opengever/meeting/model/meeting.py:69
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py:131
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -1247,12 +1252,12 @@ msgid "presidency"
 msgstr "Vorsitz"
 
 #. Default: "Proposal document"
-#: ./opengever/meeting/proposal.py:214
+#: ./opengever/meeting/proposal.py:179
 msgid "proposal_document"
 msgstr "Antragsdokument"
 
 #. Default: "Proposal document ${title}"
-#: ./opengever/meeting/proposal.py:346
+#: ./opengever/meeting/proposal.py:298
 msgid "proposal_document_title"
 msgstr "Antragsdokument ${title}"
 
@@ -1327,13 +1332,13 @@ msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:170
+#: ./opengever/meeting/model/proposal.py:160
 msgid "reactivate"
 msgstr "Wieder eröffnen"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:160
+#: ./opengever/meeting/model/proposal.py:150
 msgid "reject"
 msgstr "Zurückweisen"
 
@@ -1353,12 +1358,12 @@ msgid "revision"
 msgstr "Überarbeitung"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:162
+#: ./opengever/meeting/model/proposal.py:152
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:145
+#: ./opengever/meeting/model/proposal.py:135
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1371,12 +1376,12 @@ msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:158
+#: ./opengever/meeting/model/proposal.py:148
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:143
+#: ./opengever/meeting/model/proposal.py:133
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1400,6 +1405,7 @@ msgid "time"
 msgstr "Zeit"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:164
+#: ./opengever/meeting/model/proposal.py:154
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
+

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-04 06:48+0000\n"
+"POT-Creation-Date: 2017-07-18 14:53+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/meeting/command.py:394
+#: ./opengever/meeting/command.py:406
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
@@ -59,7 +59,7 @@ msgstr "Ajouter une nouvelle période"
 msgid "Add period"
 msgstr "Ajouter la période"
 
-#: ./opengever/meeting/command.py:428
+#: ./opengever/meeting/command.py:440
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 
@@ -116,7 +116,7 @@ msgstr "Supprimer le point de l'ordre du jour"
 msgid "Discard"
 msgstr "Écarter"
 
-#: ./opengever/meeting/command.py:357
+#: ./opengever/meeting/command.py:369
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
@@ -128,19 +128,19 @@ msgstr "Documents"
 msgid "Edit"
 msgstr "Modifier"
 
-#: ./opengever/meeting/command.py:104
+#: ./opengever/meeting/command.py:107
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "L'extrait du protocole de ${title} a été généré avec succès."
 
-#: ./opengever/meeting/command.py:109
+#: ./opengever/meeting/command.py:112
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "L'extrait du protocole ${title} a été mis à jour avec succès."
 
-#: ./opengever/meeting/command.py:168
+#: ./opengever/meeting/command.py:175
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été créé avec succès."
 
-#: ./opengever/meeting/command.py:173
+#: ./opengever/meeting/command.py:180
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été mis à jour avec succès."
 
@@ -275,11 +275,11 @@ msgstr "Protocole"
 msgid "Protocol Excerpt"
 msgstr "Extrait du protocole"
 
-#: ./opengever/meeting/command.py:51
+#: ./opengever/meeting/command.py:54
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Le protocole pour la séance ${title} a été créé avec succès."
 
-#: ./opengever/meeting/command.py:56
+#: ./opengever/meeting/command.py:59
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Le protocole pour la séance ${title} a été actualisé avec succès."
 
@@ -342,7 +342,7 @@ msgstr "Le document a été écrasé par une version plus récente du dossier pr
 msgid "Updated with a newer excerpt version."
 msgstr "Le document a été écrasé par une version plus récente de l'extrait de protocole."
 
-#: ./opengever/meeting/command.py:262
+#: ./opengever/meeting/command.py:269
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé par une nouvelle version de la réunion ${title}."
 
@@ -427,12 +427,12 @@ msgid "button_submit_attachments"
 msgstr "Soumettre des appendices"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:168
+#: ./opengever/meeting/model/proposal.py:158
 msgid "cancel"
 msgstr "Annuler"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:148
+#: ./opengever/meeting/model/proposal.py:138
 msgid "cancelled"
 msgstr "Annulé"
 
@@ -533,7 +533,7 @@ msgstr "Jusqu'à"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:166
+#: ./opengever/meeting/model/proposal.py:156
 msgid "decide"
 msgstr "Décider"
 
@@ -544,7 +544,7 @@ msgstr "Décider d'un point de l'ordre du jour"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:31
-#: ./opengever/meeting/model/proposal.py:146
+#: ./opengever/meeting/model/proposal.py:136
 msgid "decided"
 msgstr "Décidé"
 
@@ -650,7 +650,7 @@ msgstr "Modèle de la liste des points du jour"
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
 #: ./opengever/meeting/browser/submitdocuments.py:36
-#: ./opengever/meeting/proposal.py:160
+#: ./opengever/meeting/proposal.py:123
 msgid "label_attachments"
 msgstr "Appendices"
 
@@ -678,7 +678,7 @@ msgstr "Comité réactivé avec succès."
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:53
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:60
+#: ./opengever/meeting/proposal.py:54
 msgid "label_committee"
 msgstr "Comité"
 
@@ -689,18 +689,18 @@ msgstr "Le protocole a été édité entre-temps. Sie vous voulez garder vos cha
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:131
+#: ./opengever/meeting/proposal.py:146
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/protocol.py:150
-#: ./opengever/meeting/proposal.py:95
+#: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr "Copie pour information"
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:114
+#: ./opengever/meeting/browser/proposalforms.py:117
 msgid "label_creator"
 msgstr "Créé par"
 
@@ -745,17 +745,17 @@ msgstr "Fixez ce point de l'ordre du jour"
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:141
-#: ./opengever/meeting/proposal.py:241
+#: ./opengever/meeting/proposal.py:206
 msgid "label_decision"
 msgstr "Décision"
 
 #. Default: "Decision draft"
-#: ./opengever/meeting/proposal.py:80
+#: ./opengever/meeting/proposal.py:100
 msgid "label_decision_draft"
 msgstr "Brouillon de la décision"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:267
+#: ./opengever/meeting/proposal.py:232
 msgid "label_decision_number"
 msgstr "Numéro de décision"
 
@@ -771,23 +771,23 @@ msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py:147
-#: ./opengever/meeting/proposal.py:90
+#: ./opengever/meeting/proposal.py:112
 msgid "label_disclose_to"
 msgstr "\"à l'information de\""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:138
-#: ./opengever/meeting/proposal.py:412
+#: ./opengever/meeting/proposal.py:364
 msgid "label_discussion"
 msgstr "Discussion"
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:392
+#: ./opengever/meeting/proposal.py:344
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:493
+#: ./opengever/meeting/proposal.py:445
 msgid "label_dossier_not_available"
 msgstr "Dossier indisponible"
 
@@ -815,6 +815,11 @@ msgstr "Editer"
 #: ./opengever/meeting/browser/meetings/meeting.py:369
 msgid "label_edit_action"
 msgstr "Editer le titre"
+
+#. Default: "Edit after creation"
+#: ./opengever/meeting/browser/proposalforms.py:125
+msgid "label_edit_after_creation"
+msgstr "Modifier après avoir créé"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/meetings/meeting.py:367
@@ -876,7 +881,7 @@ msgstr "Groupe"
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/protocol.py:129
-#: ./opengever/meeting/proposal.py:70
+#: ./opengever/meeting/proposal.py:88
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
@@ -898,7 +903,7 @@ msgstr "Nom"
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/protocol.py:126
-#: ./opengever/meeting/proposal.py:65
+#: ./opengever/meeting/proposal.py:82
 msgid "label_legal_basis"
 msgstr "Base légale"
 
@@ -924,7 +929,7 @@ msgid "label_main_attributes"
 msgstr "Propriétés"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:205
+#: ./opengever/meeting/proposal.py:170
 msgid "label_meeting"
 msgstr "Séance"
 
@@ -934,7 +939,7 @@ msgid "label_member"
 msgstr "Membre"
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:117
+#: ./opengever/meeting/browser/proposalforms.py:120
 msgid "label_modified"
 msgstr "Dernière modification"
 
@@ -984,13 +989,13 @@ msgid "label_proposal_id"
 msgstr "Numéro de référence"
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:105
+#: ./opengever/meeting/browser/proposalforms.py:108
 msgid "label_proposal_template"
 msgstr "Modèle de proposition"
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
-#: ./opengever/meeting/proposal.py:75
+#: ./opengever/meeting/proposal.py:94
 msgid "label_proposed_action"
 msgstr "Proposition"
 
@@ -1001,7 +1006,7 @@ msgstr "Début de la numérotation des pages du protocole"
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py:144
-#: ./opengever/meeting/proposal.py:85
+#: ./opengever/meeting/proposal.py:106
 msgid "label_publish_in"
 msgstr "Publication dans"
 
@@ -1102,7 +1107,7 @@ msgid "label_upcoming_meetings"
 msgstr "Prochaines réunions"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:263
+#: ./opengever/meeting/proposal.py:228
 msgid "label_workflow_state"
 msgstr "Etat"
 
@@ -1111,7 +1116,7 @@ msgid "label_zip_download"
 msgstr "Télécharger le fichier ZIP"
 
 #. Default: "Language"
-#: ./opengever/meeting/proposal.py:100
+#: ./opengever/meeting/proposal.py:59
 msgid "language"
 msgstr "Langue"
 
@@ -1235,7 +1240,7 @@ msgstr "Participants"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:30
 #: ./opengever/meeting/model/meeting.py:69
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py:131
 msgid "pending"
 msgstr "En modification"
 
@@ -1249,12 +1254,12 @@ msgid "presidency"
 msgstr "Présidence"
 
 #. Default: "Proposal document"
-#: ./opengever/meeting/proposal.py:214
+#: ./opengever/meeting/proposal.py:179
 msgid "proposal_document"
 msgstr "Document de proposition"
 
 #. Default: "Proposal document ${title}"
-#: ./opengever/meeting/proposal.py:346
+#: ./opengever/meeting/proposal.py:298
 msgid "proposal_document_title"
 msgstr "Document de proposition ${title}"
 
@@ -1329,13 +1334,13 @@ msgid "protocol_excerpt"
 msgstr "Extrait de protocole"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:170
+#: ./opengever/meeting/model/proposal.py:160
 msgid "reactivate"
 msgstr "Réactiver"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:160
+#: ./opengever/meeting/model/proposal.py:150
 msgid "reject"
 msgstr "Rejeter"
 
@@ -1355,12 +1360,12 @@ msgid "revision"
 msgstr "Révision"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:162
+#: ./opengever/meeting/model/proposal.py:152
 msgid "schedule"
 msgstr "Mettre à l'ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:145
+#: ./opengever/meeting/model/proposal.py:135
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1373,12 +1378,12 @@ msgid "status"
 msgstr "État"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:158
+#: ./opengever/meeting/model/proposal.py:148
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:143
+#: ./opengever/meeting/model/proposal.py:133
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1402,7 +1407,7 @@ msgid "time"
 msgstr "Temps"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:164
+#: ./opengever/meeting/model/proposal.py:154
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-04 06:48+0000\n"
+"POT-Creation-Date: 2017-07-18 14:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:394
+#: ./opengever/meeting/command.py:406
 msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
@@ -56,7 +56,7 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:428
+#: ./opengever/meeting/command.py:440
 msgid "Additional document ${title} has been submitted successfully."
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:357
+#: ./opengever/meeting/command.py:369
 msgid "Document ${title} has already been submitted in that version."
 msgstr ""
 
@@ -125,19 +125,19 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:104
+#: ./opengever/meeting/command.py:107
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:109
+#: ./opengever/meeting/command.py:112
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:168
+#: ./opengever/meeting/command.py:175
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:173
+#: ./opengever/meeting/command.py:180
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -272,11 +272,11 @@ msgstr ""
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:51
+#: ./opengever/meeting/command.py:54
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/command.py:56
+#: ./opengever/meeting/command.py:59
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr ""
 
@@ -339,7 +339,7 @@ msgstr ""
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:262
+#: ./opengever/meeting/command.py:269
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
@@ -424,12 +424,12 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:168
+#: ./opengever/meeting/model/proposal.py:158
 msgid "cancel"
 msgstr ""
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:148
+#: ./opengever/meeting/model/proposal.py:138
 msgid "cancelled"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:166
+#: ./opengever/meeting/model/proposal.py:156
 msgid "decide"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:31
-#: ./opengever/meeting/model/proposal.py:146
+#: ./opengever/meeting/model/proposal.py:136
 msgid "decided"
 msgstr ""
 
@@ -647,7 +647,7 @@ msgstr ""
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
 #: ./opengever/meeting/browser/submitdocuments.py:36
-#: ./opengever/meeting/proposal.py:160
+#: ./opengever/meeting/proposal.py:123
 msgid "label_attachments"
 msgstr ""
 
@@ -675,7 +675,7 @@ msgstr ""
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py:53
 #: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:60
+#: ./opengever/meeting/proposal.py:54
 msgid "label_committee"
 msgstr ""
 
@@ -686,18 +686,18 @@ msgstr ""
 
 #. Default: "Considerations"
 #: ./opengever/meeting/browser/meetings/protocol.py:135
-#: ./opengever/meeting/proposal.py:131
+#: ./opengever/meeting/proposal.py:146
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
 #: ./opengever/meeting/browser/meetings/protocol.py:150
-#: ./opengever/meeting/proposal.py:95
+#: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:114
+#: ./opengever/meeting/browser/proposalforms.py:117
 msgid "label_creator"
 msgstr ""
 
@@ -742,17 +742,17 @@ msgstr ""
 
 #. Default: "Decision"
 #: ./opengever/meeting/browser/meetings/protocol.py:141
-#: ./opengever/meeting/proposal.py:241
+#: ./opengever/meeting/proposal.py:206
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Decision draft"
-#: ./opengever/meeting/proposal.py:80
+#: ./opengever/meeting/proposal.py:100
 msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/proposal.py:267
+#: ./opengever/meeting/proposal.py:232
 msgid "label_decision_number"
 msgstr ""
 
@@ -768,23 +768,23 @@ msgstr ""
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py:147
-#: ./opengever/meeting/proposal.py:90
+#: ./opengever/meeting/proposal.py:112
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
 #: ./opengever/meeting/browser/meetings/protocol.py:138
-#: ./opengever/meeting/proposal.py:412
+#: ./opengever/meeting/proposal.py:364
 msgid "label_discussion"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:392
+#: ./opengever/meeting/proposal.py:344
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:493
+#: ./opengever/meeting/proposal.py:445
 msgid "label_dossier_not_available"
 msgstr ""
 
@@ -811,6 +811,11 @@ msgstr ""
 #. Default: "edit title"
 #: ./opengever/meeting/browser/meetings/meeting.py:369
 msgid "label_edit_action"
+msgstr ""
+
+#. Default: "Edit after creation"
+#: ./opengever/meeting/browser/proposalforms.py:125
+msgid "label_edit_after_creation"
 msgstr ""
 
 #. Default: "Cancel"
@@ -873,7 +878,7 @@ msgstr ""
 
 #. Default: "Initial position"
 #: ./opengever/meeting/browser/meetings/protocol.py:129
-#: ./opengever/meeting/proposal.py:70
+#: ./opengever/meeting/proposal.py:88
 msgid "label_initial_position"
 msgstr ""
 
@@ -895,7 +900,7 @@ msgstr ""
 
 #. Default: "Legal basis"
 #: ./opengever/meeting/browser/meetings/protocol.py:126
-#: ./opengever/meeting/proposal.py:65
+#: ./opengever/meeting/proposal.py:82
 msgid "label_legal_basis"
 msgstr ""
 
@@ -921,7 +926,7 @@ msgid "label_main_attributes"
 msgstr ""
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:205
+#: ./opengever/meeting/proposal.py:170
 msgid "label_meeting"
 msgstr ""
 
@@ -931,7 +936,7 @@ msgid "label_member"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:117
+#: ./opengever/meeting/browser/proposalforms.py:120
 msgid "label_modified"
 msgstr ""
 
@@ -981,13 +986,13 @@ msgid "label_proposal_id"
 msgstr ""
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:105
+#: ./opengever/meeting/browser/proposalforms.py:108
 msgid "label_proposal_template"
 msgstr ""
 
 #. Default: "Proposed action"
 #: ./opengever/meeting/browser/meetings/protocol.py:132
-#: ./opengever/meeting/proposal.py:75
+#: ./opengever/meeting/proposal.py:94
 msgid "label_proposed_action"
 msgstr ""
 
@@ -998,7 +1003,7 @@ msgstr ""
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py:144
-#: ./opengever/meeting/proposal.py:85
+#: ./opengever/meeting/proposal.py:106
 msgid "label_publish_in"
 msgstr ""
 
@@ -1099,7 +1104,7 @@ msgid "label_upcoming_meetings"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:263
+#: ./opengever/meeting/proposal.py:228
 msgid "label_workflow_state"
 msgstr ""
 
@@ -1108,7 +1113,7 @@ msgid "label_zip_download"
 msgstr ""
 
 #. Default: "Language"
-#: ./opengever/meeting/proposal.py:100
+#: ./opengever/meeting/proposal.py:59
 msgid "language"
 msgstr ""
 
@@ -1232,7 +1237,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:30
 #: ./opengever/meeting/model/meeting.py:69
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py:131
 msgid "pending"
 msgstr ""
 
@@ -1246,12 +1251,12 @@ msgid "presidency"
 msgstr ""
 
 #. Default: "Proposal document"
-#: ./opengever/meeting/proposal.py:214
+#: ./opengever/meeting/proposal.py:179
 msgid "proposal_document"
 msgstr ""
 
 #. Default: "Proposal document ${title}"
-#: ./opengever/meeting/proposal.py:346
+#: ./opengever/meeting/proposal.py:298
 msgid "proposal_document_title"
 msgstr ""
 
@@ -1326,13 +1331,13 @@ msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:170
+#: ./opengever/meeting/model/proposal.py:160
 msgid "reactivate"
 msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:160
+#: ./opengever/meeting/model/proposal.py:150
 msgid "reject"
 msgstr ""
 
@@ -1352,12 +1357,12 @@ msgid "revision"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:162
+#: ./opengever/meeting/model/proposal.py:152
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:145
+#: ./opengever/meeting/model/proposal.py:135
 msgid "scheduled"
 msgstr ""
 
@@ -1370,12 +1375,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:158
+#: ./opengever/meeting/model/proposal.py:148
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:143
+#: ./opengever/meeting/model/proposal.py:133
 msgid "submitted"
 msgstr ""
 
@@ -1399,7 +1404,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:164
+#: ./opengever/meeting/model/proposal.py:154
 msgid "un-schedule"
 msgstr ""
 


### PR DESCRIPTION
Add a option for checking out and external-editing the proposal document
of newly created proposals. The option is enabled by default.

As discussed in #2829

![bildschirmfoto 2017-07-18 um 16 58 00](https://user-images.githubusercontent.com/7469/28323871-4765e822-6bda-11e7-9c0f-2875da5c0e96.png)

Not sure why there is a CSS bug; I'm using a regular z3cform checkbox widget as it is used in other places. Probably needs to be fixed in the theme.