### PR TITLE
Fix an issue with conflicting css classes breaking a link.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bundle import: Fix tree portlet assignment to repo roots. [lgraf]
+- Fix an issue with conflicting css classes breaking a link. [deiferni]
 - Word meeting: Show decision number in meeting view. [jone]
 - Add lawgiver workflows for committee and committee-container. [deiferni]
 - Add a file action button for extracting mail attachments. [Rotonen]

--- a/opengever/meeting/browser/meetings/templates/meeting-noword.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -223,7 +223,7 @@
               <div class="item">
                 <span class="title" i18n:translate="">Excerpts</span>
 
-                <a class="generate-excerpt"
+                <a class="generate-manual-excerpt"
                    tal:attributes="href view/url_manually_generate_excerpt"
                    i18n:attributes="title"
                    title="generate new excerpt"></a>

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -86,7 +86,7 @@ class TestExcerpt(IntegrationTestCase):
     def test_manual_excerpt_pre_fills_fields(self, browser):
         self.login(self.committee_responsible, browser)
         browser.open(self.meeting.model.get_url())
-        browser.css('.generate-excerpt').first.click()
+        browser.css('.generate-manual-excerpt').first.click()
 
         title_field = browser.find('Title')
 
@@ -105,7 +105,7 @@ class TestExcerpt(IntegrationTestCase):
                                self.submitted_word_proposal)
         browser.open(self.meeting.model.get_url())
 
-        browser.css('.generate-excerpt').first.click()
+        browser.css('.generate-manual-excerpt').first.click()
         browser.fill({'agenda_item-1.include:record': True,
                       'Target dossier': self.dossier})
         browser.find('Save').click()
@@ -133,7 +133,7 @@ class TestExcerpt(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         browser.open(self.meeting.model.get_url())
 
-        browser.css('.generate-excerpt').first.click()
+        browser.css('.generate-manual-excerpt').first.click()
         browser.find('form.buttons.cancel').click()
 
         self.assertEqual(self.meeting.model.get_url(), browser.url)
@@ -145,7 +145,7 @@ class TestExcerpt(IntegrationTestCase):
                                self.submitted_word_proposal)
         browser.open(self.meeting.model.get_url())
 
-        browser.css('.generate-excerpt').first.click()
+        browser.css('.generate-manual-excerpt').first.click()
         # de-select pre-selected field-checkboxes
         browser.fill({'form.widgets.include_initial_position:list': False,
                       'form.widgets.include_decision:list': False,
@@ -164,7 +164,7 @@ class TestExcerpt(IntegrationTestCase):
                                self.submitted_word_proposal)
         browser.open(self.meeting.model.get_url())
 
-        browser.css('.generate-excerpt').first.click()
+        browser.css('.generate-manual-excerpt').first.click()
         browser.fill({'Target dossier': self.dossier})
         browser.find('Save').click()
 


### PR DESCRIPTION
Fix an issue with a css class that was used in two different places for different functionality, introduced in https://github.com/4teamwork/opengever.core/pull/3245. This broke the link to generate excerpts manually.

⚠️  depends on https://github.com/4teamwork/plonetheme.teamraum/pull/576

Closes #3320.