### PR TITLE
No longer display edit period button for unprivileged users.

### DIFF
--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -12,6 +12,7 @@ from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.committee import ICommittee
 from opengever.meeting.model import Period
 from opengever.tabbedview import GeverTabMixin
+from plone import api
 from plone.directives import form
 from plone.z3cform.layout import FormWrapper
 from Products.Five.browser import BrowserView
@@ -226,3 +227,9 @@ class PeriodsTab(BrowserView, GeverTabMixin):
         """
         return Period.query.by_committee(
             self.context.load_model()).order_by(desc(Period.date_from))
+
+    def is_editable_by_current_user(self):
+        """Return whether the current user can edit periods."""
+
+        return api.user.has_permission(
+            'Modify portal content', obj=self.context)

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -118,8 +118,8 @@ class CloseCurrentPeriodStepView(FormWrapper, grok.View):
     form = CloseCurrentPeriodStep
 
     def __init__(self, *args, **kwargs):
-         FormWrapper.__init__(self, *args, **kwargs)
-         grok.View.__init__(self, *args, **kwargs)
+        FormWrapper.__init__(self, *args, **kwargs)
+        grok.View.__init__(self, *args, **kwargs)
 
     def available(self):
         return is_meeting_feature_enabled()
@@ -191,8 +191,8 @@ class AddNewPeriodStepView(FormWrapper, grok.View):
     form = AddNewPeriodStep
 
     def __init__(self, *args, **kwargs):
-         FormWrapper.__init__(self, *args, **kwargs)
-         grok.View.__init__(self, *args, **kwargs)
+        FormWrapper.__init__(self, *args, **kwargs)
+        grok.View.__init__(self, *args, **kwargs)
 
     def available(self):
         return is_meeting_feature_enabled()

--- a/opengever/meeting/browser/templates/periods.pt
+++ b/opengever/meeting/browser/templates/periods.pt
@@ -22,7 +22,7 @@
           </a>
         </li>
       </ul>
-      <ul class="actions">
+      <ul class="actions" tal:condition="view/is_editable_by_current_user">
         <li>
           <a class="edit_period"
              tal:attributes="href string:${context/absolute_url}/${period/wrapper_id}/edit"

--- a/opengever/meeting/tests/test_periods.py
+++ b/opengever/meeting/tests/test_periods.py
@@ -8,6 +8,25 @@ from ftw.testing import freeze
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.model import Period
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
+
+
+class TestPathBar(IntegrationTestCase):
+
+    features = ('meeting',)
+
+    @browsing
+    def test_committee_member_cant_see_period_edit_links(self, browser):
+        self.login(self.meeting_user, browser)
+
+        browser.open(self.committee, view='tabbedview_view-periods')
+        listing = browser.css('#period_listing').first
+        self.assertEqual(
+            '2016 (Jan 01, 2016 - Dec 31, 2016) '
+            'download TOC alphabetical '
+            'download TOC by repository',
+            listing.text
+            )
 
 
 class TestPeriod(FunctionalTestCase):


### PR DESCRIPTION
This PR displays the edit period link only when the user is actually allowed to `Modify portal content` in the corresponding committee.

Closes #3319.