### PR TITLE
Integration tests for opengever.dossier

### DIFF
--- a/opengever/dossier/tests/test_activate.py
+++ b/opengever/dossier/tests/test_activate.py
@@ -11,8 +11,9 @@ class TestDossierActivation(IntegrationTestCase):
     @browsing
     def test_recursively_activates_subdossier(self, browser):
         self.login(self.secretariat_user, browser)
-        self.set_workflow_state('dossier-state-inactive',
-                                self.dossier, self.subdossier)
+        self.set_workflow_state(
+            'dossier-state-inactive',
+            self.dossier, self.subdossier, self.subdossier2)
 
         browser.open(self.dossier)
         editbar.menu_option('Actions', 'dossier-transition-activate').click()
@@ -20,6 +21,7 @@ class TestDossierActivation(IntegrationTestCase):
 
         self.assert_workflow_state('dossier-state-active', self.dossier)
         self.assert_workflow_state('dossier-state-active', self.subdossier)
+        self.assert_workflow_state('dossier-state-active', self.subdossier2)
 
     @browsing
     def test_activate_subdossier_is_disallowed_when_main_dossier_is_inactive(
@@ -38,8 +40,9 @@ class TestDossierActivation(IntegrationTestCase):
         self.login(self.secretariat_user, browser)
         IDossier(self.dossier).end = date(2013, 2, 21)
         IDossier(self.subdossier).end = date(2013, 2, 21)
-        self.set_workflow_state('dossier-state-inactive',
-                                self.dossier, self.subdossier)
+        self.set_workflow_state(
+            'dossier-state-inactive',
+            self.dossier, self.subdossier, self.subdossier2)
         self.assertIsNotNone(IDossier(self.dossier).end)
         self.assertIsNotNone(IDossier(self.subdossier).end)
 

--- a/opengever/dossier/tests/test_adapters.py
+++ b/opengever/dossier/tests/test_adapters.py
@@ -1,38 +1,36 @@
-from ftw.builder import Builder
-from ftw.builder import create
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from zope.component import getAdapter
 
 
-class TestParentDossierFinder(FunctionalTestCase):
+class TestParentDossierFinder(IntegrationTestCase):
 
     def test_find_dossier_returns_first_dossierish_parent(self):
-        dossier = create(Builder('dossier'))
-        document_1 = create(Builder('document').within(dossier))
+        self.login(self.dossier_responsible)
+        self.assertEquals(
+            self.dossier,
+            getAdapter(self.document,
+                       name='parent-dossier-finder').find_dossier())
 
-        subdossier = create(Builder('dossier').within(dossier))
-        document_2 = create(Builder('document').within(subdossier))
-
-        finder = getAdapter(document_1, name='parent-dossier-finder')
-        self.assertEquals(dossier, finder.find_dossier())
-
-        finder = getAdapter(document_2, name='parent-dossier-finder')
-        self.assertEquals(subdossier, finder.find_dossier())
+        self.assertEquals(
+            self.subdossier,
+            getAdapter(self.subdocument,
+                       name='parent-dossier-finder').find_dossier())
 
     def test_find_dossier_works_for_tasks_and_subtask(self):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').within(dossier))
-        subtask = create(Builder('task').within(task))
+        self.login(self.dossier_responsible)
+        self.assertEquals(
+            self.dossier,
+            getAdapter(self.task,
+                       name='parent-dossier-finder').find_dossier())
 
-        finder = getAdapter(task, name='parent-dossier-finder')
-        self.assertEquals(dossier, finder.find_dossier())
-        finder = getAdapter(subtask, name='parent-dossier-finder')
-        self.assertEquals(dossier, finder.find_dossier())
+        self.assertEquals(
+            self.dossier,
+            getAdapter(self.subtask,
+                       name='parent-dossier-finder').find_dossier())
 
-    def test_find_dossier_handles_document_inside_a_task_correclty(self):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').within(dossier))
-        document = create(Builder('document').within(task))
-
-        finder = getAdapter(document, name='parent-dossier-finder')
-        self.assertEquals(dossier, finder.find_dossier())
+    def test_find_dossier_handles_document_inside_a_task_correctly(self):
+        self.login(self.dossier_responsible)
+        self.assertEquals(
+            self.dossier,
+            getAdapter(self.taskdocument,
+                       name='parent-dossier-finder').find_dossier())

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -2,340 +2,316 @@ from datetime import date
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
 from ftw.testing import freeze
+from opengever.document.behaviors.metadata import IDocumentMetadata
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.interfaces import IDossierContainerTypes
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.registry.interfaces import IRegistry
+from zope.component import getMultiAdapter
 from zope.component import getUtility
 
 
-class TestDossierContainer(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDossierContainer, self).setUp()
+class TestDossierContainer(IntegrationTestCase):
 
     def test_is_all_supplied_without_any_subdossiers(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("document").within(dossier))
-
-        self.assertTrue(dossier.is_all_supplied())
+        self.login(self.dossier_responsible)
+        create(Builder('document').within(self.empty_dossier))
+        self.assertTrue(self.empty_dossier.is_all_supplied())
 
     def test_is_not_all_supplied_with_subdossier_and_document(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("dossier").within(dossier))
-        create(Builder("document").within(dossier))
-
-        self.assertFalse(dossier.is_all_supplied())
+        self.login(self.dossier_responsible)
+        create(Builder('dossier').within(self.empty_dossier))
+        create(Builder('document').within(self.empty_dossier))
+        self.assertFalse(self.empty_dossier.is_all_supplied())
 
     def test_is_not_all_supplied_with_subdossier_and_tasks(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("dossier").within(dossier))
-        create(Builder("task").within(dossier))
-
-        self.assertFalse(dossier.is_all_supplied())
+        self.login(self.dossier_responsible)
+        create(Builder('dossier').within(self.empty_dossier))
+        create(Builder('task').within(self.empty_dossier)
+               .having(responsible=self.regular_user.getId()))
+        self.assertFalse(self.empty_dossier.is_all_supplied())
 
     def test_is_not_all_supplied_with_subdossier_and_mails(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("dossier").within(dossier))
-        create(Builder("mail").within(dossier)
-               .with_dummy_message())
-
-        self.assertFalse(dossier.is_all_supplied())
+        self.login(self.dossier_responsible)
+        create(Builder('dossier').within(self.empty_dossier))
+        create(Builder('mail').within(self.empty_dossier).with_dummy_message())
+        self.assertFalse(self.empty_dossier.is_all_supplied())
 
     def test_is_all_supplied_with_subdossier_containing_tasks_or_documents(self):
-        dossier = create(Builder("dossier"))
-        subdossier = create(Builder("dossier").within(dossier))
-        create(Builder("task").within(subdossier))
-        create(Builder("document").within(subdossier))
-
-        self.assertTrue(dossier.is_all_supplied())
+        self.login(self.dossier_responsible)
+        subdossier = create(Builder('dossier').within(self.empty_dossier))
+        create(Builder('task').within(subdossier)
+               .having(responsible=self.regular_user.getId()))
+        create(Builder('document').within(subdossier))
+        self.assertTrue(self.empty_dossier.is_all_supplied())
 
     def test_get_parents_dossier_returns_none_for_main_dossier(self):
-        dossier = create(Builder('dossier'))
-        self.assertEquals(None, dossier.get_parent_dossier())
+        self.login(self.dossier_responsible)
+        self.assertEquals(None, self.dossier.get_parent_dossier())
 
     def test_get_parents_dossier_returns_main_dossier_for_a_subdossier(self):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        self.assertEquals(dossier, subdossier.get_parent_dossier())
+        self.login(self.dossier_responsible)
+        self.assertEquals(self.dossier, self.subdossier.get_parent_dossier())
 
     def test_is_subdossier_is_false_for_main_dossiers(self):
-        dossier = create(Builder('dossier'))
-        self.assertFalse(dossier.is_subdossier())
+        self.login(self.dossier_responsible)
+        self.assertFalse(self.dossier.is_subdossier())
 
     def test_is_subdossier_is_true_for_dossiers_inside_a_dossier(self):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        self.assertTrue(subdossier.is_subdossier())
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.subdossier.is_subdossier())
 
