### PR TITLE
Breadcrumb rework

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -22,6 +22,7 @@ Changelog
 - Add a CI script to check incoming python files for pyflakes issues. [Rotonen]
 - Update ftw.zipexport to include empty folders. [elioschmutz]
 - Word meeting: update styling and placement of meeting view components. [jone]
+- Breadcrumb viewlet rework. Extend crumbs with icons and group the repository part. [phgross]
 - Add bin/test-cached helper script to execute a chached test-run. [deiferni]
 - Ungrok opengever.ogds.base [lgraf]
 - Add external_reference field and index [tarnap]

--- a/js_graph.py
+++ b/js_graph.py
@@ -45,6 +45,7 @@ graph = {
     'pin': ['jquery'],
     'prepoverlay': ['jquery'],
     'ajax-prefilter': ['jquery'],
+    'breadcrumbs': ['jquery'],
 }
 
 print tarjan(graph)

--- a/opengever/base/browser/helper.py
+++ b/opengever/base/browser/helper.py
@@ -18,15 +18,20 @@ def _get_task_css_class(task):
 
 
 # XXX object orient me!
-def get_css_class(item):
+def get_css_class(item, type_icon_only=False):
     """Returns the content-type icon css class for `item`.
 
     Arguments:
     `item` -- obj or brain
+    `type_icon_only` -- bool if it should only return the simple object
+    type icon or the detailed content icon(mimetypes for document etc.).
     """
     css_class = None
 
     normalize = getUtility(IIDNormalizer).normalize
+    if type_icon_only:
+        return "contenttype-%s" % normalize(item.portal_type)
+
     if isinstance(type(item), DeclarativeMeta) or \
             item.portal_type == 'opengever.task.task':
 

