### PR TITLE
Remove excerpt template from forms when word feature enabled

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - SPV word: Remove proposal document's title prefix. [tarnap]
+- SPV word: Hide excerpt template from form when word feature enabled. [tarnap]
 - SPV word: Remove "Ad-hoc" from the GUI. [tarnap]
 - Fix private folder creation for userids containing dashes. [phgross]
 - SPV word: Set "remove" and "delete" translations correctly. [tarnap]

--- a/opengever/meeting/browser/committeecontainer_forms.py
+++ b/opengever/meeting/browser/committeecontainer_forms.py
@@ -18,6 +18,8 @@ class AddForm(TranslatedTitleAddForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+        else:
+            self.widgets['excerpt_template'].mode = HIDDEN_MODE
 
 
 @adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
@@ -34,3 +36,5 @@ class EditForm(TranslatedTitleEditForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+        else:
+            self.widgets['excerpt_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -57,6 +57,8 @@ class AddForm(BaseWizardStepForm, dexterity.AddForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+        else:
+            self.widgets['excerpt_template'].mode = HIDDEN_MODE
 
     @buttonAndHandler(_(u'button_continue', default=u'Continue'), name='save')
     def handle_continue(self, action):
@@ -178,3 +180,5 @@ class EditForm(ModelProxyEditForm, dexterity.EditForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+        else:
+            self.widgets['excerpt_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,5 +1,6 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.model import Member
 from opengever.meeting.sources import proposal_template_source
@@ -8,6 +9,16 @@ from opengever.meeting.wrapper import MemberWrapper
 from plone.dexterity.content import Container
 from plone.directives import form
 from z3c.relationfield.schema import RelationChoice
+from zope.interface import Invalid
+
+
+def excerpt_template_constraint(value):
+    if is_word_meeting_implementation_enabled():
+        # The excerpt template is not used when word-meeting feature is enabled
+        return True
+    if not value:
+        raise Invalid()
+    return True
 
 
 class ICommitteeContainer(form.Schema):
@@ -23,7 +34,8 @@ class ICommitteeContainer(form.Schema):
     excerpt_template = RelationChoice(
         title=_('Excerpt template'),
         source=sablon_template_source,
-        required=True,
+        required=False,
+        constraint=excerpt_template_constraint,
     )
 
     agendaitem_list_template = RelationChoice(

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -17,8 +17,7 @@ class TestCommitteeContainer(IntegrationTestCase):
         self.assertIsNone(self.committee_container.get_ad_hoc_template())
 
         browser.open(self.committee_container, view='edit')
-        browser.fill({'Ad hoc agenda item template': self.proposal_template})
-        browser.find('Save').click()
+        browser.fill({'Ad hoc agenda item template': self.proposal_template}).save()
 
         statusmessages.assert_message('Changes saved')
 
@@ -33,9 +32,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         factoriesmenu.add('Committee Container')
         browser.fill({'Title': u'Sitzungen',
                       'Protocol template': self.sablon_template,
-                      'Excerpt template': self.sablon_template,
-                      'Ad hoc agenda item template': self.proposal_template})
-        browser.find('Save').click()
+                      'Ad hoc agenda item template': self.proposal_template}).save()
+        statusmessages.assert_no_error_messages()
 
         self.assertEqual(self.proposal_template,
                          browser.context.get_ad_hoc_template())
@@ -64,9 +62,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         factoriesmenu.add('Committee Container')
         browser.fill({'Title': u'Sitzungen',
                       'Protocol template': self.sablon_template,
-                      'Excerpt template': self.sablon_template,
-                      'Paragraph template': self.sablon_template})
-        browser.find('Save').click()
+                      'Paragraph template': self.sablon_template}).save()
+        statusmessages.assert_no_error_messages()
 
         self.assertEqual(self.sablon_template,
                          browser.context.get_paragraph_template())


### PR DESCRIPTION
The excerpt template is not required when the word feature is enabled.
This also improves some existing tests.

Resolves https://github.com/4teamwork/gever/issues/102