### PR TITLE
OGDS update: Truncate purely descriptive user fields:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- OGDS update: Truncate purely descriptive user fields. [lgraf]
 - Include ftw.usermigration and implement additional user migrations:
 
   - OGDS User references

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -11,6 +11,7 @@ from opengever.ogds.models.group import Group
 from opengever.ogds.models.user import User
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.LDAPMultiPlugins.interfaces import ILDAPMultiPlugin
+from sqlalchemy import String
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound
 from zope.component import adapter
@@ -201,6 +202,14 @@ class OGDSUpdater(object):
 
                     if isinstance(value, str):
                         value = value.decode('utf-8')
+
+                    # Truncate purely descriptive user fields if necessary
+                    if isinstance(col.type, String):
+                        if value and len(value) > col.type.length:
+                            logger.warn(
+                                u"Truncating value %r for column %r "
+                                u"(user: %r)" % (value, col.name, userid))
+                            value = value[:col.type.length]
 
                     setattr(user, col.name, value)
 


### PR DESCRIPTION
We do this because PostgreSQL is strict about string column lengths, and we simply can't control the information that's being passed to us from an external AD or LDAP.

So if any field value is longer than it's corresponding column's length, it will be truncated to the column length before it gets written to SQL.

Needs backport to `4.15-stable` branch.