### PR TITLE
Use original message when sending a mail as an attachement

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
+- Refactoring: Use mail get_file method to receive either the original_message or the message field. [elioschmutz]
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]
 - Fixed bug in search when sorting on relevance. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
+- Use get_file-method in send_document method to use original_message file data if available. [elioschmutz]
 - Refactoring: Add new method get_download_view_name for mail and documents. [elioschmutz]
 - Refactoring: Use mail get_file method to receive either the original_message or the message field. [elioschmutz]
 - Improve warning when opening an old version of a document. [tarnap]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
+- Refactoring: Add new method get_download_view_name for mail and documents. [elioschmutz]
 - Refactoring: Use mail get_file method to receive either the original_message or the message field. [elioschmutz]
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
+- Use get_download_view_name in oc_attach restapi view to download original_message file if available. [elioschmutz]
 - Use get_file-method in send_document method to use original_message file data if available. [elioschmutz]
 - Refactoring: Add new method get_download_view_name for mail and documents. [elioschmutz]
 - Refactoring: Use mail get_file method to receive either the original_message or the message field. [elioschmutz]

--- a/opengever/bumblebee/document.py
+++ b/opengever/bumblebee/document.py
@@ -27,20 +27,4 @@ class OGMailBumblebeeDocument(DXBumblebeeDocument):
     """
 
     def get_primary_field(self):
-        """An opengever mail has two fields for storing the mail-data.
-
-        - The primary-field contains the .eml file which is either a converted
-          version of a .msg-file or a directly uploaded .eml-file.
-
-        - The original_message-field contains the original .msg-file, but only
-          if the user uploaded one. This file will be used to generate the .eml-file
-          for the primary-field.
-
-        For the bumblebee-representation we want to use the original_message (.msg)
-        if available. Otherwise we just use the default implementation which
-        will return the primary-field. In our case, the .eml-file.
-        """
-        original_message = IOGMail(self.context).original_message
-        if original_message:
-            return original_message
-        return super(OGMailBumblebeeDocument, self).get_primary_field()
+        return self.context.get_file()

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -67,15 +67,10 @@ class ActionButtonRendererMixin(object):
         the donwload link. For mails, containing an original_message, the tag
         links to the orginal message download view.
         """
-
-        viewname = 'download'
-        if self.context.is_mail and IOGMail(self.context).original_message:
-            viewname = '@@download/original_message'
-
         dc_helper = DownloadConfirmationHelper(self.context)
         return dc_helper.get_html_tag(
             additional_classes=['function-download-copy'],
-            viewname=viewname,
+            viewname=self.context.get_download_view_name(),
             include_token=True,
         )
 

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -266,6 +266,9 @@ class Document(Item, BaseDocumentMixin):
             return self.file.filename
         return None
 
+    def get_download_view_name(self):
+        return 'download'
+
     security.declareProtected(webdav_unlock_items, 'UNLOCK')
 
     def UNLOCK(self, REQUEST, RESPONSE):

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -10,7 +10,6 @@ from opengever.document.browser.overview import FieldRow
 from opengever.document.browser.overview import Overview
 from opengever.document.browser.overview import TemplateRow
 from opengever.mail import _
-from opengever.mail.mail import IOGMail
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import instance
@@ -83,12 +82,7 @@ class OverviewTab(MailAttachmentsMixin, Overview):
 
     def __init__(self, *args, **kwargs):
         super(OverviewTab, self).__init__(*args, **kwargs)
-
-        self.ogmail = IOGMail(self.context)
-        if self.ogmail.original_message:
-            self.field = self.ogmail.original_message
-        else:
-            self.field = self.context.message
+        self.field = self.context.get_file()
 
     @property
     def file_size(self):

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -284,11 +284,7 @@ class SendDocumentForm(form.Form):
                 context=self.request))
 
         for obj in objs:
-
-            if IMail.providedBy(obj):
-                obj_file = obj.message
-            else:
-                obj_file = obj.file
+            obj_file = obj.get_file()
 
             if only_links or not obj_file:
                 # rewrite the url with current adminunit's public url

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -332,14 +332,23 @@ class OGMail(Mail, BaseDocumentMixin):
         self.message.filename = u'{}.eml'.format(normalized_subject)
 
     def get_file(self):