--- a/opengever/base/browser/helper.py
+++ b/opengever/base/browser/helper.py
@@ -10,7 +10,6 @@ def _get_task_css_class(task):
     of a task. The task may be a brain, a dexterity object or a sql alchemy
     globalindex object.
     """
-
     if ICatalogBrain.providedBy(task):
         task = Task.query.by_brain(task)
 

--- a/opengever/base/browser/modelforms.py
+++ b/opengever/base/browser/modelforms.py
@@ -67,7 +67,6 @@ class ModelEditForm(AutoExtensibleForm, EditForm):
 
     ignoreContext = True
     allow_prefill_from_GET_request = True  # XXX
-    has_model_breadcrumbs = True
     schema = None
 
     field_prefix = 'form.widgets.'

--- a/opengever/base/browser/resources/breadcrumbs.js
+++ b/opengever/base/browser/resources/breadcrumbs.js
@@ -1,0 +1,36 @@
+(function($) {
+
+  function getDropdown(toggler) {
+    return $(toggler).parent().next('.repo-dropdown').get(0);
+  }
+
+  function toggleDropdown(element) {
+    getDropdown(element).classList.toggle('dropdown-open');
+  }
+
+  function closeDropdown(element) {
+    getDropdown(element).classList.remove('dropdown-open');
+  }
+
+  function isSameElement(target, context) {
+    return target !== context && !context.contains(target);
+  }
+
+  function trackDropdown(dropdownToggle) {
+    dropdownToggle.addEventListener('click', function(event) {
+      event.preventDefault();
+      toggleDropdown(dropdownToggle);
+    });
+
+    window.addEventListener('click', function(event) {
+      if (isSameElement(event.target, dropdownToggle)) {
+        closeDropdown(dropdownToggle);
+      }
+    });
+  }
+
+  $(function() {
+    [].slice.call(document.querySelectorAll('.repo-dropdown-toggle')).forEach(trackDropdown);
+  });
+
+})(window.jQuery);

--- a/opengever/base/tests/test_pathbar.py
+++ b/opengever/base/tests/test_pathbar.py
@@ -1,65 +1,53 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestPathBar(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestPathBar, self).setUp()
-        self.admin_unit.public_url = 'http://nohost/plone'
-
-        self.root = create(Builder('repository_root').titled(u'Repository'))
-        self.repo = create(Builder('repository')
-                           .within(self.root)
-                           .titled(u'Testposition'))
-        self.subrepo = create(Builder('repository')
-                              .within(self.repo)
-                              .titled(u'Subposition'))
-        self.dossier = create(Builder('dossier')
-                              .within(self.subrepo)
-                              .titled(u'Dossier 1'))
-        self.meeting_dossier = create(
-            Builder('meeting_dossier').within(self.subrepo))
+class TestPathBar(IntegrationTestCase):
 
     @browsing
     def test_first_part_is_org_unit_title(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
 
         first_part = browser.css('#portal-breadcrumbs li a')[0]
-        self.assertEquals('Client1', first_part.text)
+        self.assertEquals('Hauptmandant', first_part.text)
         self.assertEquals(self.portal.absolute_url(), first_part.get('href'))
 
     @browsing
     def test_contains_contenttype_icon_class(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser)
+        browser.open(self.document)
 
         self.assertEquals(
             ['contenttype-plone-site',
              'contenttype-opengever-repository-repositoryfolder',
              'contenttype-opengever-repository-repositoryfolder',
              'contenttype-opengever-repository-repositoryroot',
-             'contenttype-opengever-dossier-businesscasedossier'],
+             'contenttype-opengever-dossier-businesscasedossier',
+             'contenttype-opengever-document-document'],
             [crumb.get('class') for crumb in
              browser.css('#portal-breadcrumbs li a i')])
 
     @browsing
     def test_repositories_are_grouped_in_a_sublist(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
 
         self.assertEquals(
-            ['Client1',
-             '1.1. Subposition', '1. Testposition', 'Repository',
-             'Dossier 1'],
+            [u'Hauptmandant',
+             u'1.1. Vertr\xe4ge und Vereinbarungen',
+             u'1. F\xfchrung',
+             u'Ordnungssystem',
+             u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'],
             browser.css('#portal-breadcrumbs li a').text)
 
-        self.assertEquals(['1. Testposition', 'Repository'],
+        self.assertEquals([u'1. F\xfchrung', 'Ordnungssystem'],
                           browser.css('#portal-breadcrumbs li ul a').text)
 
     @browsing
     def test_last_part_is_linked(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
 
         last_link = browser.css('#portal-breadcrumbs a')[-1]
         self.assertEqual(self.dossier.absolute_url(),
@@ -67,30 +55,22 @@ class TestPathBar(FunctionalTestCase):
 
     @browsing
     def test_proposal_is_linked_with_title(self, browser):
-        proposal = create(Builder('proposal')
-                          .within(self.dossier)
-                          .titled('My Proposal'))
+        self.login(self.regular_user, browser)
+        browser.open(self.proposal)
 
-        browser.login().open(proposal)
         last_link = browser.css('#portal-breadcrumbs a')[-1]
-        self.assertEqual(proposal.absolute_url(),
+        self.assertEqual(self.proposal.absolute_url(),
                          last_link.node.attrib['href'])
-        self.assertEqual('My Proposal', last_link.text)
+        self.assertEqual(self.proposal.title, last_link.text)
 
     @browsing
     def test_meeting_is_linked_with_title(self, browser):
-        container = create(Builder('committee_container'))
-        committee = create(Builder('committee').within(container))
-        meeting = create(Builder('meeting')
-                         .having(committee=committee.load_model())
-                         .link_with(self.meeting_dossier))
+        self.login(self.meeting_user, browser)
+        browser.open(self.meeting)
 
-        self.grant('MeetingUser', on=container)
-        self.grant('CommitteeMember', on=committee)
-        browser.login().open(meeting.get_url())
         last_link = browser.css('#portal-breadcrumbs a')[-1]
         self.assertEqual(
             'http://nohost/plone/opengever-meeting-committeecontainer/committee-1/meeting-1',
             last_link.get('href'))
 
-        self.assertEqual(meeting.get_title(), last_link.text)
+        self.assertEqual(self.meeting.get_title(), last_link.text)

--- a/opengever/base/viewlets/pathbar.pt
+++ b/opengever/base/viewlets/pathbar.pt
@@ -1,35 +1,43 @@
 <div id="portal-breadcrumbs"
      i18n:domain="plone"
-     tal:define="breadcrumbs view/breadcrumbs;
-                 is_rtl view/is_rtl">
+     tal:define="breadcrumbs view/obj_chain;
+                 repository_chain view/repository_chain;
+                 leaf_node view/leaf_node">
 
-    <span id="breadcrumbs-you-are-here" i18n:translate="you_are_here">You
-are here:</span>
-    <span id="breadcrumbs-home">
-        <a tal:attributes="href view/navigation_root_url" tal:content="view/admin_unit_label">Home</a>
-        <span tal:condition="breadcrumbs" class="breadcrumbSeparator">
-            <tal:ltr condition="not: is_rtl">/</tal:ltr>
-            <tal:rtl condition="is_rtl">\</tal:rtl>
-        </span>
-    </span>
+  <ul class="breadcrumb">
+    <li>
+      <a href=""
+         tal:attributes="href context/@@plone_portal_state/portal_url">
+        <i class="contenttype-plone-site" />
+        <span tal:content="view/admin_unit_label" />
+      </a>
+    </li>
 
-    <span tal:repeat="crumb breadcrumbs"
-          tal:attributes="dir python:is_rtl and 'rtl' or 'ltr';
-                          id string:breadcrumbs-${repeat/crumb/number}">
-        <tal:item tal:define="is_last repeat/crumb/end;
-                              url crumb/absolute_url;
-                              title crumb/Title">
-            <a href="#"
-               tal:omit-tag="not: url"
-               tal:attributes="href url"
-               tal:content="title">
-                crumb
-            </a>
-            <span class="breadcrumbSeparator" tal:condition="not: is_last">
-                <tal:ltr condition="not: is_rtl">/</tal:ltr>
-                <tal:rtl condition="is_rtl">\</tal:rtl>
-            </span>
-         </tal:item>
-    </span>
+    <li tal:condition="leaf_node">
+      <a tal:attributes="href leaf_node/absolute_url">
+        <i tal:attributes="class leaf_node/css_class" />
+        <span tal:content="leaf_node/title" label="for" />
+        <label for="repo-dropdown-toggler" class="repo-dropdown-toggle"
+               tal:condition="repository_chain" />
+      </a>
+      <input type="checkbox" id="repo-dropdown-toggler" />
+      <ul class="repo-dropdown" tal:condition="repository_chain">
+        <li tal:repeat="crumb repository_chain">
+          <a tal:attributes="href crumb/absolute_url; class crumb/css_class" tal:content="crumb/title" />
+        </li>
+      </ul>
+
+    </li>
+
+    <li tal:repeat="crumb breadcrumbs">
+      <tal:item tal:define="url crumb/absolute_url; title crumb/title">
+        <a href="#" tal:omit-tag="not: url" tal:attributes="href url">
+          <i tal:attributes="class crumb/css_class" />
+          <span tal:content="title" />
+        </a>
+      </tal:item>
+    </li>
+
+  </ul>
 
 </div>

--- a/opengever/base/viewlets/pathbar.pt
+++ b/opengever/base/viewlets/pathbar.pt
@@ -17,13 +17,15 @@
       <a tal:attributes="href leaf_node/absolute_url">
         <i tal:attributes="class leaf_node/css_class" />
         <span tal:content="leaf_node/title" label="for" />
-        <label for="repo-dropdown-toggler" class="repo-dropdown-toggle"
+        <div for="repo-dropdown-toggler" class="repo-dropdown-toggle"
                tal:condition="repository_chain" />
       </a>
-      <input type="checkbox" id="repo-dropdown-toggler" />
       <ul class="repo-dropdown" tal:condition="repository_chain">
         <li tal:repeat="crumb repository_chain">
-          <a tal:attributes="href crumb/absolute_url; class crumb/css_class" tal:content="crumb/title" />
+          <a tal:attributes="href crumb/absolute_url">
+            <i tal:attributes="class crumb/css_class"></i>
+            <span tal:content="crumb/title"></span>
+          </a>
         </li>
       </ul>
 

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -1,20 +1,66 @@
+from Acquisition import aq_chain
+from opengever.base.browser.helper import get_css_class
+from opengever.base.interfaces import ISQLObjectWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.repository.interfaces import IRepositoryFolder
+from opengever.repository.repositoryroot import IRepositoryRoot
+from plone.app.layout.navigation.interfaces import INavigationRoot
 from plone.app.layout.viewlets import common
+from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class PathBar(common.PathBarViewlet):
+    """The breadcrumb viewlet.
+
+    Unlike the plone default pathbar viewlet it groups all repository paths in
+    to a dropdown list and shows the content icon for each crumb.
+    """
+
     index = ViewPageTemplateFile('pathbar.pt')
+
+    leaf_node = None
+    repository_chain = None
+    obj_chain = None
 
     def admin_unit_label(self):
         return get_current_admin_unit().label()
 
     def update(self):
-        super(PathBar, self).update()
+        repository_items, self.obj_chain = self.get_chains()
 
-        if getattr(self.view, 'has_model_breadcrumbs', False):
-            self.append_model_breadcrumbs()
+        if repository_items:
+            self.leaf_node = repository_items[0]
+            if len(repository_items) > 1:
+                self.repository_chain = repository_items[1:]
 
-    def append_model_breadcrumbs(self):
-        model_breadcrumbs = self.view.context.get_breadcrumbs()
-        self.breadcrumbs = self.breadcrumbs + model_breadcrumbs
+    def is_part_of_repo(self, obj):
+        return IRepositoryRoot.providedBy(obj) or \
+            IRepositoryFolder.providedBy(obj)
+
+    def get_chains(self):
+        repository = []
+        chain = []
+        for obj in aq_chain(self.context):
+            if INavigationRoot.providedBy(obj):
+                break
+
+            if IHideFromBreadcrumbs.providedBy(obj):
+                continue
+
+            if ISQLObjectWrapper.providedBy(obj):
+                data = obj.get_breadcrumb()
+            else:
+                data = {
+                    'absolute_url': obj.absolute_url(),
+                    'title': obj.Title(),
+                    'css_class': get_css_class(obj, type_icon_only=True)
+                }
+
+            if self.is_part_of_repo(obj):
+                repository.append(data)
+            else:
+                chain.append(data)
+
+        chain.reverse()
+        return repository, chain

--- a/opengever/base/wrapper.py
+++ b/opengever/base/wrapper.py
@@ -1,7 +1,6 @@
 from Acquisition import Implicit
 from OFS.Traversable import Traversable
 from opengever.base.interfaces import ISQLObjectWrapper
-from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
 from zope.interface import implements
 import ExtensionClass
 
@@ -10,7 +9,7 @@ class SQLWrapperBase(ExtensionClass.Base, Implicit, Traversable):
     """SQL objects Wrapper class to fake a context.
     """
 
-    implements(IHideFromBreadcrumbs, ISQLObjectWrapper)
+    implements(ISQLObjectWrapper)
 
     default_view = 'view'
 

--- a/opengever/base/wrapper.py
+++ b/opengever/base/wrapper.py
@@ -40,7 +40,6 @@ class SQLWrapperBase(ExtensionClass.Base, Implicit, Traversable):
         Means that if a sql wrapper gets accessed directly without a view,
         the pre-traversal hook make sure that a default view gets displayed.
         """
