### PR TITLE
Generate and store agendalist item documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fixed bumblebee-overlay pdf link generation, when filename contains umlaut. [phgross]
+- Generate agenda item lists as documents. [Rotonen]
 - Replace is_subdossier FieldIndex with an BooleanIndex. [phgross]
 - Add content stats provider for file mimetypes. [lgraf]
 - Implement "checked in vs. checked out docs" content stats provider. [lgraf]

--- a/opengever/core/upgrades/20170831142434_add_agenda_list_items_to_meetings/upgrade.py
+++ b/opengever/core/upgrades/20170831142434_add_agenda_list_items_to_meetings/upgrade.py
@@ -1,0 +1,16 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+
+
+class AddAgendaListItemsToMeetings(SchemaMigration):
+    """Add AgendaListItems to Meetings.
+    """
+
+    def migrate(self):
+
+        self.op.add_column(
+            'meetings',
+            Column('agendaitem_list_document_id', Integer, ForeignKey('generateddocuments.id')),
+        )

--- a/opengever/meeting/browser/meetings/agendaitem_list.py
+++ b/opengever/meeting/browser/meetings/agendaitem_list.py
@@ -1,61 +1,146 @@
 from opengever.meeting import _
 from opengever.meeting.command import AgendaItemListOperations
-from opengever.meeting.command import MIME_DOCX
-from opengever.meeting.sablon import Sablon
+from opengever.meeting.command import CreateGeneratedDocumentCommand
+from opengever.meeting.command import UpdateGeneratedDocumentCommand
+from opengever.meeting.exceptions import AgendaItemListAlreadyGenerated
+from opengever.meeting.exceptions import AgendaItemListMissingTemplate
+from opengever.meeting.model import Meeting
+from opengever.meeting.model.generateddocument import GeneratedAgendaItemList
 from plone import api
-from plone.memoize import instance
+from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
+from zExceptions import NotFound
 
 
-class DownloadAgendaItemList(BrowserView):
+class GenerateAgendaItemList(BrowserView):
+    """Generate an agenda item list.
+
+    1. Generate a Word BLOB via sablon
+    2. Create a new document in the meeting dossier from the BLOB
+    3. Redirect back to the meeting
+    """
+
+    operations = AgendaItemListOperations()
+
+    def __call__(self):
+        meeting = self.get_meeting()
+
+        command = CreateGeneratedDocumentCommand(
+            self.context,
+            meeting,
+            self.operations,
+            )
+
+        try:
+            command.execute()
+            command.show_message()
+
+        except AgendaItemListMissingTemplate:
+            msg = _(
+                u'msg_error_agendaitem_list_missing_template',
+                default=(u'There is no agendaitem list template configured, agendaitem list could not be generated.'),
+                mapping=dict(title=meeting.get_title()),
+                )
+            api.portal.show_message(msg, self.request, type='error')
+
+        except AgendaItemListAlreadyGenerated:
+            msg = _(
+                u'msg_error_agendaitem_list_already_generated',
+                default=(u'The agenda item list for meeting ${title} has already been generated.'),
+                mapping=dict(title=meeting.get_title()),
+                )
+            api.portal.show_message(msg, self.request, type='error')
+
+        return self.request.RESPONSE.redirect(meeting.get_url())
+
+    @classmethod
+    def url_for(cls, meeting):
+        dossier = meeting.get_dossier()
+        url = '{}/@@generate_agendaitem_list?meeting-id={}'.format(
+            dossier.absolute_url(), meeting.meeting_id)
+        return addTokenToUrl(url)
+
+    def get_meeting(self):
+        meeting_id = self.request.get('meeting-id')
+        if not meeting_id:
+            raise NotFound
+
+        meeting = Meeting.query.with_for_update().get(meeting_id)
+        if not meeting:
+            raise NotFound
+
+        return meeting
+
+
+class UpdateAgendaItemList(BrowserView):
+    """Generate a new agenda item list version.
+
+    1. Generate a Word BLOB via sablon
+    2. Update the generated document in the meeting dossier with the BLOB
+    3. Redirect back to the meeting
+    """
+
+    operations = AgendaItemListOperations()
+
+    def __call__(self):
+        meeting = self.get_meeting()
+        generated_doc = self.get_generated_document()
+
+        command = UpdateGeneratedDocumentCommand(
+            generated_doc, meeting, self.operations)
+        command.execute()
+        command.show_message()
+
+        return self.request.RESPONSE.redirect(meeting.get_url())
+
+    @classmethod
+    def url_for(cls, meeting):
+        generated_document = meeting.agendaitem_list_document
+        document = generated_document.resolve_document()
+        url = '{}/@@update_agendaitem_list?document-id={}&meeting-id={}'.format(
+            document.absolute_url(),
+            generated_document.document_id,
+            meeting.meeting_id)
+        return addTokenToUrl(url)
+
+    def get_generated_document(self):
+        document_id = self.request.get('document-id')
+        if not document_id:
+            raise NotFound
+
+        document = GeneratedAgendaItemList.get(document_id)
+        if not document:
+            raise NotFound
+
+        return document
+
+    def get_meeting(self):
+        meeting_id = self.request.get('meeting-id')
+        if not meeting_id:
+            raise NotFound
+
+        meeting = Meeting.get(meeting_id)
+        if not meeting:
+            raise NotFound
+
+        return meeting
+
+
+class DownloadGeneratedAgendaItemList(BrowserView):
+    """Download the generated agenda item list for a meeting."""
 
     operations = AgendaItemListOperations()
 
     def __init__(self, context, request):
-        super(DownloadAgendaItemList, self).__init__(context, request)
-        self.model = context.model
+        super(DownloadGeneratedAgendaItemList, self).__init__(context, request)
+        self._model = context.model
 
     def get_json_data(self, pretty=False):
         return self.operations.get_meeting_data(
-            self.model).as_json(pretty=pretty)
-
-    def __call__(self):
-        template = self.get_sablon_template()
-        if not template:
-            api.portal.show_message(
-                _('msg_no_agenaitem_list_template',
-                  default=u'There is no agendaitem list template configured, '
-                  'agendaitem list could not be generated.'),
-                request=self.request,
-                type='error')
-
-            return self.request.RESPONSE.redirect(self.model.get_url())
-
-        filename = self.get_document_filename()
-        response = self.request.response
-        response.setHeader('X-Theme-Disabled', 'True')
-        response.setHeader('Content-Type', MIME_DOCX)
-        response.setHeader("Content-Disposition",
-                           'attachment; filename="{}"'.format(filename))
-        return self.create_agenda_item_list()
-
-    @instance.memoize
-    def get_sablon_template(self):
-        return self.operations.get_sablon_template(self.model)
-
-    def get_document_filename(self):
-        return self.operations.get_filename(self.model).encode('utf-8')
-
-    def create_agenda_item_list(self):
-        template = self.get_sablon_template()
-        sablon = Sablon(template)
-        sablon.process(self.get_json_data())
-        assert sablon.is_processed_successfully(), sablon.stderr
-        return sablon.file_data
+            self._model).as_json(pretty=pretty)
 
     def as_json(self):
-        """Returns the protocol data as json
-        """
+        """Renders protocol data as json."""
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -62,9 +62,23 @@
       />
 
   <browser:page
+      for="opengever.meeting.interfaces.IMeetingDossier"
+      name="generate_agendaitem_list"
+      class=".agendaitem_list.GenerateAgendaItemList"
+      permission="cmf.AddPortalContent"
+      />
+
+  <browser:page
+      for="opengever.document.document.IDocumentSchema"
+      name="update_agendaitem_list"
+      class=".agendaitem_list.UpdateAgendaItemList"
+      permission="cmf.AddPortalContent"
+      />
+
+  <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
       name="agenda_item_list"
-      class=".agendaitem_list.DownloadAgendaItemList"
+      class=".agendaitem_list.DownloadGeneratedAgendaItemList"
       permission="zope2.View"
       allowed_attributes="as_json"
       />

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -10,6 +10,8 @@ from opengever.base.oguid import Oguid
 from opengever.base.schema import UTCDatetime
 from opengever.meeting import _
 from opengever.meeting import is_word_meeting_implementation_enabled
+from opengever.meeting.browser.meetings.agendaitem_list import GenerateAgendaItemList
+from opengever.meeting.browser.meetings.agendaitem_list import UpdateAgendaItemList
 from opengever.meeting.browser.meetings.transitions import MeetingTransitionController
 from opengever.meeting.browser.protocol import GenerateProtocol
 from opengever.meeting.browser.protocol import MergeDocxProtocol
@@ -82,7 +84,6 @@ TEMPLATES_DIR = Path(__file__).joinpath('..', 'templates').abspath()
 
 def get_dm_key(committee_oguid=None):
     """Return the key used to store meeting-data in the wizard-storage."""
-
     committee_oguid = committee_oguid or get_committee_oguid()
     return 'create_meeting:{}'.format(committee_oguid)
 
@@ -242,7 +243,7 @@ class MeetingView(BrowserView):
             return self.noword_template()
 
     def get_css_class(self, document):
-        """used for display icons in the view"""
+        """Provide CSS classes for icons."""
         return get_css_class(document)
 
     def transition_url(self, transition):
@@ -256,6 +257,11 @@ class MeetingView(BrowserView):
         if self.model.protocol_document:
             return IContentListingObject(
                 self.model.protocol_document.resolve_document())
+
+    def get_agendaitem_list_document(self):
+        if self.model.agendaitem_list_document:
+            return IContentListingObject(
+                self.model.agendaitem_list_document.resolve_document())
 
     def url_protocol(self):
         return self.model.get_url(view='protocol')