-    def test_maximum_dossier_level_is_2_by_default(self):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-
+    def test_max_subdossier_depth_is_1_by_default(self):
+        self.login(self.dossier_responsible)
         self.assertIn('opengever.dossier.businesscasedossier',
-                      [fti.id for fti in dossier.allowedContentTypes()])
+                      [fti.id for fti in self.dossier.allowedContentTypes()])
 
         self.assertNotIn('opengever.dossier.businesscasedossier',
-                         [fti.id for fti in subdossier.allowedContentTypes()])
+                         [fti.id for fti in self.subdossier.allowedContentTypes()])
 
-    def test_get_subdossier_depth_from_registry(self):
-        registry = getUtility(IRegistry)
-        proxy = registry.forInterface(IDossierContainerTypes)
+    def test_max_subdossier_depth_is_configurable(self):
+        self.login(self.dossier_responsible)
+        self.assertNotIn('opengever.dossier.businesscasedossier',
+                         [fti.id for fti in self.subdossier.allowedContentTypes()])
+
+        proxy = getUtility(IRegistry).forInterface(IDossierContainerTypes)
         proxy.maximum_dossier_depth = 2
+        self.assertIn('opengever.dossier.businesscasedossier',
+                      [fti.id for fti in self.subdossier.allowedContentTypes()])
 
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        subsubdossier = create(Builder('dossier').within(subdossier))
-
-        self.assertNotIn(
-            'opengever.dossier.businesscasedossier',
-            [fti.id for fti in subsubdossier.allowedContentTypes()])
-
-    def test_get_subdossiers_returns_subsubdossiers_as_well(self):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        subsubdossier = create(Builder('dossier').within(subdossier))
+    def test_get_subdossiers_is_recursive_by_default(self):
+        self.login(self.dossier_responsible)
+        subsubdossier = create(Builder('dossier').within(self.subdossier))
+        self.assertSequenceEqual(
+            [self.subdossier, self.subdossier2, subsubdossier],
+            map(self.brain_to_object, self.dossier.get_subdossiers()))
 
         self.assertSequenceEqual(
-            [subdossier, subsubdossier],
-            self.brains_to_objects(dossier.get_subdossiers()))
-
-    def test_get_subdossiers_depth(self):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        create(Builder('dossier').within(subdossier))
-
-        self.assertSequenceEqual(
-            [subdossier],
-            self.brains_to_objects(dossier.get_subdossiers(depth=1)))
+            [self.subdossier, self.subdossier2],
+            map(self.brain_to_object, self.dossier.get_subdossiers(depth=1)))
 
     def test_sequence_number(self):
-        dossier_1 = create(Builder("dossier"))
-        subdossier = create(Builder("dossier"))
-        dossier_2 = create(Builder("dossier"))
-
-        self.assertEquals(1, dossier_1.get_sequence_number())
-        self.assertEquals(2, subdossier.get_sequence_number())
-        self.assertEquals(3, dossier_2.get_sequence_number())
+        self.login(self.dossier_responsible)
+        expected = {
+            'dossier': 1,
+            'subdossier': 2,
+            'subdossier2': 3,
+            'archive_dossier': 4,
+            'empty_dossier': 5}
+        got = {name: getattr(self, name).get_sequence_number()
+               for name in expected.keys()}
+        self.assertDictEqual(expected, got)
 
     def test_support_participations(self):
-        dossier = create(Builder("dossier"))
-        self.assertTrue(dossier.has_participation_support())
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.dossier.has_participation_support())
 
     def test_support_tasks(self):
-        dossier = create(Builder("dossier"))
-        self.assertTrue(dossier.has_task_support())
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.dossier.has_task_support())
 
     def test_reference_number(self):
-        root = create(Builder('repository_root'))
-        repo = create(Builder('repository').within(root))
-        dossier_1 = create(Builder("dossier").within(repo))
-        subdossier = create(Builder("dossier").within(dossier_1))
-        dossier_2 = create(Builder("dossier").within(repo))
+        self.login(self.dossier_responsible)
+        expected = {
+            'dossier': 'Client1 1.1 / 1',
+            'subdossier': 'Client1 1.1 / 1.1',
+            'subdossier2': 'Client1 1.1 / 1.2',
+            'archive_dossier': 'Client1 1.1 / 2',
+            'empty_dossier': 'Client1 1.1 / 3'}
+        got = {name: getattr(self, name).get_reference_number()
+               for name in expected.keys()}
+        self.assertDictEqual(expected, got)
 
-        self.assertEquals('Client1 1 / 1', dossier_1.get_reference_number())
-        self.assertEquals('Client1 1 / 1.1', subdossier.get_reference_number())
-        self.assertEquals('Client1 1 / 2', dossier_2.get_reference_number())
 
-
-class TestDossierChecks(FunctionalTestCase):
+class TestDossierChecks(IntegrationTestCase):
 
     def test_it_has_no_active_task_when_no_task_exists(self):
-        dossier = create(Builder("dossier"))
-        self.assertFalse(dossier.has_active_tasks())
+        self.login(self.dossier_responsible)
+        self.assertFalse(self.empty_dossier.has_active_tasks())
 
