### PR TITLE
Scan to gever

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -53,6 +53,7 @@ Changelog
 - SPV word: Add new meeting edit form and move edit action to editbar. [jone]
 - SPV word: Add excerpts for ad-hoc agenda items. [deiferni]
 - Update plone.restapi to 1.0a21 which provides support for locking [buchi]
+- Add @scan-in REST API endpoint for uploading scanned documents. [buchi]
 
 
 2017.5.1 (2017-09-19)

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2017-10-09
+----------
+
+- Kapitel "Scan-In" hinzugefügt
+
 2016-08-08
 ----------
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -14,6 +14,7 @@ Inhalt:
    batching.rst
    searching.rst
    workflow.rst
+   scanin.rst
    content_types.rst
    metadata.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/scanin.rst
+++ b/docs/public/dev-manual/api/scanin.rst
@@ -1,0 +1,55 @@
+.. _scanin:
+
+Scan-In
+=======
+
+Der ``/@scan-in`` Endpoint ermöglicht den Upload von Dokumenten in OneGov GEVER
+von einem Scanner.
+
+Im Unterschied zu einem herkömmlichen Upload, werden Dokumente nicht im Kontext
+des authentisierten Benutzer erstellt, sondern im Kontext des über einen Parameter
+angegebenen Benutzers. So kann ein Scanner mit einem unpersönlichen Service-Benutzer
+angebunden werden, ohne dass der jeweilige Benutzer in OneGov GEVER authentifiziert
+werden muss.
+
+Dokumente können entweder in den Eingangskorb oder in die persönlichen Ablage
+hochgeladen werden. In der persönlichen Ablage werden Dokumente in einem Dossier
+mit dem Titel "Scaneingang" abgelegt. Falls dieses nicht existiert, wird ein
+neues Dossier erstellt.
+
+Die Daten werden als `multipart/form-data` mit einem POST Request übermittelt.
+
++-------------+------------------------------------------------------------------------------------------------------------------+
+|  Parameter  |                                                   Beschreibung                                                   |
++=============+==================================================================================================================+
+| userid      | Benutzername, unter welchem Dokumente abgelegt werden sollen.                                                    |
++-------------+------------------------------------------------------------------------------------------------------------------+
+| destination | Ort an dem Dokumente abgelegt werden sollen. ``inbox`` für Eingangskorb oder ``private`` für persönliche Ablage. |
++-------------+------------------------------------------------------------------------------------------------------------------+
+| org_unit    | Titel oder ID der Organisationseinheit. Nur bei mehreren Eingangskörben relevant.                                |
++-------------+------------------------------------------------------------------------------------------------------------------+
+
+
+Beispiel: Upload eines Dokuments in die persönliche Ablage des Benutzers hugo.boss.
+
+.. sourcecode:: http
+
+  POST /gever/@scan-in HTTP/1.1
+  Authorization: [AUTH_DATA]
+  Accept: application/json
+  Content-Type: multipart/form-data; boundary=------------------------b3e801e2d0fb0cc9
+  Content-Length: [NUMBER_OF_BYTES_IN_ENTIRE_REQUEST_BODY]
+
+  --------------------------b3e801e2d0fb0cc9
+  Content-Disposition: form-data; name="userid"
+
+  hugo.boss
+  --------------------------b3e801e2d0fb0cc9
+  Content-Disposition: form-data; name="destination"
+
+  private
+  --------------------------b3e801e2d0fb0cc9
+  Content-Disposition: form-data; name="file"; filename="helloworld.pdf"
+  Content-Type: application/octet-stream
+
+  [FILE_DATA]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -36,4 +36,12 @@
       permission="opengever.document.Cancel"
       />
 
