### PR TITLE
Introduce teams as a new task responsible. 

### DIFF
--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -1,6 +1,7 @@
 from opengever.base.model import Base
+from opengever.ogds.base.actor import Actor
+from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.models import USER_ID_LENGTH
-from opengever.ogds.models.service import OGDSService
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
@@ -28,12 +29,9 @@ class Watcher(Base):
         Means for a single user, a list with the user_id and for a inbox watcher,
         a list of the userids of all inbox_group users.
         """
-        # XXX Use opengever.ogds.models.actor instead of own actor differentiation.
-        ogds_service = OGDSService(self.session)
-        if self.actorid.startswith('inbox:'):
-            org_unit_id = self.actorid.split(':', 1)[1]
-            org_unit = ogds_service.fetch_org_unit(org_unit_id)
-            return [user.userid for user in org_unit.inbox_group.users]
+        actor_lookup = ActorLookup(self.actorid)
+        if actor_lookup.is_inbox() or actor_lookup.is_team():
+            return [user.userid for user in
+                    Actor.lookup(self.actorid).representatives()]
 
-        else:
-            return [self.actorid]
+        return [self.actorid]

--- a/opengever/core/upgrades/20170907161431_add_team_model/upgrade.py
+++ b/opengever/core/upgrades/20170907161431_add_team_model/upgrade.py
@@ -1,0 +1,31 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import Boolean
+from sqlalchemy import String
+from sqlalchemy.schema import Sequence
+
+
+GROUP_ID_LENGTH = 255
+UNIT_ID_LENGTH = 30
+UNIT_TITLE_LENGTH = 255
+
+
+class AddTeamModel(SchemaMigration):
+    """Add team model.
+    """
+
+    def migrate(self):
+        self.add_team_table()
+
+    def add_team_table(self):
+        self.op.create_table(
+            'teams',
+            Column('id', Integer, Sequence('teams_id_seq'), primary_key=True),
+            Column('title', String(UNIT_TITLE_LENGTH), nullable=False),
+            Column('active', Boolean, default=True),
+            Column('groupid', String(GROUP_ID_LENGTH),
+                   ForeignKey('groups.groupid'), nullable=False),
+            Column('org_unit_id', String(UNIT_ID_LENGTH),
+                   ForeignKey('org_units.unit_id'), nullable=False))

--- a/opengever/inbox/browser/assign.py
+++ b/opengever/inbox/browser/assign.py
@@ -2,7 +2,7 @@ from five import grok
 from ftw.keywordwidget.widget import KeywordWidget
 from opengever.inbox import _
 from opengever.inbox.forwarding import IForwarding
-from opengever.ogds.base.sources import AllUsersAndInboxesSourceBinder
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.task import _ as task_mf
 from opengever.task.browser.assign import AssignTaskForm
 from opengever.task.browser.assign import IAssignSchema
@@ -20,7 +20,7 @@ class IForwardingAssignSchema(IAssignSchema):
     responsible = schema.Choice(
         title=task_mf(u"label_responsible", default=u"Responsible"),
         description=task_mf(u"help_responsible", default=""),
-        source=AllUsersAndInboxesSourceBinder(),
+        source=AllUsersInboxesAndTeamsSourceBinder(),
         required=True,
         )
 

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -4,7 +4,7 @@ from five import grok
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.inbox import _
 from opengever.inbox.activities import ForwardingAddedActivity
-from opengever.ogds.base.sources import AllUsersAndInboxesSourceBinder
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import get_ou_selector
 from opengever.task import _ as task_mf
@@ -57,7 +57,7 @@ class IForwarding(ITask):
     responsible = schema.Choice(
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible", default=""),
-        source=AllUsersAndInboxesSourceBinder(
+        source=AllUsersInboxesAndTeamsSourceBinder(
             only_current_orgunit=True),
         required=True,
     )

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -54,4 +54,12 @@
       template="templates/userdetails.pt"
       />
 
+  <browser:page
+      for="*"
+      name="team-details"
+      class=".teamdetails.TeamDetails"
+      permission="zope2.View"
+      template="templates/teamdetails.pt"
+      />
+
 </configure>

--- a/opengever/ogds/base/browser/teamdetails.py
+++ b/opengever/ogds/base/browser/teamdetails.py
@@ -1,0 +1,35 @@
+from opengever.ogds.base.actor import Actor
+from opengever.ogds.models.team import Team
+from Products.Five import BrowserView
+from zExceptions import NotFound
+from zope.component.hooks import getSite
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class TeamDetails(BrowserView):
+    """Displays infos about a team.
+    """
+
+    @classmethod
+    def url_for(cls, team_id):
+        portal = getSite()
+        return '/'.join((portal.portal_url(), '@@team-details', str(team_id)))
+
+    def get_team(self):
+        team = Team.get(int(self.team_id))
+        if not team:
+            raise NotFound
+
+        return team
+
+    def get_team_members(self):
+        return [Actor.user(user.userid)
+                for user in self.get_team().group.users]
+
+    def publishTraverse(self, request, name):  # noqa
+        """The name is the teamid of the team who should be displayed.
+        """
+        self.team_id = name
+        return self

--- a/opengever/ogds/base/browser/templates/teamdetails.pt
+++ b/opengever/ogds/base/browser/templates/teamdetails.pt
@@ -1,0 +1,49 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="opengever.ogds.base">
+
+  <body>
+    <metal:main fill-slot="main">
+      <tal:main-macro metal:define-macro="main"
+                      tal:define="team view/get_team">
+
+        <div tal:replace="structure provider:plone.abovecontenttitle" />
+        <h1 class="documentFirstHeading" tal:content="team/title"/>
+        <div tal:replace="structure provider:plone.belowcontenttitle" />
+
+        <div tal:replace="structure provider:plone.abovecontentbody" />
+
+        <table class="vertical listing">
+          <tr>
+            <th i18n:translate="label_assigned_orgunit">Assigned org unit</th>
+            <td tal:content="team/org_unit/title" />
+          </tr>
+
+          <tr>
+            <th i18n:translate="label_group">Group</th>
+            <td class="group" tal:content="team/group/title" />
+          </tr>
+
+          <tr>
+            <th i18n:translate="label_members">Members</th>
+            <td>
+              <ul class="members">
+                <li tal:repeat="member view/get_team_members ">
+                  <a tal:replace="structure member/get_link" />
+                </li>
+              </ul>
+            </td>
+          </tr>
+
+        </table>
+
+        <div tal:replace="structure provider:plone.belowcontentbody" />
+      </tal:main-macro>
+    </metal:main>
+
+  </body>
+</html>

--- a/opengever/ogds/base/browser/templates/userdetails.pt
+++ b/opengever/ogds/base/browser/templates/userdetails.pt
@@ -11,7 +11,8 @@
       <tal:main-macro metal:define-macro="main"
                       tal:define="data view/get_userdata;
                                   user data/user;
-                                  groups data/groups">
+                                  groups data/groups;
+                                  teams data/teams">
 
         <div tal:replace="structure provider:plone.abovecontenttitle" />
         <h1 class="documentFirstHeading" tal:content="user/label"/>
@@ -122,6 +123,20 @@
                   </ul>
               </td>
           </tr>
+
+          <tr tal:condition="python:len(teams) > 0">
+              <th i18n:translate="label_teams">Teams</th>
+              <td>
+                  <ul class="teams">
+                      <li tal:repeat="team teams">
+                        <a class="team"
+                           tal:attributes="href string:${portal_url}/@@team-details/${team/team_id}"
+                           tal:content="team/title"></a>
+                      </li>
+                  </ul>
+              </td>
+          </tr>
+
         </table>
 
         <div tal:replace="structure provider:plone.belowcontentbody" />

--- a/opengever/ogds/base/browser/templates/userdetails.pt
+++ b/opengever/ogds/base/browser/templates/userdetails.pt
@@ -26,28 +26,28 @@
 
         <table class="vertical listing">
           <tr>
-            <th i18n:translate="label_fullname">Name:</th>
+            <th i18n:translate="label_fullname">Name</th>
             <td tal:content="user/label"></td>
           </tr>
 
           <tr>
-            <th i18n:translate="label_active">Active:</th>
+            <th i18n:translate="label_active">Active</th>
             <td i18n:translate="active_yes" tal:condition="user/active">Yes</td>
             <td i18n:translate="active_no" tal:condition="not:user/active">No</td>
           </tr>
 
           <tr tal:condition="user/salutation">
-            <th i18n:translate="label_salutation">Salutation:</th>
+            <th i18n:translate="label_salutation">Salutation</th>
             <td tal:content="user/salutation"></td>
           </tr>
 
           <tr tal:condition="user/description">
-            <th i18n:translate="label_description">Description:</th>
+            <th i18n:translate="label_description">Description</th>
             <td tal:content="user/description"></td>
           </tr>
 
           <tr tal:condition="user/directorate">
-            <th i18n:translate="label_directorate">Directorate:</th>
+            <th i18n:translate="label_directorate">Directorate</th>
             <td>
               <tal:title tal:replace="user/directorate" />
               <span class="discreet">
@@ -57,7 +57,7 @@
           </tr>
 
           <tr tal:condition="user/department">
-            <th i18n:translate="label_department">Department:</th>
+            <th i18n:translate="label_department">Department</th>
             <td>
               <tal:title tal:replace="user/department" />
               <span class="discreet">
@@ -67,41 +67,41 @@
           </tr>
 
           <tr tal:condition="user/email">
-            <th i18n:translate="label_email">Email:</th>
+            <th i18n:translate="label_email">Email</th>
             <td><a tal:content="user/email"
                    tal:attributes="href string:mailto:${user/email}" /></td>
           </tr>
 
           <tr tal:condition="user/email2">
-            <th i18n:translate="label_email2">Email 2:</th>
+            <th i18n:translate="label_email2">Email 2</th>
             <td><a tal:content="user/email2"
                    tal:attributes="href string:mailto:${user/email2}" /></td>
           </tr>
 
           <tr tal:condition="user/url">
-            <th i18n:translate="label_url">URL:</th>
+            <th i18n:translate="label_url">URL</th>
             <td><a tal:content="user/url"
                    tal:attributes="href user/url"
                    target="_blank" /></td>
           </tr>
 
           <tr tal:condition="user/phone_office">
-            <th i18n:translate="label_phone_office">Office phone:</th>
+            <th i18n:translate="label_phone_office">Office phone</th>
             <td tal:content="user/phone_office"></td>
           </tr>
 
           <tr tal:condition="user/phone_fax">
-            <th i18n:translate="label_phone_fax">Fax:</th>
+            <th i18n:translate="label_phone_fax">Fax</th>
             <td tal:content="user/phone_fax"></td>
           </tr>
 
           <tr tal:condition="user/phone_mobile">
-            <th i18n:translate="label_phone_mobile">Mobile phone:</th>
+            <th i18n:translate="label_phone_mobile">Mobile phone</th>
             <td tal:content="user/phone_mobile"></td>
           </tr>
 
           <tr tal:condition="python:user.address1 or user.address2 or user.zip_code or user.city or user.country">
-            <th i18n:translate="label_address">Address:</th>
+            <th i18n:translate="label_address">Address</th>
             <td>
               <div tal:content="user/address1" tal:condition="user/address1" />
               <div tal:content="user/address2" tal:condition="user/address2" />
@@ -114,7 +114,7 @@
           </tr>
 
           <tr tal:condition="python:len(groups) > 0">
-              <th i18n:translate="label_groups">Groups:</th>
+              <th i18n:translate="label_groups">Groups</th>
               <td>
                   <ul class="groups">
                       <li tal:repeat="group groups">

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -26,8 +26,11 @@ class UserDetails(BrowserView):
         except RecordNotFound:
             raise NotFound
 
-        return {'user': user,
-                'groups': user.groups}
+        teams = []
+        for group in user.groups:
+            teams += group.teams
+
+        return {'user': user, 'groups': user.groups, 'teams': teams}
 
     def publishTraverse(self, request, name):  # noqa
         """The name is the userid of the user who should be displayed.

