### PR TITLE
Fix ArchiveForm, when resolving a dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Ungrok opengever.advancedsearch. [phgross]
 - Fix showroom overlay within an activated exposator. [elioschmutz]
+- Fix ArchiveForm when resolving a Dossier. [phgross]
 - Handle unknown asynchronous tooltip response. [Kevin Bieri]
 - Move language selector into the user menu (dropdown) - Implemented in plonetheme.teamraum. [mathias.leimgruber]
 - Only the Manager can access the folder_contents on the plone root. [mathias.leimgruber]

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -6,7 +6,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.dossier.interfaces import IDossierArchiver
-from opengever.dossier.interfaces import IDossierResolver
+from opengever.dossier.resolve import get_resolver
 from opengever.ogds.base.utils import get_current_admin_unit
 from persistent.dict import PersistentDict
 from plone.directives import form as directives_form
@@ -260,7 +260,7 @@ class ArchiveForm(directives_form.Form):
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 
         # archiving must passed to the resolving view
-        resolver = IDossierResolver(self.context)
+        resolver = get_resolver(self.context)
         if resolver.is_resolve_possible():
             raise TypeError
         if resolver.are_enddates_valid():


### PR DESCRIPTION
Since #2972 the dossier resolver is an named adapter, and should be
gotten with the `get_resolver`. But the use of the DossierResolver in
the ArchiveForm has not been updated and failed therefore. This PR
fixes this issue and also add tests for the ArchiveForm.