@@ -272,12 +278,25 @@ class MeetingView(BrowserView):
     def url_merge_docx_protocol(self):
         return MergeDocxProtocol.url_for(self.model)
 
+    def has_agendaitem_list_document(self):
+        return self.model.has_agendaitem_list_document()
+
     def has_protocol_document(self):
         return self.model.has_protocol_document()
 
     def url_download_protocol(self):
         if self.has_protocol_document:
             return self.model.protocol_document.get_download_url()
+
+    def url_download_agendaitem_list(self):
+        if self.has_agendaitem_list_document:
+            return self.model.agendaitem_list_document.get_download_url()
+
+    def url_generate_agendaitem_list(self):
+        if not self.model.has_agendaitem_list_document():
+            return GenerateAgendaItemList.url_for(self.model)
+        else:
+            return UpdateAgendaItemList.url_for(self.model)
 
     def url_agendaitem_list(self):
         return self.model.get_url(view='agenda_item_list')

--- a/opengever/meeting/browser/meetings/templates/meeting-noword.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -164,16 +164,41 @@
                 </dd>
               </dl>
             </div>
-            <div class="list-group-item documents"
-                 tal:define="protocol_document view/get_protocol_document">
 
-              <div class="item agendaitem_list">
-                <span class="title" i18n:translate="label_agendaitem_list">Agendaitem list</span>
-                <a href="#" class="download-agendaitem-list-btn"
-                   tal:attributes="href view/url_agendaitem_list"
-                   title="label_download_agendaitem_list"
-                   i18n:attributes="title">
-                </a>
+            <div class="list-group-item documents"
+                 tal:define="protocol_document view/get_protocol_document;
+                 agendaitem_list_document view/get_agendaitem_list_document">
+
+              <div class="item agendaitem-list">
+                <div>
+                  <span class="title" i18n:translate="">Agendaitem list</span>
+                  <a tal:condition="python: meeting.is_editable() and not view.has_agendaitem_list_document()"
+                     tal:attributes="href view/url_generate_agendaitem_list;"
+                     i18n:attributes="title"
+                     title="generate new agenda item list as word document"
+                     class="generate-agendaitem-list"></a>
+
+                  <a class="download-agendaitem-list-btn"
+                     tal:condition="python: meeting.is_editable() and agendaitem_list_document"
+                     tal:attributes="href view/url_download_agendaitem_list"
+                     i18n:attributes="title"
+                     title="Download agenda item list"></a>
+
+                  <a tal:condition="python: meeting.is_editable() and view.has_agendaitem_list_document()"
+                     tal:attributes="href view/url_generate_agendaitem_list;"
+                     i18n:attributes="title"
+                     title="generate new version as word document"
+                     class="refresh-agendaitem-list"></a>
+                </div>
+              </div>
+
+              <div class="fileinfo">
+                <span tal:condition="not:agendaitem_list_document"
+                      i18n:translate="label_no_agendaitem_list">No agenda item list has been generated yet.</span>
+
+                <span tal:condition="agendaitem_list_document">
+                  <a tal:replace="structure agendaitem_list_document/render_link" />
+                </span>
               </div>
 
               <div class="item protocol">

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -158,15 +158,38 @@
               <td></td>
             </tr>
 
-            <tr>
+            <tr tal:define="agendaitem_list_document view/get_agendaitem_list_document">
               <th i18n:translate="view_label_agendaitem_list">Agenda item list:</th>
-              <td>
-                <a tal:attributes="href view/url_agendaitem_list"
-                   i18n:translate="view_label_download_agendaitem_list">
-                  Download agenda item list
-                </a>
+              <td class="agendaitem-list">
+                <div tal:condition="not:agendaitem_list_document"
+                     i18n:translate="label_no_agendaitem_list">No agenda item list has been generated yet.</div>
+
+                <div tal:condition="agendaitem_list_document"
+                     class="agendaitem_list-file">
+                  <a tal:replace="structure agendaitem_list_document/render_link" />
+                </div>
               </td>
