### PR TITLE
Fix error in earliest_possible_end_date if there are date and datetime objects to process.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Word meeting: Replace excerpt generation with new word implementation. [jone]
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
+- Fix error in earliest_possible_end_date if there are date and datetime objects to process. [elioschmutz]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
 - Improve warning when opening an old version of a document. [tarnap]
 - Highlight search terms after fetching new search results per ajax. [elioschmutz]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -276,6 +276,8 @@ class DossierContainer(Container):
             dates.append(document_brain.document_date)
 
         dates = filter(None, dates)
+        dates = map(self._convert_to_date, dates)
+
         return max(dates) if dates else None
 
     def get_responsible_actor(self):
@@ -347,6 +349,13 @@ class DossierContainer(Container):
                 return entry.get('review_state')
 
         return None
+
+    def _convert_to_date(self, datetime_obj):
+        if isinstance(datetime_obj, datetime):
+            return datetime_obj.date()
+
+        # It is already a date-object
+        return datetime_obj
 
 
 class DefaultConstrainTypeDecider(grok.MultiAdapter):

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -314,3 +314,12 @@ class TestDateCalculations(IntegrationTestCase):
     def test_get_former_state_returns_none_for_dossiers_was_never_in_an_end_state(self):
         self.login(self.dossier_responsible)
         self.assertIsNone(self.dossier.get_former_state())
+
+    def test_earliest_possible_can_handle_datetime_objs(self):
+        self.login(self.dossier_responsible)
+
+        IDocumentMetadata(self.document).document_date = datetime(2020, 1, 1, 10, 10)
+        self.document.reindexObject(idxs=['document_date'])
+        IDossier(self.subdossier).end = date(2020, 2, 2)
+        self.subdossier.reindexObject(idxs=['end'])
+        self.assertEquals(date(2020, 2, 2), self.dossier.earliest_possible_end_date())


### PR DESCRIPTION
This PR fixes an issue in `earliest_possible_end_date` if there are `date` and `datetime` objects to compare.

closes #3238 