### PR TITLE
Add upgrade step which fixes potential missing titles on opengever.private.root objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Add upgrade step which fixes potential missing titles on opengever.private.root objects. [mathias.leimgruber]
 - Filter results for disabled OrgUnits in all sources. [mathias.leimgruber]
 - Ungrok opengever.latex. [elioschmutz]
 - Add a CI script to check incoming python files for pyflakes issues. [Rotonen]

--- a/opengever/core/upgrades/20170822083925_set_missing_titles_on_private_root/upgrade.py
+++ b/opengever/core/upgrades/20170822083925_set_missing_titles_on_private_root/upgrade.py
@@ -1,0 +1,22 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.behaviors.translated_title import ITranslatedTitle
+
+
+class SetMissingTitlesOnPrivateRoot(UpgradeStep):
+    """Set missing titles on private root.
+    """
+
+    def __call__(self):
+        query = {'portal_type': ['opengever.private.root']}
+        for folder in self.objects(query, 'Set title on private root folders'):
+            idxs = []
+
+            if not ITranslatedTitle(folder).title_de:
+                ITranslatedTitle(folder).title_de = u'Meine Ablage'
+                idxs.append('title_de')
+            if not ITranslatedTitle(folder).title_fr:
+                ITranslatedTitle(folder).title_fr = u'Mon depot'
+                idxs.append('title_fr')
+
+            if idxs:
+                folder.reindexObject(idxs=idxs)


### PR DESCRIPTION
On my local machine I was only able to reproduce this state by setting manually `title_fr` and `title_de` to a empty string.
![private](https://user-images.githubusercontent.com/437933/29553911-863d1e18-871d-11e7-832f-50292eaec477.gif)

Hope I'm not missing anything. 

Closes #2911