-              <td></td>
+              <td class="item agendaitem-list-buttons">
+                <span>
+                  <a class="generate-agendaitem-list"
+                     tal:condition="python: meeting.is_editable() and not view.has_agendaitem_list_document()"
+                     tal:attributes="href view/url_generate_agendaitem_list;"
+                     i18n:attributes="title"
+                     title="generate new agenda item list as word document" />
+
+                  <a class="download-agendaitem-list-btn"
+                     tal:condition="python: meeting.is_editable() and agendaitem_list_document"
+                     tal:attributes="href view/url_download_agendaitem_list"
+                     i18n:attributes="title"
+                     title="Download agenda item list" />
+
+                  <a class="refresh-agendaitem-list"
+                     tal:condition="python: meeting.is_editable() and view.has_agendaitem_list_document()"
+                     tal:attributes="href view/url_generate_agendaitem_list;"
+                     i18n:attributes="title"
+                     title="generate new version as word document" />
+                </span>
+              </td>
             </tr>
 
             <tr tal:define="protocol_document view/get_protocol_document">

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -1,3 +1,11 @@
+class AgendaItemListAlreadyGenerated(Exception):
+    """An agenda item list could not be generated as there already is one."""
+
+
+class AgendaItemListMissingTemplate(Exception):
+    """An agenda item list could not be generated as is no template defined."""
+
+
 class NoSubmittedDocument(Exception):
     """A document could not be updates remotely since it is not a submitted
     document.

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-31 10:24+0000\n"
+"POT-Creation-Date: 2017-09-05 15:45+0000\n"
 "PO-Revision-Date: 2017-08-22 12:18+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,21 +17,21 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:507
+#: ./opengever/meeting/command.py:540
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:253
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
 msgid "Actions"
 msgstr "Aktionen"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:77
+#: ./opengever/meeting/browser/meetings/meeting.py:79
 msgid "Add Dossier for Meeting"
 msgstr "Sitzungsdossier hinzufügen"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:76
+#: ./opengever/meeting/browser/meetings/meeting.py:78
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
@@ -58,16 +58,24 @@ msgstr "Neue Periode hinzufügen"
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:541
+#: ./opengever/meeting/command.py:574
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:247
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
 msgid "Agenda Items"
 msgstr "Traktanden"
 
+#: ./opengever/meeting/command.py:114
+msgid "Agenda item list for meeting ${title} has been generated successfully."
+msgstr "Traktandenliste für die Sitzung ${title} wurde erfolgreich erstellt."
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:174
+msgid "Agendaitem list"
+msgstr "Traktandenliste"
+
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:382
+#: ./opengever/meeting/browser/meetings/meeting.py:399
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -120,32 +128,37 @@ msgstr "Traktandum löschen"
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ./opengever/meeting/command.py:467
+#: ./opengever/meeting/command.py:500
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:292
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
 msgid "Documents"
 msgstr "Dokumente"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+msgid "Download agenda item list"
+msgstr "Traktandenliste herunterladen"
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/meeting/command.py:113
+#: ./opengever/meeting/command.py:145
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich generiert."
 
-#: ./opengever/meeting/command.py:118
+#: ./opengever/meeting/command.py:150
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/command.py:181
+#: ./opengever/meeting/command.py:214
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:186
+#: ./opengever/meeting/command.py:219
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -154,7 +167,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:224
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:249
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -219,7 +232,7 @@ msgstr "Sitzungsdossier"
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:222
+#: ./opengever/meeting/browser/meetings/meeting.py:223
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
@@ -231,7 +244,7 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:315
 msgid "Number"
 msgstr "Nummer"
 
@@ -240,15 +253,15 @@ msgstr "Nummer"
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:313
 msgid "Order"
 msgstr "Sortierung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:262
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:287
 msgid "Paragraph:"
 msgstr "Abschnitt:"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:134
+#: ./opengever/meeting/browser/meetings/excerpt.py:133
 msgid "Please select at least one agenda item."
 msgstr "Bitte wählen Sie mindestens ein Traktandum aus."
 
@@ -269,24 +282,24 @@ msgstr "Antrag"
 msgid "Proposal Template"
 msgstr "Antragsvorlage"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:297
 msgid "Proposals:"
 msgstr "Anträge"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/model/meeting.py:258
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:206
+#: ./opengever/meeting/model/meeting.py:262
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:261
+#: ./opengever/meeting/model/meeting.py:265
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
-#: ./opengever/meeting/command.py:60
+#: ./opengever/meeting/command.py:64
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:65
+#: ./opengever/meeting/command.py:69
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
@@ -300,8 +313,8 @@ msgid "Sablon Template"
 msgstr "Sablon Vorlage"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:121
-#: ./opengever/meeting/browser/meetings/protocol.py:206
+#: ./opengever/meeting/browser/meetings/excerpt.py:120
+#: ./opengever/meeting/browser/meetings/protocol.py:205
 msgid "Save"
 msgstr "Speichern"
 
@@ -313,11 +326,11 @@ msgstr "Erfolgreich traktandiert"
 msgid "Show more"
 msgstr "Mehr anzeigen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:276
 msgid "Text:"
 msgstr "Freitext:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:174
+#: ./opengever/meeting/browser/meetings/meeting.py:175
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
@@ -325,7 +338,7 @@ msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich ers
 msgid "The proposal has been rejected successfully"
 msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
 msgid "Title"
 msgstr "Titel"
 
@@ -352,7 +365,7 @@ msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier übe
 msgid "Updated with a newer excerpt version."
 msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
 
-#: ./opengever/meeting/command.py:292
+#: ./opengever/meeting/command.py:326
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
@@ -363,64 +376,64 @@ msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:332
+#: ./opengever/meeting/browser/meetings/agendaitem.py:328
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr "Traktandum kann nicht beschlossen werden: das Beschlussdokument ist noch von einer anderen Person ausgecheckt."
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:302
+#: ./opengever/meeting/browser/meetings/agendaitem.py:298
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:278
+#: ./opengever/meeting/browser/meetings/agendaitem.py:274
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:307
+#: ./opengever/meeting/browser/meetings/agendaitem.py:303
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:237
+#: ./opengever/meeting/browser/meetings/agendaitem.py:233
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:299
+#: ./opengever/meeting/browser/meetings/agendaitem.py:295
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:348
+#: ./opengever/meeting/browser/meetings/agendaitem.py:344
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:361
+#: ./opengever/meeting/browser/meetings/agendaitem.py:357
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:250
+#: ./opengever/meeting/browser/meetings/agendaitem.py:246
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:257
+#: ./opengever/meeting/browser/meetings/agendaitem.py:253
 msgid "agenda_item_update_too_long_title"
 msgstr "Der Traktandums-Titel ist zu lang."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:263
+#: ./opengever/meeting/browser/meetings/agendaitem.py:259
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:72
 #: ./opengever/meeting/browser/documents/submit.py:96
-#: ./opengever/meeting/browser/meetings/meeting.py:120
+#: ./opengever/meeting/browser/meetings/meeting.py:121
 msgid "button_cancel"
 msgstr "Abbrechen"
 
@@ -431,7 +444,7 @@ msgstr "Periode abschliessen"
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:60
-#: ./opengever/meeting/browser/meetings/meeting.py:104
+#: ./opengever/meeting/browser/meetings/meeting.py:105
 msgid "button_continue"
 msgstr "Weiter"
 
@@ -548,7 +561,7 @@ msgid "column_to"
 msgstr "Bis"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:40
+#: ./opengever/meeting/model/agendaitem.py:43
 #: ./opengever/meeting/model/proposal.py:158
 msgid "decide"
 msgstr "Beschliessen"
@@ -560,7 +573,7 @@ msgid "decide_agendaitem"
 msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/agendaitem.py:37
 #: ./opengever/meeting/model/proposal.py:138
 msgid "decided"
 msgstr "Beschlossen"
@@ -571,7 +584,7 @@ msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:377
+#: ./opengever/meeting/browser/meetings/agendaitem.py:373
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
@@ -580,18 +593,18 @@ msgstr "Sie dürfen das Dokument nicht auschecken."
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:394
+#: ./opengever/meeting/browser/meetings/agendaitem.py:390
 msgid "empty_paragraph"
 msgstr "Der Abschnitt darf nicht leer sein."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:409
+#: ./opengever/meeting/browser/meetings/agendaitem.py:405
 msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
@@ -601,7 +614,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:423
+#: ./opengever/meeting/browser/meetings/agendaitem.py:419
 msgid "error_no_permission_to_add_document"
 msgstr "Ungenügende Berechtigungen zum Hinzufügen eines Dokumentes im Sitzungsdossier."
 
@@ -616,7 +629,7 @@ msgid "excerpt_document_title"
 msgstr "Protokollauszug ${title}"
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:461
+#: ./opengever/meeting/browser/meetings/agendaitem.py:457
 msgid "excerpt_generated"
 msgstr "Protokollauszug erfolgreich generiert."
 
@@ -630,17 +643,22 @@ msgstr "Inhaltsverzeichnis ${period} ${committee} alphabetisch"
 msgid "filename_repository_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} nach Ordnungsposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:226
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+msgid "generate new agenda item list as word document"
+msgstr "Traktandenliste als Worddokument generieren"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:208
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:194
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
@@ -681,13 +699,12 @@ msgid "label_ad_hoc_template"
 msgstr "Ad Hoc Vorlage"
 
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:342
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_agenda_item_number"
 msgstr "Nummer des Traktandums in dieser Sitzung"
 
 #. Default: "Agendaitem list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
-#: ./opengever/meeting/model/meeting.py:265
+#: ./opengever/meeting/model/meeting.py:269
 #: ./opengever/meeting/protocol.py:160
 msgid "label_agendaitem_list"
 msgstr "Traktandenliste"
@@ -699,21 +716,21 @@ msgid "label_agendaitem_list_template"
 msgstr "Vorlage Traktandenliste"
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:339
+#: ./opengever/meeting/browser/meetings/meeting.py:356
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
 #: ./opengever/meeting/browser/submitdocuments.py:40
 msgid "label_attachments"
 msgstr "Anhänge"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:153
+#: ./opengever/meeting/browser/meetings/excerpt.py:152
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:36
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:38
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:241
+#: ./opengever/meeting/browser/meetings/protocol.py:240
 msgid "label_close"
 msgstr "Schliessen"
 
@@ -728,7 +745,7 @@ msgid "label_committe_reactivated"
 msgstr "Gremium erfolgreich reaktiviert."
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:59
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:54
 msgid "label_committee"
@@ -740,13 +757,13 @@ msgid "label_conflict_changes"
 msgstr "Das Protokoll wurde in der Zwischenzeit bearbeitet. Wenn Sie Ihre Änderungen beibehalten wollen, versuchen Sie die Konflikte manuell zu lösen."
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:133
 #: ./opengever/meeting/proposal.py:146
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:149
+#: ./opengever/meeting/browser/meetings/protocol.py:148
 #: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
@@ -792,12 +809,12 @@ msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:319
+#: ./opengever/meeting/browser/meetings/meeting.py:336
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:139
 #: ./opengever/meeting/proposal.py:222
 msgid "label_decision"
 msgstr "Beschluss"
@@ -808,13 +825,13 @@ msgid "label_decision_draft"
 msgstr "Beschlussentwurf"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/meetings/meeting.py:343
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:318
+#: ./opengever/meeting/browser/meetings/meeting.py:335
 msgid "label_delete_action"
 msgstr "Traktandum löschen"
 
@@ -825,13 +842,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:146
+#: ./opengever/meeting/browser/meetings/protocol.py:145
 #: ./opengever/meeting/proposal.py:112
 msgid "label_disclose_to"
 msgstr "\"Zu eröffnen\" an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:136
 #: ./opengever/meeting/proposal.py:379
 msgid "label_discussion"
 msgstr "Diskussion"
@@ -845,10 +862,6 @@ msgstr "Dossier"
 #: ./opengever/meeting/proposal.py:460
 msgid "label_dossier_not_available"
 msgstr "Dossier nicht verfügbar"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:172
-msgid "label_download_agendaitem_list"
-msgstr "Traktandenliste herunterladen"
 
 #. Default: "download TOC alphabetical"
 #: ./opengever/meeting/browser/templates/periods.pt:11
@@ -867,7 +880,7 @@ msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:317
+#: ./opengever/meeting/browser/meetings/meeting.py:334
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
@@ -877,12 +890,12 @@ msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:315
+#: ./opengever/meeting/browser/meetings/meeting.py:332
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Checkout and edit word document."
-#: ./opengever/meeting/browser/meetings/meeting.py:332
+#: ./opengever/meeting/browser/meetings/meeting.py:349
 msgid "label_edit_document_action"
 msgstr "Word-Dokument auschecken und bearbeiten."
 
@@ -897,7 +910,7 @@ msgid "label_edit_period"
 msgstr "Bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:316
+#: ./opengever/meeting/browser/meetings/meeting.py:333
 msgid "label_edit_save"
 msgstr "Speichern"
 
@@ -908,7 +921,7 @@ msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:71
+#: ./opengever/meeting/browser/meetings/meeting.py:73
 #: ./opengever/meeting/browser/meetings/protocol.py:73
 msgid "label_end"
 msgstr "Ende"
@@ -919,7 +932,7 @@ msgid "label_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Excerpts"
-#: ./opengever/meeting/browser/meetings/meeting.py:340
+#: ./opengever/meeting/browser/meetings/meeting.py:357
 #: ./opengever/meeting/proposal.py:151
 msgid "label_excerpts"
 msgstr "Protokollauszüge"
@@ -930,8 +943,8 @@ msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -942,7 +955,7 @@ msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Generate an excerpt."
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 msgid "label_generate_excerpt"
 msgstr "Protokollauszug generieren."
 
@@ -952,14 +965,14 @@ msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:127
 #: ./opengever/meeting/proposal.py:88
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:311
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:334
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -975,7 +988,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:124
 #: ./opengever/meeting/proposal.py:82
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
@@ -991,7 +1004,7 @@ msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:62
+#: ./opengever/meeting/browser/meetings/meeting.py:64
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Sitzungsort"
@@ -1021,8 +1034,14 @@ msgstr "Zuletzt bearbeitet"
 msgid "label_next_meeting"
 msgstr "Nächste Sitzung:"
 
+#. Default: "No agenda item list has been generated yet."
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
+msgid "label_no_agendaitem_list"
+msgstr "Es wurde noch keine Traktandenliste generiert."
+
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:256
 msgid "label_no_excerpts"
 msgstr "Es wurden noch keine zusätzlichen Protokollauszüge generiert."
 
@@ -1032,13 +1051,13 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:352
+#: ./opengever/meeting/browser/meetings/meeting.py:369
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:202
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:198
 msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
@@ -1068,7 +1087,7 @@ msgid "label_proposal_template"
 msgstr "Antragsvorlage"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 #: ./opengever/meeting/proposal.py:94
 msgid "label_proposed_action"
 msgstr "Antrag"
@@ -1079,7 +1098,7 @@ msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
+#: ./opengever/meeting/browser/meetings/protocol.py:142
 #: ./opengever/meeting/proposal.py:106
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
@@ -1100,12 +1119,12 @@ msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:320
+#: ./opengever/meeting/browser/meetings/meeting.py:337
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:321
+#: ./opengever/meeting/browser/meetings/meeting.py:338
 msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
@@ -1121,9 +1140,9 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
+#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -1138,14 +1157,14 @@ msgid "label_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:67
+#: ./opengever/meeting/browser/meetings/meeting.py:69
 #: ./opengever/meeting/browser/meetings/protocol.py:68
 msgid "label_start"
 msgstr "Start"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:52
+#: ./opengever/meeting/browser/meetings/meeting.py:54
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titel"
@@ -1157,7 +1176,7 @@ msgid "label_toc_template"
 msgstr "Vorlage Inhaltsverzeichnis"
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:341
+#: ./opengever/meeting/browser/meetings/meeting.py:358
 msgid "label_toggle_attachments"
 msgstr "Anhänge anzeigen / ausblenden"
 
@@ -1192,8 +1211,8 @@ msgstr "Kommende Sitzungen"
 msgid "label_workflow_state"
 msgstr "Status"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
 msgid "label_zip_download"
 msgstr "Zip-Datei herunterladen"
 
@@ -1221,24 +1240,34 @@ msgid "memberships"
 msgstr "Mitgliedschaften"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:263
+#: ./opengever/meeting/browser/meetings/protocol.py:262
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/protocol.py:255
+#: ./opengever/meeting/browser/meetings/protocol.py:254
 msgid "message_locked_by_another_user"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde von ${username} gesperrt."
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:249
+#: ./opengever/meeting/browser/meetings/protocol.py:248
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:417
+#: ./opengever/meeting/browser/meetings/agendaitem.py:413
 msgid "missing_ad_hoc_template"
 msgstr "Es konnte keine Vorlage für ein Ad Hoc Traktandum gefunden werden."
+
+#. Default: "The agenda item list for meeting ${title} has already been generated."
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
+msgid "msg_error_agendaitem_list_already_generated"
+msgstr "Die Traktandenliste für die Sitzung ${title} wurde bereits erstellt."
+
+#. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:39
+msgid "msg_error_agendaitem_list_missing_template"
+msgstr "Es ist keine Vorlage für die Traktandenliste konfiguriert, die Traktandenliste konnte nicht generiert werden."
 
 #. Default: "The protocol for meeting ${title} has already been generated."
 #: ./opengever/meeting/browser/protocol.py:76
@@ -1265,11 +1294,6 @@ msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollausz�
 #: ./opengever/meeting/browser/memberships.py:107
 msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
-
-#. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:26
-msgid "msg_no_agenaitem_list_template"
-msgstr "Es ist keine Vorlage für die Traktandenliste konfiguriert, die Traktandenliste konnte nicht generiert werden."
 
 #. Default: "There is no toc template configured, toc could not be generated."
 #: ./opengever/meeting/browser/toc.py:25
@@ -1317,7 +1341,7 @@ msgid "overview"
 msgstr "Übersicht"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:398
+#: ./opengever/meeting/browser/meetings/agendaitem.py:394
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
@@ -1326,7 +1350,7 @@ msgid "participants"
 msgstr "Teilnehmende"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:33
+#: ./opengever/meeting/model/agendaitem.py:36
 #: ./opengever/meeting/model/meeting.py:74
 #: ./opengever/meeting/model/proposal.py:133
 msgid "pending"
@@ -1433,17 +1457,17 @@ msgid "reject"
 msgstr "Zurückweisen"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:42
+#: ./opengever/meeting/model/agendaitem.py:45
 msgid "reopen"
 msgstr "Wieder eröffnen"
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:44
+#: ./opengever/meeting/model/agendaitem.py:47
 msgid "revise"
 msgstr "Überarbeiten"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:35
+#: ./opengever/meeting/model/agendaitem.py:38
 msgid "revision"
 msgstr "Überarbeitung"
 
@@ -1462,7 +1486,7 @@ msgid "secretary"
 msgstr "Protokollführer"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:220
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
 msgid "status"
 msgstr "Status"
 
@@ -1487,7 +1511,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:432
+#: ./opengever/meeting/browser/meetings/agendaitem.py:428
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
@@ -1496,7 +1520,7 @@ msgid "time"
 msgstr "Zeit"
 
 #. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py:363
+#: ./opengever/meeting/model/meeting.py:367
 msgid "title_ad_hoc_document"
 msgstr "Ad Hoc Traktandum ${title}"
 
@@ -1506,17 +1530,17 @@ msgid "un-schedule"
 msgstr "Traktandum entfernen"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
 msgid "view_label_add"
 msgstr "Hinzufügen"
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:305
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
 msgid "view_label_add_section_header"
 msgstr "Zwischentitel einfügen:"
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
 
@@ -1529,11 +1553,6 @@ msgstr "Traktandenliste:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:152
 msgid "view_label_dossier"
 msgstr "Sitzungsdossier:"
-
-#. Default: "Download agenda item list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
-msgid "view_label_download_agendaitem_list"
-msgstr "Traktandenliste herunterladen"
 
 #. Default: "Meeting end:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
@@ -1566,17 +1585,17 @@ msgid "view_label_presidency"
 msgstr "Vorsitz:"
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:173
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:196
 msgid "view_label_protocol"
 msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
 msgid "view_label_schedule_ad_hoc"
 msgstr "Ad Hoc Traktandum einfügen:"
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:275
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:298
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
 
@@ -1584,4 +1603,3 @@ msgstr "Antrag traktandieren:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
-

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,37 +4,36 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-31 10:24+0000\n"
+"POT-Creation-Date: 2017-09-05 15:45+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-meeting/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/meeting/command.py:507
+#: ./opengever/meeting/command.py:540
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:253
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
 msgid "Actions"
 msgstr "Actions"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:77
+#: ./opengever/meeting/browser/meetings/meeting.py:79
 msgid "Add Dossier for Meeting"
 msgstr "Ajouter le dossier d'une réunion"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:76
+#: ./opengever/meeting/browser/meetings/meeting.py:78
 msgid "Add Meeting"
 msgstr "Ajouter la réunion"
 
@@ -61,16 +60,24 @@ msgstr "Ajouter une nouvelle période"
 msgid "Add period"
 msgstr "Ajouter la période"
 
-#: ./opengever/meeting/command.py:541
+#: ./opengever/meeting/command.py:574
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:247
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
+#: ./opengever/meeting/command.py:114
+msgid "Agenda item list for meeting ${title} has been generated successfully."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:174
+msgid "Agendaitem list"
+msgstr ""
+
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:382
+#: ./opengever/meeting/browser/meetings/meeting.py:399
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -123,32 +130,37 @@ msgstr "Supprimer le point de l'ordre du jour"
 msgid "Discard"
 msgstr "Écarter"
 
-#: ./opengever/meeting/command.py:467
+#: ./opengever/meeting/command.py:500
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:292
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
 msgid "Documents"
 msgstr "Documents"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+msgid "Download agenda item list"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
 msgid "Edit"
 msgstr "Modifier"
 
-#: ./opengever/meeting/command.py:113
+#: ./opengever/meeting/command.py:145
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "L'extrait du protocole de ${title} a été généré avec succès."
 
-#: ./opengever/meeting/command.py:118
+#: ./opengever/meeting/command.py:150
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "L'extrait du protocole ${title} a été mis à jour avec succès."
 
-#: ./opengever/meeting/command.py:181
+#: ./opengever/meeting/command.py:214
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été créé avec succès."
 
-#: ./opengever/meeting/command.py:186
+#: ./opengever/meeting/command.py:219
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été mis à jour avec succès."
 
@@ -157,7 +169,7 @@ msgstr "L'extrait du protocole de la réunion ${title} a été mis à jour avec 
 msgid "Excerpt template"
 msgstr "Modèle du protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:224
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:249
 msgid "Excerpts"
 msgstr "Extraits de protocole"
 
@@ -222,7 +234,7 @@ msgstr "Dossier de réunion"
 msgid "Meeting number"
 msgstr "Numéro de la réunion"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:222
+#: ./opengever/meeting/browser/meetings/meeting.py:223
 msgid "Meeting on ${date}"
 msgstr "Réunion du ${date}"
 
@@ -234,7 +246,7 @@ msgstr "Informations concernant la réunion"
 msgid "Memberships"
 msgstr "Adhésions"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:315
 msgid "Number"
 msgstr "Numéro"
 
@@ -243,15 +255,15 @@ msgstr "Numéro"
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr "La réunion et le protocole associé ne pourront plus être modifiés après clôture. Les actions suivantes seront exécutées lors de la clôture:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:313
 msgid "Order"
 msgstr "Tri"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:262
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:287
 msgid "Paragraph:"
 msgstr "Paragraphe:"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:134
+#: ./opengever/meeting/browser/meetings/excerpt.py:133
 msgid "Please select at least one agenda item."
 msgstr "Veuillez choisir au moins un point de l'ordre du jour."
 
@@ -272,24 +284,24 @@ msgstr "Proposition"
 msgid "Proposal Template"
 msgstr "Modèle de proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:297
 msgid "Proposals:"
 msgstr "Propositions"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/model/meeting.py:258
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:206
+#: ./opengever/meeting/model/meeting.py:262
 msgid "Protocol"
 msgstr "Protocole"
 
-#: ./opengever/meeting/model/meeting.py:261
+#: ./opengever/meeting/model/meeting.py:265
 msgid "Protocol Excerpt"
 msgstr "Extrait du protocole"
 
-#: ./opengever/meeting/command.py:60
+#: ./opengever/meeting/command.py:64
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Le protocole pour la séance ${title} a été créé avec succès."
 
-#: ./opengever/meeting/command.py:65
+#: ./opengever/meeting/command.py:69
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Le protocole pour la séance ${title} a été actualisé avec succès."
 
@@ -303,8 +315,8 @@ msgid "Sablon Template"
 msgstr "Modèle Sablon"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:121
-#: ./opengever/meeting/browser/meetings/protocol.py:206
+#: ./opengever/meeting/browser/meetings/excerpt.py:120
+#: ./opengever/meeting/browser/meetings/protocol.py:205
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -316,11 +328,11 @@ msgstr "Joint à l'ordre du jour avec succès"
 msgid "Show more"
 msgstr "Afficher plus"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:276
 msgid "Text:"
 msgstr "Texte libre:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:174
+#: ./opengever/meeting/browser/meetings/meeting.py:175
 msgid "The meeting and its dossier were created successfully"
 msgstr "La réunion et le dossier y associé ont été créés avec succès."
 
@@ -328,7 +340,7 @@ msgstr "La réunion et le dossier y associé ont été créés avec succès."
 msgid "The proposal has been rejected successfully"
 msgstr "La proposition a été rejetée avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
 msgid "Title"
 msgstr "Titre"
 
@@ -355,7 +367,7 @@ msgstr "Le document a été écrasé par une version plus récente du dossier pr
 msgid "Updated with a newer excerpt version."
 msgstr "Le document a été écrasé par une version plus récente de l'extrait de protocole."
 
-#: ./opengever/meeting/command.py:292
+#: ./opengever/meeting/command.py:326
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé par une nouvelle version de la réunion ${title}."
 
@@ -366,64 +378,64 @@ msgid "active"
 msgstr "Actif"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:332
+#: ./opengever/meeting/browser/meetings/agendaitem.py:328
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:302
+#: ./opengever/meeting/browser/meetings/agendaitem.py:298
 msgid "agenda_item_decided"
 msgstr "Le point de l'ordre du jour a été fixé."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:278
+#: ./opengever/meeting/browser/meetings/agendaitem.py:274
 msgid "agenda_item_deleted"
 msgstr "Le point a été enlevé avec succès de l'ordre du jour."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:307
+#: ./opengever/meeting/browser/meetings/agendaitem.py:303
 msgid "agenda_item_meeting_held"
 msgstr "Le point de l'ordre du jour a été fixé et la réunion a eu lieu."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:237
+#: ./opengever/meeting/browser/meetings/agendaitem.py:233
 msgid "agenda_item_order_updated"
 msgstr "L'ordre des points de l'ordre du jour a été actualisé."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:299
+#: ./opengever/meeting/browser/meetings/agendaitem.py:295
 msgid "agenda_item_proposal_decided"
 msgstr "Le point de l'ordre du jour a été fixé, l'extrait de protocole a été généré et renvoyé."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:348
+#: ./opengever/meeting/browser/meetings/agendaitem.py:344
 msgid "agenda_item_reopened"
 msgstr "Le point d'ordre du jour a été rouvert."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:361
+#: ./opengever/meeting/browser/meetings/agendaitem.py:357
 msgid "agenda_item_revised"
 msgstr "Le point d'ordre du jour a été révisé avec succès."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:250
+#: ./opengever/meeting/browser/meetings/agendaitem.py:246
 msgid "agenda_item_update_empty_string"
 msgstr "Le titre d'un point d'ordre du jour ne peut pas être laissé vide."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:257
+#: ./opengever/meeting/browser/meetings/agendaitem.py:253
 msgid "agenda_item_update_too_long_title"
 msgstr "Le titre du point de l'ordre du jour est trop long."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:263
+#: ./opengever/meeting/browser/meetings/agendaitem.py:259
 msgid "agenda_item_updated"
 msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:72
 #: ./opengever/meeting/browser/documents/submit.py:96
-#: ./opengever/meeting/browser/meetings/meeting.py:120
+#: ./opengever/meeting/browser/meetings/meeting.py:121
 msgid "button_cancel"
 msgstr "Annuler"
 
@@ -434,7 +446,7 @@ msgstr "Clôturer une période"
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:60
-#: ./opengever/meeting/browser/meetings/meeting.py:104
+#: ./opengever/meeting/browser/meetings/meeting.py:105
 msgid "button_continue"
 msgstr "Continuer"
 
@@ -551,7 +563,7 @@ msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:40
+#: ./opengever/meeting/model/agendaitem.py:43
 #: ./opengever/meeting/model/proposal.py:158
 msgid "decide"
 msgstr "Décider"
@@ -563,7 +575,7 @@ msgid "decide_agendaitem"
 msgstr "Décider d'un point de l'ordre du jour"
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/agendaitem.py:37
 #: ./opengever/meeting/model/proposal.py:138
 msgid "decided"
 msgstr "Décidé"
@@ -574,7 +586,7 @@ msgid "description_group"
 msgstr "Pour ce groupe, les autorisations sont attribuées automatiquement au comité."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:377
+#: ./opengever/meeting/browser/meetings/agendaitem.py:373
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -583,18 +595,18 @@ msgstr ""
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
 msgid "download protocol"
 msgstr "Télécharger le protocole"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:394
+#: ./opengever/meeting/browser/meetings/agendaitem.py:390
 msgid "empty_paragraph"
 msgstr "Ce paragraphe ne doit pas rester vide."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:409
+#: ./opengever/meeting/browser/meetings/agendaitem.py:405
 msgid "empty_proposal"
 msgstr "Ce texte libre ne doit pas être vide."
 
@@ -604,7 +616,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:423
+#: ./opengever/meeting/browser/meetings/agendaitem.py:419
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -619,7 +631,7 @@ msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:461
+#: ./opengever/meeting/browser/meetings/agendaitem.py:457
 msgid "excerpt_generated"
 msgstr ""
 
@@ -633,17 +645,22 @@ msgstr "Table de matière ${period} ${committee} alphabétique"
 msgid "filename_repository_toc"
 msgstr "Table de matière ${period} ${committee} selon l'ordre des points"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:226
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+msgid "generate new agenda item list as word document"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
 msgid "generate new excerpt"
 msgstr "Générer un nouvel extrait de protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:208
 msgid "generate new protocol as word document"
 msgstr "Générer le protocole comme document Word"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:194
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
 msgid "generate new version as word document"
 msgstr "Générer une nouvelle version comme document Word"
 
@@ -684,13 +701,12 @@ msgid "label_ad_hoc_template"
 msgstr ""
 
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:342
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_agenda_item_number"
 msgstr ""
 
 #. Default: "Agendaitem list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
-#: ./opengever/meeting/model/meeting.py:265
+#: ./opengever/meeting/model/meeting.py:269
 #: ./opengever/meeting/protocol.py:160
 msgid "label_agendaitem_list"
 msgstr "Liste des points du jour"
@@ -702,21 +718,21 @@ msgid "label_agendaitem_list_template"
 msgstr "Modèle de la liste des points du jour"
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:339
+#: ./opengever/meeting/browser/meetings/meeting.py:356
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
 #: ./opengever/meeting/browser/submitdocuments.py:40
 msgid "label_attachments"
 msgstr "Appendices"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:153
+#: ./opengever/meeting/browser/meetings/excerpt.py:152
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:36
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:38
 msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:241
+#: ./opengever/meeting/browser/meetings/protocol.py:240
 msgid "label_close"
 msgstr "Clôturer"
 
@@ -731,7 +747,7 @@ msgid "label_committe_reactivated"
 msgstr "Comité réactivé avec succès."
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:59
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:54
 msgid "label_committee"
@@ -743,13 +759,13 @@ msgid "label_conflict_changes"
 msgstr "Le protocole a été édité entre-temps. Sie vous voulez garder vos changements, essayer de résoudre les conflits de façon manuelle."
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:133
 #: ./opengever/meeting/proposal.py:146
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:149
+#: ./opengever/meeting/browser/meetings/protocol.py:148
 #: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr "Copie pour information"
@@ -795,12 +811,12 @@ msgid "label_decide"
 msgstr "Décider"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:319
+#: ./opengever/meeting/browser/meetings/meeting.py:336
 msgid "label_decide_action"
 msgstr "Fixez ce point de l'ordre du jour"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:139
 #: ./opengever/meeting/proposal.py:222
 msgid "label_decision"
 msgstr "Décision"
@@ -811,13 +827,13 @@ msgid "label_decision_draft"
 msgstr "Brouillon de la décision"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/meetings/meeting.py:343
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr "Numéro de décision"
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:318
+#: ./opengever/meeting/browser/meetings/meeting.py:335
 msgid "label_delete_action"
 msgstr "Enlever ce point de l'ordre du jour"
 
@@ -828,13 +844,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:146
+#: ./opengever/meeting/browser/meetings/protocol.py:145
 #: ./opengever/meeting/proposal.py:112
 msgid "label_disclose_to"
 msgstr "\"à l'information de\""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:136
 #: ./opengever/meeting/proposal.py:379
 msgid "label_discussion"
 msgstr "Discussion"
@@ -848,10 +864,6 @@ msgstr "Dossier"
 #: ./opengever/meeting/proposal.py:460
 msgid "label_dossier_not_available"
 msgstr "Dossier indisponible"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:172
-msgid "label_download_agendaitem_list"
-msgstr "Télécharger l'ordre du jour"
 
 #. Default: "download TOC alphabetical"
 #: ./opengever/meeting/browser/templates/periods.pt:11
@@ -870,7 +882,7 @@ msgid "label_edit"
 msgstr "Editer"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:317
+#: ./opengever/meeting/browser/meetings/meeting.py:334
 msgid "label_edit_action"
 msgstr "Editer le titre"
 
@@ -880,12 +892,12 @@ msgid "label_edit_after_creation"
 msgstr "Modifier après la création"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:315
+#: ./opengever/meeting/browser/meetings/meeting.py:332
 msgid "label_edit_cancel"
 msgstr "Annuler"
 
 #. Default: "Checkout and edit word document."
-#: ./opengever/meeting/browser/meetings/meeting.py:332
+#: ./opengever/meeting/browser/meetings/meeting.py:349
 msgid "label_edit_document_action"
 msgstr ""
 
@@ -900,7 +912,7 @@ msgid "label_edit_period"
 msgstr "Editer"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:316
+#: ./opengever/meeting/browser/meetings/meeting.py:333
 msgid "label_edit_save"
 msgstr "Sauvegarder"
 
@@ -911,7 +923,7 @@ msgid "label_email"
 msgstr "e-mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:71
+#: ./opengever/meeting/browser/meetings/meeting.py:73
 #: ./opengever/meeting/browser/meetings/protocol.py:73
 msgid "label_end"
 msgstr "Fin"
@@ -922,7 +934,7 @@ msgid "label_excerpt"
 msgstr "Extrait du protocole"
 
 #. Default: "Excerpts"
-#: ./opengever/meeting/browser/meetings/meeting.py:340
+#: ./opengever/meeting/browser/meetings/meeting.py:357
 #: ./opengever/meeting/proposal.py:151
 msgid "label_excerpts"
 msgstr ""
@@ -933,8 +945,8 @@ msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
 msgid "label_filter_proposal"
 msgstr "Filtrage"
 
@@ -945,7 +957,7 @@ msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Generate an excerpt."
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 msgid "label_generate_excerpt"
 msgstr ""
 
@@ -955,14 +967,14 @@ msgid "label_group"
 msgstr "Groupe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:127
 #: ./opengever/meeting/proposal.py:88
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:311
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:334
 msgid "label_insert"
 msgstr "Insérer"
 
@@ -978,7 +990,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:124
 #: ./opengever/meeting/proposal.py:82
 msgid "label_legal_basis"
 msgstr "Base légale"
@@ -994,7 +1006,7 @@ msgid "label_linked_repository_folder"
 msgstr "Tous les dossiers de réunion et tous les documents générés automatiquement seront classés sous cette position."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:62
+#: ./opengever/meeting/browser/meetings/meeting.py:64
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr "Site"
@@ -1024,8 +1036,14 @@ msgstr "Dernière modification"
 msgid "label_next_meeting"
 msgstr "Prochaine réunion:"
 
+#. Default: "No agenda item list has been generated yet."
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
+msgid "label_no_agendaitem_list"
+msgstr ""
+
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:256
 msgid "label_no_excerpts"
 msgstr "Aucun extrait de protocole supplémentaire n'a été généré encore."
 
@@ -1035,13 +1053,13 @@ msgid "label_no_memberships"
 msgstr "Cet utilisateur n'a pas d'adhésion."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:352
+#: ./opengever/meeting/browser/meetings/meeting.py:369
 msgid "label_no_proposals"
 msgstr "Aucune proposition n'a été soumise."
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:202
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:198
 msgid "label_no_protocol"
 msgstr "Aucun protocole n'a été généré encore."
 
@@ -1071,7 +1089,7 @@ msgid "label_proposal_template"
 msgstr "Modèle de proposition"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 #: ./opengever/meeting/proposal.py:94
 msgid "label_proposed_action"
 msgstr "Proposition"
@@ -1082,7 +1100,7 @@ msgid "label_protocol_start_page_number"
 msgstr "Début de la numérotation des pages du protocole"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
+#: ./opengever/meeting/browser/meetings/protocol.py:142
 #: ./opengever/meeting/proposal.py:106
 msgid "label_publish_in"
 msgstr "Publication dans"
@@ -1103,12 +1121,12 @@ msgid "label_remove"
 msgstr "Supprimer"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:320
+#: ./opengever/meeting/browser/meetings/meeting.py:337
 msgid "label_reopen_action"
 msgstr "Rouvrir ce point de l'ordre du jour"
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:321
+#: ./opengever/meeting/browser/meetings/meeting.py:338
 msgid "label_revise_action"
 msgstr "Réviser le point de l'ordre du jour"
 
@@ -1124,9 +1142,9 @@ msgid "label_sablon_template_file"
 msgstr "Fichier-modèle"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
+#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
 msgid "label_schedule"
 msgstr "Mettre à l'ordre du jour"
 
@@ -1141,14 +1159,14 @@ msgid "label_select_dossier"
 msgstr "Fichier-cible"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:67
+#: ./opengever/meeting/browser/meetings/meeting.py:69
 #: ./opengever/meeting/browser/meetings/protocol.py:68
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:52
+#: ./opengever/meeting/browser/meetings/meeting.py:54
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr "Titre"
@@ -1160,7 +1178,7 @@ msgid "label_toc_template"
 msgstr "Modèle de la table de matière"
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:341
+#: ./opengever/meeting/browser/meetings/meeting.py:358
 msgid "label_toggle_attachments"
 msgstr ""
 
@@ -1195,8 +1213,8 @@ msgstr "Prochaines réunions"
 msgid "label_workflow_state"
 msgstr "Etat"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
 msgid "label_zip_download"
 msgstr "Télécharger le fichier ZIP"
 
@@ -1224,23 +1242,33 @@ msgid "memberships"
 msgstr "Adhésions"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:263
+#: ./opengever/meeting/browser/meetings/protocol.py:262
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/protocol.py:255
+#: ./opengever/meeting/browser/meetings/protocol.py:254
 msgid "message_locked_by_another_user"
 msgstr "Les modifications n'ont pas pu être sauvegardées; le protocole a été verrouillé par ${username}."
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:249
+#: ./opengever/meeting/browser/meetings/protocol.py:248
 msgid "message_write_conflict"
 msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été modifié entre-temps."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:417
+#: ./opengever/meeting/browser/meetings/agendaitem.py:413
 msgid "missing_ad_hoc_template"
+msgstr ""
+
+#. Default: "The agenda item list for meeting ${title} has already been generated."
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
+msgid "msg_error_agendaitem_list_already_generated"
+msgstr ""
+
+#. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:39
+msgid "msg_error_agendaitem_list_missing_template"
 msgstr ""
 
 #. Default: "The protocol for meeting ${title} has already been generated."
@@ -1268,11 +1296,6 @@ msgstr "La réunion ${title} a été clôturée avec succès, les extraits de pr
 #: ./opengever/meeting/browser/memberships.py:107
 msgid "msg_membership_deleted"
 msgstr "L'adhésion a été supprimée avec succès."
-
-#. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:26
-msgid "msg_no_agenaitem_list_template"
-msgstr "Il n'y pas de modèle d'ordre de jour configuré; l'ordre du jour n'a pas pu être généré."
 
 #. Default: "There is no toc template configured, toc could not be generated."
 #: ./opengever/meeting/browser/toc.py:25
@@ -1320,7 +1343,7 @@ msgid "overview"
 msgstr "Sommaire"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:398
+#: ./opengever/meeting/browser/meetings/agendaitem.py:394
 msgid "paragraph_added"
 msgstr "Paragraphe ajouté avec succès."
 
@@ -1329,7 +1352,7 @@ msgid "participants"
 msgstr "Participants"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:33
+#: ./opengever/meeting/model/agendaitem.py:36
 #: ./opengever/meeting/model/meeting.py:74
 #: ./opengever/meeting/model/proposal.py:133
 msgid "pending"
@@ -1436,17 +1459,17 @@ msgid "reject"
 msgstr "Rejeter"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:42
+#: ./opengever/meeting/model/agendaitem.py:45
 msgid "reopen"
 msgstr "Réactiver"
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:44
+#: ./opengever/meeting/model/agendaitem.py:47
 msgid "revise"
 msgstr "Réviser"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:35
+#: ./opengever/meeting/model/agendaitem.py:38
 msgid "revision"
 msgstr "Révision"
 
@@ -1465,7 +1488,7 @@ msgid "secretary"
 msgstr "Secrétaire"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:220
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
 msgid "status"
 msgstr "État"
 
@@ -1490,7 +1513,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:432
+#: ./opengever/meeting/browser/meetings/agendaitem.py:428
 msgid "text_added"
 msgstr "Texte libre ajouté avec succès."
 
@@ -1499,7 +1522,7 @@ msgid "time"
 msgstr "Temps"
 
 #. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py:363
+#: ./opengever/meeting/model/meeting.py:367
 msgid "title_ad_hoc_document"
 msgstr ""
 
@@ -1509,17 +1532,17 @@ msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:305
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
 msgid "view_label_agenda_items"
 msgstr ""
 
@@ -1531,11 +1554,6 @@ msgstr ""
 #. Default: "Meeting dossier:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:152
 msgid "view_label_dossier"
-msgstr ""
-
-#. Default: "Download agenda item list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
-msgid "view_label_download_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting end:"
@@ -1569,17 +1587,17 @@ msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:173
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:196
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:275
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:298
 msgid "view_label_schedule_proposal"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-31 10:24+0000\n"
+"POT-Creation-Date: 2017-09-05 15:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,20 +17,20 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:507
+#: ./opengever/meeting/command.py:540
 msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:293
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:253
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:77
+#: ./opengever/meeting/browser/meetings/meeting.py:79
 msgid "Add Dossier for Meeting"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:76
+#: ./opengever/meeting/browser/meetings/meeting.py:78
 msgid "Add Meeting"
 msgstr ""
 
@@ -57,16 +57,24 @@ msgstr ""
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:541
+#: ./opengever/meeting/command.py:574
 msgid "Additional document ${title} has been submitted successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:247
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
 msgid "Agenda Items"
 msgstr ""
 
+#: ./opengever/meeting/command.py:114
+msgid "Agenda item list for meeting ${title} has been generated successfully."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:174
+msgid "Agendaitem list"
+msgstr ""
+
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:382
+#: ./opengever/meeting/browser/meetings/meeting.py:399
 msgid "An unexpected error has occurred"
 msgstr ""
 
@@ -119,32 +127,37 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:467
+#: ./opengever/meeting/command.py:500
 msgid "Document ${title} has already been submitted in that version."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:292
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
 msgid "Documents"
 msgstr ""
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+msgid "Download agenda item list"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:113
+#: ./opengever/meeting/command.py:145
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:118
+#: ./opengever/meeting/command.py:150
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:181
+#: ./opengever/meeting/command.py:214
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:186
+#: ./opengever/meeting/command.py:219
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
@@ -153,7 +166,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:224
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:249
 msgid "Excerpts"
 msgstr ""
 
@@ -218,7 +231,7 @@ msgstr ""
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:222
+#: ./opengever/meeting/browser/meetings/meeting.py:223
 msgid "Meeting on ${date}"
 msgstr ""
 
@@ -230,7 +243,7 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:315
 msgid "Number"
 msgstr ""
 
@@ -239,15 +252,15 @@ msgstr ""
 msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:313
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:262
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:287
 msgid "Paragraph:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:134
+#: ./opengever/meeting/browser/meetings/excerpt.py:133
 msgid "Please select at least one agenda item."
 msgstr ""
 
@@ -268,24 +281,24 @@ msgstr ""
 msgid "Proposal Template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:297
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/model/meeting.py:258
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:206
+#: ./opengever/meeting/model/meeting.py:262
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:261
+#: ./opengever/meeting/model/meeting.py:265
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:60
+#: ./opengever/meeting/command.py:64
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/command.py:65
+#: ./opengever/meeting/command.py:69
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr ""
 
@@ -299,8 +312,8 @@ msgid "Sablon Template"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:121
-#: ./opengever/meeting/browser/meetings/protocol.py:206
+#: ./opengever/meeting/browser/meetings/excerpt.py:120
+#: ./opengever/meeting/browser/meetings/protocol.py:205
 msgid "Save"
 msgstr ""
 
@@ -312,11 +325,11 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:276
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:174
+#: ./opengever/meeting/browser/meetings/meeting.py:175
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
@@ -324,7 +337,7 @@ msgstr ""
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
 msgid "Title"
 msgstr ""
 
@@ -351,7 +364,7 @@ msgstr ""
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:292
+#: ./opengever/meeting/command.py:326
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
@@ -362,64 +375,64 @@ msgid "active"
 msgstr ""
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:332
+#: ./opengever/meeting/browser/meetings/agendaitem.py:328
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:302
+#: ./opengever/meeting/browser/meetings/agendaitem.py:298
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:278
+#: ./opengever/meeting/browser/meetings/agendaitem.py:274
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:307
+#: ./opengever/meeting/browser/meetings/agendaitem.py:303
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:237
+#: ./opengever/meeting/browser/meetings/agendaitem.py:233
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:299
+#: ./opengever/meeting/browser/meetings/agendaitem.py:295
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:348
+#: ./opengever/meeting/browser/meetings/agendaitem.py:344
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:361
+#: ./opengever/meeting/browser/meetings/agendaitem.py:357
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:250
+#: ./opengever/meeting/browser/meetings/agendaitem.py:246
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:257
+#: ./opengever/meeting/browser/meetings/agendaitem.py:253
 msgid "agenda_item_update_too_long_title"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:263
+#: ./opengever/meeting/browser/meetings/agendaitem.py:259
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py:72
 #: ./opengever/meeting/browser/documents/submit.py:96
-#: ./opengever/meeting/browser/meetings/meeting.py:120
+#: ./opengever/meeting/browser/meetings/meeting.py:121
 msgid "button_cancel"
 msgstr ""
 
@@ -430,7 +443,7 @@ msgstr ""
 
 #. Default: "Continue"
 #: ./opengever/meeting/browser/committeeforms.py:60
-#: ./opengever/meeting/browser/meetings/meeting.py:104
+#: ./opengever/meeting/browser/meetings/meeting.py:105
 msgid "button_continue"
 msgstr ""
 
@@ -547,7 +560,7 @@ msgid "column_to"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:40
+#: ./opengever/meeting/model/agendaitem.py:43
 #: ./opengever/meeting/model/proposal.py:158
 msgid "decide"
 msgstr ""
@@ -559,7 +572,7 @@ msgid "decide_agendaitem"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/model/agendaitem.py:34
+#: ./opengever/meeting/model/agendaitem.py:37
 #: ./opengever/meeting/model/proposal.py:138
 msgid "decided"
 msgstr ""
@@ -570,7 +583,7 @@ msgid "description_group"
 msgstr ""
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:377
+#: ./opengever/meeting/browser/meetings/agendaitem.py:373
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -579,18 +592,18 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
 msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:394
+#: ./opengever/meeting/browser/meetings/agendaitem.py:390
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:409
+#: ./opengever/meeting/browser/meetings/agendaitem.py:405
 msgid "empty_proposal"
 msgstr ""
 
@@ -600,7 +613,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:423
+#: ./opengever/meeting/browser/meetings/agendaitem.py:419
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -615,7 +628,7 @@ msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:461
+#: ./opengever/meeting/browser/meetings/agendaitem.py:457
 msgid "excerpt_generated"
 msgstr ""
 
@@ -629,17 +642,22 @@ msgstr ""
 msgid "filename_repository_toc"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:226
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+msgid "generate new agenda item list as word document"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:185
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:208
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:194
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
 msgid "generate new version as word document"
 msgstr ""
 
@@ -680,13 +698,12 @@ msgid "label_ad_hoc_template"
 msgstr ""
 
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:342
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_agenda_item_number"
 msgstr ""
 
 #. Default: "Agendaitem list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:171
-#: ./opengever/meeting/model/meeting.py:265
+#: ./opengever/meeting/model/meeting.py:269
 #: ./opengever/meeting/protocol.py:160
 msgid "label_agendaitem_list"
 msgstr ""
@@ -698,21 +715,21 @@ msgid "label_agendaitem_list_template"
 msgstr ""
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:339
+#: ./opengever/meeting/browser/meetings/meeting.py:356
 #: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
 #: ./opengever/meeting/browser/submitdocuments.py:40
 msgid "label_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:153
+#: ./opengever/meeting/browser/meetings/excerpt.py:152
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:36
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:38
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:241
+#: ./opengever/meeting/browser/meetings/protocol.py:240
 msgid "label_close"
 msgstr ""
 
@@ -727,7 +744,7 @@ msgid "label_committe_reactivated"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:57
+#: ./opengever/meeting/browser/meetings/meeting.py:59
 #: ./opengever/meeting/browser/templates/member.pt:49
 #: ./opengever/meeting/proposal.py:54
 msgid "label_committee"
@@ -739,13 +756,13 @@ msgid "label_conflict_changes"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:134
+#: ./opengever/meeting/browser/meetings/protocol.py:133
 #: ./opengever/meeting/proposal.py:146
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:149
+#: ./opengever/meeting/browser/meetings/protocol.py:148
 #: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr ""
@@ -791,12 +808,12 @@ msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:319
+#: ./opengever/meeting/browser/meetings/meeting.py:336
 msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:140
+#: ./opengever/meeting/browser/meetings/protocol.py:139
 #: ./opengever/meeting/proposal.py:222
 msgid "label_decision"
 msgstr ""
@@ -807,13 +824,13 @@ msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/meetings/meeting.py:343
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr ""
 
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:318
+#: ./opengever/meeting/browser/meetings/meeting.py:335
 msgid "label_delete_action"
 msgstr ""
 
@@ -824,13 +841,13 @@ msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:146
+#: ./opengever/meeting/browser/meetings/protocol.py:145
 #: ./opengever/meeting/proposal.py:112
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:137
+#: ./opengever/meeting/browser/meetings/protocol.py:136
 #: ./opengever/meeting/proposal.py:379
 msgid "label_discussion"
 msgstr ""
@@ -843,10 +860,6 @@ msgstr ""
 #. Default: "Dossier not available"
 #: ./opengever/meeting/proposal.py:460
 msgid "label_dossier_not_available"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:172
-msgid "label_download_agendaitem_list"
 msgstr ""
 
 #. Default: "download TOC alphabetical"
@@ -866,7 +879,7 @@ msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:317
+#: ./opengever/meeting/browser/meetings/meeting.py:334
 msgid "label_edit_action"
 msgstr ""
 
@@ -876,12 +889,12 @@ msgid "label_edit_after_creation"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:315
+#: ./opengever/meeting/browser/meetings/meeting.py:332
 msgid "label_edit_cancel"
 msgstr ""
 
 #. Default: "Checkout and edit word document."
-#: ./opengever/meeting/browser/meetings/meeting.py:332
+#: ./opengever/meeting/browser/meetings/meeting.py:349
 msgid "label_edit_document_action"
 msgstr ""
 
@@ -896,7 +909,7 @@ msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:316
+#: ./opengever/meeting/browser/meetings/meeting.py:333
 msgid "label_edit_save"
 msgstr ""
 
@@ -907,7 +920,7 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:71
+#: ./opengever/meeting/browser/meetings/meeting.py:73
 #: ./opengever/meeting/browser/meetings/protocol.py:73
 msgid "label_end"
 msgstr ""
@@ -918,7 +931,7 @@ msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Excerpts"
-#: ./opengever/meeting/browser/meetings/meeting.py:340
+#: ./opengever/meeting/browser/meetings/meeting.py:357
 #: ./opengever/meeting/proposal.py:151
 msgid "label_excerpts"
 msgstr ""
@@ -929,8 +942,8 @@ msgid "label_file"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:274
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -941,7 +954,7 @@ msgid "label_firstname"
 msgstr ""
 
 #. Default: "Generate an excerpt."
-#: ./opengever/meeting/browser/meetings/meeting.py:334
+#: ./opengever/meeting/browser/meetings/meeting.py:351
 msgid "label_generate_excerpt"
 msgstr ""
 
@@ -951,14 +964,14 @@ msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:128
+#: ./opengever/meeting/browser/meetings/protocol.py:127
 #: ./opengever/meeting/proposal.py:88
 msgid "label_initial_position"
 msgstr ""
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:265
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:311
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:334
 msgid "label_insert"
 msgstr ""
 
@@ -974,7 +987,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:125
+#: ./opengever/meeting/browser/meetings/protocol.py:124
 #: ./opengever/meeting/proposal.py:82
 msgid "label_legal_basis"
 msgstr ""
@@ -990,7 +1003,7 @@ msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:62
+#: ./opengever/meeting/browser/meetings/meeting.py:64
 #: ./opengever/meeting/browser/meetings/protocol.py:62
 msgid "label_location"
 msgstr ""
@@ -1020,8 +1033,14 @@ msgstr ""
 msgid "label_next_meeting"
 msgstr ""
 
+#. Default: "No agenda item list has been generated yet."
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
+msgid "label_no_agendaitem_list"
+msgstr ""
+
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:256
 msgid "label_no_excerpts"
 msgstr ""
 
@@ -1031,13 +1050,13 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:352
+#: ./opengever/meeting/browser/meetings/meeting.py:369
 msgid "label_no_proposals"
 msgstr ""
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:202
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:198
 msgid "label_no_protocol"
 msgstr ""
 
@@ -1067,7 +1086,7 @@ msgid "label_proposal_template"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:131
+#: ./opengever/meeting/browser/meetings/protocol.py:130
 #: ./opengever/meeting/proposal.py:94
 msgid "label_proposed_action"
 msgstr ""
@@ -1078,7 +1097,7 @@ msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:143
+#: ./opengever/meeting/browser/meetings/protocol.py:142
 #: ./opengever/meeting/proposal.py:106
 msgid "label_publish_in"
 msgstr ""
@@ -1099,12 +1118,12 @@ msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:320
+#: ./opengever/meeting/browser/meetings/meeting.py:337
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:321
+#: ./opengever/meeting/browser/meetings/meeting.py:338
 msgid "label_revise_action"
 msgstr ""
 
@@ -1120,9 +1139,9 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:254
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
+#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
 msgid "label_schedule"
 msgstr ""
 
@@ -1137,14 +1156,14 @@ msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:67
+#: ./opengever/meeting/browser/meetings/meeting.py:69
 #: ./opengever/meeting/browser/meetings/protocol.py:68
 msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:52
+#: ./opengever/meeting/browser/meetings/meeting.py:54
 #: ./opengever/meeting/browser/meetings/protocol.py:29
 msgid "label_title"
 msgstr ""
@@ -1156,7 +1175,7 @@ msgid "label_toc_template"
 msgstr ""
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:341
+#: ./opengever/meeting/browser/meetings/meeting.py:358
 msgid "label_toggle_attachments"
 msgstr ""
 
@@ -1191,8 +1210,8 @@ msgstr ""
 msgid "label_workflow_state"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
 msgid "label_zip_download"
 msgstr ""
 
@@ -1220,23 +1239,33 @@ msgid "memberships"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:263
+#: ./opengever/meeting/browser/meetings/protocol.py:262
 msgid "message_changes_saved"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/protocol.py:255
+#: ./opengever/meeting/browser/meetings/protocol.py:254
 msgid "message_locked_by_another_user"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/protocol.py:249
+#: ./opengever/meeting/browser/meetings/protocol.py:248
 msgid "message_write_conflict"
 msgstr ""
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:417
+#: ./opengever/meeting/browser/meetings/agendaitem.py:413
 msgid "missing_ad_hoc_template"
+msgstr ""
+
+#. Default: "The agenda item list for meeting ${title} has already been generated."
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
+msgid "msg_error_agendaitem_list_already_generated"
+msgstr ""
+
+#. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py:39
+msgid "msg_error_agendaitem_list_missing_template"
 msgstr ""
 
 #. Default: "The protocol for meeting ${title} has already been generated."
@@ -1263,11 +1292,6 @@ msgstr ""
 #. Default: "The membership was deleted successfully."
 #: ./opengever/meeting/browser/memberships.py:107
 msgid "msg_membership_deleted"
-msgstr ""
-
-#. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:26
-msgid "msg_no_agenaitem_list_template"
 msgstr ""
 
 #. Default: "There is no toc template configured, toc could not be generated."
@@ -1316,7 +1340,7 @@ msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:398
+#: ./opengever/meeting/browser/meetings/agendaitem.py:394
 msgid "paragraph_added"
 msgstr ""
 
@@ -1325,7 +1349,7 @@ msgid "participants"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:33
+#: ./opengever/meeting/model/agendaitem.py:36
 #: ./opengever/meeting/model/meeting.py:74
 #: ./opengever/meeting/model/proposal.py:133
 msgid "pending"
@@ -1432,17 +1456,17 @@ msgid "reject"
 msgstr ""
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:42
+#: ./opengever/meeting/model/agendaitem.py:45
 msgid "reopen"
 msgstr ""
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:44
+#: ./opengever/meeting/model/agendaitem.py:47
 msgid "revise"
 msgstr ""
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:35
+#: ./opengever/meeting/model/agendaitem.py:38
 msgid "revision"
 msgstr ""
 
@@ -1461,7 +1485,7 @@ msgid "secretary"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:220
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
 msgid "status"
 msgstr ""
 
@@ -1486,7 +1510,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:432
+#: ./opengever/meeting/browser/meetings/agendaitem.py:428
 msgid "text_added"
 msgstr ""
 
@@ -1495,7 +1519,7 @@ msgid "time"
 msgstr ""
 
 #. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py:363
+#: ./opengever/meeting/model/meeting.py:367
 msgid "title_ad_hoc_document"
 msgstr ""
 
@@ -1505,17 +1529,17 @@ msgid "un-schedule"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:305
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:248
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
 msgid "view_label_agenda_items"
 msgstr ""
 
@@ -1527,11 +1551,6 @@ msgstr ""
 #. Default: "Meeting dossier:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:152
 msgid "view_label_dossier"
-msgstr ""
-
-#. Default: "Download agenda item list"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
-msgid "view_label_download_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting end:"
@@ -1565,17 +1584,17 @@ msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:173
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:196
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:290
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:275
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:298
 msgid "view_label_schedule_proposal"
 msgstr ""
 

--- a/opengever/meeting/model/generateddocument.py
+++ b/opengever/meeting/model/generateddocument.py
@@ -17,6 +17,7 @@ class GeneratedDocument(Base):
     Keeps a reference to the created document by storing it's oguid.
 
     """
