### PR TITLE
SPV: Fix dialog text when closing a meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - Lawgiver: Ignore ftw.usermigration permission. [lgraf]
 - SPV word: Add proposal documents to meeting ZIP export. [jone]
 - SPV word: Prefix decision numbers with year. [jone]
+- SPV: Fix dialog text when closing a meeting. [jone]
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]

--- a/opengever/meeting/browser/meetings/templates/meeting-noword.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -57,7 +57,8 @@
           </div>
           <h2 i18n:translate="close_meeting">Close meeting</h2>
           <p i18n:translate="">
-            Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:
+            After closing the meeting it can no longer be edited.
+            The following tasks will be performed:
           </p>
           <ul>
             <li i18n:translate="">Close all proposals.</li>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -59,7 +59,8 @@
           </div>
           <h2 i18n:translate="close_meeting">Close meeting</h2>
           <p i18n:translate="">
-            Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:
+            After closing the meeting it can no longer be edited.
+            The following tasks will be performed:
           </p>
           <ul>
             <li i18n:translate="">Close all proposals.</li>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-19 07:09+0000\n"
-"PO-Revision-Date: 2017-09-19 09:09+0200\n"
+"POT-Creation-Date: 2017-09-21 09:43+0000\n"
+"PO-Revision-Date: 2017-09-21 11:44+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -21,8 +21,8 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:269
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:319
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:270
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -62,7 +62,12 @@ msgstr "Periode hinzufügen"
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
+msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
+msgstr "Nach Abschluss kann die Sitzung nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:273
 msgid "Agenda Items"
 msgstr "Traktanden"
 
@@ -70,7 +75,7 @@ msgstr "Traktanden"
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr "Traktandenliste für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
 msgid "Agendaitem list"
 msgstr "Traktandenliste"
 
@@ -79,17 +84,17 @@ msgstr "Traktandenliste"
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:67
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:69
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:70
 msgid "Are you sure you want to close this meeting?"
 msgstr "Wollen Sie diese Sitzung wirklich abschliessen?"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:103
 msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr "Wollen Sie diesen Protokollauszug wirklich an den Antragsteller zurücksenden?"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:83
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:84
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:86
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr "Sind Sie sicher, dass Sie dieses Traktandum beschliessen möchten?"
 
@@ -105,8 +110,8 @@ msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende
 msgid "Choose Agenda Items"
 msgstr "Traktanden auswählen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:63
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:65
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
 msgid "Close all proposals."
 msgstr "Alle Anträge werden abgeschlossen."
 
@@ -136,16 +141,16 @@ msgstr "Verwerfen"
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
 msgid "Documents"
 msgstr "Dokumente"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:205
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:206
 msgid "Download agenda item list"
 msgstr "Traktandenliste herunterladen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:99
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -170,7 +175,7 @@ msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:249
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:250
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
@@ -178,8 +183,8 @@ msgstr "Protokollauszüge"
 msgid "Export settings"
 msgstr "Export-Einstellungen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
 msgid "Generate excerpts for all proposals."
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt."
 
@@ -231,7 +236,7 @@ msgstr "Ablageposition"
 msgid "Meeting Dossier"
 msgstr "Sitzungsdossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:158
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:159
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
@@ -247,20 +252,15 @@ msgstr "Sitzungsangaben"
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:315
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
 msgid "Number"
 msgstr "Nummer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
-msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
-msgstr "Die Sitzung und ihr Protokoll können nach Abschluss nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:313
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:314
 msgid "Order"
 msgstr "Sortierung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
 msgid "Paragraph:"
 msgstr "Abschnitt:"
 
@@ -285,11 +285,11 @@ msgstr "Antrag"
 msgid "Proposal Template"
 msgstr "Antragsvorlage"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:297
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:298
 msgid "Proposals:"
 msgstr "Anträge"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:206
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
 #: ./opengever/meeting/model/meeting.py:265
 msgid "Protocol"
 msgstr "Protokoll"
@@ -329,7 +329,7 @@ msgstr "Erfolgreich traktandiert"
 msgid "Show more"
 msgstr "Mehr anzeigen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:277
 msgid "Text:"
 msgstr "Freitext:"
 
@@ -341,7 +341,7 @@ msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich ers
 msgid "The proposal has been rejected successfully"
 msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
 msgid "Title"
 msgstr "Titel"
 
@@ -355,8 +355,8 @@ msgstr "Detranktandieren"
 msgid "Unschedule proposal"
 msgstr "Traktandum detraktandieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:68
 msgid "Update or create the protocol."
 msgstr "Das Protokoll wird erstellt oder aktualisiert."
 
