### PR TITLE
Fixed OGDS group sync, when lookup_groups_base is not defined.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.0 (unreleased)
 ---------------------
 
+- Fixed OGDS group sync, when lookup_groups_base is not defined. [phgross]
 - Export msg in OGmail zip represenation if the original_message is available. [mathias.leimgruber]
 - Add original_message support to bundle import. [phgross]
 - Rename current orgunit cookie, to invalidate existing cookies. [phgross]

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -286,7 +286,8 @@ class LDAPSearch(grok.Adapter):
         search_filter = self._combine_filters(custom_filter, search_filter)
 
         if use_lookup_base:
-            base_dn = self.context.lookup_groups_base
+            base_dn = getattr(
+                self.context, 'lookup_groups_base', self.context.groups_base)
         else:
             base_dn = self.context.groups_base
 


### PR DESCRIPTION
With #2985 the new property `lookup_groups_base` is now respected
during OGDS group synchronisation. But the current implementation
failed when group_recurse is enabled but the property `lookup_groups_base` is not set. This PR fixes the issue (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3611/).