### PR TITLE
Fix caching problems in JSON responses with IE 11.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - SPV word: Add proposal documents to meeting ZIP export. [jone]
 - SPV word: Prefix decision numbers with year. [jone]
 - SPV: Fix dialog text when closing a meeting. [jone]
+- Fix caching problems in JSON responses with IE 11. [jone]
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]
 - SPV word: Move ZIP-export action to actions menu. [jone]

--- a/opengever/base/response.py
+++ b/opengever/base/response.py
@@ -76,6 +76,19 @@ class JSONResponse(object):
         self.response['proceed'] = False
         return self
 
-    def dump(self):
+    def dump(self, no_cache=True):
+        """Return a JSON string for use as response, set response headers.
+
+        The dump method sets the response headers.
+        It expects that excatly this payload is returned in the response.
+        By default, no-caching headers are set on the response.
+        This can be disabled by setting ``no_cache`` to ``False``.
+        """
+
+        if no_cache:
+            self.request.response.setHeader("Cache-Control", "no-store")
+            self.request.response.setHeader("Pragma", "no-cache")
+            self.request.response.setHeader("Expires", "0")
+
         self.request.response.setHeader("Content-type", "application/json")
         return json.dumps(self.response)

--- a/opengever/base/tests/test_json_response.py
+++ b/opengever/base/tests/test_json_response.py
@@ -98,3 +98,21 @@ class TestUnitJSONResponse(FunctionalTestCase):
              'name': 'peter',
              'proceed': True}
         ))
+
+    def test_dump_disables_caching_by_default(self):
+        # By default we disable chaing of all responses.
+        # This is especially important for IE 11 support.
+        self.response.remain().dump()
+        self.assertEquals(
+            {'content-type': 'application/json',
+             'cache-control': 'no-store',
+             'pragma': 'no-cache',
+             'expires': '0'},
+            self.request.response.headers)
+
+    def test_dump_without_disabling_caches(self):
+        # Dump can optionally be told to not send no-caching headers.
+        self.response.remain().dump(no_cache=False)
+        self.assertEquals(
+            {'content-type': 'application/json'},
+            self.request.response.headers)


### PR DESCRIPTION
The JSONResponse component is used for generating standardized JSON responses of read-only (GET) as well as writing (POST) requests.

The responses were not equipped with caching headers (such as cache-control). If a response does not have a cache-control header, some browsers, such as IE 11, may cache the response, at least of GET requests.

This component is primarely used for AJAX requests. We usually want to avoid caching AJAX responses as their content may change over time.
We especially do not want to let the browser be in control of cache invalidation.

Therefore we use no-cache headers on all AJAX responses by default.

Implementation details:
- `Cache-Control: no-store`: Neither browser nor intermediate components are allowed to keep a copy in the cache.
- `Pragma: no-cache`: No-cache command for older browser / proxies.
- `Expires: 0`: Indicates that the content has already expired and may have changed.

Bug-Report: https://github.com/4teamwork/gever/issues/61