### PR TITLE
Fix leaking reference in RestrictedVocabularyFactory

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.1 (unreleased)
 ---------------------
 
+- Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]
 - Fix encoding error when syncing proposals with SQL. [jone]

--- a/opengever/base/restricted_vocab.py
+++ b/opengever/base/restricted_vocab.py
@@ -61,10 +61,8 @@ class RestrictedVocabularyFactory(object):
         return self._choices
 
     def __call__(self, context):
-        self.context = context
-
         terms = []
-        for name in self.get_allowed_choice_names():
+        for name in self.get_allowed_choice_names(context):
             title = name
             if self.message_factory:
                 title = self.message_factory(name)
@@ -72,8 +70,8 @@ class RestrictedVocabularyFactory(object):
                 zope.schema.vocabulary.SimpleTerm(name, title=title))
         return zope.schema.vocabulary.SimpleVocabulary(terms)
 
-    def get_allowed_choice_names(self):
-        acquired_value = self._acquire_value()
+    def get_allowed_choice_names(self, context):
+        acquired_value = self._acquire_value(context)
 
         if not self.restricted:
             return self.choice_names
@@ -91,14 +89,13 @@ class RestrictedVocabularyFactory(object):
 
         return allowed_choice_names
 
-    def _acquire_value(self):
-        context = self.context
+    def _acquire_value(self, context):
         if isinstance(context, MetadataBase) or context is None:
             # we do not test the factory, it is not acquisition wrapped and
             # we cant get the request...
             return None
 
-        request = self.context.REQUEST
+        request = context.REQUEST
         if IDuringContentCreation.providedBy(request):
             # object does not yet exist, context is container (add)
             container = context


### PR DESCRIPTION
Pass `context` (received in `__call__`) to methods that require it instead of setting `self.context`. 

The `RestrictedVocabularyFactory` is instantiated and [kept as a module global](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/behaviors/classification.py#L147-L151). Than means setting `self.context` did keep a reference to a Plone object much longer than necessary, preventing it from being garbage collected.