--- a/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-09-26 11:49+0000\n"
+"POT-Creation-Date: 2017-09-26 11:54+0000\n"
 "PO-Revision-Date: 2016-07-22 16:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/de/>\n"
@@ -36,12 +36,12 @@ msgstr "Ja"
 msgid "inbox_label"
 msgstr "Eingangskorb: ${client}"
 
-#. Default: "Active:"
+#. Default: "Active"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:34
 msgid "label_active"
 msgstr "Aktiv"
 
-#. Default: "Address:"
+#. Default: "Address"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:104
 msgid "label_address"
 msgstr "Adresse"
@@ -51,32 +51,32 @@ msgstr "Adresse"
 msgid "label_assigned_orgunit"
 msgstr "Zugehörige Organisationseinheit"
 
-#. Default: "Department:"
+#. Default: "Department"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:60
 msgid "label_department"
 msgstr "Amt"
 
-#. Default: "Description:"
+#. Default: "Description"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:45
 msgid "label_description"
 msgstr "Beschreibung"
 
-#. Default: "Directorate:"
+#. Default: "Directorate"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:50
 msgid "label_directorate"
 msgstr "Direktion"
 
-#. Default: "Email:"
+#. Default: "Email"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:70
 msgid "label_email"
 msgstr "E-Mail Adresse"
 
-#. Default: "Email 2:"
+#. Default: "Email 2"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:76
 msgid "label_email2"
 msgstr "Alternative E-Mail Adresse"
 
-#. Default: "Name:"
+#. Default: "Name"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:29
 msgid "label_fullname"
 msgstr "Name"
@@ -86,7 +86,7 @@ msgstr "Name"
 msgid "label_group"
 msgstr "Gruppe"
 
-#. Default: "Groups:"
+#. Default: "Groups"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:117
 msgid "label_groups"
 msgstr "Gruppen"
@@ -96,22 +96,22 @@ msgstr "Gruppen"
 msgid "label_members"
 msgstr "Mitglieder"
 
-#. Default: "Fax:"
+#. Default: "Fax"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:94
 msgid "label_phone_fax"
 msgstr "Fax"
 
-#. Default: "Mobile phone:"
+#. Default: "Mobile phone"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:99
 msgid "label_phone_mobile"
 msgstr "Mobiltelefon"
 
-#. Default: "Office phone:"
+#. Default: "Office phone"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:89
 msgid "label_phone_office"
 msgstr "Telefon Büro"
 
-#. Default: "Salutation:"
+#. Default: "Salutation"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:40
 msgid "label_salutation"
 msgstr "Anrede"
@@ -121,7 +121,7 @@ msgstr "Anrede"
 msgid "label_teams"
 msgstr "Teams"
 
-#. Default: "URL:"
+#. Default: "URL"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:82
 msgid "label_url"
 msgstr "Homepage"

--- a/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-09-26 11:49+0000\n"
 "PO-Revision-Date: 2016-07-22 16:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/de/>\n"
@@ -21,93 +21,112 @@ msgid "Toggle orgunit selector"
 msgstr "Amtswechsler umschalten"
 
 #. Default: "No"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:35
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:36
 msgid "active_no"
 msgstr "Nein"
 
 #. Default: "Yes"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:34
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:35
 msgid "active_yes"
 msgstr "Ja"
 
 #. Default: "Inbox: ${client}"
-#: ./opengever/ogds/base/actor.py:143
-#: ./opengever/ogds/base/sources.py:71
+#: ./opengever/ogds/base/actor.py:152
+#: ./opengever/ogds/base/sources.py:103
 msgid "inbox_label"
 msgstr "Eingangskorb: ${client}"
 
 #. Default: "Active:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:33
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:34
 msgid "label_active"
 msgstr "Aktiv"
 
 #. Default: "Address:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:103
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:104
 msgid "label_address"
 msgstr "Adresse"
 
