### PR TITLE
Bundle Import: Reduce memory footprint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,8 @@ Changelog
 - Add add bumblebee gallery view for proposaltemplate. [elioschmutz]
 - Word meeting: Improve edit-document-button behavior in meeting view. [jone]
 - Fix typo in contact detail view. [elioschmutz]
+- Bundle import: Reduce memory high-water-mark by periodically re-setting the
+  Plone site using setSite(), and garbage collecting the cPickleCache. [lgraf]
 - Bundle import: Also log progress and RSS during post-processing. [lgraf]
 - Word meeting: List excerpts per agenda item in meeting view. [jone]
 - Word meeting: Replace excerpt generation with new word implementation. [jone]

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -7,6 +7,7 @@ pipeline =
     resolveguid
     disabled-catalog-indexing
     disabled-initial-version
+    garbage-collect
     constructor
     resolvetree
     fileinserter
@@ -41,6 +42,10 @@ blueprint = opengever.bundle.disabled_indexing
 
 [resolveguid]
 blueprint = opengever.bundle.resolveguid
+
+[garbage-collect]
+blueprint = opengever.bundle.garbage_collect
+every = 100
 
 [constructor]
 blueprint = opengever.bundle.constructor

--- a/opengever/bundle/sections/garbage_collect.py
+++ b/opengever/bundle/sections/garbage_collect.py
@@ -1,0 +1,49 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from zope.component.hooks import setSite
+from zope.interface import classProvides
+from zope.interface import implements
+import gc
+
+
+def garbage_collect(transmogrifier):
+    # In order to get rid of leaking references, the Plone site needs to be
+    # re-set in regular intervals using the setSite() hook. This reassigns
+    # it to the SiteInfo() module global in zope.component.hooks, and
+    # therefore allows the Python garbage collector to cut loose references
+    # it was previously holding on to.
+    setSite(transmogrifier.context)
+
+    # Trigger garbage collection for the cPickleCache
+    transmogrifier.context._p_jar.cacheGC()
+
+    # Also trigger Python garbage collection.
+    gc.collect()
+
+    # (These two don't seem to affect the memory high-water-mark,
+    # but result in a more stable / predictable growth over time.
+    #
+    # But should this cause problems at some point, it's safe
+    # to remove these without affecting the max memory consumed.)
+
+
+class GarbageCollectSection(object):
+    """Section used to facilitate regular garbage collection.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.transmogrifier = transmogrifier
+        self.every = int(options.get('every', 100))
+        self.previous = previous
+
+    def __iter__(self):
+        count = 0
+        for item in self.previous:
+            count = (count + 1) % self.every
+            if count == 0:
+                garbage_collect(self.transmogrifier)
+
+            yield item

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -29,6 +29,11 @@
       />
 
   <utility
+      component=".sections.garbage_collect.GarbageCollectSection"
+      name="opengever.bundle.garbage_collect"
+      />
+
+  <utility
       component=".sections.constructor.ConstructorSection"
       name="opengever.bundle.constructor"
       />


### PR DESCRIPTION
These changes aim to reduce the memory (RSS) footprint of a bundle import, particularly the high-water-mark.

While I was able to clean up some leaking references in earlier pull requests (x, y), that wasn't enough to significantly bring down max. memory usage.

At some point I discovered that re-setting the Plone site using the `getSite()` hook finally manages to get rid of those leaking references, and allows the Python garbage collector to do its job. In addition, the `cPickleCache` also needs to be garbage collected periodically.

So, in regular intervals the following things need to happen:

- Creating transaction savepoints
- Re-setting the Plone site using setSite()
- Garbage collecting the cPickleCache
- Python garbage collection (optional, doesn't effect high-water-mark)


I can't yet say what exact impact the interval has, and whether this is the optimal order, but at least the first three need to happen in order to get a significant reduction in the memory high-water-mark.

![memory](https://user-images.githubusercontent.com/405124/29180571-79beb468-7df8-11e7-8909-84e7d0621122.png)


