### PR TITLE
Update intelligenttext

### DIFF
--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -9,7 +9,6 @@ from plone import api
 from plone.app.testing import TEST_USER_ID
 from StringIO import StringIO
 import transaction
-import unittest
 
 
 class TestTaskOverview(FunctionalTestCase):
@@ -222,11 +221,6 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertEqual(expected, result)
 
-    @unittest.skip(
-        """Fails because we expect URLs which are embedded at the end of the
-        sentences should not contain the punctuation mark.
-        This is issued in
-        https://github.com/plone/plone.intelligenttext/issues/4""")
     @browsing
     def test_task_text_urls_in_sentences_are_transformed(self, browser):
         dossier = create(Builder('dossier').titled(u'Dossier'))
@@ -250,11 +244,6 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertEqual(expected, result)
 
-    @unittest.skip(
-        """Fails because we expect URLs which are embedded at the end of the
-        sentences should not contain the punctuation mark.
-        This is issued in
-        https://github.com/plone/plone.intelligenttext/issues/4""")
     @browsing
     def test_task_text_urls_with_get_arguments_in_sentences_are_transformed(
             self, browser):
@@ -287,11 +276,6 @@ class TestTaskOverview(FunctionalTestCase):
 
         self.assertEqual(expected, result)
 
-    @unittest.skip(
-        """Fails because we expect URLs which are embedded at the end of the
-        sentences should not contain the punctuation mark.
-        This is issued in
-        https://github.com/plone/plone.intelligenttext/issues/4""")
     @browsing
     def test_task_text_urls_with_anchors_in_sentences_are_transformed(
             self, browser):

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -66,7 +66,7 @@ class TestTaskOverview(FunctionalTestCase):
 
         browser.login().open(task, view='tabbedview_view-overview')
 
-        main_attributes_table = browser.css('#main_attributesBox .listing').first #noqa
+        main_attributes_table = browser.css('#main_attributesBox .listing').first  #noqa
         date_of_completion_row = main_attributes_table.lists()[-1]
         self.assertEquals(['Date of completion', 'Feb 02, 2015'],
                           date_of_completion_row)

--- a/versions.cfg
+++ b/versions.cfg
@@ -161,6 +161,7 @@ plone.app.transmogrifier = 1.4
 plone.app.versioningbehavior = 1.3.1
 plone.batching = 1.0.8
 plone.formwidget.autocomplete = 1.2.5
+plone.intelligenttext = 2.2.0
 plone.principalsource = 1.0
 plone.protect = 3.0.25
 plone.recipe.precompiler = 0.6


### PR DESCRIPTION
There was an improvement in `plone.intelligenttext` which allows to
unskip the previously skipped tests.
URLs which are embedded in sentences are now recognized and the
punctuation mark is split from the URL.

Resolves: #3229