### PR TITLE
🚧 Tabbedview: let the catalog sort date indexes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Tabbedview: let the catalog sort date indexes. [jone]
 - SPV word: Add new meeting edit form and move edit action to editbar. [jone]
 
 

--- a/opengever/tabbedview/browser/listing.py
+++ b/opengever/tabbedview/browser/listing.py
@@ -23,3 +23,5 @@ class CatalogListingView(ftw.tabbedview.browser.listing.CatalogListingView):
     implements(IGeverCatalogTableSourceConfig)
 
     batching = ViewPageTemplateFile("batching.pt")
+
+    custom_sort_indexes = {}

--- a/opengever/tabbedview/tests/test_table_source_configs.py
+++ b/opengever/tabbedview/tests/test_table_source_configs.py
@@ -1,0 +1,51 @@
+from itertools import chain
+from opengever.tabbedview.interfaces import IGeverCatalogTableSourceConfig
+from opengever.testing import IntegrationTestCase
+from plone.testing.zca import _REGISTRIES
+from Products.CMFCore.utils import getToolByName
+from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
+
+
+class TestTableSourceConfigs(IntegrationTestCase):
+
+    def test_no_date_indexes_with_falsy_values(self):
+        """When sorting a catalog query by a date index containing falsy values,
+        it will remove brains with falsy values from the result set.
+        It cannot do a correct job in this case because the date index does not
+        know whether falsy items need to be inserted at the top or at the bottom.
+
+        The correct approach is to write date indexers which always return a
+        datetime object. It may be in the far-future or in the far-past when the
+        actual value is not set.
+        """
+        catalog = getToolByName(self.portal, 'portal_catalog')
+        indexes_with_falsy_values = []
+
+        for index in catalog._catalog.indexes.values():
+            if not isinstance(index, DateIndex):
+                continue
+            if filter(lambda value: not value, index.uniqueValues()):
+                indexes_with_falsy_values.append(index)
+
+        self.assertEquals(
+            [], indexes_with_falsy_values,
+            'Date indexes are not allowed to contain falsy values.'
+            ' Change the indexer so that always returns a datetime object.')
+
+    def test_date_indexes_are_not_custom_sort_indexes(self):
+        """ftw.table's catalog source does not let the catalog sort by date
+        indexes because it may remove results when the index contains falsy
+        values.
+
+        We make sure that we don't have falsy values in our date indexes.
+        Therefore we can remove this protection.
+        """
+
+        adapters = chain(*(sm.registeredAdapters() for sm in _REGISTRIES))
+        adapter_factories = (adapter.factory for adapter in adapters)
+        table_source_configs = filter(IGeverCatalogTableSourceConfig.implementedBy,
+                                      adapter_factories)
+        date_index = 'Products.PluginIndexes.DateIndex.DateIndex'
+        bad_configs = filter(lambda cls: date_index in cls.custom_sort_indexes,
+                             table_source_configs)
+        self.assertEquals([], bad_configs)


### PR DESCRIPTION
ftw.table does not sort by date indexes in order to circumvent the problem that date indexes with falsy values remove result from the result set.

ftw.table instead sorts the results afterwards, breaking the lazyness and retrieving the brains. This is approach is years old and not a good solution.

The better solution to avoid such problems is to make sure that a date index never contains falsy values. For optional dates this could easily achieved by using an early (1900) or late (2199) default date in the indexer. The catalog index will decide whether to use an early or late default date because it does not have this competence.

**Proposal**
1. Make sure that we dont have falsy values in catalog date indexes.
2. Disable ftw.table's custom sort index workaround.

**Advantags**
1. Loading listings with many results when ordered by date indexes will be much faster since the catalog will do the sorting and we can access only the page while keeping a lazy result set.
2. We have a solution which applies to all catalog queries, not just tables.
3. It's easier to do sorting in other components using the ftw.table sources, such as preview galleries.

**Ensuring non-falsy values**
No action is needed at the moment for ensuring that date index are non-falsy, since they already seem to be correct.
1. A test ensures that we don't have falsy values when the fixture is created. This could protect us a bit from future errors.
2. An [opengever.maintenance](https://github.com/4teamwork/opengever.maintenance/pull/92) script can be executed on productive installations for verifying that the indexes are correct. No bad installation was found up to now.

**Changing ftw.table**
I've decided to not change ftw.table, since we cannot be sure that all other installations using it have correct indexes. They may rely on this behavior. It's a legacy we can't get rid of that easily in all projects.