### PR TITLE
Format line breaks and links in task responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fixed custom sort for catalog listings. [phgross]
+- Format line breaks and links in task responses. [phgross]
 - Bump ftw.recipe.deployment to 1.3.0 in order to get log rotation for ftw.structlog logfiles. [lgraf]
 - SPV word: Add functionality to return an excerpt to the proposer. [deiferni]
 - Fixed bumblebee-overlay pdf link generation, when filename contains umlaut. [phgross]

--- a/opengever/task/tests/test_response_viewlet.py
+++ b/opengever/task/tests/test_response_viewlet.py
@@ -13,10 +13,10 @@ class TestResponseViewlet(FunctionalTestCase):
         self.task = create(Builder('task')
                            .having(task_type='comment'))
 
-    def add_sample_answer(self, browser):
+    def add_sample_answer(self, browser, response=u'Sample response'):
         browser.login().open(self.task, view='tabbedview_view-overview')
         browser.css('#task-transition-open-in-progress').first.click()
-        browser.fill({'Response': u'Sample response'})
+        browser.fill({'Response': response})
         browser.css('#form-buttons-save').first.click()
         browser.open(self.task, view='tabbedview_view-overview')
 
@@ -49,6 +49,20 @@ class TestResponseViewlet(FunctionalTestCase):
                          answer.css('h3').first.text)
         self.assertEqual('http://nohost/plone/@@user-details/test_user_1_',
                          answer.css('h3 a').first.get('href'))
+
+    @browsing
+    def test_response_description_is_web_intelligent_transformed(self, browser):
+        self.add_sample_answer(
+            browser, response=u'Anfrage:\r\n\r\n\r\nhttp://www.example.org/')
+        answer = browser.css('div.answers .answer').first
+
+        self.assertEqual(
+            'Anfrage:\n\n\nhttp://www.example.org/',
+            browser.css('.answers .text').first.text)
+
+        link = browser.css('.answers .text a').first
+        self.assertEqual('http://www.example.org/', link.text)
+        self.assertEqual('http://www.example.org/', link.get('href'))
 
     @browsing
     def test_answer_contains_response_text(self, browser):

--- a/opengever/task/tests/test_response_viewlet.py
+++ b/opengever/task/tests/test_response_viewlet.py
@@ -61,6 +61,20 @@ class TestResponseViewlet(IntegrationTestCase):
         self.assertEqual('http://www.example.org/', link.get('href'))
 
     @browsing
