### PR TITLE
Meeting word: add proposal document to meeting view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bundle import: Display current memory usage (RSS) in progress logger. [lgraf]
+- Word meeting: show proposal files in meeting view. [jone]
 - Format line breaks in task descriptions. [tarnap]
 
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -1,5 +1,6 @@
 from opengever.base.response import JSONResponse
 from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.service import meeting_service
 from plone import api
@@ -138,6 +139,12 @@ class AgendaItemsView(BrowserView):
             if item.is_revise_possible():
                 data['revise_link'] = meeting.get_url(
                     view='agenda_items/{}/revise'.format(item.agenda_item_id))
+
+            if item.proposal and is_word_meeting_implementation_enabled():
+                proposal = item.proposal.submitted_oguid.resolve_object()
+                proposal_document = proposal.get_proposal_document()
+                data['proposal_document_link'] = (
+                    IContentListingObject(proposal_document).render_link())
 
             agenda_items.append(data)
         return agenda_items

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -319,6 +319,7 @@ class MeetingView(BrowserView):
                 _('label_decide_action', default='Decide this agenda item'),
                 _('label_reopen_action', default='Reopen this agenda item'),
                 _('label_revise_action', default='Revise this agenda item'),
+                _('label_attachments', default='Attachments'),
             ),
             max_proposal_title_length=ISubmittedProposal['title'].max_length)
 
@@ -360,3 +361,7 @@ class MeetingView(BrowserView):
         return translate(_('An unexpected error has occurred',
                            default='An unexpected error has occurred'),
                          context=self.request)
+
+    def is_word_meeting_implementation_enabled(self):
+        # Make feature flag available in meeting.pt
+        return is_word_meeting_implementation_enabled()

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -9,6 +9,7 @@ from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.schema import UTCDatetime
 from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.browser.meetings.transitions import MeetingTransitionController
 from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.browser.protocol import UpdateProtocol
@@ -291,8 +292,25 @@ class MeetingView(BrowserView):
         return IContentListing(docs)
 
     def render_handlebars_agendaitems_template(self):