-    def test_it_has_no_active_task_if_all_task_are_in_an_inactive_state(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("task").within(dossier)
-               .in_state('task-state-cancelled'))
-        create(Builder("task").within(dossier)
-               .in_state('task-state-tested-and-closed'))
-        create(Builder("task").within(dossier)
-               .in_state('task-state-tested-and-closed'))
+    def test_has_active_tasks_false_when_states_cancelled(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-cancelled', *self.dossier_tasks)
+        self.assertFalse(self.dossier.has_active_tasks())
 
-        self.assertFalse(dossier.has_active_tasks())
+    def test_has_active_tasks_false_when_states_tested_and_closed(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-tested-and-closed', *self.dossier_tasks)
+        self.assertFalse(self.dossier.has_active_tasks())
 
-    def test_it_has_no_active_task_if_tasks_and_subtasks_are_in_an_inactive_state(self):
-        dossier = create(Builder("dossier"))
-        task = create(Builder("task").within(dossier)
-                      .in_state('task-state-cancelled'))
-        subtask = create(Builder("task").within(task)
-                         .in_state('task-state-cancelled'))
-        create(Builder("task").within(subtask)
-               .in_state('task-state-tested-and-closed'))
+    def test_has_active_tasks_true_when_states_in_progress(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-in-progress', *self.dossier_tasks)
+        self.assertTrue(self.dossier.has_active_tasks())
 
-        self.assertFalse(dossier.has_active_tasks())
+    def test_has_active_tasks_true_when_states_open(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-open', *self.dossier_tasks)
+        self.assertTrue(self.dossier.has_active_tasks())
 
-    def test_it_has_active_tasks_if_a_task_is_in_an_active_state(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("task").within(dossier)
-               .in_state('task-state-open'))
+    def test_has_active_tasks_true_when_states_rejected(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-rejected', *self.dossier_tasks)
+        self.assertTrue(self.dossier.has_active_tasks())
 
-        self.assertTrue(dossier.has_active_tasks())
+    def test_has_active_tasks_true_when_states_resolved(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-resolved', *self.dossier_tasks)
+        self.assertTrue(self.dossier.has_active_tasks())
 
-    def test_has_active_tasks_checks_recursive(self):
-        dossier = create(Builder("dossier"))
-        subdossier = create(Builder("dossier").within(dossier))
-        subsubdossier = create(Builder("dossier").within(subdossier))
-        create(Builder("task").within(subsubdossier).in_state('task-state-open'))
+    def test_has_active_tasks_checks_are_recursive(self):
+        self.login(self.dossier_responsible)
+        first, second = self.dossier_tasks
+        self.set_workflow_state('task-state-resolved', first)
+        self.set_workflow_state('task-state-tested-and-closed', second)
+        self.assertTrue(self.dossier.has_active_tasks())
 
-        self.assertTrue(dossier.has_active_tasks())
+        self.set_workflow_state('task-state-resolved', second)
+        self.set_workflow_state('task-state-tested-and-closed', first)
+        self.assertTrue(self.dossier.has_active_tasks())
 
-    def test_its_all_checked_in_when_no_document_exists(self):
-        dossier = create(Builder("dossier"))
-        self.assertTrue(dossier.is_all_checked_in())
+    def test_is_all_checked_in_is_true_when_no_document_exists(self):
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.empty_dossier.is_all_checked_in())
 
-    def test_its_all_checked_in_when_no_document_is_checked_out(self):
-        dossier = create(Builder("dossier"))
-        create(Builder('document').within(dossier))
-        self.assertTrue(dossier.is_all_checked_in())
+    def test_is_all_checked_in_is_true_when_no_document_is_checked_out(self):
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.dossier.is_all_checked_in())
 
-    def test_its_not_all_checked_in_when_a_document_inside_the_dossier_is_checked_out(self):
-        dossier = create(Builder("dossier"))
-        create(Builder('document')
-               .within(dossier)
-               .checked_out())
-        self.assertFalse(dossier.is_all_checked_in())
+    def test_is_all_checked_in_is_false_when_document_in_dossier_checked_out(self):
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.dossier.is_all_checked_in())
+        getMultiAdapter((self.document, self.request),
+                        ICheckinCheckoutManager).checkout()
+        self.assertFalse(self.dossier.is_all_checked_in())
 
-    def test_its_not_all_checked_in_when_a_document_inside_the_subdossier_is_checked_out(self):
-        dossier = create(Builder("dossier"))
-        subdossier = create(Builder("dossier").within(dossier))
-        create(Builder('document')
-               .within(subdossier)
-               .checked_out())
-
-        self.assertFalse(dossier.is_all_checked_in())
+    def test_is_all_checked_in_is_false_when_document_in_subdossier_checked_out(self):
+        self.login(self.dossier_responsible)
+        self.assertTrue(self.dossier.is_all_checked_in())
+        getMultiAdapter((self.subdocument, self.request),
+                        ICheckinCheckoutManager).checkout()
+        self.assertFalse(self.dossier.is_all_checked_in())
 
 
-class TestDateCalculations(FunctionalTestCase):
+class TestDateCalculations(IntegrationTestCase):
 
-    def test_start_date_defaults_to_today(self):
-        with freeze(datetime.now()):
-            dossier = create(Builder("dossier"))
-            self.assertEqual(IDossier(dossier).start, date.today())
+    @browsing
+    def test_start_date_defaults_to_today(self, browser):
+        self.login(self.regular_user, browser)
+        with freeze(datetime(2015, 12, 22)):
+            browser.open(self.leaf_repofolder)
+            factoriesmenu.add('Business Case Dossier')
+            self.assertEquals('22.12.2015', browser.find('Opening Date').value)
 
     def test_earliest_possible_is_none_for_empty_dossiers(self):
-        dossier = create(Builder("dossier")
-                         .having(start=None))
-        self.assertEquals(None, dossier.earliest_possible_end_date())
+        self.login(self.dossier_responsible)
+        IDossier(self.empty_dossier).start = None
+        IDossier(self.empty_dossier).end = None
+        self.assertIsNone(self.empty_dossier.earliest_possible_end_date())
 
     def test_earliest_possible_is_end_date_of_a_dossiers(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 01, 01),
-                                 end=date(2012, 02, 03)))
-        self.assertEquals(date(2012, 02, 03),
-                          dossier.earliest_possible_end_date())
+        self.login(self.dossier_responsible)
+        IDossier(self.empty_dossier).start = None
+        IDossier(self.empty_dossier).end = date(2029, 9, 18)
+        self.assertEquals(date(2029, 9, 18),
+                          self.empty_dossier.earliest_possible_end_date())
 
     def test_earliest_possible_is_latest_document_date(self):
-        dossier = create(Builder("dossier").having(start=date(2012, 01, 01)))
-        create(Builder("document").within(dossier)
-               .having(document_date=date(2012, 02, 03)))
-        create(Builder("document").within(dossier)
-               .having(document_date=date(2012, 01, 01)))
-
-        self.assertEquals(date(2012, 02, 03),
-                          dossier.earliest_possible_end_date())
+        self.login(self.dossier_responsible)
+        IDocumentMetadata(self.document).document_date = date(2021, 1, 22)
+        self.document.reindexObject(idxs=['document_date'])
+        self.assertEquals(date(2021, 1, 22),
+                          self.dossier.earliest_possible_end_date())
 
     def test_earliest_possible_is_latest_of_dossiers_end_dates_and_document_dates(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 01, 01),
-                                 end=date(2012, 02, 04)))
-        create(Builder("dossier").within(dossier)
-               .having(start=date(2012, 01, 01),
-                       end=date(2012, 02, 03)))
-        create(Builder("document").within(dossier)
-               .having(document_date=date(2012, 02, 05)))
+        self.login(self.dossier_responsible)
 