+    def test_response_description_is_xss_safe(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+
+        self.add_sample_answer(
+            browser,
+            response='<img src="http://not.found/" '
+            'onerror="script:alert(\'XSS\');" />')
+
+        self.assertEqual(
+            u'&lt;img src="http://not.found/" onerror="script:alert(\'XSS\');" /&gt;',
+            browser.css('.answers .text').first.innerHTML)
+
+    @browsing
     def test_answer_contains_response_text(self, browser):
         self.login(self.dossier_responsible, browser=browser)
         browser.open(self.subtask, view='tabbedview_view-overview')

--- a/opengever/task/tests/test_response_viewlet.py
+++ b/opengever/task/tests/test_response_viewlet.py
@@ -1,71 +1,70 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestResponseViewlet(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestResponseViewlet, self).setUp()
-
-        self.dossier = create(Builder('dossier'))
-        self.task = create(Builder('task')
-                           .having(task_type='comment'))
+class TestResponseViewlet(IntegrationTestCase):
 
     def add_sample_answer(self, browser, response=u'Sample response'):
-        browser.login().open(self.task, view='tabbedview_view-overview')
-        browser.css('#task-transition-open-in-progress').first.click()
+        browser.css('#task-transition-resolved-tested-and-closed').first.click()
         browser.fill({'Response': response})
         browser.css('#form-buttons-save').first.click()
-        browser.open(self.task, view='tabbedview_view-overview')
+        browser.open(self.subtask, view='tabbedview_view-overview')
 
     @browsing
     def test_task_history(self, browser):
-        browser.login().open(self.task, view='tabbedview_view-overview')
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
 
         self.assertEqual(1, len(browser.css('#task-responses div.answer')))
 
         self.add_sample_answer(browser)
 
-        browser.open(self.task, view='tabbedview_view-overview')
+        browser.open(self.subtask, view='tabbedview_view-overview')
         self.assertEqual(2, len(browser.css('#task-responses div.answer')))
 
     @browsing
     def test_progress_starts_with_created_answer(self, browser):
-        browser.login().open(self.task, view='tabbedview_view-overview')
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
 
         answer = browser.css('div.answers .answer').first
-        self.assertEqual('Created by Test User (test_user_1_)',
+        self.assertEqual('Created by Ziegler Robert (robert.ziegler)',
                          answer.css('h3').first.text)
-        self.assertEqual('http://nohost/plone/@@user-details/test_user_1_',
+        self.assertEqual('http://nohost/plone/@@user-details/robert.ziegler',
                          answer.css('h3 a').first.get('href'))
 
     @browsing
     def test_answer_contains_response_description(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+
         self.add_sample_answer(browser)
         answer = browser.css('div.answers .answer').first
-        self.assertEqual('Accepted by Test User (test_user_1_)',
+        self.assertEqual('Closed by Ziegler Robert (robert.ziegler)',
                          answer.css('h3').first.text)
-        self.assertEqual('http://nohost/plone/@@user-details/test_user_1_',
+        self.assertEqual('http://nohost/plone/@@user-details/robert.ziegler',
                          answer.css('h3 a').first.get('href'))
 
     @browsing
     def test_response_description_is_web_intelligent_transformed(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+
         self.add_sample_answer(
             browser, response=u'Anfrage:\r\n\r\n\r\nhttp://www.example.org/')
-        answer = browser.css('div.answers .answer').first
 
         self.assertEqual(
             'Anfrage:\n\n\nhttp://www.example.org/',
             browser.css('.answers .text').first.text)
-
         link = browser.css('.answers .text a').first
         self.assertEqual('http://www.example.org/', link.text)
         self.assertEqual('http://www.example.org/', link.get('href'))
 
     @browsing
     def test_answer_contains_response_text(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+
         self.add_sample_answer(browser)
 
         answer = browser.css('div.answers .answer').first
@@ -73,6 +72,9 @@ class TestResponseViewlet(FunctionalTestCase):
 
     @browsing
     def test_manage_actions_are_not_shown_for_default_user(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+
         self.add_sample_answer(browser)
 
         self.assertEqual([], browser.css('.manageActions .delete'))
@@ -80,7 +82,9 @@ class TestResponseViewlet(FunctionalTestCase):
 
     @browsing
     def test_manage_actions_are_shown_for_managers(self, browser):
-        self.grant('Manager')
+        self.login(self.manager, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+
         self.add_sample_answer(browser)
 
         self.assertEqual('Delete',

--- a/opengever/task/viewlets/response.py
+++ b/opengever/task/viewlets/response.py
@@ -9,6 +9,7 @@ from opengever.task.adapters import IResponseContainer
 from opengever.task.response import Base
 from opengever.task.task import ITask
 from opengever.task.viewlets.manager import BeneathTask
+from plone import api
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 import datetime
@@ -29,10 +30,14 @@ class ResponseView(grok.Viewlet, Base):
         container = IResponseContainer(self.context)
         responses = []
 
+        transforms = api.portal.get_tool(name='portal_transforms')
         for id, response in enumerate(container):
             info = dict(
                 id=id,
                 response=response,
+                text=transforms.convertTo(
+                    'text/html', response.text,
+                    mimetype='text/x-web-intelligent'),
                 edit_link=self.edit_link(id),
                 delete_link=self.delete_link(id))
 

--- a/opengever/task/viewlets/response_templates/responseview.pt
+++ b/opengever/task/viewlets/response_templates/responseview.pt
@@ -29,7 +29,7 @@
               Response Header
             </h3>
 
-            <div class="text" tal:content="response/text"></div>
+            <div class="text" tal:content="structure response_info/text"></div>
 
           </div>
         </div>


### PR DESCRIPTION
The responses are now displayed in the same manner than task descriptions (see #3172)

Closes #3363

![bildschirmfoto 2017-09-11 um 16 47 48](https://user-images.githubusercontent.com/485755/30283646-e8e5af3e-9718-11e7-833c-caf320c29558.png)
![bildschirmfoto 2017-09-11 um 16 47 34](https://user-images.githubusercontent.com/485755/30283649-eba045ea-9718-11e7-95e1-818a8f50bd23.png)
