### PR TITLE
SPV word: New edit meeting form.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -489,7 +489,8 @@ Objects
       - self.meeting
       - self.submitted_proposal
       - self.submitted_word_proposal
-    - self.committee_participant
+    - self.committee_participant_1
+    - self.committee_participant_2
     - self.committee_president
     - self.committee_secretary
     - self.empty_committee

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- SPV word: Add new meeting edit form and move edit action to editbar. [jone]
 
 
 2017.5.1 (2017-09-19)
@@ -14,7 +14,6 @@ Changelog
 - Fix is_subdossier replacement upgradestep, reindex all objects. [phgross]
 - Register an is_subdossier indexer for dossiertemplates. [phgross]
 - Add missing french translations. [phgross]
-
 
 2017.5.0 (2017-09-14)
 ---------------------

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -381,6 +381,18 @@
       </property>
     </object>
 
+    <object name="edit-meeting" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Edit</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object/absolute_url}/edit-meeting</property>
+      <property name="icon_expr" />
+      <property name="available_expr">object/edit-meeting/action_visible|nothing</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 

--- a/opengever/core/upgrades/20170920094529_add_edit_action_for_meetings/actions.xml
+++ b/opengever/core/upgrades/20170920094529_add_edit_action_for_meetings/actions.xml
@@ -1,0 +1,19 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="object" meta_type="CMF Action Category">
+
+    <object name="edit-meeting" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Edit</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object/absolute_url}/edit-meeting</property>
+      <property name="icon_expr" />
+      <property name="available_expr">object/edit-meeting/action_visible|nothing</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20170920094529_add_edit_action_for_meetings/upgrade.py
+++ b/opengever/core/upgrades/20170920094529_add_edit_action_for_meetings/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddEditActionForMeetings(UpgradeStep):
+    """Add edit action for meetings.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -31,6 +31,13 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IMeetingWrapper"
+      name="edit-meeting"
+      class=".edit_meeting.EditMeetingView"
+      permission="cmf.ModifyPortalContent"
+      />
+
   <!-- registered for admin use only, not available in the UI -->
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"

--- a/opengever/meeting/browser/meetings/edit_meeting.py
+++ b/opengever/meeting/browser/meetings/edit_meeting.py
@@ -1,0 +1,164 @@
+from calendar import timegm
+from opengever.base import _ as _base
+from opengever.base.browser.modelforms import ModelEditForm
+from opengever.base.date_time import as_utc
+from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
+from opengever.meeting import require_word_meeting_feature
+from opengever.meeting.browser.meetings.protocol import IMeetingMetadata
+from opengever.meeting.model import Meeting
+from opengever.ogds.base.actor import Actor
+from plone.locking.interfaces import ILockable
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from z3c.form import button
+from zExceptions import Redirect
+
+
+class EditMeetingView(ModelEditForm):
+    """The edit meeting view provides a form for editing the meeting details.
+
+    This view is used when the word meeting feature is enabled.
+    The older implementation used the protocol view for editing these fields.
+    This view was copied from the protocol view.
+    """
+
+    ignoreContext = True
+    schema = IMeetingMetadata
+    content_type = Meeting
+    enable_unload_protection = False
+    template = ViewPageTemplateFile('templates/edit_meeting.pt')
+
+    def __init__(self, context, request):
+        """
+        Introduce ```_has_successfully_saved``` because we have two different
+        response types.
+        If the protocol has been saved we want to return a JSON response.
+        """
+        super(EditMeetingView, self).__init__(context, request, context.model)
+        self._has_write_conflict = False
+        self._is_locked_by_another_user = False
+        self._has_successfully_saved = False
+
+    def action_visible(self):
+        """Returns ``True`` when the "Edit" action should be visible.
+        """
+        if not is_word_meeting_implementation_enabled():
+            return False
+        return self.model.is_editable()
+
+    @require_word_meeting_feature
+    def update(self):
+        super(EditMeetingView, self).update()
+
+        if self.actions.executedActions:
+            return
+        if not self.is_available_for_current_user():
+            raise Redirect(self.context.absolute_url())
+
+        self.lock()
+
+    def is_available_for_current_user(self):
+        """Check whether the current meeting can be safely unlocked.
+
+        This means the current meeting is not locked by another user.
+        """
+
+        lockable = ILockable(self.context)
+        return lockable.can_safely_unlock()
+
+    def lock(self):
+        lockable = ILockable(self.context)
+        if not lockable.locked():
+            lockable.lock()
+
+    def unlock(self):
+        lockable = ILockable(self.context)
+        if lockable.can_safely_unlock():
+            lockable.unlock()
+
+    def applyChanges(self, data):
+        ModelEditForm.applyChanges(self, data)
+        self.unlock()
+        return True
+
+    # needs duplication, otherwise button does not appear
+    @button.buttonAndHandler(_base('Save', default=u'Save'), name='save')
+    def handleApply(self, action):
+        """"""
+        if self.has_write_conflict():
+            self.status = _(u'message_write_conflict',
+                            default='Your changes were not saved, the protocol has '
+                            'been modified in the meantime.')
+            return
+        if self.is_locked_by_another_user():
+            self.status = _(u'message_locked_by_another_user',
+                            default='Your changes were not saved, the protocol is '
+                            'locked by ${username}.',
+                            mapping={'username': self.get_lock_creator_user_name()})
+            return
+
+        super(EditMeetingView, self).handleApply(self, action)
+
+    def has_write_conflict(self):
+        return self.server_timestamp != self.client_timestamp
+
+    def is_locked_by_another_user(self):
+        """Return False if the document is locked by the current user or is
+        not locked at all, True otherwise.
+
+        """
+        lockable = ILockable(self.context)
+        return not lockable.can_safely_unlock()
+
+    def get_lock_creator_user_name(self):
+        lockable = ILockable(self.context)
+        creator = lockable.lock_info()[0]['creator']
+        return Actor.lookup(creator).get_label()
+
+    @button.buttonAndHandler(_base(u'label_cancel', default=u'Cancel'), name='cancel')
+    def cancel(self, action):
+        self.unlock()
+        # self as first argument is required by to the decorator
+        super(EditMeetingView, self).cancel(self, action)
+
+    def render(self):
+        return self.template()
+
+    def get_agenda_items(self, include_paragraphs=False):
+        for agenda_item in self.model.agenda_items:
+            if agenda_item.is_paragraph:
+                if include_paragraphs:
+                    yield agenda_item
+            else:
+                yield agenda_item
+
+    def nextURL(self):
+        return self.model.get_url()
+
+    def is_field_visible(self, field, agenda_item):
+        field_value = getattr(agenda_item, field.get('name'))
+        if agenda_item.is_decided() and not field_value:
+            return False
+
+        if field['needs_proposal']:
+            return agenda_item.has_proposal
+        else:
+            return not agenda_item.is_paragraph
+
+    @property
+    def server_timestamp(self):
+        """Return the modified timestamp as seconds since the epoch."""
+
+        return timegm(as_utc(self.model.modified).timetuple())
+
+    @property
+    def client_timestamp(self):
+        """Return the modified timestamp that has been submitted by the
+        client.
+
+        """
+        timestamp = self.request.get('modified')
+        if not timestamp:
+            return None
+
+        return int(timestamp)

--- a/opengever/meeting/browser/meetings/templates/edit_meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/edit_meeting.pt
@@ -1,0 +1,25 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="opengever.meeting"
+      metal:use-macro="context/main_template/macros/master">
+
+  <metal:block fill-slot="main">
+
+    <h1 class="documentFirstHeading" tal:content="view/label | nothing" />
+    <div id="content-core">
+
+      <metal:titlelessform use-macro="context/@@ploneform-macros/titlelessform">
+        <metal:formbottom fill-slot="formbottom">
+          <!-- for write conflict detection (optimistic locking) -->
+          <input type="hidden" name="modified"
+                 tal:attributes="value view/server_timestamp" />
+        </metal:formbottom>
+      </metal:titlelessform>
+
+    </div>
+
+  </metal:block>
+
+</html>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -249,11 +249,8 @@
 
         <div class="sidebar">
           <div tal:attributes="class python: 'list-group metadata' if meeting.is_editable() else 'full-width list-group metadata'">
-            <div class="list-group-item submit">
-              <div class="button-group fluid">
-                <a tal:condition="meeting/is_editable" class="button" tal:attributes="href view/url_protocol" i18n:translate="">Edit</a>
-                <metal:use use-macro="context/@@meeting-macros/workflow_actions" />
-              </div>
+            <div class="list-group-item">
+              <metal:use use-macro="context/@@meeting-macros/workflow_actions" />
             </div>
             <div class="list-group-item">
               <dl>

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -1,0 +1,137 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import editbar
+from ftw.testbrowser.pages import plone
+from ftw.testbrowser.pages import statusmessages
+from ftw.testing import freeze
+from opengever.base.date_time import utcnow_tz_aware
+from opengever.base.model import create_session
+from opengever.meeting.tests.pages import meeting_view
+from opengever.testing import IntegrationTestCase
+
+
+class TestEditMeeting(IntegrationTestCase):
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_edit_meeting_visibile_to_committe_responsible(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting)
+        self.assertIn('Edit', editbar.contentviews())
+
+    @browsing
+    def test_edit_meeting_not_visibile_to_meeting_(self, browser):
+        self.login(self.meeting_user, browser)
+        browser.open(self.meeting)
+        # The "Edit" action is not visibile since the complete editbar
+        # is not visible.
+        self.assertFalse(editbar.visible())
+
+    @browsing
+    def test_edit_meeting_metadata(self, browser):
+        self.maxDiff = None
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting)
+
+        self.assertEquals(u'9. Sitzung der Rechnungspr\xfcfungskommission',
+                          plone.first_heading())
+        self.assertEquals(
+            [['Meeting start:', 'Sep 12, 2016 05:30 PM'],
+             ['Meeting end:', 'Sep 12, 2016 07:00 PM'],
+             ['Location:', u'B\xfcren an der Aare'],
+             ['Meeting number:', ''],
+             ['Presidency:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
+             ['Secretary:', u'M\xfcller Henning (h.mueller@gmx.ch)'],
+             ['Participants:', u'Wendler Jens (jens-wendler@gmail.com)'
+              u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
+             ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
+             ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
+             ['Protocol:', 'No protocol has been generated yet.', '']],
+            meeting_view.metadata())
+
+        editbar.contentview('Edit').click()
+        browser.fill({'Title': u'New Meeting Title',
+                      'Presidency': u'W\xf6lfl Gerda (g.woelfl@hotmail.com)',
+                      'Secretary': u'Wendler Jens (jens-wendler@gmail.com)',
+                      'Participants': [
+                          u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
+                      'Other Participants': 'Staatsanwalt',
+                      'Protocol start-page': '27',
+                      'Location': 'Sitzungszimmer 3',
+                      'Start': '13.10.2016 08:00',
+                      'End': '13.10.2016 10:00'}).save()
+        statusmessages.assert_message('Changes saved')
+
+        self.assertEquals('New Meeting Title', plone.first_heading())
+        self.assertEquals(
+            [['Meeting start:', 'Oct 13, 2016 08:00 AM'],
+             ['Meeting end:', 'Oct 13, 2016 10:00 AM'],
+             ['Location:', 'Sitzungszimmer 3'],
+             ['Meeting number:', ''],
+             ['Presidency:', u'W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
+             ['Secretary:', 'Wendler Jens (jens-wendler@gmail.com)'],
+             ['Participants:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
+             ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
+             ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
+             ['Protocol:', 'No protocol has been generated yet.', '']],
+            meeting_view.metadata())
+
+    @browsing
+    def test_edit_meeting_locks_the_content(self, browser1):
+        self.login(self.committee_responsible)
+        with browser1.clone() as browser2:
+            browser1.login(self.committee_responsible)
+            browser2.login(self.administrator)
+
+            browser1.open(self.meeting, view='edit-meeting')
+            self.assertEquals('edit-meeting', plone.view(browser1))
+
+            browser2.open(self.meeting, view='edit-meeting')
+            self.assertEquals('view', plone.view(browser2))
+            statusmessages.assert_message(
+                u'This item was locked by M\xfcller Fr\xe4nzi 1 minute ago.'
+                u' If you are certain this user has abandoned the object,'
+                u' you may the object. You will then be able to edit it.',
+                browser=browser2)
+
+            browser1.click_on('Cancel')
+            browser2.open(self.meeting, view='edit-meeting')
+            self.assertEquals('edit-meeting', plone.view(browser2))
+
+    @browsing
+    def test_edit_meeting_reports_write_conflicts(self, tab1):
+        self.login(self.committee_responsible, tab1)
+        with tab1.clone() as tab2:
+            with freeze(utcnow_tz_aware()) as clock:
+                tab1.open(self.meeting, view='edit-meeting')
+                tab2.open(self.meeting, view='edit-meeting')
+
+                tab1.fill({'Title': u'Title by tab 1'}).save()
+                statusmessages.assert_message('Changes saved', browser=tab1)
+                self.assertEquals(u'Title by tab 1', plone.first_heading(browser=tab1))
+                create_session().flush()
+                clock.forward(minutes=1)
+
+                tab2.fill({'Title': u'Title by tab 2'}).save()
+                statusmessages.assert_message(
+                    'Your changes were not saved,'
+                    ' the protocol has been modified in the meantime.', browser=tab2)
+                tab2.open(self.meeting)
+                self.assertEquals(u'Title by tab 1', plone.first_heading(browser=tab2))
+
+    @browsing
+    def test_cannot_edit_closed_meeting(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.decided_meeting)
+        self.assertNotIn('Edit', editbar.contentviews())
+        with browser.expect_unauthorized():
+            browser.open(self.decided_meeting, view='edit-meeting')
+
+    @browsing
+    def test_action_is_only_visible_when_word_feature_enabled(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting)
+        self.assertIn('Edit', editbar.contentviews())
+
+        self.deactivate_feature('word-meeting')
+        browser.reload()
+        self.assertNotIn('Edit', editbar.contentviews())

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -20,12 +20,12 @@ class TestPathBar(IntegrationTestCase):
     @browsing
     def test_committee_member_cant_see_membership_edit_links(self, browser):
         self.login(self.meeting_user, browser)
-        browser.open(self.committee_participant)
+        browser.open(self.committee_participant_1)
 
         table = browser.css('#membership_listing').first
         self.assertEqual(
             [[u'Rechnungspr\xfcfungskommission',
-              'Jan 01, 2010', 'Jan 01, 2014', '']],
+              'Jan 01, 2014', 'Dec 31, 2016', '']],
             table.lists())
 
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -216,28 +216,36 @@ class OpengeverContentFixture(object):
             'committee_president',
             firstname=u'Heidrun',
             lastname=u'Sch\xf6ller',
-            email='h.schoeller@web.de')
+            email='h.schoeller@web.de',
+            date_from=datetime(2014, 1, 1),
+            date_to=datetime(2016, 12, 31))
 
         self.committee_secretary = self.create_committee_membership(
             self.committee,
             'committee_secretary',
             firstname=u'Henning',
             lastname=u'M\xfcller',
-            email='h.mueller@gmx.ch')
+            email='h.mueller@gmx.ch',
+            date_from=datetime(2016, 1, 1),
+            date_to=datetime(2016, 12, 31))
 
         self.committee_participant_1 = self.create_committee_membership(
             self.committee,
-            'committee_participant',
+            'committee_participant_1',
             firstname=u'Gerda',
             lastname=u'W\xf6lfl',
-            email='g.woelfl@hotmail.com')
+            email='g.woelfl@hotmail.com',
+            date_from=datetime(2014, 1, 1),
+            date_to=datetime(2016, 12, 31))
 
         self.committee_participant_2 = self.create_committee_membership(
             self.committee,
-            'committee_participant',
+            'committee_participant_2',
             firstname=u'Jens',
             lastname=u'Wendler',
-            email='jens-wendler@gmail.com')
+            email='jens-wendler@gmail.com',
+            date_from=datetime(2014, 1, 1),
+            date_to=datetime(2016, 12, 31))
 
         self.empty_committee = self.register(
             'empty_committee', self.create_committee(
@@ -563,13 +571,18 @@ class OpengeverContentFixture(object):
                                     member_id_register_name,
                                     firstname,
                                     lastname,
-                                    email):
+                                    email,
+                                    date_from,
+                                    date_to):
         member = create(
             Builder('member')
             .having(firstname=firstname, lastname=lastname, email=email))
 
         create(Builder('membership')
-               .having(committee=committee, member=member))
+               .having(committee=committee,
+                       member=member,
+                       date_from=date_from,
+                       date_to=date_to))
         create_session().flush()  # trigger id generation, part of path
 
         self.register_url(

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -161,6 +161,16 @@ class IntegrationTestCase(TestCase):
         else:
             raise ValueError('Invalid {!r}'.format(feature))
 
+    def deactivate_feature(self, feature):
+        """Deactivate a feature flag.
+        """
+        if feature in FEATURE_FLAGS:
+            api.portal.set_registry_record(FEATURE_FLAGS[feature], False)
+        elif feature in FEATURE_PROFILES:
+            raise NotImplementedError('Feel free to implement.')
+        else:
+            raise ValueError('Invalid {!r}'.format(feature))
+
     def __getattr__(self, name):
         """Make it possible to access objects from the content lookup table
         directly with attribute access on the test case.


