### PR TITLE
Add a CI script to run pydocstyle on incoming files

### DIFF
--- a/test-pydocstyle.cfg
+++ b/test-pydocstyle.cfg
@@ -1,0 +1,54 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-base.cfg
+    versions.cfg
+
+parts =
+    package-directory
+    pydocstyle-cfg
+    pydocstyle
+    bin-test-jenkins
+
+package-name = opengever.core
+package-namespace = opengever
+
+jenkins_python = $PYTHON27
+
+[bin-test-jenkins]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/bash
+    fork_point=$(git merge-base --fork-point origin/master)
+    files=$(git diff --name-only "$fork_point" \
+                | egrep '.py$' \
+                | grep -v bootstrap.py \
+                | grep -v pyxbgen.py \
+                | grep -ve '*/bindings/*' \
+                | grep -ve '*/skins/*' \
+                | grep -ve '*/tests/*' \
+                | tr '\r\n' ' ')
+
+    echo ''
+    if [[ "$files" = *[!\ ]* ]]
+    then
+        echo 'Detected changes in this branch in the following Python files:'
+        echo "$files" | tr ' ' '\n'
+        echo ''
+        echo 'Running pydocstyle.'
+        echo ''
+        # Expand our list to multiple arguments to be passed in
+        eval bin/pydocstyle "$files"
+        success=$?
+    else
+        echo "No Python files to be checked, done!"
+        success=0
+    fi
+
+    echo ''
+
+    exit $success
+
+    # EOF
+
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755


### PR DESCRIPTION
Runs only on incoming files and uses our shared config.

Purposefully ignores tests, at least for now.

We could later do a different ruleset for the tests or somesuch.