### PR TITLE
Update layout of agenda items in word meeting view.

### DIFF
--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -338,6 +338,8 @@ class MeetingView(BrowserView):
                 _('label_revise_action', default='Revise this agenda item'),
                 _('label_attachments', default='Attachments'),
                 _('label_excerpts', default='Excerpts'),
+                _('label_toggle_attachments', default='Toggle attachments'),
+                _('label_agenda_item_number', default='Agenda item number'),
             ),
             max_proposal_title_length=ISubmittedProposal['title'].max_length)
 

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -1,24 +1,35 @@
 <script id="agendaitemsTemplate" type="text/x-handlebars-template">
   {{#each agendaitems}}
-  <tr class="{{css_class}} word-feature" data-uid={{id}}>
+  <tr class="{{css_class}} word-feature agenda_item" data-uid={{id}}>
     {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
-    <td class="number">
-      {{number}}
+    <td class="title">
       {{#if has_documents}}
       <div class="toggle-attachements">
-        <a class="toggle-attachements-btn"></a>
+        <a class="toggle-attachements-btn"
+           title="%(label_toggle_attachments)s" />
       </div>
       {{/if}}
-    </td>
-    <td class="title">
+      <span class="number"
+            title="%(label_agenda_item_number)s">
+        {{number}}
+      </span>
       <span class="proposal_title">{{{link}}}</span>
+      <div class="edit-box">
+        <div class="input-group">
+          <input type="text" {{#if has_proposal}}maxlength="%(max_proposal_title_length)i"{{/if}} />
+          <div class="button-group">
+            <input value="%(label_edit_save)s" type="button" class="button edit-save" />
+            <input value="%(label_edit_cancel)s" type="button" class="button edit-cancel" />
+          </div>
+        </div>
+      </div>
       {{#if has_proposal}}
       <div class="proposal_document {{#if proposal_document_checked_out}}checked-out{{/if}}">{{{proposal_document_link}}}</div>
 
       {{#if excerpts}}
-      <div class="documents">
-        <div class="label_attachments">%(label_excerpts)s:</div>
-        <ul>
+      <div>
+        <div class="documents_label">%(label_excerpts)s:</div>
+        <ul class="documents-list">
           {{#each excerpts}}
           <li>
             {{{link}}}
@@ -30,8 +41,8 @@
 
       {{#if has_documents}}
       <div class="attachements">
-        <div class="label_attachments">%(label_attachments)s:</div>
-        <ul>
+        <div class="documents_label">%(label_attachments)s:</div>
+        <ul class="documents-list">
           {{#each documents}}
           <li>
             {{{link}}}
@@ -47,15 +58,6 @@
         {{{excerpt}}}
       </div>
       {{/if}}
-      <div class="edit-box">
-        <div class="input-group">
-          <input type="text" {{#if has_proposal}}maxlength="%(max_proposal_title_length)i"{{/if}} />
-          <div class="button-group">
-            <input value="%(label_edit_save)s" type="button" class="button edit-save" />
-            <input value="%(label_edit_cancel)s" type="button" class="button edit-cancel" />
-          </div>
-        </div>
-      </div>
     </td>
     {{#if ../editable}}
     <td class="actions">

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -245,10 +245,11 @@
           <table id="agenda_items">
             <thead>
               <tr>
-                <th i18n:translate=""
-                    tal:condition="meeting/is_agendalist_editable">Order</th>
-                <th i18n:translate="">Number</th>
-                <th i18n:translate="">Title</th>
+                <th i18n:translate="view_label_agenda_items"
+                    tal:define="has_sort_column meeting/is_agendalist_editable"
+                    tal:attributes="colspan python: '2' if has_sort_column else '1'">
+                  Agenda items
+                </th>
                 <th i18n:translate=""
                     tal:condition="meeting/is_editable">Actions</th>
               </tr>

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -152,12 +152,19 @@
     this.showEditbox = function(target) {
       var row = target.parents("tr");
       row.removeClass("expanded");
-      var source;
-      if($(".title > span > a", row).length) {
-        source = $(".title > span > a", row);
-      } else {
-        source = $(".title > span", row);
-      }
+      var source_selectors = [
+            /* Word: */
+            ".title > span.proposal_title > a",
+            ".title > span.proposal_title",
+            /* Non-word: */
+            ".title > span > a",
+            ".title > span"
+      ];
+      var source_selector = source_selectors.filter(function(selector) {
+        return $(selector, row).length > 0;
+      })[0];
+      var source = $(source_selector, row);
+
       new EditboxController({
         editbox: $(".edit-box", row),
         source: source,

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-21 07:40+0000\n"
-"PO-Revision-Date: 2017-08-18 16:34+0200\n"
+"POT-Creation-Date: 2017-08-22 10:17+0000\n"
+"PO-Revision-Date: 2017-08-22 12:18+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -22,7 +22,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:251
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -67,7 +67,7 @@ msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:379
+#: ./opengever/meeting/browser/meetings/meeting.py:381
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -129,7 +129,7 @@ msgid "Documents"
 msgstr "Dokumente"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:212
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -232,7 +232,6 @@ msgid "Memberships"
 msgstr "Mitgliedschaften"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Number"
 msgstr "Nummer"
 
@@ -242,7 +241,7 @@ msgid "Once closed the meeting and its protocol cannot be edited any longer. The
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:246
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Order"
 msgstr "Sortierung"
 
@@ -328,7 +327,6 @@ msgid "The proposal has been rejected successfully"
 msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:249
 msgid "Title"
 msgstr "Titel"
 
@@ -584,7 +582,7 @@ msgid "dossier"
 msgstr "Dossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
@@ -638,12 +636,12 @@ msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:185
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:194
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
@@ -676,6 +674,11 @@ msgstr "Sitzung durchführen"
 #: ./opengever/meeting/model/committee.py:31
 msgid "inactive"
 msgstr "Inaktiv"
+
+#. Default: "Agenda item number"
+#: ./opengever/meeting/browser/meetings/meeting.py:342
+msgid "label_agenda_item_number"
+msgstr "Nummer des Traktandums in dieser Sitzung"
 
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
@@ -922,7 +925,7 @@ msgstr "Datei"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:277
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -950,7 +953,7 @@ msgstr "Ausgangslage"
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:308
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:309
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -1023,13 +1026,13 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:349
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:202
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:194
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:175
 msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
@@ -1112,9 +1115,9 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:348
+#: ./opengever/meeting/browser/meetings/meeting.py:350
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:293
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:294
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -1146,6 +1149,11 @@ msgstr "Titel"
 #: ./opengever/meeting/committeecontainer.py:35
 msgid "label_toc_template"
 msgstr "Vorlage Inhaltsverzeichnis"
+
+#. Default: "Toggle attachments"
+#: ./opengever/meeting/browser/meetings/meeting.py:341
+msgid "label_toggle_attachments"
+msgstr "Anhänge anzeigen / ausblenden"
 
 #. Default: "Transition ${transition} executed"
 #: ./opengever/meeting/browser/meetings/transitions.py:25
@@ -1179,7 +1187,7 @@ msgid "label_workflow_state"
 msgstr "Status"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:229
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
 msgid "label_zip_download"
 msgstr "Zip-Datei herunterladen"
 
@@ -1443,7 +1451,7 @@ msgid "secretary"
 msgstr "Protokollführer"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:218
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:220
 msgid "status"
 msgstr "Status"
 
@@ -1482,17 +1490,22 @@ msgid "un-schedule"
 msgstr "Traktandum entfernen"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:265
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:266
 msgid "view_label_add"
 msgstr "Hinzufügen"
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:303
 msgid "view_label_add_section_header"
 msgstr "Zwischentitel einfügen:"
 
+#. Default: "Agenda items"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+msgid "view_label_agenda_items"
+msgstr "Traktanden"
+
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:161
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:162
 msgid "view_label_agendaitem_list"
 msgstr "Traktandenliste:"
 
@@ -1502,7 +1515,7 @@ msgid "view_label_dossier"
 msgstr "Sitzungsdossier:"
 
 #. Default: "Download agenda item list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
 msgid "view_label_download_agendaitem_list"
 msgstr "Traktandenliste herunterladen"
 
@@ -1537,17 +1550,17 @@ msgid "view_label_presidency"
 msgstr "Vorsitz:"
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:171
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:173
 msgid "view_label_protocol"
 msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
 msgid "view_label_schedule_ad_hoc"
 msgstr "Ad Hoc Traktandum einfügen:"
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-21 07:40+0000\n"
+"POT-Creation-Date: 2017-08-22 10:17+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -24,7 +24,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:251
 msgid "Actions"
 msgstr "Actions"
 
@@ -69,7 +69,7 @@ msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:379
+#: ./opengever/meeting/browser/meetings/meeting.py:381
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -131,7 +131,7 @@ msgid "Documents"
 msgstr "Documents"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:212
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
 msgid "Edit"
 msgstr "Modifier"
 
@@ -234,7 +234,6 @@ msgid "Memberships"
 msgstr "Adhésions"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Number"
 msgstr "Numéro"
 
@@ -244,7 +243,7 @@ msgid "Once closed the meeting and its protocol cannot be edited any longer. The
 msgstr "La réunion et le protocole associé ne pourront plus être modifiés après clôture. Les actions suivantes seront exécutées lors de la clôture:"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:246
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Order"
 msgstr "Tri"
 
@@ -330,7 +329,6 @@ msgid "The proposal has been rejected successfully"
 msgstr "La proposition a été rejetée avec succès."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:249
 msgid "Title"
 msgstr "Titre"
 
@@ -586,7 +584,7 @@ msgid "dossier"
 msgstr "Dossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
 msgid "download protocol"
 msgstr "Télécharger le protocole"
 
@@ -640,12 +638,12 @@ msgid "generate new excerpt"
 msgstr "Générer un nouvel extrait de protocole"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:185
 msgid "generate new protocol as word document"
 msgstr "Générer le protocole comme document Word"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:194
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
 msgid "generate new version as word document"
 msgstr "Générer une nouvelle version comme document Word"
 
@@ -678,6 +676,11 @@ msgstr "Tenir une réunion"
 #: ./opengever/meeting/model/committee.py:31
 msgid "inactive"
 msgstr "Inactif"
+
+#. Default: "Agenda item number"
+#: ./opengever/meeting/browser/meetings/meeting.py:342
+msgid "label_agenda_item_number"
+msgstr ""
 
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
@@ -924,7 +927,7 @@ msgstr "Fichier"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:277
 msgid "label_filter_proposal"
 msgstr "Filtrage"
 
@@ -952,7 +955,7 @@ msgstr "Situation initiale"
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:308
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:309
 msgid "label_insert"
 msgstr "Insérer"
 
@@ -1025,13 +1028,13 @@ msgid "label_no_memberships"
 msgstr "Cet utilisateur n'a pas d'adhésion."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:349
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 msgid "label_no_proposals"
 msgstr "Aucune proposition n'a été soumise."
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:202
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:194
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:175
 msgid "label_no_protocol"
 msgstr "Aucun protocole n'a été généré encore."
 
@@ -1114,9 +1117,9 @@ msgid "label_sablon_template_file"
 msgstr "Fichier-modèle"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:348
+#: ./opengever/meeting/browser/meetings/meeting.py:350
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:293
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:294
 msgid "label_schedule"
 msgstr "Mettre à l'ordre du jour"
 
@@ -1148,6 +1151,11 @@ msgstr "Titre"
 #: ./opengever/meeting/committeecontainer.py:35
 msgid "label_toc_template"
 msgstr "Modèle de la table de matière"
+
+#. Default: "Toggle attachments"
+#: ./opengever/meeting/browser/meetings/meeting.py:341
+msgid "label_toggle_attachments"
+msgstr ""
 
 #. Default: "Transition ${transition} executed"
 #: ./opengever/meeting/browser/meetings/transitions.py:25
@@ -1181,7 +1189,7 @@ msgid "label_workflow_state"
 msgstr "Etat"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:229
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
 msgid "label_zip_download"
 msgstr "Télécharger le fichier ZIP"
 
@@ -1445,7 +1453,7 @@ msgid "secretary"
 msgstr "Secrétaire"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:218
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:220
 msgid "status"
 msgstr "État"
 
@@ -1484,17 +1492,22 @@ msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:265
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:266
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:303
 msgid "view_label_add_section_header"
 msgstr ""
 
+#. Default: "Agenda items"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+msgid "view_label_agenda_items"
+msgstr ""
+
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:161
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:162
 msgid "view_label_agendaitem_list"
 msgstr ""
 
@@ -1504,7 +1517,7 @@ msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Download agenda item list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
 msgid "view_label_download_agendaitem_list"
 msgstr ""
 
@@ -1539,17 +1552,17 @@ msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:171
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:173
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
 msgid "view_label_schedule_proposal"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-21 07:40+0000\n"
+"POT-Creation-Date: 2017-08-22 10:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:251
 msgid "Actions"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:379
+#: ./opengever/meeting/browser/meetings/meeting.py:381
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgid "Documents"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:212
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
 msgid "Edit"
 msgstr ""
 
@@ -231,7 +231,6 @@ msgid "Memberships"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Number"
 msgstr ""
 
@@ -241,7 +240,7 @@ msgid "Once closed the meeting and its protocol cannot be edited any longer. The
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:246
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Order"
 msgstr ""
 
@@ -327,7 +326,6 @@ msgid "The proposal has been rejected successfully"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:249
 msgid "Title"
 msgstr ""
 
@@ -583,7 +581,7 @@ msgid "dossier"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
 msgid "download protocol"
 msgstr ""
 
@@ -637,12 +635,12 @@ msgid "generate new excerpt"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:185
 msgid "generate new protocol as word document"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:194
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
 msgid "generate new version as word document"
 msgstr ""
 
@@ -674,6 +672,11 @@ msgstr ""
 #. Default: "Inactive"
 #: ./opengever/meeting/model/committee.py:31
 msgid "inactive"
+msgstr ""
+
+#. Default: "Agenda item number"
+#: ./opengever/meeting/browser/meetings/meeting.py:342
+msgid "label_agenda_item_number"
 msgstr ""
 
 #. Default: "Agendaitem list"
@@ -921,7 +924,7 @@ msgstr ""
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:277
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -949,7 +952,7 @@ msgstr ""
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:308
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:309
 msgid "label_insert"
 msgstr ""
 
@@ -1022,13 +1025,13 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:349
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 msgid "label_no_proposals"
 msgstr ""
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:202
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:194
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:175
 msgid "label_no_protocol"
 msgstr ""
 
@@ -1111,9 +1114,9 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:348
+#: ./opengever/meeting/browser/meetings/meeting.py:350
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:293
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:294
 msgid "label_schedule"
 msgstr ""
 
@@ -1144,6 +1147,11 @@ msgstr ""
 #: ./opengever/meeting/committee.py:74
 #: ./opengever/meeting/committeecontainer.py:35
 msgid "label_toc_template"
+msgstr ""
+
+#. Default: "Toggle attachments"
+#: ./opengever/meeting/browser/meetings/meeting.py:341
+msgid "label_toggle_attachments"
 msgstr ""
 
 #. Default: "Transition ${transition} executed"
@@ -1178,7 +1186,7 @@ msgid "label_workflow_state"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:229
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
 msgid "label_zip_download"
 msgstr ""
 
@@ -1442,7 +1450,7 @@ msgid "secretary"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:218
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:220
 msgid "status"
 msgstr ""
 
@@ -1481,17 +1489,22 @@ msgid "un-schedule"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:265
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:266
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:303
 msgid "view_label_add_section_header"
 msgstr ""
 
+#. Default: "Agenda items"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+msgid "view_label_agenda_items"
+msgstr ""
+
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:161
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:162
 msgid "view_label_agendaitem_list"
 msgstr ""
 
@@ -1501,7 +1514,7 @@ msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Download agenda item list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
 msgid "view_label_download_agendaitem_list"
 msgstr ""
 
@@ -1536,17 +1549,17 @@ msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:171
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:173
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
 msgid "view_label_schedule_proposal"
 msgstr ""
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -13,6 +13,7 @@ development-packages =
 # https://github.com/4teamwork/plonetheme.teamraum/pull/566
 # https://github.com/4teamwork/plonetheme.teamraum/pull/569
 # https://github.com/4teamwork/plonetheme.teamraum/pull/571
+# https://github.com/4teamwork/plonetheme.teamraum/pull/572
 # https://github.com/4teamwork/plonetheme.teamraum/pull/574
   plonetheme.teamraum
   docxmerge


### PR DESCRIPTION
The goal is to improve the meeting view when the word feature is enabled. This is done step by step. This pull request updates the styling and positioning of the agenda item table and its contents.

- Remove the "number" column and put the number in front of the title. This makes the view more compact.
- Add a tooltip on the meeting item number, telling that this is the meeting item number.
- Increase the font size of the agenda item title and number for better visual orientation.
- Separate headings in the agenda by adding a thick line between the sections.
- Style headings so that they are centered.
- Fix title editing dialog to support new DOM structure (JS).

![bildschirmfoto 2017-08-24 um 09 15 00](https://user-images.githubusercontent.com/7469/29654258-ca92c3ca-88ac-11e7-998b-40dab625d814.png)
![bildschirmfoto 2017-08-24 um 09 14 58](https://user-images.githubusercontent.com/7469/29654257-ca8c9888-88ac-11e7-81e7-c5bc42dbeff9.png)

Part of #2829