@@ -380,57 +380,57 @@ msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:343
+#: ./opengever/meeting/browser/meetings/agendaitem.py:337
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr "Traktandum kann nicht beschlossen werden: das Beschlussdokument ist noch von einer anderen Person ausgecheckt."
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:313
+#: ./opengever/meeting/browser/meetings/agendaitem.py:307
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:289
+#: ./opengever/meeting/browser/meetings/agendaitem.py:283
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:318
+#: ./opengever/meeting/browser/meetings/agendaitem.py:312
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:248
+#: ./opengever/meeting/browser/meetings/agendaitem.py:242
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:310
+#: ./opengever/meeting/browser/meetings/agendaitem.py:304
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:359
+#: ./opengever/meeting/browser/meetings/agendaitem.py:353
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:372
+#: ./opengever/meeting/browser/meetings/agendaitem.py:366
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:261
+#: ./opengever/meeting/browser/meetings/agendaitem.py:255
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:268
+#: ./opengever/meeting/browser/meetings/agendaitem.py:262
 msgid "agenda_item_update_too_long_title"
 msgstr "Der Traktandums-Titel ist zu lang."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:274
+#: ./opengever/meeting/browser/meetings/agendaitem.py:268
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
@@ -570,20 +570,20 @@ msgid "column_to"
 msgstr "Bis"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:43
+#: ./opengever/meeting/model/agendaitem.py:49
 #: ./opengever/meeting/model/proposal.py:159
 msgid "decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide Agendaitem"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:79
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:81
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:82
 msgid "decide_agendaitem"
 msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
 #: ./opengever/meeting/browser/documents/proposalstab.py:68
-#: ./opengever/meeting/model/agendaitem.py:37
+#: ./opengever/meeting/model/agendaitem.py:43
 #: ./opengever/meeting/model/proposal.py:139
 msgid "decided"
 msgstr "Beschlossen"
@@ -594,7 +594,7 @@ msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:388
+#: ./opengever/meeting/browser/meetings/agendaitem.py:382
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
@@ -603,18 +603,18 @@ msgstr "Sie dürfen das Dokument nicht auschecken."
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:239
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:240
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:399
 msgid "empty_paragraph"
 msgstr "Der Abschnitt darf nicht leer sein."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:420
+#: ./opengever/meeting/browser/meetings/agendaitem.py:414
 msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
@@ -624,7 +624,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:434
+#: ./opengever/meeting/browser/meetings/agendaitem.py:428
 msgid "error_no_permission_to_add_document"
 msgstr "Ungenügende Berechtigungen zum Hinzufügen eines Dokumentes im Sitzungsdossier."
 
@@ -634,17 +634,17 @@ msgid "error_prosal_template_not_docx"
 msgstr "Nur Word-Dateien (.docx) sind erlaubt."
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/proposal.py:476
+#: ./opengever/meeting/model/agendaitem.py:425
 msgid "excerpt_document_title"
 msgstr "Protokollauszug ${title}"
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:472
+#: ./opengever/meeting/browser/meetings/agendaitem.py:464
 msgid "excerpt_generated"
 msgstr "Protokollauszug erfolgreich generiert."
 
 #. Default: "Excerpt was returned to proposer."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:492
+#: ./opengever/meeting/browser/meetings/agendaitem.py:484
 msgid "excerpt_returned"
 msgstr "Der Protokollauszug wurde an den Antragsteller zurückgesendet."
 
@@ -658,22 +658,22 @@ msgstr "Inhaltsverzeichnis ${period} ${committee} alphabetisch"
 msgid "filename_repository_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} nach Ordnungsposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:199
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:176
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
 msgid "generate new agenda item list as word document"
 msgstr "Traktandenliste als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:252
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:233
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:234
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:211
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:212
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
@@ -818,8 +818,8 @@ msgid "label_deactivate"
 msgstr "Gremium deaktivieren"
 
 #. Default: "Decide"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:87
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:89
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:88
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:90
 msgid "label_decide"
 msgstr "Beschliessen"
 
@@ -959,8 +959,8 @@ msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:295
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:300
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
@@ -987,8 +987,8 @@ msgid "label_initial_position"
 msgstr "Ausgangslage"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:327
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
 msgid "label_insert"
 msgstr "Einfügen"
 
@@ -1051,13 +1051,13 @@ msgid "label_next_meeting"
 msgstr "Nächste Sitzung:"
 
 #. Default: "No agenda item list has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:189
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:197
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:190
 msgid "label_no_agendaitem_list"
 msgstr "Es wurde noch keine Traktandenliste generiert."
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:256
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:257
 msgid "label_no_excerpts"
 msgstr "Es wurden noch keine zusätzlichen Protokollauszüge generiert."
 
@@ -1072,8 +1072,8 @@ msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:223
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:228
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:224
 msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
@@ -1145,7 +1145,7 @@ msgid "label_return_action"
 msgstr "Protokollauszug an Antragsteller zurücksenden"
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:107
 msgid "label_return_excerpt"
 msgstr "Protokollauszug zurücksenden"
 
@@ -1172,8 +1172,8 @@ msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/meeting.py:371
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:312
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:280
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
 msgid "label_schedule"
 msgstr "Traktandieren"
 
@@ -1242,7 +1242,7 @@ msgstr "Kommende Sitzungen"
 msgid "label_workflow_state"
 msgstr "Status"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:239
 msgid "label_zip_download"
 msgstr "Zip-Datei herunterladen"
 
