### PR TITLE
Word meeting: Show decision number in meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Word meeting: Show decision number in meeting view. [jone]
 - Add a file action button for extracting mail attachments. [Rotonen]
 - Add upgrade step which fixes potential missing titles on opengever.private.root objects. [mathias.leimgruber]
 - Point footer source-code link to 4teamwork/opengever.core, drop link to CI. [deiferni]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -175,6 +175,7 @@ class AgendaItemsView(BrowserView):
                 view='agenda_items/{}/delete'.format(item.agenda_item_id))
             data['edit_link'] = meeting.get_url(
                 view='agenda_items/{}/edit'.format(item.agenda_item_id))
+            data['decision_number'] = item.decision_number
             if item.is_decide_possible():
                 data['decide_link'] = meeting.get_url(
                     view='agenda_items/{}/decide'.format(item.agenda_item_id))

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -340,6 +340,7 @@ class MeetingView(BrowserView):
                 _('label_excerpts', default='Excerpts'),
                 _('label_toggle_attachments', default='Toggle attachments'),
                 _('label_agenda_item_number', default='Agenda item number'),
+                _('label_decision_number', default=u'Decision number'),
             ),
             max_proposal_title_length=ISubmittedProposal['title'].max_length)
 

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -3,6 +3,11 @@
   <tr class="{{css_class}} word-feature agenda_item" data-uid={{id}}>
     {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
     <td class="title">
+      {{#if decision_number}}
+      <span class="decision_number" title="%(label_decision_number)s">
+        # {{decision_number}}
+      </span>
+      {{/if}}
       {{#if has_documents}}
       <div class="toggle-attachements">
         <a class="toggle-attachements-btn"

--- a/sources.cfg
+++ b/sources.cfg
@@ -15,6 +15,7 @@ development-packages =
 # https://github.com/4teamwork/plonetheme.teamraum/pull/571
 # https://github.com/4teamwork/plonetheme.teamraum/pull/572
 # https://github.com/4teamwork/plonetheme.teamraum/pull/574
+# https://github.com/4teamwork/plonetheme.teamraum/pull/575
   plonetheme.teamraum
   docxmerge
 


### PR DESCRIPTION
When agenda items are decided, the decision number should be shown in the meeting view, at the right side of the agenda item title.

![bildschirmfoto 2017-08-24 um 09 55 07](https://user-images.githubusercontent.com/7469/29656061-663e8128-88b3-11e7-89ad-4eecfa9a4db0.png)
![bildschirmfoto 2017-08-24 um 09 55 00](https://user-images.githubusercontent.com/7469/29656062-665913b2-88b3-11e7-9a15-61ab8fadcea5.png)

Part of #2829 
Requires https://github.com/4teamwork/plonetheme.teamraum/pull/575