### PR TITLE
Ungrok opengever contact with TranslatedTitle-Forms

### DIFF
--- a/opengever/base/browser/translated_title.py
+++ b/opengever/base/browser/translated_title.py
@@ -1,9 +1,8 @@
 from opengever.base import _
 from opengever.base.behaviors.translated_title import TranslatedTitle
 from plone import api
-from plone.directives.dexterity import AddForm
-from plone.directives.dexterity import EditForm
-import martian
+from plone.dexterity.browser.add import DefaultAddForm
+from plone.dexterity.browser.edit import DefaultEditForm
 
 
 class TranslatedTitleFormMixin(object):
@@ -36,27 +35,23 @@ class TranslatedTitleFormMixin(object):
             self.widgets[fieldname].label = _(u"label_title", default=u"Title")
 
 
-class TranslatedTitleAddForm(AddForm, TranslatedTitleFormMixin):
-
-    martian.baseclass()
+class TranslatedTitleAddForm(DefaultAddForm, TranslatedTitleFormMixin):
 
     def updateFields(self):
-        super(AddForm, self).updateFields()
+        super(DefaultAddForm, self).updateFields()
         self.omit_non_active_language_fields()
 
     def updateWidgets(self):
-        super(AddForm, self).updateWidgets()
+        super(DefaultAddForm, self).updateWidgets()
         self.adjust_title_on_language_fields()
 
 
-class TranslatedTitleEditForm(EditForm, TranslatedTitleFormMixin):
-
-    martian.baseclass()
+class TranslatedTitleEditForm(DefaultEditForm, TranslatedTitleFormMixin):
 
     def updateFields(self):
-        super(EditForm, self).updateFields()
+        super(DefaultEditForm, self).updateFields()
         self.omit_non_active_language_fields()
 
     def updateWidgets(self):
-        super(EditForm, self).updateWidgets()
+        super(DefaultEditForm, self).updateWidgets()
         self.adjust_title_on_language_fields()

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -13,6 +13,14 @@
       />
 
   <browser:page
+      for="opengever.contact.contact.IContact"
+      name="contact_view"
+      class=".contact_view.View"
+      permission="zope2.View"
+      template="templates/contact_view.pt"
+      />
+
+  <browser:page
       name="tabbedview_view-local"
       for="plone.dexterity.interfaces.IDexterityContainer"
       class=".contacts_tab.Contacts"

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -160,4 +160,16 @@
       allowed_interface="opengever.contact.browser.mail.IMailAddressesActions"
       />
 
+  <adapter
+      factory=".contactfolder_forms.AddView"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      name="opengever.contact.contactfolder"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.contact.interfaces.IContactFolder"
+      class=".contactfolder_forms.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
 </configure>

--- a/opengever/contact/browser/contact_view.py
+++ b/opengever/contact/browser/contact_view.py
@@ -1,0 +1,6 @@
+from plone.dexterity.browser.view import DefaultView
+
+
+class View(DefaultView):
+    """
+    """

--- a/opengever/contact/browser/contactfolder_forms.py
+++ b/opengever/contact/browser/contactfolder_forms.py
@@ -1,0 +1,22 @@
+from opengever.base.browser.translated_title import TranslatedTitleAddForm
+from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class AddForm(TranslatedTitleAddForm):
+    """
+    """
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+    """
+    """

--- a/opengever/contact/browser/templates/contact_view.pt
+++ b/opengever/contact/browser/templates/contact_view.pt
@@ -21,7 +21,7 @@
         <table class="vertical invisible ">
           <tal:groups repeat="fieldsets python:view.groups">
             <tal:block repeat="widget fieldsets/widgets/values">
-              <tal:cond condition="widget/value">                
+              <tal:cond condition="widget/value">
                 <tr>
                   <tal:widget condition="python: widget.name not in ['form.widgets.email', 'form.widgets.email2', 'form.widgets.url']">
                       <th tal:content="widget/label" ></th>
@@ -30,7 +30,7 @@
                   <tal:widget condition="python: widget.name in ['form.widgets.email', 'form.widgets.email2']">
                       <th tal:content="widget/label" ></th>
                       <td>
-                          <a tal:attributes="href string: mailto:${widget/value}" tal:content="structure widget/render" /> 
+                          <a tal:attributes="href string: mailto:${widget/value}" tal:content="structure widget/render" />
                       </td>
                   </tal:widget>
                   <tal:widget condition="python: widget.name == 'form.widgets.url'">

--- a/opengever/contact/configure.zcml
+++ b/opengever/contact/configure.zcml
@@ -2,7 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
@@ -12,7 +11,6 @@
 
   <include file="permissions.zcml" />
 
-  <grok:grok package="." />
   <include package=".browser" />
 
   <i18n:registerTranslations directory="locales" />