@@ -1251,11 +1251,11 @@ msgstr "Zip-Datei herunterladen"
 msgid "language"
 msgstr "Sprache"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:109
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:110
 msgid "location"
 msgstr "Ort"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:150
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:151
 msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
@@ -1275,24 +1275,24 @@ msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:87
+#: ./opengever/meeting/browser/meetings/edit_meeting.py:94
 #: ./opengever/meeting/browser/meetings/protocol.py:254
 msgid "message_locked_by_another_user"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde von ${username} gesperrt."
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:82
+#: ./opengever/meeting/browser/meetings/edit_meeting.py:89
 #: ./opengever/meeting/browser/meetings/protocol.py:248
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py:422
 msgid "missing_ad_hoc_template"
 msgstr "Es konnte keine Vorlage für ein Ad Hoc Traktandum gefunden werden."
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:99
 msgid "msg_confirm_return_excerpt_dialog"
 msgstr "Der Protokollauszug wird an den Antragsteller bzw. ins Ursprungsdossier des Antrags zurückgesendet. Es können keine weiteren Protokollauszuge zurückgesendet werden."
 
@@ -1312,8 +1312,8 @@ msgid "msg_error_protocol_already_generated"
 msgstr "Das Protokoll für die Sitzung ${title} wurde schon erstellt."
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:82
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:81
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:83
 msgid "msg_hold_meeting_dialog"
 msgstr "Beim Abschluss dieses Traktandums wird die Sitzung in den Status `Durchgeführt`  versetzt. Anschliessend kann die Traktandenliste nicht mehr bearbeitet werden."
 
@@ -1378,16 +1378,16 @@ msgid "overview"
 msgstr "Übersicht"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:409
+#: ./opengever/meeting/browser/meetings/agendaitem.py:403
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:141
 msgid "participants"
 msgstr "Teilnehmende"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:36
+#: ./opengever/meeting/model/agendaitem.py:42
 #: ./opengever/meeting/model/meeting.py:75
 #: ./opengever/meeting/model/proposal.py:134
 msgid "pending"
@@ -1398,7 +1398,7 @@ msgstr "In Bearbeitung"
 msgid "periods"
 msgstr "Perioden"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:126
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:127
 msgid "presidency"
 msgstr "Vorsitz"
 
@@ -1494,22 +1494,22 @@ msgid "reject"
 msgstr "Zurückweisen"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:45
+#: ./opengever/meeting/model/agendaitem.py:51
 msgid "reopen"
 msgstr "Wieder eröffnen"
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:97
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
 msgid "return_excerpt"
 msgstr "Protokollauszug zurücksenden"
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:47
+#: ./opengever/meeting/model/agendaitem.py:53
 msgid "revise"
 msgstr "Überarbeiten"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:38
+#: ./opengever/meeting/model/agendaitem.py:44
 msgid "revision"
 msgstr "Überarbeitung"
 
@@ -1523,11 +1523,11 @@ msgstr "traktandieren"
 msgid "scheduled"
 msgstr "Traktandiert"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:133
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:134
 msgid "secretary"
 msgstr "Protokollführer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:105
 msgid "status"
 msgstr "Status"
 
@@ -1552,11 +1552,11 @@ msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:443
+#: ./opengever/meeting/browser/meetings/agendaitem.py:437
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:117
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:118
 msgid "time"
 msgstr "Zeit"
 
@@ -1571,82 +1571,82 @@ msgid "un-schedule"
 msgstr "Traktandum entfernen"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:285
 msgid "view_label_add"
 msgstr "Hinzufügen"
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:321
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:322
 msgid "view_label_add_section_header"
 msgstr "Zwischentitel einfügen:"
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:264
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:265
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:187
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:188
 msgid "view_label_agendaitem_list"
 msgstr "Traktandenliste:"
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:177
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:178
 msgid "view_label_dossier"
 msgstr "Sitzungsdossier:"
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:132
 msgid "view_label_meeting_end"
 msgstr "Sitzungsende:"
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:136
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:137
 msgid "view_label_meeting_location"
 msgstr "Ort:"
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:141
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:142
 msgid "view_label_meeting_number"
 msgstr "Sitzungsnummer:"
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:125
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:126
 msgid "view_label_meeting_start"
 msgstr "Beginn:"
 
 #. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:117
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:118
 msgid "view_label_meeting_status"
 msgstr "Status:"
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
 msgid "view_label_participants"
 msgstr "Teilnehmer:"
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:149
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:150
 msgid "view_label_presidency"
 msgstr "Vorsitz:"
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:221
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:222
 msgid "view_label_protocol"
 msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:306
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:307
 msgid "view_label_schedule_ad_hoc"
 msgstr "Ad Hoc Traktandum einfügen:"
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:292
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:156
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:157
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-19 07:09+0000\n"
+"POT-Creation-Date: 2017-09-21 09:43+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -23,8 +23,8 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:269
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:319
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:270
 msgid "Actions"
 msgstr "Actions"
 
@@ -64,7 +64,12 @@ msgstr "Ajouter la période"
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
+msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:273
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
@@ -72,7 +77,7 @@ msgstr "Points de l'ordre du jour"
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
 msgid "Agendaitem list"
 msgstr ""
 
