### PR TITLE
Remove the prefix of the proposal document's title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- SPV word: Remove proposal document's title prefix. [tarnap]
 - SPV word: Remove "Ad-hoc" from the GUI. [tarnap]
 - Fix private folder creation for userids containing dashes. [phgross]
 - SPV word: Set "remove" and "delete" translations correctly. [tarnap]

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1438,11 +1438,6 @@ msgstr "Vorsitz"
 msgid "proposal_document"
 msgstr "Antragsdokument"
 
-#. Default: "Proposal document ${title}"
-#: ./opengever/meeting/proposal.py:310
-msgid "proposal_document_title"
-msgstr "Antragsdokument ${title}"
-
 #. Default: "Proposal cancelled by ${user}"
 #: ./opengever/meeting/proposalhistory.py:196
 msgid "proposal_history_label_cancelled"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1440,11 +1440,6 @@ msgstr "Présidence"
 msgid "proposal_document"
 msgstr "Document de proposition"
 
-#. Default: "Proposal document ${title}"
-#: ./opengever/meeting/proposal.py:310
-msgid "proposal_document_title"
-msgstr "Document de proposition ${title}"
-
 #. Default: "Proposal cancelled by ${user}"
 #: ./opengever/meeting/proposalhistory.py:196
 msgid "proposal_history_label_cancelled"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -1437,11 +1437,6 @@ msgstr ""
 msgid "proposal_document"
 msgstr ""
 
-#. Default: "Proposal document ${title}"
-#: ./opengever/meeting/proposal.py:310
-msgid "proposal_document_title"
-msgstr ""
-
 #. Default: "Proposal cancelled by ${user}"
 #: ./opengever/meeting/proposalhistory.py:196
 msgid "proposal_history_label_cancelled"

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -307,11 +307,7 @@ class ProposalBase(ModelContainer):
         kwargs['context'] = self
         kwargs.setdefault('preserved_as_paper', False)
 
-        title = _(u'proposal_document_title',
-                  default=u'Proposal document ${title}',
-                  mapping={'title': safe_unicode(self.Title())})
-        title = translate(title, context=self.REQUEST).strip()
-        kwargs.setdefault('title', title)
+        kwargs.setdefault('title', safe_unicode(self.Title()))
 
         with elevated_privileges():
             obj = CreateDocumentCommand(**kwargs).execute()

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -38,7 +38,7 @@ class TestWordAgendaItem(IntegrationTestCase):
 
         document_link_html = item_data.get('document_link')
         self.assertIn(
-            u'Proposal document \xc4nderungen am Personalreglement',
+            u'\xc4nderungen am Personalreglement',
             document_link_html)
         document = self.submitted_word_proposal.get_proposal_document()
         self.assertIn(document.absolute_url() + '/tooltip', document_link_html)

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -66,7 +66,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         browser.open(self.meeting, view='export-meeting-zip')
         zip_file = ZipFile(StringIO(browser.contents), 'r')
         self.assertIn(
-            '1. Anderungen am Personalreglement/Proposal document Anderungen am Personalreglement.docx',
+            '1. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',
             zip_file.namelist())
 
     @browsing
@@ -83,7 +83,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         self.assertEquals(
             ['Protocol-9. Sitzung der Rechnungsprufungskommission.docx',
              '1. Anderungen am Personalreglement/Vertragsentwurf.docx',
-             '1. Anderungen am Personalreglement/Proposal document Anderungen am Personalreglement.docx',
+             '1. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',
              'Agendaitem list-9. Sitzung der Rechnungsprufungskommission.docx'],
             zip_file.namelist())
 

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -34,15 +34,15 @@ class TestProposalWithWord(IntegrationTestCase):
              ['Committee', u'Rechnungspr\xfcfungskommission'],
              ['Meeting', ''],
              ['Proposal document',
-              'Proposal document Baugesuch Kreuzachkreisel'],
+              'Baugesuch Kreuzachkreisel'],
              ['State', 'Pending'],
              ['Decision number', '']],
             browser.css('table.listing').first.lists())
 
-        browser.click_on('Proposal document Baugesuch Kreuzachkreisel')
+        browser.click_on('Baugesuch Kreuzachkreisel')
         browser.open(browser.context, view='tabbedview_view-overview')
         self.assertDictContainsSubset(
-            {'Title': u'Proposal document Baugesuch Kreuzachkreisel'},
+            {'Title': u'Baugesuch Kreuzachkreisel'},
             dict(browser.css('table.listing').first.lists()))
 
         self.assertEquals(
@@ -70,7 +70,7 @@ class TestProposalWithWord(IntegrationTestCase):
              ['Dossier', u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'],
              ['Meeting', ''],
              ['Proposal document',
-              u'Proposal document \xc4nderungen am Personalreglement'],
+              u'\xc4nderungen am Personalreglement'],
              ['State', 'Submitted'],
              ['Decision number', ''],
              ['Attachments', u'Vertr\xe4gsentwurf']],


### PR DESCRIPTION
The title of the proposal should be the title of the proposal's
document.

Resolves https://github.com/4teamwork/gever/issues/74