### PR TITLE
Filter results from disabled orgunits.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Filter results for disabled OrgUnits in all sources. [mathias.leimgruber]
 - Ungrok opengever.latex. [elioschmutz]
 - Add bin/test-cached helper script to execute a chached test-run. [deiferni]
 - Ungrok opengever.ogds.base [lgraf]

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -164,7 +164,8 @@ class TestSearchWithoutContent(FunctionalTestCase):
     def test_validate_searchstring_for_dossiers(self, browser):
         create(Builder('ogds_user')
                .having(firstname='Foo', lastname='Boss',
-                       userid='foo@example.com'))
+                       userid='foo@example.com')
+               .assign_to_org_units([self.org_unit]))
 
         browser.login().open(view='advanced_search')
         browser.fill({'form.widgets.searchableText': "dossier1",

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -53,7 +53,7 @@ class AllUsersAndInboxesSource(object):
         query = create_session().query(*models) \
                                 .join(OrgUnit.users_group) \
                                 .join(Group.users)
-        query = query.filter(OrgUnit.enabled)
+        query = query.filter(OrgUnit.enabled == True)
 
         if self.only_current_orgunit:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -165,7 +165,7 @@ class AllUsersAndInboxesSource(object):
                               text_filters)
 
         query = OrgUnit.query
-        query = query.filter(OrgUnit.enabled)
+        query = query.filter(OrgUnit.enabled == True)
 
         if self.only_current_inbox:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -386,7 +386,7 @@ class AssignedUsersSource(AllUsersSource):
             .filter(User.userid == groups_users.columns.userid) \
             .filter(groups_users.columns.groupid == OrgUnit.users_group_id) \
             .filter(OrgUnit.admin_unit_id == admin_unit.unit_id) \
-            .filter(OrgUnit.enabled)
+            .filter(OrgUnit.enabled == True)
 
 
 @implementer(IContextSourceBinder)

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -36,8 +36,21 @@ class AllUsersAndInboxesSource(object):
         self.only_current_inbox = kwargs.get('only_current_inbox', False)
 
     @property
+    def only_users(self):
+        return False
+
+    @property
     def base_query(self):
-        query = create_session().query(User, OrgUnit) \
+        """A base query which joins the user and orgunits together and also
+        filters the query based on some options:
+            - only_users: Decide if only the user model will be returned
+            - only_current_orgunit: Decide if only the current Orgunit will
+              be queried.
+
+        The base_query also filtes results from disabled orgunits by default.
+        """
+        models = (User, ) if self.only_users else (User, OrgUnit)
+        query = create_session().query(*models) \
                                 .join(OrgUnit.users_group) \
                                 .join(Group.users)
         query = query.filter(OrgUnit.enabled)
@@ -206,12 +219,8 @@ class AllUsersAndInboxesSourceBinder(object):
 class UsersContactsInboxesSource(AllUsersAndInboxesSource):
 
     @property
-    def base_query(self):
-        query = create_session().query(User)
-        query = query.join(OrgUnit.users_group) \
-                                .join(Group.users)
-        query = query.filter(OrgUnit.enabled)
-        return query
+    def only_users(self):
+        return True
 
     def getTerm(self, value, brain=None):
         # Contacts
@@ -302,22 +311,17 @@ class UsersContactsInboxesSourceBinder(object):
 
 
 @implementer(IQuerySource)
-class AssignedUsersSource(AllUsersAndInboxesSource):
+class AllUsersSource(AllUsersAndInboxesSource):
     """Vocabulary of all users assigned to the current admin unit.
     """
 
     @property
     def search_only_active_users(self):
-        return True
+        return False
 
     @property
-    def base_query(self):
-        admin_unit = get_current_admin_unit()
-        return create_session().query(User) \
-            .filter(User.userid == groups_users.columns.userid) \
-            .filter(groups_users.columns.groupid == OrgUnit.users_group_id) \
-            .filter(OrgUnit.admin_unit_id == admin_unit.unit_id) \
-            .filter(OrgUnit.enabled)
+    def only_users(self):
+        return True
 
     def getTermByToken(self, token):
 
@@ -360,34 +364,36 @@ class AssignedUsersSource(AllUsersAndInboxesSource):
 
 
 @implementer(IContextSourceBinder)
-class AssignedUsersSourceBinder(object):
+class AllUsersSourceBinder(object):
 
     def __call__(self, context):
-        return AssignedUsersSource(context)
+        return AllUsersSource(context)
 
 
 @implementer(IQuerySource)
-class AllUsersSource(AssignedUsersSource):
+class AssignedUsersSource(AllUsersSource):
     """Vocabulary of all users assigned to the current admin unit.
     """
 
     @property
     def search_only_active_users(self):
-        return False
+        return True
 
     @property
     def base_query(self):
-        query = create_session().query(User)
-        query = query.join(OrgUnit.users_group) \
-                                .join(Group.users)
-        query = query.filter(OrgUnit.enabled)
-        return query
+        admin_unit = get_current_admin_unit()
+        return create_session().query(User) \
+            .filter(User.userid == groups_users.columns.userid) \
+            .filter(groups_users.columns.groupid == OrgUnit.users_group_id) \
+            .filter(OrgUnit.admin_unit_id == admin_unit.unit_id) \
+            .filter(OrgUnit.enabled)
+
 
 @implementer(IContextSourceBinder)
-class AllUsersSourceBinder(object):
+class AssignedUsersSourceBinder(object):
 
     def __call__(self, context):
-        return AllUsersSource(context)
+        return AssignedUsersSource(context)
 
 
 @implementer(IQuerySource)
@@ -401,12 +407,8 @@ class AllEmailContactsAndUsersSource(UsersContactsInboxesSource):
     """
 
     @property
-    def base_query(self):
-        query = create_session().query(User)
-        query = query.join(OrgUnit.users_group) \
-                                .join(Group.users)
-        query = query.filter(OrgUnit.enabled)
-        return query
+    def only_users(self):
+        return True
 
     def getTerm(self, value, brain=None):
         email, id_ = value.split(':', 1)

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -40,6 +40,7 @@ class AllUsersAndInboxesSource(object):
         query = create_session().query(User, OrgUnit) \
                                 .join(OrgUnit.users_group) \
                                 .join(Group.users)
+        query = query.filter(OrgUnit.enabled)
 
         if self.only_current_orgunit:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -151,6 +152,7 @@ class AllUsersAndInboxesSource(object):
                               text_filters)
 
         query = OrgUnit.query
+        query = query.filter(OrgUnit.enabled)
 
         if self.only_current_inbox:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -205,7 +207,11 @@ class UsersContactsInboxesSource(AllUsersAndInboxesSource):
 
     @property
     def base_query(self):
-        return User.query
+        query = create_session().query(User)
+        query = query.join(OrgUnit.users_group) \
+                                .join(Group.users)
+        query = query.filter(OrgUnit.enabled)
+        return query
 
     def getTerm(self, value, brain=None):
         # Contacts
@@ -310,7 +316,8 @@ class AssignedUsersSource(AllUsersAndInboxesSource):
         return create_session().query(User) \
             .filter(User.userid == groups_users.columns.userid) \
             .filter(groups_users.columns.groupid == OrgUnit.users_group_id) \
-            .filter(OrgUnit.admin_unit_id == admin_unit.unit_id)
+            .filter(OrgUnit.admin_unit_id == admin_unit.unit_id) \
+            .filter(OrgUnit.enabled)
 
     def getTermByToken(self, token):
 
@@ -370,8 +377,11 @@ class AllUsersSource(AssignedUsersSource):
 
     @property
     def base_query(self):
-        return create_session().query(User)
-
+        query = create_session().query(User)
+        query = query.join(OrgUnit.users_group) \
+                                .join(Group.users)
+        query = query.filter(OrgUnit.enabled)
+        return query
 
 @implementer(IContextSourceBinder)
 class AllUsersSourceBinder(object):
@@ -392,7 +402,11 @@ class AllEmailContactsAndUsersSource(UsersContactsInboxesSource):
 
     @property
     def base_query(self):
-        return create_session().query(User)
+        query = create_session().query(User)
+        query = query.join(OrgUnit.users_group) \
+                                .join(Group.users)
+        query = query.filter(OrgUnit.enabled)
+        return query
 
     def getTerm(self, value, brain=None):
         email, id_ = value.split(':', 1)


### PR DESCRIPTION
The problem was introduced with the OGIP 15 (https://github.com/4teamwork/opengever.core/pull/2852), which turned all vocabularies (IVocabulary) into sources (ISource) to support a new kind of selection widget provided by ftw.keywordwidget.

With this change filtering for disabled OrgUnits went lost.
This PR brings back this feature.


I also slightly refactored the source a little bit, otherwise this change would introduced a lot of duplicated code. 

I also hat to fix a side effect on the advanced search form.
A test-odgs user was not properly configured, since a OrgUnit was missing.
This change basically no longer allows user without an OrgUnit, since it is required to build the query.

Fixes #3273