### PR TITLE
Add missing french translations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.5.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add missing french translations. [phgross]
 
 
 2017.5.0 (2017-09-14)

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -78,7 +78,7 @@ msgid "Dossier state changed to dossier-state-resolved"
 msgstr "Etat du dossier modifié: Fermé"
 
 msgid "Dossier with template"
-msgstr ""
+msgstr "Dossier à partir du modèle"
 
 msgid "Edit metadata"
 msgstr "Modifier les méta-données"
@@ -125,7 +125,7 @@ msgid "Submit additional documents"
 msgstr ""
 
 msgid "Usage"
-msgstr ""
+msgstr "Usage"
 
 #: plone.app.search/plone/app/search/browser.py:121
 msgid "alphabetically"
@@ -362,4 +362,3 @@ msgstr "Activer"
 
 msgid "transition-add-document"
 msgstr ""
-


### PR DESCRIPTION
Note: Currently the `plone.po` is not part of the og.base modul in the [translation tool](http://translations.onegovgever.ch), therefore those translations were not displayed in the translation tool.