### PR TITLE
Add bin/test-cached helper script to execute a chached test-run.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -776,6 +776,12 @@ You can enable the feature by setting an environment variable:
 
     GEVER_CACHE_TEST_DB=true bin/test -m opengever.dossier.tests.test_activate
 
+There is also a binary which does that for you for just one run for convenience:
+
+.. code:: sh
+
+    bin/test-cached -m opengever.dossier.tests.test_activate
+
 You can manually remove / rebuild the caches:
 
 .. code:: sh

--- a/development.cfg
+++ b/development.cfg
@@ -12,6 +12,7 @@ ogds-db-name = opengever
 
 development-parts +=
     ${buildout:sphinx-parts}
+    test-cached
 
 # this re-adds parts that would be dropped otherwise since buildout cannot really deal
 # with our complicated inheritance hierarchy
@@ -50,3 +51,11 @@ recipe = collective.recipe.cmd
 on_install=true
 on_update=true
 cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build
+
+[test-cached]
+recipe = collective.recipe.template
+output = ${buildout:directory}/bin/test-cached
+mode = 0755
+input = inline:
+    #!/usr/bin/env sh
+    GEVER_CACHE_TEST_DB=true bin/test "$@"

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Add bin/test-cached helper script to execute a chached test-run. [deiferni]
 - Ungrok opengever.ogds.base [lgraf]
 - Add external_reference field and index [tarnap]
 - Show mimetype-icon of proposaltemplate in bumblebee-listing. [elioschmutz]


### PR DESCRIPTION
This PR adds a simple wrapper script to enable cached testing on a per test-run basis. Motivation:

- i always forget the env-variable name and have to spend time figuring it out again 😢 
- i'd like to have access to a script that just remembers the name for me in an auto-completable, quick way

objections/suggestions?