@@ -81,17 +86,17 @@ msgstr ""
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:67
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:69
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:70
 msgid "Are you sure you want to close this meeting?"
 msgstr "Êtes-vous sûr de vouloir fermer cette réunion?"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:103
 msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:83
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:84
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:86
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr "Êtes-vous sûr de vouloir fixer ce point de l'ordre du jour?"
 
@@ -107,8 +112,8 @@ msgstr "Impossible de changer l'adhésion, parce qu'elle se chevauche avec une a
 msgid "Choose Agenda Items"
 msgstr "Choisir les points du l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:63
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:65
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
 msgid "Close all proposals."
 msgstr "Toutes les propositions sont clôturées."
 
@@ -138,16 +143,16 @@ msgstr "Écarter"
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
 msgid "Documents"
 msgstr "Documents"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:205
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:206
 msgid "Download agenda item list"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:99
 msgid "Edit"
 msgstr "Modifier"
 
@@ -172,7 +177,7 @@ msgstr "L'extrait du protocole de la réunion ${title} a été mis à jour avec 
 msgid "Excerpt template"
 msgstr "Modèle du protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:249
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:250
 msgid "Excerpts"
 msgstr "Extraits de protocole"
 
@@ -180,8 +185,8 @@ msgstr "Extraits de protocole"
 msgid "Export settings"
 msgstr "Paramètres de l'export"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
 msgid "Generate excerpts for all proposals."
 msgstr "Pour toutes les propositions un extrait de protocole sera généré et renvoyé au dossier de proposition."
 
@@ -233,7 +238,7 @@ msgstr "Répertoire d'archivage"
 msgid "Meeting Dossier"
 msgstr "Dossier de réunion"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:158
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:159
 msgid "Meeting number"
 msgstr "Numéro de la réunion"
 
@@ -249,20 +254,15 @@ msgstr "Informations concernant la réunion"
 msgid "Memberships"
 msgstr "Adhésions"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:315
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
 msgid "Number"
 msgstr "Numéro"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
-msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
-msgstr "La réunion et le protocole associé ne pourront plus être modifiés après clôture. Les actions suivantes seront exécutées lors de la clôture:"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:313
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:314
 msgid "Order"
 msgstr "Tri"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
 msgid "Paragraph:"
 msgstr "Paragraphe:"
 
@@ -287,11 +287,11 @@ msgstr "Proposition"
 msgid "Proposal Template"
 msgstr "Modèle de proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:297
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:298
 msgid "Proposals:"
 msgstr "Propositions"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:206
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
 #: ./opengever/meeting/model/meeting.py:265
 msgid "Protocol"
 msgstr "Protocole"
@@ -331,7 +331,7 @@ msgstr "Joint à l'ordre du jour avec succès"
 msgid "Show more"
 msgstr "Afficher plus"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:277
 msgid "Text:"
 msgstr "Texte libre:"
 
@@ -343,7 +343,7 @@ msgstr "La réunion et le dossier y associé ont été créés avec succès."
 msgid "The proposal has been rejected successfully"
 msgstr "La proposition a été rejetée avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
 msgid "Title"
 msgstr "Titre"
 
@@ -357,8 +357,8 @@ msgstr "Enlever de l'ordre du jour"
 msgid "Unschedule proposal"
 msgstr "Enlever un point de l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:68
 msgid "Update or create the protocol."
 msgstr "Le protocole est créé ou mis à jour."
 
@@ -382,57 +382,57 @@ msgid "active"
 msgstr "Actif"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:343
+#: ./opengever/meeting/browser/meetings/agendaitem.py:337
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:313
+#: ./opengever/meeting/browser/meetings/agendaitem.py:307
 msgid "agenda_item_decided"
 msgstr "Le point de l'ordre du jour a été fixé."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:289
+#: ./opengever/meeting/browser/meetings/agendaitem.py:283
 msgid "agenda_item_deleted"
 msgstr "Le point a été enlevé avec succès de l'ordre du jour."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:318
+#: ./opengever/meeting/browser/meetings/agendaitem.py:312
 msgid "agenda_item_meeting_held"
 msgstr "Le point de l'ordre du jour a été fixé et la réunion a eu lieu."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:248
+#: ./opengever/meeting/browser/meetings/agendaitem.py:242
 msgid "agenda_item_order_updated"
 msgstr "L'ordre des points de l'ordre du jour a été actualisé."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:310
+#: ./opengever/meeting/browser/meetings/agendaitem.py:304
 msgid "agenda_item_proposal_decided"
 msgstr "Le point de l'ordre du jour a été fixé, l'extrait de protocole a été généré et renvoyé."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:359
+#: ./opengever/meeting/browser/meetings/agendaitem.py:353
 msgid "agenda_item_reopened"
 msgstr "Le point d'ordre du jour a été rouvert."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:372
+#: ./opengever/meeting/browser/meetings/agendaitem.py:366
 msgid "agenda_item_revised"
 msgstr "Le point d'ordre du jour a été révisé avec succès."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:261