-        self.assertEquals(date(2012, 02, 05),
-                          dossier.earliest_possible_end_date())
+        IDocumentMetadata(self.document).document_date = date(2020, 1, 1)
+        self.document.reindexObject(idxs=['document_date'])
+        IDossier(self.subdossier).end = date(2020, 2, 2)
+        self.subdossier.reindexObject(idxs=['end'])
+        self.assertEquals(date(2020, 2, 2), self.dossier.earliest_possible_end_date())
+
+        IDocumentMetadata(self.document).document_date = date(2020, 3, 3)
+        self.document.reindexObject(idxs=['document_date'])
+        self.assertEquals(date(2020, 3, 3), self.dossier.earliest_possible_end_date())
 
     def test_calculation_ignore_inactive_subdossiers_for_calculation(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 01, 01),
-                                 end=date(2012, 02, 04)))
+        self.login(self.dossier_responsible)
 
-        create(Builder("dossier").within(dossier)
-               .having(start=date(2012, 01, 01), end=date(2012, 02, 05))
-               .in_state('dossier-state-inactive'))
+        IDossier(self.subdossier).end = date(2020, 1, 1)
+        self.subdossier.reindexObject(idxs=['end'])
+        IDossier(self.subdossier2).end = date(2020, 2, 2)
+        self.subdossier2.reindexObject(idxs=['end'])
+        self.assertEquals(date(2020, 2, 2), self.dossier.earliest_possible_end_date())
 
-        self.assertEquals(date(2012, 02, 04),
-                          dossier.earliest_possible_end_date())
+        self.set_workflow_state('dossier-state-inactive', self.subdossier2)
+        self.assertEquals(date(2020, 1, 1), self.dossier.earliest_possible_end_date())
 
     def test_none_is_not_a_valid_start_date(self):
-        dossier = create(Builder("dossier").having(start=None))
-
-        self.assertFalse(dossier.has_valid_startdate(),
-                         "None is not a valid dossier startdate")
+        self.login(self.dossier_responsible)
+        IDossier(self.empty_dossier).start = None
+        IDossier(self.empty_dossier).end = None
+        self.assertIsNone(self.empty_dossier.earliest_possible_end_date())
+        self.assertFalse(self.empty_dossier.has_valid_startdate())
 
     def test_every_date_is_a_valid_start_date(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 02, 24)))
-
-        self.assertTrue(
-            dossier.has_valid_startdate(),
-            "'%s' should be a valid startdate" % IDossier(dossier).start)
+        self.login(self.dossier_responsible)
+        self.assertEquals(date(2016, 1, 1),
+                          self.empty_dossier.earliest_possible_end_date())
+        self.assertTrue(self.empty_dossier.has_valid_startdate())
 
     def test_no_end_date_is_valid(self):
-        dossier = create(Builder("dossier"))
-        create(Builder("dossier").within(dossier)
-               .having(start=date(2012, 02, 24)))
-        self.assertTrue(dossier.has_valid_enddate())
+        self.login(self.dossier_responsible)
+        self.assertIsNone(IDossier(self.empty_dossier).end)
+        self.assertTrue(self.empty_dossier.has_valid_enddate())
 
-    def test_end_date_afterward_the_latest_document_date_is_valid(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 01, 01),
-                                 end=date(2012, 01, 02)))
-        create(Builder('document')
-               .within(dossier)
-               .having(document_date=date(2012, 01, 01)))
+    def test_dossier_end_can_be_later_than_document_date(self):
+        self.login(self.dossier_responsible)
+        IDossier(self.dossier).end = date(2020, 2, 2)
+        IDocumentMetadata(self.document).document_date = date(2020, 1, 1)
+        self.document.reindexObject(idxs=['document_date'])
+        self.assertTrue(self.dossier.has_valid_enddate())
 
-        self.assertTrue(dossier.has_valid_enddate())
+    def test_dossier_end_can_be_equal_to_document_date(self):
+        self.login(self.dossier_responsible)
+        IDossier(self.dossier).end = date(2020, 1, 1)
+        IDocumentMetadata(self.document).document_date = date(2020, 1, 1)
+        self.document.reindexObject(idxs=['document_date'])
+        self.assertTrue(self.dossier.has_valid_enddate())
 
-    def test_end_date_equal_the_latest_document_date_is_valid(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 01, 01),
-                                 end=date(2012, 01, 01)))
-        create(Builder('document')
-               .within(dossier)
-               .having(document_date=date(2012, 01, 01)))
-
-        self.assertTrue(dossier.has_valid_enddate())
-
-    def test_end_date_before_the_latest_document_date_is_invalid(self):
-        dossier = create(Builder("dossier")
-                         .having(start=date(2012, 01, 01),
-                                 end=date(2012, 01, 01)))
-
-        create(Builder('document')
-               .within(dossier)
-               .having(document_date=date(2012, 01, 02)))
-
-        self.assertFalse(dossier.has_valid_enddate())
+    def test_dossier_end_cannot_be_earlier_to_document_date(self):
+        self.login(self.dossier_responsible)
+        IDossier(self.dossier).end = date(2020, 1, 1)
+        IDocumentMetadata(self.document).document_date = date(2020, 2, 2)
+        self.document.reindexObject(idxs=['document_date'])
+        self.assertFalse(self.dossier.has_valid_enddate())
 
     def test_end_date_is_allways_valid_in_a_empty_dossier(self):