@@ -32,8 +30,35 @@
       />
 
   <subscriber
-      for="opengever.contact.interfaces.IContactFolder            zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      for="opengever.contact.interfaces.IContactFolder
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
       handler=".handlers.configure_contactfolder_portlets"
+      />
+
+  <subscriber
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
+           zope.lifecycleevent.interfaces.IObjectCopiedEvent"
+      handler=".handlers.copy_participations"
+      />
+
+  <adapter
+      factory=".contact.contactid"
+      name="contactid"
+      />
+
+  <adapter
+      factory=".contact.phone_office"
+      name="phone_office"
+      />
+
+  <adapter
+      factory=".contact.firstname"
+      name="firstname"
+      />
+
+  <adapter
+      factory=".contact.lastname"
+      name="lastname"
       />
 
 </configure>

--- a/opengever/contact/contact.py
+++ b/opengever/contact/contact.py
@@ -1,11 +1,9 @@
 from collective import dexteritytextindexer
-from five import grok
 from opengever.contact import _
 from opengever.ogds.models import EMAIL_LENGTH
 from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
 from plone.dexterity.content import Item
-from plone.directives import dexterity
 from plone.directives import form
 from plone.indexer import indexer
 from plone.namedfile.field import NamedImage
@@ -197,28 +195,18 @@ class Contact(Item):
 @indexer(IContact)
 def contactid(obj):
     return obj.contactid
-grok.global_adapter(contactid, name='contactid')
 
 
 @indexer(IContact)
 def phone_office(obj):
     return obj.phone_office
-grok.global_adapter(phone_office, name='phone_office')
 
 
 @indexer(IContact)
 def firstname(obj):
     return obj.firstname
-grok.global_adapter(firstname, name='firstname')
 
 
 @indexer(IContact)
 def lastname(obj):
     return obj.lastname
-grok.global_adapter(lastname, name='lastname')
-
-
-class View(dexterity.DisplayForm):
-    grok.context(IContact)
-    grok.require('zope2.View')
-    grok.name('contact_view')

--- a/opengever/contact/contactfolder.py
+++ b/opengever/contact/contactfolder.py
@@ -1,7 +1,4 @@
-from five import grok
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
-from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Contact
 from plone.dexterity.content import Container
@@ -38,11 +35,3 @@ class ContactFolder(Container, TranslatedTitleMixin):
         if default is _marker:
             raise KeyError(id_)
         return default
-
-
-class ContactFolderAddForm(TranslatedTitleAddForm):
-    grok.name('opengever.contact.contactfolder')
-
-
-class ContactFolderEditForm(TranslatedTitleEditForm):
-    grok.context(IContactFolder)

--- a/opengever/contact/handlers.py
+++ b/opengever/contact/handlers.py
@@ -1,12 +1,8 @@
-from five import grok
 from opengever.base.model import create_session
 from opengever.base.portlets import block_context_portlet_inheritance
 from opengever.contact.models import Participation
-from opengever.dossier.behaviors.dossier import IDossierMarker
-from zope.lifecycleevent.interfaces import IObjectCopiedEvent
 
 
-@grok.subscribe(IDossierMarker, IObjectCopiedEvent)
 def copy_participations(copied_dossier, event):
     """Make sure that participations are copied as well when copying a dossier.
     """

--- a/opengever/dossier/templatefolder/configure.zcml
+++ b/opengever/dossier/templatefolder/configure.zcml
@@ -66,6 +66,19 @@
       permission="zope2.View"
       />
 
+  <adapter
+      name="opengever.dossier.templatefolder"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".templatefolder.AddView"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.dossier.templatefolder.ITemplateFolder"
+      class=".templatefolder.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
   <subscriber
       for="opengever.dossier.templatefolder.ITemplateFolder
            zope.lifecycleevent.interfaces.IObjectAddedEvent"

--- a/opengever/dossier/templatefolder/templatefolder.py
+++ b/opengever/dossier/templatefolder/templatefolder.py
@@ -1,6 +1,5 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from five import grok
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
 from opengever.base.browser.translated_title import TranslatedTitleEditForm
@@ -8,15 +7,27 @@ from opengever.dossier.dossiertemplate import is_dossier_template_feature_enable
 from opengever.dossier.templatefolder import ITemplateFolder
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import is_word_meeting_implementation_enabled
+from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.content import Container
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
-class TemplateFolderAddForm(TranslatedTitleAddForm):
-    grok.name('opengever.dossier.templatefolder')
+class AddForm(TranslatedTitleAddForm):
+    """
+    """
 
 
-class TemplateFolderEditForm(TranslatedTitleEditForm):
-    grok.context(ITemplateFolder)
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+    """
+    """
 
 
 class TemplateFolder(Container, TranslatedTitleMixin):

