### PR TITLE
Split __init__ and __call__ properly on the integration test fixtures

### DIFF
--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -27,8 +27,9 @@ import pytz
 
 
 class OpengeverContentFixture(object):
+    """Provide a basic content fixture for integration tests."""
 
-    def __call__(self):
+    def __init__(self):
         start = time()
         self._lookup_table = {
             'manager': ('user', SITE_OWNER_NAME)}
@@ -62,6 +63,7 @@ class OpengeverContentFixture(object):
         end = time()
         print '(fixture setup in {}s) '.format(round(end - start, 3)),
 
+    def __call__(self):
         return self._lookup_table
 
     def create_units(self):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -23,6 +23,7 @@ from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
 from time import time
 from zope.component.hooks import getSite
+import logging
 import pytz
 
 
@@ -31,6 +32,7 @@ class OpengeverContentFixture(object):
 
     def __init__(self):
         start = time()
+        self._logger = logger = logging.getLogger('opengever.testing')
         self._lookup_table = {
             'manager': ('user', SITE_OWNER_NAME)}
 
@@ -60,8 +62,7 @@ class OpengeverContentFixture(object):
             with self.login(self.committee_responsible):
                 self.create_meeting()
 
-        end = time()
-        print '(fixture setup in {}s) '.format(round(end - start, 3)),
+        logger.info('(fixture setup in %ds) ', round(time() - start, 3))
 
     def __call__(self):
         return self._lookup_table


### PR DESCRIPTION
Currently we're populating local variables at __call__ time and this could be done at __init__ time.

Also migrated a print call to use an info logger instead.