### PR TITLE
Remove "Properties"-action on personal overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix encoding error when syncing proposals with SQL. [jone]
+- Remove "Properties"-action on personal overview. [elioschmutz]
 - Ungrok opengever.advancedsearch. [phgross]
 - Fix showroom overlay within an activated exposator. [elioschmutz]
 - Handle unknown asynchronous tooltip response. [Kevin Bieri]

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -441,7 +441,7 @@
       <property name="url_expr">string:${object_url}/view</property>
       <property name="icon_expr" />
       <property name="available_expr">
-                python: here.restrictedTraverse('@@plone_context_state').view_template_id() != 'view' and here.portal_type not in ('opengever.contact.contactfolder', 'opengever.inbox.yearfolder')
+                python: here.restrictedTraverse('@@plone_context_state').view_template_id() != 'view' and here.portal_type not in ('opengever.contact.contactfolder', 'opengever.inbox.yearfolder') and not globals_view.isPortalOrPortalDefaultPage()
             </property>
       <property name="permissions">
         <element value="View" />

--- a/opengever/core/upgrades/20170803115957_remove_properties_action_on_personal_overview/actions.xml
+++ b/opengever/core/upgrades/20170803115957_remove_properties_action_on_personal_overview/actions.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="properties" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="available_expr">
+                python: here.restrictedTraverse('@@plone_context_state').view_template_id() != 'view' and here.portal_type not in ('opengever.contact.contactfolder', 'opengever.inbox.yearfolder') and not globals_view.isPortalOrPortalDefaultPage()
+      </property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20170803115957_remove_properties_action_on_personal_overview/upgrade.py
+++ b/opengever/core/upgrades/20170803115957_remove_properties_action_on_personal_overview/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemovePropertiesActionOnPersonalOverview(UpgradeStep):
+    """Remove properties action on personal overview.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This PR removes the "Properties"-action on the personal overview.

closes #3173 