+#: ./opengever/meeting/browser/meetings/agendaitem.py:255
 msgid "agenda_item_update_empty_string"
 msgstr "Le titre d'un point d'ordre du jour ne peut pas être laissé vide."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:268
+#: ./opengever/meeting/browser/meetings/agendaitem.py:262
 msgid "agenda_item_update_too_long_title"
 msgstr "Le titre du point de l'ordre du jour est trop long."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:274
+#: ./opengever/meeting/browser/meetings/agendaitem.py:268
 msgid "agenda_item_updated"
 msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
 
@@ -572,20 +572,20 @@ msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:43
+#: ./opengever/meeting/model/agendaitem.py:49
 #: ./opengever/meeting/model/proposal.py:159
 msgid "decide"
 msgstr "Décider"
 
 #. Default: "Decide Agendaitem"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:79
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:81
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:82
 msgid "decide_agendaitem"
 msgstr "Décider d'un point de l'ordre du jour"
 
 #. Default: "Decided"
 #: ./opengever/meeting/browser/documents/proposalstab.py:68
-#: ./opengever/meeting/model/agendaitem.py:37
+#: ./opengever/meeting/model/agendaitem.py:43
 #: ./opengever/meeting/model/proposal.py:139
 msgid "decided"
 msgstr "Décidé"
@@ -596,7 +596,7 @@ msgid "description_group"
 msgstr "Pour ce groupe, les autorisations sont attribuées automatiquement au comité."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:388
+#: ./opengever/meeting/browser/meetings/agendaitem.py:382
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -605,18 +605,18 @@ msgstr ""
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:239
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:240
 msgid "download protocol"
 msgstr "Télécharger le protocole"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:399
 msgid "empty_paragraph"
 msgstr "Ce paragraphe ne doit pas rester vide."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:420
+#: ./opengever/meeting/browser/meetings/agendaitem.py:414
 msgid "empty_proposal"
 msgstr "Ce texte libre ne doit pas être vide."
 
@@ -626,7 +626,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:434
+#: ./opengever/meeting/browser/meetings/agendaitem.py:428
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -636,17 +636,17 @@ msgid "error_prosal_template_not_docx"
 msgstr "Seuls les fichiers Word (.docx) sont acceptés."
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/proposal.py:476
+#: ./opengever/meeting/model/agendaitem.py:425
 msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:472
+#: ./opengever/meeting/browser/meetings/agendaitem.py:464
 msgid "excerpt_generated"
 msgstr ""
 
 #. Default: "Excerpt was returned to proposer."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:492
+#: ./opengever/meeting/browser/meetings/agendaitem.py:484
 msgid "excerpt_returned"
 msgstr ""
 
@@ -660,22 +660,22 @@ msgstr "Table de matière ${period} ${committee} alphabétique"
 msgid "filename_repository_toc"
 msgstr "Table de matière ${period} ${committee} selon l'ordre des points"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:199
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:176
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
 msgid "generate new agenda item list as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:252
 msgid "generate new excerpt"
 msgstr "Générer un nouvel extrait de protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:233
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:234
 msgid "generate new protocol as word document"
 msgstr "Générer le protocole comme document Word"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:211
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:212
 msgid "generate new version as word document"
 msgstr "Générer une nouvelle version comme document Word"
 
@@ -820,8 +820,8 @@ msgid "label_deactivate"
 msgstr "Déactiver le comité"
 
 #. Default: "Decide"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:87
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:89
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:88
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:90
 msgid "label_decide"
 msgstr "Décider"
 
@@ -961,8 +961,8 @@ msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:295
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:300
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
 msgid "label_filter_proposal"
 msgstr "Filtrage"
 
@@ -989,8 +989,8 @@ msgid "label_initial_position"
 msgstr "Situation initiale"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:327
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
 msgid "label_insert"
 msgstr "Insérer"
 
@@ -1053,13 +1053,13 @@ msgid "label_next_meeting"
 msgstr "Prochaine réunion:"
 
 #. Default: "No agenda item list has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:189
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:197
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:190
 msgid "label_no_agendaitem_list"
 msgstr ""
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:256
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:257
 msgid "label_no_excerpts"
 msgstr "Aucun extrait de protocole supplémentaire n'a été généré encore."
 
@@ -1074,8 +1074,8 @@ msgid "label_no_proposals"
 msgstr "Aucune proposition n'a été soumise."
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:223
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:228
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:224
 msgid "label_no_protocol"
 msgstr "Aucun protocole n'a été généré encore."
 
@@ -1147,7 +1147,7 @@ msgid "label_return_action"
 msgstr ""
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:107
 msgid "label_return_excerpt"
 msgstr ""
 
@@ -1174,8 +1174,8 @@ msgstr "Fichier-modèle"
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/meeting.py:371
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:312
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:280
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
 msgid "label_schedule"
 msgstr "Mettre à l'ordre du jour"
 
@@ -1244,7 +1244,7 @@ msgstr "Prochaines réunions"
 msgid "label_workflow_state"
 msgstr "Etat"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:239
 msgid "label_zip_download"
 msgstr "Télécharger le fichier ZIP"
 
