### PR TITLE
Define cookie path when setting the current orgunit id in the cookie.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix: remove ftw.showroom CSS on fresh installations too. [jone]
+- Define cookie path when setting the current orgunit id in the cookie. [phgross]
 - Add version of downloaded file to journal's entry. [tarnap]
 - Allow to copy-paste single documents. [tarnap]
 - Always download MSG file if avaiable. [mathias.leimgruber]

--- a/opengever/ogds/base/tests/test_cookie_storage.py
+++ b/opengever/ogds/base/tests/test_cookie_storage.py
@@ -25,7 +25,7 @@ class TestCookieStorage(FunctionalTestCase):
 
         self.assertEquals({'foo': 'bar'}, self.request.cookies)
         self.assertDictContainsSubset(
-            {'quoted': True, 'value': 'bar'},
+            {'quoted': True, 'value': 'bar', 'path': '/'},
             self.request.RESPONSE.cookies['foo'])
 
     def test_sets_cookie_expiration_date(self):

--- a/opengever/ogds/base/utils.py
+++ b/opengever/ogds/base/utils.py
@@ -61,7 +61,8 @@ class CookieStorage(DictMixin):
 
     def __setitem__(self, key, value):
         self.request.cookies[key] = value
-        self.request.RESPONSE.setCookie(key, value, expires=self.expires)
+        self.request.RESPONSE.setCookie(
+            key, value, expires=self.expires, path='/')
 
     def __delitem__(self, key):
         del self.request.cookies[key]


### PR DESCRIPTION
This fix an issue, which the OrgUnit selector had shown a "wrong" current orgunit in some cases, for example when viewing the personal overview.