### PR TITLE
Squelch an openpyxl deprecation warning.

### DIFF
--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -52,7 +52,7 @@ class TestDispositionExcelExport(FunctionalTestCase):
                  u'Closing Date', u'Public Trial', u'Archival value',
                  u'archivalValueAnnotation', u'Appraisal'],
                 [cell.value for cell in list(workbook.active.rows)[0]])
-            self.assertTrue(workbook.active.cell('A1').font.bold)
+            self.assertTrue(workbook.active['A1'].font.bold)
 
     @browsing
     def test_value_rows(self, browser):


### PR DESCRIPTION
As per https://bitbucket.org/openpyxl/openpyxl/src/0f8537998f95c9d8d44913c2edb367516b799d4a/openpyxl/worksheet/worksheet.py?at=default&fileviewer=file-view-default#worksheet.py-302 we should not use cell-level fetching in openpyxl.