### PR TITLE
Allow to set excerpt titles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - SPV word: Represent paragraphs in the generated protocol. [jone]
+- SPV word: Allow to set custom excerpt titles. [tarnap]
 - OGDS update: Truncate purely descriptive user fields. [lgraf]
 - Include ftw.usermigration and implement additional user migrations:
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -18,6 +18,7 @@ from zExceptions import Forbidden
 from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
+from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
 from zope.publisher.interfaces import IPublishTraverse
@@ -212,6 +213,12 @@ class AgendaItemsView(BrowserView):
 
                 data['excerpts'] = self._serialize_excerpts(meeting, item)
                 if item.can_generate_excerpt():
+                    data['generate_excerpt_default_title'] = translate(
+                        _(u'excerpt_document_default_title',
+                          default=u'Excerpt ${title}',
+                          mapping={'title': safe_unicode(item.get_title())}),
+                        context=self.request,
+                    ).strip()
                     data['generate_excerpt_link'] = meeting.get_url(
                         view='agenda_items/{}/generate_excerpt'.format(
                             item.agenda_item_id))
@@ -451,7 +458,7 @@ class AgendaItemsView(BrowserView):
             raise Forbidden('Generating excerpt is not allowed in this state.')
 
         try:
-            self.agenda_item.generate_excerpt()
+            self.agenda_item.generate_excerpt(title=self.request.form['excerpt_title'])
         except MissingMeetingDossierPermissions:
             return (JSONResponse(self.request)
                     .error(_('error_no_permission_to_add_document',

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -93,7 +93,7 @@
         <a href="{{revise_link}}" title="%(label_revise_action)s" class="button revise-agenda-item"><span></span></a>
         {{/if}}
         {{#if generate_excerpt_link}}
-        <a href="{{generate_excerpt_link}}" title="%(label_generate_excerpt)s" class="button generate-excerpt"><span></span></a>
+        <a href="{{generate_excerpt_link}}" title="%(label_generate_excerpt)s" class="button generate-excerpt" data-default-title="{{generate_excerpt_default_title}}"><span></span></a>
         {{/if}}
       </div>
     </td>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -39,6 +39,7 @@
                     i18n:translate="label_cancel">Cancel</button>
           </div>
         </div>
+
         <div class="overlay" id="confirm_unschedule">
           <div class="close">
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
@@ -112,6 +113,28 @@
             <button class="button decline"
                     i18n:translate="label_cancel">Cancel</button>
           </div>
+        </div>
+
+        <div class="overlay" id="confirm_create_excerpt">
+          <h2 i18n:translate="create_excerpt">Create Excerpt</h2>
+          <p i18n:translate="msg_confirm_create_excerpt_dialog">
+            Choose a meaningful title to distinguish the created excerpts better.
+          </p>
+          <form>
+              <div class="input-group">
+                <label for="excerpt_title"
+                       i18n:translate="label_title_excerpt">Excerpt title</label>
+                <input type="text"
+                       name="excerpt_title"
+                       id="excerpt_title" />
+              </div>
+              <div class="button-group">
+                <button class="button confirm"
+                        i18n:translate="label_create_excerpt">Create Excerpt</button>
+                <button class="button decline"
+                        i18n:translate="label_cancel">Cancel</button>
+              </div>
+          </form>
         </div>
 
         <div class="meeting-metadata">

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -269,12 +269,12 @@
       });
     };
 
-    this.generateExcerpt = function(target, event) {
+    this.openGenerateExcerptDialog = function(target) {
       this.currentItem = target;
       createExcerptDialog.load();
     };
 
-    this.createExcerpt = function(target, event) {
+    this.generateExcerpt = function(target, event) {
       var link = self.currentItem[0].href;
       self = this;
       return $.post(link, $('#confirm_create_excerpt form').serialize())
@@ -335,7 +335,7 @@
       {
         method: "click",
         target: ".generate-excerpt",
-        callback: this.generateExcerpt,
+        callback: this.openGenerateExcerptDialog,
         options: {
           prevent: true
         }
@@ -361,7 +361,7 @@
       {
         method: "click",
         target: "#confirm_create_excerpt .confirm",
-        callback: this.createExcerpt,
+        callback: this.generateExcerpt,
         options: {
           prevent: true,
           loading: true,
@@ -393,7 +393,7 @@
       },
       {
         method: "click",
-        target: "#confirm_unschedule .decline, #confirm_delete .decline, #confirm_return_excerpt .decline",
+        target: "#confirm_unschedule .decline, #confirm_delete .decline, #confirm_return_excerpt .decline, #confirm_create_excerpt .decline",
         callback: this.closeModal
       },
       {

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -117,6 +117,20 @@
       closeOnEsc: false
     }).data("overlay");
 
+    var createExcerptDialog = $('#confirm_create_excerpt').overlay({
+      speed: 0,
+      closeSpeed: 0,
+      mask: { loadSpeed: 0 },
+      closeOnClick: false,
+      closeOnEsc: false,
+      onBeforeLoad: function() {
+        $('#excerpt_title').val(self.currentItem.data().defaultTitle);
+      },
+      onLoad: function() {
+        $('#excerpt_title').focus().select();
+      }
+    }).data("overlay");
+
     var sortableHelper = function(e, row) {
       var helper = row.clone();
       $.each(row.children(), function(idx, cell) {
@@ -170,6 +184,7 @@
       unscheduleDialog.close();
       deleteDialog.close();
       returnExcerptDialog.close();
+      createExcerptDialog.close();
     };
 
     this.updateSortOrder = function() {
@@ -254,9 +269,19 @@
       });
     };
 
-    this.generateExcerpt = function(target) {
-      return $.get(target.attr("href"));
+    this.generateExcerpt = function(target, event) {
+      this.currentItem = target;
+      createExcerptDialog.load();
     };
+
+    this.createExcerpt = function(target, event) {
+      var link = self.currentItem[0].href;
+      self = this;
+      return $.post(link, $('#confirm_create_excerpt form').serialize())
+              .always(function() {
+                self.closeModal();
+              });
+    }
 
     this.returnExcerpt = function() {
       self = this;
@@ -312,8 +337,7 @@
         target: ".generate-excerpt",
         callback: this.generateExcerpt,
         options: {
-          update: true,
-          loading: true
+          prevent: true
         }
       },
       {
@@ -330,6 +354,16 @@
         callback: this.returnExcerpt,
         options: {
           prevent: false,
+          loading: true,
+          update: true
+        }
+      },
+      {
+        method: "click",
+        target: "#confirm_create_excerpt .confirm",
+        callback: this.createExcerpt,
+        options: {
+          prevent: true,
           loading: true,
           update: true
         }

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -569,6 +569,11 @@ msgstr "Titel"
 msgid "column_to"
 msgstr "Bis"
 
+#. Default: "Create Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:115
+msgid "create_excerpt"
+msgstr "Protokollauszug generieren"
+
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:51
 #: ./opengever/meeting/model/proposal.py:159
@@ -634,8 +639,8 @@ msgid "error_prosal_template_not_docx"
 msgstr "Nur Word-Dateien (.docx) sind erlaubt."
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/model/agendaitem.py:438
-msgid "excerpt_document_title"
+#: ./opengever/meeting/browser/meetings/agendaitem.py:217
+msgid "excerpt_document_default_title"
 msgstr "Protokollauszug ${title}"
 
 #. Default: "Excerpt was created successfully."
@@ -782,6 +787,11 @@ msgstr "Erwägungen"
 #: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
+
+#. Default: "Create Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:127
+msgid "label_create_excerpt"
+msgstr "Protokollauszug generieren"
 
 #. Default: "Creator"
 #: ./opengever/meeting/browser/proposalforms.py:92
@@ -1206,6 +1216,11 @@ msgstr "Start"
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "Excerpt title"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:122
+msgid "label_title_excerpt"
+msgstr "Titel"
+
 #. Default: "Table of contents template"
 #: ./opengever/meeting/committee.py:78
 #: ./opengever/meeting/committeecontainer.py:37
@@ -1296,6 +1311,11 @@ msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in
 #: ./opengever/meeting/browser/meetings/agendaitem.py:422
 msgid "missing_ad_hoc_template"
 msgstr "Es konnte keine Vorlage für ein Ad Hoc Traktandum gefunden werden."
+
+#. Default: "Choose a meaningful title to distinguish the created excerpts better."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+msgid "msg_confirm_create_excerpt_dialog"
+msgstr "Wählen Sie einen aussagekräftigen Titel um die Protokollauszüge besser unterscheiden zu können."
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -571,6 +571,11 @@ msgstr "Titre"
 msgid "column_to"
 msgstr "Jusqu'à"
 
+#. Default: "Create Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:115
+msgid "create_excerpt"
+msgstr ""
+
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:51
 #: ./opengever/meeting/model/proposal.py:159
@@ -636,8 +641,8 @@ msgid "error_prosal_template_not_docx"
 msgstr "Seuls les fichiers Word (.docx) sont acceptés."
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/model/agendaitem.py:438
-msgid "excerpt_document_title"
+#: ./opengever/meeting/browser/meetings/agendaitem.py:217
+msgid "excerpt_document_default_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
@@ -784,6 +789,11 @@ msgstr "Considérations"
 #: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
 msgstr "Copie pour information"
+
+#. Default: "Create Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:127
+msgid "label_create_excerpt"
+msgstr ""
 
 #. Default: "Creator"
 #: ./opengever/meeting/browser/proposalforms.py:92
@@ -1208,6 +1218,11 @@ msgstr "Début"
 msgid "label_title"
 msgstr "Titre"
 
+#. Default: "Excerpt title"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:122
+msgid "label_title_excerpt"
+msgstr ""
+
 #. Default: "Table of contents template"
 #: ./opengever/meeting/committee.py:78
 #: ./opengever/meeting/committeecontainer.py:37
@@ -1297,6 +1312,11 @@ msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été
 #. Default: "No ad-hoc agenda-item template has been configured."
 #: ./opengever/meeting/browser/meetings/agendaitem.py:422
 msgid "missing_ad_hoc_template"
+msgstr ""
+
+#. Default: "Choose a meaningful title to distinguish the created excerpts better."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+msgid "msg_confirm_create_excerpt_dialog"
 msgstr ""
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -568,6 +568,11 @@ msgstr ""
 msgid "column_to"
 msgstr ""
 
+#. Default: "Create Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:115
+msgid "create_excerpt"
+msgstr ""
+
 #. Default: "Decide"
 #: ./opengever/meeting/model/agendaitem.py:51
 #: ./opengever/meeting/model/proposal.py:159
@@ -633,8 +638,8 @@ msgid "error_prosal_template_not_docx"
 msgstr ""
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/model/agendaitem.py:438
-msgid "excerpt_document_title"
+#: ./opengever/meeting/browser/meetings/agendaitem.py:217
+msgid "excerpt_document_default_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
@@ -780,6 +785,11 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/protocol.py:148
 #: ./opengever/meeting/proposal.py:118
 msgid "label_copy_for_attention"
+msgstr ""
+
+#. Default: "Create Excerpt"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:127
+msgid "label_create_excerpt"
 msgstr ""
 
 #. Default: "Creator"
@@ -1205,6 +1215,11 @@ msgstr ""
 msgid "label_title"
 msgstr ""
 
+#. Default: "Excerpt title"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:122
+msgid "label_title_excerpt"
+msgstr ""
+
 #. Default: "Table of contents template"
 #: ./opengever/meeting/committee.py:78
 #: ./opengever/meeting/committeecontainer.py:37
@@ -1294,6 +1309,11 @@ msgstr ""
 #. Default: "No ad-hoc agenda-item template has been configured."
 #: ./opengever/meeting/browser/meetings/agendaitem.py:422
 msgid "missing_ad_hoc_template"
+msgstr ""
+
+#. Default: "Chose a meaningful title to distinguish the created excerpts better."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+msgid "msg_confirm_create_excerpt_dialog"
 msgstr ""
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -417,7 +417,7 @@ class AgendaItem(Base):
         self.proposal.return_excerpt(document)
 
     @require_word_meeting_feature
-    def generate_excerpt(self):
+    def generate_excerpt(self, title):
         """Generate an excerpt from the agenda items document.
 
         Can either be an excerpt from the proposals document or an excerpt
@@ -434,11 +434,6 @@ class AgendaItem(Base):
         if not api.user.get_current().checkPermission(
                 'opengever.document: Add document', meeting_dossier):
             raise MissingMeetingDossierPermissions
-
-        title = _(u'excerpt_document_title',
-                  default=u'Excerpt ${title}',
-                  mapping={'title': safe_unicode(self.get_title())})
-        title = translate(title, context=meeting_dossier.REQUEST).strip()
 
         excerpt_document = CreateDocumentCommand(
             context=meeting_dossier,

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -150,7 +150,10 @@ class TestWordAgendaItem(IntegrationTestCase):
 
         # Create an excerpt.
         with self.observe_children(self.meeting_dossier) as children:
-            browser.open(item_data['generate_excerpt_link'], send_authenticator=True)
+            browser.open(
+                item_data['generate_excerpt_link'],
+                data={'excerpt_title': u'Excerpt ad-hoc'},
+                send_authenticator=True)
 
         # Generating the excerpt is confirmed with a status message.
         self.assertEquals(
@@ -201,7 +204,9 @@ class TestWordAgendaItem(IntegrationTestCase):
             agenda_item.decide()
 
         self.login(self.regular_user, browser)
-        browser.open(self.agenda_item_url(agenda_item, 'generate_excerpt'))
+        browser.open(
+            self.agenda_item_url(agenda_item, 'generate_excerpt'),
+            data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
         self.assertEquals(
             {u'messages': [
                 {u'messageTitle': u'Error',
@@ -221,7 +226,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertFalse(item_data.get('excerpts'))
 
-        excerpt = agenda_item.generate_excerpt()
+        excerpt = agenda_item.generate_excerpt(title=u'Excerpt ad-hoc')
 
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -230,12 +230,16 @@ class TestWordAgendaItem(IntegrationTestCase):
 
         # The generate excerpt link is available on decided agenda items.
         self.assertDictContainsSubset(
-            {'generate_excerpt_link': self.agenda_item_url(agenda_item, 'generate_excerpt')},
+            {'generate_excerpt_link': self.agenda_item_url(agenda_item, 'generate_excerpt'),
+             'generate_excerpt_default_title': u'Excerpt \xc4nderungen am Personalreglement'},
             item_data)
 
         # Create an excerpt.
         with self.observe_children(self.meeting_dossier) as children:
-            browser.open(item_data['generate_excerpt_link'], send_authenticator=True)
+            browser.open(
+                item_data['generate_excerpt_link'],
+                data={'excerpt_title': 'Excerption \xc3\x84nderungen'},
+                send_authenticator=True)
 
         # Generating the excerpt is confirmed with a status message.
         self.assertEquals(
@@ -250,7 +254,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         # original document.
         self.assertEquals(1, len(children['added']))
         excerpt_document, = children['added']
-        self.assertEquals('Excerpt \xc3\x84nderungen am Personalreglement',
+        self.assertEquals('Excerption \xc3\x84nderungen',
                           excerpt_document.Title())
         self.assertEquals(
             self.submitted_word_proposal.get_proposal_document().file.data,

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -297,7 +297,9 @@ class TestWordAgendaItem(IntegrationTestCase):
             agenda_item.decide()
 
         self.login(self.regular_user, browser)
-        browser.open(self.agenda_item_url(agenda_item, 'generate_excerpt'))
+        browser.open(
+            self.agenda_item_url(agenda_item, 'generate_excerpt'),
+            data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
         self.assertEquals(
             {u'messages': [
                 {u'messageTitle': u'Error',
@@ -318,7 +320,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         item_data = browser.json['items'][0]
         self.assertFalse(item_data.get('excerpts'))
 
-        excerpt = agenda_item.generate_excerpt()
+        excerpt = agenda_item.generate_excerpt(title='Excerpt \xc3\x84nderungen')
         browser.open(self.meeting, view='agenda_items/list')
         item_data = browser.json['items'][0]
         excerpt_links = item_data.get('excerpts', None)
@@ -353,7 +355,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         agenda_item = self.schedule_proposal(self.meeting,
                                              self.submitted_word_proposal)
         agenda_item.decide()
-        excerpt = agenda_item.generate_excerpt()
+        excerpt = agenda_item.generate_excerpt(title='Excerpt \xc3\x84nderungen')
 
         self.assertIsNone(agenda_item.proposal.excerpt_document)
         self.assertIsNone(agenda_item.proposal.submitted_excerpt_document)

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -76,7 +76,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         agenda_item = self.schedule_proposal(self.meeting,
                                              self.submitted_word_proposal)
         agenda_item.decide()
-        agenda_item.generate_excerpt()
+        agenda_item.generate_excerpt(title='Ahoi McEnroe!')
 
         browser.open(self.meeting, view='export-meeting-zip')
         zip_file = ZipFile(StringIO(browser.contents), 'r')

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -205,7 +205,7 @@ class TestProposalWithWord(IntegrationTestCase):
         agenda_item.decide()
 
         with self.observe_children(self.meeting_dossier) as children:
-            agenda_item.generate_excerpt()
+            agenda_item.generate_excerpt(title='Excerpt \xc3\x84nderungen')
 
         self.assertEquals(1, len(children['added']),
                           'An excerpt document should have been added to the'
@@ -213,9 +213,9 @@ class TestProposalWithWord(IntegrationTestCase):
 
         # The document should contain a copy of the proposal document file.
         excerpt_document, = children['added']
-        self.assertEquals('Excerpt \xc3\x84nderungen am Personalreglement',
+        self.assertEquals('Excerpt \xc3\x84nderungen',
                           excerpt_document.Title())
-        self.assertEquals(u'excerpt-anderungen-am-personalreglement.docx',
+        self.assertEquals(u'excerpt-anderungen.docx',
                           excerpt_document.file.filename)
         self.assertEquals(MIME_DOCX, excerpt_document.file.contentType)
         self.assertEquals(


### PR DESCRIPTION
When generating an excerpt, the user should be able to set a meaningful title, to distinguish the listed excerpts better.

![set_excerpt_titles](https://user-images.githubusercontent.com/194114/30903001-9fb8c9ac-a36d-11e7-958e-904e34181a61.gif)

Resolves https://github.com/4teamwork/gever/issues/69