### PR TITLE
Sort meeting participants alphabetically in meeting-view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 - Ensure we append the originating dossier's mail in address as BCC to OfficeConnector multiattach payloads. [Rotonen]
 - Add an attributes REST endpoint to dossiers. [Rotonen]
 - Update ftw.keyowordwidget to 1.3.3, to fix a problem while select/search new keywords. [mathias.leimgruber]
+- Sort meeting participants alphabetically in meeting-view. [elioschmutz]
 - Upgrade ftw.zopemaster which uses the new ftw.slacker for slack notifications. [elioschmutz]
 - Refactor the function: earliest_possible_end_date. [elioschmutz]
 - Upgrade plone.app.jquery from 1.7.2.1 to 1.11.2. [elioschmutz]

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -107,6 +107,7 @@ class Meeting(Base, SQLFormSupport):
     other_participants = Column(UnicodeCoercingText)
     participants = relationship('Member',
                                 secondary=meeting_participants,
+                                order_by='Member.lastname, Member.firstname',
                                 backref='meetings')
 
     dossier_admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)

--- a/opengever/meeting/protocol.py
+++ b/opengever/meeting/protocol.py
@@ -69,7 +69,6 @@ class ProtocolData(object):
                 "email": participant.email,
                 "role": membership.role if membership else None
             })
-        members.sort(key=lambda item: item['fullname'])
         participants = {
             'members': members
         }

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -163,9 +163,14 @@ class TestMeetingView(FunctionalTestCase):
     @browsing
     def test_participants_listing_participants_is_existing(self, browser):
         browser.login().open(self.meeting.get_url())
+        self.assertEquals(3, len(browser.css("#meeting_participants + dd li")))
+
+    @browsing
+    def test_participants_listing_participants_are_listed_alphabetically(self, browser):
+        browser.login().open(self.meeting.get_url())
         self.assertEquals(
-            ['Meter Peter (meter@foo.ch) Besen Hans Kuppler Roland'],
-            browser.css("#meeting_participants + dd").text)
+            ['Besen Hans', 'Kuppler Roland', 'Meter Peter (meter@foo.ch)'],
+            browser.css("#meeting_participants + dd li").text)
 
     @browsing
     def test_participants_listing_empty_participants_must_not_raise(self, browser):


### PR DESCRIPTION
This PR sorts the meeting participants alphabetically in meeting-view.

Before:

![bildschirmfoto 2017-08-02 um 09 05 08](https://user-images.githubusercontent.com/557005/28864099-c3b772be-776b-11e7-9457-d03e954f3ada.png)

After:

![bildschirmfoto 2017-08-02 um 09 14 16](https://user-images.githubusercontent.com/557005/28864112-c8a66fb4-776b-11e7-84e2-fd3d406bef59.png)

closes #3160 