+  <plone:service
+      method="POST"
+      name="@scan-in"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".scanin.ScanIn"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/scanin.py
+++ b/opengever/api/scanin.py
@@ -1,0 +1,95 @@
+from opengever.base.command import CreateDocumentCommand
+from plone import api
+from plone.restapi.services import Service
+from plone.restapi.services.content.utils import create
+from plone.restapi.services.content.utils import rename
+from zope.interface import alsoProvides
+import plone.protect.interfaces
+
+
+class ScanIn(Service):
+    """Endpoint for uploading documents from a scanner"""
+
+    def reply(self):
+
+        userid = self.request.form.get('userid')
+        if not userid:
+            return self.error(message='Missing userid.')
+
+        file_ = self.request.form.get('file')
+        if not file_:
+            return self.error(message='Missing file.')
+
+        # Disable CSRF protection
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
+
+        try:
+            adopt_user = api.env.adopt_user(username=userid)
+        except api.exc.UserNotFoundError:
+            return self.error(message='Unknown user.')
+
+        with adopt_user:
+            destination = self.destination()
+            if destination is None:
+                return self.error(message='Destination does not exist.')
+            filename = file_.filename.decode('utf8')
+            command = CreateDocumentCommand(destination, filename, file_)
+            command.execute()
+
+        self.request.response.setStatus(201)
+        return super(ScanIn, self).reply()
+
+    def destination(self):
+        """Return the destination for scanned documents."""
+        portal = api.portal.get()
+        destination = self.request.form.get('destination', 'inbox')
+        org_unit = self.request.form.get('org_unit')
+
+        if destination == 'inbox':
+            # Find inbox for the given org_unit
+            inbox_container = portal.listFolderContents(
+                contentFilter={'portal_type': 'opengever.inbox.container'})
+            if inbox_container:
+                inboxes = inbox_container[0].listFolderContents(
+                    contentFilter={'portal_type': 'opengever.inbox.inbox'})
+                for inbox in inboxes:
+                    if inbox.get_responsible_org_unit().unit_id == org_unit:
+                        return inbox
+            else:
+                inboxes = portal.listFolderContents(
+                    contentFilter={'portal_type': 'opengever.inbox.inbox'})
+                if inboxes:
+                    return inboxes[0]
+
+        elif destination == 'private':
+            # Try to find a dossier with title 'Scaneingang'
+            mtool = api.portal.get_tool(name='portal_membership')
+            private_folder = mtool.getHomeFolder()
+            if private_folder is None:
+                return
+            catalog = api.portal.get_tool(name='portal_catalog')
+            dossiers = catalog(
+                portal_type='opengever.private.dossier',
+                path={'query': '/'.join(private_folder.getPhysicalPath()),
+                      'depth': -1},
+                sortable_title='scaneingang',  # Exact match
+            )
+            if dossiers:
+                return dossiers[0].getObject()
+
+            # No dossier found, create a new one
+            obj = create(
+                private_folder,
+                'opengever.private.dossier',
+                title='Scaneingang')
+            rename(obj)
+            return obj
+
+    def error(self, status=400, type_='BadRequest', message=''):
+        self.request.response.setStatus(status)
+        return {'error': {
+            'type': type_,
+            'message': message,
+        }}

--- a/opengever/api/scanin.py
+++ b/opengever/api/scanin.py
@@ -55,7 +55,9 @@ class ScanIn(Service):
                 inboxes = inbox_container[0].listFolderContents(
                     contentFilter={'portal_type': 'opengever.inbox.inbox'})
                 for inbox in inboxes:
