### PR TITLE
bin/i18n-build: add --all option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -316,11 +316,17 @@ Updating translations can be done with the ``bin/i18n-build`` script.
 It will scan the entire ``opengever.core`` package for translation files that
 need updating, rebuild the respective ``.pot`` files and sync the ``.po`` files.
 
-Alternatively it's also possible to only update a single subpackage, for example the ``dossier`` subpackage:
+Usually you work on a specific package and you want to only rebuild this package:
 
 .. code::
 
     bin/i18n-build opengever.dossier
+
+For building all packages, use the ``--all`` option:
+
+.. code::
+
+    bin/i18n-build --all
 
 
 Updating the history file

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -9,6 +9,7 @@
 !git-changed-sh
 !git-changed-xml
 !git-fork-point
+!i18n-build
 !mtest
 !pinchecker
 !qa

--- a/bin/i18n-build
+++ b/bin/i18n-build
@@ -9,7 +9,7 @@
 # This script builds translation files for opengever.core.
 #
 # It does so by finding all the 'locales' directories, rebuilds
-# pkg.name.pot, merging pkg.name-manual.pot files if necessary, and 
+# pkg.name.pot, merging pkg.name-manual.pot files if necessary, and
 # then syncs translations to the .respective po files for all languages
 # defined in $LANGUAGES.
 

--- a/bin/i18n-build
+++ b/bin/i18n-build
@@ -2,9 +2,10 @@
 #
 # USAGE:
 # bin/i18n-build [pkgname]
+# bin/i18n-build --all
 #
 # If a [pkgname] is supplied, only translation files for that package will be
-# built. Otherwise they will be built for all packages.
+# built. Otherwise use --all for all packages.
 #
 # This script builds translation files for opengever.core.
 #
@@ -19,6 +20,13 @@ pkg_dir=`bin/package-directory`
 core_dir=`dirname $pkg_dir`
 locales_dirs=`find $pkg_dir -name 'locales'`
 
+if [ $# -eq 0 ] || [ "$1" == "--help" ]; then
+    echo "ERROR: Either provide a package name or use --all for all packages."
+    echo "Example: ./bin/i18n-build --all"
+    echo "Example: ./bin/i18n-build opengever.task"
+    exit 1
+fi
+
 for locale_dir in $locales_dirs
 do
     # Strip /locales
@@ -30,7 +38,7 @@ do
     pkgname=${pkg_relpath//\//.}            # opengever.dossier
 
     # checks if a specific package is selected
-    if [ $# -eq 1 ] && [ "$1" != "$pkgname" ]; then
+    if [ "$1" != "--all" ] && [ "$1" != "$pkgname" ]; then
       continue
     fi
 

--- a/development.cfg
+++ b/development.cfg
@@ -14,6 +14,12 @@ ogds-db-name = opengever
 development-parts +=
     ${buildout:sphinx-parts}
 
+development-parts -=
+# Disable generating a bin/i18n-build script (from plone-development.cfg),
+# because we have our own copy of bin/i18n-build committed in git.
+    i18n-build
+
+
 # this re-adds parts that would be dropped otherwise since buildout cannot really deal
 # with our complicated inheritance hierarchy
 parts +=
@@ -43,11 +49,3 @@ environment-vars +=
 [test]
 initialization +=
     os.environ['SABLON_BIN'] = '${buildout:sablon-executable}'
-
-[i18n-build]
-# Overrides the i18n-build part defined in plone-development.cfg in order to
-# provide a opengever.core specific script
-recipe = collective.recipe.cmd
-on_install=true
-on_update=true
-cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build

--- a/test-i18n-de.cfg
+++ b/test-i18n-de.cfg
@@ -21,7 +21,7 @@ input = inline:
     OUTPUT=""
 
     # Test building locales - split into 2 passes for different context lengths
-    OUTPUT+=$(bin/i18n-build 2>&1 | grep -A 3 -e '^Warning')
+    OUTPUT+=$(bin/i18n-build --all 2>&1 | grep -A 3 -e '^Warning')
 
     # Potential newline for visual clarity
     if [ -n "$OUTPUT" ]
@@ -29,7 +29,7 @@ input = inline:
         OUTPUT+="\n\n"
     fi
 
-    OUTPUT+=$(bin/i18n-build 2>&1 | grep -A 1 -e '^Merge-Warning')
+    OUTPUT+=$(bin/i18n-build --all 2>&1 | grep -A 1 -e '^Merge-Warning')
 
     if [ -n "$OUTPUT" ]
     then

--- a/test-i18n-de.cfg
+++ b/test-i18n-de.cfg
@@ -6,21 +6,12 @@ extends =
 parts =
     package-directory
     i18ndude
-    i18n-build
     bin-test-jenkins
 
 package-name = opengever.core
 package-namespace = opengever
 
 jenkins_python = $PYTHON27
-
-[i18n-build]
-# Overrides the i18n-build part defined in plone-development.cfg in order to
-# provide a opengever.core specific script
-recipe = collective.recipe.cmd
-on_install=true
-on_update=true
-cmds=cp i18n-build.in bin/i18n-build && chmod +x bin/i18n-build
 
 [bin-test-jenkins]
 recipe = collective.recipe.template


### PR DESCRIPTION
*Problem:*
From other projects I'm used to blindly run `bin/i18n-build`. When I do that in `opengever.core` I have these problems:
- it runs on all packages - I usually work on one package but I forget to add the package name as argument 🙈 
- I try to stop it, but its unstoppable (Ctrl-C just stops one process, the script continues with the next).

*Solution:*
I've changed the script to just exit with a usage when running `bin/i18n-build` without arguments.
In order to actually run all packages, just use the new `--all` option.
We have the same features as before, but now I need to decide what I really want to do 😉 

*Other changes:*
I moved the `i18n-build.in` to `bin/i18n-build` and disabled buildout from doing anything. Template and script were the same, so lets just commit to git where we want it to be.