@@ -1253,11 +1253,11 @@ msgstr "Télécharger le fichier ZIP"
 msgid "language"
 msgstr "Langue"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:109
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:110
 msgid "location"
 msgstr "Lieu"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:150
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:151
 msgid "meetingdossier"
 msgstr "Dossier de la réunion"
 
@@ -1277,24 +1277,24 @@ msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:87
+#: ./opengever/meeting/browser/meetings/edit_meeting.py:94
 #: ./opengever/meeting/browser/meetings/protocol.py:254
 msgid "message_locked_by_another_user"
 msgstr "Les modifications n'ont pas pu être sauvegardées; le protocole a été verrouillé par ${username}."
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:82
+#: ./opengever/meeting/browser/meetings/edit_meeting.py:89
 #: ./opengever/meeting/browser/meetings/protocol.py:248
 msgid "message_write_conflict"
 msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été modifié entre-temps."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py:422
 msgid "missing_ad_hoc_template"
 msgstr ""
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:99
 msgid "msg_confirm_return_excerpt_dialog"
 msgstr ""
 
@@ -1314,8 +1314,8 @@ msgid "msg_error_protocol_already_generated"
 msgstr "Le protocole pour la réunion ${title} a déjà été créé."
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:82
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:81
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:83
 msgid "msg_hold_meeting_dialog"
 msgstr "Lors de la clôture de ce point de l'ordre du jour, la réunion sera mise dans l'état \"réalisé\". Ensuite, l'ordre du jour ne pourra plus être modifié."
 
@@ -1380,16 +1380,16 @@ msgid "overview"
 msgstr "Sommaire"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:409
+#: ./opengever/meeting/browser/meetings/agendaitem.py:403
 msgid "paragraph_added"
 msgstr "Paragraphe ajouté avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:141
 msgid "participants"
 msgstr "Participants"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:36
+#: ./opengever/meeting/model/agendaitem.py:42
 #: ./opengever/meeting/model/meeting.py:75
 #: ./opengever/meeting/model/proposal.py:134
 msgid "pending"
@@ -1400,7 +1400,7 @@ msgstr "En modification"
 msgid "periods"
 msgstr "Périodes"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:126
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:127
 msgid "presidency"
 msgstr "Présidence"
 
@@ -1496,22 +1496,22 @@ msgid "reject"
 msgstr "Rejeter"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:45
+#: ./opengever/meeting/model/agendaitem.py:51
 msgid "reopen"
 msgstr "Réactiver"
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:97
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
 msgid "return_excerpt"
 msgstr ""
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:47
+#: ./opengever/meeting/model/agendaitem.py:53
 msgid "revise"
 msgstr "Réviser"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:38
+#: ./opengever/meeting/model/agendaitem.py:44
 msgid "revision"
 msgstr "Révision"
 
@@ -1525,11 +1525,11 @@ msgstr "Mettre à l'ordre du jour"
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:133
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:134
 msgid "secretary"
 msgstr "Secrétaire"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:105
 msgid "status"
 msgstr "État"
 
@@ -1554,11 +1554,11 @@ msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:443
+#: ./opengever/meeting/browser/meetings/agendaitem.py:437
 msgid "text_added"
 msgstr "Texte libre ajouté avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:117
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:118
 msgid "time"
 msgstr "Temps"
 
@@ -1573,82 +1573,82 @@ msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:285
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:321
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:322
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:264
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:265
 msgid "view_label_agenda_items"
 msgstr ""
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:187
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:188
 msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:177
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:178
 msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:132
 msgid "view_label_meeting_end"
 msgstr ""
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:136
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:137
 msgid "view_label_meeting_location"
 msgstr ""
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:141
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:142
 msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:125
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:126
 msgid "view_label_meeting_start"
 msgstr ""
 
 #. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:117
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:118
 msgid "view_label_meeting_status"
 msgstr ""
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
 msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:149
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:150
 msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:221
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:222
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:306
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:307
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:292
 msgid "view_label_schedule_proposal"
 msgstr ""
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:156
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:157
 msgid "view_label_secretary"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-19 07:09+0000\n"
+"POT-Creation-Date: 2017-09-21 09:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,8 +21,8 @@ msgstr ""
 msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:269
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:319
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:270
 msgid "Actions"
 msgstr ""
 
@@ -61,7 +61,12 @@ msgstr ""
 msgid "Additional document ${title} has been submitted successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
+msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:273
 msgid "Agenda Items"
 msgstr ""
 
@@ -69,7 +74,7 @@ msgstr ""
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:174
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
 msgid "Agendaitem list"
 msgstr ""
 
@@ -78,17 +83,17 @@ msgstr ""
 msgid "An unexpected error has occurred"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:67
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:69
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:70
 msgid "Are you sure you want to close this meeting?"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:103
 msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:83
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:84
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:86
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr ""
 
@@ -104,8 +109,8 @@ msgstr ""
 msgid "Choose Agenda Items"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:63
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:65
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
 msgid "Close all proposals."
 msgstr ""
 
