### PR TITLE
SPV word: Improve visual feedback when scheduling text or paragraph.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]
 - SPV word: Remove "Ad-hoc" from the GUI. [tarnap]
 - Fix private folder creation for userids containing dashes. [phgross]

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -336,11 +336,11 @@
                 </label>
                 <input id="schedule-text" type="text" />
                 <div class="button-group">
-                  <input type="submit"
-                         value="Schedule"
-                         i18n:attributes="value label_schedule"
-                         tal:attributes="data-url view/url_schedule_text"
-                         class="schedule-text allowMultiSubmit" />
+                  <button class="schedule-text button"
+                          tal:attributes="data-url view/url_schedule_text"
+                          i18n:translate="label_schedule">
+                    Schedule
+                  </button>
                 </div>
               </div>
 
@@ -351,11 +351,11 @@
                 </label>
                 <input id="schedule-paragraph" type="text" />
                 <div class="button-group">
-                  <input type="submit"
-                         value="Insert"
-                         i18n:attributes="value label_insert"
-                         tal:attributes="data-url view/url_schedule_paragraph"
-                         class="schedule-paragraph allowMultiSubmit" />
+                  <button class="schedule-paragraph button"
+                          tal:attributes="data-url view/url_schedule_paragraph"
+                          i18n:translate="label_insert">
+                    Insert
+                  </button>
                 </div>
               </div>
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -432,17 +432,25 @@
 
     this.addParagraph = function() {
       var input = $("#schedule-paragraph");
-      return $.post($(".schedule-paragraph").data().url, { title: input.val() }).done(function() {
+      var button = $(".schedule-paragraph");
+      button.addClass("loading");
+      return $.post(button.data().url, { title: input.val() }).done(function() {
         input.val("");
         self.updateConnected();
+      }).always(function() {
+        button.removeClass("loading");
       });
     };
 
     this.addText = function() {
       var input = $("#schedule-text");
-      return $.post($(".schedule-text").first().data().url, { title: input.val() }).done(function() {
+      var button = $(".schedule-text");
+      button.addClass("loading");
+      return $.post(button.first().data().url, { title: input.val() }).done(function() {
         input.val("");
         self.updateConnected();
+      }).always(function() {
+        button.removeClass("loading");
       });
     };
 


### PR DESCRIPTION
Adds a spinner on "schedule text" and "schedule paragraph" buttons in the meeting view in order to give visual feedback to the user that the system is doing something.

In order for this to work we need to use <button>-tags as <input>-tags do not support a :before pseudo class in CSS.

![bildschirmfoto 2017-09-27 um 18 17 30](https://user-images.githubusercontent.com/7469/30924908-6484aafc-a3b0-11e7-9f13-a43f904d5934.png)
