### PR TITLE
Fix and split up the pyflakes CI run script

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -3,7 +3,9 @@
 !cleanup-versions-cfg
 !create-schema-migration
 !create-upgrade
+!git-fork-point
 !mtest
 !pinchecker
 !remove-test-cache
 !test-cached
+!pyflakes-ci

--- a/bin/git-fork-point
+++ b/bin/git-fork-point
@@ -1,0 +1,3 @@
+#!/bin/bash
+git merge-base --fork-point origin/master
+# EOF

--- a/bin/pyflakes-ci
+++ b/bin/pyflakes-ci
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eo pipefail
+fork_point=$(bin/git-fork-point)
+
+only_modified_and_added=(
+    "| grep -E '^(M|A)'"
+    )
+
+include_files=(
+    "| grep -E '\.py$'"
+    )
+
+exclude_files=(
+    "| grep -v '__init__.py'"
+    "| grep -v 'bootstrap.py'"
+    "| grep -v 'pyxbgen.py'"
+    )
+
+exclude_directories=(
+    "| grep -v '/bindings/'"
+    "| grep -v '/skins/'"
+    )
+
+files_lister=(
+    "git diff --name-status $fork_point"
+    "${only_modified_and_added[*]}"
+    "${include_files[*]}"
+    "${exclude_files[*]}"
+    "${exclude_directories[*]}"
+    "| cut -d$'\t' -f 2"
+    )
+
+# Roll your own eval
+files=($(/bin/bash -c "${files_lister[*]}"))
+
+echo ''
+if [ "${files[*]}" ]; then
+    echo 'Detected changes in this branch in the following Python files:'
+    for file in "${files[@]}"; do
+        echo "$file"
+    done
+    echo ''
+    echo 'Running pyflakes.'
+    echo ''
+    bin/pyflakes "${files[*]}"
+    success=$?
+else
+    echo "Found nothing to complain about, well done!"
+    success=0
+fi
+
+echo ''
+
+if [ "$success" == "0" ]; then
+    exit 0
+fi
+
+# Fail per default
+exit 1
+
+# EOF

--- a/test-pyflakes.cfg
+++ b/test-pyflakes.cfg
@@ -17,38 +17,7 @@ jenkins_python = $PYTHON27
 recipe = collective.recipe.template
 input = inline:
     #!/bin/bash
-    fork_point=$(git merge-base --fork-point origin/master)
-    files=$(git diff --name-only "$fork_point" \
-                | egrep '.py$' \
-                | grep -v __init__.py \
-                | grep -v bootstrap.py \
-                | grep -v pyxbgen.py \
-                | grep -ve '*/bindings/*' \
-                | grep -ve '*/skins/*' \
-                | tr '\r\n' ' ')
-
-
-    echo ''
-    if [[ "$files" = *[!\ ]* ]]
-    then
-        echo 'Detected changes in this branch in the following Python files:'
-        echo "$files" | tr ' ' '\n'
-        echo ''
-        echo 'Running pyflakes.'
-        echo ''
-        # Expand our list to multiple arguments to be passed in
-        eval bin/pyflakes "$files"
-        success=$?
-    else
-        echo "No Python files to be checked, done!"
-        success=0
-    fi
-
-    echo ''
-
-    exit $success
-
+    bin/pyflakes-ci
     # EOF
-
 output = ${buildout:bin-directory}/test-jenkins
-mode = 755
+mode = 500


### PR DESCRIPTION
* Split the git fork point finding onto its own script
* Make a `bin/pyflakes-ci` script to be able to write unrestricted-by-buildout-internals bash
* Wrap that script with a trivial `bin/test-jenkins` via `collective.recipe.template`
* Fail per default
* Split up the parametres in a way which can be useful for future QA script code sharing

Closes #3299.