### PR TITLE
SPV word: let meeting be reopened.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 - SPV word: Prefix decision numbers with year. [jone]
 - SPV: Fix dialog text when closing a meeting. [jone]
 - Fix caching problems in JSON responses with IE 11. [jone]
+- SPV word: Add workflow transition for reopening meetings. [jone]
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -288,6 +288,20 @@ class MeetingView(BrowserView):
         if self.has_protocol_document:
             return self.model.protocol_document.get_download_url()
 
+    def will_closing_regenerate_protocol(self):
+        """This method can tell whether we will regenerate the protocol when
+        closing the meething.
+
+        The protocol will be generated while it is locked or not yet existing.
+        When the user reopens the meeting the document will be left unlocked
+        because the user may have made changes at this point.
+        The protocol is no longer regenerated automatically when it
+        may have been changed.
+        """
+        if not self.has_protocol_document():
+            return True
+        return self.model.protocol_document.is_locked()
+
     def url_download_agendaitem_list(self):
         if self.has_agendaitem_list_document:
             return self.model.agendaitem_list_document.get_download_url()

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -65,7 +65,10 @@
           <ul>
             <li i18n:translate="">Close all proposals.</li>
             <li i18n:translate="">Generate excerpts for all proposals.</li>
-            <li i18n:translate="">Update or create the protocol.</li>
+            <li i18n:translate=""
+                tal:condition="view/will_closing_regenerate_protocol">
+              Update or create the protocol.
+            </li>
           </ul>
           <p i18n:translate="">
             Are you sure you want to close this meeting?

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -20,11 +20,20 @@
     };
 
     this.closeMeeting = function() {
-      return $.post(self.currentItem.attr("href"))
-              .done(function() { location.reload(); });
+      return $.post(self.currentItem.attr("href")).done(function() {
+        location.reload();
+      });
     };
 
     this.closeModal = function() { dialog.close(); };
+
+    this.reopenMeeting = function(target) {
+      return $.post(target.attr("href")).done(function(data) {
+        if (data.redirectUrl){
+          window.location = data.redirectUrl;
+        }
+      });
+    };
 
     this.events = [
       {
@@ -39,6 +48,14 @@
         method: "click",
         target: "#held-closed",
         callback: this.openModal,
+        options: {
+          update: true
+        }
+      },
+      {
+        method: "click",
+        target: "#closed-held",
+        callback: this.reopenMeeting,
         options: {
           update: true
         }

--- a/opengever/meeting/model/generateddocument.py
+++ b/opengever/meeting/model/generateddocument.py
@@ -52,6 +52,10 @@ class GeneratedDocument(Base):
         lockable.unlock(SYS_LOCK)
         assert not lockable.locked(), 'unexpected: could not remove lock'
 
+    def is_locked(self):
+        document = self.resolve_document()
+        return ILockable(document).locked()
+
     def get_download_url(self):
         return '{}/download'.format(self.resolve_document().absolute_url())
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -186,11 +186,17 @@ class Meeting(Base, SQLFormSupport):
         from opengever.meeting.command import ProtocolOperations
         from opengever.meeting.command import UpdateGeneratedDocumentCommand
 
+        if self.has_protocol_document() and not self.protocol_document.is_locked():
+            # The protocol should never be changed when it is no longer locked:
+            # the user probably has made changes manually.
+            return
+
         operations = ProtocolOperations()
 
         if is_word_meeting_implementation_enabled():
             command = MergeDocxProtocolCommand(
-                self.get_dossier(), self, operations)
+                self.get_dossier(), self, operations,
+                lock_document_after_creation=True)
         else:
             if self.has_protocol_document():
                 command = UpdateGeneratedDocumentCommand(

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -85,7 +85,8 @@ class Meeting(Base, SQLFormSupport):
                     title=_('hold', default='Hold meeting'), visible=False),
          CloseTransition(
              'held', 'closed',
-             title=_('close_meeting', default='Close meeting'))],
+             title=_('close_meeting', default='Close meeting')),
+         Transition('closed', 'held', title=_('reopen', default='Reopen'))],
         show_in_actions_menu=True,
         transition_controller=MeetingTransitionController,
     )

