### PR TITLE
Replace is_subdossier FieldIndex with an BooleanIndex.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Replace is_subdossier FieldIndex with an BooleanIndex. [phgross]
 - Add content stats provider for file mimetypes. [lgraf]
 - Implement "checked in vs. checked out docs" content stats provider. [lgraf]
 - Include and integrate ftw.contentstats in GEVER. [lgraf]

--- a/opengever/core/upgrades/20170904162218_replace_is_subdossier_field_index_with_a_boolean_index/upgrade.py
+++ b/opengever/core/upgrades/20170904162218_replace_is_subdossier_field_index_with_a_boolean_index/upgrade.py
@@ -1,0 +1,21 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+
+
+INDEX_NAME = 'is_subdossier'
+
+
+class ReplaceIsSubdossierFieldIndexWithABooleanIndex(UpgradeStep):
+    """Replace is_subdossier field index with a boolean index.
+    """
+
+    def __call__(self):
+        self.catalog_remove_index(INDEX_NAME)
+        self.catalog_add_index(INDEX_NAME, 'BooleanIndex')
+        catalog = self.getToolByName('portal_catalog')
+
+        for obj in self.objects({'object_provides': IDossierMarker.__identifier__},
+                                'Reindex is_subdossier index'):
+
+            catalog.reindexObject(
+                obj, idxs=[INDEX_NAME], update_metadata=False)

--- a/opengever/dossier/config.py
+++ b/opengever/dossier/config.py
@@ -1,5 +1,5 @@
 INDEXES = (
-    ('is_subdossier', 'FieldIndex'),
+    ('is_subdossier', 'BooleanIndex'),
     ('containing_subdossier', 'FieldIndex'),
     ('containing_dossier', 'FieldIndex'),
     ('retention_expiration', 'DateIndex'),


### PR DESCRIPTION
Closes #3345

The upgradestep also reindexes the value for all dossiers, which fixes some dossiers with a potential wrong value because of the bug #3224. 