### PR TITLE
Fix a unicode error when creating proposals from a template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.4.1 (unreleased)
 ---------------------
 
+- SPV word: fix a unicode error when creating proposals from a template. [deiferni]
 - SPV word: merge multiple word files into one protocol. [deiferni]
 - Bundle import: Also log progress and RSS during post-processing. [lgraf]
 - Word meeting: List excerpts per agenda item in meeting view. [jone]

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -19,6 +19,7 @@ from plone.directives import dexterity
 from plone.directives.form import widget
 from plone.uuid.interfaces import IUUID
 from plone.z3cform.fieldsets.utils import move
+from Products.CMFPlone.utils import safe_unicode
 from z3c.form import field
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
 from z3c.form.interfaces import HIDDEN_MODE
@@ -101,7 +102,7 @@ def get_proposal_template_vocabulary(context):
         terms.append(SimpleVocabulary.createTerm(
             template,
             IUUID(template),
-            brain.Title))
+            safe_unicode(brain.Title)))
     return SimpleVocabulary(terms)
 
 

--- a/opengever/meeting/tests/test_proposal_template.py
+++ b/opengever/meeting/tests/test_proposal_template.py
@@ -24,7 +24,7 @@ class TestProposalTemplate(FunctionalTestCase):
         factoriesmenu.add('Proposal Template')
 
         browser.fill({
-            'Title': u'Baugesuch',
+            'Title': 'Baugesuch',
             'File': ('Binary Data', 'Baugesuch.docx', MIME_DOCX)}).save()
         statusmessages.assert_no_error_messages()
 
@@ -45,7 +45,7 @@ class TestProposalTemplate(FunctionalTestCase):
         factoriesmenu.add('Proposal Template')
 
         browser.fill({
-            'Title': u'Baugesuch',
+            'Title': u'Geb\xfchren',
             'File': ('DATA', 'Wrong.txt', 'text/plain')}).save()
         statusmessages.assert_message('There were some errors.')
         self.assertEquals(

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -21,7 +21,7 @@ class TestProposalWithWord(IntegrationTestCase):
         browser.fill(
             {'Title': u'Baugesuch Kreuzachkreisel',
              'Committee': u'Rechnungspr\xfcfungskommission',
-             'Proposal template': u'Baugesuch',
+             'Proposal template': u'Geb\xfchren',
              'Edit after creation': True}).save()
         statusmessages.assert_no_error_messages()
         self.assertIn('external_edit', browser.css('.redirector').first.text,

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -138,7 +138,7 @@ class OpengeverContentFixture(object):
         with self.features('meeting', 'word-meeting'):
             self.register('proposal_template', create(
                 Builder('proposaltemplate')
-                .titled(u'Baugesuch')
+                .titled(u'Geb\xfchren')
                 .attach_file_containing('Word Content', u'file.docx')
                 .within(templates)))
 


### PR DESCRIPTION
This PR fixes an issue when creating proposals from a template where the template has umlauts or other non-ascii chars in its title. The term title of the vocabulary used to enumerate the available was `utf8` but should have been decoded to unicode when read from the catalog.

Fixes #3261.