+#. Default: "Assigned org unit"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:22
+msgid "label_assigned_orgunit"
+msgstr "Zugehörige Organisationseinheit"
+
 #. Default: "Department:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:59
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:60
 msgid "label_department"
 msgstr "Amt"
 
 #. Default: "Description:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:44
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:45
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Directorate:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:49
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:50
 msgid "label_directorate"
 msgstr "Direktion"
 
 #. Default: "Email:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:69
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:70
 msgid "label_email"
 msgstr "E-Mail Adresse"
 
 #. Default: "Email 2:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:75
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:76
 msgid "label_email2"
 msgstr "Alternative E-Mail Adresse"
 
 #. Default: "Name:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:28
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:29
 msgid "label_fullname"
 msgstr "Name"
 
+#. Default: "Group"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:27
+msgid "label_group"
+msgstr "Gruppe"
+
 #. Default: "Groups:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:116
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:117
 msgid "label_groups"
 msgstr "Gruppen"
 
+#. Default: "Members"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:32
+msgid "label_members"
+msgstr "Mitglieder"
+
 #. Default: "Fax:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:93
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:94
 msgid "label_phone_fax"
 msgstr "Fax"
 
 #. Default: "Mobile phone:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:98
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:99
 msgid "label_phone_mobile"
 msgstr "Mobiltelefon"
 
 #. Default: "Office phone:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:88
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:89
 msgid "label_phone_office"
 msgstr "Telefon Büro"
 
 #. Default: "Salutation:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:39
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:40
 msgid "label_salutation"
 msgstr "Anrede"
 
+#. Default: "Teams"
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:128
+msgid "label_teams"
+msgstr "Teams"
+
 #. Default: "URL:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:81
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:82
 msgid "label_url"
 msgstr "Homepage"
 
 #. Default: "Show all users"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:22
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:23
 msgid "link_all_users"
 msgstr "Alle Benutzer anzeigen"
-

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-09-26 11:49+0000\n"
 "PO-Revision-Date: 2017-06-04 13:05+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/fr/>\n"
@@ -21,93 +21,113 @@ msgid "Toggle orgunit selector"
 msgstr "commuter l'agent public"
 
 #. Default: "No"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:35
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:36
 msgid "active_no"
 msgstr "Non"
 
 #. Default: "Yes"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:34
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:35
 msgid "active_yes"
 msgstr "Oui"
 
 #. Default: "Inbox: ${client}"
-#: ./opengever/ogds/base/actor.py:143
-#: ./opengever/ogds/base/sources.py:71
+#: ./opengever/ogds/base/actor.py:152
+#: ./opengever/ogds/base/sources.py:103
 msgid "inbox_label"
 msgstr "Boîte de réception"
 
 #. Default: "Active:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:33
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:34
 msgid "label_active"
 msgstr "Actif"
 
 #. Default: "Address:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:103
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:104
 msgid "label_address"
 msgstr "Adresse"
 
+#. Default: "Assigned org unit"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:22
+msgid "label_assigned_orgunit"
+msgstr ""
+
 #. Default: "Department:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:59
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:60
 msgid "label_department"
 msgstr "Service"
 
 #. Default: "Description:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:44
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:45
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Directorate:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:49
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:50
 msgid "label_directorate"
 msgstr "Direction"
 
 #. Default: "Email:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:69
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:70
 msgid "label_email"
 msgstr "Adresse email"
 
 #. Default: "Email 2:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:75
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:76
 msgid "label_email2"
 msgstr "Adresse email 2:"
 
 #. Default: "Name:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:28
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:29
 msgid "label_fullname"
 msgstr "Nom"
 
+#. Default: "Group"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:27
+msgid "label_group"
+msgstr ""
+
 #. Default: "Groups:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:116
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:117
 msgid "label_groups"
 msgstr "Groupes"
 
+#. Default: "Members"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:32
+msgid "label_members"
+msgstr ""
+
 #. Default: "Fax:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:93
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:94
 msgid "label_phone_fax"
 msgstr "Fax"
 
 #. Default: "Mobile phone:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:98
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:99
 msgid "label_phone_mobile"
 msgstr "Mobile"
 
 #. Default: "Office phone:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:88
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:89
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 
 #. Default: "Salutation:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:39
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:40
 msgid "label_salutation"
 msgstr "Titre"
 
+#. Default: "Teams"
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:128
+msgid "label_teams"
+msgstr ""
+
 #. Default: "URL:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:81
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:82
 msgid "label_url"
 msgstr "Site Internet"
 
 #. Default: "Show all users"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:22
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:23
 msgid "link_all_users"
 msgstr "Afficher tous les utilisateurs"
 

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-26 11:49+0000\n"
+"POT-Creation-Date: 2017-09-26 11:54+0000\n"
 "PO-Revision-Date: 2017-06-04 13:05+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/fr/>\n"
@@ -36,12 +36,12 @@ msgstr "Oui"
 msgid "inbox_label"
 msgstr "Boîte de réception"
 
-#. Default: "Active:"
+#. Default: "Active"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:34
 msgid "label_active"
 msgstr "Actif"
 
-#. Default: "Address:"
+#. Default: "Address"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:104
 msgid "label_address"
 msgstr "Adresse"
@@ -51,32 +51,32 @@ msgstr "Adresse"
 msgid "label_assigned_orgunit"
 msgstr ""
 
-#. Default: "Department:"
+#. Default: "Department"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:60
 msgid "label_department"
 msgstr "Service"
 
-#. Default: "Description:"
+#. Default: "Description"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:45
 msgid "label_description"
 msgstr "Description"
 
-#. Default: "Directorate:"
+#. Default: "Directorate"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:50
 msgid "label_directorate"
 msgstr "Direction"
 
-#. Default: "Email:"
+#. Default: "Email"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:70
 msgid "label_email"
 msgstr "Adresse email"
 
-#. Default: "Email 2:"
+#. Default: "Email 2"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:76
 msgid "label_email2"
-msgstr "Adresse email 2:"
+msgstr "Adresse email 2"
 
-#. Default: "Name:"
+#. Default: "Name"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:29
 msgid "label_fullname"
 msgstr "Nom"
@@ -86,7 +86,7 @@ msgstr "Nom"
 msgid "label_group"
 msgstr ""
 
-#. Default: "Groups:"
+#. Default: "Groups"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:117
 msgid "label_groups"
 msgstr "Groupes"
@@ -96,22 +96,22 @@ msgstr "Groupes"
 msgid "label_members"
 msgstr ""
 
-#. Default: "Fax:"
+#. Default: "Fax"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:94
 msgid "label_phone_fax"
 msgstr "Fax"
 
-#. Default: "Mobile phone:"
+#. Default: "Mobile phone"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:99
 msgid "label_phone_mobile"
 msgstr "Mobile"
 
-#. Default: "Office phone:"
+#. Default: "Office phone"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:89
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 
-#. Default: "Salutation:"
+#. Default: "Salutation"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:40
 msgid "label_salutation"
 msgstr "Titre"
@@ -121,7 +121,7 @@ msgstr "Titre"
 msgid "label_teams"
 msgstr ""
 
-#. Default: "URL:"
+#. Default: "URL"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:82
 msgid "label_url"
 msgstr "Site Internet"
@@ -130,4 +130,3 @@ msgstr "Site Internet"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:23
 msgid "link_all_users"
 msgstr "Afficher tous les utilisateurs"
-

--- a/opengever/ogds/base/locales/opengever.ogds.base.pot
+++ b/opengever/ogds/base/locales/opengever.ogds.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-26 11:49+0000\n"
+"POT-Creation-Date: 2017-09-26 11:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,12 +37,12 @@ msgstr ""
 msgid "inbox_label"
 msgstr ""
 
-#. Default: "Active:"
+#. Default: "Active"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:34
 msgid "label_active"
 msgstr ""
 