### PR DESCRIPTION
**Background:**
In the older SPV implementation, the meeting details were edited through the "protocol"-view, which included the meeting details form.
But with the word feature we are no longer using the "protocol"-view because the protocol is now written directly in the word files, triggered through the meeting view.
Request: https://github.com/4teamwork/gever/issues/65

**Changes:**
- The meeting details form is extracted from the "protocol"-view into a separate edit form.
- The "edit"-action is moved from the left sidebar to Plone's editbar (`object`-action), because it is the plan to get rid of the sidebar step by step.

**Implementation details:**
- The meeting-type has no `FTI` => the action can only be registred publicly.
- The published meeting wrapper does not allow unsecure access to attributes, therefore the edit-condition-check is implemented on the view.
- The fixture is updated to define explicit membership periods, so that the members get available in the edit form.
- A `deactivate_feature`-method is added to the test case base class. It makes it easier to test action availability.
- Locking and conflict detection is copied along from the protocol view.
- Because of consistency, the look-and-feel should go towards Plone / rest of GEVER.
- The status button in the sidebar is now visually broken. It will be moved to a separate place and thus fixing is not worth the effort.

![bildschirmfoto 2017-09-18 um 11 07 54](https://user-images.githubusercontent.com/7469/30535501-e4f5f2d6-9c62-11e7-9298-0c6ea0335376.png)
![bildschirmfoto 2017-09-18 um 11 07 49](https://user-images.githubusercontent.com/7469/30535502-e4ff1ff0-9c62-11e7-92bf-17a721abed8d.png)