+
     __tablename__ = 'generateddocuments'
     __table_args__ = (
         UniqueConstraint('admin_unit_id', 'int_id',
@@ -53,6 +54,12 @@ class GeneratedDocument(Base):
 
     def get_download_url(self):
         return '{}/download'.format(self.resolve_document().absolute_url())
+
+
+class GeneratedAgendaItemList(GeneratedDocument):
+
+    __mapper_args__ = {'polymorphic_identity': 'generated_agendaitem_list'}
+
 
 class GeneratedProtocol(GeneratedDocument):
 

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -22,7 +22,7 @@ class TestWordMeetingView(IntegrationTestCase):
              ['Participants:', u'Wendler Jens (jens-wendler@gmail.com)'
               u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
              ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
-             ['Agenda item list:', 'Download agenda item list', ''],
+             ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
              ['Protocol:', 'No protocol has been generated yet.', '']],
             meeting_view.metadata())
 
@@ -36,8 +36,11 @@ class TestWordMeetingView(IntegrationTestCase):
     @browsing
     def test_agenda_item_url(self, browser):
         self.login(self.committee_responsible, browser)
+
         browser.open(self.meeting)
-        link = browser.find('Download agenda item list')
+        browser.css('.generate-agendaitem-list').first.click()
+        link = browser.css('.download-agendaitem-list-btn').first
+
         self.assertEquals(
-            self.meeting.model.get_url(view='agenda_item_list'),
+            self.meeting.model.agendaitem_list_document.get_download_url(),
             link.attrib['href'])

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -284,7 +284,7 @@ class TestMeetingZipExportView(FunctionalTestCase):
 
         browser.login().open(meeting.get_url(view='zipexport'))
         zip_file = ZipFile(StringIO(browser.contents), 'r')
-        self.assertIn('Agendaitem list-community-meeting.docx',
+        self.assertIn('Agendaitem list-Community meeting.docx',
                       zip_file.namelist())
 
     @browsing

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -150,9 +150,13 @@ class OpengeverContentFixture(object):
         self.committee_container = self.register('committee_container', create(
             Builder('committee_container')
             .titled(u'Sitzungen')
-            .having(protocol_template=self.sablon_template,
-                    excerpt_template=self.sablon_template,
-                    ad_hoc_template=self.proposal_template)))
+            .having(
+                ad_hoc_template=self.proposal_template,
+                agendaitem_list_template=self.sablon_template,
+                excerpt_template=self.sablon_template,
+                protocol_template=self.sablon_template,
+                )
+            ))
         self.committee_container.manage_setLocalRoles(
             self.committee_responsible.getId(), ('MeetingUser',))
         self.committee_container.manage_setLocalRoles(


### PR DESCRIPTION
* Add a generated document schema relation for agendalist item documents
* Generate documents if they do not exist
  * Amend the meeting views for the two-stage workflow
* Link to the download views of generated documents
* Embed generated documents in zip exports of meetings (or generate if none)

Depends on 4teamwork/plonetheme.teamraum#579

Closes #3331.