### PR TITLE
Optimize reindexing for document checkout/checkin cycles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: always show excerpts in meeting view. [jone]
 - Do not render document link without View permission. [jone]
+- Optimise reindexing for document checkout/checkin cycles. [Rotonen]
 - Refactor JSON schema generation and dumping, add tests. [lgraf]
 - Ungrok opengever.dossier. [elioschmutz]
 - Ungrok opengever.document. [elioschmutz]

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -89,7 +89,14 @@ class CheckinCheckoutManager(object):
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = user_id
 
         # finally, reindex the object
-        self.context.reindexObject()
+        catalog = api.portal.get_tool('portal_catalog')
+        catalog.reindexObject(
+            self.context,
+            idxs=(
+                'checked_out',
+                ),
+            update_metadata=True,
+            )
 
         # fire the event
         notify(ObjectCheckedOutEvent(self.context, ''))
@@ -150,7 +157,14 @@ class CheckinCheckoutManager(object):
         self.versioner.create_version(comment)
 
         # finally, reindex the object
-        self.context.reindexObject()
+        catalog = api.portal.get_tool('portal_catalog')
+        catalog.reindexObject(
+            self.context,
+            idxs=(
+                'checked_out',
+                ),
+            update_metadata=True,
+            )
 
         # fire the event
         notify(ObjectCheckedInEvent(self.context, comment))
@@ -194,7 +208,14 @@ class CheckinCheckoutManager(object):
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = None
 
         # finally, reindex the object
-        self.context.reindexObject()
+        catalog = api.portal.get_tool('portal_catalog')
+        catalog.reindexObject(
+            self.context,
+            idxs=(
+                'checked_out',
+                ),
+            update_metadata=True,
+            )
 
         # Clear any WebDAV locks left over by ExternalEditor if necessary
         self.clear_locks()

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -284,6 +284,7 @@ class Document(Item, BaseDocumentMixin):
             data=data,
             filename=filename,
             contentType=content_type)
+        self.reindexObject()
 
     def has_file(self):
         return self.file is not None

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -2,7 +2,8 @@ from Acquisition import aq_inner
 from collective import dexteritytextindexer
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.classification import IClassificationMarker
-from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import ISequenceNumber
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -13,7 +14,9 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFDiffTool.utils import safe_utf8
 from ZODB.POSException import ConflictError
 from zope.component import adapter
-from zope.component import getUtility, queryMultiAdapter, getAdapter
+from zope.component import getAdapter
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
 import logging

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -22,7 +22,7 @@ class TestDocumentIndexers(FunctionalTestCase):
         doc1 = createContentInContainer(
             self.portal, 'opengever.document.document',
             title=u"Doc One", document_author=u'Hugo Boss',
-            document_date=datetime.date(2011,1,1))
+            document_date=datetime.date(2011, 1, 1))
 
         self.assertEquals(obj2brain(doc1).document_author, 'Hugo Boss')
         self.assertEquals(
@@ -50,7 +50,7 @@ class TestDocumentIndexers(FunctionalTestCase):
     def test_date_indexers(self):
         doc1 = create(Builder('document').having(
             title=u"Doc One",
-            document_date=datetime.date(2011,1,1),
+            document_date=datetime.date(2011, 1, 1),
             receipt_date=datetime.date(2011, 2, 1)))
 
         # document_date
@@ -69,7 +69,7 @@ class TestDocumentIndexers(FunctionalTestCase):
         doc1 = createContentInContainer(
             self.portal, 'opengever.document.document',
             title=u"Doc One",
-            document_date=datetime.date(2011,1,1),
+            document_date=datetime.date(2011, 1, 1),
             receipt_date=datetime.date(2011, 2, 1))
 
         self.annotations = IAnnotations(doc1)
@@ -86,7 +86,7 @@ class TestDocumentIndexers(FunctionalTestCase):
             title=u"Doc One",
             document_author=u'Hugo Boss',
             keywords=('foo', 'bar'),
-            document_date=datetime.date(2011,1,1),
+            document_date=datetime.date(2011, 1, 1),
             receipt_date=datetime.date(2011, 2, 1))
 
         self.assertItemsEqual(
@@ -215,7 +215,7 @@ class TestDefaultDocumentIndexer(MockTestCase):
         default_doc_indexer = DefaultDocumentIndexer(doc1)
         try:
             fulltext = default_doc_indexer.extract_text()
-        except:
+        except:  # noqa - this bare except is the whole point of the test
             self.fail("extract_text() didn't catch exception raised "
                       "by transform!")
         self.assertEquals('', fulltext)


### PR DESCRIPTION
* I've plugged the D'n'D upload reindexing hole
* Only reindex the `checked_out` index