### PR TITLE
Refactor the function: earliest_possible_end_date.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.1 (unreleased)
 ---------------------
 
+- Refactor the function: earliest_possible_end_date. [elioschmutz]
 - Upgrade plone.app.jquery from 1.7.2.1 to 1.11.2. [elioschmutz]
 - Bundle import: Fix logging in case of disallowed subobject type. [lgraf]
 - Bundle import: Don't unnecessarily keep references to persistent objects

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -212,12 +212,14 @@ class TestDateCalculations(IntegrationTestCase):
         self.login(self.dossier_responsible)
         IDossier(self.empty_dossier).start = None
         IDossier(self.empty_dossier).end = None
+        self.empty_dossier.reindexObject(idxs=['end', 'start'])
         self.assertIsNone(self.empty_dossier.earliest_possible_end_date())
 
     def test_earliest_possible_is_end_date_of_a_dossiers(self):
         self.login(self.dossier_responsible)
         IDossier(self.empty_dossier).start = None
         IDossier(self.empty_dossier).end = date(2029, 9, 18)
+        self.empty_dossier.reindexObject(idxs=['end', 'start'])
         self.assertEquals(date(2029, 9, 18),
                           self.empty_dossier.earliest_possible_end_date())
 
@@ -257,6 +259,7 @@ class TestDateCalculations(IntegrationTestCase):
         self.login(self.dossier_responsible)
         IDossier(self.empty_dossier).start = None
         IDossier(self.empty_dossier).end = None
+        self.empty_dossier.reindexObject(idxs=['end', 'start'])
         self.assertIsNone(self.empty_dossier.earliest_possible_end_date())
         self.assertFalse(self.empty_dossier.has_valid_startdate())
 

--- a/opengever/dossier/tests/test_retention_expiration.py
+++ b/opengever/dossier/tests/test_retention_expiration.py
@@ -39,6 +39,7 @@ class TestRetentionExpirationDate(FunctionalTestCase):
 
         with freeze(datetime(2015, 2, 21)):
             IDossier(self.dossier).end = date(2015, 2, 25)
+            self.dossier.reindexObject(idxs=['end'])
             transaction.commit()
 
             browser.login().open(self.dossier)


### PR DESCRIPTION
This PR refactors the function: `earliest_possible_end_date`.

Beside an overall code-refactoring, the following changes where made on code-optimizations:

**Objects of dossiers**
Objects of Dossier-brains are not necessary because the start and end-date are in the catalog metadata

**Convert datetime objects into date objects if necessary**
All dates are already date-objects. Otherwise, there is something wrong in consistency

**Check if dossier start-date is available or not**
We filter out None-values and get the max-date. There is no need to do this check anymore.

**Sort end-dates**
Thats not necessary because the max-function does not require a sorted list.

closes #3107