-        dossier = create(Builder("dossier").having(
-            start=date(2012, 01, 01),
-            end=date(2012, 01, 01)))
+        self.login(self.dossier_responsible)
+        IDossier(self.empty_dossier).end = date(2050, 1, 1)
+        self.assertTrue(self.empty_dossier.has_valid_enddate())
 
-        self.assertTrue(dossier.has_valid_enddate())
+        IDossier(self.empty_dossier).end = None
+        self.assertTrue(self.empty_dossier.has_valid_enddate())
 
     def test_get_former_state_returns_last_end_state_in_history(self):
-        self.grant('Manager', 'Editor', 'Publisher', 'Reviewer')
-
-        dossier = create(Builder("dossier"))
-
+        self.login(self.administrator)
+        dossier = self.empty_dossier
         api.content.transition(obj=dossier, transition='dossier-transition-deactivate')
+        self.assertEquals('dossier-state-inactive', dossier.get_former_state())
         api.content.transition(obj=dossier, transition='dossier-transition-activate')
+        self.assertEquals('dossier-state-inactive', dossier.get_former_state())
         api.content.transition(obj=dossier, transition='dossier-transition-resolve')
-        api.content.transition(obj=dossier, transition='dossier-transition-offer')
-        api.content.transition(obj=dossier, transition='dossier-transition-archive')
-
+        self.assertEquals('dossier-state-resolved', dossier.get_former_state())
+        api.content.transition(obj=dossier, transition='dossier-transition-reactivate')
         self.assertEquals('dossier-state-resolved', dossier.get_former_state())
 
     def test_get_former_state_returns_none_for_dossiers_was_never_in_an_end_state(self):
-        self.grant('Manager', 'Editor', 'Publisher', 'Reviewer')
-
-        dossier = create(Builder("dossier"))
-        self.assertIsNone(dossier.get_former_state())
+        self.login(self.dossier_responsible)
+        self.assertIsNone(self.dossier.get_former_state())

--- a/opengever/dossier/tests/test_copy_dossier.py
+++ b/opengever/dossier/tests/test_copy_dossier.py
@@ -1,43 +1,34 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.interfaces import IReferenceNumberPrefix
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 
 
-class TestCopyDossiers(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestCopyDossiers, self).setUp()
-        self.request = self.layer['request']
-
-        self.root = create(Builder('repository_root'))
-        self.source_repo = create(Builder('repository').within(self.root))
-        self.target_repo = create(Builder('repository').within(self.root))
+class TestCopyDossiers(IntegrationTestCase):
 
     def test_copying_dossier_purges_child_reference_number_mappings(self):
-        dossier = create(Builder('dossier').within(self.source_repo))
-        subdossier_1 = create(Builder('dossier').within(dossier))
-        subdossier_2 = create(Builder('dossier').within(dossier))
+        self.login(self.dossier_responsible)
+        subdossier = create(Builder('dossier').within(self.empty_dossier))
 
         dossier_copy = api.content.copy(
-            source=dossier, target=self.target_repo)
+            source=self.empty_dossier, target=self.empty_repofolder)
 
-        # there are two copied subdossiers
-        self.assertEqual(2, len(dossier_copy.listFolderContents()))
-        subdossier1_copy = dossier_copy.listFolderContents()[0]
+        # subdossier is copied
+        self.assertEqual(1, len(dossier_copy.get_subdossiers()))
+        subdossier_copy = dossier_copy.get_subdossiers()[0].getObject()
 
         # copied dossier contains mappings for copied subdossiers starting at
         # 1, the mapping was purged on copy
         ref = IReferenceNumberPrefix(dossier_copy)
-        ref.get_child_mapping(subdossier1_copy)
         self.assertItemsEqual(
-            [u'1', u'2'], ref.get_child_mapping(subdossier1_copy).keys())
+            [u'1'],
+            ref.get_child_mapping(subdossier_copy).keys())
 
         # there are no more entries for the previous subdossiers
         intids = getUtility(IIntIds)
-        prefixed_intids = ref.get_prefix_mapping(subdossier1_copy).keys()
-        self.assertNotIn(intids.getId(subdossier_1), prefixed_intids)
-        self.assertNotIn(intids.getId(subdossier_2), prefixed_intids)
+        prefixed_intids = ref.get_prefix_mapping(subdossier_copy).keys()
+        self.assertNotIn(intids.getId(subdossier), prefixed_intids)
+        self.assertIn(intids.getId(subdossier_copy), prefixed_intids)

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -3,120 +3,88 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages import editbar
+from ftw.testbrowser.pages import statusmessages
 from ftw.testing import freeze
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.testing import FunctionalTestCase
-from plone import api
-from plone.protect import createToken
+from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
 
 
-class TestDossierDeactivation(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDossierDeactivation, self).setUp()
-        self.dossier = create(Builder('dossier'))
+class TestDossierDeactivation(IntegrationTestCase):
 
     @browsing
     def test_fails_with_resolved_subdossier(self, browser):
-        create(Builder('dossier')
-               .within(self.dossier)
-               .titled(u'b\xe4\xe4\xe4h')
-               .in_state('dossier-state-resolved'))
-
-        browser.login().open(self.dossier, view='transition-deactivate',
-                             data={'_authenticator': createToken()})
-        self.assertEqual(
-            u"The Dossier can't be deactivated, the subdossier b\xe4\xe4\xe4h is already resolved",
-            error_messages()[0])
+        self.login(self.dossier_responsible, browser)
+        self.set_workflow_state('dossier-state-resolved', self.subdossier)
+        browser.open(self.dossier, view='transition-deactivate',
+                     send_authenticator=True)
+        self.assert_workflow_state('dossier-state-active', self.dossier)
+        statusmessages.assert_message(
+            u"The Dossier can\'t be deactivated,"
+            u" the subdossier 2016 is already resolved")
 
     @browsing
     def test_fails_with_checked_out_documents(self, browser):
-        create(Builder('document')
-               .within(self.dossier)
-               .checked_out())
-
-        browser.login().open(self.dossier, view='transition-deactivate',
-                             data={'_authenticator': createToken()})
-        self.assertEqual(
-            u"The Dossier can't be deactivated, not all containeddocuments "
-            "are checked in.",
-            error_messages()[0])
+        self.login(self.dossier_responsible, browser)
+        getMultiAdapter((self.document, self.request),
+                        ICheckinCheckoutManager).checkout()
+        browser.open(self.dossier, view='transition-deactivate',
+                     send_authenticator=True)
+        self.assert_workflow_state('dossier-state-active', self.dossier)
+        statusmessages.assert_message(
+            u"The Dossier can't be deactivated, not all containeddocuments"
+            u" are checked in.")
 
     @browsing
     def test_not_possible_with_not_closed_tasks(self, browser):
