### PR TITLE
Fix flaky tests

### DIFF
--- a/opengever/tabbedview/tests/test_document_listing.py
+++ b/opengever/tabbedview/tests/test_document_listing.py
@@ -1,76 +1,24 @@
-from datetime import date
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestDocumentListing(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDocumentListing, self).setUp()
-
-        self.repository = create(Builder('repository'))
-
-        self.dossier = create(Builder('dossier')
-                              .within(self.repository)
-                              .titled(u'Dossier'))
-
-        self.document_1 = create(Builder('document')
-                                 .having(document_date=date(2016, 2, 10),
-                                         document_author=u'Peter Meter',
-                                         receipt_date=date(2016, 2, 11),
-                                         delivery_date=date(2016, 2, 12),
-                                         public_trial=u'unchecked')
-                                 .within(self.dossier)
-                                 .titled(u'Document 1'))
-
-        self.document_2 = create(Builder('document')
-                                 .having(document_date=date(2016, 2, 12),
-                                         document_author=u'Meter Peter',
-                                         receipt_date=date(2016, 2, 13),
-                                         delivery_date=date(2016, 2, 14),
-                                         public_trial=u'unchecked')
-                                 .within(self.dossier)
-                                 .titled(u'Document 2'))
+class TestDocumentListing(IntegrationTestCase):
 
     @browsing
     def test_lists_documents(self, browser):
-        browser.login().open(self.dossier, view='tabbedview_view-documents')
-
-        table = browser.css('.listing').first
-        expected = [['',
-                     'Sequence Number',
-                     'Title',
-                     'Document Author',
-                     'Document Date',
-                     'Receipt Date',
-                     'Delivery Date',
-                     'Checked out by',
-                     'Subdossier',
-                     'Public Trial',
-                     'Reference Number'],
-                    ['',
-                     '1',
-                     'Document 1',
-                     'Peter Meter',     # document_author
-                     '10.02.2016',      # document_date
-                     '11.02.2016',      # receipt_date
-                     '12.02.2016',      # delivery_date
-                     '',
-                     '',
-                     'unchecked',       # public_trial
-                     'Client1 1 / 1 / 1'],
-                    ['',
-                     '2',
-                     'Document 2',
-                     'Meter Peter',
-                     '12.02.2016',
-                     '13.02.2016',
-                     '14.02.2016',
-                     '',
-                     '',
-                     'unchecked',
-                     'Client1 1 / 1 / 2']]
-
-        self.assertEquals(expected, table.lists())
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier, view='tabbedview_view-documents')
+        self.maxDiff = None
+        self.assertIn(
+            {'': '',
+             'Checked out by': '',
+             'Delivery Date': '',
+             'Document Author': '',
+             'Document Date': '31.08.2016',
+             'Public Trial': 'unchecked',
+             'Receipt Date': '',
+             'Reference Number': 'Client1 1.1 / 1 / 3',
+             'Sequence Number': '3',
+             'Subdossier': '',
+             'Title': u'Vertr\xe4gsentwurf'},
+            browser.css('.listing').first.dicts())


### PR DESCRIPTION
Fix some flaky tests:

1) Document listing tests (tabbedview): test is rewritten with integration testing and is modified to only assert that one expected item is in the list of documents. In the fixture we actually have many documents, since word-based proposals also contain a document. It is more practical / less brittle here to not assert the complete list but only verify that one document is there.

2) Bumblebee gallery tests: use a ticking creator for moving the time forward so that we dont have two objects created at the same time[1] and thus the ordering is not consistent.

[1] same time means in the same minute, since the catalog's sort-index is minutes based (for better internal tree balancing, I guess).