--- a/opengever/meeting/tests/test_meeting_word.py
+++ b/opengever/meeting/tests/test_meeting_word.py
@@ -47,3 +47,11 @@ class TestWordMeeting(IntegrationTestCase):
         self.login(self.manager, browser)
         browser.open(self.committee)
         self.assertNotIn(ZIP_EXPORT_ACTION_LABEL, editbar.menu_options('Actions'))
+
+    @browsing
+    def test_reopen_closed_meeting(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.assertEquals(u'closed', self.decided_meeting.model.workflow_state)
+        browser.open(self.decided_meeting)
+        editbar.menu_option('Actions', 'Reopen').click()
+        self.assertEquals(u'held', self.decided_meeting.model.workflow_state)

--- a/opengever/meeting/tests/test_meeting_word.py
+++ b/opengever/meeting/tests/test_meeting_word.py
@@ -55,3 +55,49 @@ class TestWordMeeting(IntegrationTestCase):
         browser.open(self.decided_meeting)
         editbar.menu_option('Actions', 'Reopen').click()
         self.assertEquals(u'held', self.decided_meeting.model.workflow_state)
+
+    @browsing
+    def test_closing_meeting_the_first_time_regenerates_the_protocol(self, browser):
+        self.login(self.committee_responsible, browser)
+        model = self.meeting.model
+        # Make sure there is already a protocol generated:
+        model.update_protocol_document()
+        self.assertEquals(0, model.protocol_document.generated_version)
+
+        # When closing the meeting, we should end up with a new version
+        browser.open(self.meeting)
+        self.assertEquals(
+            [
+                'Close all proposals.',
+                'Generate excerpts for all proposals.',
+                'Update or create the protocol.',
+            ],
+            browser.css('#confirm_close_meeting > ul > li').text)
+        model.close()
+        self.assertEquals(1, model.protocol_document.generated_version)
+
+    @browsing
+    def test_re_closing_meeting_regenerates_the_protocol(self, browser):
+        self.login(self.committee_responsible, browser)
+        model = self.meeting.model
+        # Closing the meeting generates and unlocks the protocol:
+        model.close()
+        self.assertEquals(0, model.protocol_document.generated_version)
+
+        # The user may have made changes to the protocol now.
+        # Reopen the protocol:
+        model.execute_transition('closed-held')
+        self.assertEquals(0, model.protocol_document.generated_version)
+
+        # Re-closing the meeting must not regenerate the protocol because
+        # it would potentially overwrite user-changes.
+        browser.open(self.meeting)
+        self.assertEquals(
+            [
+                'Close all proposals.',
+                'Generate excerpts for all proposals.',
+                # 'Update or create the protocol.',
+            ],
+            browser.css('#confirm_close_meeting > ul > li').text)
+        model.close()
+        self.assertEquals(0, model.protocol_document.generated_version)


### PR DESCRIPTION
**Background:**
Users make errors. Therefore a secretary of a committee / meeting should always be able to fix typos and errors in documents.

**Requirement:**
In order to be able to fix problems in documents, a user must be able to reopen an already closed meeting. A new "reopen" workflow transition of the meeting workflow allows to do so.

**Problems:**
When _closing_ a meeting, it overrides the protocol and removes the lock, allowing the user to edit the document.
By adding a "reopen" transition we create the problem that a user may have made changes to the generated protocol, but by reopening and closing again the protocol would have been overwritten.
This is addressed by 
1. not overriding protocols which are no longer locked
2. not removing the lock when reopening the meeting.

**Screenshots:**
![bildschirmfoto 2017-09-21 um 10 06 46](https://user-images.githubusercontent.com/7469/30691057-b865ea94-9ec6-11e7-9a10-491cfccb5c5f.png)
![bildschirmfoto 2017-09-21 um 12 07 27](https://user-images.githubusercontent.com/7469/30691058-b8f40c02-9ec6-11e7-95ce-8130f99842a2.png)
![bildschirmfoto 2017-09-21 um 12 07 35](https://user-images.githubusercontent.com/7469/30691060-b9efcdd0-9ec6-11e7-90c1-c3e0842d0025.png)

Request: https://github.com/4teamwork/gever/issues/97