-        create(Builder('task')
-               .within(self.dossier)
-               .in_state('task-state-in-progress'))
-
-        browser.login().open(self.dossier,
-                             view='transition-deactivate',
-                             data={'_authenticator': createToken()})
-
-        self.assertEqual('dossier-state-active',
-                         api.content.get_state(self.dossier))
-
-        self.assertEqual(
-            u"The Dossier can't be deactivated, not all contained "
-            "tasks are in a closed state.",
-            error_messages()[0])
+        self.login(self.dossier_responsible, browser)
+        self.assert_workflow_state('task-state-in-progress', self.task)
+        browser.open(self.dossier, view='transition-deactivate',
+                     send_authenticator=True)
+        self.assert_workflow_state('dossier-state-active', self.dossier)
+        statusmessages.assert_message(
+            u"The Dossier can't be deactivated, not all contained"
+            u" tasks are in a closed state.")
 
     @browsing
     def test_not_possible_with_active_proposals(self, browser):
-        repo = create(Builder('repository'))
-        dossier = create(Builder('dossier').within(repo))
-        create(Builder('proposal').within(dossier))
-
-        browser.login().open(dossier,
-                             view='transition-deactivate',
-                             data={'_authenticator': createToken()})
-
-        self.assertEqual('dossier-state-active',
-                         api.content.get_state(dossier))
-        self.assertEqual(
-            u"The Dossier can't be deactivated, it contains active proposals.",
-            error_messages()[0])
+        self.login(self.dossier_responsible, browser)
+        self.assert_workflow_state('proposal-state-active', self.proposal)
+        browser.open(self.dossier, view='transition-deactivate',
+                     send_authenticator=True)
+        self.assert_workflow_state('dossier-state-active', self.dossier)
+        statusmessages.assert_message(
+            u"The Dossier can't be deactivated,"
+            u" not all contained tasks are in a closed state.")
 
     @browsing
     def test_recursively_deactivate_subdossier(self, browser):
-        subdossier = create(Builder('dossier').within(self.dossier))
-        subsubdossier = create(Builder('dossier').within(subdossier))
-        create(Builder('task')
-               .within(self.dossier)
-               .in_state('task-state-tested-and-closed'))
-
-        browser.login().open(self.dossier, view='transition-deactivate',
-                             data={'_authenticator': createToken()})
-
-        self.assertEqual('dossier-state-inactive',
-                         api.content.get_state(self.dossier))
-        self.assertEqual('dossier-state-inactive',
-                         api.content.get_state(subdossier))
-        self.assertEqual('dossier-state-inactive',
-                         api.content.get_state(subsubdossier))
+        self.login(self.secretariat_user, browser)
+        subdossier = create(Builder('dossier').within(self.empty_dossier))
+        browser.open(self.empty_dossier)
+        editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
+        statusmessages.assert_no_error_messages()
+        self.assert_workflow_state('dossier-state-inactive', self.empty_dossier)
+        self.assert_workflow_state('dossier-state-inactive', subdossier)
 
     @browsing
     def test_already_inactive_subdossier_will_be_ignored(self, browser):
-        subdossier1 = create(Builder('dossier').within(self.dossier))
-        subdossier2 = create(Builder('dossier')
-                             .within(self.dossier)
-                             .in_state('dossier-state-inactive'))
-
-        browser.login().open(self.dossier, view='transition-deactivate',
-                             data={'_authenticator': createToken()})
-
-        self.assertEqual('dossier-state-inactive',
-                         api.content.get_state(self.dossier))
-        self.assertEqual('dossier-state-inactive',
-                         api.content.get_state(subdossier1))
-        self.assertEqual('dossier-state-inactive',
-                         api.content.get_state(subdossier2))
+        self.login(self.secretariat_user, browser)
+        subdossier = create(Builder('dossier').within(self.empty_dossier)
+                            .in_state('dossier-state-inactive'))
+        browser.open(self.empty_dossier)
+        editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
+        statusmessages.assert_no_error_messages()
+        self.assert_workflow_state('dossier-state-inactive', self.empty_dossier)
+        self.assert_workflow_state('dossier-state-inactive', subdossier)
 
     @browsing
     def test_sets_end_date_to_current_date(self, browser):
+        self.login(self.secretariat_user, browser)
         with freeze(datetime(2016, 3, 29)):
-            browser.login().open(self.dossier,
-                                 view='transition-deactivate',
-                                 data={'_authenticator': createToken()})
+            browser.open(self.empty_dossier)
+            editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
 
-        self.assertEqual(date(2016, 3, 29), IDossier(self.dossier).end)
+        self.assertEqual(date(2016, 3, 29), IDossier(self.empty_dossier).end)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -16,6 +16,7 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from time import time
 from zope.component.hooks import getSite
+import pytz
 
 
 class OpengeverContentFixture(object):
@@ -125,7 +126,7 @@ class OpengeverContentFixture(object):
             .having(protocol_template=self.sablon_template,
                     excerpt_template=self.sablon_template)))
 
