### PR TITLE
Fix showroom overlay within an activated exposator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Ungrok opengever.advancedsearch. [phgross]
+- Fix showroom overlay within an activated exposator. [elioschmutz]
 - Handle unknown asynchronous tooltip response. [Kevin Bieri]
 - Update ftw.keyowordwidget to 1.3.3, to fix a problem while select/search new keywords. [mathias.leimgruber]
 - Upgrade ftw.zopemaster which uses the new ftw.slacker for slack notifications. [elioschmutz]

--- a/opengever/base/browser/exposator.py
+++ b/opengever/base/browser/exposator.py
@@ -17,8 +17,8 @@ class ExposatorViewlet(grok.Viewlet):
     REMOTE_CLIENT_JS = '''
 <script type="text/javascript">
 $(function() {
-    $('#column-content, #portal-column-content').expose({closeOnClick: false, closeOnEsc: false});
-    $('#portal-breadcrumbs').css('z-index', '9999');
+    $('#column-content, #portal-column-content').expose({closeOnClick: false, closeOnEsc: false, zIndex: 7000});
+    $('#portal-breadcrumbs').css('z-index', '7001');
     $('#portal-breadcrumbs').append('<span style="float:right"><a href="javascript:window.close()">Fenster schliessen</a></span');
 });
 </script>


### PR DESCRIPTION
JQuery expose uses a default z-Index of 9998 (http://jquerytools.github.io/documentation/toolbox/expose.html). The ``ftw.showroom`` renders its overlay with a z-index of 8000.

The solution for the problem is to set the z-index of the expose lower than the z-index of the ``ftw.showroom``

closes #3208 