### PR TITLE
Remove separate bumblebee fetch-views

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Fix typo in contact detail view. [elioschmutz]
 - Bundle import: Reduce memory high-water-mark by periodically re-setting the
   Plone site using setSite(), and garbage collecting the cPickleCache. [lgraf]
+- Remove separate bumblebee fetch-views since they are no longer necessary because we no longer use grok. [elioschmutz]
 - Bundle import: Also log progress and RSS during post-processing. [lgraf]
 - Word meeting: List excerpts per agenda item in meeting view. [jone]
 - Word meeting: Replace excerpt generation with new word implementation. [jone]

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -35,7 +35,7 @@ class BumblebeeGalleryMixin(object):
         return self._extract_base_view_name(self.__name__)
 
     def get_fetch_url(self):
-        return '{}/{}-fetch'.format(self.context.absolute_url(), self.__name__)
+        return '{}/{}/fetch'.format(self.context.absolute_url(), self.__name__)
 
     def available(self):
         return self.number_of_documents() > 0
@@ -95,41 +95,9 @@ class DocumentsGallery(BumblebeeGalleryMixin, Documents):
     """
 
 
-class DocumentsGalleryFetch(DocumentsGallery):
-    """Returns the next gallery-items.
-
-    Unfortunately it's not possible to use a traversable method with
-    five.grok-views. Therefore we have to register an own browserview
-    to fetch the next gallery-items.
-
-    This browserview can be removed and implemented with allowed-attributes as
-    soon as the parent views are registered as Zope 3 BrowserViews.
-    """
-    # XXX implement as and traversable method instead of a separate view.
-
-    def __call__(self):
-        return self.fetch()
-
-
 class MyDocumentsGallery(BumblebeeGalleryMixin, MyDocuments):
     """
     """
-
-
-class MyDocumentsGalleryFetch(MyDocumentsGallery):
-    """Returns the next gallery-items.
-
-    Unfortunately it's not possible to use a traversable method with
-    five.grok-views. Therefore we have to register an own browserview
-    to fetch the next gallery-items.
-
-    This browserview can be removed and implemented with allowed-attributes as
-    soon as the parent views are registered as Zope 3 BrowserViews.
-    """
-    # XXX implement as and traversable method instead of a separate view.
-
-    def __call__(self):
-        return self.fetch()
 
 
 class TrashGallery(BumblebeeGalleryMixin, Trash):
@@ -137,39 +105,6 @@ class TrashGallery(BumblebeeGalleryMixin, Trash):
     """
 
 
-class TrashGalleryFetch(TrashGallery):
-    """Returns the next gallery-items.
-
-    Unfortunately it's not possible to use a traversable method with
-    five.grok-views. Therefore we have to register an own browserview
-    to fetch the next gallery-items.
-
-    This browserview can be removed and implemented with allowed-attributes as
-    soon as the parent views are registered as Zope 3 BrowserViews.
-    """
-    # XXX implement as and traversable method instead of a separate view.
-
-    def __call__(self):
-        return self.fetch()
-
-
 class RelatedDocumentsGallery(BumblebeeGalleryMixin, RelatedDocuments):
     """
     """
-
-
-class RelatedDocumentsGalleryFetch(RelatedDocumentsGallery):
-    """Returns the next gallery-items.
-
-    Unfortunately it's not possible to use a traversable method with
-    five.grok-views. Therefore we have to register an own browserview
-    to fetch the next gallery-items.
-
-    This browserview can be removed and implemented with allowed-attributes as
-    soon as the parent views are registered as Zope 3 BrowserViews.
-    """
-
-    # XXX implement as and traversable method instead of a separate view.
-
-    def __call__(self):
-        return self.fetch()

--- a/opengever/tabbedview/browser/configure.zcml
+++ b/opengever/tabbedview/browser/configure.zcml
@@ -172,13 +172,7 @@
       name="tabbedview_view-documents-gallery"
       class=".bumblebee_gallery.DocumentsGallery"
       permission="zope2.View"
-      />
-
-  <browser:page
-      for="*"
-      name="tabbedview_view-documents-gallery-fetch"
-      class=".bumblebee_gallery.DocumentsGalleryFetch"
-      permission="zope2.View"
+      allowed_attributes="fetch"
       />
 
   <browser:page
@@ -186,13 +180,7 @@
       name="tabbedview_view-mydocuments-gallery"
       class=".bumblebee_gallery.MyDocumentsGallery"
       permission="zope2.View"
-      />
-
-  <browser:page
-      for="*"
-      name="tabbedview_view-mydocuments-gallery-fetch"
-      class=".bumblebee_gallery.MyDocumentsGalleryFetch"
-      permission="zope2.View"
+      allowed_attributes="fetch"
       />
 
   <browser:page
@@ -200,13 +188,7 @@
       name="tabbedview_view-trash-gallery"
       class=".bumblebee_gallery.TrashGallery"
       permission="zope2.View"
-      />
-
-  <browser:page
-      for="*"
-      name="tabbedview_view-trash-gallery-fetch"
-      class=".bumblebee_gallery.TrashGalleryFetch"
-      permission="zope2.View"
+      allowed_attributes="fetch"
       />
 
   <browser:page
@@ -214,13 +196,7 @@
       name="tabbedview_view-relateddocuments-gallery"
       class=".bumblebee_gallery.RelatedDocumentsGallery"
       permission="zope2.View"
-      />
-
-  <browser:page
-      for="*"
-      name="tabbedview_view-relateddocuments-gallery-fetch"
-      class=".bumblebee_gallery.RelatedDocumentsGalleryFetch"
-      permission="zope2.View"
+      allowed_attributes="fetch"
       />
 
   <browser:resourceDirectory

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -123,7 +123,7 @@ class TestBumblebeeGalleryMixinGetFetchUrl(FunctionalTestCase):
             (dossier, self.request), name=viewname)
 
         self.assertEqual(
-            'http://nohost/plone/dossier-1/tabbedview_view-documents-gallery-fetch',
+            'http://nohost/plone/dossier-1/tabbedview_view-documents-gallery/fetch',
             view.get_fetch_url())
 
         viewname = "tabbedview_view-mydocuments-gallery"
@@ -131,7 +131,7 @@ class TestBumblebeeGalleryMixinGetFetchUrl(FunctionalTestCase):
             (dossier, self.request), name=viewname)
 
         self.assertEqual(
-            'http://nohost/plone/dossier-1/tabbedview_view-mydocuments-gallery-fetch',
+            'http://nohost/plone/dossier-1/tabbedview_view-mydocuments-gallery/fetch',
             view.get_fetch_url())
 
 
@@ -435,7 +435,7 @@ class TestDocumentsGalleryFetch(FunctionalTestCase):
         create(Builder('document').within(dossier))
         create(Builder('document').within(dossier))
 
-        browser.login().visit(dossier, view="tabbedview_view-documents-gallery-fetch")
+        browser.login().visit(dossier, view="tabbedview_view-documents-gallery/fetch")
 
         self.assertEqual(
             3, len(browser.css('.imageContainer')))
@@ -451,7 +451,7 @@ class TestMyDocumentsGalleryFetch(FunctionalTestCase):
         create(Builder('document').within(dossier))
         create(Builder('document').within(dossier))
 
-        browser.login().visit(dossier, view="tabbedview_view-mydocuments-gallery-fetch")
+        browser.login().visit(dossier, view="tabbedview_view-mydocuments-gallery/fetch")
 
         self.assertEqual(
             3, len(browser.css('.imageContainer')))


### PR DESCRIPTION
Remove separate bumblebee fetch-views since they are no longer necessary because we no longer use grok.

see #3205 
