### PR TITLE
Fix textfilter for sql table listings when using oracle backends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Bundle import: Fix tree portlet assignment to repo roots. [lgraf]
 - Fix an issue with conflicting css classes breaking a link. [deiferni]
+- Fix textfilter for sql table listings when using oracle backends. [phgross]
 - Word meeting: Show decision number in meeting view. [jone]
 - Add lawgiver workflows for committee and committee-container. [deiferni]
 - Add a file action button for extracting mail attachments. [Rotonen]

--- a/opengever/tabbedview/sqlsource.py
+++ b/opengever/tabbedview/sqlsource.py
@@ -89,9 +89,12 @@ class SqlTableSource(GeverTableSource):
                 # Issue #759
                 query.session
 
-                query = query.filter(or_(
-                    *[cast(field, String).ilike(term)
-                      for field in self.searchable_columns]))
+                expressions = []
+                for field in self.searchable_columns:
+                    if not issubclass(field.type.python_type, basestring):
+                        field = cast(field, String)
+                    expressions.append(field.ilike(term))
+                query = query.filter(or_(*expressions))
 
         return query
 


### PR DESCRIPTION
Currently all expressions contain a string cast statement, even if the field is already a string column. This is unnecessary and leads to an issue with oracle backends (see traceback below). The new
implementation ads casting only for not stringy fields.

`DatabaseError: (cx_Oracle.DatabaseError) ORA-00906: missing left parenthesis`

Fixes https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3749/