### PR TITLE
SPV word: Prefix decision numbers with year.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Lawgiver: Ignore ftw.usermigration permission. [lgraf]
 - SPV word: Add proposal documents to meeting ZIP export. [jone]
+- SPV word: Prefix decision numbers with year. [jone]
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -191,7 +191,7 @@ class AgendaItemsView(BrowserView):
                 view='agenda_items/{}/delete'.format(item.agenda_item_id))
             data['edit_link'] = meeting.get_url(
                 view='agenda_items/{}/edit'.format(item.agenda_item_id))
-            data['decision_number'] = item.decision_number
+            data['decision_number'] = item.get_decision_number()
             if item.is_decide_possible():
                 data['decide_link'] = meeting.get_url(
                     view='agenda_items/{}/decide'.format(item.agenda_item_id))

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -7,8 +7,10 @@ from opengever.base.widgets import trix_strip_whitespace
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
+from opengever.meeting.model import Period
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
@@ -215,6 +217,17 @@ class AgendaItem(Base):
     def get_decision_draft(self):
         if self.has_proposal:
             return self.submitted_proposal.decision_draft
+
+    def get_decision_number(self):
+        if not is_word_meeting_implementation_enabled():
+            return self.decision_number
+
+        if not self.decision_number:
+            return self.decision_number
+
+        period = Period.query.get_current_for_update(self.meeting.committee)
+        year = period.date_from.year
+        return '{} / {}'.format(year, self.decision_number)
 
     def get_dossier_reference_number(self):
         if self.has_proposal:

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -193,7 +193,7 @@ class Proposal(Base):
 
     def get_decision_number(self):
         if self.agenda_item:
-            return self.agenda_item.decision_number
+            return self.agenda_item.get_decision_number()
         return None
 
     def get_url(self):

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -127,7 +127,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.open(self.meeting, view='agenda_items/list')
         self.assertDictContainsSubset(
             {'title': u'Tisch Traktandum',
-             'decision_number': 2},
+             'decision_number': u'2016 / 2'},
             browser.json['items'][0])
 
     @browsing

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -340,7 +340,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         browser.reload()
         self.assertDictContainsSubset(
             {'title': u'\xc4nderungen am Personalreglement',
-             'decision_number': 2},
+             'decision_number': '2016 / 2'},
             browser.json['items'][0])
 
     @browsing

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 
@@ -52,6 +53,7 @@ def proposal_dicts(browser):
 
 
 class TestDossierProposalListing(IntegrationTestCase):
+    features = ('meeting',)
 
     maxDiff = None
 
@@ -130,6 +132,21 @@ class TestDossierProposalListing(IntegrationTestCase):
                      data={'proposal_state_filter': 'filter_proposals_decided'})
 
         self.assertEquals([DECIDED_PROPOSAL], proposal_dicts(browser))
+
+    @browsing
+    def test_decision_number_is_prefixed_when_word_feature_enabled(self, browser):
+        """When the word feature is enabled, the decision number is prefixed
+        with the year of the meeting.
+        """
+        self.activate_feature('word-meeting')
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier,
+                     view='tabbedview_view-proposals',
+                     data={'proposal_state_filter': 'filter_proposals_decided'})
+
+        proposal = deepcopy(DECIDED_PROPOSAL)
+        proposal['Decision number'] = '2016 / 1'
+        self.assertEquals([proposal], proposal_dicts(browser))
 
 
 class TestMyProposals(IntegrationTestCase):


### PR DESCRIPTION
Decision numbers are counted per period. A period is usually a calendar year. In order to easily distinguish the decisions, we prefix the decision number with the year ("2017 / 35").

Closes https://github.com/4teamwork/gever/issues/56