### PR TITLE
Ungrok opengever.advancedsearch.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 
 2017.4.1 (unreleased)
 ---------------------
+
+- Ungrok opengever.advancedsearch. [phgross]
 - Handle unknown asynchronous tooltip response. [Kevin Bieri]
 - Update ftw.keyowordwidget to 1.3.3, to fix a problem while select/search new keywords. [mathias.leimgruber]
 - Upgrade ftw.zopemaster which uses the new ftw.slacker for slack notifications. [elioschmutz]

--- a/opengever/advancedsearch/advanced_search.py
+++ b/opengever/advancedsearch/advanced_search.py
@@ -1,6 +1,5 @@
 from datetime import date
 from datetime import timedelta
-from five import grok
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.widget import KeywordWidget
 from opengever.advancedsearch import _
@@ -18,13 +17,13 @@ from z3c.form.browser import radio, checkbox
 from z3c.form.field import Fields
 from z3c.form.interfaces import INPUT_MODE
 from zope import schema
-from zope.interface import Interface
+from zope.interface import provider
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleVocabulary
 import urllib
 
 
-@grok.provider(IContextSourceBinder)
+@provider(IContextSourceBinder)
 def get_possible_dossier_states(context):
     wftool = getToolByName(context, 'portal_workflow')
     chain = wftool.getChainForPortalType(
@@ -35,7 +34,7 @@ def get_possible_dossier_states(context):
     return SimpleVocabulary(states)
 
 
-@grok.provider(IContextSourceBinder)
+@provider(IContextSourceBinder)
 def get_possible_task_states(context):
     wftool = getToolByName(context, 'portal_workflow')
     chain = wftool.getChainForPortalType(
@@ -46,7 +45,7 @@ def get_possible_task_states(context):
     return SimpleVocabulary(states)
 
 
-@grok.provider(IContextSourceBinder)
+@provider(IContextSourceBinder)
 def get_types(context):
     types = []
     types.append(SimpleVocabulary.createTerm(
@@ -258,9 +257,6 @@ class IAdvancedSearch(directives_form.Schema):
 
 
 class AdvancedSearchForm(directives_form.Form):
-    grok.context(Interface)
-    grok.name('advanced_search')
-    grok.require('zope2.View')
 
     label = _('advanced_search', default='advanced search')
 

--- a/opengever/advancedsearch/configure.zcml
+++ b/opengever/advancedsearch/configure.zcml
@@ -3,18 +3,22 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:cmf="http://namespaces.zope.org/cmf"
     i18n_domain="opengever.advancedsearch">
-
-  <grok:grok package="." />
 
   <i18n:registerTranslations directory="locales" />
 
   <browser:resourceDirectory
       name="opengever.advancedsearch.resources"
       directory="resources"
+      />
+
+  <browser:page
+      for="*"
+      name="advanced_search"
+      class=".advanced_search.AdvancedSearchForm"
+      permission="zope2.View"
       />
 
   <include file="skins.zcml" />


### PR DESCRIPTION
Use ZCML instead of grok for registration (part of #3205).