### PR TITLE
Fix GC / SQL bug in team tests.

### DIFF
--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -71,9 +71,13 @@ class TestTeamTasks(IntegrationTestCase):
         task = self.dossier.get('task-3')
 
         center = notification_center()
+        # Assign watchers to a local variable in order to avoid having
+        # a "stale association proxy" when the GC collects within the
+        # list comprehension.
+        watchers = center.get_watchers(task)
         self.assertEquals(
             [u'team:2', u'kathi.barfuss'],
-            [watcher.actorid for watcher in center.get_watchers(task)]
+            [watcher.actorid for watcher in watchers]
         )
 
         activity = Activity.query.one()


### PR DESCRIPTION
Assign watchers to a local variable in order to avoid having a "stale association proxy" when the GC collects within the list comprehension.

This should fix this problem:
```python
Error in test test_all_team_members_are_notified_for_a_new_team_task (opengever.task.tests.test_team_tasks.TestTeamTasks)
Traceback (most recent call last):
  File "/var/lib/jenkins/zope/eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
    testMethod()
  File "/var/lib/jenkins/zope/eggs/ftw.testbrowser-1.27.0-py2.7.egg/ftw/testbrowser/__init__.py", line 42, in test_function
    return func(self, *args, **kwargs)
  File "/var/lib/jenkins/jobs/opengever.core/workspace@2/opengever/task/tests/test_team_tasks.py", line 76, in test_all_team_members_are_notified_for_a_new_team_task
    [watcher.actorid for watcher in center.get_watchers(task)]
  File "/var/lib/jenkins/zope/eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/ext/associationproxy.py", line 604, in __iter__
    for member in self.col:
  File "/var/lib/jenkins/zope/eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/ext/associationproxy.py", line 509, in <lambda>
    col = property(lambda self: self.lazy_collection())
  File "/var/lib/jenkins/zope/eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/ext/associationproxy.py", line 465, in __call__
    "stale association proxy, parent object has gone out of "
InvalidRequestError: stale association proxy, parent object has gone out of scope
```

Discussion: https://4teamwork.slack.com/archives/C060FEYKA/p1506512950000173 ff