### PR TITLE
Add a ci script to run isort on icoming files

### DIFF
--- a/test-isort.cfg
+++ b/test-isort.cfg
@@ -1,0 +1,53 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-base.cfg
+    versions.cfg
+
+parts =
+    package-directory
+    isort-cfg
+    isort
+    bin-test-jenkins
+
+package-name = opengever.core
+package-namespace = opengever
+
+jenkins_python = $PYTHON27
+
+[bin-test-jenkins]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/bash
+    fork_point=$(git merge-base --fork-point origin/master)
+    files=$(git diff --name-only "$fork_point" \
+                | egrep '.py$' \
+                | grep -v bootstrap.py \
+                | grep -v pyxbgen.py \
+                | grep -ve '*/bindings/*' \
+                | grep -ve '*/skins/*' \
+                | tr '\r\n' ' ')
+
+    echo ''
+    if [[ "$files" = *[!\ ]* ]]
+    then
+        echo 'Detected changes in this branch in the following Python files:'
+        echo "$files" | tr ' ' '\n'
+        echo ''
+        echo 'Running isort.'
+        echo ''
+        # Expand our list to multiple arguments to be passed in
+        eval bin/isort "$files"
+        success=$?
+    else
+        echo "No Python files to be checked, done!"
+        success=0
+    fi
+
+    echo ''
+
+    exit $success
+
+    # EOF
+
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755


### PR DESCRIPTION
This uses our shared config file and runs isort with it for incoming non-blacklisted python files.