### PR TITLE
Add external reference to Dossier and its index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -362,7 +362,7 @@ Updating API docs
 -----------------
 
 In order to build the Sphinx API docs locally, use the provided
-``bin/docs-build-api`` script:
+``bin/docs-build-public`` script:
 
 .. code::
 
@@ -370,18 +370,18 @@ In order to build the Sphinx API docs locally, use the provided
 
 This will build the docs (using the ``html`` target by default). If you'd like
 to build a different output format, supply it as the fist argument to the
-script (e.g. ``bin/docs-build-api latexpdf``).
+script (e.g. ``bin/docs-build-public latexpdf``).
 
 If you made changes to any schema interfaces that need to make their way into
 the docs, you need to run the ``bin/instance dump_schemas`` script before
-running the ``docs-build-api`` script:
+running the ``docs-build-public`` script:
 
 .. code::
 
     bin/instance dump_schemas
 
 This will update the respective schema dumps in ``docs/schema-dumps/`` that
-are then used by the ``docs-build-api`` script to render restructured text
+are then used by the ``docs-build-public`` script to render restructured text
 schema docs.
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.1 (unreleased)
 ---------------------
 
+- Add external_reference field and index [tarnap]
 - Show mimetype-icon of proposaltemplate in bumblebee-listing. [elioschmutz]
 - SPV word: fix a unicode error when creating proposals from a template. [deiferni]
 - SPV word: merge multiple word files into one protocol. [deiferni]

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -74,6 +74,16 @@
        :Wertebereich: <Gültige User-ID>
 
 
+   .. py:attribute:: external_reference
+
+       :Feldname: :field-title:`Externe Referenz`
+       :Datentyp: ``TextLine``
+       
+       
+       
+       
+
+
    .. py:attribute:: filing_prefix
 
        :Feldname: :field-title:`Ablage Präfix`

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -198,6 +198,12 @@
             "description": "",
             "_zope_schema_type": "TextLine"
         },
