### PR TITLE
Trash document of deleted ad hoc agenda items

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix private folder creation for userids containing dashes. [phgross]
 - SPV word: Set "remove" and "delete" translations correctly. [tarnap]
+- SPV word: trash documents of removed ad hoc agenda items. [tarnap]
 - SPV word: Represent paragraphs in the generated protocol. [jone]
 - SPV word: Allow to set custom excerpt titles. [tarnap]
 - OGDS update: Truncate purely descriptive user fields. [lgraf]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -7,6 +7,7 @@ from opengever.meeting.exceptions import MissingAdHocTemplate
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.service import meeting_service
+from opengever.trash.trash import ITrashable
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contentlisting.interfaces import IContentListingObject
@@ -283,6 +284,12 @@ class AgendaItemsView(BrowserView):
 
         if not self.context.model.is_editable():
             raise Unauthorized("Editing is not allowed")
+
+        # the agenda_item is ad hoc if it has a document but no proposal
+        if self.agenda_item.has_document and not self.agenda_item.has_proposal:
+            document = self.agenda_item.resolve_document()
+            trasher = ITrashable(document)
+            trasher.trash()
 
         self.agenda_item.remove()
 

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import ITrashed
 from plone import api
 from plone.protect import createToken
 
@@ -33,6 +34,19 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.assertIn(
             ad_hoc_document.absolute_url() + '/tooltip',
             document_link_html)
+
+    @browsing
+    def test_document_is_trashed_when_ad_hoc_agenda_item_is_deleted(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.schedule_ad_hoc(self.meeting, u'ad-hoc')
+        document = agenda_item.resolve_document()
+
+        browser.open(
+            self.meeting,
+            view='agenda_items/{}/delete'.format(agenda_item.agenda_item_id),
+            send_authenticator=True)
+
+        self.assertTrue(ITrashed.providedBy(document))
 
     @browsing
     def test_cant_create_adhoc_when_no_access_to_meeting_dossier(self, browser):

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -4,11 +4,25 @@ from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.protect.utils import addTokenToUrl
 from plone.uuid.interfaces import IUUID
+from opengever.trash.trash import ITrashed
 
 
 class TestWordAgendaItem(IntegrationTestCase):
 
     features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_delete_agenda_item_does_not_trash_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.schedule_proposal(self.meeting,
+                                             self.submitted_word_proposal)
+        document = agenda_item.resolve_document()
+
+        browser.open(
+            self.meeting,
+            view='agenda_items/{}/delete'.format(agenda_item.agenda_item_id))
+
+        self.assertFalse(ITrashed.providedBy(document))
 
     def test_deciding_meeting_item_does_not_create_an_excerpt(self):
         """When the word meeting feature is enabled, deciding a meeting item


### PR DESCRIPTION
When a responsible of a committee creates an agenda item ad hoc, a
document is created to contain the ad hoc item's proposal / decision.
If the ad hoc item is removed, the related document should be trashed.

If the agenda item is created from a proposal (handed in by a proposer),
then the proposal should remain until a related agenda item has been
scheduled.
Therefore removing the related agenda item should keep the document
untrashed.

Resolves https://github.com/4teamwork/gever/issues/76