-
         # XXX hack around a bug(?) in BeforeTraverse.MultiHook
         # see Products.CMFCore.DynamicType.__before_publishing_traverse__
         REQUEST = arg2 or arg1

--- a/opengever/base/wrapper.py
+++ b/opengever/base/wrapper.py
@@ -26,9 +26,10 @@ class SQLWrapperBase(ExtensionClass.Base, Implicit, Traversable):
     def absolute_url(self):
         return self.model.get_url(view=None)
 
-    def get_breadcrumbs(self):
-        return ({'absolute_url': self.absolute_url(),
-                 'Title': self.get_title()},)
+    def get_breadcrumb(self):
+        return {'absolute_url': self.absolute_url(),
+                'title': self.get_title(),
+                'css_class': getattr(self.model, 'css_class', '')}
 
     def get_title(self):
         return self.model.get_title()

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -90,7 +90,8 @@ class TestParticipationWrapper(FunctionalTestCase):
 
     def setUp(self):
         super(TestParticipationWrapper, self).setUp()
-        self.dossier = create(Builder('dossier'))
+        self.dossier = create(Builder('dossier')
+                              .titled(u'Dossier'))
         self.hans = create(Builder('person')
                            .having(firstname=u'Hans', lastname=u'M\xfcller'))
         self.participation = create(Builder('contact_participation')
@@ -106,8 +107,8 @@ class TestParticipationWrapper(FunctionalTestCase):
             [u'Edit Participation of M\xfcller Hans'],
             browser.css('h1').text)
         self.assertEqual(
-            [u'You are here: Client1 / dossier-1 / Participation of M\xfcller Hans'],
-            browser.css('#portal-breadcrumbs').text)
+            ['Client1', u'Dossier', u'Participation of M\xfcller Hans'],
+            browser.css('#portal-breadcrumbs li').text)
 
     @browsing
     def test_cross_injection_raises_unauthorized(self, browser):

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -182,9 +182,20 @@
       cookable="True"
       expression=""
       enabled="True"