+        "external_reference": {
+            "type": "string",
+            "title": "Externe Referenz",
+            "description": "",
+            "_zope_schema_type": "TextLine"
+        },
         "privacy_layer": {
             "type": "string",
             "title": "Datenschutzstufe",
@@ -228,6 +234,7 @@
         "end",
         "comments",
         "responsible",
+        "external_reference",
         "filing_prefix",
         "container_type",
         "number_of_containers",

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -104,6 +104,7 @@ DOSSIER_MISSING_VALUES = {
     'date_of_cassation': None,
     'date_of_submission': None,
     'end': None,
+    'external_reference': None,
     'filing_prefix': None,
     'former_reference_number': None,
     'number_of_containers': None,

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -287,6 +287,15 @@
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
+                "external_reference": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Externe Referenz",
+                    "description": "",
+                    "_zope_schema_type": "TextLine"
+                },
                 "privacy_layer": {
                     "type": [
                         "null",
@@ -338,6 +347,7 @@
                 "end",
                 "comments",
                 "responsible",
+                "external_reference",
                 "filing_prefix",
                 "container_type",
                 "number_of_containers",

--- a/opengever/core/upgrades/20170809094247_add_external_reference_index_to_catalog/upgrade.py
+++ b/opengever/core/upgrades/20170809094247_add_external_reference_index_to_catalog/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddExternalReferenceIndexToCatalog(UpgradeStep):
+    """Add indexes to catalog.
+    """
+
+    def __call__(self):
+        self.catalog_add_index('external_reference', 'FieldIndex')

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -115,6 +115,14 @@ grok.global_adapter(document_date, name='document_date')
 
 
 @indexer(IDocumentSchema)
+def external_reference(obj):
+    """Return the foreign reference of a document."""
+    context = aq_inner(obj)
+    return IDocumentMetadata(context).foreign_reference
+grok.global_adapter(external_reference, name='external_reference')
+
+
+@indexer(IDocumentSchema)
 def receipt_date(obj):
     """receipt_date indexer, can handle None Value"""
     context = aq_inner(obj)

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -94,6 +94,16 @@ class TestDocumentIndexers(FunctionalTestCase):
             index_data_for(doc1).get('SearchableText')
             )
 
+    def test_external_reference(self):
+        doc = create(Builder('document').having(
+            author=u'Hugo Boss',
+            title=u'Docment',
+            foreign_reference=u'qpr-900-9001-\xf8'))
+
+        self.assertEquals(
+            u'qpr-900-9001-\xf8',
+            index_data_for(doc).get('external_reference'))
+
     def test_full_text_indexing_with_plain_text(self):
         sample_file = NamedBlobFile('foobar barfoo', filename=u'test.txt')
         doc1 = createContentInContainer(

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -47,6 +47,7 @@ class IDossier(form.Schema):
         label=_(u'fieldset_common', u'Common'),
         fields=[
             u'keywords',
+            u'external_reference',
             u'start',
             u'end',
             u'comments',
@@ -92,6 +93,11 @@ class IDossier(form.Schema):
         title=_(u"label_responsible", default="Responsible"),
         source=AssignedUsersSourceBinder(),
         required=True,
+    )
+
+    external_reference = schema.TextLine(
+        title=_(u'label_external_reference', default=u'External Reference'),
+        required=False,
     )
 
     form.fieldset(

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -47,10 +47,10 @@ class IDossier(form.Schema):
         label=_(u'fieldset_common', u'Common'),
         fields=[
             u'keywords',
-            u'external_reference',
             u'start',
             u'end',
             u'comments',
+            u'external_reference',
             u'responsible',
             u'relatedDossier',
         ],

--- a/opengever/dossier/config.py
+++ b/opengever/dossier/config.py
@@ -3,4 +3,5 @@ INDEXES = (
     ('containing_subdossier', 'FieldIndex'),
     ('containing_dossier', 'FieldIndex'),
     ('retention_expiration', 'DateIndex'),
+    ('external_reference', 'FieldIndex'),
 )

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -180,6 +180,10 @@ class SearchableTextExtender(grok.Adapter):
                 else keyword
                 for keyword in keywords)
 
+        external_reference = IDossier(self.context).external_reference
+        if external_reference:
+            searchable.append(external_reference.encode('utf-8'))
+
         return ' '.join(searchable)
 
 

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -80,6 +80,14 @@ def isSubdossierIndexer(obj):
 grok.global_adapter(isSubdossierIndexer, name="is_subdossier")
 
 
+@indexer(IDossierMarker)
+def external_reference(obj):
+    """Return the external reference of a dossier."""
+    context = aq_inner(obj)
+    return IDossier(context).external_reference
+grok.global_adapter(external_reference, name="external_reference")
+
+
 @indexer(IDexterityContent)
 def main_dossier_title(obj):
     """Return the title of the main dossier."""

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-08-04 07:40+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: de\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/dossier/move_items.py:148
+#: ./opengever/dossier/move_items.py:170
 msgid "${copied_items} Elements were moved successfully"
 msgstr "${copied_items} Elemente wurden erfolgreich verschoben"
 
@@ -24,16 +24,16 @@ msgstr "${copied_items} Elemente wurden erfolgreich verschoben"
 msgid "Add Business Case Dossier"
 msgstr "Geschäftsdossier hinzufügen"
 
-#: ./opengever/dossier/behaviors/dossier.py:234
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:48
+#: ./opengever/dossier/behaviors/dossier.py:241
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:49
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
-#: ./opengever/dossier/dossiertemplate/form.py:114
+#: ./opengever/dossier/dossiertemplate/form.py:127
 msgid "Add dossier"
 msgstr "Dossier hinzufügen"
 
-#: ./opengever/dossier/move_items.py:184
+#: ./opengever/dossier/move_items.py:214
 msgid "Can only move objects from open dossiers!"
 msgstr "Es können nur Objekte aus aktiven Dossiers verschoben werden!"
 
@@ -45,7 +45,7 @@ msgstr "Report konnte nicht generiert werden."
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ./opengever/dossier/move_items.py:97
+#: ./opengever/dossier/move_items.py:119
 msgid "Document ${name} is not movable."
 msgstr "Das Dokument «${name}» ist nicht verschiebbar."
 
@@ -61,8 +61,8 @@ msgstr "Dossiervorlage"
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
-#: ./opengever/dossier/behaviors/dossier.py:256
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
+#: ./opengever/dossier/behaviors/dossier.py:263
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:67
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
@@ -70,15 +70,15 @@ msgstr "Subdossier bearbeiten"
 msgid "Export selection"
 msgstr "Auswahl exportieren"
 
-#: ./opengever/dossier/move_items.py:154
+#: ./opengever/dossier/move_items.py:176
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr "Folgende Elemente konnten nicht verschoben werden: ${failed_objects}"
 
-#: ./opengever/dossier/move_items.py:160
+#: ./opengever/dossier/move_items.py:182
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr "Die folgenden Objekte konnten nicht kopiert werden: ${failed_objects}. Sie sind via WebDAV gesperrt."
 
-#: ./opengever/dossier/move_items.py:211
+#: ./opengever/dossier/move_items.py:246
 msgid "It isn't allowed to add such items there."
 msgstr "Sie dürfen dieses Objekt nicht an den Zielort verschieben."
 
@@ -110,15 +110,15 @@ msgstr "Beteiligungen"
 msgid "Participations"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/templatefolder/form.py:113
+#: ./opengever/dossier/templatefolder/form.py:114
 msgid "Select document"
 msgstr "Dokument auswählen"
 
-#: ./opengever/dossier/dossiertemplate/form.py:113
+#: ./opengever/dossier/dossiertemplate/form.py:126
 msgid "Select dossiertemplate"
 msgstr "Vorlage auswählen"
 
-#: ./opengever/dossier/templatefolder/form.py:114
+#: ./opengever/dossier/templatefolder/form.py:115
 msgid "Select recipient address"
 msgstr "Empfänger-Adresse auswählen"
 
@@ -187,15 +187,15 @@ msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das D
 msgid "The given value is not a valid Year."
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
-#: ./opengever/dossier/move_items.py:89
+#: ./opengever/dossier/move_items.py:111
 msgid "The selected objects can't be found, please try it again."
 msgstr "Die selektierten Objekte konnten nicht gefunden werden, bitte versuchen Sie es erneut."
 
-#: ./opengever/dossier/behaviors/dossier.py:197
+#: ./opengever/dossier/behaviors/dossier.py:204
 msgid "The start date must be before the end date."
 msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 
-#: ./opengever/dossier/behaviors/dossier.py:263
+#: ./opengever/dossier/behaviors/dossier.py:270
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
@@ -211,7 +211,7 @@ msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossie
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."
 
-#: ./opengever/dossier/move_items.py:194
+#: ./opengever/dossier/move_items.py:224
 msgid "You have not selected any items"
 msgstr "Sie haben kein Element ausgewählt"
 
@@ -231,22 +231,22 @@ msgstr "Speichern"
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:172
-#: ./opengever/dossier/dossiertemplate/form.py:148
+#: ./opengever/dossier/dossiertemplate/form.py:162
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:137
+#: ./opengever/dossier/dossiertemplate/form.py:150
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Save"
-#: ./opengever/dossier/templatefolder/form.py:178
+#: ./opengever/dossier/templatefolder/form.py:173
 msgid "button_save"
 msgstr "Speichern"
 
 #. Default: "Move"
-#: ./opengever/dossier/move_items.py:74
+#: ./opengever/dossier/move_items.py:96
 msgid "button_submit"
 msgstr "Verschieben"
 
@@ -261,12 +261,12 @@ msgid "column_rolelist"
 msgstr "Rolle"
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatefolder/form.py:106
+#: ./opengever/dossier/templatefolder/form.py:107
 msgid "create_document_with_template"
 msgstr "Dokument aus Vorlage erstellen"
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:109
+#: ./opengever/dossier/dossiertemplate/form.py:122
 msgid "create_dossier_with_template"
 msgstr "Geschäftsdossier aus Vorlage erstellen"
 
@@ -284,7 +284,7 @@ msgid "documents"
 msgstr "Dokumente"
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:242
+#: ./opengever/dossier/move_items.py:277
 msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in den Zielordner eingefügt werden: ${failed_objects}"
 
@@ -304,7 +304,7 @@ msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/behaviors/dossier.py:106
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Ablage"
@@ -342,7 +342,7 @@ msgstr "Ablagenummer"
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/behaviors/dossier.py:118
 #: ./opengever/dossier/browser/overview.py:249
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
@@ -363,7 +363,7 @@ msgid "heading_dossier_note"
 msgstr "Kommentar zu Dossier `${title}`"
 
 #. Default: "Move Items"
-#: ./opengever/dossier/move_items.py:56
+#: ./opengever/dossier/move_items.py:78
 msgid "heading_move_items"
 msgstr "Elemente verschieben"
 
@@ -371,16 +371,16 @@ msgstr "Elemente verschieben"
 msgid "help_contact"
 msgstr "Wählen Sie einen Benutzer oder einen Kontakt aus."
 
-#: ./opengever/dossier/behaviors/dossier.py:147
+#: ./opengever/dossier/behaviors/dossier.py:154
 msgid "help_container_location"
 msgstr "Standortangabe des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_container_type"
 msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
 #. Default: "Live Search: search the Plone Site"
-#: ./opengever/dossier/move_items.py:27
+#: ./opengever/dossier/move_items.py:33
 msgid "help_destination"
 msgstr "Live Search: Durchsuchen Sie diesen Mandanten"
 
@@ -388,11 +388,11 @@ msgstr "Live Search: Durchsuchen Sie diesen Mandanten"
 msgid "help_filing_number"
 msgstr "Geben Sie die vollständige Ablagenummer an."
 
-#: ./opengever/dossier/behaviors/dossier.py:61
+#: ./opengever/dossier/behaviors/dossier.py:62
 msgid "help_keywords"
 msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
 
-#: ./opengever/dossier/behaviors/dossier.py:141
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "help_number_of_containers"
 msgstr "Anzahl Behälter, die ein (grosses) Dossier in Papierform enthalten"
 
@@ -437,7 +437,7 @@ msgid "label_addable_dossier_templates"
 msgstr "Erlaubte Dossiervorlagen"
 
 #. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py:270
+#: ./opengever/dossier/templatefolder/form.py:265
 msgid "label_address"
 msgstr "Adresse"
 
@@ -457,7 +457,7 @@ msgid "label_close"
 msgstr "Schliessen"
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:86
+#: ./opengever/dossier/behaviors/dossier.py:87
 #: ./opengever/dossier/browser/overview.py:68
 msgid "label_comments"
 msgstr "Kommentar"
@@ -468,29 +468,29 @@ msgid "label_contact"
 msgstr "Person"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:146
+#: ./opengever/dossier/behaviors/dossier.py:153
 msgid "label_container_location"
 msgstr "Behältnis-Standort"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:129
+#: ./opengever/dossier/behaviors/dossier.py:136
 msgid "label_container_type"
 msgstr "Behältnis-Art"
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:97
-#: ./opengever/dossier/templatefolder/form.py:70
+#: ./opengever/dossier/dossiertemplate/form.py:110
+#: ./opengever/dossier/templatefolder/form.py:71
 msgid "label_creator"
 msgstr "Erstellt von"
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:253
-#: ./opengever/dossier/templatefolder/tabs.py:141
+#: ./opengever/dossier/templatefolder/tabs.py:140
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Destination"
-#: ./opengever/dossier/move_items.py:26
+#: ./opengever/dossier/move_items.py:32
 msgid "label_destination"
 msgstr "Zielposition / Zieldossier"
 
@@ -511,7 +511,7 @@ msgid "label_dossier_templates"
 msgstr "Dossiervorlagen"
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatefolder/form.py:91
+#: ./opengever/dossier/templatefolder/form.py:92
 msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
@@ -521,22 +521,28 @@ msgid "label_edit_note"
 msgstr "Bearbeiten"
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:74
+#: ./opengever/dossier/viewlets/byline.py:78
 msgid "label_email_address"
 msgstr "E-Mail"
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:81
+#: ./opengever/dossier/behaviors/dossier.py:82
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:55
+#: ./opengever/dossier/viewlets/byline.py:59
 msgid "label_end_byline"
 msgstr "Ende"
+
+#. Default: "External Reference"
+#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/viewlets/byline.py:84
+msgid "label_external_reference"
+msgstr "Externe Referenz"
 
 #. Default: "Filing Number"
 #: ./opengever/dossier/filing/byline.py:21
@@ -549,7 +555,7 @@ msgid "label_filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:174
+#: ./opengever/dossier/behaviors/dossier.py:181
 msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
@@ -564,13 +570,13 @@ msgid "label_journal"
 msgstr "Journal"
 
 #. Default: "Keywords"
-#: ./opengever/dossier/behaviors/dossier.py:60
+#: ./opengever/dossier/behaviors/dossier.py:61
 #: ./opengever/dossier/browser/overview.py:227
 msgid "label_keywords"
 msgstr "Schlagworte"
 
 #. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py:275
+#: ./opengever/dossier/templatefolder/form.py:270
 msgid "label_label"
 msgstr "Label"
 
@@ -580,13 +586,13 @@ msgid "label_linked_dossiers"
 msgstr "Verlinkte Dossiers"
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py:282
+#: ./opengever/dossier/templatefolder/form.py:277
 msgid "label_mail_address"
 msgstr "Mail Addresse"
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:100
-#: ./opengever/dossier/templatefolder/form.py:73
+#: ./opengever/dossier/dossiertemplate/form.py:113
+#: ./opengever/dossier/templatefolder/form.py:74
 msgid "label_modified"
 msgstr "Zuletzt Bearbeitet"
 
@@ -596,7 +602,7 @@ msgid "label_no_reference_number"
 msgstr "Die Archivnummer wird erst beim Erstellen generiert."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:139
+#: ./opengever/dossier/behaviors/dossier.py:146
 msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
@@ -621,7 +627,7 @@ msgid "label_participations"
 msgstr "Beteiligungen"
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py:293
+#: ./opengever/dossier/templatefolder/form.py:288
 msgid "label_phonenumber"
 msgstr "Telefonnummer"
 
@@ -641,24 +647,24 @@ msgid "label_proposals"
 msgstr "Anträge"
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py:84
+#: ./opengever/dossier/templatefolder/form.py:85
 msgid "label_recipient"
 msgstr "Empfänger"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:181
+#: ./opengever/dossier/behaviors/dossier.py:188
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:67
+#: ./opengever/dossier/viewlets/byline.py:71
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:152
+#: ./opengever/dossier/behaviors/dossier.py:159
 msgid "label_related_dossier"
 msgstr "Verwandte Dossiers"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:92
+#: ./opengever/dossier/behaviors/dossier.py:93
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
@@ -690,7 +696,7 @@ msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:61
+#: ./opengever/dossier/viewlets/byline.py:65
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
@@ -700,14 +706,14 @@ msgid "label_show_note"
 msgstr "Anzeigen"
 
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:73
+#: ./opengever/dossier/behaviors/dossier.py:74
 #: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:49
+#: ./opengever/dossier/viewlets/byline.py:53
 msgid "label_start_byline"
 msgstr "Beginn"
 
@@ -727,15 +733,15 @@ msgid "label_tasktemplate_folders"
 msgstr "Standardabläufe"
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:89
-#: ./opengever/dossier/templatefolder/form.py:61
+#: ./opengever/dossier/dossiertemplate/form.py:102
+#: ./opengever/dossier/templatefolder/form.py:62
 msgid "label_template"
 msgstr "Vorlage"
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:94
-#: ./opengever/dossier/templatefolder/form.py:66
+#: ./opengever/dossier/dossiertemplate/form.py:107
+#: ./opengever/dossier/templatefolder/form.py:67
 msgid "label_title"
 msgstr "Titel"
 
@@ -750,13 +756,13 @@ msgid "label_trash"
 msgstr "Papierkorb"
 
 #. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py:304
+#: ./opengever/dossier/templatefolder/form.py:299
 msgid "label_url"
 msgstr "URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:43
+#: ./opengever/dossier/viewlets/byline.py:47
 msgid "label_workflow_state"
 msgstr "Status"
 
@@ -822,7 +828,7 @@ msgid "tasks"
 msgstr "Aufgaben"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:123
+#: ./opengever/dossier/behaviors/dossier.py:130
 msgid "temporary_former_reference_number"
 msgstr "Temporäres früheres Aktenzeichen"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,39 +1,38 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-08-04 07:40+0000\n"
 "PO-Revision-Date: 2017-06-22 08:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-dossier/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/dossier/move_items.py:148
+#: ./opengever/dossier/move_items.py:170
 msgid "${copied_items} Elements were moved successfully"
 msgstr "${copied_items} éléments déplacés avec succès"
 
 msgid "Add Business Case Dossier"
 msgstr "Insérer un dossier d'affaire"
 
-#: ./opengever/dossier/behaviors/dossier.py:234
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:48
+#: ./opengever/dossier/behaviors/dossier.py:241
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:49
 msgid "Add Subdossier"
 msgstr "Insérer un sous-dossier"
 
-#: ./opengever/dossier/dossiertemplate/form.py:114
+#: ./opengever/dossier/dossiertemplate/form.py:127
 msgid "Add dossier"
 msgstr "Ajouter le dossier"
 
-#: ./opengever/dossier/move_items.py:184
+#: ./opengever/dossier/move_items.py:214
 msgid "Can only move objects from open dossiers!"
 msgstr "Seuls les objets de dossiers actifs peuvent être déplacés!"
 
@@ -45,7 +44,7 @@ msgstr "Impossible de générer l'affichage."
 msgid "Description"
 msgstr "Description"
 
-#: ./opengever/dossier/move_items.py:97
+#: ./opengever/dossier/move_items.py:119
 msgid "Document ${name} is not movable."
 msgstr ""
 
@@ -61,8 +60,8 @@ msgstr "Modèle de dossier"
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été à nouveau ouvert avec succès."
 
-#: ./opengever/dossier/behaviors/dossier.py:256
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
+#: ./opengever/dossier/behaviors/dossier.py:263
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:67
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
@@ -70,15 +69,15 @@ msgstr "Modifier le sous-dossier"
 msgid "Export selection"
 msgstr "Exporter le choix"
 
-#: ./opengever/dossier/move_items.py:154
+#: ./opengever/dossier/move_items.py:176
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr "Impossible de déplacer les éléments suivants: ${failed_objects}"
 
-#: ./opengever/dossier/move_items.py:160
+#: ./opengever/dossier/move_items.py:182
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr "Les objets suivants ne peuvent pas être copiés: ${failed_objects}. Ils sont verrouillés par WebDAV."
 
-#: ./opengever/dossier/move_items.py:211
+#: ./opengever/dossier/move_items.py:246
 msgid "It isn't allowed to add such items there."
 msgstr "Cet élément ne peut être déplacé ici."
 
@@ -110,15 +109,15 @@ msgstr "Participations"
 msgid "Participations"
 msgstr "Participants"
 
-#: ./opengever/dossier/templatefolder/form.py:113
+#: ./opengever/dossier/templatefolder/form.py:114
 msgid "Select document"
 msgstr "Choisir un dossier"
 
-#: ./opengever/dossier/dossiertemplate/form.py:113
+#: ./opengever/dossier/dossiertemplate/form.py:126
 msgid "Select dossiertemplate"
 msgstr "Choisir un modèle"
 
-#: ./opengever/dossier/templatefolder/form.py:114
+#: ./opengever/dossier/templatefolder/form.py:115
 msgid "Select recipient address"
 msgstr "Choisir l'adresse du destinataire"
 
@@ -186,15 +185,15 @@ msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou 
 msgid "The given value is not a valid Year."
 msgstr "L'année d'archivage indiquée n'est pas valable."
 
-#: ./opengever/dossier/move_items.py:89
+#: ./opengever/dossier/move_items.py:111
 msgid "The selected objects can't be found, please try it again."
 msgstr "Impossible de trouver les objets sélectionnés, merci de réessayer."
 
-#: ./opengever/dossier/behaviors/dossier.py:197
+#: ./opengever/dossier/behaviors/dossier.py:204
 msgid "The start date must be before the end date."
 msgstr "La date de début doit être plus récente que la date de clôture."
 
-#: ./opengever/dossier/behaviors/dossier.py:263
+#: ./opengever/dossier/behaviors/dossier.py:270
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
@@ -210,7 +209,7 @@ msgstr "Ce sous-dossier ne peut pas être réactivé parce que le dossier prinic
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution du numéro d'inventaire, tous les champs sont obligatoires."
 
-#: ./opengever/dossier/move_items.py:194
+#: ./opengever/dossier/move_items.py:224
 msgid "You have not selected any items"
 msgstr "Pas d'élément sélectionné"
 
@@ -230,22 +229,22 @@ msgstr "Enregistrer"
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:172
-#: ./opengever/dossier/dossiertemplate/form.py:148
+#: ./opengever/dossier/dossiertemplate/form.py:162
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:137
+#: ./opengever/dossier/dossiertemplate/form.py:150
 msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Save"
-#: ./opengever/dossier/templatefolder/form.py:178
+#: ./opengever/dossier/templatefolder/form.py:173
 msgid "button_save"
 msgstr "Enregistrer"
 
 #. Default: "Move"
-#: ./opengever/dossier/move_items.py:74
+#: ./opengever/dossier/move_items.py:96
 msgid "button_submit"
 msgstr "Déplacer"
 
@@ -260,12 +259,12 @@ msgid "column_rolelist"
 msgstr "Rôle"
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatefolder/form.py:106
+#: ./opengever/dossier/templatefolder/form.py:107
 msgid "create_document_with_template"
 msgstr "Créer un document à partir d'un modèle"
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:109
+#: ./opengever/dossier/dossiertemplate/form.py:122
 msgid "create_dossier_with_template"
 msgstr "Créer un dossier à partir du modèle"
 
@@ -283,7 +282,7 @@ msgid "documents"
 msgstr "Documents"
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:242
+#: ./opengever/dossier/move_items.py:277
 msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Pas d'objet déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi: ${failed_objects}"
 
@@ -303,7 +302,7 @@ msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/behaviors/dossier.py:106
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr "Classeur"
@@ -341,7 +340,7 @@ msgstr "Numéro d'inventaire"
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/behaviors/dossier.py:118
 #: ./opengever/dossier/browser/overview.py:249
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
@@ -362,7 +361,7 @@ msgid "heading_dossier_note"
 msgstr "Commentaire sur le dossier `${title}`"
 
 #. Default: "Move Items"
-#: ./opengever/dossier/move_items.py:56
+#: ./opengever/dossier/move_items.py:78
 msgid "heading_move_items"
 msgstr "Déplacer des éléments"
 
@@ -370,16 +369,16 @@ msgstr "Déplacer des éléments"
 msgid "help_contact"
 msgstr "Choix d'un utilisateur ou un contact."
 
-#: ./opengever/dossier/behaviors/dossier.py:147
+#: ./opengever/dossier/behaviors/dossier.py:154
 msgid "help_container_location"
 msgstr "Emplacement du dossier imprimé"
 
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_container_type"
 msgstr "Type de conteneur du dossier imprimé"
 
 #. Default: "Live Search: search the Plone Site"
-#: ./opengever/dossier/move_items.py:27
+#: ./opengever/dossier/move_items.py:33
 msgid "help_destination"
 msgstr "Recherche en direct: Recherche de ce client"
 
@@ -387,11 +386,11 @@ msgstr "Recherche en direct: Recherche de ce client"
 msgid "help_filing_number"
 msgstr "Saisir le numéro d'inventaire complet."
 
-#: ./opengever/dossier/behaviors/dossier.py:61
+#: ./opengever/dossier/behaviors/dossier.py:62
 msgid "help_keywords"
 msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de la position"
 
-#: ./opengever/dossier/behaviors/dossier.py:141
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "help_number_of_containers"
 msgstr "Nombre de conteneurs contenant des dossiers imprimés (volumineux)"
 
@@ -436,7 +435,7 @@ msgid "label_addable_dossier_templates"
 msgstr "Modèles de dossier autorisés"
 
 #. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py:270
+#: ./opengever/dossier/templatefolder/form.py:265
 msgid "label_address"
 msgstr "Adresse"
 
@@ -456,7 +455,7 @@ msgid "label_close"
 msgstr "Clôturer"
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:86
+#: ./opengever/dossier/behaviors/dossier.py:87
 #: ./opengever/dossier/browser/overview.py:68
 msgid "label_comments"
 msgstr "Commentaire"
@@ -467,29 +466,29 @@ msgid "label_contact"
 msgstr "Personne"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:146
+#: ./opengever/dossier/behaviors/dossier.py:153
 msgid "label_container_location"
 msgstr "Emplacement du conteneur"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:129
+#: ./opengever/dossier/behaviors/dossier.py:136
 msgid "label_container_type"
 msgstr "Type de conteneur"
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:97
-#: ./opengever/dossier/templatefolder/form.py:70
+#: ./opengever/dossier/dossiertemplate/form.py:110
+#: ./opengever/dossier/templatefolder/form.py:71
 msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:253
-#: ./opengever/dossier/templatefolder/tabs.py:141
+#: ./opengever/dossier/templatefolder/tabs.py:140
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Destination"
-#: ./opengever/dossier/move_items.py:26
+#: ./opengever/dossier/move_items.py:32
 msgid "label_destination"
 msgstr "Destination"
 
@@ -510,7 +509,7 @@ msgid "label_dossier_templates"
 msgstr "Modèles de dossier"
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatefolder/form.py:91
+#: ./opengever/dossier/templatefolder/form.py:92
 msgid "label_edit_after_creation"
 msgstr "Modifier après avoir créé"
 
@@ -520,22 +519,28 @@ msgid "label_edit_note"
 msgstr "Editer"
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:74
+#: ./opengever/dossier/viewlets/byline.py:78
 msgid "label_email_address"
 msgstr "Email"
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:81
+#: ./opengever/dossier/behaviors/dossier.py:82
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:55
+#: ./opengever/dossier/viewlets/byline.py:59
 msgid "label_end_byline"
 msgstr "Jusqu'au"
+
+#. Default: "External Reference"
+#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/viewlets/byline.py:84
+msgid "label_external_reference"
+msgstr "Référence externe"
 
 #. Default: "Filing Number"
 #: ./opengever/dossier/filing/byline.py:21
@@ -548,7 +553,7 @@ msgid "label_filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:174
+#: ./opengever/dossier/behaviors/dossier.py:181
 msgid "label_former_reference_number"
 msgstr "Ancien numéro référence"
 
@@ -563,13 +568,13 @@ msgid "label_journal"
 msgstr "Historique"
 
 #. Default: "Keywords"
-#: ./opengever/dossier/behaviors/dossier.py:60
+#: ./opengever/dossier/behaviors/dossier.py:61
 #: ./opengever/dossier/browser/overview.py:227
 msgid "label_keywords"
 msgstr "Mots-clés"
 
 #. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py:275
+#: ./opengever/dossier/templatefolder/form.py:270
 msgid "label_label"
 msgstr "label"
 
@@ -579,13 +584,13 @@ msgid "label_linked_dossiers"
 msgstr "Dossiers liés"
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py:282
+#: ./opengever/dossier/templatefolder/form.py:277
 msgid "label_mail_address"
 msgstr "Adresse e-mail"
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:100
-#: ./opengever/dossier/templatefolder/form.py:73
+#: ./opengever/dossier/dossiertemplate/form.py:113
+#: ./opengever/dossier/templatefolder/form.py:74
 msgid "label_modified"
 msgstr "Dernière modification"
 
@@ -595,7 +600,7 @@ msgid "label_no_reference_number"
 msgstr "Le numéro de classement est généré lors de la création du document."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:139
+#: ./opengever/dossier/behaviors/dossier.py:146
 msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
@@ -620,7 +625,7 @@ msgid "label_participations"
 msgstr "Participation"
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py:293
+#: ./opengever/dossier/templatefolder/form.py:288
 msgid "label_phonenumber"
 msgstr "Numéro de téléphone"
 
@@ -640,24 +645,24 @@ msgid "label_proposals"
 msgstr "Propositions"
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py:84
+#: ./opengever/dossier/templatefolder/form.py:85
 msgid "label_recipient"
 msgstr "Destinataire"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:181
+#: ./opengever/dossier/behaviors/dossier.py:188
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:67
+#: ./opengever/dossier/viewlets/byline.py:71
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:152
+#: ./opengever/dossier/behaviors/dossier.py:159
 msgid "label_related_dossier"
 msgstr "Dossiers liés"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:92
+#: ./opengever/dossier/behaviors/dossier.py:93
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
@@ -689,7 +694,7 @@ msgid "label_save"
 msgstr "Sauvegarder"
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:61
+#: ./opengever/dossier/viewlets/byline.py:65
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
@@ -699,14 +704,14 @@ msgid "label_show_note"
 msgstr "Afficher"
 
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:73
+#: ./opengever/dossier/behaviors/dossier.py:74
 #: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:49
+#: ./opengever/dossier/viewlets/byline.py:53
 msgid "label_start_byline"
 msgstr "De"
 
@@ -726,15 +731,15 @@ msgid "label_tasktemplate_folders"
 msgstr "Déroulements standards"
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:89
-#: ./opengever/dossier/templatefolder/form.py:61
+#: ./opengever/dossier/dossiertemplate/form.py:102
+#: ./opengever/dossier/templatefolder/form.py:62
 msgid "label_template"
 msgstr "Modèle"
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:94
-#: ./opengever/dossier/templatefolder/form.py:66
+#: ./opengever/dossier/dossiertemplate/form.py:107
+#: ./opengever/dossier/templatefolder/form.py:67
 msgid "label_title"
 msgstr "Titre"
 
@@ -749,13 +754,13 @@ msgid "label_trash"
 msgstr "Corbeille"
 
 #. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py:304
+#: ./opengever/dossier/templatefolder/form.py:299
 msgid "label_url"
 msgstr "Adresse URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:43
+#: ./opengever/dossier/viewlets/byline.py:47
 msgid "label_workflow_state"
 msgstr "Etat"
 
@@ -821,7 +826,7 @@ msgid "tasks"
 msgstr "Tâches"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:123
+#: ./opengever/dossier/behaviors/dossier.py:130
 msgid "temporary_former_reference_number"
 msgstr "Ancien numéro de référence temporaire"
 
@@ -847,3 +852,4 @@ msgstr "Journal du dossier ${title}, ${timestamp}"
 #: ./opengever/dossier/behaviors/participation.py:202
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation."
+

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-08-04 07:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,23 +17,23 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.dossier\n"
 
-#: ./opengever/dossier/move_items.py:148
+#: ./opengever/dossier/move_items.py:170
 msgid "${copied_items} Elements were moved successfully"
 msgstr ""
 
 msgid "Add Business Case Dossier"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:234
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:48
+#: ./opengever/dossier/behaviors/dossier.py:241
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:49
 msgid "Add Subdossier"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:114
+#: ./opengever/dossier/dossiertemplate/form.py:127
 msgid "Add dossier"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:184
+#: ./opengever/dossier/move_items.py:214
 msgid "Can only move objects from open dossiers!"
 msgstr ""
 
@@ -45,7 +45,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:97
+#: ./opengever/dossier/move_items.py:119
 msgid "Document ${name} is not movable."
 msgstr ""
 
@@ -61,8 +61,8 @@ msgstr ""
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:256
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:66
+#: ./opengever/dossier/behaviors/dossier.py:263
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:67
 msgid "Edit Subdossier"
 msgstr ""
 
@@ -70,15 +70,15 @@ msgstr ""
 msgid "Export selection"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:154
+#: ./opengever/dossier/move_items.py:176
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:160
+#: ./opengever/dossier/move_items.py:182
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:211
+#: ./opengever/dossier/move_items.py:246
 msgid "It isn't allowed to add such items there."
 msgstr ""
 
@@ -110,15 +110,15 @@ msgstr ""
 msgid "Participations"
 msgstr ""
 
-#: ./opengever/dossier/templatefolder/form.py:113
+#: ./opengever/dossier/templatefolder/form.py:114
 msgid "Select document"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:113
+#: ./opengever/dossier/dossiertemplate/form.py:126
 msgid "Select dossiertemplate"
 msgstr ""
 
-#: ./opengever/dossier/templatefolder/form.py:114
+#: ./opengever/dossier/templatefolder/form.py:115
 msgid "Select recipient address"
 msgstr ""
 
@@ -186,15 +186,15 @@ msgstr ""
 msgid "The given value is not a valid Year."
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:89
+#: ./opengever/dossier/move_items.py:111
 msgid "The selected objects can't be found, please try it again."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:197
+#: ./opengever/dossier/behaviors/dossier.py:204
 msgid "The start date must be before the end date."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:263
+#: ./opengever/dossier/behaviors/dossier.py:270
 msgid "The start or end date is invalid"
 msgstr ""
 
@@ -210,7 +210,7 @@ msgstr ""
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:194
+#: ./opengever/dossier/move_items.py:224
 msgid "You have not selected any items"
 msgstr ""
 
@@ -230,22 +230,22 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/dossier/archive.py:291
 #: ./opengever/dossier/behaviors/participation.py:172
-#: ./opengever/dossier/dossiertemplate/form.py:148
+#: ./opengever/dossier/dossiertemplate/form.py:162
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:137
+#: ./opengever/dossier/dossiertemplate/form.py:150
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/dossier/templatefolder/form.py:178
+#: ./opengever/dossier/templatefolder/form.py:173
 msgid "button_save"
 msgstr ""
 
 #. Default: "Move"
-#: ./opengever/dossier/move_items.py:74
+#: ./opengever/dossier/move_items.py:96
 msgid "button_submit"
 msgstr ""
 
@@ -260,12 +260,12 @@ msgid "column_rolelist"
 msgstr ""
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatefolder/form.py:106
+#: ./opengever/dossier/templatefolder/form.py:107
 msgid "create_document_with_template"
 msgstr ""
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:109
+#: ./opengever/dossier/dossiertemplate/form.py:122
 msgid "create_dossier_with_template"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgid "documents"
 msgstr ""
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:242
+#: ./opengever/dossier/move_items.py:277
 msgid "error_NotInContentTypes ${failed_objects}"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/behaviors/dossier.py:106
 #: ./opengever/dossier/behaviors/filing.py:17
 msgid "fieldset_filing"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 
 #. Default: "filing prefix"
 #: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:111
+#: ./opengever/dossier/behaviors/dossier.py:118
 #: ./opengever/dossier/browser/overview.py:249
 msgid "filing_prefix"
 msgstr ""
@@ -362,7 +362,7 @@ msgid "heading_dossier_note"
 msgstr ""
 
 #. Default: "Move Items"
-#: ./opengever/dossier/move_items.py:56
+#: ./opengever/dossier/move_items.py:78
 msgid "heading_move_items"
 msgstr ""
 
@@ -370,28 +370,32 @@ msgstr ""
 msgid "help_contact"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:147
+#: ./opengever/dossier/behaviors/dossier.py:154
 msgid "help_container_location"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py:137
 msgid "help_container_type"
 msgstr ""
 
 #. Default: "Live Search: search the Plone Site"
-#: ./opengever/dossier/move_items.py:27
+#: ./opengever/dossier/move_items.py:33
 msgid "help_destination"
+msgstr ""
+
+#: ./opengever/dossier/behaviors/dossier.py:100
+msgid "help_external_reference"
 msgstr ""
 
 #: ./opengever/dossier/filing/advanced_search.py:16
 msgid "help_filing_number"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:61
+#: ./opengever/dossier/behaviors/dossier.py:62
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:141
+#: ./opengever/dossier/behaviors/dossier.py:148
 msgid "help_number_of_containers"
 msgstr ""
 
@@ -436,7 +440,7 @@ msgid "label_addable_dossier_templates"
 msgstr ""
 
 #. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py:270
+#: ./opengever/dossier/templatefolder/form.py:265
 msgid "label_address"
 msgstr ""
 
@@ -456,7 +460,7 @@ msgid "label_close"
 msgstr ""
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:86
+#: ./opengever/dossier/behaviors/dossier.py:87
 #: ./opengever/dossier/browser/overview.py:68
 msgid "label_comments"
 msgstr ""
@@ -467,29 +471,29 @@ msgid "label_contact"
 msgstr ""
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:146
+#: ./opengever/dossier/behaviors/dossier.py:153
 msgid "label_container_location"
 msgstr ""
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:129
+#: ./opengever/dossier/behaviors/dossier.py:136
 msgid "label_container_type"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:97
-#: ./opengever/dossier/templatefolder/form.py:70
+#: ./opengever/dossier/dossiertemplate/form.py:110
+#: ./opengever/dossier/templatefolder/form.py:71
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Description"
 #: ./opengever/dossier/browser/overview.py:253
-#: ./opengever/dossier/templatefolder/tabs.py:141
+#: ./opengever/dossier/templatefolder/tabs.py:140
 msgid "label_description"
 msgstr ""
 
 #. Default: "Destination"
-#: ./opengever/dossier/move_items.py:26
+#: ./opengever/dossier/move_items.py:32
 msgid "label_destination"
 msgstr ""
 
@@ -510,7 +514,7 @@ msgid "label_dossier_templates"
 msgstr ""
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatefolder/form.py:91
+#: ./opengever/dossier/templatefolder/form.py:92
 msgid "label_edit_after_creation"
 msgstr ""
 
@@ -520,21 +524,27 @@ msgid "label_edit_note"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:74
+#: ./opengever/dossier/viewlets/byline.py:78
 msgid "label_email_address"
 msgstr ""
 
 #. Default: "Closing Date"
 #: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:81
+#: ./opengever/dossier/behaviors/dossier.py:82
 #: ./opengever/dossier/browser/report.py:32
 msgid "label_end"
 msgstr ""
 
 #. Default: "to"
 #: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:55
+#: ./opengever/dossier/viewlets/byline.py:59
 msgid "label_end_byline"
+msgstr ""
+
+#. Default: "External reference"
+#: ./opengever/dossier/behaviors/dossier.py:99
+#: ./opengever/dossier/viewlets/byline.py:84
+msgid "label_external_reference"
 msgstr ""
 
 #. Default: "Filing Number"
@@ -548,7 +558,7 @@ msgid "label_filing_number"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:174
+#: ./opengever/dossier/behaviors/dossier.py:181
 msgid "label_former_reference_number"
 msgstr ""
 
@@ -563,13 +573,13 @@ msgid "label_journal"
 msgstr ""
 
 #. Default: "Keywords"
-#: ./opengever/dossier/behaviors/dossier.py:60
+#: ./opengever/dossier/behaviors/dossier.py:61
 #: ./opengever/dossier/browser/overview.py:227
 msgid "label_keywords"
 msgstr ""
 
 #. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py:275
+#: ./opengever/dossier/templatefolder/form.py:270
 msgid "label_label"
 msgstr ""
 
@@ -579,13 +589,13 @@ msgid "label_linked_dossiers"
 msgstr ""
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py:282
+#: ./opengever/dossier/templatefolder/form.py:277
 msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:100
-#: ./opengever/dossier/templatefolder/form.py:73
+#: ./opengever/dossier/dossiertemplate/form.py:113
+#: ./opengever/dossier/templatefolder/form.py:74
 msgid "label_modified"
 msgstr ""
 
@@ -595,7 +605,7 @@ msgid "label_no_reference_number"
 msgstr ""
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:139
+#: ./opengever/dossier/behaviors/dossier.py:146
 msgid "label_number_of_containers"
 msgstr ""
 
@@ -620,7 +630,7 @@ msgid "label_participations"
 msgstr ""
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py:293
+#: ./opengever/dossier/templatefolder/form.py:288
 msgid "label_phonenumber"
 msgstr ""
 
@@ -640,24 +650,24 @@ msgid "label_proposals"
 msgstr ""
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py:84
+#: ./opengever/dossier/templatefolder/form.py:85
 msgid "label_recipient"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:181
+#: ./opengever/dossier/behaviors/dossier.py:188
 #: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:67
+#: ./opengever/dossier/viewlets/byline.py:71
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:152
+#: ./opengever/dossier/behaviors/dossier.py:159
 msgid "label_related_dossier"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:92
+#: ./opengever/dossier/behaviors/dossier.py:93
 #: ./opengever/dossier/browser/participants.py:169
 #: ./opengever/dossier/browser/report.py:35
 msgid "label_responsible"
@@ -689,7 +699,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:61
+#: ./opengever/dossier/viewlets/byline.py:65
 msgid "label_sequence_number"
 msgstr ""
 
@@ -699,14 +709,14 @@ msgid "label_show_note"
 msgstr ""
 
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:73
+#: ./opengever/dossier/behaviors/dossier.py:74
 #: ./opengever/dossier/browser/report.py:29
 msgid "label_start"
 msgstr ""
 
 #. Default: "from"
 #: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:49
+#: ./opengever/dossier/viewlets/byline.py:53
 msgid "label_start_byline"
 msgstr ""
 
@@ -726,15 +736,15 @@ msgid "label_tasktemplate_folders"
 msgstr ""
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:89
-#: ./opengever/dossier/templatefolder/form.py:61
+#: ./opengever/dossier/dossiertemplate/form.py:102
+#: ./opengever/dossier/templatefolder/form.py:62
 msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:94
-#: ./opengever/dossier/templatefolder/form.py:66
+#: ./opengever/dossier/dossiertemplate/form.py:107
+#: ./opengever/dossier/templatefolder/form.py:67
 msgid "label_title"
 msgstr ""
 
@@ -749,13 +759,13 @@ msgid "label_trash"
 msgstr ""
 
 #. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py:304
+#: ./opengever/dossier/templatefolder/form.py:299
 msgid "label_url"
 msgstr ""
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:43
+#: ./opengever/dossier/viewlets/byline.py:47
 msgid "label_workflow_state"
 msgstr ""
 
@@ -821,7 +831,7 @@ msgid "tasks"
 msgstr ""
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:123
+#: ./opengever/dossier/behaviors/dossier.py:130
 msgid "temporary_former_reference_number"
 msgstr ""
 

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -95,6 +95,26 @@ class TestDossierByline(TestBylineBase):
                           self.get_byline_value_by_label('Filing Number:'))
 
 
+class TestBusinessCaseDossierByline(TestDossierByline):
+
+    def create_dossier(self):
+        return create(Builder('dossier')
+                      .in_state('dossier-state-active')
+                      .having(reference_number_prefix='5',
+                              responsible='hugo.boss',
+                              start=date(2013, 11, 6),
+                              end=date(2013, 11, 7),
+                              external_reference='22900-2017'))
+
+    @browsing
+    def test_dossier_byline_external_reference_display(self, browser):
+        browser.login().open(self.dossier)
+
+        external_reference = self.get_byline_value_by_label(
+                'External Reference:')
+        self.assertEquals('22900-2017', external_reference.text)
+
+
 class TestFilingBusinessCaseByline(TestBylineBase):
 
     def setUp(self):

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -125,6 +125,17 @@ class TestIndexers(FunctionalTestCase):
             [u'1', u'3', 'client1', 'dossier', 'keyword', 'me', 'pick'],
             index_data_for(dossier_with_keywords).get('SearchableText'))
 
+    def test_dossier_searchable_text_contains_external_reference(self):
+        dossier = create(
+            Builder("dossier")
+            .titled(u"Dossier")
+            .having(external_reference=u'22900-2017')
+            .within(self.repo_folder))
+
+        self.assertItemsEqual(
+            [u'1', u'3', 'client1', 'dossier', '22900', '2017'],
+            index_data_for(dossier).get('SearchableText'))
+
     def test_dossiertemplate_searchable_text_contains_keywords(self):
         folder = create(Builder('templatefolder'))
         template_with_keywords = create(

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -148,6 +148,17 @@ class TestIndexers(FunctionalTestCase):
             [u'1', 'client1', 'dossiertemplate', 'keyword', 'thingy'],
             index_data_for(template_with_keywords).get('SearchableText'))
 
+    def test_external_reference(self):
+        dossier = create(
+            Builder("dossier")
+            .titled(u"Dossier")
+            .having(external_reference=u'qpr-900-9001-\xf7')
+            .within(self.repo_folder))
+
+        self.assertEquals(
+            u'qpr-900-9001-\xf7',
+            index_data_for(dossier).get('external_reference'))
+
 
 class TestFilingNumberIndexer(FunctionalTestCase):
 

--- a/opengever/dossier/viewlets/byline.py
+++ b/opengever/dossier/viewlets/byline.py
@@ -30,6 +30,9 @@ class BusinessCaseByline(BylineBase):
                                     ).get_email_for_object(self.context)
             return '<a href="mailto:%s">%s</a>' % (address, address)
 
