### PR TITLE
Document releases with missing backports.

### DIFF
--- a/docs/intern/index.rst
+++ b/docs/intern/index.rst
@@ -12,6 +12,7 @@ Inhalt:
    development/index.rst
    releasemanagement/index.rst
    operations/index.rst
+   notizen.rst
    meta.rst
    oggbundle/index.rst
 

--- a/docs/intern/notizen.rst
+++ b/docs/intern/notizen.rst
@@ -1,0 +1,14 @@
+Notizen
+=======
+
+Releases mit fehlenden Backports
+--------------------------------
+
+Auf folgende Releases wurden nicht alle PRs backported, welche z.T. auf
+frühere Releases aber backported wurden. Diese Releases dürfen daher nicht
+eingespielt werden:
+
+- 2017.1.x
+- 2017.2.x
+- 2017.3.x
+- 2017.4.x


### PR DESCRIPTION
Includes a list of releases with missing backports in the `intern.onegovgever.ch` docs.