-      id="++resource++opengever.base/qtip.js"
+      id="++resource++opengever.base/breadcrumbs.js"
       inline="False"
       insert-after="++resource++opengever.base/prepoverlay.js"
+      />
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.base/qtip.js"
+      inline="False"
+      insert-after="++resource++opengever.base/breadcrumbs.js"
       />
 
   <javascript

--- a/opengever/core/upgrades/20170831103505_install_breadcumbs_javascript/jsregistry.xml
+++ b/opengever/core/upgrades/20170831103505_install_breadcumbs_javascript/jsregistry.xml
@@ -1,0 +1,25 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.base/breadcrumbs.js"
+      inline="False"
+      insert-after="++resource++opengever.base/prepoverlay.js"
+      />
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.base/qtip.js"
+      inline="False"
+      insert-after="++resource++opengever.base/breadcrumbs.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20170831103505_install_breadcumbs_javascript/upgrade.py
+++ b/opengever/core/upgrades/20170831103505_install_breadcumbs_javascript/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallBreadcumbsJavascript(UpgradeStep):
+    """Install breadcumbs javascript.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/meeting/browser/meetings/excerpt.py
+++ b/opengever/meeting/browser/meetings/excerpt.py
@@ -87,7 +87,6 @@ class IGenerateExcerpt(form.Schema):
 
 class GenerateExcerpt(AutoExtensibleForm, EditForm):
 
-    has_model_breadcrumbs = True
     ignoreContext = True
     allow_prefill_from_GET_request = True  # XXX
     schema = IGenerateExcerpt

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -228,8 +228,6 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
 
 class MeetingView(BrowserView):
 
-    has_model_breadcrumbs = True
-
     noword_template = ViewPageTemplateFile('templates/meeting-noword.pt')
     word_template = ViewPageTemplateFile('templates/meeting-word.pt')
 

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -114,7 +114,6 @@ class DownloadProtocolJson(DownloadGeneratedProtocol):
 
 class EditProtocol(ModelEditForm):
 
-    has_model_breadcrumbs = True
     ignoreContext = True
     schema = IMeetingMetadata
     content_type = Meeting

--- a/opengever/meeting/browser/members.py
+++ b/opengever/meeting/browser/members.py
@@ -71,8 +71,6 @@ class MemberView(BrowserView):
     template = ViewPageTemplateFile('templates/member.pt')
     implements(IBrowserView, IPublishTraverse)
 
-    has_model_breadcrumbs = True
-
     @classmethod
     def url_for(cls, context, member):
         return member.get_url(context)

--- a/opengever/meeting/model/membership.py
+++ b/opengever/meeting/model/membership.py
@@ -15,8 +15,8 @@ from sqlalchemy.schema import Sequence
 
 class Membership(Base, SQLFormSupport):
     """Associate members with their commmission for a certain timespan.
