### PR TITLE
Add missing pinning of LEPL.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -138,6 +138,7 @@ jdcal = 1.3
 jsonschema = 2.6.0
 kombu = 3.0.29
 lxml = 3.6.0
+LEPL = 5.1.3
 meld3 = 1.0.2
 mr.bob = 0.1.2
 node = 0.9.16


### PR DESCRIPTION
Used by the new ftw.zipexport dependency rfc6266 (see #3351).