-        self.register('committee', self.create_committee(
+        self.committee = self.register('committee', self.create_committee(
             title=u'Rechnungspr\xfcfungskommission',
             repository_folder=self.repofolder1,
             group_id='committee_rpk_group',
@@ -176,6 +177,12 @@ class OpengeverContentFixture(object):
             .titled(u'Feedback zum Vertragsentwurf')
             .attach_file_containing('Feedback text',
                                     u'vertr\xe4g sentwurf.docx')))
+
+        self.register('proposal', create(
+            Builder('proposal').within(self.dossier)
+            .having(title=u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen',
+                    committee=self.committee.load_model())
+            .relate_to(document)))
 
         subdossier = self.register('subdossier', create(
             Builder('dossier').within(self.dossier).titled(u'2016')))
@@ -239,7 +246,7 @@ class OpengeverContentFixture(object):
         We move it two minutes because the catalog rounds times sometimes to
         minute precision and we want to be more precise.
         """
-        with freeze(datetime(2016, 8, 31, hour, 1, 33)) as clock:
+        with freeze(datetime(2016, 8, 31, hour, 1, 33, tzinfo=pytz.UTC)) as clock:
             with ticking_creator(clock, minutes=2):
                 yield
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -141,8 +141,48 @@ class OpengeverContentFixture(object):
                     keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
                     start=date(2016, 1, 1),
                     responsible='hugo.boss')))
-        self.register('subdossier',
-                      create(Builder('dossier').within(self.dossier).titled(u'2016')))
+
+        document = self.register('document', create(
+            Builder('document').within(self.dossier)
+            .titled(u'Vertr\xe4gsentwurf')
+            .attach_file_containing('Word dummy content',
+                                    u'vertrasentwurf.docx')))
+
+        task = self.register('task', create(
+            Builder('task').within(self.dossier)
+            .titled(u'Vertragsentwurf \xdcberpr\xfcfen')
+            .having(responsible_client=self.org_unit.id(),
+                    responsible=self.regular_user.getId(),
+                    issuer=self.dossier_responsible.getId(),
+                    task_type='correction',
+                    deadline=date(2016, 11, 1))
+            .in_state('task-state-in-progress')
+            .relate_to(document)))
+
+        self.register('subtask', create(
+            Builder('task').within(task)
+            .titled(u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen')
+            .having(responsible_client=self.org_unit.id(),
+                    responsible=self.regular_user.getId(),
+                    issuer=self.dossier_responsible.getId(),
+                    task_type='correction',
+                    deadline=date(2016, 11, 1))
+            .in_state('task-state-resolved')
+            .relate_to(document)))
+
+        self.register('taskdocument', create(
+            Builder('document').within(task)
+            .titled(u'Feedback zum Vertragsentwurf')
+            .attach_file_containing('Feedback text',
+                                    u'vertr\xe4g sentwurf.docx')))
+
+        subdossier = self.register('subdossier', create(
+            Builder('dossier').within(self.dossier).titled(u'2016')))
+
+        self.register('subdocument', create(
+            Builder('document').within(subdossier)
+            .titled(u'\xdcbersicht der Vertr\xe4ge von 2016')
+            .attach_file_containing('Excel dummy content', u'tab\xe4lle.xlsx')))
 
         self.register('archive_dossier', create(
             Builder('dossier').within(self.repofolder00)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -73,6 +73,8 @@ class OpengeverContentFixture(object):
             'dossier_responsible', u'Robert', u'Ziegler')
         self.regular_user = self.create_user(
             'regular_user', u'K\xe4thi', u'B\xe4rfuss')
+        self.secretariat_user = self.create_user(
+            'secretariat_user', u'J\xfcrgen', u'K\xf6nig')
 
     @staticuid()
     def create_repository_tree(self):
@@ -82,6 +84,8 @@ class OpengeverContentFixture(object):
                     title_fr=u'Syst\xe8me de classement')))
         self.root.manage_setLocalRoles(self.org_unit.users_group_id,
                                        ('Reader', 'Contributor', 'Editor'))
+        self.root.manage_setLocalRoles(self.secretariat_user.getId(),
+                                       ('Reviewer', 'Publisher'))
         self.root.reindexObjectSecurity()
 
         self.repofolder0 = self.register('branch_repofolder', create(

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -179,6 +179,9 @@ class OpengeverContentFixture(object):
         subdossier = self.register('subdossier', create(
             Builder('dossier').within(self.dossier).titled(u'2016')))
 
+        self.register('subdossier2', create(
+            Builder('dossier').within(self.dossier).titled(u'2015')))
+
         self.register('subdocument', create(
             Builder('document').within(subdossier)
             .titled(u'\xdcbersicht der Vertr\xe4ge von 2016')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -40,6 +40,7 @@ class OpengeverContentFixture(object):
         with self.freeze_at_hour(14):
             with self.login(self.dossier_responsible):
                 self.create_treaty_dossiers()
+                self.create_empty_dossier()
 
         with self.freeze_at_hour(15):
             with self.login(self.dossier_responsible):
@@ -196,6 +197,14 @@ class OpengeverContentFixture(object):
                     end=date(2015, 12, 31),
                     responsible='hugo.boss')
             .in_state('dossier-state-resolved')))
+
+    @staticuid()
+    def create_empty_dossier(self):
+        self.register('empty_dossier', create(
+            Builder('dossier').within(self.repofolder00)
+            .titled(u'An empty dossier')
+            .having(start=date(2016, 1, 1),
+                    responsible='hugo.boss')))
 
     @staticuid()
     def create_emails(self):

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -6,6 +6,7 @@ from functools import wraps
 from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
 from operator import methodcaller
 from plone import api
+from plone.app.testing import applyProfile
 from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from time import clock
@@ -16,6 +17,10 @@ FEATURE_FLAGS = {
     'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
     'dossiertemplate': ('opengever.dossier.dossiertemplate'
                         '.interfaces.IDossierTemplateSettings.is_feature_enabled'),
+}
+
+FEATURE_PROFILES = {
+    'filing_number': 'opengever.dossier:filing',
 }
 
 
@@ -126,7 +131,12 @@ class IntegrationTestCase(TestCase):
     def activate_feature(self, feature):
         """Activate a feature flag.
         """
-        api.portal.set_registry_record(FEATURE_FLAGS[feature], True)
+        if feature in FEATURE_FLAGS:
+            api.portal.set_registry_record(FEATURE_FLAGS[feature], True)
+        elif feature in FEATURE_PROFILES:
+            applyProfile(self.portal, FEATURE_PROFILES[feature])
+        else:
+            raise ValueError('Invalid {!r}'.format(feature))
 
     def __getattr__(self, name):
         """Make it possible to access objects from the content lookup table

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from ftw.flamegraph import flamegraph
 from functools import wraps
 from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.task.task import ITask
 from operator import methodcaller
 from plone import api
 from plone.app.testing import applyProfile
@@ -148,6 +149,13 @@ class IntegrationTestCase(TestCase):
         else:
             return self.__getattribute__(name)
 
+    @property
+    def dossier_tasks(self):
+        """All tasks within self.dossier.
+        """
+        return map(self.brain_to_object,
+                   api.content.find(self.dossier, object_provides=ITask))
+
     def _lookup_from_table(self, name):
         """This method helps to look up persistent objects or user objects which
         were created in the fixture and registered there with a name.
@@ -242,3 +250,8 @@ class IntegrationTestCase(TestCase):
         self.assertEqual(
             expected, got,
             'Object {!r} has an incorrect workflow state.'.format(obj))
+
+    def brain_to_object(self, brain):
+        """Return the object of a brain.
+        """
+        return brain.getObject()

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -161,3 +161,17 @@ class IntegrationTestCase(TestCase):
 
         else:
             raise ValueError('Unsupport lookup entry type {!r}'.format(type_))
+
+    def get_catalog_indexdata(self, obj):
+        """Return the catalog index data for an object as dict.
+        """
+        catalog = api.portal.get_tool('portal_catalog')
+        rid = catalog.getrid('/'.join(obj.getPhysicalPath()))
+        return catalog.getIndexDataForRID(rid)
+
+    def get_catalog_metadata(self, obj):
+        """Return the catalog metadata for an object as dict.
+        """
+        catalog = api.portal.get_tool('portal_catalog')
+        rid = catalog.getrid('/'.join(obj.getPhysicalPath()))
+        return catalog.getMetadataForRID(rid)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -12,6 +12,7 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from time import clock
 from unittest2 import TestCase
+import timeit
 
 
 FEATURE_FLAGS = {
@@ -85,6 +86,32 @@ class IntegrationTestCase(TestCase):
 
         """
         return flamegraph(open_svg=True)(func)
+
+    @staticmethod
+    def clock(func):
+        """Decorator for measuring the duration of a test and printing the result.
+        This function is meant to be used temporarily in development.
+
+        Example:
+        @IntegrationTestCase.clock
+        def test_something(self):
+            pass
+        """
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            timer = timeit.default_timer
+            start = timer()
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                end = timer()
+                print ''
+                print '{}.{} took {:.3f} ms'.format(
+                    type(self).__name__,
+                    func.__name__,
+                    (end-start) * 1000)
+        return wrapper
 
     def login(self, user, browser=None):
         """Login a user by passing in the user object.

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -188,12 +188,47 @@ class IntegrationTestCase(TestCase):
         rid = catalog.getrid('/'.join(obj.getPhysicalPath()))
         return catalog.getIndexDataForRID(rid)
 
+    def assert_index_value(self, expected_value, index_name, *objects):
+        """Asserts that an index exists and has a specific value for a
+        given object.
+        """
+        for obj in objects:
+            index_data = self.get_catalog_indexdata(obj)
+            self.assertIn(
+                index_name, index_data,
+                'Index {!r} does not exist.'.format(index_name))
+            self.assertEquals(
+                expected_value, index_data[index_name],
+                'Unexpected index value {!r} in index {!r} for {!r}'.format(
+                    index_data[index_name], index_name, obj))
+
     def get_catalog_metadata(self, obj):
         """Return the catalog metadata for an object as dict.
         """
         catalog = api.portal.get_tool('portal_catalog')
         rid = catalog.getrid('/'.join(obj.getPhysicalPath()))
         return catalog.getMetadataForRID(rid)
+
+    def assert_metadata_value(self, expected_value, metadata_name, *objects):
+        """Asserts that an metadata exists and has a specific value for a
+        given object.
+        """
+        for obj in objects:
+            metadata = self.get_catalog_metadata(obj)
+            self.assertIn(
+                metadata_name, metadata,
+                'Metadata {!r} does not exist.'.format(metadata_name))
+            self.assertEquals(
+                expected_value, metadata[metadata_name],
+                'Unexpected metadata value {!r} in metadata {!r} for {!r}'.format(
+                    metadata[metadata_name], metadata_name, obj))
+
+    def assert_index_and_metadata(self, expected_value, name, *objects):
+        """Assert that an index and a metadata with the same name both exist
+        and have the same value for a given object.
+        """
+        self.assert_index_value(expected_value, name, *objects)
+        self.assert_metadata_value(expected_value, name, *objects)
 
     def set_workflow_state(self, new_workflow_state_id, *objects):
         """Set the workflow state of one or many objects.

--- a/opengever/testing/tests/test_fixtures.py
+++ b/opengever/testing/tests/test_fixtures.py
@@ -15,7 +15,7 @@ class TestTestingFixture(IntegrationTestCase):
 
     def test_repository_root_has_static_creation_date(self):
         self.login(self.regular_user)
-        self.assertEquals(DateTime('2016/08/31 08:01:33 GMT+2'),
+        self.assertEquals(DateTime('2016/08/31 09:01:33 GMT+2'),
                           self.repository_root.created())
 
     def test_repository_root_has_static_uuid(self):

--- a/opengever/testing/tests/test_integration_test_case.py
+++ b/opengever/testing/tests/test_integration_test_case.py
@@ -58,3 +58,19 @@ class TestIntegrationTestCase(IntegrationTestCase):
 
         browser.open()
         self.assertFalse(plone.logged_in())
+
+    def test_get_catalog_indexdata(self):
+        self.login(self.regular_user)
+        self.maxDiff = None
+        self.assertDictContainsSubset(
+            {'Type': u'Business Case Dossier',
+             'sortable_title': 'vertrage mit der kantonalen...verwaltung'},
+            self.get_catalog_indexdata(self.dossier))
+
+    def test_get_catalog_metadata(self):
+        self.login(self.regular_user)
+        self.maxDiff = None
+        self.assertDictContainsSubset(
+            {'Type': 'Business Case Dossier',
+             'Title': 'Vertr\xc3\xa4ge mit der kantonalen Finanzverwaltung'},
+            self.get_catalog_metadata(self.dossier))

--- a/opengever/testing/tests/test_integration_test_case.py
+++ b/opengever/testing/tests/test_integration_test_case.py
@@ -74,3 +74,13 @@ class TestIntegrationTestCase(IntegrationTestCase):
             {'Type': 'Business Case Dossier',
              'Title': 'Vertr\xc3\xa4ge mit der kantonalen Finanzverwaltung'},
             self.get_catalog_metadata(self.dossier))
+
+    def test_set_workflow_state(self):
+        self.login(self.dossier_responsible)
+        self.assert_workflow_state('dossier-state-active', self.dossier)
+        self.assert_workflow_state('dossier-state-active', self.subdossier)
+
+        self.set_workflow_state('dossier-state-inactive',
+                                self.dossier, self.subdossier)
+        self.assert_workflow_state('dossier-state-inactive', self.dossier)
+        self.assert_workflow_state('dossier-state-inactive', self.subdossier)


### PR DESCRIPTION
I've started rewriting the `opengever.dossier` tests with integration testing.
Part of #3024

I'd like to have this PR merged as soon as possible because we need the fixture for basing other tests on.

### Changes: 

**Enhance the integration test case base class:**
- catalog helpers
- workflow state helpers
- property for accesing all dossier tasks
- support for generic-setup-profile based feature flags; add filing number feature
- `IntegrationTestCase.clock` decorator

**Fixture enhancements**
- an empty dossier, which can be used for setting up a specific testing scenario
- a "secretariat user", who can archive / unarchive dossiers
- new subdossiers
- tasks and subtasks
- documents in main dossiers, subdossier and task
- proposal
- use UTC timezone as base for everything, since we should always use timezones

**Rewrite dossier tests**
8 test modules were rewritten.