-        return self.message
+        """An opengever mail has two fields for storing the mail-data.
+
+        - The primary-field contains the .eml file which is either a converted
+          version of a .msg-file or a directly uploaded .eml-file.
+
+        - The original_message-field contains the original .msg-file, but only
+          if the user uploaded one. This file will be used to generate the .eml-file
+          for the primary-field.
+        """
+        return self.original_message or self.message
 
     def has_file(self):
         return self.message is not None
 
     def get_filename(self):
         if self.has_file():
-            return self.message.filename
+            return self.get_file().filename
         return None
 
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -351,6 +351,11 @@ class OGMail(Mail, BaseDocumentMixin):
             return self.get_file().filename
         return None
 
+    def get_download_view_name(self):
+        if self.original_message:
+            return '@@download/original_message'
+        return 'download'
+
 
 class OGMailBase(metadata.MetadataBase):
     """Behavior that adds a title field.

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -162,6 +162,18 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
         self.assertEquals(event.intids, map(intids.getId, documents))
 
     @browsing
+    def test_send_msg_if_there_is_a_original_message(self, browser):
+        dossier = create(Builder("dossier"))
+        mail = create(Builder("mail").within(dossier)
+                      .with_dummy_message()
+                      .with_dummy_original_message())
+
+        mail = self.send_documents(dossier, [mail])
+
+        self.assert_attachment(mail, 'dummy.msg', 'application/vnd.ms-outlook')
+
+
+    @browsing
     def test_sent_mail_gets_filed_in_dossier(self, browser):
         dossier = create(Builder("dossier"))
         document = create(Builder("document")

--- a/opengever/mail/zipexport.py
+++ b/opengever/mail/zipexport.py
@@ -1,25 +1,15 @@
+from ftw.zipexport.events import ItemZippedEvent
 from ftw.zipexport.representations import dexterity
-from opengever.mail.mail import IOGMail
 from opengever.mail.mail import IOGMailMarker
 from zope.component import adapts
-from zope.interface import Interface
-from ftw.zipexport.events import ItemZippedEvent
 from zope.event import notify
+from zope.interface import Interface
 
 
 class OGMailZipExport(dexterity.DexterityItemZipRepresentation):
     adapts(IOGMailMarker, Interface)
 
     def get_files(self, *args, **kwargs):
-        ogmail = IOGMail(self.context)
-        if ogmail.original_message:
-            notify(ItemZippedEvent(self.context))
-
-            yield self.get_file_tuple(ogmail.original_message,
-                                      kwargs.get('path_prefix', ''))
-
-        else:
-            for item in super(OGMailZipExport, self).get_files(
-                    *args, **kwargs):
-
-                yield item
+        notify(ItemZippedEvent(self.context))
+        yield self.get_file_tuple(self.context.get_file(),
+                                  kwargs.get('path_prefix', ''))

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -100,7 +100,7 @@ class OfficeConnectorPayload(Service):
                     'csrf-token': createToken(),
                     'document-url': document.absolute_url(),
                     'document': document,
-                    'download': 'download',
+                    'download': document.get_download_view_name(),
                     'filename': document.get_filename(),
                     }
                 )

--- a/opengever/officeconnector/tests/test_api.py
+++ b/opengever/officeconnector/tests/test_api.py
@@ -532,6 +532,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         data = response.json()[0]
         self.assertEqual('application/vnd.ms-outlook', data.get('content-type'))
         self.assertEqual('dummy.msg', data.get('filename'))
+        self.assertEqual('@@download/original_message', data.get('download'))
 
     def test_attach_mail_to_outlook_uses_message_if_no_original_message_is_available(self):
         mail = create(Builder('mail')
@@ -549,6 +550,7 @@ class TestOfficeconnectorAPI(FunctionalTestCase):
         data = response.json()[0]
         self.assertEqual('message/rfc822', data.get('content-type'))
         self.assertEqual('mail.eml', data.get('filename'))
+        self.assertEqual('download', data.get('download'))
 
     def test_document_checkout_url_without_file(self):
         self.enable_oc_checkout()


### PR DESCRIPTION
Dieser PR implementiert die `original_message` beim versenden einer E-Mail.

Zudem gibt es zwei commits mit einem Refactoring. Die Implementation für `original_message` wurde bereits mehrfach wiederholt. 

closes #3181 