--- a/opengever/inbox/browser/configure.zcml
+++ b/opengever/inbox/browser/configure.zcml
@@ -54,4 +54,30 @@
       permission="zope2.View"
       />
 
+  <adapter
+      name="opengever.inbox.container"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".inboxcontainer_forms.AddView"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.inbox.container.IInboxContainer"
+      class=".inboxcontainer_forms.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <adapter
+      name="opengever.inbox.inbox"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".inbox_forms.AddView"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.inbox.inbox.IInbox"
+      class=".inbox_forms.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/inbox/browser/inbox_forms.py
+++ b/opengever/inbox/browser/inbox_forms.py
@@ -1,0 +1,22 @@
+from opengever.base.browser.translated_title import TranslatedTitleAddForm
+from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class AddForm(TranslatedTitleAddForm):
+    """
+    """
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+    """
+    """

--- a/opengever/inbox/browser/inboxcontainer_forms.py
+++ b/opengever/inbox/browser/inboxcontainer_forms.py
@@ -1,0 +1,22 @@
+from opengever.base.browser.translated_title import TranslatedTitleAddForm
+from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class AddForm(TranslatedTitleAddForm):
+    """
+    """
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+    """
+    """

--- a/opengever/inbox/container.py
+++ b/opengever/inbox/container.py
@@ -1,7 +1,4 @@
-from five import grok
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
-from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.ogds.base.utils import get_current_org_unit
 from plone.dexterity.content import Container
 from plone.directives import form
@@ -10,14 +7,6 @@ from plone.directives import form
 class IInboxContainer(form.Schema):
     """Base schema for a the inbox container.
     """
-
-
-class InboxContainerAddForm(TranslatedTitleAddForm):
-    grok.name('opengever.inbox.container')
-
-
-class InboxContainerEditForm(TranslatedTitleEditForm):
-    grok.context(IInboxContainer)
 
 
 class InboxContainer(Container, TranslatedTitleMixin):

--- a/opengever/inbox/inbox.py
+++ b/opengever/inbox/inbox.py
@@ -1,8 +1,5 @@
-from five import grok
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
-from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.inbox import _
 from opengever.ogds.base.utils import ogds_service
 from opengever.repository.behaviors.responsibleorg import IResponsibleOrgUnit
@@ -26,14 +23,6 @@ class IInbox(form.Schema, ITabbedviewUploadable):
         description=_(u'help_inbox_group', default=u''),
         required=False,
     )
-
-
-class InboxAddForm(TranslatedTitleAddForm):
-    grok.name('opengever.inbox.inbox')
-
-
-class InboxEditForm(TranslatedTitleEditForm):
-    grok.context(IInbox)
 
 
 class Inbox(Container, TranslatedTitleMixin):

--- a/opengever/meeting/browser/committeecontainer_forms.py
+++ b/opengever/meeting/browser/committeecontainer_forms.py
@@ -1,0 +1,22 @@
+from opengever.base.browser.translated_title import TranslatedTitleAddForm
+from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class AddForm(TranslatedTitleAddForm):
+    """
+    """
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+    """
+    """

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -197,4 +197,16 @@
       permission="zope2.View"
       />
 
+  <adapter
+      name="opengever.meeting.committeecontainer"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".committeecontainer_forms.AddView"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.meeting.committeecontainer.ICommitteeContainer"
+      class=".committeecontainer_forms.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
 </configure>

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,7 +1,4 @@
-from five import grok
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
-from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.meeting import _
 from opengever.meeting.model import Member
 from opengever.meeting.sources import sablon_template_source
@@ -40,14 +37,6 @@ class ICommitteeContainer(form.Schema):
         source=sablon_template_source,
         required=False,
     )
-
-
-class CommitteeContainerAddForm(TranslatedTitleAddForm):
-    grok.name('opengever.meeting.committeecontainer')
-
-
-class CommitteeContainerEditForm(TranslatedTitleEditForm):
-    grok.context(ICommitteeContainer)
 
 
 _marker = object()

