### PR TITLE
Fixed bug in search when sorting on relevance.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]
+- Fixed bug in search when sorting on relevance. [phgross]
 - Fix encoding error when syncing proposals with SQL. [jone]
 - Remove "Properties"-action on personal overview. [elioschmutz]
 - Ungrok opengever.advancedsearch. [phgross]

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -113,12 +113,15 @@ class OpengeverSearch(Search):
             'range': usage
         }
 
-    def filter_query(self, query):
-        """The filter query of the standard search view (plone.app.search)
+    def _filter_query(self, query):
+        """The _filter_query of the standard search view (plone.app.search)
         cancel the query generation if not SearchableText is given.
         In some case (for example in opengever.advancedsearch), we generate
         also searches without a searchabletext. So we temporarily fake
         the SearchableText.
+
+        Besides that we also handle date range queries and subject queries
+        separately.
 
         XXX This method should be removed, after the solr integration
         meta-XXX should it? now it contains custom stuff.

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -37,6 +37,16 @@ class TestOpengeverSearch(FunctionalTestCase):
         self.assertEqual(25, len(browser.css('dl.searchResults dt')))
 
     @browsing
+    def test_sorting_on_relevance_is_handled_correctly(self, browser):
+        create(Builder('dossier').titled(u'Test A'))
+        create(Builder('dossier').titled(u'Test B'))
+
+        browser.login().open(self.portal, view='@@search?sort_on=relevance')
+
+        self.assertEqual(['Test A', 'Test B'],
+                         browser.css('.searchItem dt').text)
+
+    @browsing
     def test_no_bubmlebee_preview_rendered_when_feature_not_enabled(self, browser):
         browser.login().open(self.portal, view='search')
         self.assertEqual(0, len(browser.css('.searchImage')))


### PR DESCRIPTION
The filter_query, which is customized by GEVER to handle some query parameters separate, has been refactored in the plone release. The previous method `filter_query` has been renamed to `_filter_query` and the method `filter_query` is now a wrapper of the `_filter_query`
method. Therefore the fix is only a rename of our customized `filter_query` method (see https://github.com/plone/plone.app.search/pull/18).

I've also checked, if the customization is still necessary and it is (date range queries, subject queries, empty SearchableText handling)

Closes #3220