### PR TITLE
Disable reference number column in the document listing of the inbox.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Move handlebar templates to template files. [jone]
+- Disable reference number column in the document listing of the inbox. [phgross]
 - Fix: remove ftw.showroom CSS on fresh installations too. [jone]
 - Define cookie path when setting the current orgunit id in the cookie. [phgross]
 - Add version of downloaded file to journal's entry. [tarnap]

--- a/opengever/inbox/browser/tabs.py
+++ b/opengever/inbox/browser/tabs.py
@@ -103,7 +103,7 @@ class InboxDocuments(Documents):
         """Remove default columns `containing_subdossier`, `checked_out`
         and `external_edit`.
         """
-        remove_columns = ['containing_subdossier', 'checked_out']
+        remove_columns = ['containing_subdossier', 'checked_out', 'reference']
         columns = []
 
         for col in super(InboxDocuments, self).columns:

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -37,7 +37,7 @@ class TestInboxTabbedview(FunctionalTestCase):
         self.assertEquals([document_2],
                           [brain.getObject() for brain in view.contents])
 
-    def test_document_listings_does_not_contain_subdossier_and_checked_out_column(self):
+    def test_document_listings_does_not_contain_subdossier_checked_out_and_reference_column(self):
         document_view = self.inbox.restrictedTraverse('tabbedview_view-documents')
 
         columns = [col.get('column') for col in document_view.columns
@@ -45,6 +45,7 @@ class TestInboxTabbedview(FunctionalTestCase):
 
         self.assertNotIn('containing_subdossier', columns)
         self.assertNotIn('checked_out', columns)
+        self.assertNotIn('reference', columns)
 
     def test_documents_listing_only_show_documents_from_the_current_inbox(self):
         second_inbox = create(Builder('inbox'))

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -175,7 +175,8 @@ class Documents(BaseCatalogListingTab):
          'transform': translate_public_trial_options},
 
         {'column': 'reference',
-         'column_title': _(u'label_reference', default=u'Reference Number')},
+         'column_title': _(u'label_document_reference',
+                           default=u'Reference Number')},
         )
 
     major_actions = [

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-07-19 08:51+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:278
+#: ./opengever/tabbedview/browser/tabs.py:282
 #: ./opengever/tabbedview/browser/users.py:62
 msgid "Active"
 msgstr "Aktiv"
@@ -72,42 +72,42 @@ msgid "checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:91
+#: ./opengever/tabbedview/browser/tasklisting.py:92
 msgid "column_date_of_completion"
 msgstr "Erledigt am"
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:87
+#: ./opengever/tabbedview/browser/tasklisting.py:88
 msgid "column_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:104
+#: ./opengever/tabbedview/browser/tasklisting.py:105
 msgid "column_issued_at"
 msgstr "Erstellt am"
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:111
+#: ./opengever/tabbedview/browser/tasklisting.py:113
 msgid "column_issuing_org_unit"
 msgstr "Organisationseinheit"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:75
+#: ./opengever/tabbedview/browser/tasklisting.py:76
 msgid "column_review_state"
 msgstr "Status"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:117
+#: ./opengever/tabbedview/browser/tasklisting.py:119
 msgid "column_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:83
+#: ./opengever/tabbedview/browser/tasklisting.py:84
 msgid "column_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:79
+#: ./opengever/tabbedview/browser/tasklisting.py:80
 msgid "column_title"
 msgstr "Titel"
 
@@ -122,7 +122,7 @@ msgid "contact"
 msgstr "Beteiligter"
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:108
+#: ./opengever/tabbedview/browser/tasklisting.py:109
 msgid "containing_dossier"
 msgstr "Dossier"
 
@@ -184,7 +184,7 @@ msgstr "Ende"
 msgid "events"
 msgstr "Termine"
 
-#: ./opengever/tabbedview/browser/tabs.py:281
+#: ./opengever/tabbedview/browser/tabs.py:285
 msgid "expired"
 msgstr "Abgelaufen"
 
@@ -233,18 +233,23 @@ msgstr "Autor"
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
+#. Default: "Reference Number"
+#: ./opengever/tabbedview/browser/tabs.py:178
+msgid "label_document_reference"
+msgstr "Aktenzeichen"
+
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:251
+#: ./opengever/tabbedview/browser/tabs.py:255
 msgid "label_dossier_responsible"
 msgstr "Federführung"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:260
+#: ./opengever/tabbedview/browser/tabs.py:264
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:100
+#: ./opengever/tabbedview/browser/tasklisting.py:101
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -264,12 +269,12 @@ msgid "label_no_contents"
 msgstr "Keine Inhalte"
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:65
+#: ./opengever/tabbedview/browser/tasklisting.py:66
 msgid "label_pending"
 msgstr "Pendent"
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:181
+#: ./opengever/tabbedview/helper.py:198
 msgid "label_preview"
 msgstr "Vorschau"
 
@@ -284,27 +289,27 @@ msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:239
+#: ./opengever/tabbedview/browser/tabs.py:243
 msgid "label_reference"
 msgstr "Aktenzeichen"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:96
+#: ./opengever/tabbedview/browser/tasklisting.py:97
 msgid "label_responsible_task"
 msgstr "Auftragnehmer"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:247
+#: ./opengever/tabbedview/browser/tabs.py:251
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:171
+#: ./opengever/tabbedview/helper.py:188
 msgid "label_showroom_version_title"
 msgstr "Version ${version} vom ${timestamp}"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:256
+#: ./opengever/tabbedview/browser/tabs.py:260
 msgid "label_start"
 msgstr "Beginn"
 
@@ -313,8 +318,8 @@ msgstr "Beginn"
 msgid "label_subdossier"
 msgstr "Subdossier"
 
-#: ./opengever/tabbedview/browser/tabs.py:276
-#: ./opengever/tabbedview/browser/tasklisting.py:63
+#: ./opengever/tabbedview/browser/tabs.py:280
+#: ./opengever/tabbedview/browser/tasklisting.py:64
 #: ./opengever/tabbedview/browser/users.py:61
 msgid "label_tabbedview_filter_all"
 msgstr "Alle"
@@ -443,4 +448,3 @@ msgstr "Titel"
 
 msgid "trash"
 msgstr "Papierkorb"
-

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,23 +1,22 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-07-19 08:51+0000\n"
 "PO-Revision-Date: 2017-06-04 17:01+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-tabbedview/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tabbedview/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:278
+#: ./opengever/tabbedview/browser/tabs.py:282
 #: ./opengever/tabbedview/browser/users.py:62
 msgid "Active"
 msgstr "Actif"
@@ -72,42 +71,42 @@ msgid "checkout_and_edit"
 msgstr "Checkout et modifier"
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:91
+#: ./opengever/tabbedview/browser/tasklisting.py:92
 msgid "column_date_of_completion"
 msgstr "Accompli le"
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:87
+#: ./opengever/tabbedview/browser/tasklisting.py:88
 msgid "column_deadline"
 msgstr "A accomplir jusqu'au"
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:104
+#: ./opengever/tabbedview/browser/tasklisting.py:105
 msgid "column_issued_at"
 msgstr "Créé le"
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:111
+#: ./opengever/tabbedview/browser/tasklisting.py:113
 msgid "column_issuing_org_unit"
 msgstr "Unité d'organisation"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:75
+#: ./opengever/tabbedview/browser/tasklisting.py:76
 msgid "column_review_state"
 msgstr "Etat"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:117
+#: ./opengever/tabbedview/browser/tasklisting.py:119
 msgid "column_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:83
+#: ./opengever/tabbedview/browser/tasklisting.py:84
 msgid "column_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:79
+#: ./opengever/tabbedview/browser/tasklisting.py:80
 msgid "column_title"
 msgstr "Titre"
 
@@ -121,7 +120,7 @@ msgid "contact"
 msgstr "Participant"
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:108
+#: ./opengever/tabbedview/browser/tasklisting.py:109
 msgid "containing_dossier"
 msgstr "Dossier"
 
@@ -180,7 +179,7 @@ msgstr "Fin"
 msgid "events"
 msgstr "Rendez-vous"
 
-#: ./opengever/tabbedview/browser/tabs.py:281
+#: ./opengever/tabbedview/browser/tabs.py:285
 msgid "expired"
 msgstr "Expiré"
 
@@ -228,18 +227,23 @@ msgstr "Auteur"
 msgid "label_document_date"
 msgstr "Date du document"
 
+#. Default: "Reference Number"
+#: ./opengever/tabbedview/browser/tabs.py:178
+msgid "label_document_reference"
+msgstr "Numéro de référence"
+
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:251
+#: ./opengever/tabbedview/browser/tabs.py:255
 msgid "label_dossier_responsible"
 msgstr "Responsable"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:260
+#: ./opengever/tabbedview/browser/tabs.py:264
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:100
+#: ./opengever/tabbedview/browser/tasklisting.py:101
 msgid "label_issuer"
 msgstr "Mandataire"
 
@@ -259,12 +263,12 @@ msgid "label_no_contents"
 msgstr "Aucun contenu"
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:65
+#: ./opengever/tabbedview/browser/tasklisting.py:66
 msgid "label_pending"
 msgstr "En suspens"
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:181
+#: ./opengever/tabbedview/helper.py:198
 msgid "label_preview"
 msgstr "Aperçu"
 
@@ -279,27 +283,27 @@ msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:239
+#: ./opengever/tabbedview/browser/tabs.py:243
 msgid "label_reference"
 msgstr "Numéro de référence"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:96
+#: ./opengever/tabbedview/browser/tasklisting.py:97
 msgid "label_responsible_task"
 msgstr "Mandataire"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:247
+#: ./opengever/tabbedview/browser/tabs.py:251
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:171
+#: ./opengever/tabbedview/helper.py:188
 msgid "label_showroom_version_title"
 msgstr "Version ${version} de ${timestamp}"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:256
+#: ./opengever/tabbedview/browser/tabs.py:260
 msgid "label_start"
 msgstr "Début"
 
@@ -308,8 +312,8 @@ msgstr "Début"
 msgid "label_subdossier"
 msgstr "Sous-dossier"
 
-#: ./opengever/tabbedview/browser/tabs.py:276
-#: ./opengever/tabbedview/browser/tasklisting.py:63
+#: ./opengever/tabbedview/browser/tabs.py:280
+#: ./opengever/tabbedview/browser/tasklisting.py:64
 #: ./opengever/tabbedview/browser/users.py:61
 msgid "label_tabbedview_filter_all"
 msgstr "Tous"

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-07-19 08:51+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: opengever.tabbedview\n"
 "X-Poedit-Language: German\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:278
+#: ./opengever/tabbedview/browser/tabs.py:282
 #: ./opengever/tabbedview/browser/users.py:62
 msgid "Active"
 msgstr ""
@@ -70,42 +70,42 @@ msgid "checkout_and_edit"
 msgstr ""
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:91
+#: ./opengever/tabbedview/browser/tasklisting.py:92
 msgid "column_date_of_completion"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:87
+#: ./opengever/tabbedview/browser/tasklisting.py:88
 msgid "column_deadline"
 msgstr ""
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:104
+#: ./opengever/tabbedview/browser/tasklisting.py:105
 msgid "column_issued_at"
 msgstr ""
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:111
+#: ./opengever/tabbedview/browser/tasklisting.py:113
 msgid "column_issuing_org_unit"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:75
+#: ./opengever/tabbedview/browser/tasklisting.py:76
 msgid "column_review_state"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:117
+#: ./opengever/tabbedview/browser/tasklisting.py:119
 msgid "column_sequence_number"
 msgstr ""
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:83
+#: ./opengever/tabbedview/browser/tasklisting.py:84
 msgid "column_task_type"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:79
+#: ./opengever/tabbedview/browser/tasklisting.py:80
 msgid "column_title"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgid "contact"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:108
+#: ./opengever/tabbedview/browser/tasklisting.py:109
 msgid "containing_dossier"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "events"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:281
+#: ./opengever/tabbedview/browser/tabs.py:285
 msgid "expired"
 msgstr ""
 
@@ -226,18 +226,23 @@ msgstr ""
 msgid "label_document_date"
 msgstr ""
 
+#. Default: "Reference Number"
+#: ./opengever/tabbedview/browser/tabs.py:178
+msgid "label_document_reference"
+msgstr ""
+
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:251
+#: ./opengever/tabbedview/browser/tabs.py:255
 msgid "label_dossier_responsible"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:260
+#: ./opengever/tabbedview/browser/tabs.py:264
 msgid "label_end"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:100
+#: ./opengever/tabbedview/browser/tasklisting.py:101
 msgid "label_issuer"
 msgstr ""
 
@@ -257,12 +262,12 @@ msgid "label_no_contents"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:65
+#: ./opengever/tabbedview/browser/tasklisting.py:66
 msgid "label_pending"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:181
+#: ./opengever/tabbedview/helper.py:198
 msgid "label_preview"
 msgstr ""
 
@@ -277,27 +282,27 @@ msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:239
+#: ./opengever/tabbedview/browser/tabs.py:243
 msgid "label_reference"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:96
+#: ./opengever/tabbedview/browser/tasklisting.py:97
 msgid "label_responsible_task"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:247
+#: ./opengever/tabbedview/browser/tabs.py:251
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:171
+#: ./opengever/tabbedview/helper.py:188
 msgid "label_showroom_version_title"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:256
+#: ./opengever/tabbedview/browser/tabs.py:260
 msgid "label_start"
 msgstr ""
 
@@ -306,8 +311,8 @@ msgstr ""
 msgid "label_subdossier"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:276
-#: ./opengever/tabbedview/browser/tasklisting.py:63
+#: ./opengever/tabbedview/browser/tabs.py:280
+#: ./opengever/tabbedview/browser/tasklisting.py:64
 #: ./opengever/tabbedview/browser/users.py:61
 msgid "label_tabbedview_filter_all"
 msgstr ""


### PR DESCRIPTION
Because documents inside the inbox does not have a meaningful reference number, the recently introduced column should be removed for the document listing of inboxes.