--- a/opengever/repository/browser/configure.zcml
+++ b/opengever/repository/browser/configure.zcml
@@ -27,4 +27,30 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter
+      factory=".repositoryroot_forms.AddView"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      name="opengever.repository.repositoryroot"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.repository.repositoryroot.IRepositoryRoot"
+      class=".repositoryroot_forms.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <adapter
+      factory=".repositoryfolder_forms.AddView"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      name="opengever.repository.repositoryfolder"
+      />
+
+  <browser:page
+      name="edit"
+      for="opengever.repository.repositoryfolder.IRepositoryFolder"
+      class=".repositoryfolder_forms.EditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/repository/browser/repositoryfolder_forms.py
+++ b/opengever/repository/browser/repositoryfolder_forms.py
@@ -1,0 +1,53 @@
+from opengever.base.behaviors.utils import hide_fields_from_behavior
+from opengever.base.browser.translated_title import TranslatedTitleAddForm
+from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.repository import _
+from plone import api
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class AddForm(TranslatedTitleAddForm):
+
+    def render(self):
+        if self.contains_dossiers():
+            msg = _('msg_leafnode_warning',
+                    default=u'You are adding a repositoryfolder to a leafnode '
+                    'which already contains dossiers. This is only '
+                    'temporarily allowed and all dossiers must be moved into '
+                    'a new leafnode afterwards.')
+
+            api.portal.show_message(
+                msg, request=self.request, type='warning')
+
+        return super(AddForm, self).render()
+
+    def contains_dossiers(self):
+        dossiers = api.content.find(context=self.context,
+                                    depth=1,
+                                    object_provides=IDossierMarker)
+        return bool(dossiers)
+
+    def updateFields(self):
+        super(AddForm, self).updateFields()
+        hide_fields_from_behavior(self,
+                                  ['IClassification.public_trial',
+                                   'IClassification.public_trial_statement'])
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+
+    def updateFields(self):
+        super(EditForm, self).updateFields()
+        hide_fields_from_behavior(self,
+                                  ['IClassification.public_trial',
+                                   'IClassification.public_trial_statement'])

--- a/opengever/repository/browser/repositoryroot_forms.py
+++ b/opengever/repository/browser/repositoryroot_forms.py
@@ -1,0 +1,22 @@
+from opengever.base.browser.translated_title import TranslatedTitleAddForm
+from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import adapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class AddForm(TranslatedTitleAddForm):
+    """
+    """
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class AddView(DefaultAddView):
+    form = AddForm
+
+
+class EditForm(TranslatedTitleEditForm):
+    """
+    """

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -1,14 +1,9 @@
 from five import grok
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.behaviors.translated_title import ITranslatedTitle
-from opengever.base.behaviors.utils import hide_fields_from_behavior
-from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.base.interfaces import IReferenceNumber
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.repository import _
 from opengever.repository.interfaces import IRepositoryFolder
-from plone import api
 from plone.app.content.interfaces import INameFromTitle
 from plone.dexterity import content
 from plone.directives import form
@@ -135,45 +130,6 @@ class RepositoryFolder(content.Container):
             if obj.portal_type == self.portal_type:
                 return False
         return True
-
-
-class AddForm(TranslatedTitleAddForm):
-    grok.name('opengever.repository.repositoryfolder')
-
-    def render(self):
-        if self.contains_dossiers():
-            msg = _('msg_leafnode_warning',
-                    default=u'You are adding a repositoryfolder to a leafnode '
-                    'which already contains dossiers. This is only '
-                    'temporarily allowed and all dossiers must be moved into '
-                    'a new leafnode afterwards.')
-
-            api.portal.show_message(
-                msg, request=self.request, type='warning')
-
-        return super(AddForm, self).render()
-
-    def contains_dossiers(self):
-        dossiers = api.content.find(context=self.context,
-                                    depth=1,
-                                    object_provides=IDossierMarker)
-        return bool(dossiers)
-
-    def updateFields(self):
-        super(AddForm, self).updateFields()
-        hide_fields_from_behavior(self,
-                                  ['IClassification.public_trial',
-                                   'IClassification.public_trial_statement'])
-
-
-class EditForm(TranslatedTitleEditForm):
-    grok.context(IRepositoryFolder)
-
-    def updateFields(self):
-        super(EditForm, self).updateFields()
-        hide_fields_from_behavior(self,
-                                  ['IClassification.public_trial',
-                                   'IClassification.public_trial_statement'])
 
 
 class NameFromTitle(grok.Adapter):

--- a/opengever/repository/repositoryroot.py
+++ b/opengever/repository/repositoryroot.py
@@ -1,8 +1,6 @@
 from five import grok
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
-from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.repository import _
 from plone.app.content.interfaces import INameFromTitle
 from plone.dexterity.content import Container
@@ -39,14 +37,6 @@ class RepositoryRoot(Container, TranslatedTitleMixin):
     """
 
     Title = TranslatedTitleMixin.Title
-
-
-class RepositoryRootAddForm(TranslatedTitleAddForm):
-    grok.name('opengever.repository.repositoryroot')
-
-
-class RepositoryRootEditForm(TranslatedTitleEditForm):
-    grok.context(IRepositoryRoot)
 
 
 def zero_fill(matchobj):


### PR DESCRIPTION
This PR ungroks `opengever.contact`.

Because of dependencies, I had to ungrok all the TranslatedTitle-Forms, too.

related to #3205 
