### PR TITLE
Bundle import: Don't unnecessarily keep references to persistent objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,9 @@ Changelog
 ---------------------
 
 - Upgrade plone.app.jquery from 1.7.2.1 to 1.11.2. [elioschmutz]
+- Bundle import: Don't unnecessarily keep references to persistent objects
+  over the lifetime of the entire import. This lets the garbage collector
+  do its job, and reduces growth of memory usage during import. [lgraf]
 - Bundle import: Display current memory usage (RSS) in progress logger. [lgraf]
 - Word meeting: show proposal files in meeting view. [jone]
 - Format line breaks in task descriptions. [tarnap]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Upgrade plone.app.jquery from 1.7.2.1 to 1.11.2. [elioschmutz]
+- Bundle import: Fix logging in case of disallowed subobject type. [lgraf]
 - Bundle import: Don't unnecessarily keep references to persistent objects
   over the lifetime of the entire import. This lets the garbage collector
   do its job, and reduces growth of memory usage during import. [lgraf]

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -1,5 +1,6 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import traverse
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_NAMES
 from opengever.base.interfaces import IDontIssueDossierReferenceNumber
@@ -113,7 +114,8 @@ class ConstructorSection(object):
 
             parent_guid = item.get(u'parent_guid')
             if parent_guid:
-                context = self.bundle.item_by_guid[parent_guid][u'_object']
+                path = self.bundle.item_by_guid[parent_guid][u'_path']
+                context = traverse(self.site, path, None)
             else:
                 context = self.site
 
@@ -129,6 +131,5 @@ class ConstructorSection(object):
 
             # build path relative to plone site
             item[u'_path'] = '/'.join(obj.getPhysicalPath()[2:])
-            item[u'_object'] = obj
 
             yield item

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -119,9 +119,10 @@ class ConstructorSection(object):
             else:
                 context = self.site
 
+            parent_path = '/'.join(context.getPhysicalPath())
+
             try:
                 obj = self._construct_object(context, portal_type, item)
-                parent_path = '/'.join(context.getPhysicalPath())
                 logger.info("Constructed %r" % obj)
             except ValueError as e:
                 logger.warning(

--- a/opengever/bundle/sections/fileloader.py
+++ b/opengever/bundle/sections/fileloader.py
@@ -1,6 +1,7 @@
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultMatcher
+from collective.transmogrifier.utils import traverse
 from ftw.mail.mail import IMail
 from mimetypes import guess_type
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
@@ -12,6 +13,7 @@ from opengever.mail.mail import initalize_title
 from opengever.mail.mail import initialize_metadata
 from opengever.mail.mail import IOGMail
 from opengever.mail.mail import NO_SUBJECT_TITLE_FALLBACK
+from plone import api
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import classProvides
 from zope.interface import implements
@@ -41,6 +43,7 @@ class FileLoaderSection(object):
     def __init__(self, transmogrifier, name, options, previous):
         self.previous = previous
         self.context = transmogrifier.context
+        self.site = api.portal.get()
 
         # TODO: Might want to also use defaultMatcher for this key to make it
         # configurable instead of hard coding it here.
@@ -67,7 +70,7 @@ class FileLoaderSection(object):
                 yield item
                 continue
 
-            obj = item.get('_object')
+            obj = traverse(self.site, path, None)
             if obj is None:
                 logger.warning(
                     "Cannot set file. Document %s doesn't exist." % path)

--- a/opengever/bundle/tests/assets/business_rule_violations.oggbundle/documents.json
+++ b/opengever/bundle/tests/assets/business_rule_violations.oggbundle/documents.json
@@ -34,5 +34,14 @@
     "filepath": "files/sample.msg",
     "review_state": "document-state-draft",
     "title": "Document whose file has an disallowed extension"
+  },
+  {
+    "guid": "GUID-document-A-1-disallowed-subobject-type",
+    "parent_guid": "GUID-repofolder-A-1",
+    "document_author": "lukas.graf",
+    "document_date": "2007-01-01",
+    "filepath": "files/word.docx",
+    "review_state": "document-state-draft",
+    "title": "Document directly in repofolder (disallowed subobject type)"
   }
 ]

--- a/opengever/bundle/tests/test_section_constructor.py
+++ b/opengever/bundle/tests/test_section_constructor.py
@@ -56,8 +56,10 @@ class TestConstructor(FunctionalTestCase):
         list(section)
 
         portal = api.portal.get()
