### PR TITLE
Touch orphaned upgrade, add safeguard.

### DIFF
--- a/opengever/core/upgrades/20170906100343_add_agenda_list_items_to_meetings/upgrade.py
+++ b/opengever/core/upgrades/20170906100343_add_agenda_list_items_to_meetings/upgrade.py
@@ -9,8 +9,14 @@ class AddAgendaListItemsToMeetings(SchemaMigration):
     """
 
     def migrate(self):
+        if self.has_column('meetings', 'agendaitem_list_document_id'):
+            return
 
         self.op.add_column(
             'meetings',
             Column('agendaitem_list_document_id', Integer, ForeignKey('generateddocuments.id')),
         )
+
+    def has_column(self, table_name, column_name):
+        table = self.metadata.tables.get(table_name)
+        return column_name in table.columns


### PR DESCRIPTION
The upgrade has been merged in orphaned state. Schemamigrations currently
can't handle installing orphaned upgrade, so this upgrade was skipped. We
touch the upgrade and add a guard for systems where it has been previously
installed.