### PR TITLE
Lawgiver: Ignore ftw.usermigration permission:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Lawgiver: Ignore ftw.usermigration permission. [lgraf]
 - SPV word: Add proposal documents to meeting ZIP export. [jone]
 - SPV word: Move workflow transitions to actions menu in meeting view. [jone]
 - SPV word: Move meeting status in meeting view. [jone]

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -158,6 +158,13 @@
                    "
       />
 
+  <!--  "ftw.usermigration: Migrate users" is never managed via workflows -->
+  <lawgiver:ignore
+      permissions="
+                   ftw.usermigration: Migrate users,
+                   "
+      />
+
 
   <!-- Ignore default Plone permissions. This means we are not managing in the
        workflows. This does not mean that the permissions are disabled: disabling


### PR DESCRIPTION
Lawgiver: Ignore `ftw.usermigration` permission: This is required as preparation for including `ftw.usermigration` in `opengever.core`.

This is done as a separate commit to ease backporting, because in the version that the usermigration stuff will be backported to, lawgiver isn't part of `opengever.core` yet. On the other hand, it's required in `opengever.core:master` so that tests will pass for the usermigration-PR.