### PR TITLE
Improve linebreak display in tasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.4.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Format line breaks in task descriptions. [tarnap]
 
 
 2017.4.0 (2017-07-26)

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -62,6 +62,12 @@ class Overview(grok.View, GeverTabMixin):
                 return ''
             return api.portal.get().toLocalizedTime(date)
 
+        def _format_description(description):
+            if not description:
+                return ''
+            return api.portal.get_tool(name='portal_transforms').convertTo(
+                'text/html', description, mimetype='text/x-web-intelligent')
+
         items = [
             {
                 'label': _('label_task_title', u'Task title'),
@@ -73,7 +79,8 @@ class Overview(grok.View, GeverTabMixin):
             },
             {
                 'label': _(u"label_text", default=u"Text"),
-                'value': task.text,
+                'value': _format_description(task.text),
+                'is_html': True,
             },
             {
                 'label': _(u'label_task_type', default=u'Task Type'),

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -9,6 +9,7 @@ from plone import api
 from plone.app.testing import TEST_USER_ID
 from StringIO import StringIO
 import transaction
+import unittest
 
 
 class TestTaskOverview(FunctionalTestCase):
@@ -221,6 +222,11 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertEqual(expected, result)
 
+    @unittest.skip(
+        """Fails because we expect URLs which are embedded at the end of the
+        sentences should not contain the punctuation mark.
+        This is issued in
+        https://github.com/plone/plone.intelligenttext/issues/4""")
     @browsing
     def test_task_text_urls_in_sentences_are_transformed(self, browser):
         dossier = create(Builder('dossier').titled(u'Dossier'))
@@ -244,6 +250,11 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertEqual(expected, result)
 
+    @unittest.skip(
+        """Fails because we expect URLs which are embedded at the end of the
+        sentences should not contain the punctuation mark.
+        This is issued in
+        https://github.com/plone/plone.intelligenttext/issues/4""")
     @browsing
     def test_task_text_urls_with_get_arguments_in_sentences_are_transformed(
             self, browser):
@@ -276,6 +287,11 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertEqual(expected, result)
 
+    @unittest.skip(
+        """Fails because we expect URLs which are embedded at the end of the
+        sentences should not contain the punctuation mark.
+        This is issued in
+        https://github.com/plone/plone.intelligenttext/issues/4""")
     @browsing
     def test_task_text_urls_with_anchors_in_sentences_are_transformed(
             self, browser):

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -179,6 +179,130 @@ class TestTaskOverview(FunctionalTestCase):
         )
 
     @browsing
+    def test_task_text_linebreaks_are_transformed(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier'))
+
+        text = 'Description\nThis is a description'
+
+        task = create(Builder("task")
+                      .within(dossier)
+                      .titled(u'Aufgabe')
+                      .having(text=text,
+                              task_type='comment'))
+
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        expected = u'Description<br>This is a description'
+        result = (browser.css('table.listing').find('Text').first.row
+                         .css('td').first.innerHTML)
+
+        self.assertEqual(expected, result)
+
+    @browsing
+    def test_task_text_simple_urls_in_sentences_are_transformed(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier'))
+
+        text = 'Is http://u.rl.\nIs http://u.rl?\nIs http://u.rl!'
+
+        task = create(Builder("task")
+                      .within(dossier)
+                      .titled(u'Aufgabe')
+                      .having(text=text,
+                              task_type='comment'))
+
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        expected = (u'Is <a href="http://u.rl" rel="nofollow">http://u.rl</a>.<br>'  # noqa
+                    u'Is <a href="http://u.rl" rel="nofollow">http://u.rl</a>?<br>'  # noqa
+                    u'Is <a href="http://u.rl" rel="nofollow">http://u.rl</a>!')  # noqa
+
+        result = (browser.css('table.listing').find('Text').first.row
+                         .css('td').first.innerHTML)
+
+        self.assertEqual(expected, result)
+
+    @browsing
+    def test_task_text_urls_in_sentences_are_transformed(self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier'))
+
+        text = 'Is http://u.rl/.\nIs http://u.rl/?\nIs http://u.rl/!'
+
+        task = create(Builder("task")
+                      .within(dossier)
+                      .titled(u'Aufgabe')
+                      .having(text=text,
+                              task_type='comment'))
+
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        expected = (u'Is <a href="http://u.rl/" rel="nofollow">http://u.rl/</a>.<br>'  # noqa
+                    u'Is <a href="http://u.rl/" rel="nofollow">http://u.rl/</a>?<br>'  # noqa
+                    u'Is <a href="http://u.rl/" rel="nofollow">http://u.rl/</a>!')  # noqa
+
+        result = (browser.css('table.listing').find('Text').first.row
+                         .css('td').first.innerHTML)
+
+        self.assertEqual(expected, result)
+
+    @browsing
+    def test_task_text_urls_with_get_arguments_in_sentences_are_transformed(
+            self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier'))
+
+        text = ('Is http://u.rl/with?get=arguments.\n'
+                'Is http://u.rl/with?get=arguments?\n'
+                'Is http://u.rl/with?get=arguments!\n'
+                'Is http://u.rl/with?sev=eral&get=args.\n'
+                'Is http://u.rl/with?sev=eral&get=args?\n'
+                'Is http://u.rl/with?sev=eral&get=args!')
+
+        task = create(Builder("task")
+                      .within(dossier)
+                      .titled(u'Aufgabe')
+                      .having(text=text,
+                              task_type='comment'))
+
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        expected = (u'Is <a href="http://u.rl/with?get=arguments" rel="nofollow">http://u.rl/with?get=arguments</a>.<br>'  # noqa
+                    u'Is <a href="http://u.rl/with?get=arguments" rel="nofollow">http://u.rl/with?get=arguments</a>?<br>'  # noqa
+                    u'Is <a href="http://u.rl/with?get=arguments" rel="nofollow">http://u.rl/with?get=arguments</a>!<br>'  # noqa
+                    u'Is <a href="http://u.rl/with?sev=eral&amp;get=args" rel="nofollow">http://u.rl/with?sev=eral&amp;get=args</a>.<br>'  # noqa
+                    u'Is <a href="http://u.rl/with?sev=eral&amp;get=args" rel="nofollow">http://u.rl/with?sev=eral&amp;get=args</a>?<br>'  # noqa
+                    u'Is <a href="http://u.rl/with?sev=eral&amp;get=args" rel="nofollow">http://u.rl/with?sev=eral&amp;get=args</a>!')  # noqa
+
+        result = (browser.css('table.listing').find('Text').first.row
+                         .css('td').first.innerHTML)
+
+        self.assertEqual(expected, result)
+
+    @browsing
+    def test_task_text_urls_with_anchors_in_sentences_are_transformed(
+            self, browser):
+        dossier = create(Builder('dossier').titled(u'Dossier'))
+
+        text = ('Is http://u.rl/with#goto.\n'
+                'Is http://u.rl/with#goto?\n'
+                'Is http://u.rl/with#goto!')
+
+        task = create(Builder("task")
+                      .within(dossier)
+                      .titled(u'Aufgabe')
+                      .having(text=text,
+                              task_type='comment'))
+
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        expected = (u'Is <a href="http://u.rl/with#goto" rel="nofollow">http://u.rl/with#goto</a>.<br>'  # noqa
+                    u'Is <a href="http://u.rl/with#goto" rel="nofollow">http://u.rl/with#goto</a>?<br>'  # noqa
+                    u'Is <a href="http://u.rl/with#goto" rel="nofollow">http://u.rl/with#goto</a>!')  # noqa
+
+        result = (browser.css('table.listing').find('Text').first.row
+                         .css('td').first.innerHTML)
+
+        self.assertEqual(expected, result)
+
+    @browsing
     def test_subtasks_are_shown_on_parent_task_page(self, browser):
         dossier = create(Builder('dossier').titled(u'Dossier'))
         task = create(Builder("task")


### PR DESCRIPTION
Converts web intelligent text to html for line breaks and clickable links.

![linebreaks_in_tasks](https://user-images.githubusercontent.com/194114/28628835-02f517c4-7226-11e7-987a-43f3302933dd.png)

URLs embedded at the end of sentences remain an issue.

Resolves: #3054
See also: https://github.com/plone/plone.intelligenttext/issues/4