### PR TITLE
Update integration testing example in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -500,8 +500,7 @@ Example integration test with browser:
 
        @browsing
        def test_example_view(self, browser):
-           self.login(self.dossier_responsible)
-           browser.login(self.dossier_responsible)
+           self.login(self.dossier_responsible, browser)
            browser.open(self.dossier, view='example_view')
            statusmessages.assert_no_error_messages()
 


### PR DESCRIPTION
The integration testing example in the readme was wrong regarding browser login:
We have greed to pass the browser to `self.login` and not use `browser.login` in #3053.