### PR TITLE
Fix broken code with removed backreferences.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]
 - Fixed bug in search when sorting on relevance. [phgross]
+- Fix broken remove-condition-checker if backreferences were deleted. [elioschmutz]
 - Fix broken overview-listing if backreferences were deleted. [elioschmutz]
 - Fix encoding error when syncing proposals with SQL. [jone]
 - Remove "Properties"-action on personal overview. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]
 - Fixed bug in search when sorting on relevance. [phgross]
+- Fix broken overview-listing if backreferences were deleted. [elioschmutz]
 - Fix encoding error when syncing proposals with SQL. [jone]
 - Remove "Properties"-action on personal overview. [elioschmutz]
 - Ungrok opengever.advancedsearch. [phgross]

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -205,7 +205,7 @@ class DossierOverview(BoxesViewMixin, grok.View, GeverTabMixin):
         relations = catalog.findRelations(
             {'to_id': intids.getId(aq_inner(self.context)),
              'from_attribute': 'relatedDossier'})
-        return [relation.from_id for relation in relations]
+        return [relation.from_id for relation in relations if relation.from_object]
 
     def get_keywords(self):
         linked_keywords = []

--- a/opengever/trash/remover.py
+++ b/opengever/trash/remover.py
@@ -85,7 +85,11 @@ class RemoveConditionsChecker(object):
         relations = catalog.findRelations(
             {'to_id': intids.getId(self.document),
              'from_attribute': 'relatedItems'})
+
         for relation in relations:
+            if not relation.from_object:
+                continue
+
             objs.append(intids.queryObject(relation.from_id))
 
         return objs

--- a/opengever/trash/remover.py
+++ b/opengever/trash/remover.py
@@ -80,16 +80,9 @@ class RemoveConditionsChecker(object):
     def get_backreferences(self):
         catalog = getUtility(ICatalog)
         intids = getUtility(IIntIds)
-        objs = []
 
         relations = catalog.findRelations(
             {'to_id': intids.getId(self.document),
              'from_attribute': 'relatedItems'})
 
-        for relation in relations:
-            if not relation.from_object:
-                continue
-
-            objs.append(intids.queryObject(relation.from_id))
-
-        return objs
+        return [rel.from_object for rel in relations if rel.from_object]


### PR DESCRIPTION
Dieser PR fixt zwei Stellen im GEVER, welche gelöschte Backlinks nicht korrekt berücksichtigen.

Siehe PR #3108, dort wird über die Thematik diskutiert.

Dieser PR löst das Problem, so wie es in der Plone-Dokumentation beschrieben wird, indem nicht mehr existierende Referenzen gefiltert werden.

Die Ursache des Problems ist jedoch, dass gelöschte Backreferenzen nicht aus dem Referenz-Katalog gelöscht werden. Diese Implementation wäre mit mehr Aufwand verbunden und sollte in einem eigenen Issue behandelt werden da dies ein generelles Problem (oder Feature ;-) ) ist.

closes #2706 