@@ -135,16 +140,16 @@ msgstr ""
 msgid "Document ${title} has already been submitted in that version."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
 msgid "Documents"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:181
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:205
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:206
 msgid "Download agenda item list"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:98
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:99
 msgid "Edit"
 msgstr ""
 
@@ -169,7 +174,7 @@ msgstr ""
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:249
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:250
 msgid "Excerpts"
 msgstr ""
 
@@ -177,8 +182,8 @@ msgstr ""
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
 msgid "Generate excerpts for all proposals."
 msgstr ""
 
@@ -230,7 +235,7 @@ msgstr ""
 msgid "Meeting Dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:158
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:159
 msgid "Meeting number"
 msgstr ""
 
@@ -246,20 +251,15 @@ msgstr ""
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:315
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
 msgid "Number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
-msgid "Once closed the meeting and its protocol cannot be edited any longer. The following tasks will be perfomed:"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:313
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:314
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:287
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
 msgid "Paragraph:"
 msgstr ""
 
@@ -284,11 +284,11 @@ msgstr ""
 msgid "Proposal Template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:297
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:298
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:206
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
 #: ./opengever/meeting/model/meeting.py:265
 msgid "Protocol"
 msgstr ""
@@ -328,7 +328,7 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:276
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:277
 msgid "Text:"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgstr ""
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
 msgid "Title"
 msgstr ""
 
@@ -354,8 +354,8 @@ msgstr ""
 msgid "Unschedule proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:68
 msgid "Update or create the protocol."
 msgstr ""
 
@@ -379,57 +379,57 @@ msgid "active"
 msgstr ""
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:343
+#: ./opengever/meeting/browser/meetings/agendaitem.py:337
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:313
+#: ./opengever/meeting/browser/meetings/agendaitem.py:307
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:289
+#: ./opengever/meeting/browser/meetings/agendaitem.py:283
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:318
+#: ./opengever/meeting/browser/meetings/agendaitem.py:312
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:248
+#: ./opengever/meeting/browser/meetings/agendaitem.py:242
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:310
+#: ./opengever/meeting/browser/meetings/agendaitem.py:304
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:359
+#: ./opengever/meeting/browser/meetings/agendaitem.py:353
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:372
+#: ./opengever/meeting/browser/meetings/agendaitem.py:366
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:261
+#: ./opengever/meeting/browser/meetings/agendaitem.py:255
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:268
+#: ./opengever/meeting/browser/meetings/agendaitem.py:262
 msgid "agenda_item_update_too_long_title"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:274
+#: ./opengever/meeting/browser/meetings/agendaitem.py:268
 msgid "agenda_item_updated"
 msgstr ""
 
@@ -569,20 +569,20 @@ msgid "column_to"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:43
+#: ./opengever/meeting/model/agendaitem.py:49
 #: ./opengever/meeting/model/proposal.py:159
 msgid "decide"
 msgstr ""
 
 #. Default: "Decide Agendaitem"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:79
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:81
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:82
 msgid "decide_agendaitem"
 msgstr ""
 
 #. Default: "Decided"
 #: ./opengever/meeting/browser/documents/proposalstab.py:68
-#: ./opengever/meeting/model/agendaitem.py:37
+#: ./opengever/meeting/model/agendaitem.py:43
 #: ./opengever/meeting/model/proposal.py:139
 msgid "decided"
 msgstr ""
@@ -593,7 +593,7 @@ msgid "description_group"
 msgstr ""
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:388
+#: ./opengever/meeting/browser/meetings/agendaitem.py:382
 msgid "document_checkout_not_allowed"
 msgstr ""
 
@@ -602,18 +602,18 @@ msgstr ""
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:213
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:239
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:214
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:240
 msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:405
+#: ./opengever/meeting/browser/meetings/agendaitem.py:399
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:420
+#: ./opengever/meeting/browser/meetings/agendaitem.py:414
 msgid "empty_proposal"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgid "error_must_checkin_documents_for_transition"
 msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:434
+#: ./opengever/meeting/browser/meetings/agendaitem.py:428
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
@@ -633,17 +633,17 @@ msgid "error_prosal_template_not_docx"
 msgstr ""
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/proposal.py:476
+#: ./opengever/meeting/model/agendaitem.py:425
 msgid "excerpt_document_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:472
+#: ./opengever/meeting/browser/meetings/agendaitem.py:464
 msgid "excerpt_generated"
 msgstr ""
 
 #. Default: "Excerpt was returned to proposer."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:492
+#: ./opengever/meeting/browser/meetings/agendaitem.py:484
 msgid "excerpt_returned"
 msgstr ""
 
@@ -657,22 +657,22 @@ msgstr ""
 msgid "filename_repository_toc"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:199
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:176
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
 msgid "generate new agenda item list as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:251
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:252
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:233
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:208
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:234
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:187
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:211
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:212
 msgid "generate new version as word document"
 msgstr ""
 
@@ -817,8 +817,8 @@ msgid "label_deactivate"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:87
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:89
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:88
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:90
 msgid "label_decide"
 msgstr ""
 
@@ -958,8 +958,8 @@ msgid "label_file"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:299
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:295
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:300
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:296
 msgid "label_filter_proposal"
 msgstr ""
 
