### PR TITLE
Add upgradestep to cleanup no longer existing interfaces from zc.relation catalog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.0 (unreleased)
 ---------------------
 
+- Add upgradestep to cleanup no longer existing interfaces from zc.relation catalog. [phgross]
 - Move handlebar templates to template files. [jone]
 - Disable reference number column in the document listing of the inbox. [phgross]
 - Enable \*.msg download for all download copy links. [phgross]

--- a/opengever/core/upgrades/20170720153900_cleanup_i_creator_interfaces_from_relation_catalog/upgrade.py
+++ b/opengever/core/upgrades/20170720153900_cleanup_i_creator_interfaces_from_relation_catalog/upgrade.py
@@ -1,0 +1,62 @@
+from BTrees.check import check
+from ftw.upgrade import UpgradeStep
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+import logging
+
+logger = logging.getLogger('opengever.core')
+
+TO_REMOVE = ['opengever.base.behaviors.creator.ICreatorAware',
+             'opengever.base.behaviors.creator.ICreator']
+
+
+class CleanupICreatorInterfacesFromRelationCatalog(UpgradeStep):
+    """The behavior ICreator has been removed. But because the zc.relation
+    cataog persists provided interfaces, the removed interfaces must be
+    removed manually from the zc.relation catalog.
+
+    Copied from opengever.base.to4502.CleanupRelationsCatalog.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        self.catalog = getUtility(ICatalog)
+
+        for iface_name in TO_REMOVE:
+            self.cleanup_to_mapping(iface_name, 'to_interfaces_flattened')
+            self.cleanup_to_mapping(iface_name, 'from_interfaces_flattened')
+            self.cleanup_objtokenset(
+                ['from_interfaces_flattened', 'to_interfaces_flattened'])
+
+    def cleanup_to_mapping(self, iface_name, mapping_key):
+        # Check the BTree consistency, to avoid key errors when deleting
+        # entries in the BTree.
+        # If the check method detects an inconsistency, we fix the Btree by
+        # creating a copy of it.
+        #
+        # See http://do3.cc/blog/2012/09/264/debugging-zcrelations---broken-btrees/
+        # for more information.
+
+        try:
+            check(self.catalog._name_TO_mapping[mapping_key])
+        except AssertionError:
+            btree = self.catalog._name_TO_mapping[mapping_key]
+            self.catalog._name_TO_mapping[mapping_key] = btree.__class__(btree)
+            logger.warning(
+                'Inconsistent BTree detected and fixed by recreating it.')
+
+        for iface in self.catalog._name_TO_mapping[mapping_key].keys():
+            if '{}.{}'.format(iface.__module__, iface.__name__) == iface_name:
+                del self.catalog._name_TO_mapping[mapping_key][iface]
+                break
+
+    def cleanup_objtokenset(self, attribute_names):
+        for (key, value) in self.catalog._reltoken_name_TO_objtokenset.items():
+            token, name = key
+            if name in attribute_names:
+                broken_values = [iface for iface in value
+                                 if '{}.{}'.format(iface.__module__, iface.__name__) in TO_REMOVE]
+
+                for broken in broken_values:
+                    value.remove(broken)


### PR DESCRIPTION
With #2949 the `ICreator` and `ICreatorAware` interfaces has been removed. But because the zc.relation cataog persists provided interfaces, the removed interfaces has been removed manually from the zc.relation catalog.

Closes #3164