### PR TITLE
Word-meeting: Create document from configured template for ad-hoc agenda items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Implement "checked in vs. checked out docs" content stats provider. [lgraf]
 - Include and integrate ftw.contentstats in GEVER. [lgraf]
 - Add ftw.structlog as a dependency to opengever.core. [lgraf]
+- SPV word: add support for ad-hoc agenda items, add configurable ad-hoc agenda item. [deiferni]
 - Add configuration option to hide the mail preview tab. [phgross]
 - Update ftw.keywordwidget to 1.3.6: Fix a bug while adding new keywords. [mathias.leimgruber]
 - Hide contact field in the manual journal entry form, when contact feature is disabled. [phgross]

--- a/opengever/core/upgrades/20170905152010_add_document_to_agenda_item/upgrade.py
+++ b/opengever/core/upgrades/20170905152010_add_document_to_agenda_item/upgrade.py
@@ -1,0 +1,20 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import Integer
+from sqlalchemy import String
+
+
+UNIT_ID_LENGTH = 30
+
+
+class AddDocumentToAgendaItem(SchemaMigration):
+    """Add document to agenda-item.
+    """
+
+    def migrate(self):
+        self.op.add_column(
+            'agendaitems',
+            Column('ad_hoc_document_int_id', Integer))
+        self.op.add_column(
+            'agendaitems',
+            Column('ad_hoc_document_admin_unit_id', String(UNIT_ID_LENGTH)))

--- a/opengever/meeting/browser/committeecontainer_forms.py
+++ b/opengever/meeting/browser/committeecontainer_forms.py
@@ -1,15 +1,22 @@
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
 from opengever.base.browser.translated_title import TranslatedTitleEditForm
+from opengever.meeting import is_word_meeting_implementation_enabled
 from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFCore.interfaces import IFolderish
+from z3c.form.interfaces import HIDDEN_MODE
 from zope.component import adapter
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
 class AddForm(TranslatedTitleAddForm):
-    """
-    """
+    """Add form for opengever.meeting.committeecontainer."""
+
+    def updateWidgets(self):
+        super(AddForm, self).updateWidgets()
+
+        if not is_word_meeting_implementation_enabled():
+            self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
 
 
 @adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
@@ -18,5 +25,10 @@ class AddView(DefaultAddView):
 
 
 class EditForm(TranslatedTitleEditForm):
-    """
-    """
+    """Edit form for opengever.meeting.committeecontainer."""
+
+    def updateWidgets(self):
+        super(EditForm, self).updateWidgets()
+
+        if not is_word_meeting_implementation_enabled():
+            self.widgets['ad_hoc_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -6,6 +6,7 @@ from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.browser.periods import IPeriodModel
 from opengever.meeting.committee import Committee
 from opengever.meeting.committee import ICommittee
@@ -19,6 +20,7 @@ from plone.z3cform.layout import FormWrapper
 from z3c.form import field
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
+from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import IDataConverter
 from zope.component import getUtility
 
@@ -48,6 +50,12 @@ class AddForm(BaseWizardStepForm, dexterity.AddForm):
 
     step_name = 'add-meeting-dossier'
     steps = ADD_COMMITTEE_STEPS
+
+    def updateWidgets(self):
+        super(AddForm, self).updateWidgets()
+
+        if not is_word_meeting_implementation_enabled():
+            self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
 
     @buttonAndHandler(_(u'button_continue', default=u'Continue'), name='save')
     def handle_continue(self, action):
@@ -162,3 +170,9 @@ class EditForm(ModelProxyEditForm, dexterity.EditForm):
     grok.context(ICommittee)
     fields = field.Fields(Committee.model_schema, ignoreContext=True)
     content_type = Committee
+
+    def updateWidgets(self):
+        super(EditForm, self).updateWidgets()
+
+        if not is_word_meeting_implementation_enabled():
+            self.widgets['ad_hoc_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -162,7 +162,7 @@ class AgendaItemsView(BrowserView):
         return {
             'document_checked_out': bool(
                 checkout_manager.get_checked_out_by()),
-            'edit_proposal_document_button': button}
+            'edit_document_button': button}
 
     def _get_agenda_items(self):
         meeting = self.context.model
@@ -413,13 +413,13 @@ class AgendaItemsView(BrowserView):
                         _('missing_ad_hoc_template',
                           default=u"No ad-hoc agenda-item template has been "
                                   u"configured.")
-                    ).proceed().dump()
+                    ).remain().dump()
             except MissingMeetingDossierPermissions:
                 return JSONResponse(self.request).error(
                         _('error_no_permission_to_add_document',
                           default=u'Insufficient privileges to add a'
                                   u' document to the meeting dossier.')
-                       ).proceed().dump()
+                       ).remain().dump()
 
         else:
             self.meeting.schedule_text(title)

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -28,8 +28,8 @@
           </div>
         </div>
       </div>