+        obj = portal.restrictedTraverse(item['_path'])
+
         self.assertEqual('reporoot', item['_path'])
-        self.assertEqual(portal.get('reporoot'), item['_object'])
+        self.assertEqual(portal.get('reporoot'), obj)
 
     def test_creates_itranslated_title_content(self):
         item = {
@@ -83,7 +85,9 @@ class TestConstructor(FunctionalTestCase):
         section = self.setup_section(previous=[item])
         list(section)
 
-        content = item['_object']
+        portal = api.portal.get()
+        content = portal.restrictedTraverse(item['_path'])
+
         self.assertEqual(u'Dossier', content.title)
         self.assertFalse(hasattr(content, 'title_de'))
         self.assertFalse(hasattr(content, 'title_Fr'))
@@ -98,7 +102,9 @@ class TestConstructor(FunctionalTestCase):
         section = self.setup_section(previous=[item])
         list(section)
 
-        content = item['_object']
+        portal = api.portal.get()
+        content = portal.restrictedTraverse(item['_path'])
+
         self.assertEqual(guid, IAnnotations(content)[BUNDLE_GUID_KEY])
 
     def test_catalog(self):
@@ -110,7 +116,9 @@ class TestConstructor(FunctionalTestCase):
         section = self.setup_section(previous=[item])
         list(section)
 
-        obj_path = '/'.join(item['_object'].getPhysicalPath())
+        portal = api.portal.get()
+        obj_path = '/'.join(portal.getPhysicalPath() + (item['_path'],))
+
         query = {'path': {'query': obj_path,
                           'depth': 0}}
 
@@ -133,7 +141,9 @@ class TestConstructor(FunctionalTestCase):
         section = self.setup_section(previous=[item])
         list(section)
 
-        content = item['_object']
+        portal = api.portal.get()
+        content = portal.restrictedTraverse(item['_path'])
+
         self.assertEqual(u'My Mail', content.title)
         self.assertFalse(hasattr(content, 'title_de'))
         self.assertFalse(hasattr(content, 'title_Fr'))

--- a/opengever/bundle/tests/test_section_fileloader.py
+++ b/opengever/bundle/tests/test_section_fileloader.py
@@ -48,7 +48,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_type": u"opengever.document.document",
             u"_path": relative_path,
             u"filepath": u"files/beschluss.pdf",
-            u"_object": doc,
         }
         section = self.setup_section(previous=[item])
         list(section)
@@ -66,7 +65,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_type": u"opengever.document.document",
             u"_path": relative_path,
             u"filepath": u"files/beschluss.pdf",
-            u"_object": doc,
         }
         section = self.setup_section(previous=[item])
         list(section)
@@ -81,7 +79,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_type": u"opengever.document.document",
             u"_path": '/'.join(mail.getPhysicalPath()[2:]),
             u"filepath": u"files/missing.file",
-            u"_object": mail,
         }
         section = self.setup_section(previous=[item])
         list(section)
@@ -98,7 +95,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_type": u"opengever.document.document",
             u"_path": '/'.join(mail.getPhysicalPath()[2:]),
             u"filepath": u'\\\\host\\unmapped\\foo.docx',
-            u"_object": mail,
         }
         section = self.setup_section(previous=[item])
         list(section)
@@ -120,7 +116,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_type": u"ftw.mail.mail",
             u"_path": relative_path,
             u"filepath": u"files/sample.eml",
-            u"_object": mail,
         }
         section = self.setup_section(previous=[item])
         list(section)
@@ -141,7 +136,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_path": relative_path,
             u"filepath": u"files/sample.eml",
             u"original_message_path": u"files/sample.msg",
-            u"_object": mail,
         }
         section = self.setup_section(previous=[item])
         list(section)
@@ -158,7 +152,6 @@ class TestFileLoader(FunctionalTestCase):
             u"_type": u"ftw.mail.mail",
             u"_path": '/'.join(mail2.getPhysicalPath()[2:]),
             u"filepath": u"files/sample.eml",
-            u"_object": mail2,
             u"title": 'Test Mail',
         }
         section = self.setup_section(previous=[item])


### PR DESCRIPTION
Avoid keeping references to the constructed objects in hope that this will reduce the memory footprint of large migrations.

Also fixes an issue where failures to construct objects because of disallowed subobject type could not be logged properly.

Recommendation: Review commit by commit.