### PR TITLE
SPV word: Add proposal documents to meeting ZIP export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- SPV word: Add proposal documents to meeting ZIP export. [jone]
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -59,6 +59,17 @@ class TestMeetingZipExportView(IntegrationTestCase):
             zip_file.namelist())
 
     @browsing
+    def test_export_proposal_word_documents(self, browser):
+        self.activate_feature('word-meeting')
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        browser.open(self.meeting, view='export-meeting-zip')
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+        self.assertIn(
+            '1. Anderungen am Personalreglement/Proposal document Anderungen am Personalreglement.docx',
+            zip_file.namelist())
+
+    @browsing
     def test_excerpt_is_not_exported(self, browser):
         self.activate_feature('word-meeting')
         self.login(self.committee_responsible, browser)
@@ -72,6 +83,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         self.assertEquals(
             ['Protocol-9. Sitzung der Rechnungsprufungskommission.docx',
              '1. Anderungen am Personalreglement/Vertragsentwurf.docx',
+             '1. Anderungen am Personalreglement/Proposal document Anderungen am Personalreglement.docx',
              'Agendaitem list-9. Sitzung der Rechnungsprufungskommission.docx'],
             zip_file.namelist())
 


### PR DESCRIPTION
When the word-meeting feature flag is enabled, the ZIP export of a meeting should also contain the proposal documents.

Closes https://github.com/4teamwork/gever/issues/95