-      {{#if has_proposal}}
-      <div class="proposal_document {{#if proposal_document_checked_out}}checked-out{{/if}}">{{{proposal_document_link}}}</div>
+      {{#if document_link}}
+      <div class="proposal_document {{#if document_checked_out}}checked-out{{/if}}">{{{document_link}}}</div>
 
       {{#if excerpts}}
       <div>

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -67,8 +67,8 @@
     {{#if ../editable}}
     <td class="actions">
       <div class="button-group">
-        {{#if edit_proposal_document_button.visible}}
-        <a href="{{edit_proposal_document_button.url}}" title="%(label_edit_document_action)s" class="button edit-document" {{#unless edit_proposal_document_button.active}}disabled{{/unless}}><span></span></a>
+        {{#if edit_document_button.visible}}
+        <a href="{{edit_document_button.url}}" title="%(label_edit_document_action)s" class="button edit-document" {{#unless edit_document_button.active}}disabled{{/unless}}><span></span></a>
         {{/if}}
         {{#if ../agendalist_editable}}
         <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -3,7 +3,6 @@ from ftw.table import helper
 from opengever.base.schema import TableChoice
 from opengever.base.widgets import TrixFieldWidget
 from opengever.document.interfaces import ICheckinCheckoutManager
-from opengever.dossier.templatefolder import get_template_folder
 from opengever.meeting import _
 from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.form import ModelProxyAddForm
@@ -12,22 +11,18 @@ from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.proposal import Proposal
 from opengever.meeting.proposal import SubmittedProposal
+from opengever.meeting.vocabulary import get_proposal_template_vocabulary
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
 from plone.directives import dexterity
 from plone.directives.form import widget
-from plone.uuid.interfaces import IUUID
 from plone.z3cform.fieldsets.utils import move
-from Products.CMFPlone.utils import safe_unicode
 from z3c.form import field
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
 from z3c.form.interfaces import HIDDEN_MODE
 from zope.component import getMultiAdapter
-from zope.interface import provider
 from zope.schema import Bool
-from zope.schema.interfaces import IContextSourceBinder
-from zope.schema.vocabulary import SimpleVocabulary
 
 
 class FieldConfigurationMixin(object):
@@ -80,30 +75,6 @@ class SubmittedProposalEditForm(FieldConfigurationMixin,
     def updateWidgets(self):
         super(SubmittedProposalEditForm, self).updateWidgets()
         self.widgets['relatedItems'].mode = HIDDEN_MODE
-
-
-@provider(IContextSourceBinder)
-def get_proposal_template_vocabulary(context):
-    template_folder = get_template_folder()
-    if template_folder is None:
-        # this may happen when the user does not have permissions to
-        # view templates and/or during ++widget++ traversal
-        return SimpleVocabulary([])
-
-    templates = api.content.find(
-        context=template_folder,
-        depth=-1,
-        portal_type="opengever.meeting.proposaltemplate",
-        sort_on='sortable_title', sort_order='ascending')
-
-    terms = []
-    for brain in templates:
-        template = brain.getObject()
-        terms.append(SimpleVocabulary.createTerm(
-            template,
-            IUUID(template),
-            safe_unicode(brain.Title)))
-    return SimpleVocabulary(terms)
 
 
 class IAddProposal(IProposal):

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -389,7 +389,7 @@ class UpdateExcerptInDossierCommand(object):
         self.document = self.submitted_excerpt.resolve_document()
 
     def execute(self):
-        #XXX handle errors when executing across admin units.
+        # XXX handle errors when executing across admin units.
         Transporter().transport_to(
             self.document,
             self.excerpt.admin_unit_id,

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -317,17 +317,16 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
             builder = DocumentBuilder(Document(master_path))
 
             for index, item in enumerate(self.meeting.agenda_items):
-                if not item.has_proposal:
+                if not item.has_document:
                     continue
 
-                proposal = item.proposal.submitted_oguid.resolve_object()
-                proposal_document = proposal.get_proposal_document()
-                proposal_path = join(
-                    tmpdir_path, 'proposal{}.docx'.format(index))
+                document = item.resolve_document()
+                agenda_item_path = join(
+                    tmpdir_path, 'agenda_item_{}.docx'.format(index))
 
-                with open(proposal_path, 'wb') as proposal_file:
-                    proposal_file.write(proposal_document.file.data)
-                builder.append(Document(proposal_path))
+                with open(agenda_item_path, 'wb') as agenda_item_file:
+                    agenda_item_file.write(document.file.data)
+                builder.append(Document(agenda_item_path))
 
             builder.save(output_path)
             with open(output_path, 'rb') as merged_file:

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from five import grok
 from opengever.base.validators import BaseRepositoryfolderValidator
 from opengever.meeting import _
+from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.committeeroles import CommitteeRoles
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.model import Committee as CommitteeModel
@@ -10,6 +11,7 @@ from opengever.meeting.model import Meeting
 from opengever.meeting.model import Membership
 from opengever.meeting.model import Period
 from opengever.meeting.service import meeting_service
+from opengever.meeting.sources import proposal_template_source
 from opengever.meeting.sources import repository_folder_source
 from opengever.meeting.sources import sablon_template_source
 from opengever.meeting.wrapper import MeetingWrapper
@@ -87,6 +89,13 @@ class ICommittee(form.Schema):
                     u'for this committee.'),
         source=repository_folder_source,
         required=True)
+
+    ad_hoc_template = RelationChoice(
+        title=_('label_ad_hoc_template',
+                default=u'Ad hoc agenda item template'),
+        source=proposal_template_source,
+        required=False,
+    )
 
 
 class RepositoryfolderValidator(BaseRepositoryfolderValidator):
@@ -234,6 +243,13 @@ class Committee(ModelContainer):
             return self.toc_template.to_object
 
         return self.get_committee_container().get_toc_template()
+
+    @require_word_meeting_feature
+    def get_ad_hoc_template(self):
+        if self.ad_hoc_template:
+            return self.ad_hoc_template.to_object
+
+        return self.get_committee_container().get_ad_hoc_template()
 
     def get_repository_folder(self):
         return self.repository_folder.to_object

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,6 +1,8 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.meeting import _
+from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.model import Member
+from opengever.meeting.sources import proposal_template_source
 from opengever.meeting.sources import sablon_template_source
 from opengever.meeting.wrapper import MemberWrapper
 from plone.dexterity.content import Container
@@ -35,6 +37,13 @@ class ICommitteeContainer(form.Schema):
         title=_('label_toc_template',
                 default=u'Table of contents template'),
         source=sablon_template_source,
+        required=False,
+    )
+
+    ad_hoc_template = RelationChoice(
+        title=_('label_ad_hoc_template',
+                default=u'Ad hoc agenda item template'),
+        source=proposal_template_source,
         required=False,
     )
 
@@ -81,5 +90,12 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
     def get_toc_template(self):
         if self.toc_template:
             return self.toc_template.to_object
+
+        return None
+
+    @require_word_meeting_feature
+    def get_ad_hoc_template(self):
+        if self.ad_hoc_template:
+            return self.ad_hoc_template.to_object
 
         return None

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -14,3 +14,13 @@ class WordMeetingImplementationDisabledError(Exception):
     """The word meeting implementation feature is not enabled but a method
     was called which requires this feature.
     """
+
+
+class MissingMeetingDossierPermissions(Exception):
+    """The user has access to a meeting but no access to the meeting's dossier.
+    """
+
+
+class MissingAdHocTemplate(Exception):
+    """No ad-hoc template could be found for the committee or its container.
+    """

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-22 10:17+0000\n"
+"POT-Creation-Date: 2017-08-31 10:24+0000\n"
 "PO-Revision-Date: 2017-08-22 12:18+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:253
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -41,20 +41,20 @@ msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
 #. Default: "Add Membership"
-#: ./opengever/meeting/browser/memberships.py:43
+#: ./opengever/meeting/browser/memberships.py:45
 msgid "Add Membership"
 msgstr "Mitgliedschaft hinzufügen"
 
-#: ./opengever/meeting/browser/committeeforms.py:28
+#: ./opengever/meeting/browser/committeeforms.py:29
 msgid "Add committee"
 msgstr "Gremium hinzufügen"
 
-#: ./opengever/meeting/browser/periods.py:49
+#: ./opengever/meeting/browser/periods.py:50
 msgid "Add new period"
 msgstr "Neue Periode hinzufügen"
 
-#: ./opengever/meeting/browser/committeeforms.py:29
-#: ./opengever/meeting/browser/periods.py:136
+#: ./opengever/meeting/browser/committeeforms.py:30
+#: ./opengever/meeting/browser/periods.py:137
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
@@ -67,7 +67,7 @@ msgid "Agenda Items"
 msgstr "Traktanden"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:381
+#: ./opengever/meeting/browser/meetings/meeting.py:382
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -81,11 +81,11 @@ msgstr "Wollen Sie diese Sitzung wirklich abschliessen?"
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr "Sind Sie sicher, dass Sie dieses Traktandum beschliessen möchten?"
 
-#: ./opengever/meeting/browser/memberships.py:51
+#: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Die Mitgliedschaft kann nicht erstellt werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis ${date_to} überschneidet."
 
-#: ./opengever/meeting/browser/memberships.py:85
+#: ./opengever/meeting/browser/memberships.py:87
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis zum ${date_to} überschneidet."
 
@@ -98,11 +98,11 @@ msgstr "Traktanden auswählen"
 msgid "Close all proposals."
 msgstr "Alle Anträge werden abgeschlossen."
 
-#: ./opengever/meeting/browser/periods.py:68
+#: ./opengever/meeting/browser/periods.py:69
 msgid "Close currently active period"
 msgstr "Aktuelle Periode abschliessen"
 
-#: ./opengever/meeting/browser/periods.py:48
+#: ./opengever/meeting/browser/periods.py:49
 msgid "Close period"
 msgstr "Periode abschliessen"
 
@@ -149,8 +149,8 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:61
-#: ./opengever/meeting/committeecontainer.py:22
+#: ./opengever/meeting/committee.py:65
+#: ./opengever/meeting/committeecontainer.py:24
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
@@ -207,7 +207,7 @@ msgstr "Rechtsgrundlage einfügen"
 msgid "Include proposed action"
 msgstr "Antrag einfügen"
 
-#: ./opengever/meeting/committee.py:81
+#: ./opengever/meeting/committee.py:85
 msgid "Linked repository folder"
 msgstr "Ablageposition"
 
@@ -241,7 +241,6 @@ msgid "Once closed the meeting and its protocol cannot be edited any longer. The
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Order"
 msgstr "Sortierung"
 
@@ -275,11 +274,11 @@ msgid "Proposals:"
 msgstr "Anträge"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/model/meeting.py:254
+#: ./opengever/meeting/model/meeting.py:258
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:257
+#: ./opengever/meeting/model/meeting.py:261
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
@@ -291,8 +290,8 @@ msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:55
-#: ./opengever/meeting/committeecontainer.py:16
+#: ./opengever/meeting/committee.py:59
+#: ./opengever/meeting/committeecontainer.py:18
 msgid "Protocol template"
 msgstr "Vorlage Protokoll"
 
@@ -358,80 +357,80 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
 #. Default: "Active"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py:29
 #: ./opengever/meeting/model/period.py:21
 msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:323
+#: ./opengever/meeting/browser/meetings/agendaitem.py:332
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr "Traktandum kann nicht beschlossen werden: das Beschlussdokument ist noch von einer anderen Person ausgecheckt."
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:293
+#: ./opengever/meeting/browser/meetings/agendaitem.py:302
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:269
+#: ./opengever/meeting/browser/meetings/agendaitem.py:278
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:298
+#: ./opengever/meeting/browser/meetings/agendaitem.py:307
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:228
+#: ./opengever/meeting/browser/meetings/agendaitem.py:237
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:290
+#: ./opengever/meeting/browser/meetings/agendaitem.py:299
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:339
+#: ./opengever/meeting/browser/meetings/agendaitem.py:348
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:352
+#: ./opengever/meeting/browser/meetings/agendaitem.py:361
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:241
+#: ./opengever/meeting/browser/meetings/agendaitem.py:250
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:248
+#: ./opengever/meeting/browser/meetings/agendaitem.py:257
 msgid "agenda_item_update_too_long_title"
 msgstr "Der Traktandums-Titel ist zu lang."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:254
+#: ./opengever/meeting/browser/meetings/agendaitem.py:263
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/committeeforms.py:65
+#: ./opengever/meeting/browser/committeeforms.py:72
 #: ./opengever/meeting/browser/documents/submit.py:96
 #: ./opengever/meeting/browser/meetings/meeting.py:120
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:91
+#: ./opengever/meeting/browser/periods.py:92
 msgid "button_close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Continue"
-#: ./opengever/meeting/browser/committeeforms.py:53
+#: ./opengever/meeting/browser/committeeforms.py:60
 #: ./opengever/meeting/browser/meetings/meeting.py:104
 msgid "button_continue"
 msgstr "Weiter"
@@ -443,19 +442,19 @@ msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:157
+#: ./opengever/meeting/model/proposal.py:160
 msgid "cancel"
 msgstr "Stornieren"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:140
 msgid "cancelled"
 msgstr "Storniert"
 
 #. Default: "Close meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:58
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:60
-#: ./opengever/meeting/model/meeting.py:78
+#: ./opengever/meeting/model/meeting.py:82
 msgid "close_meeting"
 msgstr "Abschliessen"
 
@@ -465,7 +464,7 @@ msgid "close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:76
 #: ./opengever/meeting/model/period.py:22
 msgid "closed"
 msgstr "geschlossen"
@@ -549,8 +548,8 @@ msgid "column_to"
 msgstr "Bis"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:155
+#: ./opengever/meeting/model/agendaitem.py:40
+#: ./opengever/meeting/model/proposal.py:158
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -561,18 +560,18 @@ msgid "decide_agendaitem"
 msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/agendaitem.py:31
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/proposal.py:138
 msgid "decided"
 msgstr "Beschlossen"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:110
+#: ./opengever/meeting/committee.py:122
 msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:369
+#: ./opengever/meeting/browser/meetings/agendaitem.py:377
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
@@ -587,12 +586,12 @@ msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:386
+#: ./opengever/meeting/browser/meetings/agendaitem.py:394
 msgid "empty_paragraph"
 msgstr "Der Abschnitt darf nicht leer sein."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:401
+#: ./opengever/meeting/browser/meetings/agendaitem.py:409
 msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
@@ -602,7 +601,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:425
+#: ./opengever/meeting/browser/meetings/agendaitem.py:423
 msgid "error_no_permission_to_add_document"
 msgstr "Ungenügende Berechtigungen zum Hinzufügen eines Dokumentes im Sitzungsdossier."
 
@@ -617,7 +616,7 @@ msgid "excerpt_document_title"
 msgstr "Protokollauszug ${title}"
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:434
+#: ./opengever/meeting/browser/meetings/agendaitem.py:461
 msgid "excerpt_generated"
 msgstr "Protokollauszug erfolgreich generiert."
 
@@ -651,7 +650,7 @@ msgid "heading_reject_proposal_form"
 msgstr "Antrag zurückweisen"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:71
+#: ./opengever/meeting/model/meeting.py:75
 msgid "held"
 msgstr "Durchgeführt"
 
@@ -666,14 +665,20 @@ msgid "help_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt werden soll."
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:80
+#: ./opengever/meeting/model/meeting.py:84
 msgid "hold"
 msgstr "Sitzung durchführen"
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:31
+#: ./opengever/meeting/model/committee.py:30
 msgid "inactive"
 msgstr "Inaktiv"
+
+#. Default: "Ad hoc agenda item template"
+#: ./opengever/meeting/committee.py:94
+#: ./opengever/meeting/committeecontainer.py:44
+msgid "label_ad_hoc_template"
+msgstr ""
 
 #. Default: "Agenda item number"
 #: ./opengever/meeting/browser/meetings/meeting.py:342
@@ -682,14 +687,14 @@ msgstr "Nummer des Traktandums in dieser Sitzung"
 
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
-#: ./opengever/meeting/model/meeting.py:261
+#: ./opengever/meeting/model/meeting.py:265
 #: ./opengever/meeting/protocol.py:160
 msgid "label_agendaitem_list"
 msgstr "Traktandenliste"
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:67
-#: ./opengever/meeting/committeecontainer.py:28
+#: ./opengever/meeting/committee.py:71
+#: ./opengever/meeting/committeecontainer.py:30
 msgid "label_agendaitem_list_template"
 msgstr "Vorlage Traktandenliste"
 
@@ -713,12 +718,12 @@ msgid "label_close"
 msgstr "Schliessen"
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committee.py:89
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:77
 msgid "label_committe_deactivated"
 msgstr "Gremium erfolgreich deaktiviert."
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committee.py:111
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:50
 msgid "label_committe_reactivated"
 msgstr "Gremium erfolgreich reaktiviert."
 
@@ -747,36 +752,36 @@ msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:121
+#: ./opengever/meeting/browser/proposalforms.py:92
 msgid "label_creator"
 msgstr "Ersteller"
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:38
+#: ./opengever/meeting/browser/committee.py:36
 msgid "label_current_members"
 msgstr "Aktuelle Mitglieder"
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:23
+#: ./opengever/meeting/browser/committee.py:21
 msgid "label_current_period"
 msgstr "Aktuelle Periode"
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/memberships.py:19
-#: ./opengever/meeting/browser/periods.py:36
+#: ./opengever/meeting/browser/memberships.py:21
+#: ./opengever/meeting/browser/periods.py:37
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "Von"
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/memberships.py:24
-#: ./opengever/meeting/browser/periods.py:42
+#: ./opengever/meeting/browser/memberships.py:26
+#: ./opengever/meeting/browser/periods.py:43
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Bis"
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:37
+#: ./opengever/meeting/model/committee.py:36
 msgid "label_deactivate"
 msgstr "Gremium deaktivieren"
 
@@ -803,6 +808,7 @@ msgid "label_decision_draft"
 msgstr "Beschlussentwurf"
 
 #. Default: "Decision number"
+#: ./opengever/meeting/browser/meetings/meeting.py:343
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
@@ -855,7 +861,7 @@ msgid "label_download_repository_toc"
 msgstr "Inhaltsverzeichnis nach Ordnungsposition"
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/templates/member.pt:62
+#: ./opengever/meeting/browser/templates/member.pt:65
 #: ./opengever/meeting/browser/templates/periods.pt:27
 msgid "label_edit"
 msgstr "Bearbeiten"
@@ -866,7 +872,7 @@ msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Edit after creation"
-#: ./opengever/meeting/browser/proposalforms.py:129
+#: ./opengever/meeting/browser/proposalforms.py:100
 msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
@@ -881,12 +887,12 @@ msgid "label_edit_document_action"
 msgstr "Word-Dokument auschecken und bearbeiten."
 
 #. Default: "Edit Membership"
-#: ./opengever/meeting/browser/memberships.py:71
+#: ./opengever/meeting/browser/memberships.py:73
 msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "Edit Period"
-#: ./opengever/meeting/browser/periods.py:203
+#: ./opengever/meeting/browser/periods.py:204
 msgid "label_edit_period"
 msgstr "Bearbeiten"
 
@@ -925,7 +931,7 @@ msgstr "Datei"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:277
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:279
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -941,7 +947,7 @@ msgid "label_generate_excerpt"
 msgstr "Protokollauszug generieren."
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:109
+#: ./opengever/meeting/committee.py:121
 msgid "label_group"
 msgstr "Gruppe"
 
@@ -953,7 +959,7 @@ msgstr "Ausgangslage"
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:309
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:311
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -980,7 +986,7 @@ msgid "label_linked_meeting"
 msgstr "Sitzung"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:82
+#: ./opengever/meeting/committee.py:86
 msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
@@ -1001,12 +1007,12 @@ msgid "label_meeting"
 msgstr "Sitzung"
 
 #. Default: "Member"
-#: ./opengever/meeting/browser/memberships.py:28
+#: ./opengever/meeting/browser/memberships.py:30
 msgid "label_member"
 msgstr "Mitglied"
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:124
+#: ./opengever/meeting/browser/proposalforms.py:95
 msgid "label_modified"
 msgstr "Zuletzt bearbeitet"
 
@@ -1026,7 +1032,7 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
+#: ./opengever/meeting/browser/meetings/meeting.py:352
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
@@ -1057,7 +1063,7 @@ msgid "label_proposal_id"
 msgstr "Laufnummer"
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:112
+#: ./opengever/meeting/browser/proposalforms.py:83
 msgid "label_proposal_template"
 msgstr "Antragsvorlage"
 
@@ -1079,7 +1085,7 @@ msgid "label_publish_in"
 msgstr "Veröffentlichung in"
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:41
+#: ./opengever/meeting/model/committee.py:40
 msgid "label_reactivate"
 msgstr "Gremium reaktivieren"
 
@@ -1089,7 +1095,7 @@ msgid "label_reject_proposal_text"
 msgstr "Kommentar"
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/templates/member.pt:66
+#: ./opengever/meeting/browser/templates/member.pt:70
 msgid "label_remove"
 msgstr "Löschen"
 
@@ -1104,7 +1110,7 @@ msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/memberships.py:33
+#: ./opengever/meeting/browser/memberships.py:35
 #: ./opengever/meeting/browser/templates/member.pt:52
 msgid "label_role"
 msgstr "Rolle"
@@ -1115,9 +1121,9 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:294
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -1145,8 +1151,8 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Table of contents template"
-#: ./opengever/meeting/committee.py:74
-#: ./opengever/meeting/committeecontainer.py:35
+#: ./opengever/meeting/committee.py:78
+#: ./opengever/meeting/committeecontainer.py:37
 msgid "label_toc_template"
 msgstr "Vorlage Inhaltsverzeichnis"
 
@@ -1172,12 +1178,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich detraktandieren?"
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:32
+#: ./opengever/meeting/browser/committee.py:30
 msgid "label_unscheduled_proposals"
 msgstr "Nicht traktandierte Anträge"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:27
+#: ./opengever/meeting/browser/committee.py:25
 msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
@@ -1229,6 +1235,11 @@ msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde vo
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
+#. Default: "No ad-hoc agenda-item template has been configured."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:417
+msgid "missing_ad_hoc_template"
+msgstr ""
+
 #. Default: "The protocol for meeting ${title} has already been generated."
 #: ./opengever/meeting/browser/protocol.py:76
 msgid "msg_error_protocol_already_generated"
@@ -1246,12 +1257,12 @@ msgid "msg_inactive_committee_selected"
 msgstr "Das ausgewählte Gremium wurde deaktiviert, der Antrag konnte nicht eingereicht werden."
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:58
+#: ./opengever/meeting/model/meeting.py:62
 msgid "msg_meeting_successfully_closed"
 msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollauszüge wurden generiert und an die Urprungsdossiers zurückgespielt."
 
 #. Default: "The membership was deleted successfully."
-#: ./opengever/meeting/browser/memberships.py:104
+#: ./opengever/meeting/browser/memberships.py:107
 msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
@@ -1266,7 +1277,7 @@ msgid "msg_no_toc_template"
 msgstr "Es ist keine Vorlage für das Inhaltsverzeichnis konfiguriert, das Inhaltsverzeichnis konnte nicht generiert werden."
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committee.py:72
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:58
 msgid "msg_pending_meetings"
 msgstr "Nicht alle Sitzungen sind abgeschlossen."
 
@@ -1291,7 +1302,7 @@ msgid "msg_successfully_deleted"
 msgstr "Das Objekt wurde erfolgreich gelöscht."
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committee.py:80
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:66
 msgid "msg_unscheduled_proposals"
 msgstr "Es gibt nicht traktandierte Anträge, die diesem Gremium zugewiesen sind."
 
@@ -1306,7 +1317,7 @@ msgid "overview"
 msgstr "Übersicht"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:390
+#: ./opengever/meeting/browser/meetings/agendaitem.py:398
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
@@ -1315,9 +1326,9 @@ msgid "participants"
 msgstr "Teilnehmende"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/agendaitem.py:33
+#: ./opengever/meeting/model/meeting.py:74
+#: ./opengever/meeting/model/proposal.py:133
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -1411,38 +1422,38 @@ msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:159
+#: ./opengever/meeting/model/proposal.py:162
 msgid "reactivate"
 msgstr "Wieder eröffnen"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:149
+#: ./opengever/meeting/model/proposal.py:152
 msgid "reject"
 msgstr "Zurückweisen"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:39
+#: ./opengever/meeting/model/agendaitem.py:42
 msgid "reopen"
 msgstr "Wieder eröffnen"
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:41
+#: ./opengever/meeting/model/agendaitem.py:44
 msgid "revise"
 msgstr "Überarbeiten"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:32
+#: ./opengever/meeting/model/agendaitem.py:35
 msgid "revision"
 msgstr "Überarbeitung"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:151
+#: ./opengever/meeting/model/proposal.py:154
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:134
+#: ./opengever/meeting/model/proposal.py:137
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1456,12 +1467,12 @@ msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:147
+#: ./opengever/meeting/model/proposal.py:150
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:132
+#: ./opengever/meeting/model/proposal.py:135
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1476,7 +1487,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:432
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
@@ -1484,23 +1495,28 @@ msgstr "Freitext erfolgreich hinzugefügt"
 msgid "time"
 msgstr "Zeit"
 
+#. Default: "Ad hoc agenda item ${title}"
+#: ./opengever/meeting/model/meeting.py:363
+msgid "title_ad_hoc_document"
+msgstr "Ad Hoc Traktandum ${title}"
+
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:153
+#: ./opengever/meeting/model/proposal.py:156
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:266
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
 msgid "view_label_add"
 msgstr "Hinzufügen"
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:303
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:305
 msgid "view_label_add_section_header"
 msgstr "Zwischentitel einfügen:"
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
 
@@ -1555,12 +1571,12 @@ msgid "view_label_protocol"
 msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:290
 msgid "view_label_schedule_ad_hoc"
 msgstr "Ad Hoc Traktandum einfügen:"
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:275
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
 
@@ -1568,3 +1584,4 @@ msgstr "Antrag traktandieren:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
+

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -678,7 +678,7 @@ msgstr "Inaktiv"
 #: ./opengever/meeting/committee.py:94
 #: ./opengever/meeting/committeecontainer.py:44
 msgid "label_ad_hoc_template"
-msgstr ""
+msgstr "Ad Hoc Vorlage"
 
 #. Default: "Agenda item number"
 #: ./opengever/meeting/browser/meetings/meeting.py:342
@@ -1238,7 +1238,7 @@ msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in
 #. Default: "No ad-hoc agenda-item template has been configured."
 #: ./opengever/meeting/browser/meetings/agendaitem.py:417
 msgid "missing_ad_hoc_template"
-msgstr ""
+msgstr "Es konnte keine Vorlage für ein Ad Hoc Traktandum gefunden werden."
 
 #. Default: "The protocol for meeting ${title} has already been generated."
 #: ./opengever/meeting/browser/protocol.py:76

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-22 10:17+0000\n"
-"PO-Revision-Date: 2017-09-03 07:09+0000\n"
+"POT-Creation-Date: 2017-08-31 10:24+0000\n"
+"PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
 "gever/opengever-meeting/fr/>\n"
@@ -25,7 +25,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:253
 msgid "Actions"
 msgstr "Actions"
 
@@ -44,20 +44,20 @@ msgid "Add Member"
 msgstr "Ajouter un membre"
 
 #. Default: "Add Membership"
-#: ./opengever/meeting/browser/memberships.py:43
+#: ./opengever/meeting/browser/memberships.py:45
 msgid "Add Membership"
 msgstr "Ajouter une adhésion"
 
-#: ./opengever/meeting/browser/committeeforms.py:28
+#: ./opengever/meeting/browser/committeeforms.py:29
 msgid "Add committee"
 msgstr "Ajouter un comité"
 
-#: ./opengever/meeting/browser/periods.py:49
+#: ./opengever/meeting/browser/periods.py:50
 msgid "Add new period"
 msgstr "Ajouter une nouvelle période"
 
-#: ./opengever/meeting/browser/committeeforms.py:29
-#: ./opengever/meeting/browser/periods.py:136
+#: ./opengever/meeting/browser/committeeforms.py:30
+#: ./opengever/meeting/browser/periods.py:137
 msgid "Add period"
 msgstr "Ajouter la période"
 
@@ -70,7 +70,7 @@ msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:381
+#: ./opengever/meeting/browser/meetings/meeting.py:382
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -84,11 +84,11 @@ msgstr "Êtes-vous sûr de vouloir fermer cette réunion?"
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr "Êtes-vous sûr de vouloir fixer ce point de l'ordre du jour?"
 
-#: ./opengever/meeting/browser/memberships.py:51
+#: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Impossible d'ajouter une adhésion, parce qu'elle se chevauche avec une adhésion existante du ${date_from} jusqu'au ${date_to}."
 
-#: ./opengever/meeting/browser/memberships.py:85
+#: ./opengever/meeting/browser/memberships.py:87
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Impossible de changer l'adhésion, parce qu'elle se chevauche avec une adhésion existante du ${date_from} jusqu'au ${date_to}."
 
@@ -101,11 +101,11 @@ msgstr "Choisir les points du l'ordre du jour"
 msgid "Close all proposals."
 msgstr "Toutes les propositions sont clôturées."
 
-#: ./opengever/meeting/browser/periods.py:68
+#: ./opengever/meeting/browser/periods.py:69
 msgid "Close currently active period"
 msgstr "Clôturer la période actuellement active"
 
-#: ./opengever/meeting/browser/periods.py:48
+#: ./opengever/meeting/browser/periods.py:49
 msgid "Close period"
 msgstr "Clôturer la période"
 
@@ -152,8 +152,8 @@ msgstr "L'extrait du protocole de la réunion ${title} a été créé avec succ�
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été mis à jour avec succès."
 
-#: ./opengever/meeting/committee.py:61
-#: ./opengever/meeting/committeecontainer.py:22
+#: ./opengever/meeting/committee.py:65
+#: ./opengever/meeting/committeecontainer.py:24
 msgid "Excerpt template"
 msgstr "Modèle du protocole"
 
@@ -210,7 +210,7 @@ msgstr "Insérer des fondements juridiques"
 msgid "Include proposed action"
 msgstr "Insérer une proposition"
 
-#: ./opengever/meeting/committee.py:81
+#: ./opengever/meeting/committee.py:85
 msgid "Linked repository folder"
 msgstr "Répertoire d'archivage"
 
@@ -244,7 +244,6 @@ msgid "Once closed the meeting and its protocol cannot be edited any longer. The
 msgstr "La réunion et le protocole associé ne pourront plus être modifiés après clôture. Les actions suivantes seront exécutées lors de la clôture:"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Order"
 msgstr "Tri"
 
@@ -278,11 +277,11 @@ msgid "Proposals:"
 msgstr "Propositions"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/model/meeting.py:254
+#: ./opengever/meeting/model/meeting.py:258
 msgid "Protocol"
 msgstr "Protocole"
 
-#: ./opengever/meeting/model/meeting.py:257
+#: ./opengever/meeting/model/meeting.py:261
 msgid "Protocol Excerpt"
 msgstr "Extrait du protocole"
 
@@ -294,8 +293,8 @@ msgstr "Le protocole pour la séance ${title} a été créé avec succès."
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Le protocole pour la séance ${title} a été actualisé avec succès."
 
-#: ./opengever/meeting/committee.py:55
-#: ./opengever/meeting/committeecontainer.py:16
+#: ./opengever/meeting/committee.py:59
+#: ./opengever/meeting/committeecontainer.py:18
 msgid "Protocol template"
 msgstr "Modèle du protocole"
 
@@ -361,80 +360,80 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé par une nouvelle version de la réunion ${title}."
 
 #. Default: "Active"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py:29
 #: ./opengever/meeting/model/period.py:21
 msgid "active"
 msgstr "Actif"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:323
+#: ./opengever/meeting/browser/meetings/agendaitem.py:332
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:293
+#: ./opengever/meeting/browser/meetings/agendaitem.py:302
 msgid "agenda_item_decided"
 msgstr "Le point de l'ordre du jour a été fixé."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:269
+#: ./opengever/meeting/browser/meetings/agendaitem.py:278
 msgid "agenda_item_deleted"
 msgstr "Le point a été enlevé avec succès de l'ordre du jour."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:298
+#: ./opengever/meeting/browser/meetings/agendaitem.py:307
 msgid "agenda_item_meeting_held"
 msgstr "Le point de l'ordre du jour a été fixé et la réunion a eu lieu."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:228
+#: ./opengever/meeting/browser/meetings/agendaitem.py:237
 msgid "agenda_item_order_updated"
 msgstr "L'ordre des points de l'ordre du jour a été actualisé."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:290
+#: ./opengever/meeting/browser/meetings/agendaitem.py:299
 msgid "agenda_item_proposal_decided"
 msgstr "Le point de l'ordre du jour a été fixé, l'extrait de protocole a été généré et renvoyé."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:339
+#: ./opengever/meeting/browser/meetings/agendaitem.py:348
 msgid "agenda_item_reopened"
 msgstr "Le point d'ordre du jour a été rouvert."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:352
+#: ./opengever/meeting/browser/meetings/agendaitem.py:361
 msgid "agenda_item_revised"
 msgstr "Le point d'ordre du jour a été révisé avec succès."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:241
+#: ./opengever/meeting/browser/meetings/agendaitem.py:250
 msgid "agenda_item_update_empty_string"
 msgstr "Le titre d'un point d'ordre du jour ne peut pas être laissé vide."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:248
+#: ./opengever/meeting/browser/meetings/agendaitem.py:257
 msgid "agenda_item_update_too_long_title"
 msgstr "Le titre du point de l'ordre du jour est trop long."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:254
+#: ./opengever/meeting/browser/meetings/agendaitem.py:263
 msgid "agenda_item_updated"
 msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/committeeforms.py:65
+#: ./opengever/meeting/browser/committeeforms.py:72
 #: ./opengever/meeting/browser/documents/submit.py:96
 #: ./opengever/meeting/browser/meetings/meeting.py:120
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:91
+#: ./opengever/meeting/browser/periods.py:92
 msgid "button_close_period"
 msgstr "Clôturer une période"
 
 #. Default: "Continue"
-#: ./opengever/meeting/browser/committeeforms.py:53
+#: ./opengever/meeting/browser/committeeforms.py:60
 #: ./opengever/meeting/browser/meetings/meeting.py:104
 msgid "button_continue"
 msgstr "Continuer"
@@ -446,19 +445,19 @@ msgid "button_submit_attachments"
 msgstr "Soumettre des appendices"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:157
+#: ./opengever/meeting/model/proposal.py:160
 msgid "cancel"
 msgstr "Annuler"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:140
 msgid "cancelled"
 msgstr "Annulé"
 
 #. Default: "Close meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:58
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:60
-#: ./opengever/meeting/model/meeting.py:78
+#: ./opengever/meeting/model/meeting.py:82
 msgid "close_meeting"
 msgstr "Clôturer"
 
@@ -468,7 +467,7 @@ msgid "close_period"
 msgstr "Clôturer une période"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:76
 #: ./opengever/meeting/model/period.py:22
 msgid "closed"
 msgstr "clôturé"
@@ -552,8 +551,8 @@ msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:155
+#: ./opengever/meeting/model/agendaitem.py:40
+#: ./opengever/meeting/model/proposal.py:158
 msgid "decide"
 msgstr "Décider"
 
@@ -564,18 +563,18 @@ msgid "decide_agendaitem"
 msgstr "Décider d'un point de l'ordre du jour"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/agendaitem.py:31
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/proposal.py:138
 msgid "decided"
 msgstr "Décidé"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:110
+#: ./opengever/meeting/committee.py:122
 msgid "description_group"
 msgstr "Pour ce groupe, les autorisations sont attribuées automatiquement au comité."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:369
+#: ./opengever/meeting/browser/meetings/agendaitem.py:377
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -590,12 +589,12 @@ msgid "download protocol"
 msgstr "Télécharger le protocole"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:386
+#: ./opengever/meeting/browser/meetings/agendaitem.py:394
 msgid "empty_paragraph"
 msgstr "Ce paragraphe ne doit pas rester vide."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:401
+#: ./opengever/meeting/browser/meetings/agendaitem.py:409
 msgid "empty_proposal"
 msgstr "Ce texte libre ne doit pas être vide."
 
@@ -605,7 +604,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:425
+#: ./opengever/meeting/browser/meetings/agendaitem.py:423
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -620,7 +619,7 @@ msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:434
+#: ./opengever/meeting/browser/meetings/agendaitem.py:461
 msgid "excerpt_generated"
 msgstr ""
 
@@ -654,7 +653,7 @@ msgid "heading_reject_proposal_form"
 msgstr "Rejeter la proposition"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:71
+#: ./opengever/meeting/model/meeting.py:75
 msgid "held"
 msgstr "Tenue"
 
@@ -669,14 +668,20 @@ msgid "help_select_dossier"
 msgstr "Choisissez le dossier, dans lequel l'extrait de protocole doit être déposé."
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:80
+#: ./opengever/meeting/model/meeting.py:84
 msgid "hold"
 msgstr "Tenir une réunion"
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:31
+#: ./opengever/meeting/model/committee.py:30
 msgid "inactive"
 msgstr "Inactif"
+
+#. Default: "Ad hoc agenda item template"
+#: ./opengever/meeting/committee.py:94
+#: ./opengever/meeting/committeecontainer.py:44
+msgid "label_ad_hoc_template"
+msgstr ""
 
 #. Default: "Agenda item number"
 #: ./opengever/meeting/browser/meetings/meeting.py:342
@@ -685,14 +690,14 @@ msgstr ""
 
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
-#: ./opengever/meeting/model/meeting.py:261
+#: ./opengever/meeting/model/meeting.py:265
 #: ./opengever/meeting/protocol.py:160
 msgid "label_agendaitem_list"
 msgstr "Liste des points du jour"
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:67
-#: ./opengever/meeting/committeecontainer.py:28
+#: ./opengever/meeting/committee.py:71
+#: ./opengever/meeting/committeecontainer.py:30
 msgid "label_agendaitem_list_template"
 msgstr "Modèle de la liste des points du jour"
 
@@ -716,12 +721,12 @@ msgid "label_close"
 msgstr "Clôturer"
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committee.py:89
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:77
 msgid "label_committe_deactivated"
 msgstr "Comité déactivé avec succès."
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committee.py:111
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:50
 msgid "label_committe_reactivated"
 msgstr "Comité réactivé avec succès."
 
@@ -750,36 +755,36 @@ msgid "label_copy_for_attention"
 msgstr "Copie pour information"
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:121
+#: ./opengever/meeting/browser/proposalforms.py:92
 msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:38
+#: ./opengever/meeting/browser/committee.py:36
 msgid "label_current_members"
 msgstr "Membres actuels"
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:23
+#: ./opengever/meeting/browser/committee.py:21
 msgid "label_current_period"
 msgstr "Période actuelle"
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/memberships.py:19
-#: ./opengever/meeting/browser/periods.py:36
+#: ./opengever/meeting/browser/memberships.py:21
+#: ./opengever/meeting/browser/periods.py:37
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr "De"
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/memberships.py:24
-#: ./opengever/meeting/browser/periods.py:42
+#: ./opengever/meeting/browser/memberships.py:26
+#: ./opengever/meeting/browser/periods.py:43
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr "Jusqu'à"
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:37
+#: ./opengever/meeting/model/committee.py:36
 msgid "label_deactivate"
 msgstr "Déactiver le comité"
 
@@ -806,6 +811,7 @@ msgid "label_decision_draft"
 msgstr "Brouillon de la décision"
 
 #. Default: "Decision number"
+#: ./opengever/meeting/browser/meetings/meeting.py:343
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr "Numéro de décision"
@@ -858,7 +864,7 @@ msgid "label_download_repository_toc"
 msgstr "Table de matière selon l'ordre des points"
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/templates/member.pt:62
+#: ./opengever/meeting/browser/templates/member.pt:65
 #: ./opengever/meeting/browser/templates/periods.pt:27
 msgid "label_edit"
 msgstr "Editer"
@@ -869,7 +875,7 @@ msgid "label_edit_action"
 msgstr "Editer le titre"
 
 #. Default: "Edit after creation"
-#: ./opengever/meeting/browser/proposalforms.py:129
+#: ./opengever/meeting/browser/proposalforms.py:100
 msgid "label_edit_after_creation"
 msgstr "Modifier après la création"
 
@@ -884,12 +890,12 @@ msgid "label_edit_document_action"
 msgstr ""
 
 #. Default: "Edit Membership"
-#: ./opengever/meeting/browser/memberships.py:71
+#: ./opengever/meeting/browser/memberships.py:73
 msgid "label_edit_membership"
 msgstr "Editer l'adhésion"
 
 #. Default: "Edit Period"
-#: ./opengever/meeting/browser/periods.py:203
+#: ./opengever/meeting/browser/periods.py:204
 msgid "label_edit_period"
 msgstr "Editer"
 
@@ -928,7 +934,7 @@ msgstr "Fichier"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:277
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:279
 msgid "label_filter_proposal"
 msgstr "Filtrage"
 
@@ -944,7 +950,7 @@ msgid "label_generate_excerpt"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:109
+#: ./opengever/meeting/committee.py:121
 msgid "label_group"
 msgstr "Groupe"
 
@@ -956,7 +962,7 @@ msgstr "Situation initiale"
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:309
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:311
 msgid "label_insert"
 msgstr "Insérer"
 
@@ -983,7 +989,7 @@ msgid "label_linked_meeting"
 msgstr "Réunion"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:82
+#: ./opengever/meeting/committee.py:86
 msgid "label_linked_repository_folder"
 msgstr "Tous les dossiers de réunion et tous les documents générés automatiquement seront classés sous cette position."
 
@@ -1004,12 +1010,12 @@ msgid "label_meeting"
 msgstr "Séance"
 
 #. Default: "Member"
-#: ./opengever/meeting/browser/memberships.py:28
+#: ./opengever/meeting/browser/memberships.py:30
 msgid "label_member"
 msgstr "Membre"
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:124
+#: ./opengever/meeting/browser/proposalforms.py:95
 msgid "label_modified"
 msgstr "Dernière modification"
 
@@ -1029,7 +1035,7 @@ msgid "label_no_memberships"
 msgstr "Cet utilisateur n'a pas d'adhésion."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
+#: ./opengever/meeting/browser/meetings/meeting.py:352
 msgid "label_no_proposals"
 msgstr "Aucune proposition n'a été soumise."
 
@@ -1060,7 +1066,7 @@ msgid "label_proposal_id"
 msgstr "Numéro de référence"
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:112
+#: ./opengever/meeting/browser/proposalforms.py:83
 msgid "label_proposal_template"
 msgstr "Modèle de proposition"
 
@@ -1082,7 +1088,7 @@ msgid "label_publish_in"
 msgstr "Publication dans"
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:41
+#: ./opengever/meeting/model/committee.py:40
 msgid "label_reactivate"
 msgstr "Réactiver le comité"
 
@@ -1092,7 +1098,7 @@ msgid "label_reject_proposal_text"
 msgstr "Commentaire"
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/templates/member.pt:66
+#: ./opengever/meeting/browser/templates/member.pt:70
 msgid "label_remove"
 msgstr "Supprimer"
 
@@ -1107,7 +1113,7 @@ msgid "label_revise_action"
 msgstr "Réviser le point de l'ordre du jour"
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/memberships.py:33
+#: ./opengever/meeting/browser/memberships.py:35
 #: ./opengever/meeting/browser/templates/member.pt:52
 msgid "label_role"
 msgstr "Rôle"
@@ -1118,9 +1124,9 @@ msgid "label_sablon_template_file"
 msgstr "Fichier-modèle"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:294
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
 msgid "label_schedule"
 msgstr "Mettre à l'ordre du jour"
 
@@ -1148,8 +1154,8 @@ msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Table of contents template"
-#: ./opengever/meeting/committee.py:74
-#: ./opengever/meeting/committeecontainer.py:35
+#: ./opengever/meeting/committee.py:78
+#: ./opengever/meeting/committeecontainer.py:37
 msgid "label_toc_template"
 msgstr "Modèle de la table de matière"
 
@@ -1175,12 +1181,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:32
+#: ./opengever/meeting/browser/committee.py:30
 msgid "label_unscheduled_proposals"
 msgstr "Propositions imprévues"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:27
+#: ./opengever/meeting/browser/committee.py:25
 msgid "label_upcoming_meetings"
 msgstr "Prochaines réunions"
 
@@ -1232,6 +1238,11 @@ msgstr "Les modifications n'ont pas pu être sauvegardées; le protocole a été
 msgid "message_write_conflict"
 msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été modifié entre-temps."
 
+#. Default: "No ad-hoc agenda-item template has been configured."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:417
+msgid "missing_ad_hoc_template"
+msgstr ""
+
 #. Default: "The protocol for meeting ${title} has already been generated."
 #: ./opengever/meeting/browser/protocol.py:76
 msgid "msg_error_protocol_already_generated"
@@ -1249,12 +1260,12 @@ msgid "msg_inactive_committee_selected"
 msgstr "Le comité sélectionné a été désactivé; la proposition n'a pas pu être soumise."
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:58
+#: ./opengever/meeting/model/meeting.py:62
 msgid "msg_meeting_successfully_closed"
 msgstr "La réunion ${title} a été clôturée avec succès, les extraits de protocole ont été générés et renvoyés aux dossiers initiaux."
 
 #. Default: "The membership was deleted successfully."
-#: ./opengever/meeting/browser/memberships.py:104
+#: ./opengever/meeting/browser/memberships.py:107
 msgid "msg_membership_deleted"
 msgstr "L'adhésion a été supprimée avec succès."
 
@@ -1269,7 +1280,7 @@ msgid "msg_no_toc_template"
 msgstr "Il n'y a pas de modèle configuré pour la table des matières; la table des matières n'a pas pu être générée."
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committee.py:72
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:58
 msgid "msg_pending_meetings"
 msgstr "Il y a des réunions non clôturées."
 
@@ -1294,7 +1305,7 @@ msgid "msg_successfully_deleted"
 msgstr "L'objet a été supprimé avec succès."
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committee.py:80
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:66
 msgid "msg_unscheduled_proposals"
 msgstr "Des propositions qui ne figurent pas à l'ordre du jour ont été attribuées à ce comité."
 
@@ -1309,7 +1320,7 @@ msgid "overview"
 msgstr "Sommaire"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:390
+#: ./opengever/meeting/browser/meetings/agendaitem.py:398
 msgid "paragraph_added"
 msgstr "Paragraphe ajouté avec succès."
 
@@ -1318,9 +1329,9 @@ msgid "participants"
 msgstr "Participants"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/agendaitem.py:33
+#: ./opengever/meeting/model/meeting.py:74
+#: ./opengever/meeting/model/proposal.py:133
 msgid "pending"
 msgstr "En modification"
 
@@ -1414,38 +1425,38 @@ msgid "protocol_excerpt"
 msgstr "Extrait de protocole"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:159
+#: ./opengever/meeting/model/proposal.py:162
 msgid "reactivate"
 msgstr "Réactiver"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:149
+#: ./opengever/meeting/model/proposal.py:152
 msgid "reject"
 msgstr "Rejeter"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:39
+#: ./opengever/meeting/model/agendaitem.py:42
 msgid "reopen"
 msgstr "Réactiver"
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:41
+#: ./opengever/meeting/model/agendaitem.py:44
 msgid "revise"
 msgstr "Réviser"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:32
+#: ./opengever/meeting/model/agendaitem.py:35
 msgid "revision"
 msgstr "Révision"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:151
+#: ./opengever/meeting/model/proposal.py:154
 msgid "schedule"
 msgstr "Mettre à l'ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:134
+#: ./opengever/meeting/model/proposal.py:137
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1459,12 +1470,12 @@ msgid "status"
 msgstr "État"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:147
+#: ./opengever/meeting/model/proposal.py:150
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:132
+#: ./opengever/meeting/model/proposal.py:135
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1479,7 +1490,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:432
 msgid "text_added"
 msgstr "Texte libre ajouté avec succès."
 
@@ -1487,23 +1498,28 @@ msgstr "Texte libre ajouté avec succès."
 msgid "time"
 msgstr "Temps"
 
+#. Default: "Ad hoc agenda item ${title}"
+#: ./opengever/meeting/model/meeting.py:363
+msgid "title_ad_hoc_document"
+msgstr ""
+
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:153
+#: ./opengever/meeting/model/proposal.py:156
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:266
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:303
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:305
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "view_label_agenda_items"
 msgstr ""
 
@@ -1558,12 +1574,12 @@ msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:290
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:275
 msgid "view_label_schedule_proposal"
 msgstr ""
 
@@ -1571,3 +1587,4 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
 msgid "view_label_secretary"
 msgstr ""
+

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-22 10:17+0000\n"
+"POT-Creation-Date: 2017-08-31 10:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:253
 msgid "Actions"
 msgstr ""
 
@@ -40,20 +40,20 @@ msgid "Add Member"
 msgstr ""
 
 #. Default: "Add Membership"
-#: ./opengever/meeting/browser/memberships.py:43
+#: ./opengever/meeting/browser/memberships.py:45
 msgid "Add Membership"
 msgstr ""
 
-#: ./opengever/meeting/browser/committeeforms.py:28
+#: ./opengever/meeting/browser/committeeforms.py:29
 msgid "Add committee"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:49
+#: ./opengever/meeting/browser/periods.py:50
 msgid "Add new period"
 msgstr ""
 
-#: ./opengever/meeting/browser/committeeforms.py:29
-#: ./opengever/meeting/browser/periods.py:136
+#: ./opengever/meeting/browser/committeeforms.py:30
+#: ./opengever/meeting/browser/periods.py:137
 msgid "Add period"
 msgstr ""
 
@@ -66,7 +66,7 @@ msgid "Agenda Items"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:381
+#: ./opengever/meeting/browser/meetings/meeting.py:382
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -80,11 +80,11 @@ msgstr ""
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr ""
 
-#: ./opengever/meeting/browser/memberships.py:51
+#: ./opengever/meeting/browser/memberships.py:53
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
-#: ./opengever/meeting/browser/memberships.py:85
+#: ./opengever/meeting/browser/memberships.py:87
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
@@ -97,11 +97,11 @@ msgstr ""
 msgid "Close all proposals."
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:68
+#: ./opengever/meeting/browser/periods.py:69
 msgid "Close currently active period"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:48
+#: ./opengever/meeting/browser/periods.py:49
 msgid "Close period"
 msgstr ""
 
@@ -148,8 +148,8 @@ msgstr ""
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:61
-#: ./opengever/meeting/committeecontainer.py:22
+#: ./opengever/meeting/committee.py:65
+#: ./opengever/meeting/committeecontainer.py:24
 msgid "Excerpt template"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Include proposed action"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:81
+#: ./opengever/meeting/committee.py:85
 msgid "Linked repository folder"
 msgstr ""
 
@@ -240,7 +240,6 @@ msgid "Once closed the meeting and its protocol cannot be edited any longer. The
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "Order"
 msgstr ""
 
@@ -274,11 +273,11 @@ msgid "Proposals:"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/model/meeting.py:254
+#: ./opengever/meeting/model/meeting.py:258
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:257
+#: ./opengever/meeting/model/meeting.py:261
 msgid "Protocol Excerpt"
 msgstr ""
 
@@ -290,8 +289,8 @@ msgstr ""
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr ""
 
-#: ./opengever/meeting/committee.py:55
-#: ./opengever/meeting/committeecontainer.py:16
+#: ./opengever/meeting/committee.py:59
+#: ./opengever/meeting/committeecontainer.py:18
 msgid "Protocol template"
 msgstr ""
 
@@ -357,80 +356,80 @@ msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py:29
 #: ./opengever/meeting/model/period.py:21
 msgid "active"
 msgstr ""
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:323
+#: ./opengever/meeting/browser/meetings/agendaitem.py:332
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:293
+#: ./opengever/meeting/browser/meetings/agendaitem.py:302
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:269
+#: ./opengever/meeting/browser/meetings/agendaitem.py:278
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:298
+#: ./opengever/meeting/browser/meetings/agendaitem.py:307
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:228
+#: ./opengever/meeting/browser/meetings/agendaitem.py:237
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:290
+#: ./opengever/meeting/browser/meetings/agendaitem.py:299
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:339
+#: ./opengever/meeting/browser/meetings/agendaitem.py:348
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:352
+#: ./opengever/meeting/browser/meetings/agendaitem.py:361
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:241
+#: ./opengever/meeting/browser/meetings/agendaitem.py:250
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:248
+#: ./opengever/meeting/browser/meetings/agendaitem.py:257
 msgid "agenda_item_update_too_long_title"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:254
+#: ./opengever/meeting/browser/meetings/agendaitem.py:263
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/committeeforms.py:65
+#: ./opengever/meeting/browser/committeeforms.py:72
 #: ./opengever/meeting/browser/documents/submit.py:96
 #: ./opengever/meeting/browser/meetings/meeting.py:120
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:91
+#: ./opengever/meeting/browser/periods.py:92
 msgid "button_close_period"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/meeting/browser/committeeforms.py:53
+#: ./opengever/meeting/browser/committeeforms.py:60
 #: ./opengever/meeting/browser/meetings/meeting.py:104
 msgid "button_continue"
 msgstr ""
@@ -442,19 +441,19 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:157
+#: ./opengever/meeting/model/proposal.py:160
 msgid "cancel"
 msgstr ""
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:140
 msgid "cancelled"
 msgstr ""
 
 #. Default: "Close meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:58
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:60
-#: ./opengever/meeting/model/meeting.py:78
+#: ./opengever/meeting/model/meeting.py:82
 msgid "close_meeting"
 msgstr ""
 
@@ -464,7 +463,7 @@ msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:72
+#: ./opengever/meeting/model/meeting.py:76
 #: ./opengever/meeting/model/period.py:22
 msgid "closed"
 msgstr ""
@@ -548,8 +547,8 @@ msgid "column_to"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:155
+#: ./opengever/meeting/model/agendaitem.py:40
+#: ./opengever/meeting/model/proposal.py:158
 msgid "decide"
 msgstr ""
 
@@ -560,18 +559,18 @@ msgid "decide_agendaitem"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/agendaitem.py:31
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/proposal.py:138
 msgid "decided"
 msgstr ""
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:110
+#: ./opengever/meeting/committee.py:122
 msgid "description_group"
 msgstr ""
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:369
+#: ./opengever/meeting/browser/meetings/agendaitem.py:377
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -586,12 +585,12 @@ msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:386
+#: ./opengever/meeting/browser/meetings/agendaitem.py:394
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:401
+#: ./opengever/meeting/browser/meetings/agendaitem.py:409
 msgid "empty_proposal"
 msgstr ""
 
@@ -601,7 +600,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:425
+#: ./opengever/meeting/browser/meetings/agendaitem.py:423
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -616,7 +615,7 @@ msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:434
+#: ./opengever/meeting/browser/meetings/agendaitem.py:461
 msgid "excerpt_generated"
 msgstr ""
 
@@ -650,7 +649,7 @@ msgid "heading_reject_proposal_form"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:71
+#: ./opengever/meeting/model/meeting.py:75
 msgid "held"
 msgstr ""
 
@@ -665,13 +664,19 @@ msgid "help_select_dossier"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:80
+#: ./opengever/meeting/model/meeting.py:84
 msgid "hold"
 msgstr ""
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:31
+#: ./opengever/meeting/model/committee.py:30
 msgid "inactive"
+msgstr ""
+
+#. Default: "Ad hoc agenda item template"
+#: ./opengever/meeting/committee.py:94
+#: ./opengever/meeting/committeecontainer.py:44
+msgid "label_ad_hoc_template"
 msgstr ""
 
 #. Default: "Agenda item number"
@@ -681,14 +686,14 @@ msgstr ""
 
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
-#: ./opengever/meeting/model/meeting.py:261
+#: ./opengever/meeting/model/meeting.py:265
 #: ./opengever/meeting/protocol.py:160
 msgid "label_agendaitem_list"
 msgstr ""
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:67
-#: ./opengever/meeting/committeecontainer.py:28
+#: ./opengever/meeting/committee.py:71
+#: ./opengever/meeting/committeecontainer.py:30
 msgid "label_agendaitem_list_template"
 msgstr ""
 
@@ -712,12 +717,12 @@ msgid "label_close"
 msgstr ""
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committee.py:89
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:77
 msgid "label_committe_deactivated"
 msgstr ""
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committee.py:111
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:50
 msgid "label_committe_reactivated"
 msgstr ""
 
@@ -746,36 +751,36 @@ msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:121
+#: ./opengever/meeting/browser/proposalforms.py:92
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:38
+#: ./opengever/meeting/browser/committee.py:36
 msgid "label_current_members"
 msgstr ""
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:23
+#: ./opengever/meeting/browser/committee.py:21
 msgid "label_current_period"
 msgstr ""
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/memberships.py:19
-#: ./opengever/meeting/browser/periods.py:36
+#: ./opengever/meeting/browser/memberships.py:21
+#: ./opengever/meeting/browser/periods.py:37
 #: ./opengever/meeting/browser/templates/member.pt:50
 msgid "label_date_from"
 msgstr ""
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/memberships.py:24
-#: ./opengever/meeting/browser/periods.py:42
+#: ./opengever/meeting/browser/memberships.py:26
+#: ./opengever/meeting/browser/periods.py:43
 #: ./opengever/meeting/browser/templates/member.pt:51
 msgid "label_date_to"
 msgstr ""
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:37
+#: ./opengever/meeting/model/committee.py:36
 msgid "label_deactivate"
 msgstr ""
 
@@ -802,6 +807,7 @@ msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
+#: ./opengever/meeting/browser/meetings/meeting.py:343
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr ""
@@ -854,7 +860,7 @@ msgid "label_download_repository_toc"
 msgstr ""
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/templates/member.pt:62
+#: ./opengever/meeting/browser/templates/member.pt:65
 #: ./opengever/meeting/browser/templates/periods.pt:27
 msgid "label_edit"
 msgstr ""
@@ -865,7 +871,7 @@ msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Edit after creation"
-#: ./opengever/meeting/browser/proposalforms.py:129
+#: ./opengever/meeting/browser/proposalforms.py:100
 msgid "label_edit_after_creation"
 msgstr ""
 
@@ -880,12 +886,12 @@ msgid "label_edit_document_action"
 msgstr ""
 
 #. Default: "Edit Membership"
-#: ./opengever/meeting/browser/memberships.py:71
+#: ./opengever/meeting/browser/memberships.py:73
 msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Edit Period"
-#: ./opengever/meeting/browser/periods.py:203
+#: ./opengever/meeting/browser/periods.py:204
 msgid "label_edit_period"
 msgstr ""
 
@@ -924,7 +930,7 @@ msgstr ""
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:277
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:279
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -940,7 +946,7 @@ msgid "label_generate_excerpt"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:109
+#: ./opengever/meeting/committee.py:121
 msgid "label_group"
 msgstr ""
 
@@ -952,7 +958,7 @@ msgstr ""
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:309
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:311
 msgid "label_insert"
 msgstr ""
 
@@ -979,7 +985,7 @@ msgid "label_linked_meeting"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:82
+#: ./opengever/meeting/committee.py:86
 msgid "label_linked_repository_folder"
 msgstr ""
 
@@ -1000,12 +1006,12 @@ msgid "label_meeting"
 msgstr ""
 
 #. Default: "Member"
-#: ./opengever/meeting/browser/memberships.py:28
+#: ./opengever/meeting/browser/memberships.py:30
 msgid "label_member"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:124
+#: ./opengever/meeting/browser/proposalforms.py:95
 msgid "label_modified"
 msgstr ""
 
@@ -1025,7 +1031,7 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
+#: ./opengever/meeting/browser/meetings/meeting.py:352
 msgid "label_no_proposals"
 msgstr ""
 
@@ -1056,7 +1062,7 @@ msgid "label_proposal_id"
 msgstr ""
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:112
+#: ./opengever/meeting/browser/proposalforms.py:83
 msgid "label_proposal_template"
 msgstr ""
 
@@ -1078,7 +1084,7 @@ msgid "label_publish_in"
 msgstr ""
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:41
+#: ./opengever/meeting/model/committee.py:40
 msgid "label_reactivate"
 msgstr ""
 
@@ -1088,7 +1094,7 @@ msgid "label_reject_proposal_text"
 msgstr ""
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/templates/member.pt:66
+#: ./opengever/meeting/browser/templates/member.pt:70
 msgid "label_remove"
 msgstr ""
 
@@ -1103,7 +1109,7 @@ msgid "label_revise_action"
 msgstr ""
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/memberships.py:33
+#: ./opengever/meeting/browser/memberships.py:35
 #: ./opengever/meeting/browser/templates/member.pt:52
 msgid "label_role"
 msgstr ""
@@ -1114,9 +1120,9 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:294
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
 msgid "label_schedule"
 msgstr ""
 
@@ -1144,8 +1150,8 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Table of contents template"
-#: ./opengever/meeting/committee.py:74
-#: ./opengever/meeting/committeecontainer.py:35
+#: ./opengever/meeting/committee.py:78
+#: ./opengever/meeting/committeecontainer.py:37
 msgid "label_toc_template"
 msgstr ""
 
@@ -1171,12 +1177,12 @@ msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:32
+#: ./opengever/meeting/browser/committee.py:30
 msgid "label_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:27
+#: ./opengever/meeting/browser/committee.py:25
 msgid "label_upcoming_meetings"
 msgstr ""
 
@@ -1228,6 +1234,11 @@ msgstr ""
 msgid "message_write_conflict"
 msgstr ""
 
+#. Default: "No ad-hoc agenda-item template has been configured."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:417
+msgid "missing_ad_hoc_template"
+msgstr ""
+
 #. Default: "The protocol for meeting ${title} has already been generated."
 #: ./opengever/meeting/browser/protocol.py:76
 msgid "msg_error_protocol_already_generated"
@@ -1245,12 +1256,12 @@ msgid "msg_inactive_committee_selected"
 msgstr ""
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:58
+#: ./opengever/meeting/model/meeting.py:62
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 
 #. Default: "The membership was deleted successfully."
-#: ./opengever/meeting/browser/memberships.py:104
+#: ./opengever/meeting/browser/memberships.py:107
 msgid "msg_membership_deleted"
 msgstr ""
 
@@ -1265,7 +1276,7 @@ msgid "msg_no_toc_template"
 msgstr ""
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committee.py:72
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:58
 msgid "msg_pending_meetings"
 msgstr ""
 
@@ -1290,7 +1301,7 @@ msgid "msg_successfully_deleted"
 msgstr ""
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committee.py:80
+#: ./opengever/meeting/browser/committeetransitioncontroller.py:66
 msgid "msg_unscheduled_proposals"
 msgstr ""
 
@@ -1305,7 +1316,7 @@ msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:390
+#: ./opengever/meeting/browser/meetings/agendaitem.py:398
 msgid "paragraph_added"
 msgstr ""
 
@@ -1314,9 +1325,9 @@ msgid "participants"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:30
-#: ./opengever/meeting/model/meeting.py:70
-#: ./opengever/meeting/model/proposal.py:130
+#: ./opengever/meeting/model/agendaitem.py:33
+#: ./opengever/meeting/model/meeting.py:74
+#: ./opengever/meeting/model/proposal.py:133
 msgid "pending"
 msgstr ""
 
@@ -1410,38 +1421,38 @@ msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:159
+#: ./opengever/meeting/model/proposal.py:162
 msgid "reactivate"
 msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:149
+#: ./opengever/meeting/model/proposal.py:152
 msgid "reject"
 msgstr ""
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:39
+#: ./opengever/meeting/model/agendaitem.py:42
 msgid "reopen"
 msgstr ""
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:41
+#: ./opengever/meeting/model/agendaitem.py:44
 msgid "revise"
 msgstr ""
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:32
+#: ./opengever/meeting/model/agendaitem.py:35
 msgid "revision"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:151
+#: ./opengever/meeting/model/proposal.py:154
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:134
+#: ./opengever/meeting/model/proposal.py:137
 msgid "scheduled"
 msgstr ""
 
@@ -1455,12 +1466,12 @@ msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:147
+#: ./opengever/meeting/model/proposal.py:150
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:132
+#: ./opengever/meeting/model/proposal.py:135
 msgid "submitted"
 msgstr ""
 
@@ -1475,7 +1486,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:432
 msgid "text_added"
 msgstr ""
 
@@ -1483,23 +1494,28 @@ msgstr ""
 msgid "time"
 msgstr ""
 
+#. Default: "Ad hoc agenda item ${title}"
+#: ./opengever/meeting/model/meeting.py:363
+msgid "title_ad_hoc_document"
+msgstr ""
+
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:153
+#: ./opengever/meeting/model/proposal.py:156
 msgid "un-schedule"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:266
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:303
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:305
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
 msgid "view_label_agenda_items"
 msgstr ""
 
@@ -1554,12 +1570,12 @@ msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:290
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:275
 msgid "view_label_schedule_proposal"
 msgstr ""
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -293,6 +293,16 @@ class AgendaItem(Base):
                                            ICheckinCheckoutManager)
         checkout_manager.checkin()
 
+    @require_word_meeting_feature
+    def checkin_document(self):
+        document = self.resolve_document()
+        if not document:
+            return
+
+        checkout_manager = getMultiAdapter((document, document.REQUEST),
+                                           ICheckinCheckoutManager)
+        checkout_manager.checkin()
+
     @property
     def legal_basis(self):
         return self.submitted_proposal.legal_basis if self.has_proposal else None

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -370,12 +370,12 @@ class Meeting(Base, SQLFormSupport):
             data=ad_hoc_template.file.data,
             content_type=ad_hoc_template.file.contentType,
             title=translate(document_title, context=getRequest())).execute()
+        agenda_item = AgendaItem(
+            title=title, document=ad_hoc_document, is_paragraph=False)
 
-        self.agenda_items.append(
-            AgendaItem(title=title,
-                       document=ad_hoc_document,
-                       is_paragraph=False))
+        self.agenda_items.append(agenda_item)
         self.reorder_agenda_items()
+        return agenda_item
 
     def _set_agenda_item_order(self, new_order):
         agenda_items_by_id = OrderedDict((item.agenda_item_id, item)

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -360,12 +360,16 @@ class Meeting(Base, SQLFormSupport):
             'opengever.document: Add document', meeting_dossier):
             raise MissingMeetingDossierPermissions
 
+        document_title = _(u'title_ad_hoc_document',
+                           default=u'Ad hoc agenda item ${title}',
+                           mapping={u'title': title})
+
         ad_hoc_document = CreateDocumentCommand(
             context=meeting_dossier,
             filename=ad_hoc_template.file.filename,
             data=ad_hoc_template.file.data,
             content_type=ad_hoc_template.file.contentType,
-            title=title).execute()
+            title=translate(document_title, context=getRequest())).execute()
 
         self.agenda_items.append(
             AgendaItem(title=title,

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -305,7 +305,16 @@ class Proposal(Base):
 
     def revise(self, agenda_item):
         assert self.get_state() == self.STATE_DECIDED
-        self.update_excerpt(agenda_item)
+        if is_word_meeting_implementation_enabled():
+            document = self.resolve_submitted_proposal().get_proposal_document()
+            checkout_manager = getMultiAdapter((document, document.REQUEST),
+                                               ICheckinCheckoutManager)
+            if checkout_manager.get_checked_out_by() is not None:
+                raise ValueError(
+                    'Cannot revise proposal when proposal document is checked out.')
+        else:
+            self.update_excerpt(agenda_item)
+
         IHistory(self.resolve_submitted_proposal()).append_record(u'revised')
 
     def reopen(self, agenda_item):

--- a/opengever/meeting/sources.py
+++ b/opengever/meeting/sources.py
@@ -14,6 +14,17 @@ sablon_template_source = ObjPathSourceBinder(
 )
 
 
+proposal_template_source = ObjPathSourceBinder(
+    portal_type=("opengever.meeting.proposaltemplate"),
+    navigation_tree_query={
+        'object_provides':
+            ['opengever.dossier.templatefolder.interfaces.ITemplateFolder',
+             'opengever.meeting.proposaltemplate.IProposalTemplate',
+             ],
+        }
+)
+
+
 all_open_dossiers_source = RepositoryPathSourceBinder(
     object_provides='opengever.dossier.behaviors.dossier.IDossierMarker',
     review_state=DOSSIER_STATES_OPEN,

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -1,0 +1,131 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone import api
+from plone.protect import createToken
+
+
+class TestWordAgendaItem(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_ad_hoc_document_is_created_from_template(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        with self.observe_children(self.meeting_dossier) as children:
+            self.schedule_ad_hoc(self.meeting, u'R\xfccktritt')
+
+        self.assertEqual(1, len(children['added']))
+        ad_hoc_document = children['added'].pop()
+
+        self.assertEqual(
+            ad_hoc_document.file.data,
+            self.proposal_template.file.data,
+            "Expected agenda item document to be a copy of proposal template.")
+
+        browser.open(self.meeting, view='agenda_items/list')
+        item_data = browser.json['items'][0]
+
+        document_link_html = item_data.get('document_link')
+        self.assertIn(
+            u'Ad hoc agenda item R\xfccktritt',
+            document_link_html)
+        self.assertIn(
+            ad_hoc_document.absolute_url() + '/tooltip',
+            document_link_html)
+
+    @browsing
+    def test_cant_create_adhoc_when_no_access_to_meeting_dossier(self, browser):
+        with self.login(self.administrator):
+            # Let committee_responsible have no access to meeting_dossier
+            self.meeting_dossier.__ac_local_roles_block__ = True
+            self.meeting_dossier.reindexObjectSecurity()
+
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting, view='agenda_items/schedule_text',
+                     data={'title': u'Fail',
+                           '_authenticator': createToken()})
+        self.assertEquals(
+            {u'messages': [
+                {u'messageTitle': u'Error',
+                 u'message': u'Insufficient privileges to add a document '
+                              'to the meeting dossier.',
+                 u'messageClass': u'error'}],
+             u'proceed': False},
+            browser.json)
+
+    @browsing
+    def test_edit_ad_hoc_document_possible_when_scheduled(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        agenda_item = self.meeting.model.schedule_ad_hoc(u'ad-hoc')
+
+        browser.open(self.meeting, view='agenda_items/list')
+        item_data = browser.json['items'][0]
+        self.assertDictContainsSubset(
+            {'document_checked_out': False,
+             'edit_document_button': {
+                 'visible': True,
+                 'active': True,
+                 'url': self.agenda_item_url(agenda_item, 'edit_document')}},
+            item_data)
+
+    @browsing
+    def test_edit_ad_hoc_document_possible_when_i_have_checked_it_out(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.meeting.model.schedule_ad_hoc(u'ad-hoc')
+
+        document = agenda_item.resolve_document()
+        self.checkout_document(document)
+
+        browser.open(self.meeting, view='agenda_items/list')
+        item_data = browser.json['items'][0]
+        self.assertDictContainsSubset(
+            {'document_checked_out': True,
+             'edit_document_button': {
+                 'visible': True,
+                 'active': True,
+                 'url': self.agenda_item_url(agenda_item, 'edit_document')}},
+            item_data)
+        self.assertTrue(
+            api.user.has_permission('WebDAV Lock items', obj=document),
+            'Should be able to lock documents after checkout.')
+
+    @browsing
+    def test_edit_ad_hoc_document_not_possible_when_sb_else_checked_it_out(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.meeting.model.schedule_ad_hoc(u'ad-hoc')
+
+        with self.login(self.administrator):
+            self.checkout_document(agenda_item.resolve_document())
+
+        browser.open(self.meeting, view='agenda_items/list')
+        item_data = browser.json['items'][0]
+        self.assertDictContainsSubset(
+            {'document_checked_out': True,
+             'edit_document_button': {
+                 'visible': True,
+                 'active': False,
+                 'url': self.agenda_item_url(agenda_item, 'edit_document')}},
+            item_data)
+
+    @browsing
+    def test_decision_number_for_adhoc_agenda_item(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting, view='agenda_items/schedule_text',
+                     data={'title': u'Tisch Traktandum',
+                           '_authenticator': createToken()})
+        self.assertDictContainsSubset({'proceed': True}, browser.json)
+
+        browser.open(self.meeting, view='agenda_items/list')
+        self.assertDictContainsSubset(
+            {'title': u'Tisch Traktandum',
+             'decision_number': None},
+            browser.json['items'][0])
+
+        browser.open(browser.json['items'][0]['decide_link'])
+        browser.open(self.meeting, view='agenda_items/list')
+        self.assertDictContainsSubset(
+            {'title': u'Tisch Traktandum',
+             'decision_number': 1},
+            browser.json['items'][0])

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -2,7 +2,6 @@ from contextlib import nested
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from plone import api
-from plone.protect import createToken
 
 
 class TestWordAgendaItem(IntegrationTestCase):
@@ -51,7 +50,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
             {'document_checked_out': False,
-             'edit_proposal_document_button': {
+             'edit_document_button': {
                  'visible': True,
                  'active': True,
                  'url': self.agenda_item_url(agenda_item, 'edit_document')}},
@@ -69,7 +68,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
             {'document_checked_out': True,
-             'edit_proposal_document_button': {
+             'edit_document_button': {
                  'visible': True,
                  'active': True,
                  'url': self.agenda_item_url(agenda_item, 'edit_document')}},
@@ -93,7 +92,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
             {'document_checked_out': True,
-             'edit_proposal_document_button': {
+             'edit_document_button': {
                  'visible': True,
                  'active': False,
                  'url': self.agenda_item_url(agenda_item, 'edit_document')}},
@@ -112,7 +111,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
             {'document_checked_out': False,
-             'edit_proposal_document_button': {
+             'edit_document_button': {
                  'visible': True,
                  'active': True,
                  'url': self.agenda_item_url(agenda_item, 'edit_document')}},
@@ -340,30 +339,3 @@ class TestWordAgendaItem(IntegrationTestCase):
             {'title': u'\xc4nderungen am Personalreglement',
              'decision_number': 1},
             browser.json['items'][0])
-
-    @browsing
-    def test_decision_number_for_adhoc_agenda_item(self, browser):
-        self.login(self.committee_responsible, browser)
-        browser.open(self.meeting, view='agenda_items/schedule_text',
-                     data={'title': u'Tisch Traktandum',
-                           '_authenticator': createToken()})
-        self.assertDictContainsSubset({'proceed': True}, browser.json)
-
-        browser.open(self.meeting, view='agenda_items/list')
-        self.assertDictContainsSubset(
-            {'title': u'Tisch Traktandum',
-             'decision_number': None},
-            browser.json['items'][0])
-
-        browser.open(browser.json['items'][0]['decide_link'])
-        browser.open(self.meeting, view='agenda_items/list')
-        self.assertDictContainsSubset(
-            {'title': u'Tisch Traktandum',
-             'decision_number': 1},
-            browser.json['items'][0])
-
-    def agenda_item_url(self, agenda_item, endpoint):
-        return '{}/agenda_items/{}/{}'.format(
-            agenda_item.meeting.get_url(view=None),
-            agenda_item.agenda_item_id,
-            endpoint)

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -2,9 +2,11 @@ from contextlib import nested
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from plone import api
+from plone.protect import createToken
 
 
 class TestWordAgendaItem(IntegrationTestCase):
+
     features = ('meeting', 'word-meeting')
 
     def test_deciding_meeting_item_does_not_create_an_excerpt(self):
@@ -33,7 +35,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
 
-        document_link_html = item_data.get('proposal_document_link')
+        document_link_html = item_data.get('document_link')
         self.assertIn(
             u'Proposal document \xc4nderungen am Personalreglement',
             document_link_html)
@@ -48,7 +50,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
-            {'proposal_document_checked_out': False,
+            {'document_checked_out': False,
              'edit_proposal_document_button': {
                  'visible': True,
                  'active': True,
@@ -66,7 +68,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
-            {'proposal_document_checked_out': True,
+            {'document_checked_out': True,
              'edit_proposal_document_button': {
                  'visible': True,
                  'active': True,
@@ -90,7 +92,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
-            {'proposal_document_checked_out': True,
+            {'document_checked_out': True,
              'edit_proposal_document_button': {
                  'visible': True,
                  'active': False,
@@ -109,7 +111,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
         self.assertDictContainsSubset(
-            {'proposal_document_checked_out': False,
+            {'document_checked_out': False,
              'edit_proposal_document_button': {
                  'visible': True,
                  'active': True,
@@ -343,7 +345,8 @@ class TestWordAgendaItem(IntegrationTestCase):
     def test_decision_number_for_adhoc_agenda_item(self, browser):
         self.login(self.committee_responsible, browser)
         browser.open(self.meeting, view='agenda_items/schedule_text',
-                     data={'title': u'Tisch Traktandum'})
+                     data={'title': u'Tisch Traktandum',
+                           '_authenticator': createToken()})
         self.assertDictContainsSubset({'proceed': True}, browser.json)
 
         browser.open(self.meeting, view='agenda_items/list')

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -1,0 +1,40 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser.pages import factoriesmenu
+
+
+class TestCommitteeContainer(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_can_configure_ad_hoc_template(self, browser):
+        self.login(self.administrator, browser)
+
+        self.assertIsNone(self.committee_container.ad_hoc_template)
+        self.assertIsNone(self.committee_container.get_ad_hoc_template())
+
+        browser.open(self.committee_container, view='edit')
+        browser.fill({'Ad hoc agenda item template': self.proposal_template})
+        browser.find('Save').click()
+
+        statusmessages.assert_message('Changes saved')
+
+        self.assertIsNotNone(self.committee_container.ad_hoc_template)
+        self.assertEqual(self.proposal_template,
+                         self.committee_container.get_ad_hoc_template())
+
+    @browsing
+    def test_can_add_with_ad_hoc_template(self, browser):
+        self.login(self.manager, browser)
+        browser.open()
+        factoriesmenu.add('Committee Container')
+        browser.fill({'Title': u'Sitzungen',
+                      'Protocol template': self.sablon_template,
+                      'Excerpt template': self.sablon_template,
+                      'Ad hoc agenda item template': self.proposal_template})
+        browser.find('Save').click()
+
+        self.assertEqual(self.proposal_template,
+                         browser.context.get_ad_hoc_template())

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -11,6 +11,7 @@ class TestCommitteeContainer(IntegrationTestCase):
     @browsing
     def test_can_configure_ad_hoc_template(self, browser):
         self.login(self.administrator, browser)
+        self.committee_container.ad_hoc_template = None
 
         self.assertIsNone(self.committee_container.ad_hoc_template)
         self.assertIsNone(self.committee_container.get_ad_hoc_template())

--- a/opengever/meeting/tests/test_committee_word.py
+++ b/opengever/meeting/tests/test_committee_word.py
@@ -1,0 +1,42 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import IntegrationTestCase
+
+
+class TestCommitteeWord(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_can_configure_ad_hoc_template(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        self.assertIsNone(self.committee.ad_hoc_template)
+        self.assertIsNone(self.committee.get_ad_hoc_template())
+
+        browser.open(self.committee, view='edit')
+        browser.fill({'Ad hoc agenda item template': self.proposal_template})
+        browser.find('Save').click()
+
+        statusmessages.assert_message('Changes saved')
+
+        self.assertIsNotNone(self.committee.ad_hoc_template)
+        self.assertEqual(self.proposal_template,
+                         self.committee.get_ad_hoc_template())
+
+    def test_get_ad_hoc_template_returns_committee_template_if_available(self):
+        self.login(self.committee_responsible)
+        self.committee.ad_hoc_template = self.as_relation_value(
+            self.proposal_template)
+
+        self.assertEqual(
+            self.proposal_template, self.committee.get_ad_hoc_template())
+
+    def test_get_ad_hoc_template_falls_back_to_container(self):
+        self.login(self.administrator)
+        self.committee_container.ad_hoc_template = self.as_relation_value(
+            self.proposal_template)
+
+        self.assertIsNone(self.committee.ad_hoc_template)
+        self.assertEqual(
+            self.proposal_template, self.committee.get_ad_hoc_template())

--- a/opengever/meeting/tests/test_committee_word.py
+++ b/opengever/meeting/tests/test_committee_word.py
@@ -12,7 +12,6 @@ class TestCommitteeWord(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
 
         self.assertIsNone(self.committee.ad_hoc_template)
-        self.assertIsNone(self.committee.get_ad_hoc_template())
 
         browser.open(self.committee, view='edit')
         browser.fill({'Ad hoc agenda item template': self.proposal_template})

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -139,7 +139,7 @@ class OpengeverContentFixture(object):
             .with_asset_file('sablon_template.docx')))
 
         with self.features('meeting', 'word-meeting'):
-            self.register('proposal_template', create(
+            self.proposal_template = self.register('proposal_template', create(
                 Builder('proposaltemplate')
                 .titled(u'Geb\xfchren')
                 .attach_file_containing('Word Content', u'file.docx')
@@ -151,7 +151,8 @@ class OpengeverContentFixture(object):
             Builder('committee_container')
             .titled(u'Sitzungen')
             .having(protocol_template=self.sablon_template,
-                    excerpt_template=self.sablon_template)))
+                    excerpt_template=self.sablon_template,
+                    ad_hoc_template=self.proposal_template)))
         self.committee_container.manage_setLocalRoles(
             self.committee_responsible.getId(), ('MeetingUser',))
         self.committee_container.manage_setLocalRoles(

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -388,6 +388,14 @@ class IntegrationTestCase(TestCase):
         agenda_item = AgendaItem.query.order_by(desc('id')).first()
         return agenda_item
 
+    def schedule_ad_hoc(self, meeting, title):
+        if isinstance(meeting, MeetingWrapper):
+            meeting = meeting.model
+
+        meeting.schedule_ad_hoc(title)
+        agenda_item = AgendaItem.query.order_by(desc('id')).first()
+        return agenda_item
+
     def as_relation_value(self, obj):
         return RelationValue(getUtility(IIntIds).getId(obj))
 
@@ -402,3 +410,9 @@ class IntegrationTestCase(TestCase):
         old_file = IMail(self.mail).message
         IMail(self.mail).message = NamedBlobFile(
             data=data, filename=old_file.filename)
+
+    def agenda_item_url(self, agenda_item, endpoint):
+        return '{}/agenda_items/{}/{}'.format(
+            agenda_item.meeting.get_url(view=None),
+            agenda_item.agenda_item_id,
+            endpoint)


### PR DESCRIPTION
This PR adds support for ad-hoc agenda items for the word-meeting feature. The ad-hoc agenda-items have the same user-interface as proposal base agenda items:

![screen shot 2017-09-04 at 13 54 33](https://user-images.githubusercontent.com/736583/30025496-1548944c-9179-11e7-9f30-be952996709e.png)

They require an ad-hoc proposal template to be configured on the committee or committee-
container.

![screen shot 2017-09-04 at 13 57 17](https://user-images.githubusercontent.com/736583/30025480-09674b64-9179-11e7-95ef-d6b6a58f7a93.png)

When the user creates an ad-hoc agenda item the proposal template is copied into the meeting dossier and the copy is linked to the agenda-item. That file can then be edited the same way as the document of a proposal. Currently when the agenda-item is deleted the document will remain in the meeting dossier.

2do:
- [x] configure an ad-hoc template on committee-container
- [x] configure an (optional) ad-hoc template on committee
- [x] create a copy of that template into the meeting-dossier and reference from agenda-item
- [x] make quick checkout available
- [x] put into protocol
- ~~[ ] delete from dossier when agenda-item is deleted?~~