### PR TITLE
Fix original message (*.msg) download

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Move handlebar templates to template files. [jone]
 - Disable reference number column in the document listing of the inbox. [phgross]
+- Fix mail download: Convert LF to CRLF only for EML mails. [phgross]
 - Fix: remove ftw.showroom CSS on fresh installations too. [jone]
 - Define cookie path when setting the current orgunit id in the cookie. [phgross]
 - Make sure unicode is stored in proposal sql. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Move handlebar templates to template files. [jone]
 - Disable reference number column in the document listing of the inbox. [phgross]
+- Enable \*.msg download for all download copy links. [phgross]
 - Fix mail download: Convert LF to CRLF only for EML mails. [phgross]
 - Fix: remove ftw.showroom CSS on fresh installations too. [jone]
 - Define cookie path when setting the current orgunit id in the cookie. [phgross]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -63,6 +63,10 @@ class BaseDocumentMixin(object):
     def is_removed(self):
         return api.content.get_state(obj=self) == self.removed_state
 
+    @property
+    def is_mail(self):
+        return False
+
     def related_items(self):
         raise NotImplementedError
 

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -1,6 +1,7 @@
 from opengever.base.pdfconverter import is_pdfconverter_enabled
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.mail.mail import IOGMail
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from plone import api
 from plone.locking.interfaces import IRefreshableLockable
@@ -62,11 +63,21 @@ class ActionButtonRendererMixin(object):
         return not self.is_checked_out_by_another_user()
 
     def get_download_copy_tag(self):
+        """Returns the DownloadConfirmationHelper tag containing
+        the donwload link. For mails, containing an original_message, the tag
+        links to the orginal message download view.
+        """
+
+        viewname = 'download'
+        if self.context.is_mail and IOGMail(self.context).original_message:
+            viewname = '@@download/original_message'
+
         dc_helper = DownloadConfirmationHelper(self.context)
         return dc_helper.get_html_tag(
             additional_classes=['function-download-copy'],
+            viewname=viewname,
             include_token=True,
-            )
+        )
 
     def is_attach_to_email_available(self):
         if not is_officeconnector_attach_feature_enabled():

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -9,7 +9,6 @@ from opengever.document import _
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.browser import archival_file_form
 from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
-from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.base import DOSSIER_STATES_CLOSED
@@ -253,13 +252,6 @@ class Overview(DisplayForm, GeverTabMixin, ActionButtonRendererMixin):
         state = api.content.get_state(
             self.context.get_parent_dossier(), default=None)
         return can_edit and state in DOSSIER_STATES_CLOSED
-
-    def get_download_copy_tag(self):
-        dc_helper = DownloadConfirmationHelper(self.context)
-        return dc_helper.get_html_tag(
-            additional_classes=['function-download-copy'],
-            include_token=True
-            )
 
     def show_preview(self):
         return is_bumblebee_feature_enabled()

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -70,6 +70,10 @@ class TestDocument(FunctionalTestCase):
         field.set(document, file)
         self.assertTrue(field.get(document).data == 'bla bla')
 
+    def test_is_not_a_mail(self):
+        document = create(Builder('document'))
+        self.assertFalse(document.is_mail)
+
     def test_filename_getter_returns_filename_if_file_is_available(self):
         document = create(Builder('document')
                           .titled('Foo')

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -169,6 +169,17 @@ class TestDocumentTooltip(FunctionalTestCase):
         self.assertNotIn(
             'Download copy', browser.css('.file-action-buttons a').text)
 
+    @browsing
+    def test_download_link_redirects_to_orginal_message_when_exists(self, browser):  # noqa
+        mail = create(Builder('mail')
+                      .with_dummy_message()
+                      .with_dummy_original_message())
+        browser.login().open(mail, view='tooltip')
+
+        self.assertTrue(
+            browser.find('Download copy').get('href').startswith(
+                'http://nohost/plone/document-1/@@download/original_message?'))
+
 
 class TestDocumentLinkWidgetWithActivatedBumblebee(FunctionalTestCase):
     """Test document link widget interactions with Bumblebee."""

--- a/opengever/mail/browser/download.py
+++ b/opengever/mail/browser/download.py
@@ -1,5 +1,6 @@
 from opengever.document.browser.download import DocumentishDownload
 from plone.namedfile.interfaces import HAVE_BLOBS
+from opengever.mail.mail import IOGMail
 
 if HAVE_BLOBS:
     from plone.namedfile.interfaces import IBlobby
@@ -25,6 +26,9 @@ class MailDownload(DocumentishDownload):
         return ''.join(lines)
 
     def stream_data(self, named_file):
+        if self.fieldname == IOGMail['original_message'].getName():
+            return super(MailDownload, self).stream_data(named_file)
+
         if HAVE_BLOBS:
             if IBlobby.providedBy(named_file):
                 if named_file._blob._p_blob_uncommitted:

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -5,7 +5,6 @@ from ftw.mail.mail import IMail
 from ftw.mail.mail import View
 from opengever.base import _ as ogbmf
 from opengever.document import _ as ogdmf
-from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.browser.overview import CustomRow
 from opengever.document.browser.overview import FieldRow
 from opengever.document.browser.overview import Overview
@@ -94,21 +93,6 @@ class OverviewTab(MailAttachmentsMixin, Overview):
     @property
     def file_size(self):
         return byteDisplay(self.field.getSize())
-
-    def get_download_copy_tag(self):
-        dc_helper = DownloadConfirmationHelper(self.context)
-
-        if self.ogmail.original_message:
-            return dc_helper.get_html_tag(
-                additional_classes=['function-download-copy'],
-                viewname="@@download/original_message",
-                include_token=True
-                )
-        else:
-            return dc_helper.get_html_tag(
-                additional_classes=['function-download-copy'],
-                include_token=True
-                )
 
     def get_metadata_config(self):
         rows = [

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -154,6 +154,10 @@ class OGMail(Mail, BaseDocumentMixin):
         self._update_attachment_infos()
         self._reset_header_cache()
 
+    @property
+    def is_mail(self):
+        return True
+
     def get_extraction_parent(self):
         """Return the parent that accepts extracted attachments."""
         return self.get_parent_dossier() or self.get_parent_inbox()

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -104,6 +104,8 @@ class TestMailDownloadCopy(FunctionalTestCase):
 
     @browsing
     def test_download_copy_delivers_msg_if_available(self, browser):
+        msg_data = 'mock-msg-body'
+
         dossier = create(Builder('dossier'))
 
         class MockMsg2MimeTransform(object):
@@ -113,7 +115,7 @@ class TestMailDownloadCopy(FunctionalTestCase):
 
         command = CreateEmailCommand(dossier,
                                      'testm\xc3\xa4il.msg',
-                                     'mock-msg-body',
+                                     msg_data,
                                      transform=MockMsg2MimeTransform())
         mail = command.execute()
         transaction.commit()
@@ -129,3 +131,5 @@ class TestMailDownloadCopy(FunctionalTestCase):
             'content-disposition': 'attachment; filename="testm\xc3\xa4il.msg"',
             },
             browser.headers)
+
+        self.assertEquals(msg_data, browser.contents)


### PR DESCRIPTION
- Fix mail download: Convert LF to CRLF only for EML mails.
- Enable *.msg download for all download copy links, also in the tooltip or bumblebeeoverlay


