### PR TITLE
Hide contact field in the manual journal entry form, 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Hide contact field in the manual journal entry form, when contact feature is disabled. [phgross]
 - Bundle import: Fix tree portlet assignment to repo roots. [lgraf]
 - Word meeting: Show decision number in meeting view. [jone]
 - Add lawgiver workflows for committee and committee-container. [deiferni]

--- a/opengever/journal/form.py
+++ b/opengever/journal/form.py
@@ -1,5 +1,6 @@
 from ftw.keywordwidget.widget import KeywordWidget
 from opengever.base.source import DossierPathSourceBinder
+from opengever.contact import is_contact_feature_enabled
 from opengever.contact.sources import ContactsSourceBinder
 from opengever.journal import _
 from opengever.journal.entry import ManualJournalEntry
@@ -10,6 +11,7 @@ from z3c.form import button
 from z3c.form.field import Fields
 from z3c.form.form import AddForm
 from z3c.form.i18n import MessageFactory as z3c_mf
+from z3c.form.interfaces import HIDDEN_MODE
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
@@ -66,6 +68,11 @@ class ManualJournalEntryAddForm(AddForm):
         KeywordWidget,
         async=True
     )
+
+    def updateWidgets(self, prefix=None):
+        super(ManualJournalEntryAddForm, self).updateWidgets(prefix=prefix)
+        if not is_contact_feature_enabled():
+            self.widgets['contacts'].mode = HIDDEN_MODE
 
     @button.buttonAndHandler(z3c_mf('Add'), name='add')
     def handleAdd(self, action):

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -3,7 +3,9 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.contact.interfaces import IContactSettings
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
+from opengever.core.testing import toggle_feature
 from opengever.testing import FunctionalTestCase
 from opengever.testing.helpers import get_contacts_token
 
@@ -14,6 +16,7 @@ class TestManualJournalEntry(FunctionalTestCase):
         super(TestManualJournalEntry, self).setUp()
         self.dossier = create(Builder('dossier'))
         self.contactfolder = create(Builder('contactfolder'))
+        toggle_feature(IContactSettings, enabled=True)
 
     @browsing
     def test_adds_entry_to_context_journal(self, browser):
@@ -166,3 +169,11 @@ class TestManualJournalEntry(FunctionalTestCase):
 
         self.assertEquals(
             '{}#journal'.format(self.dossier.absolute_url()), browser.url)
+
+    @browsing
+    def test_contact_field_is_hidden_when_contact_feature_is_disabled(self, browser):
+        toggle_feature(IContactSettings, enabled=False)
+
+        browser.login().open(self.dossier, view='add-journal-entry')
+
+        self.assertIsNone(browser.find_field_by_text('Contacts'))


### PR DESCRIPTION
when contact feature is disabled.

Because the implemented feature to add a reference to contacts in the manual entry form only works for the "new contact type", we decided to hide the contact field for installations with a disabled feature flag.