### PR TITLE
Only the Manager can access the folder_contents on the plone root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Fix showroom overlay within an activated exposator. [elioschmutz]
 - Handle unknown asynchronous tooltip response. [Kevin Bieri]
 - Move language selector into the user menu (dropdown) - Implemented in plonetheme.teamraum. [mathias.leimgruber]
+- Only the Manager can access the folder_contents on the plone root. [mathias.leimgruber]
 - Update ftw.keyowordwidget to 1.3.3, to fix a problem while select/search new keywords. [mathias.leimgruber]
 - Upgrade ftw.zopemaster which uses the new ftw.slacker for slack notifications. [elioschmutz]
 - Refactor the function: earliest_possible_end_date. [elioschmutz]

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -199,5 +199,10 @@
       <role name="Manager" />
       <role name="APIUser" />
     </permission>
+
+    <permission name="List folder contents" acquire="True">
+      <role name="Manager" />
+    </permission>
+
   </permissions>
 </rolemap>

--- a/opengever/core/tests/test_folder_contents.py
+++ b/opengever/core/tests/test_folder_contents.py
@@ -1,0 +1,22 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone.app.testing import setRoles
+
+
+class TestFolderContents(IntegrationTestCase):
+
+    @browsing
+    def test_manager_can_sort_portal_root(self, browser):
+        self.login(self.manager, browser)
+        browser.visit(view='@@folder_contents')
+        self.assertTrue(browser.css('#foldercontents-order-column'),
+                        'Expect the order column as manager on plone root')
+
+    @browsing
+    def test_others_cannot_sort_on_portal_root(self, browser):
+        setRoles(self.portal, self.administrator.getId(),
+                 ['Administrator', 'Reviewer', 'Editor', 'Contributor'])
+        self.login(self.administrator, browser)
+
+        with browser.expect_unauthorized():
+            browser.visit(view='@@folder_contents')

--- a/opengever/core/upgrades/20170724104729_disallow_reordering_on_root__only_managers_are_whitelistet/rolemap.xml
+++ b/opengever/core/upgrades/20170724104729_disallow_reordering_on_root__only_managers_are_whitelistet/rolemap.xml
@@ -1,0 +1,10 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="List folder contents" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20170724104729_disallow_reordering_on_root__only_managers_are_whitelistet/upgrade.py
+++ b/opengever/core/upgrades/20170724104729_disallow_reordering_on_root__only_managers_are_whitelistet/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DisallowReorderingOnRoot_onlyManagersAreWhitelistet(UpgradeStep):
+    """Disallow reordering on root, only managers are whitelistet.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Fixes #3159

Before other roles like `Contributor`, 'Editor' and `Reviewer` were able to reorder items on the plone root. 

This is now no longer possible. The folder_contents View on the Plone root is only accessable with the `Manager` role. 