-
     """
+
     __tablename__ = 'memberships'
     __mapper_args__ = {'order_by': 'date_from'}
     __table_args__ = (UniqueConstraint('committee_id',

--- a/opengever/meeting/model/membership.py
+++ b/opengever/meeting/model/membership.py
@@ -43,6 +43,10 @@ class Membership(Base, SQLFormSupport):
             self.date_from,
             self.date_to)
 
+    @property
+    def css_class(self):
+        return 'contenttype-opengever-meeting-membership'
+
     def is_removable(self):
         return True
 

--- a/opengever/meeting/wrapper.py
+++ b/opengever/meeting/wrapper.py
@@ -8,11 +8,15 @@ from zope.interface import implements
 
 
 class MeetingWrapper(SQLWrapperBase):
+    """SQLWrapper for meeting objects.
+    """
 
     implements(IMeetingWrapper, ISQLLockable)
 
 
 class PeriodWrapper(SQLWrapperBase):
+    """SQLWrapper for period objects.
+    """
 
     implements(IPeriodWrapper)
 
@@ -23,6 +27,8 @@ class PeriodWrapper(SQLWrapperBase):
 
 
 class MemberWrapper(SQLWrapperBase):
+    """SQLWrapper for member objects.
+    """
 
     implements(IMemberWrapper)
 
@@ -34,6 +40,8 @@ class MemberWrapper(SQLWrapperBase):
 
 
 class MembershipWrapper(SQLWrapperBase):
+    """SQLWrapper for membership objects.
+    """
 
     implements(IMembershipWrapper)
 

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -52,7 +52,7 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
 
     def setUp(self):
         super(TestPrivateFolderTabbedView, self).setUp()
-        self.root = create(Builder('private_root'))
+        self.root = create(Builder('private_root').titled(u'Private root'))
         self.folder = create_members_folder(self.root)
 
     @browsing
@@ -66,8 +66,8 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
     def test_private_root_is_hidden_from_breadcrumbs(self, browser):
         browser.login().open(self.folder)
         self.assertEqual(
-            'You are here: Client1 / Test User (test_user_1_)',
-            browser.css('#portal-breadcrumbs').first.text)
+            ['Client1', 'Test User (test_user_1_)'],
+            browser.css('#portal-breadcrumbs li').text)
 
     @browsing
     def test_dossier_tab_lists_all_containig_private_dossiers(self, browser):


### PR DESCRIPTION
<img width="1027" alt="bildschirmfoto 2017-08-23 um 07 33 48" src="https://user-images.githubusercontent.com/485755/29600325-7035078a-87d5-11e7-8367-080bd8c866b6.png">

<img width="1033" alt="bildschirmfoto 2017-08-23 um 07 33 27" src="https://user-images.githubusercontent.com/485755/29600326-703632ea-87d5-11e7-85b0-4b94dea093ef.png">

This PR replaces the current implementation of the Pathbar viewlet, with our own to provide the following features:
 - extend the crumbs with icons
 - group the repository in to a dropdown list, to save space

It also no longer uses the breadcrumb view and uses the aq chain to generate the breadcrumb.

⚠️ Needs styling PR (https://github.com/4teamwork/plonetheme.teamraum/pull/573) merge first

Closes #2389 