### PR TITLE
Rename current orgunit cookie, to invalidate existing cookies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Export msg in OGmail zip represenation if the original_message is available. [mathias.leimgruber]
 - Add original_message support to bundle import. [phgross]
+- Rename current orgunit cookie, to invalidate existing cookies. [phgross]
 - Move handlebar templates to template files. [jone]
 - Disable reference number column in the document listing of the inbox. [phgross]
 - Enable \*.msg download for all download copy links. [phgross]

--- a/opengever/ogds/base/ou_selector.py
+++ b/opengever/ogds/base/ou_selector.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from Products.CMFPlone import PloneMessageFactory as pmf
 
 
-CURRENT_ORG_UNIT_KEY = 'current_org_unit'
+CURRENT_ORG_UNIT_KEY = 'current_org_unit_v2'
 
 
 class OrgUnitSelector(object):

--- a/opengever/ogds/base/tests/test_ou_selector.py
+++ b/opengever/ogds/base/tests/test_ou_selector.py
@@ -43,7 +43,7 @@ class TestOrgUnitSelector(unittest2.TestCase):
                                    [self.unit_a, self.unit_b])
 
         self.assertEquals(self.unit_a, selector.get_current_unit())
-        self.assertEquals({'current_org_unit': 'clienta'}, storage)
+        self.assertEquals({CURRENT_ORG_UNIT_KEY: 'clienta'}, storage)
 
     def test_fallback_is_first_of_intersection_between_users_and_current_adminunit_units(self):
         selector = OrgUnitSelector({},


### PR DESCRIPTION
Otherwise the fixes in #3151 has no effect for users with an existing cookie, because the current orgunit cookie has a validity of 30 days.