### PR TITLE
Fix Drag'n'Drop replacing for documents inside a resolved task.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Hide contact field in the manual journal entry form, when contact feature is disabled. [phgross]
 - Only show membership edit links for CommitteeResponsibles. [deiferni]
+- Fix Drag'n'Drop replacing for documents inside a resolved task. [phgross]
 - Bundle import: Fix tree portlet assignment to repo roots. [lgraf]
 - Fix an issue with conflicting css classes breaking a link. [deiferni]
 - Fix textfilter for sql table listings when using oracle backends. [phgross]

--- a/opengever/document/browser/tabbed.py
+++ b/opengever/document/browser/tabbed.py
@@ -4,12 +4,16 @@ from zope.component import getMultiAdapter
 
 
 class DocumentTabbedView(TabbedView):
+    """Tabbedview for documentish types, implements a separate check for the
+    uploadbox, to allow drag and drop replacing of a file.
+    """
 
     def show_uploadbox(self):
+        """Only checks if a file_upload is available, means document is
+        checked out and not locked.
+        """
+
         manager = getMultiAdapter((self.context, self.context.REQUEST),
                                   ICheckinCheckoutManager)
 
-        if not manager.is_file_upload_allowed():
-            return False
-
-        return super(DocumentTabbedView, self).show_uploadbox()
+        return manager.is_file_upload_allowed()

--- a/opengever/document/tests/test_tabbed.py
+++ b/opengever/document/tests/test_tabbed.py
@@ -1,60 +1,59 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.testing import IntegrationTestCase
 from plone.locking.interfaces import IRefreshableLockable
+from zope.component import queryMultiAdapter
 
 
-class TestDocumentQuickupload(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDocumentQuickupload, self).setUp()
-        self.dossier = create(Builder('dossier'))
+class TestDocumentQuickupload(IntegrationTestCase):
 
     @browsing
     def test_upload_box_is_hidden_when_document_is_not_checked_out(self, browser):
-        document = create(Builder('document').within(self.dossier))
-
-        browser.login().open(document)
+        self.login(self.regular_user, browser)
+        browser.open(self.document)
         self.assertEquals([], browser.css('#uploadbox'),
                           'uploadbox is wrongly displayed')
 
     @browsing
     def test_upload_box_is_hidden_when_document_is_locked(self, browser):
-        document = create(Builder('document').within(self.dossier))
-        IRefreshableLockable(document).lock()
+        self.login(self.regular_user, browser)
 
-        browser.login().open(document)
+        manager = queryMultiAdapter(
+            (self.document, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+        IRefreshableLockable(self.document).lock()
+
+        browser.open(self.document)
         self.assertEquals([], browser.css('#uploadbox'),
                           'uploadbox is wrongly displayed')
 
     @browsing
     def test_upload_box_is_shown_when_document_is_checked_out_and_not_locked(self, browser):
-        document = create(Builder('document')
-                          .within(self.dossier)
-                          .checked_out())
+        self.login(self.regular_user, browser)
+        browser.open(self.document)
 
-        browser.login().open(document)
-        self.assertNotEquals(0, len(browser.css('#uploadbox')),
-                             'Uploadbox is not displayed, but should.')
+        manager = queryMultiAdapter(
+            (self.document, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+
+        browser.open(self.document)
+        self.assertGreater(len(browser.css('#uploadbox')), 0,
+                           'Uploadbox is not displayed, but should.')
 
     @browsing
     def test_upload_box_is_also_shown_in_a_resolved_task(self, browser):
-        create(Builder('ogds_user').id(u'hugo.boss'))
-        task = create(Builder('task')
-                      .having(responsible='hugo.boss', issuer='hugo.boss')
-                      .within(self.dossier)
-                      .in_state('task-state-tested-and-closed'))
-        document = create(Builder('document')
-                          .within(task)
-                          .checked_out())
+        self.login(self.regular_user, browser)
 
-        self.grant('Reader')
+        self.set_workflow_state('task-state-tested-and-closed', self.task)
         self.dossier.manage_setLocalRoles(
-            TEST_USER_ID, ['Reader', 'Contributor', 'Editor'])
+            'kathi.barfuss', ['Reader', 'Contributor', 'Editor'])
         self.dossier.reindexObjectSecurity()
 
-        browser.login().open(document)
-        self.assertNotEquals(0, len(browser.css('#uploadbox')),
-                             'Uploadbox is not displayed, but should.')
+        manager = queryMultiAdapter(
+            (self.taskdocument, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+
+        browser.open(self.taskdocument)
+
+        self.assertGreater(len(browser.css('#uploadbox')), 0,
+                           'Uploadbox is not displayed, but should.')


### PR DESCRIPTION
The former implementation also calls the baseclass checks, but those
are wrong for the drag'n'drop replacing use case. A check for `add
portal content` permission makes no sense.