-#. Default: "Address:"
+#. Default: "Address"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:104
 msgid "label_address"
 msgstr ""
@@ -52,32 +52,32 @@ msgstr ""
 msgid "label_assigned_orgunit"
 msgstr ""
 
-#. Default: "Department:"
+#. Default: "Department"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:60
 msgid "label_department"
 msgstr ""
 
-#. Default: "Description:"
+#. Default: "Description"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:45
 msgid "label_description"
 msgstr ""
 
-#. Default: "Directorate:"
+#. Default: "Directorate"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:50
 msgid "label_directorate"
 msgstr ""
 
-#. Default: "Email:"
+#. Default: "Email"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:70
 msgid "label_email"
 msgstr ""
 
-#. Default: "Email 2:"
+#. Default: "Email 2"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:76
 msgid "label_email2"
 msgstr ""
 
-#. Default: "Name:"
+#. Default: "Name"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:29
 msgid "label_fullname"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "label_group"
 msgstr ""
 
-#. Default: "Groups:"
+#. Default: "Groups"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:117
 msgid "label_groups"
 msgstr ""
@@ -97,22 +97,22 @@ msgstr ""
 msgid "label_members"
 msgstr ""
 
-#. Default: "Fax:"
+#. Default: "Fax"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:94
 msgid "label_phone_fax"
 msgstr ""
 
-#. Default: "Mobile phone:"
+#. Default: "Mobile phone"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:99
 msgid "label_phone_mobile"
 msgstr ""
 
-#. Default: "Office phone:"
+#. Default: "Office phone"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:89
 msgid "label_phone_office"
 msgstr ""
 
-#. Default: "Salutation:"
+#. Default: "Salutation"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:40
 msgid "label_salutation"
 msgstr ""
@@ -122,7 +122,7 @@ msgstr ""
 msgid "label_teams"
 msgstr ""
 
-#. Default: "URL:"
+#. Default: "URL"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt:82
 msgid "label_url"
 msgstr ""

--- a/opengever/ogds/base/locales/opengever.ogds.base.pot
+++ b/opengever/ogds/base/locales/opengever.ogds.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-09-26 11:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,93 +22,113 @@ msgid "Toggle orgunit selector"
 msgstr ""
 
 #. Default: "No"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:35
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:36
 msgid "active_no"
 msgstr ""
 
 #. Default: "Yes"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:34
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:35
 msgid "active_yes"
 msgstr ""
 
 #. Default: "Inbox: ${client}"
-#: ./opengever/ogds/base/actor.py:143
-#: ./opengever/ogds/base/sources.py:71
+#: ./opengever/ogds/base/actor.py:152
+#: ./opengever/ogds/base/sources.py:103
 msgid "inbox_label"
 msgstr ""
 
 #. Default: "Active:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:33
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:34
 msgid "label_active"
 msgstr ""
 
 #. Default: "Address:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:103
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:104
 msgid "label_address"
 msgstr ""
 
+#. Default: "Assigned org unit"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:22
+msgid "label_assigned_orgunit"
+msgstr ""
+
 #. Default: "Department:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:59
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:60
 msgid "label_department"
 msgstr ""
 
 #. Default: "Description:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:44
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:45
 msgid "label_description"
 msgstr ""
 
 #. Default: "Directorate:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:49
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:50
 msgid "label_directorate"
 msgstr ""
 
 #. Default: "Email:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:69
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:70
 msgid "label_email"
 msgstr ""
 
 #. Default: "Email 2:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:75
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:76
 msgid "label_email2"
 msgstr ""
 
 #. Default: "Name:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:28
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:29
 msgid "label_fullname"
 msgstr ""
 
+#. Default: "Group"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:27
+msgid "label_group"
+msgstr ""
+
 #. Default: "Groups:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:116
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:117
 msgid "label_groups"
 msgstr ""
 
+#. Default: "Members"
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt:32
+msgid "label_members"
+msgstr ""
+
 #. Default: "Fax:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:93
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:94
 msgid "label_phone_fax"
 msgstr ""
 
 #. Default: "Mobile phone:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:98
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:99
 msgid "label_phone_mobile"
 msgstr ""
 
 #. Default: "Office phone:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:88
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:89
 msgid "label_phone_office"
 msgstr ""
 
 #. Default: "Salutation:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:39
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:40
 msgid "label_salutation"
 msgstr ""
 
+#. Default: "Teams"
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:128
+msgid "label_teams"
+msgstr ""
+
 #. Default: "URL:"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:81
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:82
 msgid "label_url"
 msgstr ""
 
 #. Default: "Show all users"
-#: ./opengever/ogds/base/browser/userdetails_templates/userdetails.pt:22
+#: ./opengever/ogds/base/browser/templates/userdetails.pt:23
 msgid "link_all_users"
 msgstr ""
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -8,6 +8,7 @@ from opengever.ogds.models.group import Group
 from opengever.ogds.models.group import groups_users
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.query import extend_query_with_textfilter
+from opengever.ogds.models.team import Team
 from opengever.ogds.models.user import User
 from plone import api
 from sqlalchemy import func
@@ -22,7 +23,7 @@ from zope.schema.vocabulary import SimpleTerm
 
 
 @implementer(IQuerySource)
-class AllUsersAndInboxesSource(object):
+class AllUsersInboxesAndTeamsSource(object):
     """This example of a IQuerySource is taken from the
     plone.formwidget.autocomplete
     """
@@ -34,6 +35,7 @@ class AllUsersAndInboxesSource(object):
 
         self.only_current_orgunit = kwargs.get('only_current_orgunit', False)
         self.only_current_inbox = kwargs.get('only_current_inbox', False)
+        self.include_teams = kwargs.get('include_teams', False)
 
     @property
     def only_users(self):
@@ -105,6 +107,13 @@ class AllUsersAndInboxesSource(object):
 
             return SimpleTerm(value, token, title)
 
+        if ActorLookup(value).is_team():
+            if not self.include_teams:
+                raise LookupError
+
+            team = Team.query.get_by_actor_id(value)
+            return SimpleTerm(team.actor_id(), team.actor_id(), team.label())
+
         user, orgunit = self.base_query.filter(OrgUnit.unit_id == orgunit_id) \
                                        .filter(User.userid == userid).one()
 
@@ -153,6 +162,9 @@ class AllUsersAndInboxesSource(object):
                 self.getTerm(u'{}:{}'.format(orgunit.id(), user.userid)))
 
         self._extend_terms_with_inboxes(text_filters)
+        if self.include_teams:
+            self._extend_terms_with_teams(text_filters)
+
         return self.terms
 
     def _extend_terms_with_inboxes(self, text_filters):
@@ -178,6 +190,13 @@ class AllUsersAndInboxesSource(object):
         for orgunit in query.all():
             self.terms.insert(0, self.getTerm(orgunit.inbox().id()))
 
