### PR TITLE
Fixed bumblebee-overlay pdf link generation, when filename contains umlaut.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Fixed bumblebee-overlay pdf link generation, when filename contains umlaut. [phgross]
 - Replace is_subdossier FieldIndex with an BooleanIndex. [phgross]
 - Add content stats provider for file mimetypes. [lgraf]
 - Implement "checked in vs. checked out docs" content stats provider. [lgraf]

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -176,7 +176,8 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
 
     def get_open_as_pdf_url(self):
         return u'{}/bumblebee-open-pdf?filename={}'.format(
-            self.context.absolute_url(), quote(self._get_pdf_filename()))
+            self.context.absolute_url(),
+            quote(self._get_pdf_filename().encode('utf-8')))
 
     def get_checkout_url(self):
         return None

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -1,71 +1,59 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.mail.mail import IMail
 from opengever.bumblebee.browser.overlay import BumblebeeMailOverlay
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
 
 
-class TestAdapterRegisteredProperly(FunctionalTestCase):
+class TestAdapterRegisteredProperly(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_get_overlay_adapter_for_mails(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
+        self.login(self.regular_user)
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertIsInstance(adapter, BumblebeeMailOverlay)
 
     def test_verify_implemented_interfaces(self):
         verifyClass(IBumblebeeOverlay, BumblebeeMailOverlay)
 
 
-class TestHasFile(FunctionalTestCase):
+class TestHasFile(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_returns_true_if_mail_has_a_file(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
-
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertTrue(adapter.has_file())
 
     def test_returns_false_if_mail_has_no_file(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').within(dossier))
+        self.login(self.regular_user)
+        IMail(self.mail).message = None
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertFalse(adapter.has_file())
 
 
-class TestGetFile(FunctionalTestCase):
+class TestGetFile(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_returns_none_if_document_has_no_file(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').within(dossier))
+        self.login(self.regular_user)
+        IMail(self.mail).message = None
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_file())
 
     def test_returns_file_if_document_has_file(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
+        self.login(self.regular_user)
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
 
-        self.assertEqual(mail.message, adapter.get_file())
+        self.assertEqual(self.mail.message, adapter.get_file())
 
 
 class TestGetOpenAsPdfLink(IntegrationTestCase):
@@ -91,40 +79,35 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
             adapter.get_open_as_pdf_url())
 
 
-class TestGetCheckoutUrl(FunctionalTestCase):
+class TestGetCheckoutUrl(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_returns_none_because_its_not_possible_to_checkout_emails(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
+        self.login(self.regular_user)
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_checkout_url())
 
 
-class TestGetCheckinWithoutCommentUrl(FunctionalTestCase):
+class TestGetCheckinWithoutCommentUrl(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_returns_none_because_its_not_possible_to_checkin_emails(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
+        self.login(self.regular_user)
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_checkin_without_comment_url())
 
 
-class TestGetCheckinWithCommentUrl(FunctionalTestCase):
+class TestGetCheckinWithCommentUrl(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_returns_none_because_its_not_possible_to_checkin_emails(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
+        self.login(self.regular_user)
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
 
         self.assertIsNone(adapter.get_checkin_with_comment_url())

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -1,9 +1,11 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.mail.mail import IMail
 from opengever.bumblebee.browser.overlay import BumblebeeMailOverlay
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
 
@@ -66,18 +68,16 @@ class TestGetFile(FunctionalTestCase):
         self.assertEqual(mail.message, adapter.get_file())
 
 
-class TestGetOpenAsPdfLink(FunctionalTestCase):
+class TestGetOpenAsPdfLink(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     def test_returns_none_for_unsupported_mail_conversion(self):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').with_dummy_message().within(dossier))
+        self.login(self.regular_user)
 
-        adapter = getMultiAdapter((mail, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertEqual(
-            'http://nohost/plone/dossier-1/document-1/bumblebee-open-pdf?filename=no-subject.pdf',
+            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-11/bumblebee-open-pdf?filename=die-burgschaft.pdf',
             adapter.get_open_as_pdf_url())
 
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -80,6 +80,16 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
             'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-11/bumblebee-open-pdf?filename=die-burgschaft.pdf',
             adapter.get_open_as_pdf_url())
 
+    def test_handles_non_ascii_characters_in_filename(self):
+        self.login(self.regular_user)
+
+        IMail(self.mail).message.filename = u'GEVER - \xdcbernahme.msg'
+
+        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        self.assertEqual(
+            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-11/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
+            adapter.get_open_as_pdf_url())
+
 
 class TestGetCheckoutUrl(FunctionalTestCase):
 

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -36,6 +36,7 @@ FEATURE_FLAGS = {
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',
     'ech0147-import': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_import_enabled',
     'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
+    'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
 }
 
 FEATURE_PROFILES = {


### PR DESCRIPTION
When the filename of a mail contains non ascii characters, the BumblebeeOverlay raised an KeyError (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3904/), this PR fixes that issue and also convert all MailBumblebeeoverlay tests to IntegrationTestCases.