### PR TITLE
Point source-code link to 4teamwork/opengever.core.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add upgrade step which fixes potential missing titles on opengever.private.root objects. [mathias.leimgruber]
+- Point footer source-code link to 4teamwork/opengever.core, drop link to CI. [deiferni]
 - Filter results for disabled OrgUnits in all sources. [mathias.leimgruber]
 - Install ftw.tika if necessary. [mathias.leimgruber]
 - Ungrok opengever.latex. [elioschmutz]

--- a/opengever/base/viewlets/footer.pt
+++ b/opengever/base/viewlets/footer.pt
@@ -2,8 +2,7 @@
     <div id="footer-column-1" class="column cell position-0 width-4">
         <h2>OneGov GEVER</h2>
         <p><a href="https://onegovgever.ch">Über OneGov GEVER</a></p>
-        <p><a href="https://github.com/OneGov/onegov.gever">Quellcode</a></p>
-        <p><a href="https://jenkins.4teamwork.ch/view/OneGov%20GEVER/">Software Tests</a></p>
+        <p><a href="https://github.com/4teamwork/opengever.core">Quellcode</a></p>
         <p><a href="https://onegovgever.ch/aktuell">Release-Informationen</a></p>
         <p>Version: <span tal:content="view/get_gever_version" /></p>
     </div>


### PR DESCRIPTION
As discussed in https://4teamwork.slack.com/archives/C060FEYKA/p1502960325000375 we'd like to update the footer link and point it to this repo instead of https://github.com/OneGov/onegov.gever.

What about the link to CI?
<img width="172" alt="screen shot 2017-08-21 at 17 54 18" src="https://user-images.githubusercontent.com/736583/29527650-d9ba2b50-8699-11e7-8a6d-d5f838581ba1.png">
It currently points to a view in Jenkins, but that view contains outdated and manually configured dependencies. I propose to:
- remove the link to CI in the footer
- also remove the view, i don't think that we use it anymore since CI-Governor has take over, also the list is fairly outdated

objections (@phabegger, @phgross , @lukasgraf, @jone)? 