### PR TITLE
Excerpts for ad-hoc agenda items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]
 - SPV word: Add new meeting edit form and move edit action to editbar. [jone]
+- SPV word: Add excerpts for ad-hoc agenda items. [deiferni]
 
 
 2017.5.1 (2017-09-19)

--- a/opengever/core/upgrades/20170920143453_add_excerpts_table/upgrade.py
+++ b/opengever/core/upgrades/20170920143453_add_excerpts_table/upgrade.py
@@ -1,0 +1,26 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.schema import Sequence
+
+
+UNIT_ID_LENGTH = 30
+
+
+class AddExcerptsTable(SchemaMigration):
+    """Add excerpts table.
+    """
+
+    def migrate(self):
+        self.op.create_table(
+            'excerpts',
+            Column('id', Integer, Sequence('excerpts_id_seq'),
+                   primary_key=True),
+
+            Column('agenda_item_id', Integer, ForeignKey('agendaitems.id')),
+            Column('excerpt_admin_unit_id',
+                   String(UNIT_ID_LENGTH), nullable=False),
+            Column('excerpt_int_id', Integer, nullable=False)
+        )

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -43,7 +43,7 @@
               {{#if return_link}}
                 <a href="{{return_link}}" title="%(label_return_action)s" class="return-excerpt-btn"></a>
               {{/if}}
-              {{#if is_excerpt}}
+              {{#if is_excerpt_in_source_dossier}}
                 <span title="%(label_returned_excerpt)s" class="returned-excerpt-icon"></span>
               {{/if}}
               </span>

--- a/opengever/meeting/model/__init__.py
+++ b/opengever/meeting/model/__init__.py
@@ -8,6 +8,7 @@ from opengever.meeting.model.member import Member  # noqa
 from opengever.meeting.model.membership import Membership  # noqa
 from opengever.meeting.model.proposal import Proposal  # noqa
 from opengever.meeting.model.submitteddocument import SubmittedDocument  # noqa
+from opengever.meeting.model.excerpt import Excerpt  # noqa
 import opengever.meeting.model.query  # noqa
 
 
@@ -23,4 +24,5 @@ tables = [
     'periods',
     'proposals',
     'submitteddocuments',
+    'excerpts',
 ]

--- a/opengever/meeting/model/__init__.py
+++ b/opengever/meeting/model/__init__.py
@@ -1,14 +1,14 @@
-from opengever.meeting.model.period import Period
-from opengever.meeting.model.agendaitem import AgendaItem
-from opengever.meeting.model.meeting import Meeting
-from opengever.meeting.model.committee import Committee
-from opengever.meeting.model.generateddocument import GeneratedExcerpt
-from opengever.meeting.model.generateddocument import GeneratedProtocol
-from opengever.meeting.model.member import Member
-from opengever.meeting.model.membership import Membership
-from opengever.meeting.model.proposal import Proposal
-from opengever.meeting.model.submitteddocument import SubmittedDocument
-import opengever.meeting.model.query  # keep, initializes query classes!
+from opengever.meeting.model.period import Period  # noqa
+from opengever.meeting.model.agendaitem import AgendaItem  # noqa
+from opengever.meeting.model.meeting import Meeting  # noqa
+from opengever.meeting.model.committee import Committee  # noqa
+from opengever.meeting.model.generateddocument import GeneratedExcerpt  # noqa
+from opengever.meeting.model.generateddocument import GeneratedProtocol  # noqa
+from opengever.meeting.model.member import Member  # noqa
+from opengever.meeting.model.membership import Membership  # noqa
+from opengever.meeting.model.proposal import Proposal  # noqa
+from opengever.meeting.model.submitteddocument import SubmittedDocument  # noqa
+import opengever.meeting.model.query  # noqa
 
 
 tables = [

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -293,16 +293,6 @@ class AgendaItem(Base):
                                            ICheckinCheckoutManager)
         checkout_manager.checkin()
 
-    @require_word_meeting_feature
-    def checkin_document(self):
-        document = self.resolve_document()
-        if not document:
-            return
-
-        checkout_manager = getMultiAdapter((document, document.REQUEST),
-                                           ICheckinCheckoutManager)
-        checkout_manager.checkin()
-
     @property
     def legal_basis(self):
         return self.submitted_proposal.legal_basis if self.has_proposal else None

--- a/opengever/meeting/model/excerpt.py
+++ b/opengever/meeting/model/excerpt.py
@@ -1,0 +1,28 @@
+from opengever.base.model import Base
+from opengever.base.oguid import Oguid
+from opengever.ogds.models import UNIT_ID_LENGTH
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.orm import backref
+from sqlalchemy.orm import composite
+from sqlalchemy.orm import relationship
+from sqlalchemy.schema import Sequence
+
+
+class Excerpt(Base):
+    """Relation to an excerpt for ad-hoc agenda items."""
+
+    __tablename__ = 'excerpts'
+
+    excerpt_id = Column("id", Integer, Sequence("excerpts_id_seq"),
+                        primary_key=True)
+    agenda_item_id = Column(Integer, ForeignKey('agendaitems.id'))
+    agenda_item = relationship("AgendaItem", uselist=False,
+                               backref=backref('excerpts'))
+
+    excerpt_admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
+    excerpt_int_id = Column(Integer, nullable=False)
+    excerpt_oguid = composite(
+        Oguid, excerpt_admin_unit_id, excerpt_int_id)

--- a/opengever/meeting/model/excerpt.py
+++ b/opengever/meeting/model/excerpt.py
@@ -26,3 +26,6 @@ class Excerpt(Base):
     excerpt_int_id = Column(Integer, nullable=False)
     excerpt_oguid = composite(
         Oguid, excerpt_admin_unit_id, excerpt_int_id)
+
+    def resolve_document(self):
+        return self.excerpt_oguid.resolve_object()

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -465,30 +465,6 @@ class SubmittedProposal(ProposalBase):
             dossier.title)
 
     @require_word_meeting_feature
-    def generate_excerpt(self, target_dossier):
-        """Create a new excerpt from this agenda item by copying it's
-        proposal document into the target dossier.
-        """
-        source_document = self.get_proposal_document()
-        if not source_document:
-            raise ValueError('The proposal has no proposal document.')
-
-        title = _(u'excerpt_document_title',
-                  default=u'Excerpt ${title}',
-                  mapping={'title': safe_unicode(self.Title())})
-        title = translate(title, context=target_dossier.REQUEST).strip()
-
-        excerpt_document = CreateDocumentCommand(
-            context=target_dossier,
-            filename=source_document.file.filename,
-            data=source_document.file.data,
-            content_type=source_document.file.contentType,
-            title=title).execute()
-
-        self.append_excerpt(excerpt_document)
-        return excerpt_document
-
-    @require_word_meeting_feature
     def get_excerpts(self):
         """Return a restricted list of document objects which are excerpts
         of the current proposal.

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -314,9 +314,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertFalse(item_data.get('excerpts'))
 
-        excerpt = self.submitted_word_proposal.generate_excerpt(
-            self.meeting_dossier)
-
+        excerpt = agenda_item.generate_excerpt()
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
         excerpt_links = item_data.get('excerpts', None)
@@ -351,8 +349,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         agenda_item = self.schedule_proposal(self.meeting,
                                              self.submitted_word_proposal)
         agenda_item.decide()
-        excerpt = self.submitted_word_proposal.generate_excerpt(
-            self.meeting_dossier)
+        excerpt = agenda_item.generate_excerpt()
 
         self.assertIsNone(agenda_item.proposal.excerpt_document)
         self.assertIsNone(agenda_item.proposal.submitted_excerpt_document)

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -46,8 +46,8 @@ class TestProposalWithWord(IntegrationTestCase):
             dict(browser.css('table.listing').first.lists()))
 
         self.assertEquals(
-            'Word Content',
-            proposal.get_proposal_document().file.open().read())
+            self.proposal_template.file.data,
+            proposal.get_proposal_document().file.data)
 
         self.assertFalse(
             is_officeconnector_checkout_feature_enabled(),
@@ -200,15 +200,19 @@ class TestProposalWithWord(IntegrationTestCase):
             [],
             ISubmittedProposal(self.submitted_word_proposal).excerpts)
 
+        agenda_item = self.schedule_proposal(self.meeting,
+                              self.submitted_word_proposal)
+        agenda_item.decide()
+
         with self.observe_children(self.meeting_dossier) as children:
-            self.submitted_word_proposal.generate_excerpt(self.meeting_dossier)
+            agenda_item.generate_excerpt()
 
         self.assertEquals(1, len(children['added']),
                           'An excerpt document should have been added to the'
                           ' meeting dossier.')
 
         # The document should contain a copy of the proposal document file.
-        excerpt_document ,= children['added']
+        excerpt_document, = children['added']
         self.assertEquals('Excerpt \xc3\x84nderungen am Personalreglement',
                           excerpt_document.Title())
         self.assertEquals(u'excerpt-anderungen-am-personalreglement.docx',

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -178,7 +178,7 @@ class OpengeverContentFixture(object):
             self.proposal_template = self.register('proposal_template', create(
                 Builder('proposaltemplate')
                 .titled(u'Geb\xfchren')
-                .attach_file_containing('Word Content', u'file.docx')
+                .with_asset_file(u'vertragsentwurf.docx')
                 .within(templates)))
 
     @staticuid()


### PR DESCRIPTION
This PR adds excerpts for ad-hoc agenda items.

Up to now excerpts could only be generated for proposal based agenda-items. We also want excerpts for ad-hoc items. Those excerpts are also stored in the meeting-dossier and referenced from the agenda-item. Since the agenda-items are stored in SQL only, we must (temporarily until the content is moved to plone) add a table to reference excerpts in SQL.

The button to generate excerpts now also appears for ad-hoc agenda items, once they are decided:

![screen shot 2017-09-20 at 14 28 39](https://user-images.githubusercontent.com/736583/30643657-13f855de-9e10-11e7-9aae-53b64c71b271.png)

Note the absence of the functionality to return an excerpt. This, of course, is not possible since we do not have a proposal. Since the excerpts are stored in the meeting dossier one can further process them as one pleases, with tasks, for example.

Closes #3371.