-                    if inbox.get_responsible_org_unit().unit_id == org_unit:
+                    inbox_ou = inbox.get_responsible_org_unit()
+                    if (inbox_ou.unit_id == org_unit or
+                            inbox_ou.title == org_unit):
                         return inbox
             else:
                 inboxes = portal.listFolderContents(

--- a/opengever/api/tests/test_scanin.py
+++ b/opengever/api/tests/test_scanin.py
@@ -1,0 +1,161 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone import api
+from requests_toolbelt.multipart.encoder import MultipartEncoder
+
+
+class TestScanIn(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestScanIn, self).setUp()
+
+    def create_single_inbox(self):
+        inbox = create(Builder('inbox').titled(u'Inbox'))
+        inbox.manage_setLocalRoles(self.regular_user.getId(),
+                                   ('Reader', 'Contributor', 'Editor'))
+        return inbox
+
+    def create_org_unit_inbox(self):
+        container = create(Builder('inbox_container').titled(u'Inboxes'))
+        container.manage_setLocalRoles(self.regular_user.getId(),
+                                       ('Reader', 'Contributor', 'Editor'))
+        return create(Builder('inbox')
+                      .titled(u'Inbox')
+                      .within(container)
+                      .having(responsible_org_unit='fa'))
+
+    def create_private_folder(self):
+        private_root = create(Builder('private_root'))
+        mtool = api.portal.get_tool('portal_membership')
+        mtool.setMembersFolderById(private_root.id)
+        mtool.setMemberAreaType('opengever.private.folder')
+        mtool.setMemberareaCreationFlag()
+        mtool.createMemberArea(member_id=self.regular_user.getId())
+        return private_root[self.regular_user.getId()]
+
+    def prepare_request(self, userid='', destination='inbox', org_unit=''):
+        fields = {
+            'userid': userid or self.regular_user.getId(),
+            'destination': destination,
+            'file': ('mydocument.txt', 'my text', 'text/plain'),
+        }
+        if org_unit:
+            fields['org_unit'] = org_unit
+
+        encoder = MultipartEncoder(fields=fields)
+        return encoder.to_string(), {
+            'Content-Type': encoder.content_type,
+            'Accept': 'application/json',
+        }
+
+    @browsing
+    def test_scanin_to_inbox(self, browser):
+        self.login(self.administrator, browser)
+        inbox = self.create_single_inbox()
+        body, headers = self.prepare_request()
+
+        browser.open(self.portal.absolute_url() + '/@scan-in',
+                     method='POST',
+                     headers=headers,
+                     data=body)
+
+        self.assertEqual(201, browser.status_code)
+        doc = inbox.objectValues()[0]
+        self.assertEqual('mydocument', doc.Title())
+
+    @browsing
+    def test_scanin_to_org_unit_inbox(self, browser):
+        self.login(self.administrator, browser)
+        inbox = self.create_org_unit_inbox()
+
+        body, headers = self.prepare_request(org_unit='fa')
+        browser.open(self.portal.absolute_url() + '/@scan-in',
+                     method='POST',
+                     headers=headers,
+                     data=body)
+
+        self.assertEqual(201, browser.status_code)
+        doc = inbox.objectValues()[0]
+        self.assertEqual('mydocument', doc.Title())
+
+    @browsing
+    def test_scanin_to_new_private_dossier(self, browser):
+        self.login(self.manager, browser)
+        private_folder = self.create_private_folder()
+
+        body, headers = self.prepare_request(destination='private')
+        browser.open(self.portal.absolute_url() + '/@scan-in',
+                     method='POST',
+                     headers=headers,
+                     data=body)
+
+        self.assertEqual(201, browser.status_code)
+        dossier = private_folder.objectValues()[0]
+        self.assertEqual('Scaneingang', dossier.Title())
+        doc = dossier.objectValues()[0]
+        self.assertEqual('mydocument', doc.Title())
+
+    @browsing
+    def test_scanin_to_existing_private_dossier(self, browser):
+        self.login(self.manager, browser)
+        private_folder = self.create_private_folder()
+        dossier = create(Builder('private_dossier')
+                         .within(private_folder)
+                         .titled(u'Scaneingang'))
+
+        body, headers = self.prepare_request(destination='private')
+        browser.open(self.portal.absolute_url() + '/@scan-in',
+                     method='POST',
+                     headers=headers,
+                     data=body)
+
+        self.assertEqual(201, browser.status_code)
+        self.assertEqual(1, len(private_folder.objectIds()))
+        doc = dossier.objectValues()[0]
+        self.assertEqual('mydocument', doc.Title())
+
+    @browsing
+    def test_scanin_with_missing_userid(self, browser):
+        self.login(self.administrator, browser)
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.portal.absolute_url() + '/@scan-in',
+                         method='POST',
+                         headers={'Accept': 'application/json'},
+                         data={})
+        self.assertIn('Missing userid.', browser.contents)
+
+    @browsing
+    def test_scanin_with_unkown_userid(self, browser):
+        self.login(self.administrator, browser)
+
+        body, headers = self.prepare_request(userid='chief')
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.portal.absolute_url() + '/@scan-in',
+                         method='POST',
+                         headers=headers,
+                         data=body)
+        self.assertIn('Unknown user.', browser.contents)
+
+    @browsing
+    def test_scanin_without_file(self, browser):
+        self.login(self.administrator, browser)
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.portal.absolute_url() + '/@scan-in',
+                         method='POST',
+                         headers={'Accept': 'application/json'},
+                         data={'userid': self.regular_user.getId()})
+        self.assertIn('Missing file.', browser.contents)
+
+    @browsing
+    def test_scanin_to_unknown_destination(self, browser):
+        self.login(self.administrator, browser)
+
+        body, headers = self.prepare_request(destination='unknown')
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.portal.absolute_url() + '/@scan-in',
+                         method='POST',
+                         headers=headers,
+                         data=body)
+        self.assertIn('Destination does not exist.', browser.contents)

