### PR TITLE
Reindex is_subdossier-index after moving the dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 - Use get_file-method in send_document method to use original_message file data if available. [elioschmutz]
 - Refactoring: Add new method get_download_view_name for mail and documents. [elioschmutz]
 - Refactoring: Use mail get_file method to receive either the original_message or the message field. [elioschmutz]
+- Reindex is_subdossier-index after moving the dossier. [elioschmutz]
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]
 - Fixed bug in search when sorting on relevance. [phgross]

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -133,6 +133,13 @@ def reindex_containing_dossier(dossier, event):
                             sync_task(brain.getObject(), event)
 
 
+@grok.subscribe(IDossierMarker, IObjectMovedEvent)
+def reindex_is_subdossier(dossier, event):
+    """Reindex the is_subdossier index after the dossier have been moved.
+    """
+    dossier.reindexObject(idxs=['is_subdossier'])
+
+
 @grok.subscribe(IDossierMarker, IObjectCopiedEvent)
 def purge_reference_number_mappings(copied_dossier, event):
     """Reset the reference number mapping when copying (or actually pasting)

--- a/opengever/dossier/tests/test_catalog.py
+++ b/opengever/dossier/tests/test_catalog.py
@@ -1,5 +1,6 @@
 from opengever.dossier.interfaces import IDossierArchiver
 from opengever.testing import IntegrationTestCase
+from plone import api
 
 
 class TestCatalog(IntegrationTestCase):
@@ -12,6 +13,11 @@ class TestCatalog(IntegrationTestCase):
         self.assert_index_value(False, 'is_subdossier', self.dossier)
         self.assert_index_value(True, 'is_subdossier', self.subdossier)
         self.assert_index_value('', 'is_subdossier', self.leaf_repofolder)
+
+    def test_reindex_is_subdossier_index_after_moving_subdossier(self):
+        self.login(self.dossier_responsible)
+        api.content.move(source=self.subdossier, target=self.leaf_repofolder)
+        self.assert_index_value(False, 'is_subdossier', self.subdossier)
 
     def test_containing_dossier_index_and_metadata(self):
         """The ``containing_dossier`` index contains the title of the main


### PR DESCRIPTION
This PR reindexes the `is_subdossier` index after moving the dossier.

closes #3224 