### PR TITLE
Fixture: improve documentation and assert readme updated.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -481,36 +481,36 @@ Objects
 
 .. code::
 
-  - self.templates
-    - self.proposal_template
-    - self.sablon_template
+  - self.committee_container
+    - self.committee
+      - self.meeting
+      - self.submitted_proposal
+      - self.submitted_word_proposal
+    - self.empty_committee
   - self.repository_root
     - self.branch_repofolder
       - self.leaf_repofolder
         - self.archive_dossier
-        - self.meeting_dossier
         - self.dossier
-          - self.mail_msg
-          - self.mail_eml
           - self.document
-          - self.proposal
-          - self.task
-            - self.taskdocument
-            - self.subtask
-          - self.word_proposal
           - self.draft_proposal
           - self.draft_word_proposal
-          - self.subdossier2
+          - self.mail_eml
+          - self.mail_msg
+          - self.proposal
           - self.subdossier
             - self.subdocument
+          - self.subdossier2
+          - self.task
+            - self.subtask
+            - self.taskdocument
+          - self.word_proposal
         - self.empty_dossier
+        - self.meeting_dossier
     - self.empty_repofolder
-  - self.committee_container
-    - self.empty_committee
-    - self.committee
-      - self.meeting
-      - self.submitted_word_proposal
-      - self.submitted_proposal
+  - self.templates
+    - self.proposal_template
+    - self.sablon_template
 
 .. </fixture:objects>
 

--- a/README.rst
+++ b/README.rst
@@ -481,36 +481,36 @@ Objects
 
 .. code::
 
-  - self.meeting
   - self.templates
     - self.proposal_template
     - self.sablon_template
   - self.repository_root
-    - self.empty_repofolder
     - self.branch_repofolder
       - self.leaf_repofolder
-        - self.meeting_dossier
         - self.archive_dossier
-        - self.empty_dossier
+        - self.meeting_dossier
         - self.dossier
+          - self.mail_msg
+          - self.mail_eml
+          - self.document
+          - self.proposal
           - self.task
             - self.taskdocument
             - self.subtask
-          - self.mail_eml
-          - self.mail_msg
+          - self.word_proposal
           - self.draft_proposal
+          - self.draft_word_proposal
+          - self.subdossier2
           - self.subdossier
             - self.subdocument
-          - self.subdossier2
-          - self.draft_word_proposal
-          - self.proposal
-          - self.word_proposal
-          - self.document
-  - self.submitted_word_proposal
-  - self.submitted_proposal
+        - self.empty_dossier
+    - self.empty_repofolder
   - self.committee_container
     - self.empty_committee
     - self.committee
+      - self.meeting
+      - self.submitted_word_proposal
+      - self.submitted_proposal
 
 .. </fixture:objects>
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -373,6 +373,9 @@ class OpengeverContentFixture(object):
     def register_path(self, attrname, path):
         """Add an object to the lookup table by path.
         """
+        portal_path = '/'.join(api.portal.get().getPhysicalPath())
+        if path.startswith(portal_path):
+            path = path[len(portal_path):].lstrip('/')
         self._lookup_table[attrname] = ('object', path)
 
     def register_raw(self, attrname, value):

--- a/opengever/testing/tests/test_dump_fixture_structure.py
+++ b/opengever/testing/tests/test_dump_fixture_structure.py
@@ -39,8 +39,12 @@ class TestDumpFixtureStrutureToReadme(IntegrationTestCase):
                                   level=1)))
 
         md5_after = self._readme_md5()
-        self.assertEquals(md5_before, md5_after,
-                          'Fixture has changed and readme was not updated.')
+        self.assertEquals(
+            md5_before, md5_after,
+            'Fixture has changed and readme was not updated.\n'
+            'run:\n'
+            ' $ bin/test -t TestDumpFixtureStrutureToReadme\n'
+            'then commit the changes in the README.rst.')
 
     def _build_tree(self, name_to_path):
         nodes_by_path = {path: {'name': name, 'children': []}

--- a/opengever/testing/tests/test_dump_fixture_structure.py
+++ b/opengever/testing/tests/test_dump_fixture_structure.py
@@ -1,4 +1,5 @@
 from opengever.testing import IntegrationTestCase
+from operator import itemgetter
 from path import Path
 import hashlib
 import os.path
@@ -61,7 +62,7 @@ class TestDumpFixtureStrutureToReadme(IntegrationTestCase):
     def _render_tree(self, nodes, level=0):
         lines = []
         indent = ' ' * 2 * level
-        for node in nodes:
+        for node in sorted(nodes, key=itemgetter('name')):
             lines.append('{}- self.{}'.format(indent, node['name']))
             lines.extend(self._render_tree(node['children'], level=level+1))
         return lines


### PR DESCRIPTION
1) Fix the tree in the fixture documentation, so that it works with real Plone objects as well as SQL wrappers. The problem was that some were prefixed with the Plone site path, others were relative to the Plone site. Since the IntegrationTestCase traverses on the Plone site it is correct to make all paths relative to the Plone site.

2) Let the test fail if the readme was udpated when running the test. This does only fail once and then leave an uncommitted, changed readme behind, which must be committed be the developer. On the CI-server it will fail when a PR changes the fixture but misses the readme update.

<img width="1147" alt="bildschirmfoto 2017-08-14 um 10 06 12" src="https://user-images.githubusercontent.com/7469/29263406-e1949534-80d8-11e7-9923-795720ea6465.png">