+    def _extend_terms_with_teams(self, text_filters):
+        query = Team.query.filter(Team.active == True)
+        query = extend_query_with_textfilter(query, [Team.title], text_filters)
+
+        for team in query:
+            self.terms.insert(0, self.getTerm(team.actor_id()))
+
     def get_client_id(self):
         """Tries to get the client from the request. If no client is found None
         is returned.
@@ -199,24 +218,27 @@ class AllUsersAndInboxesSource(object):
 
 
 @implementer(IContextSourceBinder)
-class AllUsersAndInboxesSourceBinder(object):
+class AllUsersInboxesAndTeamsSourceBinder(object):
 
     def __init__(self,
                  only_current_orgunit=False,
-                 only_current_inbox=False):
+                 only_current_inbox=False,
+                 include_teams=False):
 
         self.only_current_orgunit = only_current_orgunit
         self.only_current_inbox = only_current_inbox
+        self.include_teams = include_teams
 
     def __call__(self, context):
-        return AllUsersAndInboxesSource(
+        return AllUsersInboxesAndTeamsSource(
             context,
             only_current_orgunit=self.only_current_orgunit,
-            only_current_inbox=self.only_current_inbox)
+            only_current_inbox=self.only_current_inbox,
+            include_teams=self.include_teams)
 
 
 @implementer(IQuerySource)
-class UsersContactsInboxesSource(AllUsersAndInboxesSource):
+class UsersContactsInboxesSource(AllUsersInboxesAndTeamsSource):
 
     @property
     def only_users(self):
@@ -311,7 +333,7 @@ class UsersContactsInboxesSourceBinder(object):
 
 
 @implementer(IQuerySource)
-class AllUsersSource(AllUsersAndInboxesSource):
+class AllUsersSource(AllUsersInboxesAndTeamsSource):
     """Vocabulary of all users assigned to the current admin unit.
     """
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -157,7 +157,7 @@ class AllUsersInboxesAndTeamsSource(object):
         query = query.order_by(asc(func.lower(User.lastname)),
                                asc(func.lower(User.firstname)))
 
-        for user, orgunit in query.all():
+        for user, orgunit in query:
             self.terms.append(
                 self.getTerm(u'{}:{}'.format(orgunit.id(), user.userid)))
 
@@ -187,7 +187,7 @@ class AllUsersInboxesAndTeamsSource(object):
             [OrgUnit.title, OrgUnit.unit_id],
             text_filters)
 
-        for orgunit in query.all():
+        for orgunit in query:
             self.terms.insert(0, self.getTerm(orgunit.inbox().id()))
 
     def _extend_terms_with_teams(self, text_filters):
@@ -304,7 +304,7 @@ class UsersContactsInboxesSource(AllUsersInboxesAndTeamsSource):
         query = query.order_by(asc(func.lower(User.lastname)),
                                asc(func.lower(User.firstname)))
 
-        for user in query.all():
+        for user in query:
             self.terms.append(
                 self.getTerm(u'{}'.format(user.userid)))
 
@@ -379,7 +379,7 @@ class AllUsersSource(AllUsersInboxesAndTeamsSource):
         query = query.order_by(asc(func.lower(User.lastname)),
                                asc(func.lower(User.firstname)))
 
-        for user in query.all():
+        for user in query:
             self.terms.append(
                 self.getTerm(u'{}'.format(user.userid)))
         return self.terms
@@ -486,7 +486,7 @@ class AllEmailContactsAndUsersSource(UsersContactsInboxesSource):
         query = query.order_by(asc(func.lower(User.lastname)),
                                asc(func.lower(User.firstname)))
 
-        for user in query.all():
+        for user in query:
             if user.email:
                 self.terms.append(
                     self.getTerm(u'{}:{}'.format(user.email, user.userid)))

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -55,7 +55,7 @@ class AllUsersInboxesAndTeamsSource(object):
         query = create_session().query(*models) \
                                 .join(OrgUnit.users_group) \
                                 .join(Group.users)
-        query = query.filter(OrgUnit.enabled == True)
+        query = query.filter(OrgUnit.enabled == True)  # noqa
 
         if self.only_current_orgunit:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -177,7 +177,7 @@ class AllUsersInboxesAndTeamsSource(object):
                               text_filters)
 
         query = OrgUnit.query
-        query = query.filter(OrgUnit.enabled == True)
+        query = query.filter(OrgUnit.enabled == True)  # noqa
 
         if self.only_current_inbox:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -191,7 +191,7 @@ class AllUsersInboxesAndTeamsSource(object):
             self.terms.insert(0, self.getTerm(orgunit.inbox().id()))
 
     def _extend_terms_with_teams(self, text_filters):
-        query = Team.query.filter(Team.active == True)
+        query = Team.query.filter(Team.active == True)  # noqa
         query = extend_query_with_textfilter(query, [Team.title], text_filters)
 
         for team in query:
@@ -408,7 +408,7 @@ class AssignedUsersSource(AllUsersSource):
             .filter(User.userid == groups_users.columns.userid) \
             .filter(groups_users.columns.groupid == OrgUnit.users_group_id) \
             .filter(OrgUnit.admin_unit_id == admin_unit.unit_id) \
-            .filter(OrgUnit.enabled == True)
+            .filter(OrgUnit.enabled == True)  # noqa
 
 
 @implementer(IContextSourceBinder)

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -31,6 +31,15 @@ class TestActorLookup(IntegrationTestCase):
         self.assertIn(actor.get_label(), link)
         self.assertIn(actor.get_profile_url(), link)
 
+    def test_team_actor_lookup(self):
+        self.login(self.regular_user)
+        actor = Actor.lookup('team:1')
+
+        self.assertEqual(u'Projekt \xdcberbaung Dorfmatte (Finanzamt)',
+                         actor.get_label())
+        self.assertEqual('http://nohost/plone/@@team-details/1',
+                         actor.get_profile_url())
+
     def test_user_actor_ogds_user(self):
         actor = Actor.lookup('jurgen.konig')
 
@@ -81,6 +90,16 @@ class TestActorCorresponding(IntegrationTestCase):
         self.assertFalse(
             actor.corresponds_to(self.get_ogds_user(self.regular_user)))
 
+    def test_team_corresponds_to_all_team_group_members(self):
+        actor = Actor.lookup('team:1')
+
+        self.assertTrue(
+            actor.corresponds_to(self.get_ogds_user(self.regular_user)))
+        self.assertTrue(
+            actor.corresponds_to(self.get_ogds_user(self.dossier_responsible)))
+        self.assertFalse(
+            actor.corresponds_to(self.get_ogds_user(self.secretariat_user)))
+
 
 class TestActorRepresentatives(IntegrationTestCase):
 
@@ -102,3 +121,18 @@ class TestActorRepresentatives(IntegrationTestCase):
     def test_contact_has_no_representatives(self):
         actor = Actor.lookup('contact:meier-franz')
         self.assertItemsEqual([], actor.representatives())
+
+    def test_all_group_members_are_team_representatives(self):
+        actor = Actor.lookup('team:1')
+        self.assertItemsEqual(
+            [self.get_ogds_user(self.regular_user),
+             self.get_ogds_user(self.dossier_responsible)],
+            actor.representatives())
+
+
+class TestActorPermissionIdentifier(IntegrationTestCase):
+
+    def test_groupid_is_team_actors_permission_identifier(self):
+        actor = Actor.lookup('team:1')
+
+        self.assertEquals('projekt_a', actor.permission_identifier)

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -1,134 +1,104 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from opengever.ogds.base.actor import Actor
-from opengever.ogds.base.utils import ogds_service
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
+from opengever.testing import IntegrationTestCase
 
 
-class TestActorLookup(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestActorLookup, self).setUp()
-        self.grant('Reader', 'Contributor')
+class TestActorLookup(IntegrationTestCase):
 
     def test_null_actor(self):
         actor = Actor.lookup('not-existing')
-
         self.assertEqual('not-existing', actor.get_label())
         self.assertIsNone(actor.get_profile_url())
         self.assertEqual('not-existing', actor.get_link())
 
     def test_inbox_actor_lookup(self):
-        create(Builder('org_unit')
-               .id('foobar')
-               .having(title='Huhu',
-                       admin_unit=self.admin_unit)
-               .with_default_groups())
-        actor = Actor.lookup('inbox:foobar')
+        actor = Actor.lookup('inbox:fa')
 
-        self.assertEqual('Inbox: Huhu', actor.get_label())
+        self.assertEqual(u'Inbox: Finanzamt', actor.get_label())
         self.assertIsNone(actor.get_profile_url())
-        self.assertEqual('Inbox: Huhu', actor.get_link())
-        self.assertEqual(u'foobar_inbox_users', actor.permission_identifier)
+        self.assertEqual('Inbox: Finanzamt', actor.get_link())
+        self.assertEqual(u'fa_inbox_users', actor.permission_identifier)
 
     def test_contact_actor_lookup(self):
-        contact = create(Builder('contact')
-                         .having(firstname=u'Hanspeter',
-                                 lastname=u'Blahbla',
-                                 email='h@example.com')
-                         .in_state('published'))
-        actor = Actor.lookup('contact:{}'.format(contact.id))
-        self.assertEqual('Blahbla Hanspeter (h@example.com)',
+        self.login(self.regular_user)
+        actor = Actor.lookup('contact:{}'.format(self.franz_meier.id))
+
+        self.assertEqual('Meier Franz (meier.f@example.com)',
                          actor.get_label())
-        self.assertEqual(contact.absolute_url(), actor.get_profile_url())
+        self.assertEqual(self.franz_meier.absolute_url(),
+                         actor.get_profile_url())
 
         link = actor.get_link()
         self.assertIn(actor.get_label(), link)
         self.assertIn(actor.get_profile_url(), link)
 
     def test_user_actor_ogds_user(self):
-        create(Builder('fixture'))
-        create(Builder('ogds_user')
-               .id('hugo.boss')
-               .having(firstname='H\xc3\xbcgo'.decode('utf-8'),
-                       lastname='Boss'))
-
-        actor = Actor.lookup('hugo.boss')
-
-        self.assertEqual(u'Boss H\xfcgo (hugo.boss)', actor.get_label())
-        self.assertEqual('hugo.boss', actor.permission_identifier)
-        self.assertTrue(
-            actor.get_profile_url().endswith('@@user-details/hugo.boss'))
+        actor = Actor.lookup('jurgen.konig')
 
         self.assertEqual(
-            u'<a href="http://nohost/plone/@@user-details/hugo.boss">Boss H\xfcgo (hugo.boss)</a>',
+            u'K\xf6nig J\xfcrgen (jurgen.konig)', actor.get_label())
+        self.assertEqual('jurgen.konig', actor.permission_identifier)
+        self.assertTrue(
+            actor.get_profile_url().endswith('@@user-details/jurgen.konig'))
+
+        self.assertEqual(
+            u'<a href="http://nohost/plone/@@user-details/jurgen.konig">'
+            u'K\xf6nig J\xfcrgen (jurgen.konig)</a>',
             actor.get_link())
 
         self.assertEqual(
-            u'<a href="http://nohost/plone/@@user-details/hugo.boss" class="contenttype-opengever-actor">Boss H\xfcgo (hugo.boss)</a>',
+            u'<a href="http://nohost/plone/@@user-details/jurgen.konig" '
+            u'class="contenttype-opengever-actor">K\xf6nig J\xfcrgen '
+            u'(jurgen.konig)</a>',
             actor.get_link(with_icon=True))
 
     def test_get_link_returns_safe_html(self):
-        contact = create(Builder('contact')
-                         .having(firstname=u"Foo <b onmouseover=alert('Foo!')>click me!</b>",
-                                 lastname=u'Blahbla',
-                                 email='h@example.com')
-                         .in_state('published'))
-        actor = Actor.lookup('contact:{}'.format(contact.id))
+        self.login(self.regular_user)
+
+        self.franz_meier.firstname = u"Foo <b onmouseover=alert('Foo!')>click me!</b>"
+        self.franz_meier.reindexObject()
+        actor = Actor.lookup('contact:meier-franz')
 
         self.assertEquals(
-            u'<a href="http://nohost/plone/blahbla-foo-b-onmouseover-alert-foo-click-me-b">'
-            'Blahbla Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (h@example.com)</a>',
+            u'<a href="http://nohost/plone/kontakte/meier-franz">Meier Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (meier.f@example.com)</a>',
             actor.get_link())
 
 
-class TestActorCorresponding(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestActorCorresponding, self).setUp()
-        self.hugo = create(Builder('ogds_user')
-                           .id('hugo.boss')
-                           .having(firstname='H\xc3\xbcgo'.decode('utf-8'),
-                                   lastname='Boss'))
+class TestActorCorresponding(IntegrationTestCase):
 
     def test_user_corresponds_to_current_user(self):
-        actor = Actor.lookup(TEST_USER_ID)
+        actor = Actor.lookup('jurgen.konig')
 
-        self.assertTrue(actor.corresponds_to(self.user))
-        self.assertFalse(actor.corresponds_to(self.hugo))
+        self.assertTrue(
+            actor.corresponds_to(self.get_ogds_user(self.secretariat_user)))
+        self.assertFalse(
+            actor.corresponds_to(self.get_ogds_user(self.regular_user)))
 
     def test_inbox_corresponds_to_all_inbox_assigned_users(self):
-        actor = Actor.lookup('inbox:client1')
+        actor = Actor.lookup('inbox:fa')
 
-        self.assertTrue(actor.corresponds_to(self.user))
-        self.assertFalse(actor.corresponds_to(self.hugo))
+        self.assertTrue(
+            actor.corresponds_to(self.get_ogds_user(self.secretariat_user)))
+        self.assertFalse(
+            actor.corresponds_to(self.get_ogds_user(self.regular_user)))
 
 
-class TestActorRepresentatives(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestActorRepresentatives, self).setUp()
-        group = ogds_service().fetch_group(self.org_unit.inbox_group_id)
-        self.hugo = create(Builder('ogds_user').id('hugo.boss').in_group(group))
-        self.peter = create(Builder('ogds_user').id('peter'))
-        self.james = create(Builder('ogds_user').id('james').in_group(group))
+class TestActorRepresentatives(IntegrationTestCase):
 
     def test_user_is_the_only_representatives_of_a_user(self):
-        self.assertEquals([self.user],
-                          Actor.lookup(TEST_USER_ID).representatives())
-        self.assertEquals([self.peter],
-                          Actor.lookup('peter').representatives())
+        actor = Actor.lookup('jurgen.konig')
+        self.assertEquals([self.get_ogds_user(self.secretariat_user)],
+                          actor.representatives())
+
+        actor = Actor.lookup(self.regular_user.getId())
+        self.assertEquals([self.get_ogds_user(self.regular_user)],
+                          actor.representatives())
 
     def test_all_users_of_the_inbox_group_are_inbox_representatives(self):
-        actor = Actor.lookup('inbox:client1')
-        self.assertItemsEqual([self.user, self.hugo, self.james],
-                               actor.representatives())
+        actor = Actor.lookup('inbox:fa')
+        self.assertItemsEqual(
+            [self.get_ogds_user(self.secretariat_user)],
+            actor.representatives())
 
     def test_contact_has_no_representatives(self):
-        contact = create(Builder('contact')
-                         .having(firstname=u'Paul')
-                         .in_state('published'))
-
-        actor = Actor.lookup('contact:{}'.format(contact.id))
+        actor = Actor.lookup('contact:meier-franz')
         self.assertItemsEqual([], actor.representatives())

--- a/opengever/ogds/base/tests/test_team_details.py
+++ b/opengever/ogds/base/tests/test_team_details.py
@@ -1,0 +1,47 @@
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser import browsing
+
+
+class TestTeamDetails(IntegrationTestCase):
+
+    @browsing
+    def test_title(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.portal, view='team-details/1')
+
+        self.assertEquals(
+            [u'Projekt \xdcberbaung Dorfmatte'], browser.css('h1').text)
+
+    @browsing
+    def test_raises_not_found_with_invalid_id(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        with browser.expect_http_error(code=404):
+            browser.open(self.portal, view='team-details/123')
+
+    @browsing
+    def test_metadata_table(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.portal, view='team-details/1')
+
+        items = browser.css('.listing').first.lists()
+        self.assertEquals(
+            ['Assigned org unit', 'Finanzamt'], items[0])
+        self.assertEquals(
+            ['Group', 'Projekt A'], items[1])
+
+    @browsing
+    def test_list_and_link_team_members(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.portal, view='team-details/1')
+
+        links = browser.css('.members a')
+        self.assertEquals(
+            [u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+             'Ziegler Robert (robert.ziegler)'],
+            links.text)
+
+        self.assertEquals(
+            ['http://nohost/plone/@@user-details/kathi.barfuss',
+             'http://nohost/plone/@@user-details/robert.ziegler'],
+            [link.get('href') for link in links])

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -16,11 +16,21 @@ class TestUserDetails(IntegrationTestCase):
         metadata = browser.css('.vertical').first.lists()
 
         self.assertEquals(
-            ['Name:', u'B\xe4rfuss K\xe4thi (kathi.barfuss)'], metadata[0])
-        self.assertEquals(['Active:', 'Yes'], metadata[1])
-        self.assertEquals(['Email:', 'kathi.barfuss@gever.local'], metadata[2])
+            ['Name', u'B\xe4rfuss K\xe4thi (kathi.barfuss)'], metadata[0])
+        self.assertEquals(['Active', 'Yes'], metadata[1])
+        self.assertEquals(['Email', 'kathi.barfuss@gever.local'], metadata[2])
 
     @browsing
     def test_user_details_return_not_found_for_not_exisiting_user(self, browser):
         with browser.expect_http_error(code=404):
             browser.login().open(self.portal, view='@@user-details/not.found')
+
+    @browsing
+    def test_list_all_team_memberships(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal, view='@@user-details/kathi.barfuss')
+
+        self.assertEquals(
+            [u'Projekt \xdcberbaung Dorfmatte'], browser.css('.teams li').text)
+        self.assertEquals('http://nohost/plone/@@team-details/1',
+                          browser.css('.teams a').first.get('href'))

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -1,23 +1,26 @@
-from opengever.testing import FunctionalTestCase
 from ftw.testbrowser import browsing
-from opengever.testing import create_ogds_user
+from opengever.testing import IntegrationTestCase
 
 
-class TestUserDetails(FunctionalTestCase):
+class TestUserDetails(IntegrationTestCase):
 
     @browsing
     def test_user_details(self, browser):
-        create_ogds_user('hugo.boss', lastname='Boss', firstname='Hugo',
-                         groups=('group_a', 'group_b'))
+        self.login(self.regular_user, browser)
 
-        browser.login().open(self.portal, view='@@user-details/hugo.boss')
+        browser.open(self.portal, view='@@user-details/kathi.barfuss')
 
-        self.assertEquals(['Boss Hugo (hugo.boss)'],
+        self.assertEquals([u'B\xe4rfuss K\xe4thi (kathi.barfuss)'],
                           browser.css('h1.documentFirstHeading').text)
-        self.assertEquals(['group_a', 'group_b'],
-                          browser.css('.groups a').text)
+
+        metadata = browser.css('.vertical').first.lists()
+
+        self.assertEquals(
+            ['Name:', u'B\xe4rfuss K\xe4thi (kathi.barfuss)'], metadata[0])
+        self.assertEquals(['Active:', 'Yes'], metadata[1])
+        self.assertEquals(['Email:', 'kathi.barfuss@gever.local'], metadata[2])
 
     @browsing
     def test_user_details_return_not_found_for_not_exisiting_user(self, browser):
-        with browser.expect_http_error(reason='Not Found'):
-            browser.login().open(self.portal, view='@@user-details/hugo.boss')
+        with browser.expect_http_error(code=404):
+            browser.login().open(self.portal, view='@@user-details/not.found')

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -1,6 +1,6 @@
 from five import grok
 from ftw.keywordwidget.widget import KeywordWidget
-from opengever.ogds.base.sources import AllUsersAndInboxesSourceBinder
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import _
 from opengever.task.activities import TaskReassignActivity
@@ -37,7 +37,7 @@ class IAssignSchema(form.Schema):
     responsible = schema.Choice(
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible_single_client_setup", default=""),
-        source=AllUsersAndInboxesSourceBinder(
+        source=AllUsersInboxesAndTeamsSourceBinder(
             only_current_inbox=True,
             only_current_orgunit=True),
         required=True,

--- a/opengever/task/browser/delegate/recipients.py
+++ b/opengever/task/browser/delegate/recipients.py
@@ -1,7 +1,7 @@
 from five import grok
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.keywordwidget.widget import KeywordWidget
-from opengever.ogds.base.sources import AllUsersAndInboxesSourceBinder
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.task import _
 from opengever.task.browser.delegate import vocabulary
 from opengever.task.browser.delegate.main import DelegateWizardFormMixin
@@ -30,7 +30,7 @@ class ISelectRecipientsSchema(Schema):
             u'responsible a subtask will be created and assigned.'),
         required=True,
         value_type=schema.Choice(
-            source=AllUsersAndInboxesSourceBinder()))
+            source=AllUsersInboxesAndTeamsSourceBinder()))
 
     documents = schema.List(
         title=_(u'delegate_label_documents', default=u'Attach documents'),

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -5,6 +5,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
+from plone import api
 from plone.dexterity.interfaces import IDexterityContent
 from Products.CMFCore.interfaces import IActionSucceededEvent
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
@@ -59,3 +60,12 @@ def set_dates(task, event):
         task.date_of_completion = date.today()
     if event.action == 'task-transition-resolved-in-progress':
         task.date_of_completion = None
+
+
+@grok.subscribe(ITask, IActionSucceededEvent)
+def reassign_team_tasks(task, event):
+    if event.action != 'task-transition-open-in-progress':
+        return
+
+    if task.is_team_task:
+        ITask(task).responsible = api.user.get_current().getId()

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -15,6 +15,7 @@ from opengever.base.source import DossierPathSourceBinder
 from opengever.dossier.utils import get_containing_dossier
 from opengever.globalindex.model.task import Task as TaskModel
 from opengever.ogds.base.actor import Actor
+from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -260,6 +261,11 @@ class Task(Container):
     def is_editable(self):
         current_state = api.content.get_state(self)
         return current_state in ['task-state-open', 'task-state-in-progress']
+
+    @property
+    def is_team_task(self):
+        """Is true if the task responsible is a team."""
+        return ActorLookup(self.responsible).is_team()
 
     def get_issuer_label(self):
         return self.get_sql_object().get_issuer_label()

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -15,7 +15,7 @@ from opengever.base.source import DossierPathSourceBinder
 from opengever.dossier.utils import get_containing_dossier
 from opengever.globalindex.model.task import Task as TaskModel
 from opengever.ogds.base.actor import Actor
-from opengever.ogds.base.sources import AllUsersAndInboxesSourceBinder
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
@@ -124,7 +124,7 @@ class ITask(form.Schema):
     responsible = schema.Choice(
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible", default=""),
-        source=AllUsersAndInboxesSourceBinder(),
+        source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True),
         required=True,
         )
 
@@ -219,7 +219,7 @@ class IAddTaskSchema(ITask):
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible_multiple", default=""),
         value_type=schema.Choice(
-            source=AllUsersAndInboxesSourceBinder()),
+            source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True)),
         required=True,
         missing_value=[],
         default=[]

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -1,0 +1,24 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.testing import IntegrationTestCase
+
+
+class TestTeamTasks(IntegrationTestCase):
+
+    @browsing
+    def test_select_a_team_as_responsible_is_possible(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.dossier)
+        factoriesmenu.add('Task')
+
+        browser.fill({'Title': u'Team Task', 'Task Type': 'To comment'})
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill('team:1')
+        browser.find('Save').click()
+
+        task = self.dossier.get('task-3')
+
+        self.assertEquals('Team Task', task.title)
+        self.assertEquals('team:1', task.responsible)
+        self.assertEquals(u'fa', task.responsible_client)

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -7,7 +7,6 @@ from opengever.task.task import ITask
 from opengever.testing import IntegrationTestCase
 
 
-
 class TestTeamTasks(IntegrationTestCase):
 
     features = ('activity', )
@@ -55,3 +54,22 @@ class TestTeamTasks(IntegrationTestCase):
         self.assertEquals(
             [u'franzi.muller', u'herbert.jager'],
             [note.userid for note in activity.notifications])
+
+    @browsing
+    def test_set_current_user_as_responsible_when_accepting_a_team_task(self, browser):
+        self.login(self.regular_user, browser)
+
+        ITask(self.task).responsible = u'team:1'
+        self.task.get_sql_object().responsible = u'team:1'
+        self.set_workflow_state('task-state-open', self.task)
+
+        browser.open(self.task, view='tabbedview_view-overview')
+
+        browser.click_on('task-transition-open-in-progress')
+        browser.fill({'Response': u'Das \xfcbernehme ich!'})
+        browser.click_on('Save')
+
+        self.assertEquals(self.regular_user.getId(),
+                          ITask(self.task).responsible)
+        self.assertEquals(self.regular_user.getId(),
+                          self.task.get_sql_object().responsible)

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -70,9 +70,9 @@ def getTaskTypeVocabulary(context):
         reg_key = 'opengever.task.interfaces.ITaskSettings.%s' % (
             category)
 
+        key = 'opengever.task.%s' % (category)
         for term in wrap_vocabulary(
-            'opengever.task.%s' % (category),
-            visible_terms_from_registry=reg_key)(context):
+                key, visible_terms_from_registry=reg_key)(context):
 
             terms.append(term)
 

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -1,6 +1,7 @@
 from collective.elephantvocabulary import wrap_vocabulary
 from five import grok
 from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.models.team import Team
 from opengever.task import _
 from opengever.task.activities import TaskTransitionActivity
 from persistent.list import PersistentList
@@ -218,6 +219,11 @@ def update_reponsible_field_data(data):
     if ActorLookup(data['responsible']).is_inbox():
         client = data['responsible'].split(':', 1)[1]
         data['responsible_client'] = client
+        data['responsible'] = data['responsible']
+
+    elif ActorLookup(data['responsible']).is_team():
+        team = Team.query.get_by_actor_id(data['responsible'])
+        data['responsible_client'] = team.org_unit.unit_id
         data['responsible'] = data['responsible']
 
     else:

--- a/opengever/tasktemplates/sources.py
+++ b/opengever/tasktemplates/sources.py
@@ -1,5 +1,5 @@
 from opengever.ogds.base.sources import UsersContactsInboxesSource
-from opengever.ogds.base.sources import AllUsersAndInboxesSource
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSource
 from opengever.tasktemplates import _
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope.globalrequest import getRequest
@@ -56,7 +56,7 @@ class TaskTemplateIssuerSourceBinder(object):
 
 
 @implementer(IQuerySource)
-class TaskResponsibleSource(AllUsersAndInboxesSource):
+class TaskResponsibleSource(AllUsersInboxesAndTeamsSource):
     """Source with the default users and clients extended with the
     interactive users.
     """

--- a/opengever/tasktemplates/tests/test_sources.py
+++ b/opengever/tasktemplates/tests/test_sources.py
@@ -29,7 +29,7 @@ class TestTaskTemplateIssuerSource(base.TestUsersContactsInboxesSource):
         self.assertEquals('Current user', result[0].title)
 
 
-class TestTaskResponsibleSource(base.TestAllUsersAndInboxesSource):
+class TestTaskResponsibleSource(base.TestAllUsersInboxesAndTeamsSource):
 
     def setUp(self):
         super(TestTaskResponsibleSource, self).setUp()

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -41,6 +41,7 @@ class OpengeverContentFixture(object):
 
         with self.freeze_at_hour(7):
             self.create_users()
+            self.create_teams()
             self.create_contacts()
 
         with self.freeze_at_hour(8):
@@ -99,6 +100,27 @@ class OpengeverContentFixture(object):
             group=self.org_unit.inbox_group)
         self.committee_responsible = self.create_user(
             'committee_responsible', u'Fr\xe4nzi', u'M\xfcller')
+
+    def create_teams(self):
+        users = [ogds_service().find_user(user.getId())
+                 for user in [self.regular_user, self.dossier_responsible]]
+        group_a = create(Builder('ogds_group')
+                         .having(groupid='projekt_a',
+                                 title=u'Projekt A', users=users))
+        self.projekt_a = create(
+            Builder('ogds_team')
+            .having(title=u'Projekt \xdcberbaung Dorfmatte',
+                    group=group_a, org_unit=self.org_unit))
+
+        users = [ogds_service().find_user(user.getId())
+                 for user in [self.committee_responsible, self.meeting_user]]
+        group_b = create(Builder('ogds_group')
+                         .having(groupid='projekt_b',
+                                 title=u'Projekt B', users=users))
+        self.projekt_b = create(
+            Builder('ogds_team')
+            .having(title=u'Sekretariat Abteilung XY',
+                    group=group_b, org_unit=self.org_unit))
 
     @staticuid()
     def create_repository_tree(self):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -95,7 +95,8 @@ class OpengeverContentFixture(object):
         self.meeting_user = self.create_user(
             'meeting_user', u'Herbert', u'J\xe4ger')
         self.secretariat_user = self.create_user(
-            'secretariat_user', u'J\xfcrgen', u'K\xf6nig')
+            'secretariat_user', u'J\xfcrgen', u'K\xf6nig',
+            group=self.org_unit.inbox_group)
         self.committee_responsible = self.create_user(
             'committee_responsible', u'Fr\xe4nzi', u'M\xfcller')
 
@@ -542,7 +543,7 @@ class OpengeverContentFixture(object):
         """
         self._lookup_table[attrname] = ('raw', value)
 
