### PR TITLE
Word meeting: Improve edit-document-button behavior in meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - SPV word: merge multiple word files into one protocol. [deiferni]
 - Add add bumblebee gallery view for proposaltemplate. [elioschmutz]
+- Word meeting: Improve edit-document-button behavior in meeting view. [jone]
 - Bundle import: Also log progress and RSS during post-processing. [lgraf]
 - Word meeting: List excerpts per agenda item in meeting view. [jone]
 - Word meeting: Replace excerpt generation with new word implementation. [jone]

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -60,8 +60,8 @@
     {{#if ../editable}}
     <td class="actions">
       <div class="button-group">
-        {{#if edit_document_link}}
-        <a href="{{edit_document_link}}" title="%(label_edit_document_action)s" class="button edit-document" {{#unless edit_document_possible}}disabled{{/unless}}><span></span></a>
+        {{#if edit_proposal_document_button.visible}}
+        <a href="{{edit_proposal_document_button.url}}" title="%(label_edit_document_action)s" class="button edit-document" {{#unless edit_proposal_document_button.active}}disabled{{/unless}}><span></span></a>
         {{/if}}
         {{#if ../agendalist_editable}}
         <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>


### PR DESCRIPTION
This pull-request improves the behavior and appeareance of the
edit-document button in the meeting view. The button is available per agenda item. When clicked, the proposal document is checked out and opened with office connector.

New behavior of the button:
- ~~The button is available when the agenda item is in the "pending"
  state or in the "revision" state.~~
- The button is only visible when the user has the permission to edit the document.
- The button is active as long as I can checkout and edit.
- The button is inactive when the document is checkout out by somebody
  else in order to communicate to the user that he could edit the
  document if it wouldn't be checked out.

![bildschirmfoto 2017-08-09 um 10 18 05](https://user-images.githubusercontent.com/7469/29112036-d16fe95a-7cec-11e7-90a8-54dfd91ace7b.png)
![bildschirmfoto 2017-08-09 um 10 18 38](https://user-images.githubusercontent.com/7469/29112034-d1567254-7cec-11e7-8248-f90b1e08590d.png)
![bildschirmfoto 2017-08-09 um 10 19 07](https://user-images.githubusercontent.com/7469/29112035-d157ca82-7cec-11e7-9fe1-43dc59b33f3c.png)
