### PR TITLE
Fix shared default value for excerpt lists.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fixed custom sort for catalog listings. [phgross]
 - Bump ftw.recipe.deployment to 1.3.0 in order to get log rotation for ftw.structlog logfiles. [lgraf]
 - SPV word: Add functionality to return an excerpt to the proposer. [deiferni]
+- Fix shared default value for excerpt lists. [deiferni]
 - Fixed bumblebee-overlay pdf link generation, when filename contains umlaut. [phgross]
 - Generate agenda item lists as documents. [Rotonen]
 - Replace is_subdossier FieldIndex with an BooleanIndex. [phgross]

--- a/opengever/core/upgrades/20170912122143_fix_shared_excerpt_list_reference/upgrade.py
+++ b/opengever/core/upgrades/20170912122143_fix_shared_excerpt_list_reference/upgrade.py
@@ -1,0 +1,49 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixSharedExcerptListReference(UpgradeStep):
+    """Fix shared excerpt list reference.
+
+    Excerpts are stored in the meeting-dossier. We fix shared excerpt lists by
+    creating a new list instance and filtering out the excerpts that come from
+    foreign meeting dossiers should they be present in the excerpt list.
+
+    We can't completely fix relations within the same meeting, so it may happen
+    that multiple submitted proposals point to the same excerpt within the same
+    meeting dossier.
+    """
+    def __call__(self):
+        msg = 'Fix shared excerpt list reference.'
+        query = {'portal_type': 'opengever.meeting.submittedproposal'}
+
+        for submitted_proposal in self.objects(query, msg):
+            self._fix_excerpts_relation(submitted_proposal)
+
+    def _fix_excerpts_relation(self, submitted_proposal):
+        # getattr will/should always return the default value from the
+        # ISubmittedProposal schema, but to be extra certain that we don't
+        # cause unexpected errors we add this safeguard here
+        excerpt_relations = getattr(submitted_proposal, 'excerpts', None)
+        if not excerpt_relations:
+            # empty lists will be correctly intialized/replaced with a new
+            # instance when the first excerpt is created, we don't need to
+            # set the attribute in that case
+            return
+
+        meeting_dossier = self._get_meeting_dossier(submitted_proposal)
+        valid_excerpts = set(meeting_dossier.listFolderContents())
+        valid_relations = []
+
+        for relation_value in excerpt_relations:
+            excerpt_document = relation_value.to_object
+            if excerpt_document in valid_excerpts:
+                valid_relations.append(relation_value)
+
+        submitted_proposal.excerpts = valid_relations
+
+    def _get_meeting_dossier(self, submitted_proposal):
+        proposal_model = submitted_proposal.load_model()
+        if not proposal_model.agenda_item:
+            return None
+
+        return proposal_model.agenda_item.meeting.get_dossier()

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -506,8 +506,25 @@ class SubmittedProposal(ProposalBase):
     def append_excerpt(self, excerpt_document):
         """Add a relation to a new excerpt document.
         """
+        excerpts = getattr(self, 'excerpts', None)
+        if not excerpts:
+            # The missing_value attribute of a z3c-form field is used
+            # as soon as an object has no default_value i.e. after creating
+            # an object trough the command-line.
+            #
+            # Because the excerpts field needs a list as a missing_value,
+            # we will fall into the "mutable keyword argument"-python gotcha.
+            # The excerpts will be shared between the object-instances.
+            #
+            # Unfortunately the z3c-form field does not provide a
+            # missing_value-factory (like the defaultFactory) which would be
+            # necessary to fix this issue properly.
+            #
+            # As a workaround we reassign the field with a new list if the
+            # excerpts-attribute has never been assigned before.
+            excerpts = []
+
         intid = getUtility(IIntIds).getId(excerpt_document)
-        excerpts = getattr(self, 'excerpts', [])
         excerpts.append(RelationValue(intid))
         self.excerpts = excerpts
 


### PR DESCRIPTION
This PR fixes an issue with mutable default arguments in combination with a `RelationList`.

When creating a new excerpt for a submitted proposal and setting the excerpt list attribute/field on the submitted proposal the default value from the `ISubmittedProposal` schema was used instead of a new list instance. This happened by using `getattr` which already returns
the schema default. This lead to the default value being shared between multiple instances of submitted proposals.

We attempt to fix this with an upgrade step. Excerpts are stored in the meeting-dossier. We fix shared excerpt lists by creating a new list instance and filtering out the excerpts that come from foreign meeting dossiers should they be present in the excerpt list.

We can't completely fix relations within the same meeting, so it may happen that multiple submitted proposals point to the same excerpt within the same meeting dossier. Since this issue never entered production that should be rare and unproblematic though.

See also #3368 for a proposal/discussion how to address the problem in the future.