--- a/opengever/api/tests/test_scanin.py
+++ b/opengever/api/tests/test_scanin.py
@@ -81,6 +81,21 @@ class TestScanIn(IntegrationTestCase):
         self.assertEqual('mydocument', doc.Title())
 
     @browsing
+    def test_scanin_to_org_unit_inbox_by_title(self, browser):
+        self.login(self.administrator, browser)
+        inbox = self.create_org_unit_inbox()
+
+        body, headers = self.prepare_request(org_unit='Finanzamt')
+        browser.open(self.portal.absolute_url() + '/@scan-in',
+                     method='POST',
+                     headers=headers,
+                     data=body)
+
+        self.assertEqual(201, browser.status_code)
+        doc = inbox.objectValues()[0]
+        self.assertEqual('mydocument', doc.Title())
+
+    @browsing
     def test_scanin_to_new_private_dossier(self, browser):
         self.login(self.manager, browser)
         private_folder = self.create_private_folder()

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -126,4 +126,10 @@
 
   <adapter factory=".reference.PlatformReferenceNumber" />
 
+  <utility
+      name="ZPublisher.HTTPRequest.FileUpload"
+      provides="plone.namedfile.interfaces.IStorage"
+      factory=".namedfile.FileUploadStorable"
+      />
+
 </configure>

--- a/opengever/base/namedfile.py
+++ b/opengever/base/namedfile.py
@@ -1,0 +1,25 @@
+from plone.namedfile.interfaces import IStorage
+from plone.namedfile.interfaces import NotStorable
+from zope.interface import implementer
+from ZPublisher.HTTPRequest import FileUpload
+
+MAXCHUNKSIZE = 1 << 16
+
+
+# IStorage utility for good old ZPublisher.HTTPRequest.FileUpload
+# Would make sense to have this in plone.namedfile
+@implementer(IStorage)
+class FileUploadStorable(object):
+
+    def store(self, data, blob):
+        if not isinstance(data, FileUpload):
+            raise NotStorable('Could not store data (not of "FileUpload").')
+
+        data.seek(0)
+
+        fp = blob.open('w')
+        block = data.read(MAXCHUNKSIZE)
+        while block:
+            fp.write(block)
+            block = data.read(MAXCHUNKSIZE)
+        fp.close()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ tests_require = [
     'Products.CMFPlone',
     'PyJWT',
     'pyquery',
+    'requests_toolbelt',
     'xlrd',
     'z3c.blobfile',
     'z3c.form',


### PR DESCRIPTION
Provides a new REST API endpoint `@scan-in` for uploading scanned documents.
The uploaded documents are created in the context of the given user either in the inbox or in a private dossier with the title "Scaneingang".

The permission `plone.restapi: Use REST API` is required to access the endpoint. 

The endpoint expects multipart form data containing:
- userid: 
- destination: inbox or private
- org_unit: id or name of the org unit, only needed with destination inbox
- file: file data

Example request:
```
POST /gever/@scan-in HTTP/1.1
Authorization: [AUTH_DATA]
Accept: application/json
Content-Type: multipart/form-data; boundary=------------------------b3e801e2d0fb0cc9
Content-Length: [NUMBER_OF_BYTES_IN_ENTIRE_REQUEST_BODY]

--------------------------b3e801e2d0fb0cc9
Content-Disposition: form-data; name="userid"

donald.duck
--------------------------b3e801e2d0fb0cc9
Content-Disposition: form-data; name="org_unit"

fd
--------------------------b3e801e2d0fb0cc9
Content-Disposition: form-data; name="destination"

private
--------------------------b3e801e2d0fb0cc9
Content-Disposition: form-data; name="file"; filename="helloworld.pdf"
Content-Type: application/octet-stream

[FILE_DATA]
```