+    def external_reference(self):
+        return IDossier(self.context).external_reference
+
     def get_items(self):
         items = [
             {
@@ -74,6 +77,13 @@ class BusinessCaseByline(BylineBase):
                 'label': _('label_email_address', default='E-Mail'),
                 'content': self.mailto_link(),
                 'replace': True
+            },
+            {
+                'class': 'external_reference',
+                'label': _('label_external_reference',
+                           default=u'External Reference'),
+                'content': self.external_reference(),
+                'replace': False
             }
         ]
 


### PR DESCRIPTION
Some institutions use an unambiguous reference field to find dossiers.
The composition of this field varies between the institutions using it
and therefore cannot be generated but is furnished by the user.

Overview of the made steps:
-  Zusätzliches TextLine Feld external_reference zum IDossier behavior hinzufügen.
-  Der Wert soll im SearchableText aufgenommen werden.
-  Darstelllung in der Byline falls Wert vorhanden
-  Update API Schema Docs using `bin/instange dump_schemas` and `bin/build-docs-public`
-  Update `README.rst`
-  Ein separater Index `external_reference` wurde hinzugefügt zum indexieren der `IDossier.external_reference` so wie `IDocumentMetadata.foreign_reference`. (Eine Abfrage ist vorerst nur via API oder GET-Parameter möglich. Siehe Screenshot in der Besprechung.)
- Tests für Volltextsuche so wie den `external_reference`-Index wurden hinzugefügt.

Resolves: #3080