### PR TITLE
Register an is_subdossier indexer for dossiertemplates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.1 (unreleased)
 ---------------------
 
+- Fix is_subdossier replacement upgradestep, reindex all objects. [phgross]
 - Register an is_subdossier indexer for dossiertemplates. [phgross]
 - Add missing french translations. [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.1 (unreleased)
 ---------------------
 
+- Register an is_subdossier indexer for dossiertemplates. [phgross]
 - Add missing french translations. [phgross]
 
 

--- a/opengever/core/upgrades/20170919144003_replace_is_subdossier_field_index_with_a_boolean_index/upgrade.py
+++ b/opengever/core/upgrades/20170919144003_replace_is_subdossier_field_index_with_a_boolean_index/upgrade.py
@@ -12,10 +12,4 @@ class ReplaceIsSubdossierFieldIndexWithABooleanIndex(UpgradeStep):
     def __call__(self):
         self.catalog_remove_index(INDEX_NAME)
         self.catalog_add_index(INDEX_NAME, 'BooleanIndex')
-        catalog = self.getToolByName('portal_catalog')
-
-        for obj in self.objects({'object_provides': IDossierMarker.__identifier__},
-                                'Reindex is_subdossier index'):
-
-            catalog.reindexObject(
-                obj, idxs=[INDEX_NAME], update_metadata=False)
+        self.catalog_rebuild_index(INDEX_NAME)

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -80,6 +80,13 @@ def isSubdossierIndexer(obj):
 grok.global_adapter(isSubdossierIndexer, name="is_subdossier")
 
 
+@indexer(IDossierTemplateMarker)
+def is_subdossier_dossiertemplate(obj):
+    return obj.is_subdossier()
+
+grok.global_adapter(is_subdossier_dossiertemplate, name="is_subdossier")
+
+
 @indexer(IDossierMarker)
 def external_reference(obj):
     """Return the external reference of a dossier."""

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -22,6 +22,8 @@ from zope.component import getUtility
 def DossierSubjectIndexer(obj):
     aobj = IDossier(obj)
     return aobj.keywords
+
+
 grok.global_adapter(DossierSubjectIndexer, name="Subject")
 
 
@@ -29,6 +31,8 @@ grok.global_adapter(DossierSubjectIndexer, name="Subject")
 def DossierTemplateSubjectIndexer(obj):
     aobj = IDossier(obj)
     return aobj.keywords
+
+
 grok.global_adapter(DossierTemplateSubjectIndexer, name="Subject")
 
 
@@ -38,6 +42,8 @@ def startIndexer(obj):
     if aobj.start is None:
         return None
     return aobj.start
+
+
 grok.global_adapter(startIndexer, name="start")
 
 
@@ -47,6 +53,8 @@ def endIndexer(obj):
     if aobj.end is None:
         return None
     return aobj.end
+
+
 grok.global_adapter(endIndexer, name="end")
 
 
@@ -57,6 +65,8 @@ def retention_expiration(obj):
         # don't have a retention period, or expiration thereof
         return None
     return obj.get_retention_expiration_date()
+
+
 grok.global_adapter(retention_expiration, name="retention_expiration")
 
 
@@ -66,6 +76,8 @@ def responsibleIndexer(obj):
     if aobj.responsible is None:
         return None
     return aobj.responsible
+
+
 grok.global_adapter(responsibleIndexer, name="responsible")
 
 
@@ -77,12 +89,15 @@ def isSubdossierIndexer(obj):
     if IDossierMarker.providedBy(parent):
         return True
     return False
+
+
 grok.global_adapter(isSubdossierIndexer, name="is_subdossier")
 
 
 @indexer(IDossierTemplateMarker)
 def is_subdossier_dossiertemplate(obj):
     return obj.is_subdossier()
+
 
 grok.global_adapter(is_subdossier_dossiertemplate, name="is_subdossier")
 
@@ -92,6 +107,8 @@ def external_reference(obj):
     """Return the external reference of a dossier."""
     context = aq_inner(obj)
     return IDossier(context).external_reference
+
+
 grok.global_adapter(external_reference, name="external_reference")
 
 
@@ -119,6 +136,8 @@ def main_dossier_title(obj):
         else:
             raise
     return title
+
+
 grok.global_adapter(main_dossier_title, name="containing_dossier")
 
 
@@ -130,7 +149,7 @@ def containing_subdossier(obj):
     """
     context = aq_inner(obj)
     # Only compute for types that actually can be contained in a dossier
-    if not context.portal_type in ['opengever.document.document',
+    if context.portal_type not in ['opengever.document.document',
                                    'opengever.task.task',
                                    'ftw.mail.mail']:
         return ''
@@ -151,6 +170,8 @@ def containing_subdossier(obj):
         # parent dossier is a subdossier
         return parent_dossier.Title()
     return ''
+
+
 grok.global_adapter(containing_subdossier, name='containing_subdossier')
 
 

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -56,10 +56,14 @@ class TestIndexers(FunctionalTestCase):
         transaction.commit()
 
     def test_is_subdossier_index(self):
-        self.assertEquals(index_data_for(self.dossier).get('is_subdossier'),
-                          False)
-        self.assertEquals(index_data_for(self.subdossier).get('is_subdossier'),
-                          True)
+        self.assertFalse(index_data_for(self.dossier).get('is_subdossier'))
+        self.assertTrue(index_data_for(self.subdossier).get('is_subdossier'))
+
+        dossiertemplate = create(Builder('dossiertemplate'))
+        sub_dossiertemplate = create(Builder('dossiertemplate')
+                                     .within(dossiertemplate))
+        self.assertFalse(index_data_for(dossiertemplate).get('is_subdossier'))
+        self.assertTrue(index_data_for(sub_dossiertemplate).get('is_subdossier'))
 
     def test_containing_subdossier(self):
         self.assertEquals(obj2brain(self.subdossier).containing_subdossier, '')


### PR DESCRIPTION
We querying dossiertemplates with an `is_subdossier=False` query in the dossiertemplate listing, but there is no indexer for dossiertemplates.

With a former change which has changed the `is_subdossier` index from a FieldIndex to a BooleanIndex, this leads to a confusing behavior when switching for the dossiertemplate listing tab to the template document tab and back.

Note: Lukas will take a further look in to that confusing behavior, but for now the additional indexer and reindexing all dossiertemplates "solves" the problem.