-    def create_user(self, attrname, firstname, lastname, globalroles=()):
+    def create_user(self, attrname, firstname, lastname, globalroles=(), group=None):
         """Create an OGDS user and a Plone user.
         The user is member of the current org unit user group.
         The ``attrname`` is the attribute name used to access this user
@@ -562,7 +563,8 @@ class OpengeverContentFixture(object):
         create(Builder('ogds_user')
                .id(plone_user.getId())
                .having(firstname=firstname, lastname=lastname, email=email)
-               .assign_to_org_units([self.org_unit]))
+               .assign_to_org_units([self.org_unit])
+               .in_group(group))
 
         self._lookup_table[attrname] = ('user', plone_user.getId())
         return plone_user

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -38,6 +38,7 @@ FEATURE_FLAGS = {
     'ech0147-import': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_import_enabled',
     'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
     'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
+    'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled'
 }
 
 FEATURE_PROFILES = {

--- a/sources.cfg
+++ b/sources.cfg
@@ -10,6 +10,7 @@ development-packages =
   collective.js.timeago
 # https://github.com/4teamwork/plonetheme.teamraum/pull/584
   plonetheme.teamraum
+  opengever.ogds.models
 
 # Please cleanup your pull-request so that you are not adding ftw.*-packages
 # to the development-packages. It is your responsibility to release the


### PR DESCRIPTION
Thats the first part of the OGIP 24 - Teamaufgaben implementiation

 - Upgradestep for the new model introduce in opengever.ogds.models (https://github.com/4teamwork/opengever.ogds.models/pull/48) Closes #3410 
 - Display team memberships in the user-details view, closes #3412 
 - Detailview for teams, closes #3413 
 - Add additional option `include_teams` to the AllUsersAndInbox source. Which has been renamed to `AllUsersInboxesAndTeamsSource`.
 - Allow to select a team as a task responsible and change the responsible to current user, when a team task gets accepted. Closes #3414 

Currently there is no need for a feature flag, if no team exists none of these changes are visible for a user.

![bildschirmfoto 2017-09-25 um 16 35 51](https://user-images.githubusercontent.com/485755/30814143-acd1ae06-a20f-11e7-9512-16264e7533ff.png)
![bildschirmfoto 2017-09-25 um 16 35 40](https://user-images.githubusercontent.com/485755/30814144-acd32524-a20f-11e7-99c2-c6b9bed5b16b.png)
![bildschirmfoto 2017-09-25 um 16 36 53 1](https://user-images.githubusercontent.com/485755/30814194-c42bc082-a20f-11e7-95cf-4fe2bcbcb8db.png)

Styling: https://github.com/4teamwork/plonetheme.teamraum/pull/585
