### PR TITLE
Add functionality to return an excerpt to the proposer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bump ftw.recipe.deployment to 1.3.0 in order to get log rotation for ftw.structlog logfiles. [lgraf]
+- SPV word: Add functionality to return an excerpt to the proposer. [deiferni]
 - Fixed bumblebee-overlay pdf link generation, when filename contains umlaut. [phgross]
 - Generate agenda item lists as documents. [Rotonen]
 - Replace is_subdossier FieldIndex with an BooleanIndex. [phgross]

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -355,9 +355,12 @@ class MeetingView(BrowserView):
                 _('label_revise_action', default='Revise this agenda item'),
                 _('label_attachments', default='Attachments'),
                 _('label_excerpts', default='Excerpts'),
+                _('label_return_action', default='Return excerpt to proposer'),
                 _('label_toggle_attachments', default='Toggle attachments'),
                 _('label_agenda_item_number', default='Agenda item number'),
                 _('label_decision_number', default=u'Decision number'),
+                _('label_returned_excerpt',
+                  default='This excerpt was returned to the dossier'),
             ),
             max_proposal_title_length=ISubmittedProposal['title'].max_length)
 

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -32,13 +32,22 @@
       <div class="proposal_document {{#if document_checked_out}}checked-out{{/if}}">{{{document_link}}}</div>
 
       {{#if excerpts}}
+
       <div>
         <div class="documents_label">%(label_excerpts)s:</div>
         <ul class="documents-list">
           {{#each excerpts}}
-          <li>
-            {{{link}}}
-          </li>
+            <li>
+              {{{link}}}
+              <span class="excerpt_buttons">
+              {{#if return_link}}
+                <a href="{{return_link}}" title="%(label_return_action)s" class="return-excerpt-btn"></a>
+              {{/if}}
+              {{#if is_excerpt}}
+                <span title="%(label_returned_excerpt)s" class="returned-excerpt-icon"></span>
+              {{/if}}
+              </span>
+            </li>
           {{/each}}
         </ul>
       </div>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -93,6 +93,23 @@
           </div>
         </div>
 
+        <div class="overlay" id="confirm_return_excerpt">
+          <h2 i18n:translate="return_excerpt">Return Excerpt</h2>
+          <p i18n:translate="msg_confirm_return_excerpt_dialog">
+            When returning an excerpt to the proposer the selected document will be sent
+            back to the proposals originating dossier. No other excerpts can be returned.
+          </p>
+          <p i18n:translate="">
+            Are you sure you want to return this excerpt to the proposer?
+          </p>
+          <div class="button-group">
+            <button class="button confirm"
+                    i18n:translate="label_return_excerpt">Return Excerpt</button>
+            <button class="button decline"
+                    i18n:translate="label_cancel">Cancel</button>
+          </div>
+        </div>
+
         <div class="meeting-metadata">
           <table class="meeting-metadata">
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -92,6 +92,14 @@
       closeOnEsc: false
     }).data("overlay");
 
+    var returnExcerptDialog = $("#confirm_return_excerpt").overlay({
+      speed: 0,
+      closeSpeed: 0,
+      mask: { loadSpeed: 0 },
+      closeOnClick: false,
+      closeOnEsc: false
+    }).data("overlay");
+
     var sortableHelper = function(e, row) {
       var helper = row.clone();
       $.each(row.children(), function(idx, cell) {
@@ -131,6 +139,11 @@
       }
     };
 
+    this.confirmReturnExcerpt = function(target) {
+      this.currentItem = target;
+      returnExcerptDialog.load();
+    };
+
     this.unschedule = function() {
       this.closeModal();
       return $.post(this.currentItem.attr("href"));
@@ -139,6 +152,7 @@
     this.closeModal = function() {
       unscheduleDialog.close();
       deleteDialog.close();
+      returnExcerptDialog.close();
     };
 
     this.updateSortOrder = function() {
@@ -227,6 +241,13 @@
       return $.get(target.attr("href"));
     };
 
+    this.returnExcerpt = function() {
+      self = this;
+      return $.get(this.currentItem.attr("href")).always(function() {
+        self.closeModal();
+      });
+    };
+
     this.events = [
       {
         method: "click",
@@ -279,6 +300,24 @@
         }
       },
       {
+        method: "click",
+        target: ".return-excerpt-btn",
+        callback: this.confirmReturnExcerpt,
+        options: {
+          prevent: true
+        }
+      },
+      {
+        method: "click",
+        target: "#confirm_return_excerpt .confirm",
+        callback: this.returnExcerpt,
+        options: {
+          prevent: false,
+          loading: true,
+          update: true
+        }
+      },
+      {
         method: "sortupdate",
         target: "#agenda_items tbody",
         callback: this.updateSortOrder,
@@ -303,7 +342,7 @@
       },
       {
         method: "click",
-        target: "#confirm_unschedule .decline, #confirm_delete .decline",
+        target: "#confirm_unschedule .decline, #confirm_delete .decline, #confirm_return_excerpt .decline",
         callback: this.closeModal
       },
       {

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -218,7 +218,7 @@
       return $.get(target.attr("href")).done(function(response) {
         if(response.proceed === true) {
           window.location = response.officeConnectorURL;
-          $(target).parents('tr').find('.proposal_document').addClass('checked-out');
+          $(target).parents("tr").find(".proposal_document").addClass("checked-out");
         }
       });
     };

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-05 15:45+0000\n"
+"POT-Creation-Date: 2017-09-07 09:54+0000\n"
 "PO-Revision-Date: 2017-08-22 12:18+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:293
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -75,7 +75,7 @@ msgid "Agendaitem list"
 msgstr "Traktandenliste"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:399
+#: ./opengever/meeting/browser/meetings/meeting.py:402
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
@@ -83,6 +83,10 @@ msgstr "Ein unerwarteter Fehler ist aufgetreten"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:69
 msgid "Are you sure you want to close this meeting?"
 msgstr "Wollen Sie diese Sitzung wirklich abschliessen?"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+msgid "Are you sure you want to return this excerpt to the proposer?"
+msgstr "Wollen Sie diesen Protokollauszug wirklich an den Antragsteller zurücksenden?"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:83
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
@@ -137,12 +141,12 @@ msgid "Documents"
 msgstr "Dokumente"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
 msgid "Download agenda item list"
 msgstr "Traktandenliste herunterladen"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -376,57 +380,57 @@ msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:328
+#: ./opengever/meeting/browser/meetings/agendaitem.py:342
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr "Traktandum kann nicht beschlossen werden: das Beschlussdokument ist noch von einer anderen Person ausgecheckt."
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:298
+#: ./opengever/meeting/browser/meetings/agendaitem.py:312
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:274
+#: ./opengever/meeting/browser/meetings/agendaitem.py:288
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:303
+#: ./opengever/meeting/browser/meetings/agendaitem.py:317
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:233
+#: ./opengever/meeting/browser/meetings/agendaitem.py:247
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:295
+#: ./opengever/meeting/browser/meetings/agendaitem.py:309
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:344
+#: ./opengever/meeting/browser/meetings/agendaitem.py:358
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:357
+#: ./opengever/meeting/browser/meetings/agendaitem.py:371
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:246
+#: ./opengever/meeting/browser/meetings/agendaitem.py:260
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:253
+#: ./opengever/meeting/browser/meetings/agendaitem.py:267
 msgid "agenda_item_update_too_long_title"
 msgstr "Der Traktandums-Titel ist zu lang."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:259
+#: ./opengever/meeting/browser/meetings/agendaitem.py:273
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
@@ -455,12 +459,12 @@ msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:160
+#: ./opengever/meeting/model/proposal.py:161
 msgid "cancel"
 msgstr "Stornieren"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:140
+#: ./opengever/meeting/model/proposal.py:141
 msgid "cancelled"
 msgstr "Storniert"
 
@@ -562,7 +566,7 @@ msgstr "Bis"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:43
-#: ./opengever/meeting/model/proposal.py:158
+#: ./opengever/meeting/model/proposal.py:159
 msgid "decide"
 msgstr "Beschliessen"
 
@@ -574,7 +578,7 @@ msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:138
+#: ./opengever/meeting/model/proposal.py:139
 msgid "decided"
 msgstr "Beschlossen"
 
@@ -584,7 +588,7 @@ msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:373
+#: ./opengever/meeting/browser/meetings/agendaitem.py:387
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
@@ -594,17 +598,17 @@ msgid "dossier"
 msgstr "Dossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:390
+#: ./opengever/meeting/browser/meetings/agendaitem.py:404
 msgid "empty_paragraph"
 msgstr "Der Abschnitt darf nicht leer sein."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:419
 msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
@@ -614,7 +618,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:419
+#: ./opengever/meeting/browser/meetings/agendaitem.py:433
 msgid "error_no_permission_to_add_document"
 msgstr "Ungenügende Berechtigungen zum Hinzufügen eines Dokumentes im Sitzungsdossier."
 
@@ -629,9 +633,14 @@ msgid "excerpt_document_title"
 msgstr "Protokollauszug ${title}"
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:457
+#: ./opengever/meeting/browser/meetings/agendaitem.py:471
 msgid "excerpt_generated"
 msgstr "Protokollauszug erfolgreich generiert."
+
+#. Default: "Excerpt was returned to proposer."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:491
+msgid "excerpt_returned"
+msgstr "Der Protokollauszug wurde an den Antragsteller zurückgesendet."
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py:60
@@ -644,7 +653,7 @@ msgid "filename_repository_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} nach Ordnungsposition"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
 msgid "generate new agenda item list as word document"
 msgstr "Traktandenliste als Worddokument generieren"
 
@@ -653,12 +662,12 @@ msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:225
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:203
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
@@ -699,7 +708,7 @@ msgid "label_ad_hoc_template"
 msgstr "Ad Hoc Vorlage"
 
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_agenda_item_number"
 msgstr "Nummer des Traktandums in dieser Sitzung"
 
@@ -825,7 +834,7 @@ msgid "label_decision_draft"
 msgstr "Beschlussentwurf"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
@@ -944,7 +953,7 @@ msgstr "Datei"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -972,7 +981,7 @@ msgstr "Ausgangslage"
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:334
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:351
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -1036,7 +1045,7 @@ msgstr "Nächste Sitzung:"
 
 #. Default: "No agenda item list has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:181
 msgid "label_no_agendaitem_list"
 msgstr "Es wurde noch keine Traktandenliste generiert."
 
@@ -1051,13 +1060,13 @@ msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:369
+#: ./opengever/meeting/browser/meetings/meeting.py:372
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:198
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:215
 msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
@@ -1123,6 +1132,21 @@ msgstr "Löschen"
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
+#. Default: "Return excerpt to proposer"
+#: ./opengever/meeting/browser/meetings/meeting.py:358
+msgid "label_return_action"
+msgstr "Protokollauszug an Antragsteller zurücksenden"
+
+#. Default: "Return Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+msgid "label_return_excerpt"
+msgstr "Protokollauszug zurücksenden"
+
+#. Default: "This excerpt was returned to the dossier"
+#: ./opengever/meeting/browser/meetings/meeting.py:362
+msgid "label_returned_excerpt"
+msgstr "Dieser Protokollauszug wurde an den Antragsteller zurückgesendet."
+
 #. Default: "Revise this agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py:338
 msgid "label_revise_action"
@@ -1140,9 +1164,9 @@ msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:336
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -1176,7 +1200,7 @@ msgid "label_toc_template"
 msgstr "Vorlage Inhaltsverzeichnis"
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:358
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_toggle_attachments"
 msgstr "Anhänge anzeigen / ausblenden"
 
@@ -1212,7 +1236,7 @@ msgid "label_workflow_state"
 msgstr "Status"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
 msgid "label_zip_download"
 msgstr "Zip-Datei herunterladen"
 
@@ -1255,9 +1279,14 @@ msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:413
+#: ./opengever/meeting/browser/meetings/agendaitem.py:427
 msgid "missing_ad_hoc_template"
 msgstr "Es konnte keine Vorlage für ein Ad Hoc Traktandum gefunden werden."
+
+#. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
+msgid "msg_confirm_return_excerpt_dialog"
+msgstr "Der Protokollauszug wird an den Antragsteller bzw. ins Ursprungsdossier des Antrags zurückgesendet. Es können keine weiteren Protokollauszuge zurückgesendet werden."
 
 #. Default: "The agenda item list for meeting ${title} has already been generated."
 #: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
@@ -1281,7 +1310,7 @@ msgid "msg_hold_meeting_dialog"
 msgstr "Beim Abschluss dieses Traktandums wird die Sitzung in den Status `Durchgeführt`  versetzt. Anschliessend kann die Traktandenliste nicht mehr bearbeitet werden."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:39
+#: ./opengever/meeting/model/proposal.py:40
 msgid "msg_inactive_committee_selected"
 msgstr "Das ausgewählte Gremium wurde deaktiviert, der Antrag konnte nicht eingereicht werden."
 
@@ -1306,17 +1335,17 @@ msgid "msg_pending_meetings"
 msgstr "Nicht alle Sitzungen sind abgeschlossen."
 
 #. Default: "Proposal cancelled successfully."
-#: ./opengever/meeting/model/proposal.py:67
+#: ./opengever/meeting/model/proposal.py:68
 msgid "msg_proposal_cancelled"
 msgstr "Der Antrag wurde storniert."
 
 #. Default: "Proposal reactivated successfully."
-#: ./opengever/meeting/model/proposal.py:78
+#: ./opengever/meeting/model/proposal.py:79
 msgid "msg_proposal_reactivated"
 msgstr "Der Antrag wurde wieder eröffnet."
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:49
+#: ./opengever/meeting/model/proposal.py:50
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
 
@@ -1341,7 +1370,7 @@ msgid "overview"
 msgstr "Übersicht"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:394
+#: ./opengever/meeting/browser/meetings/agendaitem.py:408
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
@@ -1352,7 +1381,7 @@ msgstr "Teilnehmende"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:36
 #: ./opengever/meeting/model/meeting.py:74
-#: ./opengever/meeting/model/proposal.py:133
+#: ./opengever/meeting/model/proposal.py:134
 msgid "pending"
 msgstr "In Bearbeitung"
 
@@ -1446,13 +1475,13 @@ msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:162
+#: ./opengever/meeting/model/proposal.py:163
 msgid "reactivate"
 msgstr "Wieder eröffnen"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:152
+#: ./opengever/meeting/model/proposal.py:153
 msgid "reject"
 msgstr "Zurückweisen"
 
@@ -1460,6 +1489,11 @@ msgstr "Zurückweisen"
 #: ./opengever/meeting/model/agendaitem.py:45
 msgid "reopen"
 msgstr "Wieder eröffnen"
+
+#. Default: "Return Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:97
+msgid "return_excerpt"
+msgstr "Protokollauszug zurücksenden"
 
 #. Default: "Revise"
 #: ./opengever/meeting/model/agendaitem.py:47
@@ -1472,12 +1506,12 @@ msgid "revision"
 msgstr "Überarbeitung"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:154
+#: ./opengever/meeting/model/proposal.py:155
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:138
 msgid "scheduled"
 msgstr "Traktandiert"
 
@@ -1486,17 +1520,17 @@ msgid "secretary"
 msgstr "Protokollführer"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:260
 msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:150
+#: ./opengever/meeting/model/proposal.py:151
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/proposal.py:136
 msgid "submitted"
 msgstr "Eingereicht"
 
@@ -1511,7 +1545,7 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py:442
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
@@ -1525,81 +1559,82 @@ msgid "title_ad_hoc_document"
 msgstr "Ad Hoc Traktandum ${title}"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:156
+#: ./opengever/meeting/model/proposal.py:157
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:308
 msgid "view_label_add"
 msgstr "Hinzufügen"
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:345
 msgid "view_label_add_section_header"
 msgstr "Zwischentitel einfügen:"
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:162
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:179
 msgid "view_label_agendaitem_list"
 msgstr "Traktandenliste:"
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:152
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:169
 msgid "view_label_dossier"
 msgstr "Sitzungsdossier:"
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:123
 msgid "view_label_meeting_end"
 msgstr "Sitzungsende:"
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:111
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:128
 msgid "view_label_meeting_location"
 msgstr "Ort:"
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:133
 msgid "view_label_meeting_number"
 msgstr "Sitzungsnummer:"
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:100
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:117
 msgid "view_label_meeting_start"
 msgstr "Beginn:"
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:138
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:155
 msgid "view_label_participants"
 msgstr "Teilnehmer:"
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:124
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:141
 msgid "view_label_presidency"
 msgstr "Vorsitz:"
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:196
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:213
 msgid "view_label_protocol"
 msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:330
 msgid "view_label_schedule_ad_hoc"
 msgstr "Ad Hoc Traktandum einfügen:"
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:298
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:315
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:148
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
+

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-05 15:45+0000\n"
+"POT-Creation-Date: 2017-09-07 09:54+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -24,7 +24,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:293
 msgid "Actions"
 msgstr "Actions"
 
@@ -77,7 +77,7 @@ msgid "Agendaitem list"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:399
+#: ./opengever/meeting/browser/meetings/meeting.py:402
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
@@ -85,6 +85,10 @@ msgstr "Une erreur imprévue est apparue"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:69
 msgid "Are you sure you want to close this meeting?"
 msgstr "Êtes-vous sûr de vouloir fermer cette réunion?"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+msgid "Are you sure you want to return this excerpt to the proposer?"
+msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:83
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
@@ -139,12 +143,12 @@ msgid "Documents"
 msgstr "Documents"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
 msgid "Download agenda item list"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
 msgid "Edit"
 msgstr "Modifier"
 
@@ -378,57 +382,57 @@ msgid "active"
 msgstr "Actif"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:328
+#: ./opengever/meeting/browser/meetings/agendaitem.py:342
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:298
+#: ./opengever/meeting/browser/meetings/agendaitem.py:312
 msgid "agenda_item_decided"
 msgstr "Le point de l'ordre du jour a été fixé."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:274
+#: ./opengever/meeting/browser/meetings/agendaitem.py:288
 msgid "agenda_item_deleted"
 msgstr "Le point a été enlevé avec succès de l'ordre du jour."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:303
+#: ./opengever/meeting/browser/meetings/agendaitem.py:317
 msgid "agenda_item_meeting_held"
 msgstr "Le point de l'ordre du jour a été fixé et la réunion a eu lieu."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:233
+#: ./opengever/meeting/browser/meetings/agendaitem.py:247
 msgid "agenda_item_order_updated"
 msgstr "L'ordre des points de l'ordre du jour a été actualisé."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:295
+#: ./opengever/meeting/browser/meetings/agendaitem.py:309
 msgid "agenda_item_proposal_decided"
 msgstr "Le point de l'ordre du jour a été fixé, l'extrait de protocole a été généré et renvoyé."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:344
+#: ./opengever/meeting/browser/meetings/agendaitem.py:358
 msgid "agenda_item_reopened"
 msgstr "Le point d'ordre du jour a été rouvert."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:357
+#: ./opengever/meeting/browser/meetings/agendaitem.py:371
 msgid "agenda_item_revised"
 msgstr "Le point d'ordre du jour a été révisé avec succès."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:246
+#: ./opengever/meeting/browser/meetings/agendaitem.py:260
 msgid "agenda_item_update_empty_string"
 msgstr "Le titre d'un point d'ordre du jour ne peut pas être laissé vide."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:253
+#: ./opengever/meeting/browser/meetings/agendaitem.py:267
 msgid "agenda_item_update_too_long_title"
 msgstr "Le titre du point de l'ordre du jour est trop long."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:259
+#: ./opengever/meeting/browser/meetings/agendaitem.py:273
 msgid "agenda_item_updated"
 msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
 
@@ -457,12 +461,12 @@ msgid "button_submit_attachments"
 msgstr "Soumettre des appendices"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:160
+#: ./opengever/meeting/model/proposal.py:161
 msgid "cancel"
 msgstr "Annuler"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:140
+#: ./opengever/meeting/model/proposal.py:141
 msgid "cancelled"
 msgstr "Annulé"
 
@@ -564,7 +568,7 @@ msgstr "Jusqu'à"
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:43
-#: ./opengever/meeting/model/proposal.py:158
+#: ./opengever/meeting/model/proposal.py:159
 msgid "decide"
 msgstr "Décider"
 
@@ -576,7 +580,7 @@ msgstr "Décider d'un point de l'ordre du jour"
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:138
+#: ./opengever/meeting/model/proposal.py:139
 msgid "decided"
 msgstr "Décidé"
 
@@ -586,7 +590,7 @@ msgid "description_group"
 msgstr "Pour ce groupe, les autorisations sont attribuées automatiquement au comité."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:373
+#: ./opengever/meeting/browser/meetings/agendaitem.py:387
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -596,17 +600,17 @@ msgid "dossier"
 msgstr "Dossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
 msgid "download protocol"
 msgstr "Télécharger le protocole"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:390
+#: ./opengever/meeting/browser/meetings/agendaitem.py:404
 msgid "empty_paragraph"
 msgstr "Ce paragraphe ne doit pas rester vide."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:419
 msgid "empty_proposal"
 msgstr "Ce texte libre ne doit pas être vide."
 
@@ -616,7 +620,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:419
+#: ./opengever/meeting/browser/meetings/agendaitem.py:433
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -631,8 +635,13 @@ msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:457
+#: ./opengever/meeting/browser/meetings/agendaitem.py:471
 msgid "excerpt_generated"
+msgstr ""
+
+#. Default: "Excerpt was returned to proposer."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:491
+msgid "excerpt_returned"
 msgstr ""
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
@@ -646,7 +655,7 @@ msgid "filename_repository_toc"
 msgstr "Table de matière ${period} ${committee} selon l'ordre des points"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
 msgid "generate new agenda item list as word document"
 msgstr ""
 
@@ -655,12 +664,12 @@ msgid "generate new excerpt"
 msgstr "Générer un nouvel extrait de protocole"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:225
 msgid "generate new protocol as word document"
 msgstr "Générer le protocole comme document Word"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:203
 msgid "generate new version as word document"
 msgstr "Générer une nouvelle version comme document Word"
 
@@ -701,7 +710,7 @@ msgid "label_ad_hoc_template"
 msgstr ""
 
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_agenda_item_number"
 msgstr ""
 
@@ -827,7 +836,7 @@ msgid "label_decision_draft"
 msgstr "Brouillon de la décision"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr "Numéro de décision"
@@ -946,7 +955,7 @@ msgstr "Fichier"
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
 msgid "label_filter_proposal"
 msgstr "Filtrage"
 
@@ -974,7 +983,7 @@ msgstr "Situation initiale"
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:334
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:351
 msgid "label_insert"
 msgstr "Insérer"
 
@@ -1038,7 +1047,7 @@ msgstr "Prochaine réunion:"
 
 #. Default: "No agenda item list has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:181
 msgid "label_no_agendaitem_list"
 msgstr ""
 
@@ -1053,13 +1062,13 @@ msgid "label_no_memberships"
 msgstr "Cet utilisateur n'a pas d'adhésion."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:369
+#: ./opengever/meeting/browser/meetings/meeting.py:372
 msgid "label_no_proposals"
 msgstr "Aucune proposition n'a été soumise."
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:198
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:215
 msgid "label_no_protocol"
 msgstr "Aucun protocole n'a été généré encore."
 
@@ -1125,6 +1134,21 @@ msgstr "Supprimer"
 msgid "label_reopen_action"
 msgstr "Rouvrir ce point de l'ordre du jour"
 
+#. Default: "Return excerpt to proposer"
+#: ./opengever/meeting/browser/meetings/meeting.py:358
+msgid "label_return_action"
+msgstr ""
+
+#. Default: "Return Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+msgid "label_return_excerpt"
+msgstr ""
+
+#. Default: "This excerpt was returned to the dossier"
+#: ./opengever/meeting/browser/meetings/meeting.py:362
+msgid "label_returned_excerpt"
+msgstr ""
+
 #. Default: "Revise this agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py:338
 msgid "label_revise_action"
@@ -1142,9 +1166,9 @@ msgid "label_sablon_template_file"
 msgstr "Fichier-modèle"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:336
 msgid "label_schedule"
 msgstr "Mettre à l'ordre du jour"
 
@@ -1178,7 +1202,7 @@ msgid "label_toc_template"
 msgstr "Modèle de la table de matière"
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:358
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_toggle_attachments"
 msgstr ""
 
@@ -1214,7 +1238,7 @@ msgid "label_workflow_state"
 msgstr "Etat"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
 msgid "label_zip_download"
 msgstr "Télécharger le fichier ZIP"
 
@@ -1257,8 +1281,13 @@ msgid "message_write_conflict"
 msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été modifié entre-temps."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:413
+#: ./opengever/meeting/browser/meetings/agendaitem.py:427
 msgid "missing_ad_hoc_template"
+msgstr ""
+
+#. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
+msgid "msg_confirm_return_excerpt_dialog"
 msgstr ""
 
 #. Default: "The agenda item list for meeting ${title} has already been generated."
@@ -1283,7 +1312,7 @@ msgid "msg_hold_meeting_dialog"
 msgstr "Lors de la clôture de ce point de l'ordre du jour, la réunion sera mise dans l'état \"réalisé\". Ensuite, l'ordre du jour ne pourra plus être modifié."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:39
+#: ./opengever/meeting/model/proposal.py:40
 msgid "msg_inactive_committee_selected"
 msgstr "Le comité sélectionné a été désactivé; la proposition n'a pas pu être soumise."
 
@@ -1308,17 +1337,17 @@ msgid "msg_pending_meetings"
 msgstr "Il y a des réunions non clôturées."
 
 #. Default: "Proposal cancelled successfully."
-#: ./opengever/meeting/model/proposal.py:67
+#: ./opengever/meeting/model/proposal.py:68
 msgid "msg_proposal_cancelled"
 msgstr "Proposition annulée avec succès."
 
 #. Default: "Proposal reactivated successfully."
-#: ./opengever/meeting/model/proposal.py:78
+#: ./opengever/meeting/model/proposal.py:79
 msgid "msg_proposal_reactivated"
 msgstr "La proposition a été réactivée."
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:49
+#: ./opengever/meeting/model/proposal.py:50
 msgid "msg_proposal_submitted"
 msgstr "Proposition soumise avec succès."
 
@@ -1343,7 +1372,7 @@ msgid "overview"
 msgstr "Sommaire"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:394
+#: ./opengever/meeting/browser/meetings/agendaitem.py:408
 msgid "paragraph_added"
 msgstr "Paragraphe ajouté avec succès."
 
@@ -1354,7 +1383,7 @@ msgstr "Participants"
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:36
 #: ./opengever/meeting/model/meeting.py:74
-#: ./opengever/meeting/model/proposal.py:133
+#: ./opengever/meeting/model/proposal.py:134
 msgid "pending"
 msgstr "En modification"
 
@@ -1448,13 +1477,13 @@ msgid "protocol_excerpt"
 msgstr "Extrait de protocole"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:162
+#: ./opengever/meeting/model/proposal.py:163
 msgid "reactivate"
 msgstr "Réactiver"
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:152
+#: ./opengever/meeting/model/proposal.py:153
 msgid "reject"
 msgstr "Rejeter"
 
@@ -1462,6 +1491,11 @@ msgstr "Rejeter"
 #: ./opengever/meeting/model/agendaitem.py:45
 msgid "reopen"
 msgstr "Réactiver"
+
+#. Default: "Return Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:97
+msgid "return_excerpt"
+msgstr ""
 
 #. Default: "Revise"
 #: ./opengever/meeting/model/agendaitem.py:47
@@ -1474,12 +1508,12 @@ msgid "revision"
 msgstr "Révision"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:154
+#: ./opengever/meeting/model/proposal.py:155
 msgid "schedule"
 msgstr "Mettre à l'ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:138
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
@@ -1488,17 +1522,17 @@ msgid "secretary"
 msgstr "Secrétaire"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:260
 msgid "status"
 msgstr "État"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:150
+#: ./opengever/meeting/model/proposal.py:151
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/proposal.py:136
 msgid "submitted"
 msgstr "Soumis"
 
@@ -1513,7 +1547,7 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py:442
 msgid "text_added"
 msgstr "Texte libre ajouté avec succès."
 
@@ -1527,82 +1561,82 @@ msgid "title_ad_hoc_document"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:156
+#: ./opengever/meeting/model/proposal.py:157
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:308
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:345
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
 msgid "view_label_agenda_items"
 msgstr ""
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:162
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:179
 msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:152
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:169
 msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:123
 msgid "view_label_meeting_end"
 msgstr ""
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:111
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:128
 msgid "view_label_meeting_location"
 msgstr ""
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:133
 msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:100
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:117
 msgid "view_label_meeting_start"
 msgstr ""
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:138
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:155
 msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:124
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:141
 msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:196
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:213
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:330
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:298
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:315
 msgid "view_label_schedule_proposal"
 msgstr ""
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:148
 msgid "view_label_secretary"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-05 15:45+0000\n"
+"POT-Creation-Date: 2017-09-07 09:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:293
 msgid "Actions"
 msgstr ""
 
@@ -74,13 +74,17 @@ msgid "Agendaitem list"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:399
+#: ./opengever/meeting/browser/meetings/meeting.py:402
 msgid "An unexpected error has occurred"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:67
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:69
 msgid "Are you sure you want to close this meeting?"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:83
@@ -136,12 +140,12 @@ msgid "Documents"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:180
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:197
 msgid "Download agenda item list"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
 msgid "Edit"
 msgstr ""
 
@@ -375,57 +379,57 @@ msgid "active"
 msgstr ""
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:328
+#: ./opengever/meeting/browser/meetings/agendaitem.py:342
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:298
+#: ./opengever/meeting/browser/meetings/agendaitem.py:312
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:274
+#: ./opengever/meeting/browser/meetings/agendaitem.py:288
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:303
+#: ./opengever/meeting/browser/meetings/agendaitem.py:317
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:233
+#: ./opengever/meeting/browser/meetings/agendaitem.py:247
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:295
+#: ./opengever/meeting/browser/meetings/agendaitem.py:309
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:344
+#: ./opengever/meeting/browser/meetings/agendaitem.py:358
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:357
+#: ./opengever/meeting/browser/meetings/agendaitem.py:371
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:246
+#: ./opengever/meeting/browser/meetings/agendaitem.py:260
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:253
+#: ./opengever/meeting/browser/meetings/agendaitem.py:267
 msgid "agenda_item_update_too_long_title"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:259
+#: ./opengever/meeting/browser/meetings/agendaitem.py:273
 msgid "agenda_item_updated"
 msgstr ""
 
@@ -454,12 +458,12 @@ msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:160
+#: ./opengever/meeting/model/proposal.py:161
 msgid "cancel"
 msgstr ""
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:140
+#: ./opengever/meeting/model/proposal.py:141
 msgid "cancelled"
 msgstr ""
 
@@ -561,7 +565,7 @@ msgstr ""
 
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:43
-#: ./opengever/meeting/model/proposal.py:158
+#: ./opengever/meeting/model/proposal.py:159
 msgid "decide"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/model/agendaitem.py:37
-#: ./opengever/meeting/model/proposal.py:138
+#: ./opengever/meeting/model/proposal.py:139
 msgid "decided"
 msgstr ""
 
@@ -583,7 +587,7 @@ msgid "description_group"
 msgstr ""
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:373
+#: ./opengever/meeting/browser/meetings/agendaitem.py:387
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -593,17 +597,17 @@ msgid "dossier"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:231
 msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:390
+#: ./opengever/meeting/browser/meetings/agendaitem.py:404
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:419
 msgid "empty_proposal"
 msgstr ""
 
@@ -613,7 +617,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:419
+#: ./opengever/meeting/browser/meetings/agendaitem.py:433
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -628,8 +632,13 @@ msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:457
+#: ./opengever/meeting/browser/meetings/agendaitem.py:471
 msgid "excerpt_generated"
+msgstr ""
+
+#. Default: "Excerpt was returned to proposer."
+#: ./opengever/meeting/browser/meetings/agendaitem.py:491
+msgid "excerpt_returned"
 msgstr ""
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
@@ -643,7 +652,7 @@ msgid "filename_repository_toc"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
 msgid "generate new agenda item list as word document"
 msgstr ""
 
@@ -652,12 +661,12 @@ msgid "generate new excerpt"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:225
 msgid "generate new protocol as word document"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:186
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:203
 msgid "generate new version as word document"
 msgstr ""
 
@@ -698,7 +707,7 @@ msgid "label_ad_hoc_template"
 msgstr ""
 
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:359
+#: ./opengever/meeting/browser/meetings/meeting.py:360
 msgid "label_agenda_item_number"
 msgstr ""
 
@@ -824,7 +833,7 @@ msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/meetings/meeting.py:360
+#: ./opengever/meeting/browser/meetings/meeting.py:361
 #: ./opengever/meeting/proposal.py:248
 msgid "label_decision_number"
 msgstr ""
@@ -943,7 +952,7 @@ msgstr ""
 
 #. Default: "Filter"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:302
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -971,7 +980,7 @@ msgstr ""
 
 #. Default: "Insert"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:334
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:351
 msgid "label_insert"
 msgstr ""
 
@@ -1035,7 +1044,7 @@ msgstr ""
 
 #. Default: "No agenda item list has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:181
 msgid "label_no_agendaitem_list"
 msgstr ""
 
@@ -1050,13 +1059,13 @@ msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:369
+#: ./opengever/meeting/browser/meetings/meeting.py:372
 msgid "label_no_proposals"
 msgstr ""
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:198
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:215
 msgid "label_no_protocol"
 msgstr ""
 
@@ -1122,6 +1131,21 @@ msgstr ""
 msgid "label_reopen_action"
 msgstr ""
 
+#. Default: "Return excerpt to proposer"
+#: ./opengever/meeting/browser/meetings/meeting.py:358
+msgid "label_return_action"
+msgstr ""
+
+#. Default: "Return Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+msgid "label_return_excerpt"
+msgstr ""
+
+#. Default: "This excerpt was returned to the dossier"
+#: ./opengever/meeting/browser/meetings/meeting.py:362
+msgid "label_returned_excerpt"
+msgstr ""
+
 #. Default: "Revise this agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py:338
 msgid "label_revise_action"
@@ -1139,9 +1163,9 @@ msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:368
+#: ./opengever/meeting/browser/meetings/meeting.py:371
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:319
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:336
 msgid "label_schedule"
 msgstr ""
 
@@ -1175,7 +1199,7 @@ msgid "label_toc_template"
 msgstr ""
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:358
+#: ./opengever/meeting/browser/meetings/meeting.py:359
 msgid "label_toggle_attachments"
 msgstr ""
 
@@ -1211,7 +1235,7 @@ msgid "label_workflow_state"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:254
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
 msgid "label_zip_download"
 msgstr ""
 
@@ -1254,8 +1278,13 @@ msgid "message_write_conflict"
 msgstr ""
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:413
+#: ./opengever/meeting/browser/meetings/agendaitem.py:427
 msgid "missing_ad_hoc_template"
+msgstr ""
+
+#. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
+msgid "msg_confirm_return_excerpt_dialog"
 msgstr ""
 
 #. Default: "The agenda item list for meeting ${title} has already been generated."
@@ -1280,7 +1309,7 @@ msgid "msg_hold_meeting_dialog"
 msgstr ""
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:39
+#: ./opengever/meeting/model/proposal.py:40
 msgid "msg_inactive_committee_selected"
 msgstr ""
 
@@ -1305,17 +1334,17 @@ msgid "msg_pending_meetings"
 msgstr ""
 
 #. Default: "Proposal cancelled successfully."
-#: ./opengever/meeting/model/proposal.py:67
+#: ./opengever/meeting/model/proposal.py:68
 msgid "msg_proposal_cancelled"
 msgstr ""
 
 #. Default: "Proposal reactivated successfully."
-#: ./opengever/meeting/model/proposal.py:78
+#: ./opengever/meeting/model/proposal.py:79
 msgid "msg_proposal_reactivated"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:49
+#: ./opengever/meeting/model/proposal.py:50
 msgid "msg_proposal_submitted"
 msgstr ""
 
@@ -1340,7 +1369,7 @@ msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:394
+#: ./opengever/meeting/browser/meetings/agendaitem.py:408
 msgid "paragraph_added"
 msgstr ""
 
@@ -1351,7 +1380,7 @@ msgstr ""
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py:36
 #: ./opengever/meeting/model/meeting.py:74
-#: ./opengever/meeting/model/proposal.py:133
+#: ./opengever/meeting/model/proposal.py:134
 msgid "pending"
 msgstr ""
 
@@ -1445,19 +1474,24 @@ msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:162
+#: ./opengever/meeting/model/proposal.py:163
 msgid "reactivate"
 msgstr ""
 
 #. Default: "Reject"
 #: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:152
+#: ./opengever/meeting/model/proposal.py:153
 msgid "reject"
 msgstr ""
 
 #. Default: "Reopen"
 #: ./opengever/meeting/model/agendaitem.py:45
 msgid "reopen"
+msgstr ""
+
+#. Default: "Return Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:97
+msgid "return_excerpt"
 msgstr ""
 
 #. Default: "Revise"
@@ -1471,12 +1505,12 @@ msgid "revision"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:154
+#: ./opengever/meeting/model/proposal.py:155
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:137
+#: ./opengever/meeting/model/proposal.py:138
 msgid "scheduled"
 msgstr ""
 
@@ -1485,17 +1519,17 @@ msgid "secretary"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:260
 msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:150
+#: ./opengever/meeting/model/proposal.py:151
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:135
+#: ./opengever/meeting/model/proposal.py:136
 msgid "submitted"
 msgstr ""
 
@@ -1510,7 +1544,7 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py:442
 msgid "text_added"
 msgstr ""
 
@@ -1524,82 +1558,82 @@ msgid "title_ad_hoc_document"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:156
+#: ./opengever/meeting/model/proposal.py:157
 msgid "un-schedule"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:308
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:345
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:271
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
 msgid "view_label_agenda_items"
 msgstr ""
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:162
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:179
 msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:152
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:169
 msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:123
 msgid "view_label_meeting_end"
 msgstr ""
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:111
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:128
 msgid "view_label_meeting_location"
 msgstr ""
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:133
 msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:100
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:117
 msgid "view_label_meeting_start"
 msgstr ""
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:138
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:155
 msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:124
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:141
 msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:196
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:213
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:330
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:298
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:315
 msgid "view_label_schedule_proposal"
 msgstr ""
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:148
 msgid "view_label_secretary"
 msgstr ""
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -403,3 +403,6 @@ class AgendaItem(Base):
         if not self.is_paragraph:
             return self.get_state() == self.STATE_REVISION
         return False
+
+    def return_excerpt(self, document):
+        self.proposal.return_excerpt(document)


### PR DESCRIPTION
This PR adds functionality to return *one* excerpt to the proposer/to the proposal's dossier.

⚠️  Requires styling from https://github.com/4teamwork/plonetheme.teamraum/pull/582.

The excerpt listing of an agenda-item now has a button behind each excerpt to return it:

![screen shot 2017-09-07 at 17 47 12](https://user-images.githubusercontent.com/736583/30172944-6caa5732-93f6-11e7-8e4d-47dba3adc6cd.png)

Returning requires a confirmation:
![screen shot 2017-09-07 at 17 47 19](https://user-images.githubusercontent.com/736583/30172977-82d43604-93f6-11e7-8737-4e955eb76ca2.png)

After returning the excerpt will be copied and linked to the dossier. Edits on the proposal side will be synced to the copy in the dossier.

The returned excerpt is highlighted in the listing:
![screen shot 2017-09-07 at 17 47 56](https://user-images.githubusercontent.com/736583/30173065-d164fae2-93f6-11e7-87e6-beba68c27872.png)


This PR re-uses existing functionality that was already present for the of auto-generated excerpts. Thus the UI is a bit limited but will most likely be expanded/improved upon in future PRs.

Part of https://github.com/4teamwork/opengever.core/issues/2829.