### PR TITLE
Only run the XML format check for changed xml files

### DIFF
--- a/test-xml-convention.cfg
+++ b/test-xml-convention.cfg
@@ -5,3 +5,41 @@ extends =
 
 package-name = opengever.core
 package-namespace = opengever
+
+[test-jenkins]
+recipe = collective.recipe.template
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755
+input = inline:
+    #!/bin/bash
+
+    fork_point=$(git merge-base --fork-point origin/master)
+    files=$(git diff --name-only "$fork_point" \
+                | egrep '(.xml|.zcml)$' \
+                | grep -v definition.xml \
+                | grep -ve '*/upgrades/*' \
+                | tr '\r\n' ' ')
+
+
+    if [[ "$files" = *[!\ ]* ]]
+    then
+        echo 'Detected changes in this branch in the following Python files:'
+        echo "$files" | tr ' ' '\n'
+        echo 'Running bin/format-xml --check:'
+        eval ${buildout:bin-directory}/format-xml --check "$files"
+        result=$?
+    fi
+
+    if [[ "$result" == 0 ]]
+    then
+       echo 'All XMLs formatted correctly.'
+    elif [ -z "$result" ]
+    then
+        echo ''
+        echo 'No XML files changed.'
+        echo ''
+        exit 0
+    fi
+    echo ''
+    echo 'The files above failed the format check!'
+    exit $result


### PR DESCRIPTION
Include XML, ZCML. Exclude `definition.xml`, `*/upgrades/*`.