### PR TITLE
OGGBundle: Fix title encoding in constructor section.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.0 (unreleased)
 ---------------------
 
+- OGGBundle: Fix title encoding in constructor section. [phgross]
 - Fixed custom sort for catalog listings. [phgross]
 - Bump ftw.recipe.deployment to 1.3.0 in order to get log rotation for ftw.structlog logfiles. [lgraf]
 - SPV word: Add functionality to return an excerpt to the proposer. [deiferni]

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -74,7 +74,14 @@ class ConstructorSection(object):
         else:
             title_keys = (u'title',)
 
-        title_args = dict((key, item.get(key)) for key in title_keys)
+        title_args = {}
+        for key in title_keys:
+            value = item.get(key)
+            if value and not isinstance(value, unicode):
+                value = value.decode('utf-8')
+
+            title_args[key] = value
+
         return title_args
 
     def _set_guid(self, obj, item):

--- a/opengever/bundle/tests/test_section_constructor.py
+++ b/opengever/bundle/tests/test_section_constructor.py
@@ -92,6 +92,22 @@ class TestConstructor(FunctionalTestCase):
         self.assertFalse(hasattr(content, 'title_de'))
         self.assertFalse(hasattr(content, 'title_Fr'))
 
+    def test_title_is_unicode(self):
+        item = {
+            u"guid": "12345xy",
+            u"_type": u"opengever.document.document",
+            u"title": u'Bewerbung Hanspeter M\xfcller'.encode('utf-8'),
+        }
+
+        section = self.setup_section(previous=[item])
+        list(section)
+
+        portal = api.portal.get()
+        content = portal.restrictedTraverse(item['_path'])
+
+        self.assertTrue(isinstance(content.title, unicode))
+        self.assertEquals(u'Bewerbung Hanspeter M\xfcller', content.title)
+
     def test_sets_bundle_guid_on_obj(self):
         guid = "12345xy"
         item = {


### PR DESCRIPTION
Currently the construtor section does not ensure the encoding for the title attribute, which must be unicode. This can lead in to broken `zope.i18nmessageid.message.Message` objects in the journal of an object, which raises an `UnicodeDecodeError` (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3941/) when trying to translate the Message by `zope.i18n.translate`.

Therefore the journal of those object can not be rendered or converted in to a PDF when resolving the Dossier.