### PR TITLE
Meeting workflow fixes

### DIFF
--- a/opengever/base/menu.py
+++ b/opengever/base/menu.py
@@ -136,6 +136,8 @@ class OGCombinedActionsWorkflowMenu(CombinedActionsWorkflowMenu):
                 'extra': {
                     # JS event handlers register with an ID selector.
                     'id': transition.name,
+                    'separator': None,
+                    'class': '',
                 },
                 'submenu': None,
             })

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -489,7 +489,7 @@ msgstr "Periode abschliessen"
 #: ./opengever/meeting/model/meeting.py:77
 #: ./opengever/meeting/model/period.py:22
 msgid "closed"
-msgstr "geschlossen"
+msgstr "Abgeschlossen"
 
 #. Default: "Comittee"
 #: ./opengever/meeting/browser/documents/proposalstab.py:95
@@ -1681,4 +1681,3 @@ msgstr "Antrag traktandieren:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:160
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
-

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -86,7 +86,9 @@ class Meeting(Base, SQLFormSupport):
          CloseTransition(
              'held', 'closed',
              title=_('close_meeting', default='Close meeting')),
-         Transition('closed', 'held', title=_('reopen', default='Reopen'))],
+         Transition('closed', 'held',
+                    title=_('reopen', default='Reopen'),
+                    condition=is_word_meeting_implementation_enabled)],
         show_in_actions_menu=True,
         transition_controller=MeetingTransitionController,
     )

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -151,6 +151,18 @@ class TestMeeting(FunctionalTestCase):
             info_messages())
         self.assertIsNone(browser.find(close_meeting_button_name))
 
+    def test_reopen_transition_not_available(self):
+        """Meetings can only be reopened when the word-feature is enabled.
+        """
+        meeting = create(Builder('meeting')
+                         .having(committee=self.committee_model,
+                                 workflow_state='closed'))
+        self.assertEquals(
+            [],
+            [transition.name for transition
+             in meeting.workflow.get_transitions(meeting.get_state())
+             if meeting.workflow.can_execute_transition(meeting, transition.name)])
+
 
 class TestCommitteeMemberVocabulary(FunctionalTestCase):
 

--- a/opengever/meeting/workflow.py
+++ b/opengever/meeting/workflow.py
@@ -33,21 +33,29 @@ class State(object):
 
 class Transition(object):
 
-    def __init__(self, state_from, state_to, title=None, visible=True):
+    def __init__(self, state_from, state_to, title=None, visible=True,
+                 condition=None):
         self.state_from = state_from
         self.state_to = state_to
         self.title = title or self.name
-        self.visible = visible
+        self._visible = visible
+        self.condition = condition or (lambda: True)
 
     @property
     def name(self):
         return '-'.join((self.state_from, self.state_to))
+
+    @property
+    def visible(self):
+        return self._visible and self.condition()
 
     def execute(self, obj, model):
         assert self.can_execute(model)
         model.workflow_state = self.state_to
 
     def can_execute(self, model):
+        if not self.condition():
+            return False
         return model.workflow_state == self.state_from
 
     def __repr__(self):


### PR DESCRIPTION
1) Change the workflow state translation from "geschlossen" to "Abgeschlossen".
2) Protect the reopen transition (closed-held) so that it only appears when the word-meeting feature is enabled.
3) Fix a potential problem in the when gerating the menu items for transitions: the menu requires the "separator" and "class" keys.