### PR TITLE
Fix ordering in bumblebee gallery.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]
+- Fix ordering in bumblebee gallery. [jone]
 - SPV word: Add new meeting edit form and move edit action to editbar. [jone]
 - SPV word: Add excerpts for ad-hoc agenda items. [deiferni]
 

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -65,6 +65,12 @@ class BumblebeeGalleryMixin(object):
             'searchable_text', '')
 
         query = self.table_source.build_query()
+
+        # When https://github.com/4teamwork/opengever.core/pull/3399 is fixed,
+        # set the default ordering on the table source config instead.
+        if isinstance(query, dict) and 'sort_on' not in query:
+            query['sort_on'] = 'modified'
+            query['sort_order'] = 'descending'
         return self.table_source.search_results(query)
 
     def fetch(self):


### PR DESCRIPTION
Content listings should be ordered in a way the user can interpret. Currently we order by the catalog's internal values, such as the rid, which is confusing for users and considered a bug.

It's best to order by modified date by now, in order to show the latest changes, so that users can find recently used documents easily.

In the future we will hopefully implement an ordering menu, where the user can decide how to order. But modified date is a good fix for now.