@@ -986,8 +986,8 @@ msgid "label_initial_position"
 msgstr ""
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:290
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:327
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:328
 msgid "label_insert"
 msgstr ""
 
@@ -1050,13 +1050,13 @@ msgid "label_next_meeting"
 msgstr ""
 
 #. Default: "No agenda item list has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:196
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:189
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:197
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:190
 msgid "label_no_agendaitem_list"
 msgstr ""
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:256
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:257
 msgid "label_no_excerpts"
 msgstr ""
 
@@ -1071,8 +1071,8 @@ msgid "label_no_proposals"
 msgstr ""
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:227
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:223
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:228
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:224
 msgid "label_no_protocol"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgid "label_return_action"
 msgstr ""
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:107
 msgid "label_return_excerpt"
 msgstr ""
 
@@ -1171,8 +1171,8 @@ msgstr ""
 
 #. Default: "Schedule"
 #: ./opengever/meeting/browser/meetings/meeting.py:371
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:279
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:312
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:280
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:313
 msgid "label_schedule"
 msgstr ""
 
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "label_workflow_state"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:238
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:239
 msgid "label_zip_download"
 msgstr ""
 
@@ -1250,11 +1250,11 @@ msgstr ""
 msgid "language"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:109
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:110
 msgid "location"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:150
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:151
 msgid "meetingdossier"
 msgstr ""
 
@@ -1274,24 +1274,24 @@ msgid "message_changes_saved"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:87
+#: ./opengever/meeting/browser/meetings/edit_meeting.py:94
 #: ./opengever/meeting/browser/meetings/protocol.py:254
 msgid "message_locked_by_another_user"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:82
+#: ./opengever/meeting/browser/meetings/edit_meeting.py:89
 #: ./opengever/meeting/browser/meetings/protocol.py:248
 msgid "message_write_conflict"
 msgstr ""
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py:422
 msgid "missing_ad_hoc_template"
 msgstr ""
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:99
 msgid "msg_confirm_return_excerpt_dialog"
 msgstr ""
 
@@ -1311,8 +1311,8 @@ msgid "msg_error_protocol_already_generated"
 msgstr ""
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:82
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:81
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:83
 msgid "msg_hold_meeting_dialog"
 msgstr ""
 
@@ -1377,16 +1377,16 @@ msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:409
+#: ./opengever/meeting/browser/meetings/agendaitem.py:403
 msgid "paragraph_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:141
 msgid "participants"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:36
+#: ./opengever/meeting/model/agendaitem.py:42
 #: ./opengever/meeting/model/meeting.py:75
 #: ./opengever/meeting/model/proposal.py:134
 msgid "pending"
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "periods"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:126
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:127
 msgid "presidency"
 msgstr ""
 
@@ -1493,22 +1493,22 @@ msgid "reject"
 msgstr ""
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:45
+#: ./opengever/meeting/model/agendaitem.py:51
 msgid "reopen"
 msgstr ""
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:97
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:98
 msgid "return_excerpt"
 msgstr ""
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:47
+#: ./opengever/meeting/model/agendaitem.py:53
 msgid "revise"
 msgstr ""
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:38
+#: ./opengever/meeting/model/agendaitem.py:44
 msgid "revision"
 msgstr ""
 
@@ -1522,11 +1522,11 @@ msgstr ""
 msgid "scheduled"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:133
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:134
 msgid "secretary"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:104
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:105
 msgid "status"
 msgstr ""
 
@@ -1551,11 +1551,11 @@ msgid "tab_matches"
 msgstr ""
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:443
+#: ./opengever/meeting/browser/meetings/agendaitem.py:437
 msgid "text_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:117
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:118
 msgid "time"
 msgstr ""
 
@@ -1570,82 +1570,82 @@ msgid "un-schedule"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:284
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:285
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:321
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:322
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:264
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:265
 msgid "view_label_agenda_items"
 msgstr ""
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:187
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:188
 msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:177
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:178
 msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:131
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:132
 msgid "view_label_meeting_end"
 msgstr ""
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:136
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:137
 msgid "view_label_meeting_location"
 msgstr ""
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:141
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:142
 msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:125
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:126
 msgid "view_label_meeting_start"
 msgstr ""
 
 #. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:117
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:118
 msgid "view_label_meeting_status"
 msgstr ""
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:163
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:164
 msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:149
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:150
 msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:221
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:222
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:306
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:307
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:291
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:292
 msgid "view_label_schedule_proposal"
 msgstr ""
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:156
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:157
 msgid "view_label_secretary"
 msgstr ""
 


### PR DESCRIPTION
At any point in the process, the committee responsible must be able to go back so that all documents can be edited.

![bildschirmfoto 2017-09-21 um 10 32 38](https://user-images.githubusercontent.com/7469/30686339-4150902a-9eb8-11e7-95bd-e4c0a300e6ff.png)
![bildschirmfoto 2017-09-21 um 10 07 47](https://user-images.githubusercontent.com/7469/30686340-41551c30-9eb8-11e7-9786-3bb079d1b3af.png)

This is changed in both, the old meeting implementation and the new word implementation.