### PR TITLE
Fix custom sort for catalog listing tabs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- Fixed custom sort for catalog listings. [phgross]
 - Bump ftw.recipe.deployment to 1.3.0 in order to get log rotation for ftw.structlog logfiles. [lgraf]
 - Fixed bumblebee-overlay pdf link generation, when filename contains umlaut. [phgross]
 - Generate agenda item lists as documents. [Rotonen]

--- a/opengever/tabbedview/browser/base_tabs.py
+++ b/opengever/tabbedview/browser/base_tabs.py
@@ -167,7 +167,7 @@ class BaseListingTab(GeverTabMixin, ListingView):
     model = None
 
 
-class BaseCatalogListingTab(CatalogListingView, GeverTabMixin):
+class BaseCatalogListingTab(GeverTabMixin, CatalogListingView):
     """Base view for catalog listing tabs.
     """
 

--- a/opengever/tabbedview/browser/base_tabs.py
+++ b/opengever/tabbedview/browser/base_tabs.py
@@ -157,7 +157,7 @@ class BaseListingTab(GeverTabMixin, ListingView):
 
     sort_on = 'modified'
     sort_reverse = False
-    #lazy must be false otherwise there will be no correct batching
+    # lazy must be false otherwise there will be no correct batching
     lazy = False
 
     # the model attributes is used for a dynamic textfiltering functionality

--- a/opengever/tabbedview/tests/test_base_tabs.py
+++ b/opengever/tabbedview/tests/test_base_tabs.py
@@ -1,0 +1,27 @@
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser import browsing
+from plone import api
+from opengever.base.interfaces import IReferenceNumberSettings
+
+
+class TestGeverTabMixin(IntegrationTestCase):
+
+    @browsing
+    def test_reference_number_custom_sort(self, browser):
+        self.login(self.regular_user)
+
+        api.portal.set_registry_record(
+            name='formatter',
+            value='grouped_by_three',
+            interface=IReferenceNumberSettings)
+
+        listing_view = self.leaf_repofolder.restrictedTraverse(
+            'tabbedview_view-dossiers')
+
+        results = listing_view.custom_sort(
+            ['OG 921.11-2', 'OG 921.11-1', 'OG 921.11-12', 'OG 921.11-11'],
+            sort_on='reference', sort_reverse=False)
+
+        self.assertEquals(
+            ['OG 921.11-1', 'OG 921.11-2', 'OG 921.11-11', 'OG 921.11-12'],
+            results)


### PR DESCRIPTION
During the opengever.tabbedview ungrok work (#3239), the `BaseCatalogListingTab` has been reworked and does no longer inherit from the GeverTabMixin first. Therefore the custom_sort method from `ftw.tabbedview.browser.listing` has been called instead of the GeverTabMixin.custom_sort, which provides custom sorting for `reference`, `sequence`, users etc.

Closes #3356 

