### PR TITLE
Fix private folder creation for userids containing dashes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Fix private folder creation for userids containing dashes. [phgross]
 - SPV word: Represent paragraphs in the generated protocol. [jone]
 - OGDS update: Truncate purely descriptive user fields. [lgraf]
 - Include ftw.usermigration and implement additional user migrations:

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -21,7 +21,8 @@ class PrivateFolder(Container):
     """
 
     def Title(self):
-        return Actor.lookup(self.id).get_label(self).encode('utf-8')
+        return Actor.lookup(
+            self.getOwner().getId()).get_label(self).encode('utf-8')
 
     def notifyMemberAreaCreated(self):
         """Add additional local_roles to the members folder.
@@ -29,5 +30,5 @@ class PrivateFolder(Container):
         This method is called by the MembershipTool after MembersFolder
         creation.
         """
-        api.user.grant_roles(username=self.id, obj=self,
+        api.user.grant_roles(username=self.getOwner().getId(), obj=self,
                              roles=PRIVATE_FOLDER_DEFAULT_ROLES)

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -45,6 +45,20 @@ class TestPrivateFolder(FunctionalTestCase):
              'Contributor', 'Reviewer'],
             api.user.get_roles(username=TEST_USER_ID, obj=self.folder))
 
+    def test_handles_dashes_in_userids(self):
+        create(Builder('user').with_userid('peter-mustermann'))
+        create(Builder('ogds_user')
+               .having(userid='peter-mustermann',
+                       firstname='Peter',
+                       lastname='Mustermann'))
+
+        mtool = api.portal.get_tool('portal_membership')
+        mtool.createMemberArea(member_id='peter-mustermann')
+
+        folder = mtool.getHomeFolder(id='peter-mustermann')
+        self.assertEquals(
+            'Mustermann Peter (peter-mustermann)', folder.Title())
+
 
 class TestPrivateFolderTabbedView(FunctionalTestCase):
 


### PR DESCRIPTION
The current PrivateFolder implementation assumes that the folder id is exactly the same than the id of the corresponding user. But the portal_membership tool, convert the id (for example `-` gets
replaced with `--`, see https://github.com/plone/Products.PlonePAS/blob/master/src/Products/PlonePAS/tools/membership.py#L318) therefore this assumption is wrong and leads to the following error when trying to create a member area for userid containing dashes:
```
  File "/plone.api-1.7-py2.7.egg/plone/api/user.py", line 373, in grant_roles
    raise InvalidParameterError('User could not be found')
InvalidParameterError: User could not be found
```

So I've changed the implementation and using `getOwner()` to get the corresponding userid of an private folder.


Needs possibly a backport to 2017.5-stable.