### PR TITLE
Fix encoding error when syncing proposals with SQL.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.1 (unreleased)
 ---------------------
 
+- Fix encoding error when syncing proposals with SQL. [jone]
 - Ungrok opengever.advancedsearch. [phgross]
 - Fix showroom overlay within an activated exposator. [elioschmutz]
 - Handle unknown asynchronous tooltip response. [Kevin Bieri]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -535,8 +535,8 @@ class Proposal(ProposalBase):
 
         reference_number = IReferenceNumber(
             self.get_containing_dossier().get_main_dossier()).get_number()
-        repository_folder_title = self.get_repository_folder_title(
-            proposal_model.language)
+        repository_folder_title = safe_unicode(self.get_repository_folder_title(
+            proposal_model.language))
 
         proposal_model.physical_path = self.get_physical_path()
         proposal_model.dossier_reference_number = reference_number


### PR DESCRIPTION
Fix another encoding error when syncing a proposal with the SQL record.

@phgross I wanted to fix this one too in #3200, but amended the wrong commit 🙈 