+        if is_word_meeting_implementation_enabled():
+            return self.render_handlebars_agendaitems_template_word()
+
         return prepare_handlebars_template(
             TEMPLATES_DIR.joinpath('agendaitems.html'),
+            translations=(
+                _('label_edit_cancel', default='Cancel'),
+                _('label_edit_save', default='Save'),
+                _('label_edit_action', default='edit title'),
+                _('label_delete_action', default='delete this agenda item'),
+                _('label_decide_action', default='Decide this agenda item'),
+                _('label_reopen_action', default='Reopen this agenda item'),
+                _('label_revise_action', default='Revise this agenda item'),
+            ),
+            max_proposal_title_length=ISubmittedProposal['title'].max_length)
+
+    def render_handlebars_agendaitems_template_word(self):
+        return prepare_handlebars_template(
+            TEMPLATES_DIR.joinpath('agendaitems-word.html'),
             translations=(
                 _('label_edit_cancel', default='Cancel'),
                 _('label_edit_save', default='Save'),

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -1,0 +1,58 @@
+<script id="agendaitemsTemplate" type="text/x-handlebars-template">
+  {{#each agendaitems}}
+  <tr class="{{css_class}}" data-uid={{id}}>
+    {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
+    <td class="number">{{number}}</td>
+    <td class="title">
+      <span>{{{link}}}</span>
+      {{#if has_proposal}}
+      <ul class="attachements">
+        {{#each documents}}
+        <li>
+          {{{link}}}
+        </li>
+        {{/each}}
+      </ul>
+      {{/if}}
+      {{#if excerpt}}
+      <div class="summary">
+        {{{excerpt}}}
+      </div>
+      {{/if}}
+      <div class="edit-box">
+        <div class="input-group">
+          <input type="text" {{#if has_proposal}}maxlength="%(max_proposal_title_length)i"{{/if}} />
+          <div class="button-group">
+            <input value="%(label_edit_save)s" type="button" class="button edit-save" />
+            <input value="%(label_edit_cancel)s" type="button" class="button edit-cancel" />
+          </div>
+        </div>
+      </div>
+    </td>
+    <td class="toggle-attachements">
+      {{#if has_documents}}
+      <a class="toggle-attachements-btn"></a>
+      {{/if}}
+    </td>
+    {{#if ../editable}}
+    <td class="actions">
+      <div class="button-group">
+        {{#if ../agendalist_editable}}
+        <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>
+        <a href="{{delete_link}}" title="%(label_delete_action)s" class="button delete-agenda-item"></a>
+        {{/if}}
+        {{#if decide_link}}
+        <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>
+        {{/if}}
+        {{#if reopen_link}}
+        <a href="{{reopen_link}}" title="%(label_reopen_action)s" class="button reopen-agenda-item"><span></span></a>
+        {{/if}}
+        {{#if revise_link}}
+        <a href="{{revise_link}}" title="%(label_revise_action)s" class="button revise-agenda-item"><span></span></a>
+        {{/if}}
+      </div>
+    </td>
+    {{/if}}
+  </tr>
+  {{/each}}
+</script>

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -1,18 +1,32 @@
 <script id="agendaitemsTemplate" type="text/x-handlebars-template">
   {{#each agendaitems}}
-  <tr class="{{css_class}}" data-uid={{id}}>
+  <tr class="{{css_class}} word-feature" data-uid={{id}}>
     {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
-    <td class="number">{{number}}</td>
+    <td class="number">
+      {{number}}
+      {{#if has_documents}}
+      <div class="toggle-attachements">
+        <a class="toggle-attachements-btn"></a>
+      </div>
+      {{/if}}
+    </td>
     <td class="title">
-      <span>{{{link}}}</span>
+      <span class="proposal_title">{{{link}}}</span>
       {{#if has_proposal}}
-      <ul class="attachements">
-        {{#each documents}}
-        <li>
-          {{{link}}}
-        </li>
-        {{/each}}
-      </ul>
+      <div class="proposal_document">{{{proposal_document_link}}}</div>
+
+      {{#if has_documents}}
+      <div class="attachements">
+        <div class="label_attachments">%(label_attachments)s:</div>
+        <ul>
+          {{#each documents}}
+          <li>
+            {{{link}}}
+          </li>
+          {{/each}}
+        </ul>
+      </div>
+      {{/if}}
       {{/if}}
       {{#if excerpt}}
       <div class="summary">
@@ -28,11 +42,6 @@
           </div>
         </div>
       </div>
-    </td>
-    <td class="toggle-attachements">
-      {{#if has_documents}}
-      <a class="toggle-attachements-btn"></a>
-      {{/if}}
     </td>
     {{#if ../editable}}
     <td class="actions">

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -16,6 +16,7 @@
   <metal:content-core fill-slot="content-core">
       <metal:content-core define-macro="content-core"
                           tal:define="meeting view/model;
+                                      meeting_word_enabled view/is_word_meeting_implementation_enabled;
                                       unscheduled_proposals view/unscheduled_proposals">
       <div id="opengever_meeting_meeting"
            tal:attributes="data-update-agenda-item-order-url view/url_update_agenda_item_order;
@@ -289,7 +290,7 @@
                     tal:condition="meeting/is_agendalist_editable">Order</th>
                 <th i18n:translate="">Number</th>
                 <th i18n:translate="">Title</th>
-                <th i18n:translate="">Documents</th>
+                <th i18n:translate="" tal:condition="not:meeting_word_enabled">Documents</th>
                 <th i18n:translate=""
                     tal:condition="meeting/is_editable">Actions</th>
               </tr>

--- a/sources.cfg
+++ b/sources.cfg
@@ -8,6 +8,8 @@ extensions += mr.developer
 development-packages =
   opengever.maintenance
   collective.js.timeago
+# https://github.com/4teamwork/plonetheme.teamraum/pull/564
+  plonetheme.teamraum
 
 # Please cleanup your pull-request so that you are not adding ftw.*-packages
 # to the development-packages. It is your responsibility to release the


### PR DESCRIPTION
~⚠️ _requires https://github.com/4teamwork/plonetheme.teamraum/pull/564_~
ℹ️ _part of #2829_ 

Update the meeting view so that the proposal document is listed and can directly be edited.

Changes:
- Show proposal document right beneath proposal; the tooltip allows for fast checkout and edit.
- Make proposal title text bold, because it is the important part of the proposal.
- Prefix attachments with a "Attachments"-label; this was not clear enough.
- Move Attachment-Toggle from a separate "Documents" column to the left side (into the number column), because a toggle should be at the left side from a UX viewpoint and because the documents column did consume too much space.
- These changes are feature-flagged with the word-changes-feature.

![bildschirmfoto 2017-07-19 um 16 46 09](https://user-images.githubusercontent.com/7469/28374009-cb5c0728-6ca3-11e7-863c-5a8e3aa690f3.png)
