### PR TITLE
Disable ExtJS in integration testing.

### DIFF
--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -30,6 +30,7 @@ FEATURE_FLAGS = {
                         '.interfaces.IDossierTemplateSettings.is_feature_enabled'),
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',
     'ech0147-import': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_import_enabled',
+    'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
 }
 
 FEATURE_PROFILES = {
@@ -45,6 +46,7 @@ class IntegrationTestCase(TestCase):
         super(IntegrationTestCase, self).setUp()
         self.portal = self.layer['portal']
         self.request = self.layer['request']
+        self.deactivate_extjs()
         map(self.activate_feature, self.features)
 
     @staticmethod
@@ -130,6 +132,17 @@ class IntegrationTestCase(TestCase):
                      for (name, value) in browser_auth_headers]
 
         return login_context_manager()
+
+    def deactivate_extjs(self):
+        """ExtJS is JavaScript and therefore currently untestable with
+        ftw.testbrowser.
+        In order to test listing tabs, we disable ExtJS in tests by default.
+        It can be reactivated by activating the fature "extjs":
+
+        >>> self.activate_feature('extjs')
+        """
+        api.portal.set_registry_record(
+            'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled', False)
 
     def activate_feature(self, feature):
         """Activate a feature flag.

--- a/opengever/testing/tests/test_integration_test_case.py
+++ b/opengever/testing/tests/test_integration_test_case.py
@@ -87,3 +87,21 @@ class TestIntegrationTestCase(IntegrationTestCase):
                                 self.dossier, self.subdossier)
         self.assert_workflow_state('dossier-state-inactive', self.dossier)
         self.assert_workflow_state('dossier-state-inactive', self.subdossier)
+
+    def test_extjs_is_disabled_by_default(self):
+        """ExtJS is disabled by default in the integration test case,
+        so that tabbedview listings render the table as simple HTML,
+        which is testable with the testbrowser.
+        """
+        self.assertFalse(api.portal.get_registry_record(
+            'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled'))
+
+    def test_extjs_can_be_enabled_as_feature(self):
+        """In order for actually testing ExtJS behavior, ExtJS can be enabled
+        like a feature.
+        """
+        self.assertFalse(api.portal.get_registry_record(
+            'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled'))
+        self.activate_feature('extjs')
+        self.assertTrue(api.portal.get_registry_record(
+            'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled'))


### PR DESCRIPTION
ExtJS is implemented in JavaScript, but ftw.testbrowser does not support JavaScript.
In order to test listing tabs anyway, ExtJS is deactivated for integration tests so that ftw.tabbedview renders a simple table, which is testable with ftw.testbrowser.
ExtJS is also deactivated in functional testing, so this will behave the same.