### PR TITLE
Fix remote wf changes without permission

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -20,6 +20,7 @@ Changelog
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
 - Fix error in earliest_possible_end_date if there are date and datetime objects to process. [elioschmutz]
+- Fix change workflow on remote tasks if the successor has no write-permission on the remote task does no longer fail with unauthorized. [elioschmutz]
 - Do no more send None as text while syncing tasks if there is no text. [elioschmutz]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
 - Use get_download_view_name in oc_attach restapi view to download original_message file if available. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -20,6 +20,7 @@ Changelog
 - Word meeting: Automatically checkin document when deciding an agenda item. [jone]
 - Word meeting: Update submitted proposal workflow: let group members checkout documents. [jone]
 - Fix error in earliest_possible_end_date if there are date and datetime objects to process. [elioschmutz]
+- Do no more send None as text while syncing tasks if there is no text. [elioschmutz]
 - Fix leaking reference in RestrictedVocabularyFactory. [lgraf]
 - Use get_download_view_name in oc_attach restapi view to download original_message file if available. [elioschmutz]
 - Use get_file-method in send_document method to use original_message file data if available. [elioschmutz]

--- a/opengever/task/response_syncer/__init__.py
+++ b/opengever/task/response_syncer/__init__.py
@@ -70,7 +70,7 @@ class BaseResponseSyncerSender(object):
 
     def sync_related_task(self, task, transition, text, **kwargs):
         payload = {'transition': transition,
-                   'text': safe_utf8(text)}
+                   'text': safe_utf8(text or '')}
         self.extend_payload(payload, task, **kwargs)
 
         response = self._dispatch_request(

--- a/opengever/task/response_syncer/workflow.py
+++ b/opengever/task/response_syncer/workflow.py
@@ -1,3 +1,4 @@
+from opengever.base.security import elevated_privileges
 from opengever.task import _
 from opengever.task.response_syncer import BaseResponseSyncerReceiver
 from opengever.task.response_syncer import BaseResponseSyncerSender
@@ -58,7 +59,8 @@ class WorkflowResponseSyncerReceiver(BaseResponseSyncerReceiver):
         before = wftool.getInfoFor(self.context, 'review_state')
         before = wftool.getTitleForStateOnType(before, self.context.Type())
 
-        wftool.doActionFor(self.context, transition)
+        with elevated_privileges():
+            wftool.doActionFor(self.context, transition)
 
         after = wftool.getInfoFor(self.context, 'review_state')
         after = wftool.getTitleForStateOnType(after, self.context.Type())


### PR DESCRIPTION
This PR fixes an issue where the user is not able to change the workflow-state of a remote task.

It is possible, that the task-successor wants to reassign or close a synced task. This action will end up in an unauthorized error if the successor has no write permission on the remote task.

To fix this issue, we give more access to the user while updating the workflow.

It seems, that this issue have always existed: https://github.com/4teamwork/opengever.core/pull/2828/commits/cd0bd98226bf89083e5428197a00d54774389eed#diff-10e13c62c57ce071c5f962b24d62b024L121

closes #3242 