### PR TITLE
Translation files: remove lines from comments.

### DIFF
--- a/bin/i18n-build
+++ b/bin/i18n-build
@@ -55,6 +55,7 @@ do
     build_cmd="bin/i18ndude rebuild-pot --pot $potfile --create $pkgname $merge_cmd ./${pkg_relpath}"
     echo $build_cmd
     eval $build_cmd
+    sed -i.bak 's/\(#: .*\):.*/\1/' $potfile && rm $potfile.bak
 
     # Sync all lanuguages defined in $LANGUAGES
     for lang in $LANGUAGES

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:20+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,47 +18,47 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:52
+#: ./opengever/activity/browser/listing.py
 msgid "column_Actor"
 msgstr "Akteur"
 
 #. Default: "Kind"
-#: ./opengever/activity/browser/listing.py:42
+#: ./opengever/activity/browser/listing.py
 msgid "column_kind"
 msgstr "Typ"
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:47
+#: ./opengever/activity/browser/listing.py
 msgid "column_title"
 msgstr "Titel"
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:57
+#: ./opengever/activity/browser/listing.py
 msgid "created"
 msgstr "Erstellt"
 
 #. Default: "Notifications"
-#: ./opengever/activity/viewlets/notification.pt:3
+#: ./opengever/activity/viewlets/notification.pt
 msgid "heading_notifications"
 msgstr "Benachrichtigungen"
 
 #. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt:42
+#: ./opengever/activity/templates/notification.pt
 msgid "label_details"
 msgstr "Details:"
 
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:41
+#: ./opengever/activity/viewlets/notification.pt
 msgid "label_notifications_overview"
 msgstr "Alle Benachrichtigungen"
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
-#: ./opengever/activity/center.py:228
+#: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht oder nur zum Teil ausgelöst."
 
 #. Default: "GEVER Task"
-#: ./opengever/activity/mail.py:112
+#: ./opengever/activity/mail.py
 msgid "subject_prefix"
 msgstr "GEVER Aufgabe"
 

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:20+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2016-08-10 04:42+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -20,47 +20,47 @@ msgstr ""
 "X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:52
+#: ./opengever/activity/browser/listing.py
 msgid "column_Actor"
 msgstr "Acteur"
 
 #. Default: "Kind"
-#: ./opengever/activity/browser/listing.py:42
+#: ./opengever/activity/browser/listing.py
 msgid "column_kind"
 msgstr "Type"
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:47
+#: ./opengever/activity/browser/listing.py
 msgid "column_title"
 msgstr "Titre"
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:57
+#: ./opengever/activity/browser/listing.py
 msgid "created"
 msgstr "Créé"
 
 #. Default: "Notifications"
-#: ./opengever/activity/viewlets/notification.pt:3
+#: ./opengever/activity/viewlets/notification.pt
 msgid "heading_notifications"
 msgstr "Notifications"
 
 #. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt:42
+#: ./opengever/activity/templates/notification.pt
 msgid "label_details"
 msgstr "Détails:"
 
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:41
+#: ./opengever/activity/viewlets/notification.pt
 msgid "label_notifications_overview"
 msgstr "Toutes les notifications"
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
-#: ./opengever/activity/center.py:228
+#: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr "Un problème a apparu pendant la création de la notification. La notification n’a pas pu être produite ou seulement partiellement."
 
 #. Default: "GEVER Task"
-#: ./opengever/activity/mail.py:112
+#: ./opengever/activity/mail.py
 msgid "subject_prefix"
 msgstr "Tâche GEVER"
 

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:20+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,47 +18,47 @@ msgstr ""
 "Domain: opengever.activity\n"
 
 #. Default: "Actor"
-#: ./opengever/activity/browser/listing.py:52
+#: ./opengever/activity/browser/listing.py
 msgid "column_Actor"
 msgstr ""
 
 #. Default: "Kind"
-#: ./opengever/activity/browser/listing.py:42
+#: ./opengever/activity/browser/listing.py
 msgid "column_kind"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/activity/browser/listing.py:47
+#: ./opengever/activity/browser/listing.py
 msgid "column_title"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/activity/browser/listing.py:57
+#: ./opengever/activity/browser/listing.py
 msgid "created"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./opengever/activity/viewlets/notification.pt:3
+#: ./opengever/activity/viewlets/notification.pt
 msgid "heading_notifications"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt:42
+#: ./opengever/activity/templates/notification.pt
 msgid "label_details"
 msgstr ""
 
 #. Default: "All Notifications"
-#: ./opengever/activity/viewlets/notification.pt:41
+#: ./opengever/activity/viewlets/notification.pt
 msgid "label_notifications_overview"
 msgstr ""
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
-#: ./opengever/activity/center.py:228
+#: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr ""
 
 #. Default: "GEVER Task"
-#: ./opengever/activity/mail.py:112
+#: ./opengever/activity/mail.py
 msgid "subject_prefix"
 msgstr ""
 

--- a/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/de/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:33+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2012-12-06 12:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,146 +15,146 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:265
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "advanced_search"
 msgstr "Erweiterte Suche"
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:455
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "button_search"
 msgstr "Suchen"
 
-#: ./opengever/advancedsearch/advanced_search.py:67
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "document"
 msgstr "Dokument"
 
-#: ./opengever/advancedsearch/advanced_search.py:55
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/advancedsearch/advanced_search.py:229
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_issuer"
 msgstr "Auftraggeber auswählen"
 
 #. Default: "Select the contenttype to be searched for."
-#: ./opengever/advancedsearch/advanced_search.py:121
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_portal_type"
 msgstr "Wählen Sie den Inhaltstyp aus, nach dem gesucht werden soll."
 
 #. Default: "Select the contenttype to be searched for.It searches only items from the current client."
-#: ./opengever/advancedsearch/advanced_search.py:353
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_portal_type_multiclient_setup"
 msgstr ""
 "Wählen Sie den Inhaltstyp aus, nach dem gesucht werden soll.\n"
 "Durchsucht werden nur Inhalte, die sich im aktuellen Mandanten befinden."
 
-#: ./opengever/advancedsearch/advanced_search.py:152
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_reference_number"
 msgstr "Aktenzeichen angeben (z.B: OG 2.4 / 1 / 3)"
 
-#: ./opengever/advancedsearch/advanced_search.py:115
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_searchable_text"
 msgstr "Suchbegriffe eingeben."
 
-#: ./opengever/advancedsearch/advanced_search.py:158
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_sequence_number"
 msgstr "Genaue Laufnummer eingeben."
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:216
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_checked_out"
 msgstr "Ausgecheckt von"
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:235
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_deadline"
 msgstr "Frist"
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:189
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:211
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_document_author"
 msgstr "Autor des Dokuments"
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:200
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "End date"
-#: ./opengever/advancedsearch/advanced_search.py:140
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_end"
 msgstr "Enddatum"
 
 #. Default: "From"
-#: ./opengever/advancedsearch/advanced_search.py:130
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_from"
 msgstr "Von"
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:228
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "Type"
-#: ./opengever/advancedsearch/advanced_search.py:120
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_portal_type"
 msgstr "Inhaltstyp"
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:178
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference number"
-#: ./opengever/advancedsearch/advanced_search.py:151
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Responsible"
-#: ./opengever/advancedsearch/advanced_search.py:163
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_reponsible"
 msgstr "Federführung"
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Text"
-#: ./opengever/advancedsearch/advanced_search.py:114
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_searchable_text"
 msgstr "Suchtext"
 
 #. Default: "Sequence number"
-#: ./opengever/advancedsearch/advanced_search.py:157
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Start date"
-#: ./opengever/advancedsearch/advanced_search.py:129
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_start"
 msgstr "Startdatum"
 
-#: ./opengever/advancedsearch/advanced_search.py:247
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_tasktype"
 msgstr "Auftragstyp"
 
 #. Default: "To"
-#: ./opengever/advancedsearch/advanced_search.py:135
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_to"
 msgstr "Bis"
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:222
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_trashed"
 msgstr "Papierkorb auch durchsuchen"
 
-#: ./opengever/advancedsearch/advanced_search.py:61
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "task"
 msgstr "lokal gespeicherte Aufgaben"
 

--- a/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
+++ b/opengever/advancedsearch/locales/fr/LC_MESSAGES/opengever.advancedsearch.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:33+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-06-03 19:19+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-advancedsearch/fr/>\n"
@@ -17,146 +17,146 @@ msgstr ""
 "X-Generator: Weblate 2.13.1\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:265
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "advanced_search"
 msgstr "Recherche avancée"
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:455
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "button_search"
 msgstr "Rechercher"
 
-#: ./opengever/advancedsearch/advanced_search.py:67
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "document"
 msgstr "Document"
 
-#: ./opengever/advancedsearch/advanced_search.py:55
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/advancedsearch/advanced_search.py:229
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_issuer"
 msgstr "Choix du client"
 
 #. Default: "Select the contenttype to be searched for."
-#: ./opengever/advancedsearch/advanced_search.py:121
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_portal_type"
 msgstr "Choix du type de contenu à rechercher."
 
 #. Default: "Select the contenttype to be searched for.It searches only items from the current client."
-#: ./opengever/advancedsearch/advanced_search.py:353
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_portal_type_multiclient_setup"
 msgstr ""
 "Choix du type de contenu à rechercher. \n"
 "Ne sont parcourus que les contenus du mandant actuel."
 
-#: ./opengever/advancedsearch/advanced_search.py:152
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_reference_number"
 msgstr "Saisir le numéro de référence (p.ex.: OG 2.4 / 1 / 3)"
 
-#: ./opengever/advancedsearch/advanced_search.py:115
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_searchable_text"
 msgstr "Saisir les critères de recherche."
 
-#: ./opengever/advancedsearch/advanced_search.py:158
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_sequence_number"
 msgstr "Saisir le numéro courant exact."
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:216
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_checked_out"
 msgstr "Check-out fait par"
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:235
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_deadline"
 msgstr "Délai"
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:189
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:211
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_document_author"
 msgstr "Auteur du document"
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:200
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "End date"
-#: ./opengever/advancedsearch/advanced_search.py:140
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_end"
 msgstr "Date de fin"
 
 #. Default: "From"
-#: ./opengever/advancedsearch/advanced_search.py:130
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_from"
 msgstr "de"
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:228
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "Type"
-#: ./opengever/advancedsearch/advanced_search.py:120
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_portal_type"
 msgstr "Type de contenu"
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:178
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference number"
-#: ./opengever/advancedsearch/advanced_search.py:151
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Responsible"
-#: ./opengever/advancedsearch/advanced_search.py:163
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_reponsible"
 msgstr "Responsable"
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Text"
-#: ./opengever/advancedsearch/advanced_search.py:114
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_searchable_text"
 msgstr "Texte de recherche"
 
 #. Default: "Sequence number"
-#: ./opengever/advancedsearch/advanced_search.py:157
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Start date"
-#: ./opengever/advancedsearch/advanced_search.py:129
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_start"
 msgstr "Date de début"
 
-#: ./opengever/advancedsearch/advanced_search.py:247
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_tasktype"
 msgstr "Type de mandat"
 
 #. Default: "To"
-#: ./opengever/advancedsearch/advanced_search.py:135
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_to"
 msgstr "à"
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:222
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_trashed"
 msgstr "Parcourir également la corbeille"
 
-#: ./opengever/advancedsearch/advanced_search.py:61
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "task"
 msgstr "Tâches sauvegardées localement"
 

--- a/opengever/advancedsearch/locales/opengever.advancedsearch.pot
+++ b/opengever/advancedsearch/locales/opengever.advancedsearch.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:33+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,144 +18,144 @@ msgstr ""
 "Domain: opengever.advancedsearch\n"
 
 #. Default: "advanced search"
-#: ./opengever/advancedsearch/advanced_search.py:265
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "advanced_search"
 msgstr ""
 
 #. Default: "Search"
-#: ./opengever/advancedsearch/advanced_search.py:455
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "button_search"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:67
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "document"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:55
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:229
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_issuer"
 msgstr ""
 
 #. Default: "Select the contenttype to be searched for."
-#: ./opengever/advancedsearch/advanced_search.py:121
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_portal_type"
 msgstr ""
 
 #. Default: "Select the contenttype to be searched for.It searches only items from the current client."
-#: ./opengever/advancedsearch/advanced_search.py:353
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_portal_type_multiclient_setup"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:152
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_reference_number"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:115
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_searchable_text"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:158
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "help_sequence_number"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/advancedsearch/advanced_search.py:216
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/advancedsearch/advanced_search.py:235
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "delivery date"
-#: ./opengever/advancedsearch/advanced_search.py:189
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Document author"
-#: ./opengever/advancedsearch/advanced_search.py:211
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/advancedsearch/advanced_search.py:200
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "End date"
-#: ./opengever/advancedsearch/advanced_search.py:140
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_end"
 msgstr ""
 
 #. Default: "From"
-#: ./opengever/advancedsearch/advanced_search.py:130
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_from"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/advancedsearch/advanced_search.py:228
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_issuer"
 msgstr ""
 
 #. Default: "Type"
-#: ./opengever/advancedsearch/advanced_search.py:120
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_portal_type"
 msgstr ""
 
 #. Default: "Receipt date"
-#: ./opengever/advancedsearch/advanced_search.py:178
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference number"
-#: ./opengever/advancedsearch/advanced_search.py:151
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/advancedsearch/advanced_search.py:163
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_reponsible"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/advancedsearch/advanced_search.py:169
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Text"
-#: ./opengever/advancedsearch/advanced_search.py:114
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_searchable_text"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/advancedsearch/advanced_search.py:157
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Start date"
-#: ./opengever/advancedsearch/advanced_search.py:129
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_start"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:247
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_tasktype"
 msgstr ""
 
 #. Default: "To"
-#: ./opengever/advancedsearch/advanced_search.py:135
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_to"
 msgstr ""
 
 #. Default: "Also search in the recycle bin"
-#: ./opengever/advancedsearch/advanced_search.py:222
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "label_trashed"
 msgstr ""
 
-#: ./opengever/advancedsearch/advanced_search.py:61
+#: ./opengever/advancedsearch/advanced_search.py
 msgid "task"
 msgstr ""
 

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-17 12:42+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -18,48 +18,48 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
-#: ./opengever/base/browser/list_groupmembers.pt:5
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "(INACTIVE)"
 msgstr "(INAKTIV)"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:35
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "Are you sure you want to deleted this items?"
 msgstr "Wollen Sie diese Inhalte wirklich löschen?"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:38
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "No content"
 msgstr "Keine Inhalte"
 
-#: ./opengever/base/viewlets/download.py:22
+#: ./opengever/base/viewlets/download.py
 msgid "No file in in this version"
 msgstr "In dieser Version ist keine Datei vorhanden"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:43
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "No items to delete"
 msgstr "Es werden keine Inhalte gelöscht"
 
 #. Default: "Save"
-#: ./opengever/base/browser/modelforms.py:41
+#: ./opengever/base/browser/modelforms.py
 msgid "Save"
 msgstr "Speichern"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:19
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "Some items won't be deleted!"
 msgstr "Einige Inhalte werden nicht gelöscht!"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:21
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "The following items are referenced by another item and will not be deleted"
 msgstr "Die folgenden Inhalte werden von anderen Inhalten referenziert und werden deshalb nicht gelöscht."
 
-#: ./opengever/base/browser/list_groupmembers.pt:14
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "There are no members in this group."
 msgstr "In dieser Gruppe befinden sich keine Benutzer."
 
-#: ./opengever/base/browser/list_groupmembers.pt:3
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "Users of group:"
 msgstr "Benutzer der Gruppe"
 
-#: ./opengever/base/validators.py:15
+#: ./opengever/base/validators.py
 msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
 msgstr "Sie können in der ausgewählten Ordnungsposition keine Dossiers erstellen. Die Ordnungsposition enthält entweder weitere Ordnungspositionen oder Sie besitzen nicht die erforderlichen Berechtigungen."
 
@@ -84,206 +84,206 @@ msgid "confidential"
 msgstr "Vertraulich"
 
 #. Default: "Confirm that you'd like to perform this action."
-#: ./opengever/base/browser/confirm.pt:20
+#: ./opengever/base/browser/confirm.pt
 msgid "desc_confirm_action"
 msgstr "Bestätigen Sie bitte, dass Sie diese Aktion durchführen möchten."
 
 #. Default: "If you need to report this to the responsible person, please include this entry number in your message."
-#: ./opengever/base/browser/templates/error.pt:101
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_include_error_in_admin_message"
 msgstr "Wenn Sie diesen Fehler dem Fachapplikationsverantwortlichen melden wollen, fügen Sie bitte die Fehlernummer hinzu."
 
 #. Default: "We apologize for the inconvenience, but the page you were trying to access is not at this address."
-#: ./opengever/base/browser/templates/error.pt:62
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error"
 msgstr "Entschuldigung, aber die Webseite die Sie versucht haben zu erreichen ist hier nicht verfügbar."
 
 #. Default: "Please contact the responsible person if this problem persists."
-#: ./opengever/base/browser/templates/error.pt:66
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
 msgstr "Bitte kontaktieren Sie den Fachapplikationsverantwortlichen, wenn dieses Problem längerfristig besteht."
 
 #. Default: "You have not selected any Items."
-#: ./opengever/base/browser/copy_items.py:23
+#: ./opengever/base/browser/copy_items.py
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt"
 
 #. Default: "The item you selected cannot be copied."
-#: ./opengever/base/browser/copy_items.py:30
+#: ./opengever/base/browser/copy_items.py
 msgid "error_not_copyable"
 msgstr "Der gewählte Inhalt kann nicht kopiert werden"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:62
+#: ./opengever/base/behaviors/classification.py
 msgid "fieldset_classification"
 msgstr "Sichtbarkeit"
 
 #. Default: "Common"
-#: ./opengever/base/behaviors/base.py:15
+#: ./opengever/base/behaviors/base.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Life Cycle"
-#: ./opengever/base/behaviors/lifecycle.py:31
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "fieldset_lifecycle"
 msgstr "Lebenszyklus"
 
 #. Default: "Archival value code"
-#: ./opengever/base/behaviors/lifecycle.py:60
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_archival_value"
 msgstr "Archivwürdigkeit"
 
 #. Default: ""
-#: ./opengever/base/behaviors/classification.py:73
+#: ./opengever/base/behaviors/classification.py
 msgid "help_classification"
 msgstr "Grad, in dem die Unterlagen vor unberechtigter Einsicht geschützt werden müssen."
 
-#: ./opengever/base/behaviors/lifecycle.py:75
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_custody_period"
 msgstr "Dauer, während der nach der Archivierung die Dokumente vor öffentlicher Einsichtnahme geschützt sind."
 
 #. Default: ""
-#: ./opengever/base/behaviors/classification.py:80
+#: ./opengever/base/behaviors/classification.py
 msgid "help_privacy_layer"
 msgstr "Markierung, die angibt, ob die Unterlagen besonders schützenswerte Personendaten oder Persönlichkeitsprofile gemäss Datenschutzrecht enthalten."
 
-#: ./opengever/base/behaviors/classification.py:87
+#: ./opengever/base/behaviors/classification.py
 msgid "help_public_trial"
 msgstr "Angabe, ob die Unterlagen gemäss Öffentlichkeitsgesetz zugänglich sind oder nicht."
 
-#: ./opengever/base/behaviors/classification.py:96
+#: ./opengever/base/behaviors/classification.py
 msgid "help_public_trial_statement"
 msgstr "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier"
 
-#: ./opengever/base/behaviors/lifecycle.py:45
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_retention_period"
 msgstr "Zeitraum zwischen dem jüngsten Dokumentdatum eines in einem Dossier enthaltenen Dokuments und dem Zeitpunkt, an dem dieses für die Geschäftstätigkeit der Verwaltungseinheit nicht mehr benötigt wird."
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:209
+#: ./opengever/base/adapters.py
 msgid "label_already_removed"
 msgstr "-- Bereits gelöscht --"
 
 #. Default: "Archival value"
-#: ./opengever/base/behaviors/lifecycle.py:59
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_archival_value"
 msgstr "Archivwürdigkeit"
 
 #. Default: "archivalValueAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:67
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_archival_value_annotation"
 msgstr "Kommentar zur Archivwürdigkeit"
 
 #. Default: "Cancel"
-#: ./opengever/base/browser/modelforms.py:53
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:62
+#: ./opengever/base/browser/modelforms.py
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Change public trial information."
-#: ./opengever/base/browser/edit_public_trial.py:62
+#: ./opengever/base/browser/edit_public_trial.py
 msgid "label_change_public_trial"
 msgstr "Öffentlichkeitsstatus ändern"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:72
+#: ./opengever/base/behaviors/classification.py
 msgid "label_classification"
 msgstr "Klassifikation"
 
 #. Default: "Confirm action"
-#: ./opengever/base/browser/confirm.pt:41
+#: ./opengever/base/browser/confirm.pt
 msgid "label_confirm_action"
 msgstr "Aktion bestätigen"
 
 #. Default: "Created"
-#: ./opengever/base/viewlets/byline.py:67
+#: ./opengever/base/viewlets/byline.py
 msgid "label_created"
 msgstr "Erstellt am"
 
 #. Default: "Custody period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:74
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_custody_period"
 msgstr "Archivische Schutzfrist (Jahre)"
 
 #. Default: "Date of cassation"
-#: ./opengever/base/behaviors/lifecycle.py:83
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofcassation"
 msgstr "Kassationsdatum"
 
 #. Default: "Date of submission"
-#: ./opengever/base/behaviors/lifecycle.py:90
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofsubmission"
 msgstr "Anbietezeitpunkt"
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:130
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "label_default_error_message"
 msgstr "Ein unerwarteter Fehler ist aufgetreten."
 
 #. Default: "Description"
-#: ./opengever/base/behaviors/base.py:30
+#: ./opengever/base/behaviors/base.py
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Dossier:"
-#: ./opengever/base/browser/search.pt:331
+#: ./opengever/base/browser/search.pt
 msgid "label_dossier"
 msgstr "Dossier:"
 
 #. Default: "Last modified"
-#: ./opengever/base/viewlets/byline.py:72
+#: ./opengever/base/viewlets/byline.py
 msgid "label_last_modified"
 msgstr "Zuletzt verändert"
 
 #. Default: "Privacy layer"
-#: ./opengever/base/behaviors/classification.py:79
+#: ./opengever/base/behaviors/classification.py
 msgid "label_privacy_layer"
 msgstr "Datenschutzstufe"
 
 #. Default: "Public Trial"
-#: ./opengever/base/behaviors/classification.py:86
+#: ./opengever/base/behaviors/classification.py
 msgid "label_public_trial"
 msgstr "Öffentlichkeitsstatus"
 
 #. Default: "Public trial statement"
-#: ./opengever/base/behaviors/classification.py:94
+#: ./opengever/base/behaviors/classification.py
 msgid "label_public_trial_statement"
 msgstr "Bearbeitungsinformation"
 
 #. Default: "Retention period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:44
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_retention_period"
 msgstr "Aufbewahrungsdauer (Jahre)"
 
 #. Default: "retentionPeriodAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:52
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_retention_period_annotation"
 msgstr "Kommentar zur Aufbewahrungsdauer"
 
 #. Default: "Search"
-#: ./opengever/base/browser/search.pt:65
+#: ./opengever/base/browser/search.pt
 msgid "label_search"
 msgstr "Suche"
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:129
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "label_severity_error"
 msgstr "Fehler"
 
 #. Default: "Title"
-#: ./opengever/base/behaviors/base.py:24
-#: ./opengever/base/browser/translated_title.py:35
-#: ./opengever/base/widgets.py:106
+#: ./opengever/base/behaviors/base.py
+#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/widgets.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Title (German)"
-#: ./opengever/base/behaviors/translated_title.py:39
+#: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_de"
 msgstr "Titel (deutsch)"
 
 #. Default: "Title (French)"
-#: ./opengever/base/behaviors/translated_title.py:45
+#: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
 msgstr "Titel (französisch)"
 
@@ -293,57 +293,57 @@ msgid "limited-public"
 msgstr "Eingeschränkt öffentlich"
 
 #. Default: "Changes saved"
-#: ./opengever/base/browser/modelforms.py:122
+#: ./opengever/base/browser/modelforms.py
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
 #. Default: "Record created"
-#: ./opengever/base/browser/modelforms.py:49
+#: ./opengever/base/browser/modelforms.py
 msgid "message_record_created"
 msgstr "Eintrag erzeugt"
 
 #. Default: "Error"
-#: ./opengever/base/response.py:41
+#: ./opengever/base/response.py
 msgid "message_title_error"
 msgstr "Fehler"
 
 #. Default: "Information"
-#: ./opengever/base/response.py:27
+#: ./opengever/base/response.py
 msgid "message_title_info"
 msgstr "Information"
 
 #. Default: "Can't paste items; the clipboard is emtpy"
-#: ./opengever/base/browser/paste.py:25
+#: ./opengever/base/browser/paste.py
 msgid "msg_empty_clipboard"
 msgstr "Es können keine Objekte eingefügt werden; die Zwischenablage ist leer."
 
 #. Default: "No items available"
-#: ./opengever/base/widgets.py:78
+#: ./opengever/base/widgets.py
 msgid "msg_no_items_available"
 msgstr "Es sind keine Elemente verfügbar."
 
 #. Default: "Can't paste items, the context does not allow pasting items."
-#: ./opengever/base/browser/paste.py:40
+#: ./opengever/base/browser/paste.py
 msgid "msg_pasting_not_allowed"
 msgstr "Es ist nicht erlaubt die Objekte an diesem Ort einzufügen."
 
 #. Default: "Can't paste items, it's not allowed to add objects of this type."
-#: ./opengever/base/browser/paste.py:32
+#: ./opengever/base/browser/paste.py
 msgid "msg_pasting_type_not_allowed"
 msgstr "Es ist nicht erlaubt Objekte dieses Typs einzufügen."
 
 #. Default: "Selected objects successfully copied."
-#: ./opengever/base/browser/copy_items.py:37
+#: ./opengever/base/browser/copy_items.py
 msgid "msg_successfuly_copied"
 msgstr "Die selektierten Objekte wurden kopiert."
 
 #. Default: "Objects from clipboard successfully pasted."
-#: ./opengever/base/browser/paste.py:49
+#: ./opengever/base/browser/paste.py
 msgid "msg_successfuly_pasted"
 msgstr "Die Objekte der Zwischenablage wurden eingefügt."
 
 #. Default: "Careful, it's possible someone is executing an exploit against you. Verify you just performed an action on this site and that you were not referred here by a different website or email."
-#: ./opengever/base/browser/confirm.pt:27
+#: ./opengever/base/browser/confirm.pt
 msgid "msg_verify_you_performed_this_action"
 msgstr "Bitte bestätigen Sie, dass Sie selbst diese Aktion durchgeführt haben und nicht durch einen Link in einem E-Mail oder von einer externen Website auf GEVER weitergeleitet wurden. Dies ist eine Sicherheitsmassnahme, um sogenannte CSRF-Angriffe zu verhindern. Falls Sie diese Meldung sehen, obwohl Sie eine Aktion innerhalb GEVER durchgeführt haben, teilen Sie dies bitte dem Support mit (inkl. einem Screenshot dieser Meldung und der untenstehenden URL)."
 
@@ -378,31 +378,31 @@ msgid "public"
 msgstr "Öffentlich"
 
 #. Default: "Did you not find what you were looking for? Try the ${advanced_search} to refine your search."
-#: ./opengever/base/browser/search.pt:89
+#: ./opengever/base/browser/search.pt
 msgid "search_results_advanced"
 msgstr "Haben Sie nicht gefunden, wonach Sie gesucht haben? Die ${advanced_search} bietet Ihnen präzisere Suchmöglichkeiten."
 
 #. Default: "Advanced Search"
-#: ./opengever/base/browser/search.pt:90
+#: ./opengever/base/browser/search.pt
 msgid "search_results_advanced_link"
 msgstr "erweiterte Suche"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:105
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "show all"
 msgstr "Alle anzeigen"
 
 #. Default: "Back to the portal"
-#: ./opengever/base/browser/templates/error.pt:69
+#: ./opengever/base/browser/templates/error.pt
 msgid "text_back_to_portal"
 msgstr "Zurück zum Portal"
 
 #. Default: "Confirming User Action."
-#: ./opengever/base/browser/confirm.pt:14
+#: ./opengever/base/browser/confirm.pt
 msgid "title_confirming_user_action"
 msgstr "Benutzer-Aktion bestätigen"
 
 #. Default: "You are not allowed to see this reference"
-#: ./opengever/base/browser/folder_delete_confirmation.py:132
+#: ./opengever/base/browser/folder_delete_confirmation.py
 msgid "unauthorized_backreference"
 msgstr "Sie sind nicht berechtig, diese Referenz zu sehen."
 
@@ -416,3 +416,4 @@ msgstr "Nicht geprüft"
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr "Nicht klassifiziert"
+

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,71 +4,65 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-17 12:42+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-09-04 06:11+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-base/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/base/browser/list_groupmembers.pt:5
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "(INACTIVE)"
 msgstr "(INACTIF)"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:35
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "Are you sure you want to deleted this items?"
 msgstr "Êtes-vous sûr de vouloir supprimer ces contenus?"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:38
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "No content"
 msgstr "Pas de contenu"
 
-#: ./opengever/base/viewlets/download.py:22
+#: ./opengever/base/viewlets/download.py
 msgid "No file in in this version"
 msgstr "Pas de fichier pour cette version"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:43
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "No items to delete"
 msgstr "Aucun contenu à supprimer"
 
 #. Default: "Save"
-#: ./opengever/base/browser/modelforms.py:41
+#: ./opengever/base/browser/modelforms.py
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:19
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "Some items won't be deleted!"
 msgstr "Certains contenus ne seront pas supprimés!"
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:21
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "The following items are referenced by another item and will not be deleted"
-msgstr ""
-"Les contenus ci-après sont référencés par d'autres, c'est pourquoi ils ne "
-"seront pas supprimés."
+msgstr "Les contenus ci-après sont référencés par d'autres, c'est pourquoi ils ne seront pas supprimés."
 
-#: ./opengever/base/browser/list_groupmembers.pt:14
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "There are no members in this group."
 msgstr "Pas d'utilisateur dans ce groupe."
 
-#: ./opengever/base/browser/list_groupmembers.pt:3
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "Users of group:"
 msgstr "Utilisateurs du groupe"
 
-#: ./opengever/base/validators.py:15
+#: ./opengever/base/validators.py
 msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
-msgstr ""
-"Vous ne pouvez créer aucun dossier dans ce numéro de classement. Ou bien ce "
-"dernier contient d'autres numéros de classement, ou bien vous n'avez pas les "
-"droits suffisants pour effectuer cette tâche."
+msgstr "Vous ne pouvez créer aucun dossier dans ce numéro de classement. Ou bien ce dernier contient d'autres numéros de classement, ou bien vous n'avez pas les droits suffisants pour effectuer cette tâche."
 
 #. Default ""
 #: opengever/repository/classification.py
@@ -91,210 +85,204 @@ msgid "confidential"
 msgstr "Confidentiel"
 
 #. Default: "Confirm that you'd like to perform this action."
-#: ./opengever/base/browser/confirm.pt:20
+#: ./opengever/base/browser/confirm.pt
 msgid "desc_confirm_action"
 msgstr "Veuillez confirmer que vous souhaitez effectuer cette action."
 
 #. Default: "If you need to report this to the responsible person, please include this entry number in your message."
-#: ./opengever/base/browser/templates/error.pt:101
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_include_error_in_admin_message"
-msgstr ""
-"Si vous voulez signaler cette erreur au responsable de l'application, "
-"veuillez ajouter le numéro d'erreur,  s'il vous plaît."
+msgstr "Si vous voulez signaler cette erreur au responsable de l'application, veuillez ajouter le numéro d'erreur,  s'il vous plaît."
 
 #. Default: "We apologize for the inconvenience, but the page you were trying to access is not at this address."
-#: ./opengever/base/browser/templates/error.pt:62
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error"
 msgstr "Nous nous excusons pour la gêne occasionnée, mais la page à laquelle vous tentez d'accéder n'est pas à cette adresse."
 
 #. Default: "Please contact the responsible person if this problem persists."
-#: ./opengever/base/browser/templates/error.pt:66
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
-msgstr ""
-"Si ce problème subsiste, veuillez contacter le responsable de l'application, "
-"s'il vous plaît."
+msgstr "Si ce problème subsiste, veuillez contacter le responsable de l'application, s'il vous plaît."
 
 #. Default: "You have not selected any Items."
-#: ./opengever/base/browser/copy_items.py:23
+#: ./opengever/base/browser/copy_items.py
 msgid "error_no_items"
 msgstr "Aucun élément sélectionné."
 
 #. Default: "The item you selected cannot be copied."
-#: ./opengever/base/browser/copy_items.py:30
+#: ./opengever/base/browser/copy_items.py
 msgid "error_not_copyable"
 msgstr "Le contenu choisi ne peut être copié."
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:62
+#: ./opengever/base/behaviors/classification.py
 msgid "fieldset_classification"
 msgstr "Visibilité"
 
 #. Default: "Common"
-#: ./opengever/base/behaviors/base.py:15
+#: ./opengever/base/behaviors/base.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Life Cycle"
-#: ./opengever/base/behaviors/lifecycle.py:31
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "fieldset_lifecycle"
 msgstr "Cycle de vie"
 
 #. Default: "Archival value code"
-#: ./opengever/base/behaviors/lifecycle.py:60
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_archival_value"
 msgstr "Valeur archivistique"
 
-#: ./opengever/base/behaviors/classification.py:73
+#: ./opengever/base/behaviors/classification.py
 msgid "help_classification"
 msgstr "Degré de besoin de protection des documents contre la consultation non-autorisée."
 
-#: ./opengever/base/behaviors/lifecycle.py:75
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_custody_period"
 msgstr "Délai de protection des documents contre la consultation publique après l'archivage."
 
-#: ./opengever/base/behaviors/classification.py:80
+#: ./opengever/base/behaviors/classification.py
 msgid "help_privacy_layer"
 msgstr "Marquage des documents contenant des données sensibles ou des profils de la personnalité selon la loi sur la protection des données."
 
-#: ./opengever/base/behaviors/classification.py:87
+#: ./opengever/base/behaviors/classification.py
 msgid "help_public_trial"
 msgstr "Mention, si les documents sont accessibles ou non selon la loi sur la protection des données."
 
-#: ./opengever/base/behaviors/classification.py:96
+#: ./opengever/base/behaviors/classification.py
 msgid "help_public_trial_statement"
-msgstr ""
-"Date de la requête, requérant, date de la décision, référence vers le "
-"dossier de la requête GEVER"
+msgstr "Date de la requête, requérant, date de la décision, référence vers le dossier de la requête GEVER"
 
-#: ./opengever/base/behaviors/lifecycle.py:45
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_retention_period"
 msgstr "Durée entre la date du document plus récent contenu dans un dossier et la date à partir de laquelle le document n'est plus requis pour les activités administratives."
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:209
+#: ./opengever/base/adapters.py
 msgid "label_already_removed"
 msgstr "-- Déjà annulé --"
 
 #. Default: "Archival value"
-#: ./opengever/base/behaviors/lifecycle.py:59
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_archival_value"
 msgstr "Valeur archivistique"
 
 #. Default: "archivalValueAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:67
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_archival_value_annotation"
 msgstr "Commentaire concernant la valeur archivistique"
 
 #. Default: "Cancel"
-#: ./opengever/base/browser/modelforms.py:53
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:62
+#: ./opengever/base/browser/modelforms.py
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Change public trial information."
-#: ./opengever/base/browser/edit_public_trial.py:62
+#: ./opengever/base/browser/edit_public_trial.py
 msgid "label_change_public_trial"
 msgstr "Modifier le 'statut public'"
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:72
+#: ./opengever/base/behaviors/classification.py
 msgid "label_classification"
 msgstr "Classification"
 
 #. Default: "Confirm action"
-#: ./opengever/base/browser/confirm.pt:41
+#: ./opengever/base/browser/confirm.pt
 msgid "label_confirm_action"
 msgstr "Confirmer l'action"
 
 #. Default: "Created"
-#: ./opengever/base/viewlets/byline.py:67
+#: ./opengever/base/viewlets/byline.py
 msgid "label_created"
 msgstr "Créé le"
 
 #. Default: "Custody period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:74
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_custody_period"
 msgstr "Délai de protection archivistique (années)"
 
 #. Default: "Date of cassation"
-#: ./opengever/base/behaviors/lifecycle.py:83
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofcassation"
 msgstr "Date d'élimination"
 
 #. Default: "Date of submission"
-#: ./opengever/base/behaviors/lifecycle.py:90
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofsubmission"
 msgstr "Date de proposition (des documents)"
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:130
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "label_default_error_message"
 msgstr "Une erreur inattendue est survenue."
 
 #. Default: "Description"
-#: ./opengever/base/behaviors/base.py:30
+#: ./opengever/base/behaviors/base.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Dossier:"
-#: ./opengever/base/browser/search.pt:331
+#: ./opengever/base/browser/search.pt
 msgid "label_dossier"
 msgstr "Dossier:"
 
 #. Default: "Last modified"
-#: ./opengever/base/viewlets/byline.py:72
+#: ./opengever/base/viewlets/byline.py
 msgid "label_last_modified"
 msgstr "Dernière modification"
 
 #. Default: "Privacy layer"
-#: ./opengever/base/behaviors/classification.py:79
+#: ./opengever/base/behaviors/classification.py
 msgid "label_privacy_layer"
 msgstr "Niveau de confidentialité"
 
 #. Default: "Public Trial"
-#: ./opengever/base/behaviors/classification.py:86
+#: ./opengever/base/behaviors/classification.py
 msgid "label_public_trial"
 msgstr "Statut public"
 
 #. Default: "Public trial statement"
-#: ./opengever/base/behaviors/classification.py:94
+#: ./opengever/base/behaviors/classification.py
 msgid "label_public_trial_statement"
 msgstr "Justification pour le retrait du statut public"
 
 #. Default: "Retention period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:44
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_retention_period"
 msgstr "Délai de conservation (années)"
 
 #. Default: "retentionPeriodAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:52
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_retention_period_annotation"
 msgstr "Commentaire concernant le délai de conservation"
 
 #. Default: "Search"
-#: ./opengever/base/browser/search.pt:65
+#: ./opengever/base/browser/search.pt
 msgid "label_search"
 msgstr "Recherche"
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:129
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "label_severity_error"
 msgstr "Erreur"
 
 #. Default: "Title"
-#: ./opengever/base/behaviors/base.py:24
-#: ./opengever/base/browser/translated_title.py:35
-#: ./opengever/base/widgets.py:106
+#: ./opengever/base/behaviors/base.py
+#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/widgets.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Title (German)"
-#: ./opengever/base/behaviors/translated_title.py:39
+#: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_de"
 msgstr "Titre (allemand)"
 
 #. Default: "Title (French)"
-#: ./opengever/base/behaviors/translated_title.py:45
+#: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
 msgstr "Titre (français)"
 
@@ -304,57 +292,57 @@ msgid "limited-public"
 msgstr "Accès public restreint"
 
 #. Default: "Changes saved"
-#: ./opengever/base/browser/modelforms.py:122
+#: ./opengever/base/browser/modelforms.py
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
 #. Default: "Record created"
-#: ./opengever/base/browser/modelforms.py:49
+#: ./opengever/base/browser/modelforms.py
 msgid "message_record_created"
 msgstr "Enregistrement créé"
 
 #. Default: "Error"
-#: ./opengever/base/response.py:41
+#: ./opengever/base/response.py
 msgid "message_title_error"
 msgstr "Erreur"
 
 #. Default: "Information"
-#: ./opengever/base/response.py:27
+#: ./opengever/base/response.py
 msgid "message_title_info"
 msgstr "Information"
 
 #. Default: "Can't paste items; the clipboard is emtpy"
-#: ./opengever/base/browser/paste.py:25
+#: ./opengever/base/browser/paste.py
 msgid "msg_empty_clipboard"
 msgstr "Aucun objet ne peut être ajouté; le presse-papier est vide."
 
 #. Default: "No items available"
-#: ./opengever/base/widgets.py:78
+#: ./opengever/base/widgets.py
 msgid "msg_no_items_available"
 msgstr "Il n'y a pas d'objets disponibles."
 
 #. Default: "Can't paste items, the context does not allow pasting items."
-#: ./opengever/base/browser/paste.py:40
+#: ./opengever/base/browser/paste.py
 msgid "msg_pasting_not_allowed"
 msgstr "Il n'est pas permis d'insérer des objets de ce type."
 
 #. Default: "Can't paste items, it's not allowed to add objects of this type."
-#: ./opengever/base/browser/paste.py:32
+#: ./opengever/base/browser/paste.py
 msgid "msg_pasting_type_not_allowed"
 msgstr "Il n'est pas permis d'ajouter des objets de ce type."
 
 #. Default: "Selected objects successfully copied."
-#: ./opengever/base/browser/copy_items.py:37
+#: ./opengever/base/browser/copy_items.py
 msgid "msg_successfuly_copied"
 msgstr "Les objets sélectionnés ont été copiés."
 
 #. Default: "Objects from clipboard successfully pasted."
-#: ./opengever/base/browser/paste.py:49
+#: ./opengever/base/browser/paste.py
 msgid "msg_successfuly_pasted"
 msgstr "Les objets du presse-papier ont été ajoutés."
 
 #. Default: "Careful, it's possible someone is executing an exploit against you. Verify you just performed an action on this site and that you were not referred here by a different website or email."
-#: ./opengever/base/browser/confirm.pt:27
+#: ./opengever/base/browser/confirm.pt
 msgid "msg_verify_you_performed_this_action"
 msgstr "Veuillez confirmer que vous êtes à l'origine de cette action et que la requête ne provient ni d'un lien courriel, ni d'un site web externe à GEVER. Cette mesure de protection permet de prévenir les éventuelles attaques CSRF. Si ce message apparaît suite à une action entreprise dans l'espace GEVER, veuillez en informer le support (avec capture d'écran du message et le lien URL correspondant)."
 
@@ -389,31 +377,31 @@ msgid "public"
 msgstr "Public"
 
 #. Default: "Did you not find what you were looking for? Try the ${advanced_search} to refine your search."
-#: ./opengever/base/browser/search.pt:89
+#: ./opengever/base/browser/search.pt
 msgid "search_results_advanced"
 msgstr "Vous n'avez pas trouvé ce que vous avez cherché? La ${advanced_search} vous offre des possibilités de recherche plus précises."
 
 #. Default: "Advanced Search"
-#: ./opengever/base/browser/search.pt:90
+#: ./opengever/base/browser/search.pt
 msgid "search_results_advanced_link"
 msgstr "Recherche avancée"
 
-#: ./opengever/base/browser/templates/gever-macros.pt:105
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "show all"
 msgstr "Tout afficher"
 
 #. Default: "Back to the portal"
-#: ./opengever/base/browser/templates/error.pt:69
+#: ./opengever/base/browser/templates/error.pt
 msgid "text_back_to_portal"
 msgstr "Retourner au portail"
 
 #. Default: "Confirming User Action."
-#: ./opengever/base/browser/confirm.pt:14
+#: ./opengever/base/browser/confirm.pt
 msgid "title_confirming_user_action"
 msgstr "Confirmation de l'action"
 
 #. Default: "You are not allowed to see this reference"
-#: ./opengever/base/browser/folder_delete_confirmation.py:132
+#: ./opengever/base/browser/folder_delete_confirmation.py
 msgid "unauthorized_backreference"
 msgstr "Vous n'êtes pas autorisé(e) à voir cette référence."
 
@@ -426,3 +414,4 @@ msgstr "Non contrôlé"
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr "Non classé"
+

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -362,3 +362,4 @@ msgstr "Activer"
 
 msgid "transition-add-document"
 msgstr ""
+

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-17 12:42+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,48 +17,48 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.repository\n"
 
-#: ./opengever/base/browser/list_groupmembers.pt:5
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "(INACTIVE)"
 msgstr ""
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:35
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "Are you sure you want to deleted this items?"
 msgstr ""
 
-#: ./opengever/base/browser/templates/gever-macros.pt:38
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "No content"
 msgstr ""
 
-#: ./opengever/base/viewlets/download.py:22
+#: ./opengever/base/viewlets/download.py
 msgid "No file in in this version"
 msgstr ""
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:43
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "No items to delete"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/base/browser/modelforms.py:41
+#: ./opengever/base/browser/modelforms.py
 msgid "Save"
 msgstr ""
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:19
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "Some items won't be deleted!"
 msgstr ""
 
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:21
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "The following items are referenced by another item and will not be deleted"
 msgstr ""
 
-#: ./opengever/base/browser/list_groupmembers.pt:14
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "There are no members in this group."
 msgstr ""
 
-#: ./opengever/base/browser/list_groupmembers.pt:3
+#: ./opengever/base/browser/list_groupmembers.pt
 msgid "Users of group:"
 msgstr ""
 
-#: ./opengever/base/validators.py:15
+#: ./opengever/base/validators.py
 msgid "You cannot add dossiers in the selected repository folder. Either you do not have the privileges or the repository folder contains another repository folder."
 msgstr ""
 
@@ -83,204 +83,204 @@ msgid "confidential"
 msgstr ""
 
 #. Default: "Confirm that you'd like to perform this action."
-#: ./opengever/base/browser/confirm.pt:20
+#: ./opengever/base/browser/confirm.pt
 msgid "desc_confirm_action"
 msgstr ""
 
 #. Default: "If you need to report this to the responsible person, please include this entry number in your message."
-#: ./opengever/base/browser/templates/error.pt:101
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_include_error_in_admin_message"
 msgstr ""
 
 #. Default: "We apologize for the inconvenience, but the page you were trying to access is not at this address."
-#: ./opengever/base/browser/templates/error.pt:62
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error"
 msgstr ""
 
 #. Default: "Please contact the responsible person if this problem persists."
-#: ./opengever/base/browser/templates/error.pt:66
+#: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
 msgstr ""
 
 #. Default: "You have not selected any Items."
-#: ./opengever/base/browser/copy_items.py:23
+#: ./opengever/base/browser/copy_items.py
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "The item you selected cannot be copied."
-#: ./opengever/base/browser/copy_items.py:30
+#: ./opengever/base/browser/copy_items.py
 msgid "error_not_copyable"
 msgstr ""
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:62
+#: ./opengever/base/behaviors/classification.py
 msgid "fieldset_classification"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/base/behaviors/base.py:15
+#: ./opengever/base/behaviors/base.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Life Cycle"
-#: ./opengever/base/behaviors/lifecycle.py:31
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "fieldset_lifecycle"
 msgstr ""
 
 #. Default: "Archival value code"
-#: ./opengever/base/behaviors/lifecycle.py:60
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_archival_value"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:73
+#: ./opengever/base/behaviors/classification.py
 msgid "help_classification"
 msgstr ""
 
-#: ./opengever/base/behaviors/lifecycle.py:75
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_custody_period"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:80
+#: ./opengever/base/behaviors/classification.py
 msgid "help_privacy_layer"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:87
+#: ./opengever/base/behaviors/classification.py
 msgid "help_public_trial"
 msgstr ""
 
-#: ./opengever/base/behaviors/classification.py:96
+#: ./opengever/base/behaviors/classification.py
 msgid "help_public_trial_statement"
 msgstr ""
 
-#: ./opengever/base/behaviors/lifecycle.py:45
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "help_retention_period"
 msgstr ""
 
 #. Default: "-- Already removed object --"
-#: ./opengever/base/adapters.py:209
+#: ./opengever/base/adapters.py
 msgid "label_already_removed"
 msgstr ""
 
 #. Default: "Archival value"
-#: ./opengever/base/behaviors/lifecycle.py:59
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_archival_value"
 msgstr ""
 
 #. Default: "archivalValueAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:67
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_archival_value_annotation"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/base/browser/modelforms.py:53
-#: ./opengever/base/browser/templates/folder_delete_confirmation.pt:62
+#: ./opengever/base/browser/modelforms.py
+#: ./opengever/base/browser/templates/folder_delete_confirmation.pt
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Change public trial information."
-#: ./opengever/base/browser/edit_public_trial.py:62
+#: ./opengever/base/browser/edit_public_trial.py
 msgid "label_change_public_trial"
 msgstr ""
 
 #. Default: "Classification"
-#: ./opengever/base/behaviors/classification.py:72
+#: ./opengever/base/behaviors/classification.py
 msgid "label_classification"
 msgstr ""
 
 #. Default: "Confirm action"
-#: ./opengever/base/browser/confirm.pt:41
+#: ./opengever/base/browser/confirm.pt
 msgid "label_confirm_action"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/base/viewlets/byline.py:67
+#: ./opengever/base/viewlets/byline.py
 msgid "label_created"
 msgstr ""
 
 #. Default: "Custody period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:74
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_custody_period"
 msgstr ""
 
 #. Default: "Date of cassation"
-#: ./opengever/base/behaviors/lifecycle.py:83
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofcassation"
 msgstr ""
 
 #. Default: "Date of submission"
-#: ./opengever/base/behaviors/lifecycle.py:90
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofsubmission"
 msgstr ""
 
 #. Default: "An unexpected error has occured"
-#: ./opengever/base/browser/templates/gever-macros.pt:130
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "label_default_error_message"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/base/behaviors/base.py:30
+#: ./opengever/base/behaviors/base.py
 msgid "label_description"
 msgstr ""
 
 #. Default: "Dossier:"
-#: ./opengever/base/browser/search.pt:331
+#: ./opengever/base/browser/search.pt
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Last modified"
-#: ./opengever/base/viewlets/byline.py:72
+#: ./opengever/base/viewlets/byline.py
 msgid "label_last_modified"
 msgstr ""
 
 #. Default: "Privacy layer"
-#: ./opengever/base/behaviors/classification.py:79
+#: ./opengever/base/behaviors/classification.py
 msgid "label_privacy_layer"
 msgstr ""
 
 #. Default: "Public Trial"
-#: ./opengever/base/behaviors/classification.py:86
+#: ./opengever/base/behaviors/classification.py
 msgid "label_public_trial"
 msgstr ""
 
 #. Default: "Public trial statement"
-#: ./opengever/base/behaviors/classification.py:94
+#: ./opengever/base/behaviors/classification.py
 msgid "label_public_trial_statement"
 msgstr ""
 
 #. Default: "Retention period (years)"
-#: ./opengever/base/behaviors/lifecycle.py:44
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_retention_period"
 msgstr ""
 
 #. Default: "retentionPeriodAnnotation"
-#: ./opengever/base/behaviors/lifecycle.py:52
+#: ./opengever/base/behaviors/lifecycle.py
 msgid "label_retention_period_annotation"
 msgstr ""
 
 #. Default: "Search"
-#: ./opengever/base/browser/search.pt:65
+#: ./opengever/base/browser/search.pt
 msgid "label_search"
 msgstr ""
 
 #. Default: "Error"
-#: ./opengever/base/browser/templates/gever-macros.pt:129
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "label_severity_error"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/base/behaviors/base.py:24
-#: ./opengever/base/browser/translated_title.py:35
-#: ./opengever/base/widgets.py:106
+#: ./opengever/base/behaviors/base.py
+#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/widgets.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Title (German)"
-#: ./opengever/base/behaviors/translated_title.py:39
+#: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_de"
 msgstr ""
 
 #. Default: "Title (French)"
-#: ./opengever/base/behaviors/translated_title.py:45
+#: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
 msgstr ""
 
@@ -289,57 +289,57 @@ msgid "limited-public"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/base/browser/modelforms.py:122
+#: ./opengever/base/browser/modelforms.py
 msgid "message_changes_saved"
 msgstr ""
 
 #. Default: "Record created"
-#: ./opengever/base/browser/modelforms.py:49
+#: ./opengever/base/browser/modelforms.py
 msgid "message_record_created"
 msgstr ""
 
 #. Default: "Error"
-#: ./opengever/base/response.py:41
+#: ./opengever/base/response.py
 msgid "message_title_error"
 msgstr ""
 
 #. Default: "Information"
-#: ./opengever/base/response.py:27
+#: ./opengever/base/response.py
 msgid "message_title_info"
 msgstr ""
 
 #. Default: "Can't paste items; the clipboard is emtpy"
-#: ./opengever/base/browser/paste.py:25
+#: ./opengever/base/browser/paste.py
 msgid "msg_empty_clipboard"
 msgstr ""
 
 #. Default: "No items available"
-#: ./opengever/base/widgets.py:78
+#: ./opengever/base/widgets.py
 msgid "msg_no_items_available"
 msgstr ""
 
 #. Default: "Can't paste items, the context does not allow pasting items."
-#: ./opengever/base/browser/paste.py:40
+#: ./opengever/base/browser/paste.py
 msgid "msg_pasting_not_allowed"
 msgstr ""
 
 #. Default: "Can't paste items, it's not allowed to add objects of this type."
-#: ./opengever/base/browser/paste.py:32
+#: ./opengever/base/browser/paste.py
 msgid "msg_pasting_type_not_allowed"
 msgstr ""
 
 #. Default: "Selected objects successfully copied."
-#: ./opengever/base/browser/copy_items.py:37
+#: ./opengever/base/browser/copy_items.py
 msgid "msg_successfuly_copied"
 msgstr ""
 
 #. Default: "Objects from clipboard successfully pasted."
-#: ./opengever/base/browser/paste.py:49
+#: ./opengever/base/browser/paste.py
 msgid "msg_successfuly_pasted"
 msgstr ""
 
 #. Default: "Careful, it's possible someone is executing an exploit against you. Verify you just performed an action on this site and that you were not referred here by a different website or email."
-#: ./opengever/base/browser/confirm.pt:27
+#: ./opengever/base/browser/confirm.pt
 msgid "msg_verify_you_performed_this_action"
 msgstr ""
 
@@ -374,31 +374,31 @@ msgid "public"
 msgstr ""
 
 #. Default: "Did you not find what you were looking for? Try the ${advanced_search} to refine your search."
-#: ./opengever/base/browser/search.pt:89
+#: ./opengever/base/browser/search.pt
 msgid "search_results_advanced"
 msgstr ""
 
 #. Default: "Advanced Search"
-#: ./opengever/base/browser/search.pt:90
+#: ./opengever/base/browser/search.pt
 msgid "search_results_advanced_link"
 msgstr ""
 
-#: ./opengever/base/browser/templates/gever-macros.pt:105
+#: ./opengever/base/browser/templates/gever-macros.pt
 msgid "show all"
 msgstr ""
 
 #. Default: "Back to the portal"
-#: ./opengever/base/browser/templates/error.pt:69
+#: ./opengever/base/browser/templates/error.pt
 msgid "text_back_to_portal"
 msgstr ""
 
 #. Default: "Confirming User Action."
-#: ./opengever/base/browser/confirm.pt:14
+#: ./opengever/base/browser/confirm.pt
 msgid "title_confirming_user_action"
 msgstr ""
 
 #. Default: "You are not allowed to see this reference"
-#: ./opengever/base/browser/folder_delete_confirmation.py:132
+#: ./opengever/base/browser/folder_delete_confirmation.py
 msgid "unauthorized_backreference"
 msgstr ""
 
@@ -411,3 +411,4 @@ msgstr ""
 #: opengever/repository/classification.py
 msgid "unprotected"
 msgstr ""
+

--- a/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-23 06:43+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,33 +14,33 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:7
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Creator:"
 msgstr "Ersteller:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:25
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Description:"
 msgstr "Beschreibung:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:11
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Document date:"
 msgstr "Dokumentdatum:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:15
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Dossier:"
 msgstr "Dossier:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:21
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Reference number:"
 msgstr "Aktenzeichen:"
 
 #. Default: "Revert document"
-#: ./opengever/bumblebee/browser/overlay.py:161
+#: ./opengever/bumblebee/browser/overlay.py
 msgid "label_revert"
 msgstr "Dokument zurücksetzen"
 
 #. Default: "You are looking at a versioned file."
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:40
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "warning_on_versioned_context"
 msgstr "Sie sehen sich eine alte Version an."
 

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-23 06:43+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,33 +14,33 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:7
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Creator:"
 msgstr "Créateur:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:25
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Description:"
 msgstr "Description:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:11
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Document date:"
 msgstr "Date du document:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:15
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Dossier:"
 msgstr "Dossier:"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:21
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Reference number:"
 msgstr "Numéro de référence:"
 
 #. Default: "Revert document"
-#: ./opengever/bumblebee/browser/overlay.py:161
+#: ./opengever/bumblebee/browser/overlay.py
 msgid "label_revert"
 msgstr "Reculer le document"
 
 #. Default: "You are looking at a versioned file."
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:40
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "warning_on_versioned_context"
 msgstr "Vous regardez un ficher dépassé."
 

--- a/opengever/bumblebee/locales/opengever.bumblebee.pot
+++ b/opengever/bumblebee/locales/opengever.bumblebee.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-01 07:42+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +17,33 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.bumblebee\n"
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:7
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Creator:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:25
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Description:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:11
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Document date:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:15
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Dossier:"
 msgstr ""
 
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:21
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Reference number:"
 msgstr ""
 
 #. Default: "Revert document"
-#: ./opengever/bumblebee/browser/overlay.py:161
+#: ./opengever/bumblebee/browser/overlay.py
 msgid "label_revert"
 msgstr ""
 
 #. Default: "You are looking at a versioned file."
-#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt:40
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "warning_on_versioned_context"
 msgstr ""
+

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,449 +15,450 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Add Person"
-#: ./opengever/contact/browser/person.py:123
+#: ./opengever/contact/browser/person.py
 msgid "Add Person"
 msgstr "Person hinzufügen"
 
-#: ./opengever/contact/contact.py:187
+#: ./opengever/contact/contact.py
 msgid "Contact"
 msgstr "Kontakt"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:26
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete"
 msgstr "Löschen"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:23
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete mailaddress"
 msgstr "E-Mail-Adresse löschen"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:38
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailadddress"
 msgstr "E-Mail-Adresse"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:33
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailaddresses"
 msgstr "E-Mail-Adressen"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:37
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Label"
 msgstr "Label"
 
-#: ./opengever/contact/browser/participation_forms.py:125
+#: ./opengever/contact/browser/participation_forms.py
 msgid "Remove"
 msgstr "Löschen"
 
 #. Default: "Address"
-#: ./opengever/contact/contact.py:54
+#: ./opengever/contact/contact.py
 msgid "address"
 msgstr "Adresse"
 
 #. Default: "Edit"
-#: ./opengever/contact/browser/templates/participations.pt:18
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "button_edit"
 msgstr "Bearbeiten"
 
 #. Default: "Remove"
-#: ./opengever/contact/browser/templates/participations.pt:25
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "button_remove"
 msgstr "Löschen"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person_listing.py:36
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_academic_title"
 msgstr "Titel"
 
 #. Default: "Active"
-#: ./opengever/contact/browser/organization_listing.py:37
-#: ./opengever/contact/browser/person_listing.py:48
+#: ./opengever/contact/browser/organization_listing.py
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_active"
 msgstr "Aktiv"
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person_listing.py:40
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_firstname"
 msgstr "Vorname"
 
 #. Default: "Former contact id"
-#: ./opengever/contact/browser/organization_listing.py:41
-#: ./opengever/contact/browser/person_listing.py:57
+#: ./opengever/contact/browser/organization_listing.py
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_former_contact_id"
 msgstr "Frühere Kontakt ID"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person_listing.py:44
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_lastname"
 msgstr "Nachname"
 
 #. Default: "Name"
-#: ./opengever/contact/browser/organization_listing.py:33
+#: ./opengever/contact/browser/organization_listing.py
 msgid "column_name"
 msgstr "Name"
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/person_listing.py:52
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_organizations"
 msgstr "Organisationen"
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person_listing.py:33
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_salutation"
 msgstr "Anrede"
 
 #. Default: "Email address updated."
-#: ./opengever/contact/browser/mail.py:115
+#: ./opengever/contact/browser/mail.py
 msgid "email_address_updated"
 msgstr "E-Mail-Adresse wurde aktualisiert."
 
 #. Default: "Please specify a valid email address"
-#: ./opengever/contact/browser/mail.py:153
+#: ./opengever/contact/browser/mail.py
 msgid "error_invalid_email"
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein."
 
 #. Default: "Please specify an email address"
-#: ./opengever/contact/browser/mail.py:149
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_email"
 msgstr "Bitte geben Sie eine E-Mail-Adresse ein."
 
 #. Default: "Please specify a label for your email address"
-#: ./opengever/contact/browser/mail.py:145
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_label"
 msgstr "Bitte geben Sie ein Label für Ihre E-Mail-Adresse ein."
 
 #. Default: "Please specify a label and an email address."
-#: ./opengever/contact/browser/mail.py:139
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_label_and_email"
 msgstr "Bitte geben Sie ein Label sowie eine E-Mail-Adresse ein."
 
 #. Default: "The email address was created successfully"
-#: ./opengever/contact/browser/mail.py:93
+#: ./opengever/contact/browser/mail.py
 msgid "info_mailaddress_created"
 msgstr "Die E-Mail-Adresse wurde erstellt."
 
 #. Default: "Participation removed"
-#: ./opengever/contact/browser/participation_forms.py:134
+#: ./opengever/contact/browser/participation_forms.py
 msgid "info_participation_removed"
 msgstr "Beteiligung gelöscht"
 
 #. Default: "Internet"
-#: ./opengever/contact/contact.py:35
+#: ./opengever/contact/contact.py
 msgid "internet"
 msgstr "Internet"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person.py:97
-#: ./opengever/contact/browser/templates/person.pt:30
-#: ./opengever/contact/contact.py:69
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/browser/templates/person.pt
+#: ./opengever/contact/contact.py
 msgid "label_academic_title"
 msgstr "Titel"
 
 #. Default: "Active"
-#: ./opengever/contact/browser/byline.py:16
-#: ./opengever/contact/browser/templates/organization.pt:89
+#: ./opengever/contact/browser/byline.py
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_active"
 msgstr "Aktiv"
 
 #. Default: "Add Participation"
-#: ./opengever/contact/browser/participation_forms.py:44
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_add_participation"
 msgstr "Beteiligung hinzufügen"
 
 #. Default: "Address 1"
-#: ./opengever/contact/contact.py:150
+#: ./opengever/contact/contact.py
 msgid "label_address1"
 msgstr "Adresse (Strasse / Nr.)"
 
 #. Default: "Address 2"
-#: ./opengever/contact/contact.py:155
+#: ./opengever/contact/contact.py
 msgid "label_address2"
 msgstr "Adresszusatz"
 
 #. Default: "Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:25
-#: ./opengever/contact/browser/templates/person.pt:35
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_addresses"
 msgstr "Adressen"
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:142
-#: ./opengever/contact/browser/templates/person.pt:144
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_addresses"
 msgstr "Archivierte Adressen"
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:165
-#: ./opengever/contact/browser/templates/person.pt:167
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_mail"
 msgstr "Archivierte E-Mail-Adressen"
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:124
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_archived_organizations"
 msgstr "Archivierte Informationen"
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:117
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_persons"
 msgstr "Archivierte persönliche Informationen"
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:184
-#: ./opengever/contact/browser/templates/person.pt:186
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_phone_numbers"
 msgstr "Archivierte Telefonnummern"
 
 #. Default: "Cancel"
-#: ./opengever/contact/browser/participation_forms.py:140
-#: ./opengever/contact/browser/templates/person_edit.pt:28
+#: ./opengever/contact/browser/participation_forms.py
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "City"
-#: ./opengever/contact/contact.py:165
+#: ./opengever/contact/contact.py
 msgid "label_city"
 msgstr "Ort"
 
 #. Default: "Company"
-#: ./opengever/contact/contact.py:88
+#: ./opengever/contact/contact.py
 msgid "label_company"
 msgstr "Firma"
 
 #. Default: "Contact"
-#: ./opengever/contact/browser/participation_forms.py:25
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_contact"
 msgstr "Kontakt"
 
 #. Default: "Country"
-#: ./opengever/contact/contact.py:170
+#: ./opengever/contact/contact.py
 msgid "label_country"
 msgstr "Land"
 
 #. Default: "Are you sure you want to delete this mail address?"
-#: ./opengever/contact/browser/templates/person_edit.pt:24
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_delete_mail_address_confirm_text"
 msgstr "Wollen Sie die E-Mail-Adresse wirklich löschen?"
 
 #. Default: "Department"
-#: ./opengever/contact/contact.py:93
+#: ./opengever/contact/contact.py
 msgid "label_department"
 msgstr "Abteilung"
 
 #. Default: "Description"
-#: ./opengever/contact/browser/person.py:112
-#: ./opengever/contact/contact.py:145
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Edit ${title}"
-#: ./opengever/contact/browser/participation_forms.py:87
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_edit_participation"
 msgstr "Beteiligung von ${title} bearbeiten"
 
 #. Default: "email"
-#: ./opengever/contact/contact.py:103
-#: ./opengever/contact/contactfolder.py:108
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/contact.py
 msgid "label_email"
 msgstr "E-Mail 1"
 
 #. Default: "Email 2"
-#: ./opengever/contact/contact.py:109
+#: ./opengever/contact/contact.py
 msgid "label_email2"
 msgstr "E-Mail 2"
 
 #. Default: "Fax"
-#: ./opengever/contact/ogdsuser.py:217
+#: ./opengever/contact/ogdsuser.py
 msgid "label_fax"
 msgstr "Fax"
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person.py:102
-#: ./opengever/contact/contact.py:82
-#: ./opengever/contact/contactfolder.py:103
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Former contact ID"
-#: ./opengever/contact/browser/byline.py:21
+#: ./opengever/contact/browser/byline.py
 msgid "label_former_contact_id"
 msgstr "Frühere Kontakt ID"
 
 #. Default: "Inactive"
-#: ./opengever/contact/browser/templates/organization.pt:102
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_inactive"
 msgstr "Inaktiv"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person.py:107
-#: ./opengever/contact/contact.py:75
-#: ./opengever/contact/contactfolder.py:98
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Latest participations"
-#: ./opengever/contact/browser/templates/latest_participations.pt:4
+#: ./opengever/contact/browser/templates/latest_participations.pt
 msgid "label_latest_participations"
 msgstr "Letzte Beteiligungen"
 
 #. Default: "Local"
-#: ./opengever/contact/browser/tabbed.py:25
+#: ./opengever/contact/browser/tabbed.py
 msgid "label_local"
 msgstr "Lokal"
 
 #. Default: "Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:44
-#: ./opengever/contact/browser/templates/person.pt:54
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_mail"
 msgstr "E-Mail-Adressen"
 
 #. Default: "Mobile"
-#: ./opengever/contact/ogdsuser.py:218
+#: ./opengever/contact/ogdsuser.py
 msgid "label_mobile"
 msgstr "Mobiltelefon"
 
 #. Default: "Name"
-#: ./opengever/contact/browser/templates/organization.pt:21
-#: ./opengever/contact/browser/templates/person.pt:22
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_name"
 msgstr "Name"
 
 #. Default: "No participations"
-#: ./opengever/contact/browser/templates/participations.pt:35
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "label_no_participations"
 msgstr "Keine Beteiligungen"
 
 #. Default: "Office"
-#: ./opengever/contact/ogdsuser.py:216
+#: ./opengever/contact/ogdsuser.py
 msgid "label_office"
 msgstr "Büro"
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:98
+#: ./opengever/contact/browser/tabbed.py
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_organizations"
 msgstr "Organisationen"
 
 #. Default: "Participation of ${contact_title}"
-#: ./opengever/contact/models/participation.py:54
+#: ./opengever/contact/models/participation.py
 msgid "label_participation_of"
 msgstr "Beteiligung von ${contact_title}"
 
 #. Default: "Personal information:"
-#: ./opengever/contact/browser/templates/person.pt:19
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_personal_information"
 msgstr "Persönliche Informationen:"
 
 #. Default: "Persons"
-#: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:88
+#: ./opengever/contact/browser/tabbed.py
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_persons"
 msgstr "Personen"
 
 #. Default: "Fax"
-#: ./opengever/contact/contact.py:125
+#: ./opengever/contact/contact.py
 msgid "label_phone_fax"
 msgstr "Fax Arbeit"
 
 #. Default: "Phone home"
-#: ./opengever/contact/contact.py:135
+#: ./opengever/contact/contact.py
 msgid "label_phone_home"
 msgstr "Telefon Privat"
 
 #. Default: "Mobile"
-#: ./opengever/contact/contact.py:130
+#: ./opengever/contact/contact.py
 msgid "label_phone_mobile"
 msgstr "Telefon Mobile"
 
 #. Default: "Phone numbers"
-#: ./opengever/contact/browser/templates/organization.pt:59
-#: ./opengever/contact/browser/templates/person.pt:69
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_phone_numbers"
 msgstr "Telefonnummern"
 
 #. Default: "Phone office"
-#: ./opengever/contact/contact.py:120
-#: ./opengever/contact/contactfolder.py:113
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/contact.py
 msgid "label_phone_office"
 msgstr "Telefon Arbeit"
 
 #. Default: "Picture"
-#: ./opengever/contact/contact.py:140
+#: ./opengever/contact/contact.py
 msgid "label_picture"
 msgstr "Bild"
 
 #. Default: "Remove ${title}"
-#: ./opengever/contact/browser/participation_forms.py:121
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_remove_participation"
 msgstr "${title} löschen"
 
 #. Default: "Roles"
-#: ./opengever/contact/browser/participation_forms.py:31
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_roles"
 msgstr "Rollen"
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person.py:92
-#: ./opengever/contact/browser/templates/person.pt:26
-#: ./opengever/contact/contact.py:64
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/browser/templates/person.pt
+#: ./opengever/contact/contact.py
 msgid "label_salutation"
 msgstr "Anrede"
 
 #. Default: "Sequence Number"
-#: ./opengever/contact/browser/byline.py:11
+#: ./opengever/contact/browser/byline.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Show all ${total} participations"
-#: ./opengever/contact/browser/participations.py:48
+#: ./opengever/contact/browser/participations.py
 msgid "label_show_all"
 msgstr "Alle ${total} Beteiligungen anzeigen"
 
 #. Default: "Url"
-#: ./opengever/contact/contact.py:115
+#: ./opengever/contact/contact.py
 msgid "label_url"
 msgstr "URL"
 
 #. Default: "URLs"
-#: ./opengever/contact/browser/templates/organization.pt:73
-#: ./opengever/contact/browser/templates/person.pt:83
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_urls"
 msgstr "URLs"
 
 #. Default: "Users"
-#: ./opengever/contact/browser/tabbed.py:33
+#: ./opengever/contact/browser/tabbed.py
 msgid "label_users"
 msgstr "Benutzer"
 
 #. Default: "ZIP"
-#: ./opengever/contact/contact.py:160
+#: ./opengever/contact/contact.py
 msgid "label_zip"
 msgstr "PLZ"
 
 #. Default: "Function"
-#: ./opengever/contact/contact.py:98
+#: ./opengever/contact/contact.py
 msgid "lable_function"
 msgstr "Funktion"
 
 #. Default: "Mailaddress successfully deleted"
-#: ./opengever/contact/browser/mail.py:122
+#: ./opengever/contact/browser/mail.py
 msgid "mail_address_deleted"
 msgstr "Die E-Mail-Adresse wurde gelöscht."
 
 #. Default: "There already exists a participation for this contact."
-#: ./opengever/contact/browser/participation_forms.py:64
+#: ./opengever/contact/browser/participation_forms.py
 msgid "msg_participation_already_exists"
 msgstr "Für diesen Kontakt existiert bereits eine Beteiligung."
 
 #. Default: "Personal Stuff"
-#: ./opengever/contact/contact.py:20
+#: ./opengever/contact/contact.py
 msgid "personal"
 msgstr "Persönliche Angaben"
 
 #. Default: "${amount} matches"
-#: ./opengever/contact/no_selection_amount.pt:3
+#: ./opengever/contact/browser/templates/no_selection_amount.pt
 msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Telefon"
-#: ./opengever/contact/contact.py:44
+#: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr "Telefon"
+

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-06-02 16:00+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
@@ -17,450 +17,450 @@ msgstr ""
 "X-Generator: Weblate 2.13.1\n"
 
 #. Default: "Add Person"
-#: ./opengever/contact/browser/person.py:123
+#: ./opengever/contact/browser/person.py
 msgid "Add Person"
 msgstr "Ajouter une personne"
 
-#: ./opengever/contact/contact.py:187
+#: ./opengever/contact/contact.py
 msgid "Contact"
 msgstr "Contact"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:26
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:23
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete mailaddress"
 msgstr "Supprimer l'adresse e-mail"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:38
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailadddress"
 msgstr "Adresse e-mail"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:33
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailaddresses"
 msgstr "Adresses e-mail"
 
-#: ./opengever/contact/browser/templates/person_edit.pt:37
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Label"
 msgstr "Libellé"
 
-#: ./opengever/contact/browser/participation_forms.py:125
+#: ./opengever/contact/browser/participation_forms.py
 msgid "Remove"
 msgstr "Effacer"
 
 #. Default: "Address"
-#: ./opengever/contact/contact.py:54
+#: ./opengever/contact/contact.py
 msgid "address"
 msgstr "Adresse"
 
 #. Default: "Edit"
-#: ./opengever/contact/browser/templates/participations.pt:18
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "button_edit"
 msgstr "Editer"
 
 #. Default: "Remove"
-#: ./opengever/contact/browser/templates/participations.pt:25
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "button_remove"
 msgstr "Effacer"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person_listing.py:36
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_academic_title"
 msgstr "Titre"
 
 #. Default: "Active"
-#: ./opengever/contact/browser/organization_listing.py:37
-#: ./opengever/contact/browser/person_listing.py:48
+#: ./opengever/contact/browser/organization_listing.py
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_active"
 msgstr "Actif"
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person_listing.py:40
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_firstname"
 msgstr "Prénom"
 
 #. Default: "Former contact id"
-#: ./opengever/contact/browser/organization_listing.py:41
-#: ./opengever/contact/browser/person_listing.py:57
+#: ./opengever/contact/browser/organization_listing.py
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_former_contact_id"
 msgstr "Contacts antérieurs ID"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person_listing.py:44
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_lastname"
 msgstr "Nom"
 
 #. Default: "Name"
-#: ./opengever/contact/browser/organization_listing.py:33
+#: ./opengever/contact/browser/organization_listing.py
 msgid "column_name"
 msgstr "Nom"
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/person_listing.py:52
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_organizations"
 msgstr "Organisations"
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person_listing.py:33
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_salutation"
 msgstr "Formule de salutation"
 
 #. Default: "Email address updated."
-#: ./opengever/contact/browser/mail.py:115
+#: ./opengever/contact/browser/mail.py
 msgid "email_address_updated"
 msgstr "Adresse électronique mise à jour."
 
 #. Default: "Please specify a valid email address"
-#: ./opengever/contact/browser/mail.py:153
+#: ./opengever/contact/browser/mail.py
 msgid "error_invalid_email"
 msgstr "Veuillez indiquer une adresse électronique valide."
 
 #. Default: "Please specify an email address"
-#: ./opengever/contact/browser/mail.py:149
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_email"
 msgstr "Veuillez indiquer une adresse électronique."
 
 #. Default: "Please specify a label for your email address"
-#: ./opengever/contact/browser/mail.py:145
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_label"
 msgstr "Veuillez indiquer une étiquette pour votre adresse électronique."
 
 #. Default: "Please specify a label and an email address."
-#: ./opengever/contact/browser/mail.py:139
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_label_and_email"
 msgstr "Veuillez indiquer un libellé ainsi qu'une adresse électronique."
 
 #. Default: "The email address was created successfully"
-#: ./opengever/contact/browser/mail.py:93
+#: ./opengever/contact/browser/mail.py
 msgid "info_mailaddress_created"
 msgstr "L'adresse électronique a été créée avec succès."
 
 #. Default: "Participation removed"
-#: ./opengever/contact/browser/participation_forms.py:134
+#: ./opengever/contact/browser/participation_forms.py
 msgid "info_participation_removed"
 msgstr "Participation supprimée"
 
 #. Default: "Internet"
-#: ./opengever/contact/contact.py:35
+#: ./opengever/contact/contact.py
 msgid "internet"
 msgstr "Site internet"
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person.py:97
-#: ./opengever/contact/browser/templates/person.pt:30
-#: ./opengever/contact/contact.py:69
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/browser/templates/person.pt
+#: ./opengever/contact/contact.py
 msgid "label_academic_title"
 msgstr "Titre"
 
 #. Default: "Active"
-#: ./opengever/contact/browser/byline.py:16
-#: ./opengever/contact/browser/templates/organization.pt:89
+#: ./opengever/contact/browser/byline.py
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_active"
 msgstr "Actif"
 
 #. Default: "Add Participation"
-#: ./opengever/contact/browser/participation_forms.py:44
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_add_participation"
 msgstr "Ajouter une participation"
 
 #. Default: "Address 1"
-#: ./opengever/contact/contact.py:150
+#: ./opengever/contact/contact.py
 msgid "label_address1"
 msgstr "Adresse (rue / n°)"
 
 #. Default: "Address 2"
-#: ./opengever/contact/contact.py:155
+#: ./opengever/contact/contact.py
 msgid "label_address2"
 msgstr "Complément d'adresse"
 
 #. Default: "Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:25
-#: ./opengever/contact/browser/templates/person.pt:35
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_addresses"
 msgstr "Adresses"
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:142
-#: ./opengever/contact/browser/templates/person.pt:144
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_addresses"
 msgstr "Adresses archivées"
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:165
-#: ./opengever/contact/browser/templates/person.pt:167
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_mail"
 msgstr "Adresses électroniques archivées"
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:124
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_archived_organizations"
 msgstr "Informations archivées"
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:117
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_persons"
 msgstr "Informations personnelles archivées"
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:184
-#: ./opengever/contact/browser/templates/person.pt:186
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_phone_numbers"
 msgstr "Numéros de téléphones archivés"
 
 #. Default: "Cancel"
-#: ./opengever/contact/browser/participation_forms.py:140
-#: ./opengever/contact/browser/templates/person_edit.pt:28
+#: ./opengever/contact/browser/participation_forms.py
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "City"
-#: ./opengever/contact/contact.py:165
+#: ./opengever/contact/contact.py
 msgid "label_city"
 msgstr "Localité"
 
 #. Default: "Company"
-#: ./opengever/contact/contact.py:88
+#: ./opengever/contact/contact.py
 msgid "label_company"
 msgstr "Entreprise"
 
 #. Default: "Contact"
-#: ./opengever/contact/browser/participation_forms.py:25
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_contact"
 msgstr "Contact"
 
 #. Default: "Country"
-#: ./opengever/contact/contact.py:170
+#: ./opengever/contact/contact.py
 msgid "label_country"
 msgstr "Pays"
 
 #. Default: "Are you sure you want to delete this mail address?"
-#: ./opengever/contact/browser/templates/person_edit.pt:24
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_delete_mail_address_confirm_text"
 msgstr "Voulez-vous vraiment effacer l'adresse électronique?"
 
 #. Default: "Department"
-#: ./opengever/contact/contact.py:93
+#: ./opengever/contact/contact.py
 msgid "label_department"
 msgstr "Service"
 
 #. Default: "Description"
-#: ./opengever/contact/browser/person.py:112
-#: ./opengever/contact/contact.py:145
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Edit ${title}"
-#: ./opengever/contact/browser/participation_forms.py:87
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_edit_participation"
 msgstr "Editer la participation de ${title}"
 
 #. Default: "email"
-#: ./opengever/contact/contact.py:103
-#: ./opengever/contact/contactfolder.py:108
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/contact.py
 msgid "label_email"
 msgstr "Email 1"
 
 #. Default: "Email 2"
-#: ./opengever/contact/contact.py:109
+#: ./opengever/contact/contact.py
 msgid "label_email2"
 msgstr "Email 2"
 
 #. Default: "Fax"
-#: ./opengever/contact/ogdsuser.py:217
+#: ./opengever/contact/ogdsuser.py
 msgid "label_fax"
 msgstr "Fax"
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person.py:102
-#: ./opengever/contact/contact.py:82
-#: ./opengever/contact/contactfolder.py:103
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Former contact ID"
-#: ./opengever/contact/browser/byline.py:21
+#: ./opengever/contact/browser/byline.py
 msgid "label_former_contact_id"
 msgstr "Contact ID antérieur"
 
 #. Default: "Inactive"
-#: ./opengever/contact/browser/templates/organization.pt:102
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_inactive"
 msgstr "Inactif"
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person.py:107
-#: ./opengever/contact/contact.py:75
-#: ./opengever/contact/contactfolder.py:98
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Latest participations"
-#: ./opengever/contact/browser/templates/latest_participations.pt:4
+#: ./opengever/contact/browser/templates/latest_participations.pt
 msgid "label_latest_participations"
 msgstr "Dernières participations"
 
 #. Default: "Local"
-#: ./opengever/contact/browser/tabbed.py:25
+#: ./opengever/contact/browser/tabbed.py
 msgid "label_local"
 msgstr "Local"
 
 #. Default: "Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:44
-#: ./opengever/contact/browser/templates/person.pt:54
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_mail"
 msgstr "Adresses électroniques"
 
 #. Default: "Mobile"
-#: ./opengever/contact/ogdsuser.py:218
+#: ./opengever/contact/ogdsuser.py
 msgid "label_mobile"
 msgstr "Téléphone portable"
 
 #. Default: "Name"
-#: ./opengever/contact/browser/templates/organization.pt:21
-#: ./opengever/contact/browser/templates/person.pt:22
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_name"
 msgstr "Nom"
 
 #. Default: "No participations"
-#: ./opengever/contact/browser/templates/participations.pt:35
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "label_no_participations"
 msgstr "Pas de participations"
 
 #. Default: "Office"
-#: ./opengever/contact/ogdsuser.py:216
+#: ./opengever/contact/ogdsuser.py
 msgid "label_office"
 msgstr "Bureau"
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:98
+#: ./opengever/contact/browser/tabbed.py
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_organizations"
 msgstr "Organisations"
 
 #. Default: "Participation of ${contact_title}"
-#: ./opengever/contact/models/participation.py:54
+#: ./opengever/contact/models/participation.py
 msgid "label_participation_of"
 msgstr "Participation de ${contact_title}"
 
 #. Default: "Personal information:"
-#: ./opengever/contact/browser/templates/person.pt:19
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_personal_information"
 msgstr "Informations personnelles:"
 
 #. Default: "Persons"
-#: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:88
+#: ./opengever/contact/browser/tabbed.py
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_persons"
 msgstr "Personnes"
 
 #. Default: "Fax"
-#: ./opengever/contact/contact.py:125
+#: ./opengever/contact/contact.py
 msgid "label_phone_fax"
 msgstr "Fax professionnel"
 
 #. Default: "Phone home"
-#: ./opengever/contact/contact.py:135
+#: ./opengever/contact/contact.py
 msgid "label_phone_home"
 msgstr "Téléphone privé"
 
 #. Default: "Mobile"
-#: ./opengever/contact/contact.py:130
+#: ./opengever/contact/contact.py
 msgid "label_phone_mobile"
 msgstr "Téléphone mobile"
 
 #. Default: "Phone numbers"
-#: ./opengever/contact/browser/templates/organization.pt:59
-#: ./opengever/contact/browser/templates/person.pt:69
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_phone_numbers"
 msgstr "Numéros de téléphone"
 
 #. Default: "Phone office"
-#: ./opengever/contact/contact.py:120
-#: ./opengever/contact/contactfolder.py:113
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/contact.py
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 
 #. Default: "Picture"
-#: ./opengever/contact/contact.py:140
+#: ./opengever/contact/contact.py
 msgid "label_picture"
 msgstr "Image"
 
 #. Default: "Remove ${title}"
-#: ./opengever/contact/browser/participation_forms.py:121
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_remove_participation"
 msgstr "Effacer ${title}"
 
 #. Default: "Roles"
-#: ./opengever/contact/browser/participation_forms.py:31
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_roles"
 msgstr "Rôles"
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person.py:92
-#: ./opengever/contact/browser/templates/person.pt:26
-#: ./opengever/contact/contact.py:64
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/browser/templates/person.pt
+#: ./opengever/contact/contact.py
 msgid "label_salutation"
 msgstr "Titre"
 
 #. Default: "Sequence Number"
-#: ./opengever/contact/browser/byline.py:11
+#: ./opengever/contact/browser/byline.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Show all ${total} participations"
-#: ./opengever/contact/browser/participations.py:48
+#: ./opengever/contact/browser/participations.py
 msgid "label_show_all"
 msgstr "Indiquer toutes les participations ${total}"
 
 #. Default: "Url"
-#: ./opengever/contact/contact.py:115
+#: ./opengever/contact/contact.py
 msgid "label_url"
 msgstr "Adresse URL"
 
 #. Default: "URLs"
-#: ./opengever/contact/browser/templates/organization.pt:73
-#: ./opengever/contact/browser/templates/person.pt:83
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_urls"
 msgstr "URLs"
 
 #. Default: "Users"
-#: ./opengever/contact/browser/tabbed.py:33
+#: ./opengever/contact/browser/tabbed.py
 msgid "label_users"
 msgstr "Utilisateurs"
 
 #. Default: "ZIP"
-#: ./opengever/contact/contact.py:160
+#: ./opengever/contact/contact.py
 msgid "label_zip"
 msgstr "NP"
 
 #. Default: "Function"
-#: ./opengever/contact/contact.py:98
+#: ./opengever/contact/contact.py
 msgid "lable_function"
 msgstr "Fonction"
 
 #. Default: "Mailaddress successfully deleted"
-#: ./opengever/contact/browser/mail.py:122
+#: ./opengever/contact/browser/mail.py
 msgid "mail_address_deleted"
 msgstr "L'adresse électronique a été effacée."
 
 #. Default: "There already exists a participation for this contact."
-#: ./opengever/contact/browser/participation_forms.py:64
+#: ./opengever/contact/browser/participation_forms.py
 msgid "msg_participation_already_exists"
 msgstr "Il y a déjà une participation pour ce contact."
 
 #. Default: "Personal Stuff"
-#: ./opengever/contact/contact.py:20
+#: ./opengever/contact/contact.py
 msgid "personal"
 msgstr "Coordonnées"
 
 #. Default: "${amount} matches"
-#: ./opengever/contact/no_selection_amount.pt:3
+#: ./opengever/contact/browser/templates/no_selection_amount.pt
 msgid "tab_matches"
 msgstr "Résultat(s): ${amount}"
 
 #. Default: "Telefon"
-#: ./opengever/contact/contact.py:44
+#: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr "Téléphone"
 

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,450 +18,450 @@ msgstr ""
 "Domain: opengever.contact\n"
 
 #. Default: "Add Person"
-#: ./opengever/contact/browser/person.py:123
+#: ./opengever/contact/browser/person.py
 msgid "Add Person"
 msgstr ""
 
-#: ./opengever/contact/contact.py:187
+#: ./opengever/contact/contact.py
 msgid "Contact"
 msgstr ""
 
-#: ./opengever/contact/browser/templates/person_edit.pt:26
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/contact/browser/templates/person_edit.pt:23
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete mailaddress"
 msgstr ""
 
-#: ./opengever/contact/browser/templates/person_edit.pt:38
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailadddress"
 msgstr ""
 
-#: ./opengever/contact/browser/templates/person_edit.pt:33
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailaddresses"
 msgstr ""
 
-#: ./opengever/contact/browser/templates/person_edit.pt:37
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Label"
 msgstr ""
 
-#: ./opengever/contact/browser/participation_forms.py:125
+#: ./opengever/contact/browser/participation_forms.py
 msgid "Remove"
 msgstr ""
 
 #. Default: "Address"
-#: ./opengever/contact/contact.py:54
+#: ./opengever/contact/contact.py
 msgid "address"
 msgstr ""
 
 #. Default: "Edit"
-#: ./opengever/contact/browser/templates/participations.pt:18
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "button_edit"
 msgstr ""
 
 #. Default: "Remove"
-#: ./opengever/contact/browser/templates/participations.pt:25
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "button_remove"
 msgstr ""
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person_listing.py:36
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_academic_title"
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/contact/browser/organization_listing.py:37
-#: ./opengever/contact/browser/person_listing.py:48
+#: ./opengever/contact/browser/organization_listing.py
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_active"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person_listing.py:40
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_firstname"
 msgstr ""
 
 #. Default: "Former contact id"
-#: ./opengever/contact/browser/organization_listing.py:41
-#: ./opengever/contact/browser/person_listing.py:57
+#: ./opengever/contact/browser/organization_listing.py
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_former_contact_id"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person_listing.py:44
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_lastname"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/contact/browser/organization_listing.py:33
+#: ./opengever/contact/browser/organization_listing.py
 msgid "column_name"
 msgstr ""
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/person_listing.py:52
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_organizations"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person_listing.py:33
+#: ./opengever/contact/browser/person_listing.py
 msgid "column_salutation"
 msgstr ""
 
 #. Default: "Email address updated."
-#: ./opengever/contact/browser/mail.py:115
+#: ./opengever/contact/browser/mail.py
 msgid "email_address_updated"
 msgstr ""
 
 #. Default: "Please specify a valid email address"
-#: ./opengever/contact/browser/mail.py:153
+#: ./opengever/contact/browser/mail.py
 msgid "error_invalid_email"
 msgstr ""
 
 #. Default: "Please specify an email address"
-#: ./opengever/contact/browser/mail.py:149
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_email"
 msgstr ""
 
 #. Default: "Please specify a label for your email address"
-#: ./opengever/contact/browser/mail.py:145
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_label"
 msgstr ""
 
 #. Default: "Please specify a label and an email address."
-#: ./opengever/contact/browser/mail.py:139
+#: ./opengever/contact/browser/mail.py
 msgid "error_no_label_and_email"
 msgstr ""
 
 #. Default: "The email address was created successfully"
-#: ./opengever/contact/browser/mail.py:93
+#: ./opengever/contact/browser/mail.py
 msgid "info_mailaddress_created"
 msgstr ""
 
 #. Default: "Participation removed"
-#: ./opengever/contact/browser/participation_forms.py:134
+#: ./opengever/contact/browser/participation_forms.py
 msgid "info_participation_removed"
 msgstr ""
 
 #. Default: "Internet"
-#: ./opengever/contact/contact.py:35
+#: ./opengever/contact/contact.py
 msgid "internet"
 msgstr ""
 
 #. Default: "Academic title"
-#: ./opengever/contact/browser/person.py:97
-#: ./opengever/contact/browser/templates/person.pt:30
-#: ./opengever/contact/contact.py:69
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/browser/templates/person.pt
+#: ./opengever/contact/contact.py
 msgid "label_academic_title"
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/contact/browser/byline.py:16
-#: ./opengever/contact/browser/templates/organization.pt:89
+#: ./opengever/contact/browser/byline.py
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_active"
 msgstr ""
 
 #. Default: "Add Participation"
-#: ./opengever/contact/browser/participation_forms.py:44
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_add_participation"
 msgstr ""
 
 #. Default: "Address 1"
-#: ./opengever/contact/contact.py:150
+#: ./opengever/contact/contact.py
 msgid "label_address1"
 msgstr ""
 
 #. Default: "Address 2"
-#: ./opengever/contact/contact.py:155
+#: ./opengever/contact/contact.py
 msgid "label_address2"
 msgstr ""
 
 #. Default: "Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:25
-#: ./opengever/contact/browser/templates/person.pt:35
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_addresses"
 msgstr ""
 
 #. Default: "Archived Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:142
-#: ./opengever/contact/browser/templates/person.pt:144
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_addresses"
 msgstr ""
 
 #. Default: "Archived Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:165
-#: ./opengever/contact/browser/templates/person.pt:167
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_mail"
 msgstr ""
 
 #. Default: "Archived Information"
-#: ./opengever/contact/browser/templates/organization.pt:124
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_archived_organizations"
 msgstr ""
 
 #. Default: "Archived Personal Information"
-#: ./opengever/contact/browser/templates/person.pt:117
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_persons"
 msgstr ""
 
 #. Default: "Archived Phone Numbers"
-#: ./opengever/contact/browser/templates/organization.pt:184
-#: ./opengever/contact/browser/templates/person.pt:186
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_phone_numbers"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/contact/browser/participation_forms.py:140
-#: ./opengever/contact/browser/templates/person_edit.pt:28
+#: ./opengever/contact/browser/participation_forms.py
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "City"
-#: ./opengever/contact/contact.py:165
+#: ./opengever/contact/contact.py
 msgid "label_city"
 msgstr ""
 
 #. Default: "Company"
-#: ./opengever/contact/contact.py:88
+#: ./opengever/contact/contact.py
 msgid "label_company"
 msgstr ""
 
 #. Default: "Contact"
-#: ./opengever/contact/browser/participation_forms.py:25
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_contact"
 msgstr ""
 
 #. Default: "Country"
-#: ./opengever/contact/contact.py:170
+#: ./opengever/contact/contact.py
 msgid "label_country"
 msgstr ""
 
 #. Default: "Are you sure you want to delete this mail address?"
-#: ./opengever/contact/browser/templates/person_edit.pt:24
+#: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_delete_mail_address_confirm_text"
 msgstr ""
 
 #. Default: "Department"
-#: ./opengever/contact/contact.py:93
+#: ./opengever/contact/contact.py
 msgid "label_department"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/contact/browser/person.py:112
-#: ./opengever/contact/contact.py:145
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_description"
 msgstr ""
 
 #. Default: "Edit ${title}"
-#: ./opengever/contact/browser/participation_forms.py:87
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_edit_participation"
 msgstr ""
 
 #. Default: "email"
-#: ./opengever/contact/contact.py:103
-#: ./opengever/contact/contactfolder.py:108
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/contact.py
 msgid "label_email"
 msgstr ""
 
 #. Default: "Email 2"
-#: ./opengever/contact/contact.py:109
+#: ./opengever/contact/contact.py
 msgid "label_email2"
 msgstr ""
 
 #. Default: "Fax"
-#: ./opengever/contact/ogdsuser.py:217
+#: ./opengever/contact/ogdsuser.py
 msgid "label_fax"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/contact/browser/person.py:102
-#: ./opengever/contact/contact.py:82
-#: ./opengever/contact/contactfolder.py:103
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_firstname"
 msgstr ""
 
 #. Default: "Former contact ID"
-#: ./opengever/contact/browser/byline.py:21
+#: ./opengever/contact/browser/byline.py
 msgid "label_former_contact_id"
 msgstr ""
 
 #. Default: "Inactive"
-#: ./opengever/contact/browser/templates/organization.pt:102
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_inactive"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/contact/browser/person.py:107
-#: ./opengever/contact/contact.py:75
-#: ./opengever/contact/contactfolder.py:98
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/contact.py
 msgid "label_lastname"
 msgstr ""
 
 #. Default: "Latest participations"
-#: ./opengever/contact/browser/templates/latest_participations.pt:4
+#: ./opengever/contact/browser/templates/latest_participations.pt
 msgid "label_latest_participations"
 msgstr ""
 
 #. Default: "Local"
-#: ./opengever/contact/browser/tabbed.py:25
+#: ./opengever/contact/browser/tabbed.py
 msgid "label_local"
 msgstr ""
 
 #. Default: "Mail Addresses"
-#: ./opengever/contact/browser/templates/organization.pt:44
-#: ./opengever/contact/browser/templates/person.pt:54
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_mail"
 msgstr ""
 
 #. Default: "Mobile"
-#: ./opengever/contact/ogdsuser.py:218
+#: ./opengever/contact/ogdsuser.py
 msgid "label_mobile"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/contact/browser/templates/organization.pt:21
-#: ./opengever/contact/browser/templates/person.pt:22
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_name"
 msgstr ""
 
 #. Default: "No participations"
-#: ./opengever/contact/browser/templates/participations.pt:35
+#: ./opengever/contact/browser/templates/participations.pt
 msgid "label_no_participations"
 msgstr ""
 
 #. Default: "Office"
-#: ./opengever/contact/ogdsuser.py:216
+#: ./opengever/contact/ogdsuser.py
 msgid "label_office"
 msgstr ""
 
 #. Default: "Organizations"
-#: ./opengever/contact/browser/tabbed.py:17
-#: ./opengever/contact/browser/templates/person.pt:98
+#: ./opengever/contact/browser/tabbed.py
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_organizations"
 msgstr ""
 
 #. Default: "Participation of ${contact_title}"
-#: ./opengever/contact/models/participation.py:54
+#: ./opengever/contact/models/participation.py
 msgid "label_participation_of"
 msgstr ""
 
 #. Default: "Personal information:"
-#: ./opengever/contact/browser/templates/person.pt:19
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_personal_information"
 msgstr ""
 
 #. Default: "Persons"
-#: ./opengever/contact/browser/tabbed.py:12
-#: ./opengever/contact/browser/templates/organization.pt:88
+#: ./opengever/contact/browser/tabbed.py
+#: ./opengever/contact/browser/templates/organization.pt
 msgid "label_persons"
 msgstr ""
 
 #. Default: "Fax"
-#: ./opengever/contact/contact.py:125
+#: ./opengever/contact/contact.py
 msgid "label_phone_fax"
 msgstr ""
 
 #. Default: "Phone home"
-#: ./opengever/contact/contact.py:135
+#: ./opengever/contact/contact.py
 msgid "label_phone_home"
 msgstr ""
 
 #. Default: "Mobile"
-#: ./opengever/contact/contact.py:130
+#: ./opengever/contact/contact.py
 msgid "label_phone_mobile"
 msgstr ""
 
 #. Default: "Phone numbers"
-#: ./opengever/contact/browser/templates/organization.pt:59
-#: ./opengever/contact/browser/templates/person.pt:69
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_phone_numbers"
 msgstr ""
 
 #. Default: "Phone office"
-#: ./opengever/contact/contact.py:120
-#: ./opengever/contact/contactfolder.py:113
+#: ./opengever/contact/browser/contacts_tab.py
+#: ./opengever/contact/contact.py
 msgid "label_phone_office"
 msgstr ""
 
 #. Default: "Picture"
-#: ./opengever/contact/contact.py:140
+#: ./opengever/contact/contact.py
 msgid "label_picture"
 msgstr ""
 
 #. Default: "Remove ${title}"
-#: ./opengever/contact/browser/participation_forms.py:121
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_remove_participation"
 msgstr ""
 
 #. Default: "Roles"
-#: ./opengever/contact/browser/participation_forms.py:31
+#: ./opengever/contact/browser/participation_forms.py
 msgid "label_roles"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/contact/browser/person.py:92
-#: ./opengever/contact/browser/templates/person.pt:26
-#: ./opengever/contact/contact.py:64
+#: ./opengever/contact/browser/person.py
+#: ./opengever/contact/browser/templates/person.pt
+#: ./opengever/contact/contact.py
 msgid "label_salutation"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/contact/browser/byline.py:11
+#: ./opengever/contact/browser/byline.py
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Show all ${total} participations"
-#: ./opengever/contact/browser/participations.py:48
+#: ./opengever/contact/browser/participations.py
 msgid "label_show_all"
 msgstr ""
 
 #. Default: "Url"
-#: ./opengever/contact/contact.py:115
+#: ./opengever/contact/contact.py
 msgid "label_url"
 msgstr ""
 
 #. Default: "URLs"
-#: ./opengever/contact/browser/templates/organization.pt:73
-#: ./opengever/contact/browser/templates/person.pt:83
+#: ./opengever/contact/browser/templates/organization.pt
+#: ./opengever/contact/browser/templates/person.pt
 msgid "label_urls"
 msgstr ""
 
 #. Default: "Users"
-#: ./opengever/contact/browser/tabbed.py:33
+#: ./opengever/contact/browser/tabbed.py
 msgid "label_users"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./opengever/contact/contact.py:160
+#: ./opengever/contact/contact.py
 msgid "label_zip"
 msgstr ""
 
 #. Default: "Function"
-#: ./opengever/contact/contact.py:98
+#: ./opengever/contact/contact.py
 msgid "lable_function"
 msgstr ""
 
 #. Default: "Mailaddress successfully deleted"
-#: ./opengever/contact/browser/mail.py:122
+#: ./opengever/contact/browser/mail.py
 msgid "mail_address_deleted"
 msgstr ""
 
 #. Default: "There already exists a participation for this contact."
-#: ./opengever/contact/browser/participation_forms.py:64
+#: ./opengever/contact/browser/participation_forms.py
 msgid "msg_participation_already_exists"
 msgstr ""
 
 #. Default: "Personal Stuff"
-#: ./opengever/contact/contact.py:20
+#: ./opengever/contact/contact.py
 msgid "personal"
 msgstr ""
 
 #. Default: "${amount} matches"
-#: ./opengever/contact/no_selection_amount.pt:3
+#: ./opengever/contact/browser/templates/no_selection_amount.pt
 msgid "tab_matches"
 msgstr ""
 
 #. Default: "Telefon"
-#: ./opengever/contact/contact.py:44
+#: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr ""
 

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-09-18 13:20+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -103,7 +103,7 @@ msgid "Dossier template"
 msgstr "Dossiervorlage"
 
 #: ./opengever/core/profiles/default/actions.xml
-#: ./opengever/core/upgrades/20170918145304_add_zipexport_action_for_meetings/actions.xml
+#: ./opengever/core/upgrades/20170920132556_add_zipexport_action_for_meetings/actions.xml
 msgid "Export as Zip"
 msgstr "Als Zip-Datei exportieren"
 

--- a/opengever/core/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/de/LC_MESSAGES/plone.po
@@ -55,8 +55,9 @@ msgstr "Manager"
 msgid "opengever_committee_workflow--ROLE-DESCRIPTION--CommitteeMember"
 msgstr "Ein Gremien-Mitglied ist Teil eines Gremiums und kann Inhalte wie Sitzungen und Anträge des Gremiums ansehen."
 
-#. Default: "The committe responsible is in charge of a committee. This involves creating, planing and hold meetings as well as configuring and deactivating the committee."
+#. Default: "The committe responsible is in charge of a committee. This involves creating, planing and hold meetings as well as configuring and deactivating the committee. The committee responsible role is assigned automatically to the group that can be configured per committee."
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#, fuzzy
 msgid "opengever_committee_workflow--ROLE-DESCRIPTION--CommitteeResponsible"
 msgstr "Die Gremien-Verantwortliche Person ist zuständig für ein Kommitee. Sie erstellt, traktandiert und protokolliert Sitzungen und kann das Gremium konfigurieren und deaktivieren. Diese Rolle wird vom System automatisch vergeben."
 

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-09-18 13:20+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -100,7 +100,7 @@ msgid "Dossier template"
 msgstr "Modèle de dossier"
 
 #: ./opengever/core/profiles/default/actions.xml
-#: ./opengever/core/upgrades/20170918145304_add_zipexport_action_for_meetings/actions.xml
+#: ./opengever/core/upgrades/20170920132556_add_zipexport_action_for_meetings/actions.xml
 msgid "Export as Zip"
 msgstr "Exporter comme fichier ZIP"
 
@@ -259,3 +259,4 @@ msgstr "Avec commentaire"
 #: ./opengever/core/profiles/default/actions.xml
 msgid "without comment"
 msgstr "Sans commentaire"
+

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -55,7 +55,7 @@ msgstr ""
 msgid "opengever_committee_workflow--ROLE-DESCRIPTION--CommitteeMember"
 msgstr ""
 
-#. Default: "The committe responsible is in charge of a committee. This involves creating, planing and hold meetings as well as configuring and deactivating the committee."
+#. Default: "The committe responsible is in charge of a committee. This involves creating, planing and hold meetings as well as configuring and deactivating the committee. The committee responsible role is assigned automatically to the group that can be configured per committee."
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
 msgid "opengever_committee_workflow--ROLE-DESCRIPTION--CommitteeResponsible"
 msgstr ""

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-18 13:20+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,7 +103,7 @@ msgid "Dossier template"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
-#: ./opengever/core/upgrades/20170918145304_add_zipexport_action_for_meetings/actions.xml
+#: ./opengever/core/upgrades/20170920132556_add_zipexport_action_for_meetings/actions.xml
 msgid "Export as Zip"
 msgstr ""
 

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,246 +14,246 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/disposition/browser/excel_export.py:75
+#: ./opengever/disposition/browser/excel_export.py
 msgid "The report could not been generated."
 msgstr "Der Report konnte nicht generiert werden."
 
-#: ./opengever/disposition/browser/listing.py:30
+#: ./opengever/disposition/browser/listing.py
 msgid "active"
 msgstr "Aktiv"
 
-#: ./opengever/disposition/browser/listing.py:28
+#: ./opengever/disposition/browser/listing.py
 msgid "all"
 msgstr "Alle"
 
 #. Default: "Sequence Number"
-#: ./opengever/disposition/browser/listing.py:43
+#: ./opengever/disposition/browser/listing.py
 msgid "document_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:29
+#: ./opengever/disposition/validators.py
 msgid "error_offered_in_a_different_disposition"
 msgstr "Das Dossier ${title} ist bereits in einem anderen Angebot angeboten."
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:23
+#: ./opengever/disposition/validators.py
 msgid "error_retention_period_not_expired"
 msgstr "Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen."
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:132
+#: ./opengever/disposition/disposition.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Action"
-#: ./opengever/disposition/browser/removal_protocol.py:90
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_action"
 msgstr "Aktion"
 
 #. Default: "Actor"
-#: ./opengever/disposition/browser/removal_protocol.py:86
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_actor"
 msgstr "Akteur"
 
 #. Default: "Appraisal"
-#: ./opengever/disposition/browser/excel_export.py:62
+#: ./opengever/disposition/browser/excel_export.py
 msgid "label_appraisal"
 msgstr "Bewertungsentscheid"
 
 #. Default: "Archive"
-#: ./opengever/disposition/browser/templates/overview.pt:48
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_archive"
 msgstr "Archivieren"
 
 #. Default: "Archive all"
-#: ./opengever/disposition/browser/templates/overview.pt:86
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_archive_all"
 msgstr "Alle archivieren"
 
 #. Default: "Archived"
-#: ./opengever/disposition/browser/removal_protocol.py:68
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_archived"
 msgstr "Archiviert"
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:227
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_details"
 msgstr "Details:"
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:122
+#: ./opengever/disposition/disposition.py
 msgid "label_disposition"
 msgstr "Angebot"
 
 #. Default: "Disposition added"
-#: ./opengever/disposition/activities.py:19
-#: ./opengever/disposition/history.py:86
+#: ./opengever/disposition/activities.py
+#: ./opengever/disposition/history.py
 msgid "label_disposition_added"
 msgstr "Angebot hinzugefügt"
 
 #. Default: "Disposition edited"
-#: ./opengever/disposition/history.py:105
+#: ./opengever/disposition/history.py
 msgid "label_disposition_edited"
 msgstr "Angebot bearbeitet"
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:77
+#: ./opengever/disposition/browser/overview.py
 msgid "label_dispositon_package_download"
 msgstr "Ablieferungspaket herunterladen"
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:147
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dont_archive"
 msgstr "Nicht archivieren"
 
 #. Default: "Do not archive all"
-#: ./opengever/disposition/browser/templates/overview.pt:89
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dont_archive_all"
 msgstr "Alle nicht archivieren"
 
 #. Default: "Dossier"
-#: ./opengever/disposition/browser/templates/overview.pt:68
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/browser/removal_protocol.py:122
-#: ./opengever/disposition/browser/templates/overview.pt:67
-#: ./opengever/disposition/disposition.py:145
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/browser/templates/overview.pt
+#: ./opengever/disposition/disposition.py
 msgid "label_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:83
+#: ./opengever/disposition/browser/overview.py
 msgid "label_download_removal_protocol"
 msgstr "Löschprotokoll herunterladen"
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:71
+#: ./opengever/disposition/browser/overview.py
 msgid "label_export_appraisal_list_as_excel"
 msgstr "Bewertungsliste als Excel exportieren"
 
 #. Default: "History"
-#: ./opengever/disposition/browser/removal_protocol.py:126
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_history"
 msgstr "Verlauf"
 
 #. Default: "Inactive Dossiers"
-#: ./opengever/disposition/browser/overview.py:49
+#: ./opengever/disposition/browser/overview.py
 msgid "label_inactive_dossiers"
 msgstr "Stornierte Dossiers"
 
 #. Default: "No"
-#: ./opengever/disposition/browser/removal_protocol.py:55
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_no"
 msgstr "Nein"
 
 #. Default: "Reference number"
-#: ./opengever/disposition/browser/removal_protocol.py:60
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Removal protocol"
-#: ./opengever/disposition/browser/removal_protocol.py:118
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_removal_protocol"
 msgstr "Löschprotokoll"
 
 #. Default: "Resolved Dossiers"
-#: ./opengever/disposition/browser/overview.py:47
+#: ./opengever/disposition/browser/overview.py
 msgid "label_resolved_dossiers"
 msgstr "Abgeschlossene Dossiers"
 
 #. Default: "Review state"
-#: ./opengever/disposition/browser/listing.py:53
+#: ./opengever/disposition/browser/listing.py
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Time"
-#: ./opengever/disposition/browser/removal_protocol.py:82
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_time"
 msgstr "Zeitpunkt"
 
 #. Default: "Title"
-#: ./opengever/disposition/browser/listing.py:48
-#: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:138
+#: ./opengever/disposition/browser/listing.py
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/disposition.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Transfer number"
-#: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:166
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr "Ablieferungsnummer"
 
 #. Default: "Yes"
-#: ./opengever/disposition/browser/removal_protocol.py:53
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_yes"
 msgstr "Ja"
 
 #. Default: "The appraisal is incomplete, appraisal could not be finalized."
-#: ./opengever/disposition/browser/views.py:37
+#: ./opengever/disposition/browser/views.py
 msgid "msg_appraisal_incomplete"
 msgstr "Die Bewertung ist nicht komplett, die Bewertung konnte nicht finalisiert werden."
 
 #. Default: "Added by ${user}"
-#: ./opengever/disposition/history.py:80
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_added"
 msgstr "Hinzugefügt durch ${user}"
 
 #. Default: "Appraisal finalized by ${user}"
-#: ./opengever/disposition/history.py:116
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_appraised"
 msgstr "Bewertung finalisiert durch ${user}"
 
 #. Default: "The archiving confirmed by ${user}"
-#: ./opengever/disposition/history.py:140
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_archived"
 msgstr "Archivierung bestätigt durch ${user}"
 
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
-#: ./opengever/disposition/history.py:152
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_close"
 msgstr "Angebot abgeschlossen und alle Dossiers vernichtet durch ${user}"
 
 #. Default: "Disposition disposed for the archive by ${user}"
-#: ./opengever/disposition/history.py:128
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_disposed"
 msgstr "Zur Archivierung angeboten durch ${user}"
 
 #. Default: "Edited by ${user}"
-#: ./opengever/disposition/history.py:98
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_edited"
 msgstr "Editiert durch ${user}"
 
 #. Default: "Disposition refused by ${user}"
-#: ./opengever/disposition/history.py:171
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_refuse"
 msgstr "Angebot abgelehnt durch ${user}"
 
 #. Default: "Updated by ${user}"
-#: ./opengever/disposition/history.py:60
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_updated"
 msgstr "Aktualisiert durch ${user}"
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:110
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "period"
 msgstr "Periode"
 
 #. Default: "Progress"
-#: ./opengever/disposition/browser/templates/overview.pt:214
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
 msgstr "Verlauf"
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
-#: ./opengever/disposition/activities.py:24
+#: ./opengever/disposition/activities.py
 msgid "summary_disposition_added"
 msgstr "Neues Angebot hinzugefügt durch ${user} im Mandanten ${admin_unit}"
 
 #. Default: "Removal protocol for ${disposition}"
-#: ./opengever/disposition/browser/removal_protocol.py:40
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
 msgstr "Löschprotokoll zu ${disposition}"
 

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-06-04 17:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -16,246 +16,246 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/disposition/browser/excel_export.py:75
+#: ./opengever/disposition/browser/excel_export.py
 msgid "The report could not been generated."
 msgstr ""
 
-#: ./opengever/disposition/browser/listing.py:30
+#: ./opengever/disposition/browser/listing.py
 msgid "active"
 msgstr "Actif"
 
-#: ./opengever/disposition/browser/listing.py:28
+#: ./opengever/disposition/browser/listing.py
 msgid "all"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/disposition/browser/listing.py:43
+#: ./opengever/disposition/browser/listing.py
 msgid "document_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:29
+#: ./opengever/disposition/validators.py
 msgid "error_offered_in_a_different_disposition"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:23
+#: ./opengever/disposition/validators.py
 msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:132
+#: ./opengever/disposition/disposition.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Action"
-#: ./opengever/disposition/browser/removal_protocol.py:90
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_action"
 msgstr ""
 
 #. Default: "Actor"
-#: ./opengever/disposition/browser/removal_protocol.py:86
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_actor"
 msgstr ""
 
 #. Default: "Appraisal"
-#: ./opengever/disposition/browser/excel_export.py:62
+#: ./opengever/disposition/browser/excel_export.py
 msgid "label_appraisal"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/disposition/browser/templates/overview.pt:48
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_archive"
 msgstr ""
 
 #. Default: "Archive all"
-#: ./opengever/disposition/browser/templates/overview.pt:86
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_archive_all"
 msgstr ""
 
 #. Default: "Archived"
-#: ./opengever/disposition/browser/removal_protocol.py:68
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_archived"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:227
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_details"
 msgstr "Détails:"
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:122
+#: ./opengever/disposition/disposition.py
 msgid "label_disposition"
 msgstr ""
 
 #. Default: "Disposition added"
-#: ./opengever/disposition/activities.py:19
-#: ./opengever/disposition/history.py:86
+#: ./opengever/disposition/activities.py
+#: ./opengever/disposition/history.py
 msgid "label_disposition_added"
 msgstr ""
 
 #. Default: "Disposition edited"
-#: ./opengever/disposition/history.py:105
+#: ./opengever/disposition/history.py
 msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:77
+#: ./opengever/disposition/browser/overview.py
 msgid "label_dispositon_package_download"
 msgstr ""
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:147
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dont_archive"
 msgstr ""
 
 #. Default: "Do not archive all"
-#: ./opengever/disposition/browser/templates/overview.pt:89
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dont_archive_all"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/disposition/browser/templates/overview.pt:68
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/browser/removal_protocol.py:122
-#: ./opengever/disposition/browser/templates/overview.pt:67
-#: ./opengever/disposition/disposition.py:145
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/browser/templates/overview.pt
+#: ./opengever/disposition/disposition.py
 msgid "label_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:83
+#: ./opengever/disposition/browser/overview.py
 msgid "label_download_removal_protocol"
 msgstr ""
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:71
+#: ./opengever/disposition/browser/overview.py
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
 #. Default: "History"
-#: ./opengever/disposition/browser/removal_protocol.py:126
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_history"
 msgstr ""
 
 #. Default: "Inactive Dossiers"
-#: ./opengever/disposition/browser/overview.py:49
+#: ./opengever/disposition/browser/overview.py
 msgid "label_inactive_dossiers"
 msgstr ""
 
 #. Default: "No"
-#: ./opengever/disposition/browser/removal_protocol.py:55
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_no"
 msgstr "Non"
 
 #. Default: "Reference number"
-#: ./opengever/disposition/browser/removal_protocol.py:60
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Removal protocol"
-#: ./opengever/disposition/browser/removal_protocol.py:118
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_removal_protocol"
 msgstr ""
 
 #. Default: "Resolved Dossiers"
-#: ./opengever/disposition/browser/overview.py:47
+#: ./opengever/disposition/browser/overview.py
 msgid "label_resolved_dossiers"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/disposition/browser/listing.py:53
+#: ./opengever/disposition/browser/listing.py
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Time"
-#: ./opengever/disposition/browser/removal_protocol.py:82
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_time"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/disposition/browser/listing.py:48
-#: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:138
+#: ./opengever/disposition/browser/listing.py
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/disposition.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Transfer number"
-#: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:166
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr ""
 
 #. Default: "Yes"
-#: ./opengever/disposition/browser/removal_protocol.py:53
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_yes"
 msgstr "Oui"
 
 #. Default: "The appraisal is incomplete, appraisal could not be finalized."
-#: ./opengever/disposition/browser/views.py:37
+#: ./opengever/disposition/browser/views.py
 msgid "msg_appraisal_incomplete"
 msgstr ""
 
 #. Default: "Added by ${user}"
-#: ./opengever/disposition/history.py:80
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_added"
 msgstr ""
 
 #. Default: "Appraisal finalized by ${user}"
-#: ./opengever/disposition/history.py:116
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_appraised"
 msgstr ""
 
 #. Default: "The archiving confirmed by ${user}"
-#: ./opengever/disposition/history.py:140
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_archived"
 msgstr ""
 
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
-#: ./opengever/disposition/history.py:152
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_close"
 msgstr ""
 
 #. Default: "Disposition disposed for the archive by ${user}"
-#: ./opengever/disposition/history.py:128
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_disposed"
 msgstr ""
 
 #. Default: "Edited by ${user}"
-#: ./opengever/disposition/history.py:98
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_edited"
 msgstr ""
 
 #. Default: "Disposition refused by ${user}"
-#: ./opengever/disposition/history.py:171
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_refuse"
 msgstr ""
 
 #. Default: "Updated by ${user}"
-#: ./opengever/disposition/history.py:60
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_updated"
 msgstr ""
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:110
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "period"
 msgstr ""
 
 #. Default: "Progress"
-#: ./opengever/disposition/browser/templates/overview.pt:214
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
 msgstr ""
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
-#: ./opengever/disposition/activities.py:24
+#: ./opengever/disposition/activities.py
 msgid "summary_disposition_added"
 msgstr ""
 
 #. Default: "Removal protocol for ${disposition}"
-#: ./opengever/disposition/browser/removal_protocol.py:40
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
 msgstr ""
 

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,246 +17,246 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.disposition\n"
 
-#: ./opengever/disposition/browser/excel_export.py:75
+#: ./opengever/disposition/browser/excel_export.py
 msgid "The report could not been generated."
 msgstr ""
 
-#: ./opengever/disposition/browser/listing.py:30
+#: ./opengever/disposition/browser/listing.py
 msgid "active"
 msgstr ""
 
-#: ./opengever/disposition/browser/listing.py:28
+#: ./opengever/disposition/browser/listing.py
 msgid "all"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/disposition/browser/listing.py:43
+#: ./opengever/disposition/browser/listing.py
 msgid "document_sequence_number"
 msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
-#: ./opengever/disposition/validators.py:29
+#: ./opengever/disposition/validators.py
 msgid "error_offered_in_a_different_disposition"
 msgstr ""
 
 #. Default: "The retention period of the selected dossiers is not expired."
-#: ./opengever/disposition/validators.py:23
+#: ./opengever/disposition/validators.py
 msgid "error_retention_period_not_expired"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/disposition/disposition.py:132
+#: ./opengever/disposition/disposition.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/disposition/browser/removal_protocol.py:90
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_action"
 msgstr ""
 
 #. Default: "Actor"
-#: ./opengever/disposition/browser/removal_protocol.py:86
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_actor"
 msgstr ""
 
 #. Default: "Appraisal"
-#: ./opengever/disposition/browser/excel_export.py:62
+#: ./opengever/disposition/browser/excel_export.py
 msgid "label_appraisal"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/disposition/browser/templates/overview.pt:48
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_archive"
 msgstr ""
 
 #. Default: "Archive all"
-#: ./opengever/disposition/browser/templates/overview.pt:86
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_archive_all"
 msgstr ""
 
 #. Default: "Archived"
-#: ./opengever/disposition/browser/removal_protocol.py:68
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_archived"
 msgstr ""
 
 #. Default: "Details:"
-#: ./opengever/disposition/browser/templates/overview.pt:227
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_details"
 msgstr ""
 
 #. Default: "Disposition"
-#: ./opengever/disposition/disposition.py:122
+#: ./opengever/disposition/disposition.py
 msgid "label_disposition"
 msgstr ""
 
 #. Default: "Disposition added"
-#: ./opengever/disposition/activities.py:19
-#: ./opengever/disposition/history.py:86
+#: ./opengever/disposition/activities.py
+#: ./opengever/disposition/history.py
 msgid "label_disposition_added"
 msgstr ""
 
 #. Default: "Disposition edited"
-#: ./opengever/disposition/history.py:105
+#: ./opengever/disposition/history.py
 msgid "label_disposition_edited"
 msgstr ""
 
 #. Default: "Download disposition package"
-#: ./opengever/disposition/browser/overview.py:77
+#: ./opengever/disposition/browser/overview.py
 msgid "label_dispositon_package_download"
 msgstr ""
 
 #. Default: "Don't archive"
-#: ./opengever/disposition/browser/templates/overview.pt:147
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dont_archive"
 msgstr ""
 
 #. Default: "Do not archive all"
-#: ./opengever/disposition/browser/templates/overview.pt:89
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dont_archive_all"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/disposition/browser/templates/overview.pt:68
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/disposition/browser/removal_protocol.py:122
-#: ./opengever/disposition/browser/templates/overview.pt:67
-#: ./opengever/disposition/disposition.py:145
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/browser/templates/overview.pt
+#: ./opengever/disposition/disposition.py
 msgid "label_dossiers"
 msgstr ""
 
 #. Default: "Download removal protocol"
-#: ./opengever/disposition/browser/overview.py:83
+#: ./opengever/disposition/browser/overview.py
 msgid "label_download_removal_protocol"
 msgstr ""
 
 #. Default: "Export appraisal list as excel"
-#: ./opengever/disposition/browser/overview.py:71
+#: ./opengever/disposition/browser/overview.py
 msgid "label_export_appraisal_list_as_excel"
 msgstr ""
 
 #. Default: "History"
-#: ./opengever/disposition/browser/removal_protocol.py:126
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_history"
 msgstr ""
 
 #. Default: "Inactive Dossiers"
-#: ./opengever/disposition/browser/overview.py:49
+#: ./opengever/disposition/browser/overview.py
 msgid "label_inactive_dossiers"
 msgstr ""
 
 #. Default: "No"
-#: ./opengever/disposition/browser/removal_protocol.py:55
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_no"
 msgstr ""
 
 #. Default: "Reference number"
-#: ./opengever/disposition/browser/removal_protocol.py:60
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Removal protocol"
-#: ./opengever/disposition/browser/removal_protocol.py:118
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_removal_protocol"
 msgstr ""
 
 #. Default: "Resolved Dossiers"
-#: ./opengever/disposition/browser/overview.py:47
+#: ./opengever/disposition/browser/overview.py
 msgid "label_resolved_dossiers"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/disposition/browser/listing.py:53
+#: ./opengever/disposition/browser/listing.py
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Time"
-#: ./opengever/disposition/browser/removal_protocol.py:82
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_time"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/disposition/browser/listing.py:48
-#: ./opengever/disposition/browser/removal_protocol.py:64
-#: ./opengever/disposition/disposition.py:138
+#: ./opengever/disposition/browser/listing.py
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/disposition.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transfer number"
-#: ./opengever/disposition/browser/removal_protocol.py:135
-#: ./opengever/disposition/disposition.py:166
+#: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr ""
 
 #. Default: "Yes"
-#: ./opengever/disposition/browser/removal_protocol.py:53
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_yes"
 msgstr ""
 
 #. Default: "The appraisal is incomplete, appraisal could not be finalized."
-#: ./opengever/disposition/browser/views.py:37
+#: ./opengever/disposition/browser/views.py
 msgid "msg_appraisal_incomplete"
 msgstr ""
 
 #. Default: "Added by ${user}"
-#: ./opengever/disposition/history.py:80
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_added"
 msgstr ""
 
 #. Default: "Appraisal finalized by ${user}"
-#: ./opengever/disposition/history.py:116
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_appraised"
 msgstr ""
 
 #. Default: "The archiving confirmed by ${user}"
-#: ./opengever/disposition/history.py:140
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_archived"
 msgstr ""
 
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
-#: ./opengever/disposition/history.py:152
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_close"
 msgstr ""
 
 #. Default: "Disposition disposed for the archive by ${user}"
-#: ./opengever/disposition/history.py:128
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_disposed"
 msgstr ""
 
 #. Default: "Edited by ${user}"
-#: ./opengever/disposition/history.py:98
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_edited"
 msgstr ""
 
 #. Default: "Disposition refused by ${user}"
-#: ./opengever/disposition/history.py:171
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_refuse"
 msgstr ""
 
 #. Default: "Updated by ${user}"
-#: ./opengever/disposition/history.py:60
+#: ./opengever/disposition/history.py
 msgid "msg_disposition_updated"
 msgstr ""
 
 #. Default: "Period"
-#: ./opengever/disposition/browser/templates/overview.pt:110
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "period"
 msgstr ""
 
 #. Default: "Progress"
-#: ./opengever/disposition/browser/templates/overview.pt:214
+#: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
 msgstr ""
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
-#: ./opengever/disposition/activities.py:24
+#: ./opengever/disposition/activities.py
 msgid "summary_disposition_added"
 msgstr ""
 
 #. Default: "Removal protocol for ${disposition}"
-#: ./opengever/disposition/browser/removal_protocol.py:40
+#: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
 msgstr ""
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 15:10+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -19,63 +19,63 @@ msgstr ""
 msgid "Attach selection"
 msgstr "Mit Mailprogramm versenden"
 
-#: ./opengever/document/browser/edit.py:104
+#: ./opengever/document/browser/edit.py
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr "Das Dokument kann momentan nicht bearbeitet werden, es ist gesperrt."
 
-#: ./opengever/document/checkout/cancel.py:89
+#: ./opengever/document/checkout/cancel.py
 msgid "Cancel checkout: ${title}"
 msgstr "Checkout abgebrochen für ${title}"
 
-#: ./opengever/document/checkout/checkin.py:63
+#: ./opengever/document/checkout/checkin.py
 msgid "Checked in: ${title}"
 msgstr "Dokument eingecheckt: ${title}"
 
-#: ./opengever/document/browser/edit.py:133
-#: ./opengever/document/checkout/checkout.py:111
+#: ./opengever/document/browser/edit.py
+#: ./opengever/document/checkout/checkout.py
 msgid "Checked out: ${title}"
 msgstr "Dokument ausgecheckt: ${title}"
 
-#: ./opengever/document/browser/templates/macros.pt:66
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin with comment"
 msgstr "Mit Kommentar einchecken"
 
-#: ./opengever/document/browser/templates/macros.pt:63
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
 msgstr "Ohne Kommentar einchecken"
 
-#: ./opengever/document/checkout/cancel.py:81
+#: ./opengever/document/checkout/cancel.py
 msgid "Could not cancel checkout on document ${title}."
 msgstr "Das Auschecken des Dokuments ${title} konnte nicht widerrufen werden."
 
-#: ./opengever/document/checkout/checkin.py:73
+#: ./opengever/document/checkout/checkin.py
 msgid "Could not check in ${title}, it is not a document."
 msgstr "${title} ist kein Dokument und konnte deshalb nicht eingecheckt werden."
 
-#: ./opengever/document/checkout/checkin.py:55
+#: ./opengever/document/checkout/checkin.py
 msgid "Could not check in document ${title}"
 msgstr "Konnte Dokument nicht einchecken: ${title}"
 
-#: ./opengever/document/browser/edit.py:121
-#: ./opengever/document/checkout/checkout.py:102
+#: ./opengever/document/browser/edit.py
+#: ./opengever/document/checkout/checkout.py
 msgid "Could not check out document ${title}."
 msgstr "Es ist nicht erlaubt, das Dokument ${title} auszuchecken."
 
-#: ./opengever/document/checkout/checkout.py:60
+#: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
 msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
 
-#: ./opengever/document/browser/report.py:81
+#: ./opengever/document/browser/report.py
 msgid "Could not generate the report."
 msgstr "Rapport konnte nicht generiert werden."
 
-#: ./opengever/document/browser/overview.py:209
+#: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
 msgstr "Aktuelle Version: ${version}"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:22
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "Don't show this message again."
 msgstr "Diese Meldung nicht mehr anzeigen."
 
@@ -83,12 +83,12 @@ msgstr "Diese Meldung nicht mehr anzeigen."
 msgid "Export selection"
 msgstr "Auswahl exportieren"
 
-#: ./opengever/document/browser/templates/logout_overlay.pt:19
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "Logout"
 msgstr "GEVER verlassen"
 
-#: ./opengever/document/checkout/manager.py:288
-#: ./opengever/document/checkout/revert.py:26
+#: ./opengever/document/checkout/manager.py
+#: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
 
@@ -96,448 +96,449 @@ msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
 msgid "Submit additional documents"
 msgstr "Zusätzliche Anhänge einreichen"
 
-#: ./opengever/document/browser/overview.py:205
+#: ./opengever/document/browser/overview.py
 msgid "Submitted version: ${version}"
 msgstr "Eingereichte Version: ${version}"
 
-#: ./opengever/document/browser/overview.py:174
+#: ./opengever/document/browser/overview.py
 msgid "Submitted with"
 msgstr "Eingereicht bei"
 
-#: ./opengever/document/browser/download.py:40
-#: ./opengever/document/browser/edit.py:81
+#: ./opengever/document/browser/download.py
+#: ./opengever/document/browser/edit.py
 msgid "The Document ${title} has no File."
 msgstr "Das Dokument ${title} enthält keine Datei."
 
-#: ./opengever/document/browser/edit.py:113
+#: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
 msgstr "Das Dokument ist bereits von ${userid} ausgecheckt."
 
-#: ./opengever/document/browser/templates/submitted_with.pt:18
+#: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"
 msgstr "Eingereichte Version aktualisieren"
 
-#: ./opengever/document/browser/edit.py:59
+#: ./opengever/document/browser/edit.py
 msgid "You are not authorized to edit the document ${title}."
 msgstr "Sie sind nicht berechtigt, das Dokument ${title} zu bearbeiten."
 
-#: ./opengever/document/checkout/cancel.py:28
-#: ./opengever/document/checkout/checkin.py:197
-#: ./opengever/document/checkout/checkout.py:34
+#: ./opengever/document/checkout/cancel.py
+#: ./opengever/document/checkout/checkin.py
+#: ./opengever/document/checkout/checkout.py
 msgid "You have not selected any documents."
 msgstr "Sie haben keine Dokumente ausgewählt."
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
-#: ./opengever/document/browser/templates/logout_overlay.pt:3
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "alert_not_checked_in_documents"
 msgstr "Sie haben noch ausgecheckte Dokumente. Wollen Sie OneGov GEVER wirklich verlassen?"
 
 #. Default: "Cancel"
-#: ./opengever/document/checkout/checkin.py:112
+#: ./opengever/document/checkout/checkin.py
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Checkin"
-#: ./opengever/document/checkout/checkin.py:103
+#: ./opengever/document/checkout/checkin.py
 msgid "button_checkin"
 msgstr "Einchecken"
 
 #. Default: "PDF"
-#: ./opengever/document/browser/versions_tab.py:143
+#: ./opengever/document/browser/versions_tab.py
 msgid "button_pdf"
 msgstr "PDF-Vorschau"
 
 #. Default: "copy of"
-#: ./opengever/document/subscribers.py:93
+#: ./opengever/document/subscribers.py
 msgid "copy_of"
 msgstr "Kopie von"
 
 #. Default: "You're downloading a copy of the document ${filename}"
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:12
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "description_download_confirmation"
 msgstr "Sie sind dabei, eine Kopie des Dokuments ${filename} herunterzuladen."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:198
+#: ./opengever/document/behaviors/metadata.py
 msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:98
+#: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
 
 #. Default: "You have not selected any Items"
-#: ./opengever/document/browser/report.py:65
+#: ./opengever/document/browser/report.py
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:75
+#: ./opengever/document/document.py
 msgid "error_title_or_file_required"
 msgstr "Ein Titel oder eine Datei muss angegeben werden."
 
 #. Default: "Archive file"
-#: ./opengever/document/behaviors/metadata.py:60
+#: ./opengever/document/behaviors/metadata.py
 msgid "fieldset_archive_file"
 msgstr "Archivdatei"
 
 #. Default: "Common"
-#: ./opengever/document/behaviors/metadata.py:41
-#: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:51
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/behaviors/related_docs.py
+#: ./opengever/document/document.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Keep existing file"
-#: ./opengever/document/widgets/no_download_input.pt:45
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_keep"
 msgstr "Vorhandene Datei behalten"
 
 #. Default: "Remove existing file"
-#: ./opengever/document/widgets/no_download_input.pt:58
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_remove"
 msgstr "Vorhandene Datei löschen"
 
 #. Default: "Replace with new file"
-#: ./opengever/document/widgets/no_download_input.pt:70
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_replace"
 msgstr "Mit neuer Datei ersetzen"
 
 #. Default: "Checkin Documents"
-#: ./opengever/document/checkout/checkin.py:97
+#: ./opengever/document/checkout/checkin.py
 msgid "heading_checkin_comment_form"
 msgstr "Dokumente einchecken"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:148
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_archival_file"
 msgstr "Archivtaugliche Version der Originaldatei"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:124
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_author"
 msgstr "Nachname Vorname oder ein Benutzerkürzel (wird automatisch nach Nachname Vorname aufgelöst)"
 
 #. Default: "Describe, why you checkin the selected documents"
-#: ./opengever/document/checkout/checkin.py:86
+#: ./opengever/document/checkout/checkin.py
 msgid "help_checkin_journal_comment"
 msgstr "Was wurde am Dokument geändert?"
 
-#: ./opengever/document/behaviors/metadata.py:109
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_delivery_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg versandt worden ist"
 
-#: ./opengever/document/behaviors/metadata.py:92
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_document_date"
 msgstr "Datum des Dokuments"
 
 #. Default: ""
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py
 msgid "help_file"
 msgstr "Datei, die zu einem Dossier hinzugefügt wird"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:84
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_foreign_reference"
 msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
 msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:139
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: ""
-#: ./opengever/document/behaviors/metadata.py:167
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_preview"
 msgstr "Online Voransicht des Originaldokuments"
 
-#: ./opengever/document/behaviors/metadata.py:101
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_receipt_date"
 msgstr "Datum, an dem das Dokument über den Korrespondenzweg angekommen ist"
 
 #. Default: "Initial version"
-#: ./opengever/document/checkout/handlers.py:58
+#: ./opengever/document/checkout/handlers.py
 msgid "initial_document_version_change_note"
 msgstr "Dokument erstellt (Initialversion)"
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:281
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:147
-#: ./opengever/document/browser/overview.py:169
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/overview.py
 msgid "label_archival_file"
 msgstr "Archivdatei"
 
 #. Default: "Archival file state"
-#: ./opengever/document/behaviors/metadata.py:154
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_archival_file_state"
 msgstr "Status Archivdatei"
 
 #. Default: "Attach to email"
-#: ./opengever/document/browser/templates/macros.pt:85
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_attach_to_email"
 msgstr "Mit Mailprogramm versenden"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:123
-#: ./opengever/document/browser/report.py:32
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/report.py
 msgid "label_author"
 msgstr "Autor"
 
 #. Default: "by"
-#: ./opengever/document/viewlets/byline.py:17
+#: ./opengever/document/viewlets/byline.py
 msgid "label_by_author"
 msgstr "Autor"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:26
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Change archival file"
-#: ./opengever/document/browser/archival_file_form.py:49
-#: ./opengever/document/browser/templates/archiv_file.pt:24
+#: ./opengever/document/browser/archival_file_form.py
+#: ./opengever/document/browser/templates/archiv_file.pt
 msgid "label_change_archival_file"
 msgstr "Archivdatei ändern"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:151
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
+#: ./opengever/document/browser/overview.py
+#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
 msgid "label_checked_out"
 msgstr "Ausgecheckt"
 
 #. Default: "Journal Comment"
-#: ./opengever/document/checkout/checkin.py:84
+#: ./opengever/document/checkout/checkin.py
 msgid "label_checkin_journal_comment"
 msgstr "Journal-Kommentar"
 
 #. Default: "Checkout and edit"
-#: ./opengever/document/browser/templates/macros.pt:35
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:289
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:147
+#: ./opengever/document/browser/overview.py
 msgid "label_creator"
 msgstr "Ersteller"
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:285
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_date"
 msgstr "Datum"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:108
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:66
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:132
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_digitally_available"
 msgstr "Digital verfügbar"
 
-#: ./opengever/document/browser/report.py:44
+#: ./opengever/document/browser/report.py
 msgid "label_document_checked_out_by"
 msgstr "In Bearbeitung"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:91
-#: ./opengever/document/browser/report.py:35
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/report.py
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
-#: ./opengever/document/browser/report.py:41
+#: ./opengever/document/browser/report.py
 msgid "label_document_delivery_date"
 msgstr "Eingangsdatum"
 
-#: ./opengever/document/browser/report.py:38
+#: ./opengever/document/browser/report.py
 msgid "label_document_receipt_date"
 msgstr "Ausgangsdatum"
 
-#: ./opengever/document/browser/report.py:26
+#: ./opengever/document/browser/report.py
 msgid "label_document_reference_number"
 msgstr "Referenznummer"
 
-#: ./opengever/document/browser/report.py:28
+#: ./opengever/document/browser/report.py
 msgid "label_document_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
 msgstr "Dokumenttyp"
 
-#: ./opengever/document/browser/report.py:51
+#: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
 msgstr "Dossier-Titel"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:25
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_download"
 msgstr "Herunterladen"
 
 #. Default: "Download copy"
-#: ./opengever/document/browser/download.py:140
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/templates/macros.pt:76
+#: ./opengever/document/browser/download.py
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:153
-#: ./opengever/document/document.py:67
+#: ./opengever/document/browser/overview.py
+#: ./opengever/document/document.py
 msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:83
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
 msgstr "Fremdzeichen"
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/document/subscribers.py:28
+#: ./opengever/document/subscribers.py
 msgid "label_initial_version_copied"
 msgstr "Dokument kopiert (Initialversion)"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_keywords"
 msgstr "Schlagworte"
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:83
+#: ./opengever/document/browser/overview.py
 msgid "label_no"
 msgstr "Nein"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:40
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_ok"
 msgstr "OK"
 
 #. Default: "Open detail view"
-#: ./opengever/document/browser/templates/macros.pt:129
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_open_detail_view"
 msgstr "Detailansicht öffnen"
 
 #. Default: "Open as PDF"
-#: ./opengever/document/browser/templates/macros.pt:114
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_open_document_as_pdf"
 msgstr "Dokument als PDF öffnen"
 
 #. Default: "Open document preview"
-#: ./opengever/document/widgets/tooltip.pt:15
+#: ./opengever/document/widgets/tooltip.pt
 msgid "label_open_document_preview"
 msgstr "Dokumentvorschau öffnen"
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/templates/macros.pt:103
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_pdf_preview"
 msgstr "PDF-Vorschau"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:138
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_preserved_as_paper"
 msgstr "In Papierform aufbewahrt"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:166
-#: ./opengever/document/browser/versions_tab.py:307
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_preview"
 msgstr "Vorschau"
 
-#: ./opengever/document/browser/report.py:47
+#: ./opengever/document/browser/report.py
 msgid "label_public_trial"
 msgstr "Öffentlichkeitsstatus"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:100
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference Number"
-#: ./opengever/document/viewlets/byline.py:35
+#: ./opengever/document/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Related Documents"
-#: ./opengever/document/behaviors/related_docs.py:17
+#: ./opengever/document/behaviors/related_docs.py
+#: ./opengever/document/browser/overview.py
 msgid "label_related_documents"
 msgstr "Verwandte Dokumente"
 
 #. Default: "Revert"
-#: ./opengever/document/browser/versions_tab.py:158
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
 msgstr "Zurücksetzen"
 
 #. Default: "Sequence Number"
-#: ./opengever/document/viewlets/byline.py:29
+#: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "from"
-#: ./opengever/document/viewlets/byline.py:23
+#: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Dokumentdatum"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:160
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_thumbnail"
 msgstr "Kurzbild"
 
 #. Default: "Title"
-#: ./opengever/document/browser/report.py:30
-#: ./opengever/document/document.py:61
+#: ./opengever/document/browser/report.py
+#: ./opengever/document/document.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:277
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
 msgstr "Version"
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py
 msgid "label_yes"
 msgstr "Ja"
 
 #. Default: "This item is being checked out by ${creator}."
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:9
+#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr "Dieses Dokument wurde von ${creator} ausgecheckt."
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
-#: ./opengever/document/checkout/cancel.py:67
+#: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Das Dokument `${title}` konnte nicht ausgecheckt werden, da Mails den Check-in-/Check-out-Prozess nicht unterstützen."
 
 #. Default: "No file"
-#: ./opengever/document/browser/templates/archiv_file.pt:18
-#: ./opengever/document/browser/templates/macros.pt:138
+#: ./opengever/document/browser/templates/archiv_file.pt
+#: ./opengever/document/browser/templates/macros.pt
 msgid "no_file"
 msgstr "Keine Datei"
 
 #. Default: "Following documents are checked out:"
-#: ./opengever/document/browser/templates/logout_overlay.pt:8
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "overview_not_checked_in_documents"
 msgstr "Folgende Dokumente sind ausgecheckt:"
 
 #. Default: "Please note that in this case changes on the document wouldn't be saved in to GEVER."
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:17
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "warning_download_confirmation"
 msgstr "Bitte beachten Sie, dass in diesem Fall Änderungen an diesem Dokument NICHT in GEVER gespeichert werden."
 
@@ -548,3 +549,4 @@ msgstr "Mit Kommentar"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Ohne Kommentar"
+

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,84 +1,83 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 15:10+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-document/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
 #: ./opengever/document/upgrades/20170322142153_add_office_connector_multi_attach_action_to_documents/actions.xml
 #: ./opengever/document/upgrades/20170424163920_adjust_sort_order_of_actions/actions.xml
 msgid "Attach selection"
 msgstr "Envoyer par le programme de messagerie"
 
-#: ./opengever/document/browser/edit.py:104
+#: ./opengever/document/browser/edit.py
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr "Impossible de modifier le document en ce moment car il est verrouillé."
 
-#: ./opengever/document/checkout/cancel.py:89
+#: ./opengever/document/checkout/cancel.py
 msgid "Cancel checkout: ${title}"
 msgstr "Annuler le checkout pour  ${title}"
 
-#: ./opengever/document/checkout/checkin.py:63
+#: ./opengever/document/checkout/checkin.py
 msgid "Checked in: ${title}"
 msgstr "Checkin du document:  ${title}"
 
-#: ./opengever/document/browser/edit.py:133
-#: ./opengever/document/checkout/checkout.py:111
+#: ./opengever/document/browser/edit.py
+#: ./opengever/document/checkout/checkout.py
 msgid "Checked out: ${title}"
 msgstr "Checkout du document:  ${title}"
 
-#: ./opengever/document/browser/templates/macros.pt:66
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin with comment"
 msgstr "Checkin avec commentaire"
 
-#: ./opengever/document/browser/templates/macros.pt:63
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
 msgstr "Checkin sans commentaire"
 
-#: ./opengever/document/checkout/cancel.py:81
+#: ./opengever/document/checkout/cancel.py
 msgid "Could not cancel checkout on document ${title}."
 msgstr "Checkout du document ${title} inabouti."
 
-#: ./opengever/document/checkout/checkin.py:73
+#: ./opengever/document/checkout/checkin.py
 msgid "Could not check in ${title}, it is not a document."
 msgstr "${title} n'est pas un document, par consequent checkin n'a pas abouti."
 
-#: ./opengever/document/checkout/checkin.py:55
+#: ./opengever/document/checkout/checkin.py
 msgid "Could not check in document ${title}"
 msgstr "Checkin de ${title} n'a pas abouti"
 
-#: ./opengever/document/browser/edit.py:121
-#: ./opengever/document/checkout/checkout.py:102
+#: ./opengever/document/browser/edit.py
+#: ./opengever/document/checkout/checkout.py
 msgid "Could not check out document ${title}."
 msgstr "Checkout de ${title} n'a pas abouti."
 
-#: ./opengever/document/checkout/checkout.py:60
+#: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
 msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti."
 
-#: ./opengever/document/browser/report.py:81
+#: ./opengever/document/browser/report.py
 msgid "Could not generate the report."
 msgstr "Le rapport n'a pas pu être généré."
 
-#: ./opengever/document/browser/overview.py:209
+#: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
 msgstr "Version actuelle: ${version}"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:22
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "Don't show this message again."
 msgstr "Ne plus afficher ce message."
 
@@ -86,12 +85,12 @@ msgstr "Ne plus afficher ce message."
 msgid "Export selection"
 msgstr "Exporter le choix"
 
-#: ./opengever/document/browser/templates/logout_overlay.pt:19
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "Logout"
 msgstr "Quitter GEVER"
 
-#: ./opengever/document/checkout/manager.py:288
-#: ./opengever/document/checkout/revert.py:26
+#: ./opengever/document/checkout/manager.py
+#: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
 msgstr "Retour à la version ${version_id} du document."
 
@@ -99,445 +98,444 @@ msgstr "Retour à la version ${version_id} du document."
 msgid "Submit additional documents"
 msgstr "Soumettre des documents additionnels"
 
-#: ./opengever/document/browser/overview.py:205
+#: ./opengever/document/browser/overview.py
 msgid "Submitted version: ${version}"
 msgstr "Version soumise: ${version}"
 
-#: ./opengever/document/browser/overview.py:174
+#: ./opengever/document/browser/overview.py
 msgid "Submitted with"
 msgstr "Soumis par"
 
-#: ./opengever/document/browser/download.py:40
-#: ./opengever/document/browser/edit.py:81
+#: ./opengever/document/browser/download.py
+#: ./opengever/document/browser/edit.py
 msgid "The Document ${title} has no File."
 msgstr "Le dodument  ${title} ne contient pas de fichier."
 
-#: ./opengever/document/browser/edit.py:113
+#: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
 msgstr "Le document a déjà un checkout par ${userid}."
 
-#: ./opengever/document/browser/templates/submitted_with.pt:18
+#: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"
 msgstr "Actualiser la version soumise"
 
-#: ./opengever/document/browser/edit.py:59
+#: ./opengever/document/browser/edit.py
 msgid "You are not authorized to edit the document ${title}."
 msgstr "Vous n'avez pas les droits de modifier le document ${title}."
 
-#: ./opengever/document/checkout/cancel.py:28
-#: ./opengever/document/checkout/checkin.py:197
-#: ./opengever/document/checkout/checkout.py:34
+#: ./opengever/document/checkout/cancel.py
+#: ./opengever/document/checkout/checkin.py
+#: ./opengever/document/checkout/checkout.py
 msgid "You have not selected any documents."
 msgstr "Vous n'avez sélectionné aucun document."
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
-#: ./opengever/document/browser/templates/logout_overlay.pt:3
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "alert_not_checked_in_documents"
 msgstr "Vous avez encore des documents en checkout! Voulez-vous quand même quitter GEVER?"
 
 #. Default: "Cancel"
-#: ./opengever/document/checkout/checkin.py:112
+#: ./opengever/document/checkout/checkin.py
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Checkin"
-#: ./opengever/document/checkout/checkin.py:103
+#: ./opengever/document/checkout/checkin.py
 msgid "button_checkin"
 msgstr "Checkin"
 
 #. Default: "PDF"
-#: ./opengever/document/browser/versions_tab.py:143
+#: ./opengever/document/browser/versions_tab.py
 msgid "button_pdf"
 msgstr "Aperçu pdf"
 
 #. Default: "copy of"
-#: ./opengever/document/subscribers.py:93
+#: ./opengever/document/subscribers.py
 msgid "copy_of"
 msgstr "Copie de"
 
 #. Default: "You're downloading a copy of the document ${filename}"
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:12
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "description_download_confirmation"
 msgstr "Vous étes en train de télécharger une copie du document ${filename}."
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:198
+#: ./opengever/document/behaviors/metadata.py
 msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:98
+#: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
 
 #. Default: "You have not selected any Items"
-#: ./opengever/document/browser/report.py:65
+#: ./opengever/document/browser/report.py
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun élément."
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:75
+#: ./opengever/document/document.py
 msgid "error_title_or_file_required"
 msgstr "Un titre ou un fichier est requis."
 
 #. Default: "Archive file"
-#: ./opengever/document/behaviors/metadata.py:60
+#: ./opengever/document/behaviors/metadata.py
 msgid "fieldset_archive_file"
 msgstr "Fichier d'archivage"
 
 #. Default: "Common"
-#: ./opengever/document/behaviors/metadata.py:41
-#: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:51
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/behaviors/related_docs.py
+#: ./opengever/document/document.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Keep existing file"
-#: ./opengever/document/widgets/no_download_input.pt:45
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_keep"
 msgstr "Garder le fichier existant"
 
 #. Default: "Remove existing file"
-#: ./opengever/document/widgets/no_download_input.pt:58
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_remove"
 msgstr "Effacer le fichier existant"
 
 #. Default: "Replace with new file"
-#: ./opengever/document/widgets/no_download_input.pt:70
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_replace"
 msgstr "Remplacer par un nouveau fichier"
 
 #. Default: "Checkin Documents"
-#: ./opengever/document/checkout/checkin.py:97
+#: ./opengever/document/checkout/checkin.py
 msgid "heading_checkin_comment_form"
 msgstr "Faire le checkin des documents"
 
-#: ./opengever/document/behaviors/metadata.py:148
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_archival_file"
 msgstr "Version en format d'archivage du fichier original"
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:124
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_author"
 msgstr "Nom, prénom ou acronyme de l'utilisateur (sera automatiquement créé d'après le nom le prénom)"
 
 #. Default: "Describe, why you checkin the selected documents"
-#: ./opengever/document/checkout/checkin.py:86
+#: ./opengever/document/checkout/checkin.py
 msgid "help_checkin_journal_comment"
 msgstr "Modification(s) faite(s) dans le document?"
 
-#: ./opengever/document/behaviors/metadata.py:109
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_delivery_date"
 msgstr "Date, à laquelle le document a été envoyé par écrit"
 
-#: ./opengever/document/behaviors/metadata.py:92
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_document_date"
 msgstr "Date de création du document"
 
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py
 msgid "help_file"
 msgstr "Ficher, ajouté dans un dossier"
 
-#: ./opengever/document/behaviors/metadata.py:84
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_foreign_reference"
 msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr ""
-"Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de "
-"classement."
+msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement."
 
-#: ./opengever/document/behaviors/metadata.py:139
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"
 msgstr "Conserver sous forme papier"
 
-#: ./opengever/document/behaviors/metadata.py:167
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_preview"
 msgstr "Aperçu en ligne du document original"
 
-#: ./opengever/document/behaviors/metadata.py:101
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_receipt_date"
 msgstr "Date de réception du document écrit"
 
 #. Default: "Initial version"
-#: ./opengever/document/checkout/handlers.py:58
+#: ./opengever/document/checkout/handlers.py
 msgid "initial_document_version_change_note"
 msgstr "Document créé (version initiale)"
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:281
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:147
-#: ./opengever/document/browser/overview.py:169
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/overview.py
 msgid "label_archival_file"
 msgstr "Fichier archivé"
 
 #. Default: "Archival file state"
-#: ./opengever/document/behaviors/metadata.py:154
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_archival_file_state"
 msgstr "Etat du ficher d'archivage"
 
 #. Default: "Attach to email"
-#: ./opengever/document/browser/templates/macros.pt:85
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_attach_to_email"
 msgstr "Envoyer par programme de messagerie"
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:123
-#: ./opengever/document/browser/report.py:32
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/report.py
 msgid "label_author"
 msgstr "Auteur"
 
 #. Default: "by"
-#: ./opengever/document/viewlets/byline.py:17
+#: ./opengever/document/viewlets/byline.py
 msgid "label_by_author"
 msgstr "Auteur"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:26
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Change archival file"
-#: ./opengever/document/browser/archival_file_form.py:49
-#: ./opengever/document/browser/templates/archiv_file.pt:24
+#: ./opengever/document/browser/archival_file_form.py
+#: ./opengever/document/browser/templates/archiv_file.pt
 msgid "label_change_archival_file"
 msgstr "Modifier le fichier d'archivage"
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:151
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
+#: ./opengever/document/browser/overview.py
+#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
 msgid "label_checked_out"
 msgstr "Avec check-out"
 
 #. Default: "Journal Comment"
-#: ./opengever/document/checkout/checkin.py:84
+#: ./opengever/document/checkout/checkin.py
 msgid "label_checkin_journal_comment"
 msgstr "Commentaire de l'historique"
 
 #. Default: "Checkout and edit"
-#: ./opengever/document/browser/templates/macros.pt:35
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_checkout_and_edit"
 msgstr "Faire le check-out / éditer"
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:289
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_comment"
 msgstr "commentaire"
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:147
+#: ./opengever/document/browser/overview.py
 msgid "label_creator"
 msgstr "Auteur"
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:285
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_date"
 msgstr "Date"
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:108
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:66
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:132
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_digitally_available"
 msgstr "Disponble sous forme numérique"
 
-#: ./opengever/document/browser/report.py:44
+#: ./opengever/document/browser/report.py
 msgid "label_document_checked_out_by"
 msgstr "En cours de traitement"
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:91
-#: ./opengever/document/browser/report.py:35
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/report.py
 msgid "label_document_date"
 msgstr "Date du document"
 
-#: ./opengever/document/browser/report.py:41
+#: ./opengever/document/browser/report.py
 msgid "label_document_delivery_date"
 msgstr "Date d'entrée"
 
-#: ./opengever/document/browser/report.py:38
+#: ./opengever/document/browser/report.py
 msgid "label_document_receipt_date"
 msgstr "Date de sortie"
 
-#: ./opengever/document/browser/report.py:26
+#: ./opengever/document/browser/report.py
 msgid "label_document_reference_number"
 msgstr "Numéro de référence"
 
-#: ./opengever/document/browser/report.py:28
+#: ./opengever/document/browser/report.py
 msgid "label_document_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
 msgstr "Type de document"
 
-#: ./opengever/document/browser/report.py:51
+#: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:25
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_download"
 msgstr "Télécharger"
 
 #. Default: "Download copy"
-#: ./opengever/document/browser/download.py:140
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/templates/macros.pt:76
+#: ./opengever/document/browser/download.py
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:153
-#: ./opengever/document/document.py:67
+#: ./opengever/document/browser/overview.py
+#: ./opengever/document/document.py
 msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:83
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
 msgstr "Code externe"
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/document/subscribers.py:28
+#: ./opengever/document/subscribers.py
 msgid "label_initial_version_copied"
 msgstr "Version initiale (documents copiés)"
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_keywords"
 msgstr "Mots-clés"
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:83
+#: ./opengever/document/browser/overview.py
 msgid "label_no"
 msgstr "Non"
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:40
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_ok"
 msgstr "OK"
 
 #. Default: "Open detail view"
-#: ./opengever/document/browser/templates/macros.pt:129
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_open_detail_view"
 msgstr "Ouvrir l'aperçu détaillé"
 
 #. Default: "Open as PDF"
-#: ./opengever/document/browser/templates/macros.pt:114
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_open_document_as_pdf"
 msgstr "Ouvrir au format PDF"
 
 #. Default: "Open document preview"
-#: ./opengever/document/widgets/tooltip.pt:15
+#: ./opengever/document/widgets/tooltip.pt
 msgid "label_open_document_preview"
 msgstr "Ouvrir la visualisation du document"
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/templates/macros.pt:103
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_pdf_preview"
 msgstr "Aperçu en pdf"
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:138
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_preserved_as_paper"
 msgstr "Conservé sous forme papier"
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:166
-#: ./opengever/document/browser/versions_tab.py:307
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_preview"
 msgstr "Aperçu"
 
-#: ./opengever/document/browser/report.py:47
+#: ./opengever/document/browser/report.py
 msgid "label_public_trial"
 msgstr "Statut public"
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:100
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference Number"
-#: ./opengever/document/viewlets/byline.py:35
+#: ./opengever/document/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Related Documents"
-#: ./opengever/document/behaviors/related_docs.py:17
+#: ./opengever/document/behaviors/related_docs.py
+#: ./opengever/document/browser/overview.py
 msgid "label_related_documents"
 msgstr "Documents liés"
 
 #. Default: "Revert"
-#: ./opengever/document/browser/versions_tab.py:158
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
 msgstr "Reculer"
 
 #. Default: "Sequence Number"
-#: ./opengever/document/viewlets/byline.py:29
+#: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "from"
-#: ./opengever/document/viewlets/byline.py:23
+#: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Date du document"
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:160
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_thumbnail"
 msgstr "Vignette"
 
 #. Default: "Title"
-#: ./opengever/document/browser/report.py:30
-#: ./opengever/document/document.py:61
+#: ./opengever/document/browser/report.py
+#: ./opengever/document/document.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:277
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
 msgstr "Version"
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py
 msgid "label_yes"
 msgstr "Oui"
 
 #. Default: "This item is being checked out by ${creator}."
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:9
+#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr "Ce document a été verrouillé par ${creator}."
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
-#: ./opengever/document/checkout/cancel.py:67
+#: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Le document `${title}` n'a pas pu être verrouillé, car les e-mails ne sont pas supportés par le processus de check-in / check-out."
 
 #. Default: "No file"
-#: ./opengever/document/browser/templates/archiv_file.pt:18
-#: ./opengever/document/browser/templates/macros.pt:138
+#: ./opengever/document/browser/templates/archiv_file.pt
+#: ./opengever/document/browser/templates/macros.pt
 msgid "no_file"
 msgstr "Aucun fichier trouvé"
 
 #. Default: "Following documents are checked out:"
-#: ./opengever/document/browser/templates/logout_overlay.pt:8
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "overview_not_checked_in_documents"
 msgstr "Les documents suivants ont été verrouillés:"
 
 #. Default: "Please note that in this case changes on the document wouldn't be saved in to GEVER."
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:17
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "warning_download_confirmation"
 msgstr "Attention! En ouvrant le document de cette manière, toutes les modifications apportées ne seront PAS sauvegardées en GEVER."
 
@@ -548,3 +546,4 @@ msgstr "Avec commentaire"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Sans commentaire"
+

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 15:10+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,63 +22,63 @@ msgstr ""
 msgid "Attach selection"
 msgstr ""
 
-#: ./opengever/document/browser/edit.py:104
+#: ./opengever/document/browser/edit.py
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr ""
 
-#: ./opengever/document/checkout/cancel.py:89
+#: ./opengever/document/checkout/cancel.py
 msgid "Cancel checkout: ${title}"
 msgstr ""
 
-#: ./opengever/document/checkout/checkin.py:63
+#: ./opengever/document/checkout/checkin.py
 msgid "Checked in: ${title}"
 msgstr ""
 
-#: ./opengever/document/browser/edit.py:133
-#: ./opengever/document/checkout/checkout.py:111
+#: ./opengever/document/browser/edit.py
+#: ./opengever/document/checkout/checkout.py
 msgid "Checked out: ${title}"
 msgstr ""
 
-#: ./opengever/document/browser/templates/macros.pt:66
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin with comment"
 msgstr ""
 
-#: ./opengever/document/browser/templates/macros.pt:63
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
 msgstr ""
 
-#: ./opengever/document/checkout/cancel.py:81
+#: ./opengever/document/checkout/cancel.py
 msgid "Could not cancel checkout on document ${title}."
 msgstr ""
 
-#: ./opengever/document/checkout/checkin.py:73
+#: ./opengever/document/checkout/checkin.py
 msgid "Could not check in ${title}, it is not a document."
 msgstr ""
 
-#: ./opengever/document/checkout/checkin.py:55
+#: ./opengever/document/checkout/checkin.py
 msgid "Could not check in document ${title}"
 msgstr ""
 
-#: ./opengever/document/browser/edit.py:121
-#: ./opengever/document/checkout/checkout.py:102
+#: ./opengever/document/browser/edit.py
+#: ./opengever/document/checkout/checkout.py
 msgid "Could not check out document ${title}."
 msgstr ""
 
-#: ./opengever/document/checkout/checkout.py:60
+#: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
 msgstr ""
 
-#: ./opengever/document/browser/report.py:81
+#: ./opengever/document/browser/report.py
 msgid "Could not generate the report."
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:209
+#: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
 msgstr ""
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:22
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "Don't show this message again."
 msgstr ""
 
@@ -86,12 +86,12 @@ msgstr ""
 msgid "Export selection"
 msgstr ""
 
-#: ./opengever/document/browser/templates/logout_overlay.pt:19
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "Logout"
 msgstr ""
 
-#: ./opengever/document/checkout/manager.py:288
-#: ./opengever/document/checkout/revert.py:26
+#: ./opengever/document/checkout/manager.py
+#: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
 msgstr ""
 
@@ -99,443 +99,444 @@ msgstr ""
 msgid "Submit additional documents"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:205
+#: ./opengever/document/browser/overview.py
 msgid "Submitted version: ${version}"
 msgstr ""
 
-#: ./opengever/document/browser/overview.py:174
+#: ./opengever/document/browser/overview.py
 msgid "Submitted with"
 msgstr ""
 
-#: ./opengever/document/browser/download.py:40
-#: ./opengever/document/browser/edit.py:81
+#: ./opengever/document/browser/download.py
+#: ./opengever/document/browser/edit.py
 msgid "The Document ${title} has no File."
 msgstr ""
 
-#: ./opengever/document/browser/edit.py:113
+#: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
 msgstr ""
 
-#: ./opengever/document/browser/templates/submitted_with.pt:18
+#: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"
 msgstr ""
 
-#: ./opengever/document/browser/edit.py:59
+#: ./opengever/document/browser/edit.py
 msgid "You are not authorized to edit the document ${title}."
 msgstr ""
 
-#: ./opengever/document/checkout/cancel.py:28
-#: ./opengever/document/checkout/checkin.py:197
-#: ./opengever/document/checkout/checkout.py:34
+#: ./opengever/document/checkout/cancel.py
+#: ./opengever/document/checkout/checkin.py
+#: ./opengever/document/checkout/checkout.py
 msgid "You have not selected any documents."
 msgstr ""
 
 #. Default: "You have not checked in documents. Do you realy want to logout?"
-#: ./opengever/document/browser/templates/logout_overlay.pt:3
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "alert_not_checked_in_documents"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/document/checkout/checkin.py:112
+#: ./opengever/document/checkout/checkin.py
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Checkin"
-#: ./opengever/document/checkout/checkin.py:103
+#: ./opengever/document/checkout/checkin.py
 msgid "button_checkin"
 msgstr ""
 
 #. Default: "PDF"
-#: ./opengever/document/browser/versions_tab.py:143
+#: ./opengever/document/browser/versions_tab.py
 msgid "button_pdf"
 msgstr ""
 
 #. Default: "copy of"
-#: ./opengever/document/subscribers.py:93
+#: ./opengever/document/subscribers.py
 msgid "copy_of"
 msgstr ""
 
 #. Default: "You're downloading a copy of the document ${filename}"
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:12
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "description_download_confirmation"
 msgstr ""
 
 #. Default: "You don't select a file and document is also not preserved in paper_form, please correct it."
-#: ./opengever/document/behaviors/metadata.py:198
+#: ./opengever/document/behaviors/metadata.py
 msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
-#: ./opengever/document/document.py:98
+#: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr ""
 
 #. Default: "You have not selected any Items"
-#: ./opengever/document/browser/report.py:65
+#: ./opengever/document/browser/report.py
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "Either the title or the file is required."
-#: ./opengever/document/document.py:75
+#: ./opengever/document/document.py
 msgid "error_title_or_file_required"
 msgstr ""
 
 #. Default: "Archive file"
-#: ./opengever/document/behaviors/metadata.py:60
+#: ./opengever/document/behaviors/metadata.py
 msgid "fieldset_archive_file"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/document/behaviors/metadata.py:41
-#: ./opengever/document/behaviors/related_docs.py:39
-#: ./opengever/document/document.py:51
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/behaviors/related_docs.py
+#: ./opengever/document/document.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Keep existing file"
-#: ./opengever/document/widgets/no_download_input.pt:45
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_keep"
 msgstr ""
 
 #. Default: "Remove existing file"
-#: ./opengever/document/widgets/no_download_input.pt:58
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_remove"
 msgstr ""
 
 #. Default: "Replace with new file"
-#: ./opengever/document/widgets/no_download_input.pt:70
+#: ./opengever/document/widgets/no_download_input.pt
 msgid "file_replace"
 msgstr ""
 
 #. Default: "Checkin Documents"
-#: ./opengever/document/checkout/checkin.py:97
+#: ./opengever/document/checkout/checkin.py
 msgid "heading_checkin_comment_form"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:148
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_archival_file"
 msgstr ""
 
 #. Default: "Surname firstname or a userid(would be automatically resolved to fullname)"
-#: ./opengever/document/behaviors/metadata.py:124
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_author"
 msgstr ""
 
 #. Default: "Describe, why you checkin the selected documents"
-#: ./opengever/document/checkout/checkin.py:86
+#: ./opengever/document/checkout/checkin.py
 msgid "help_checkin_journal_comment"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:109
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_delivery_date"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:92
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_document_date"
 msgstr ""
 
-#: ./opengever/document/document.py:68
+#: ./opengever/document/document.py
 msgid "help_file"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:84
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_foreign_reference"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:73
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:139
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:167
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_preview"
 msgstr ""
 
-#: ./opengever/document/behaviors/metadata.py:101
+#: ./opengever/document/behaviors/metadata.py
 msgid "help_receipt_date"
 msgstr ""
 
 #. Default: "Initial version"
-#: ./opengever/document/checkout/handlers.py:58
+#: ./opengever/document/checkout/handlers.py
 msgid "initial_document_version_change_note"
 msgstr ""
 
 #. Default: "Changed by"
-#: ./opengever/document/browser/versions_tab.py:281
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
 msgstr ""
 
 #. Default: "Archival File"
-#: ./opengever/document/behaviors/metadata.py:147
-#: ./opengever/document/browser/overview.py:169
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/overview.py
 msgid "label_archival_file"
 msgstr ""
 
 #. Default: "Archival file state"
-#: ./opengever/document/behaviors/metadata.py:154
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_archival_file_state"
 msgstr ""
 
 #. Default: "Attach to email"
-#: ./opengever/document/browser/templates/macros.pt:85
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_attach_to_email"
 msgstr ""
 
 #. Default: "Author"
-#: ./opengever/document/behaviors/metadata.py:123
-#: ./opengever/document/browser/report.py:32
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/report.py
 msgid "label_author"
 msgstr ""
 
 #. Default: "by"
-#: ./opengever/document/viewlets/byline.py:17
+#: ./opengever/document/viewlets/byline.py
 msgid "label_by_author"
 msgstr ""
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:26
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Change archival file"
-#: ./opengever/document/browser/archival_file_form.py:49
-#: ./opengever/document/browser/templates/archiv_file.pt:24
+#: ./opengever/document/browser/archival_file_form.py
+#: ./opengever/document/browser/templates/archiv_file.pt
 msgid "label_change_archival_file"
 msgstr ""
 
 #. Default: "Checked out"
-#: ./opengever/document/browser/overview.py:151
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:5
+#: ./opengever/document/browser/overview.py
+#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Journal Comment"
-#: ./opengever/document/checkout/checkin.py:84
+#: ./opengever/document/checkout/checkin.py
 msgid "label_checkin_journal_comment"
 msgstr ""
 
 #. Default: "Checkout and edit"
-#: ./opengever/document/browser/templates/macros.pt:35
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_checkout_and_edit"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/document/browser/versions_tab.py:289
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_comment"
 msgstr ""
 
 #. Default: "creator"
-#: ./opengever/document/browser/overview.py:147
+#: ./opengever/document/browser/overview.py
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/document/browser/versions_tab.py:285
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_date"
 msgstr ""
 
 #. Default: "Date of delivery"
-#: ./opengever/document/behaviors/metadata.py:108
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/document/behaviors/metadata.py:66
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_description"
 msgstr ""
 
 #. Default: "Digital Available"
-#: ./opengever/document/behaviors/metadata.py:132
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_digitally_available"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:44
+#: ./opengever/document/browser/report.py
 msgid "label_document_checked_out_by"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/document/behaviors/metadata.py:91
-#: ./opengever/document/browser/report.py:35
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/report.py
 msgid "label_document_date"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:41
+#: ./opengever/document/browser/report.py
 msgid "label_document_delivery_date"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:38
+#: ./opengever/document/browser/report.py
 msgid "label_document_receipt_date"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:26
+#: ./opengever/document/browser/report.py
 msgid "label_document_reference_number"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:28
+#: ./opengever/document/browser/report.py
 msgid "label_document_sequence_number"
 msgstr ""
 
 #. Default: "Document Type"
-#: ./opengever/document/behaviors/metadata.py:114
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:51
+#: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
 msgstr ""
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:25
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_download"
 msgstr ""
 
 #. Default: "Download copy"
-#: ./opengever/document/browser/download.py:140
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:4
-#: ./opengever/document/browser/templates/macros.pt:76
+#: ./opengever/document/browser/download.py
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_download_copy"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/document/browser/overview.py:153
-#: ./opengever/document/document.py:67
+#: ./opengever/document/browser/overview.py
+#: ./opengever/document/document.py
 msgid "label_file"
 msgstr ""
 
 #. Default: "Foreign Reference"
-#: ./opengever/document/behaviors/metadata.py:83
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
 msgstr ""
 
 #. Default: "Initial version (document copied)"
-#: ./opengever/document/subscribers.py:28
+#: ./opengever/document/subscribers.py
 msgid "label_initial_version_copied"
 msgstr ""
 
 #. Default: "Keywords"
-#: ./opengever/document/behaviors/metadata.py:72
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_keywords"
 msgstr ""
 
 #. Default: "no"
-#: ./opengever/document/browser/overview.py:83
+#: ./opengever/document/browser/overview.py
 msgid "label_no"
 msgstr ""
 
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:40
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_ok"
 msgstr ""
 
 #. Default: "Open detail view"
-#: ./opengever/document/browser/templates/macros.pt:129
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_open_detail_view"
 msgstr ""
 
 #. Default: "Open as PDF"
-#: ./opengever/document/browser/templates/macros.pt:114
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_open_document_as_pdf"
 msgstr ""
 
 #. Default: "Open document preview"
-#: ./opengever/document/widgets/tooltip.pt:15
+#: ./opengever/document/widgets/tooltip.pt
 msgid "label_open_document_preview"
 msgstr ""
 
 #. Default: "PDF Preview"
-#: ./opengever/document/browser/templates/macros.pt:103
+#: ./opengever/document/browser/templates/macros.pt
 msgid "label_pdf_preview"
 msgstr ""
 
 #. Default: "Preserved as paper"
-#: ./opengever/document/behaviors/metadata.py:138
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_preserved_as_paper"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/document/behaviors/metadata.py:166
-#: ./opengever/document/browser/versions_tab.py:307
+#: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_preview"
 msgstr ""
 
-#: ./opengever/document/browser/report.py:47
+#: ./opengever/document/browser/report.py
 msgid "label_public_trial"
 msgstr ""
 
 #. Default: "Date of receipt"
-#: ./opengever/document/behaviors/metadata.py:100
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/document/viewlets/byline.py:35
+#: ./opengever/document/viewlets/byline.py
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Related Documents"
-#: ./opengever/document/behaviors/related_docs.py:17
+#: ./opengever/document/behaviors/related_docs.py
+#: ./opengever/document/browser/overview.py
 msgid "label_related_documents"
 msgstr ""
 
 #. Default: "Revert"
-#: ./opengever/document/browser/versions_tab.py:158
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/document/viewlets/byline.py:29
+#: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "from"
-#: ./opengever/document/viewlets/byline.py:23
+#: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Thumbnail"
-#: ./opengever/document/behaviors/metadata.py:160
+#: ./opengever/document/behaviors/metadata.py
 msgid "label_thumbnail"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/document/browser/report.py:30
-#: ./opengever/document/document.py:61
+#: ./opengever/document/browser/report.py
+#: ./opengever/document/document.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Version"
-#: ./opengever/document/browser/versions_tab.py:277
+#: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
 msgstr ""
 
 #. Default: "yes"
-#: ./opengever/document/browser/overview.py:82
+#: ./opengever/document/browser/overview.py
 msgid "label_yes"
 msgstr ""
 
 #. Default: "This item is being checked out by ${creator}."
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt:9
+#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr ""
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
-#: ./opengever/document/checkout/cancel.py:67
+#: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr ""
 
 #. Default: "No file"
-#: ./opengever/document/browser/templates/archiv_file.pt:18
-#: ./opengever/document/browser/templates/macros.pt:138
+#: ./opengever/document/browser/templates/archiv_file.pt
+#: ./opengever/document/browser/templates/macros.pt
 msgid "no_file"
 msgstr ""
 
 #. Default: "Following documents are checked out:"
-#: ./opengever/document/browser/templates/logout_overlay.pt:8
+#: ./opengever/document/browser/templates/logout_overlay.pt
 msgid "overview_not_checked_in_documents"
 msgstr ""
 
 #. Default: "Please note that in this case changes on the document wouldn't be saved in to GEVER."
-#: ./opengever/document/browser/templates/downloadconfirmation.pt:17
+#: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "warning_download_confirmation"
 msgstr ""
 

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-08-04 07:40+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: de\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/dossier/move_items.py:170
+#: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
 msgstr "${copied_items} Elemente wurden erfolgreich verschoben"
 
@@ -24,32 +24,32 @@ msgstr "${copied_items} Elemente wurden erfolgreich verschoben"
 msgid "Add Business Case Dossier"
 msgstr "Geschäftsdossier hinzufügen"
 
-#: ./opengever/dossier/behaviors/dossier.py:241
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:49
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Add Subdossier"
 msgstr "Subdossier hinzufügen"
 
-#: ./opengever/dossier/dossiertemplate/form.py:127
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "Add dossier"
 msgstr "Dossier hinzufügen"
 
-#: ./opengever/dossier/move_items.py:214
+#: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
 msgstr "Es können nur Objekte aus aktiven Dossiers verschoben werden!"
 
-#: ./opengever/dossier/browser/report.py:75
+#: ./opengever/dossier/browser/report.py
 msgid "Could not generate the report."
 msgstr "Report konnte nicht generiert werden."
 
-#: ./opengever/dossier/browser/overview.py:102
+#: ./opengever/dossier/browser/overview.py
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ./opengever/dossier/move_items.py:119
+#: ./opengever/dossier/move_items.py
 msgid "Document ${name} is not movable."
 msgstr "Das Dokument «${name}» ist nicht verschiebbar."
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+#: ./opengever/dossier/browser/overview_templates/overview.pt
 msgid "Dossier structure"
 msgstr "Dossier-Struktur"
 
@@ -57,12 +57,12 @@ msgstr "Dossier-Struktur"
 msgid "Dossier template"
 msgstr "Dossiervorlage"
 
-#: ./opengever/dossier/resolve.py:113
+#: ./opengever/dossier/resolve.py
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
-#: ./opengever/dossier/behaviors/dossier.py:263
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:67
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Edit Subdossier"
 msgstr "Subdossier bearbeiten"
 
@@ -70,60 +70,60 @@ msgstr "Subdossier bearbeiten"
 msgid "Export selection"
 msgstr "Auswahl exportieren"
 
-#: ./opengever/dossier/move_items.py:176
+#: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr "Folgende Elemente konnten nicht verschoben werden: ${failed_objects}"
 
-#: ./opengever/dossier/move_items.py:182
+#: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr "Die folgenden Objekte konnten nicht kopiert werden: ${failed_objects}. Sie sind via WebDAV gesperrt."
 
-#: ./opengever/dossier/move_items.py:246
+#: ./opengever/dossier/move_items.py
 msgid "It isn't allowed to add such items there."
 msgstr "Sie dürfen dieses Objekt nicht an den Zielort verschieben."
 
-#: ./opengever/dossier/resolve.py:118
+#: ./opengever/dossier/resolve.py
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossier muss wieder eröffnet werden."
 
-#: ./opengever/dossier/browser/overview.py:98
+#: ./opengever/dossier/browser/overview.py
 msgid "Newest documents"
 msgstr "Neuste Dokumente"
 
-#: ./opengever/dossier/browser/overview.py:88
+#: ./opengever/dossier/browser/overview.py
 msgid "Newest tasks"
 msgstr "Neuste Aufgaben"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:28
+#: ./opengever/dossier/browser/overview_templates/overview.pt
 msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
 
-#: ./opengever/dossier/archive.py:56
+#: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
 msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 
-#: ./opengever/dossier/browser/overview.py:83
+#: ./opengever/dossier/browser/overview.py
 msgid "Participants"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/browser/overview.py:76
+#: ./opengever/dossier/browser/overview.py
 msgid "Participations"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/templatefolder/form.py:114
+#: ./opengever/dossier/templatefolder/form.py
 msgid "Select document"
 msgstr "Dokument auswählen"
 
-#: ./opengever/dossier/dossiertemplate/form.py:126
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
 msgstr "Vorlage auswählen"
 
-#: ./opengever/dossier/templatefolder/form.py:115
+#: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
 msgstr "Empfänger-Adresse auswählen"
 
-#: ./opengever/dossier/dossiertemplate/menu.py:15
-#: ./opengever/dossier/menu.py:19
+#: ./opengever/dossier/dossiertemplate/menu.py
+#: ./opengever/dossier/menu.py
 msgid "Subdossier"
 msgstr "Subdossier"
 
@@ -135,83 +135,83 @@ msgstr "Vorlagenordner"
 msgid "Templates"
 msgstr "Vorlagen"
 
-#: ./opengever/dossier/deactivate.py:58
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Das Dossier kann nicht storniert werden, es enthält aktive Anträge."
 
-#: ./opengever/dossier/deactivate.py:76
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
 
-#: ./opengever/dossier/deactivate.py:52
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokumente eingecheckt sind."
 
-#: ./opengever/dossier/deactivate.py:66
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr "Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} bereits abgeschlossen ist. Das Subdossier muss vorgängig wieder eröffnet werden."
 
-#: ./opengever/dossier/activate.py:41
+#: ./opengever/dossier/activate.py
 msgid "The Dossier has been activated"
 msgstr "Das Dossier wurde aktiviert."
 
-#: ./opengever/dossier/deactivate.py:36
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier has been deactivated"
 msgstr "Das Dossier wurde storniert."
 
-#: ./opengever/dossier/archive.py:288
+#: ./opengever/dossier/archive.py
 msgid "The Dossier has been resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen"
 
-#: ./opengever/dossier/resolve.py:76
+#: ./opengever/dossier/resolve.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "Das Dossier ${dossier} hat ein ungültiges Enddatum."
 
-#: ./opengever/dossier/resolve.py:29
+#: ./opengever/dossier/resolve.py
 msgid "The dossier contains active proposals."
 msgstr "Das Dossier enthält aktive Anträge."
 
-#: ./opengever/dossier/resolve.py:94
+#: ./opengever/dossier/resolve.py
 msgid "The dossier has been succesfully resolved."
 msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 
-#: ./opengever/dossier/archive.py:259
+#: ./opengever/dossier/archive.py
 msgid "The filing number has been given."
 msgstr "Die Ablagenummer wurde vergeben."
 
-#: ./opengever/dossier/archive.py:71
+#: ./opengever/dossier/archive.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date})."
 
-#: ./opengever/dossier/archive.py:91
+#: ./opengever/dossier/archive.py
 msgid "The given value is not a valid Year."
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
-#: ./opengever/dossier/move_items.py:111
+#: ./opengever/dossier/move_items.py
 msgid "The selected objects can't be found, please try it again."
 msgstr "Die selektierten Objekte konnten nicht gefunden werden, bitte versuchen Sie es erneut."
 
-#: ./opengever/dossier/behaviors/dossier.py:204
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "The start date must be before the end date."
 msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 
-#: ./opengever/dossier/behaviors/dossier.py:270
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
-#: ./opengever/dossier/resolve.py:90
+#: ./opengever/dossier/resolve.py
 msgid "The subdossier has been succesfully resolved."
 msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 
-#: ./opengever/dossier/activate.py:28
+#: ./opengever/dossier/activate.py
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier storniert ist."
 
-#: ./opengever/dossier/archive.py:215
+#: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."
 
-#: ./opengever/dossier/move_items.py:224
+#: ./opengever/dossier/move_items.py
 msgid "You have not selected any items"
 msgstr "Sie haben kein Element ausgewählt"
 
@@ -219,64 +219,64 @@ msgid "additional_attributes"
 msgstr "Zusatzattribute"
 
 #. Default: "Add"
-#: ./opengever/dossier/behaviors/participation.py:159
+#: ./opengever/dossier/behaviors/participation.py
 msgid "button_add"
 msgstr "Erstellen"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:232
+#: ./opengever/dossier/archive.py
 msgid "button_archive"
 msgstr "Speichern"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:291
-#: ./opengever/dossier/behaviors/participation.py:172
-#: ./opengever/dossier/dossiertemplate/form.py:162
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/participation.py
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:150
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Save"
-#: ./opengever/dossier/templatefolder/form.py:173
+#: ./opengever/dossier/templatefolder/form.py
 msgid "button_save"
 msgstr "Speichern"
 
 #. Default: "Move"
-#: ./opengever/dossier/move_items.py:96
+#: ./opengever/dossier/move_items.py
 msgid "button_submit"
 msgstr "Verschieben"
 
 #. Default: "Contact"
-#: ./opengever/dossier/browser/participants.py:112
+#: ./opengever/dossier/browser/participants.py
 msgid "column_contact"
 msgstr "Kontakt"
 
 #. Default: "role_list"
-#: ./opengever/dossier/browser/participants.py:116
+#: ./opengever/dossier/browser/participants.py
 msgid "column_rolelist"
 msgstr "Rolle"
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatefolder/form.py:107
+#: ./opengever/dossier/templatefolder/form.py
 msgid "create_document_with_template"
 msgstr "Dokument aus Vorlage erstellen"
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:122
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "create_dossier_with_template"
 msgstr "Geschäftsdossier aus Vorlage erstellen"
 
 #. Default: "The defined keywords will be preselected for new dossies from template."
-#: ./opengever/dossier/dossiertemplate/behaviors.py:45
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
 msgstr "Durch Aktivieren dieser Option werden bei der Erstellung des Dossiers ab Vorlage die angegebenen Schlagworte bereits vorausgefüllt."
 
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:56
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_restrict_keywords"
 msgstr "Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab Vorlage nur noch die in der Vorlage angegebenen Schlagworte zur Auswahl.<br>Der Benutzer kann dadurch auch keine neuen Schlagworte erfassen."
 
@@ -284,51 +284,51 @@ msgid "documents"
 msgstr "Dokumente"
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:277
+#: ./opengever/dossier/move_items.py
 msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in den Zielordner eingefügt werden: ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:66
+#: ./opengever/dossier/archive.py
 msgid "error_enddate"
 msgstr "Enddatum erforderlich"
 
 #. Default: "You have not selected any items."
-#: ./opengever/dossier/browser/report.py:59
+#: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Common"
-#: ./opengever/dossier/behaviors/dossier.py:47
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:106
-#: ./opengever/dossier/behaviors/filing.py:17
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/behaviors/filing.py
 msgid "fieldset_filing"
 msgstr "Ablage"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:202
+#: ./opengever/dossier/archive.py
 msgid "filing_action"
 msgstr "Aktion"
 
 #. Default: "Filing number"
-#: ./opengever/dossier/behaviors/filing.py:23
-#: ./opengever/dossier/filing/report.py:65
+#: ./opengever/dossier/behaviors/filing.py
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no"
 msgstr "Ablagenummer"
 
-#: ./opengever/dossier/filing/report.py:53
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_filing"
 msgstr "Ablage"
 
-#: ./opengever/dossier/filing/report.py:61
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_number"
 msgstr "Ablagenummer"
 
-#: ./opengever/dossier/filing/report.py:57
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_year"
 msgstr "Ablagejahr"
 
@@ -336,485 +336,485 @@ msgid "filing_nr"
 msgstr "Ablagenummer vergeben"
 
 #. Default: "Filing Number"
-#: ./opengever/dossier/filing/tabs.py:10
+#: ./opengever/dossier/filing/tabs.py
 msgid "filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:118
-#: ./opengever/dossier/browser/overview.py:249
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:195
+#: ./opengever/dossier/archive.py
 msgid "filing_year"
 msgstr "Ablage Jahr"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:224
+#: ./opengever/dossier/archive.py
 msgid "heading_archive_form"
 msgstr "Dossier ablegen"
 
 #. Default: "${title} notes / comments"
-#: ./opengever/dossier/viewlets/templates/note.pt:40
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "heading_dossier_note"
 msgstr "Kommentar zu Dossier `${title}`"
 
 #. Default: "Move Items"
-#: ./opengever/dossier/move_items.py:78
+#: ./opengever/dossier/move_items.py
 msgid "heading_move_items"
 msgstr "Elemente verschieben"
 
-#: ./opengever/dossier/behaviors/participation.py:94
+#: ./opengever/dossier/behaviors/participation.py
 msgid "help_contact"
 msgstr "Wählen Sie einen Benutzer oder einen Kontakt aus."
 
-#: ./opengever/dossier/behaviors/dossier.py:154
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_location"
 msgstr "Standortangabe des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
-#: ./opengever/dossier/behaviors/dossier.py:137
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_type"
 msgstr "Art des Behälters, in dem ein Dossier in Papierform abgelegt ist"
 
 #. Default: "Live Search: search the Plone Site"
-#: ./opengever/dossier/move_items.py:33
+#: ./opengever/dossier/move_items.py
 msgid "help_destination"
 msgstr "Live Search: Durchsuchen Sie diesen Mandanten"
 
-#: ./opengever/dossier/filing/advanced_search.py:16
+#: ./opengever/dossier/filing/advanced_search.py
 msgid "help_filing_number"
 msgstr "Geben Sie die vollständige Ablagenummer an."
 
-#: ./opengever/dossier/behaviors/dossier.py:62
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
 msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
 
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"
 msgstr "Anzahl Behälter, die ein (grosses) Dossier in Papierform enthalten"
 
 #. Default: "Create a new note"
-#: ./opengever/dossier/viewlets/templates/note.pt:19
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_add_note"
 msgstr "Neuen Kommentar erfassen."
 
 #. Default: "There is a note"
-#: ./opengever/dossier/viewlets/templates/note.pt:11
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_edit_note"
 msgstr "Es wurde ein Kommentar erfasst!"
 
 #. Default: "View note"
-#: ./opengever/dossier/viewlets/templates/note.pt:28
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_view_note"
 msgstr "Kommentar anzeigen."
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:35
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_title_help"
 msgstr "Empfehlung für Titel. Wird beim Erstellen eines Dossiers ab Vorlage als Hilfetext dargestellt."
 
 #. Default: "Participation created."
-#: ./opengever/dossier/behaviors/participation.py:167
+#: ./opengever/dossier/behaviors/participation.py
 msgid "info_participation_create"
 msgstr "Die Beteiligung wurde gespeichert."
 
 #. Default: "Removed participations."
-#: ./opengever/dossier/behaviors/participation.py:212
+#: ./opengever/dossier/behaviors/participation.py
 msgid "info_removed_participations"
 msgstr "Die Beteiligungen wurde entfernt."
 
 #. Default: "Add Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:22
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_add_note"
 msgstr "Erfassen"
 
 #. Default: "Addable dossier templates"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:107
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_addable_dossier_templates"
 msgstr "Erlaubte Dossiervorlagen"
 
 #. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py:265
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_address"
 msgstr "Adresse"
 
 #. Default: "by ${author}"
-#: ./opengever/dossier/project_templates/byline.pt:10
+#: ./opengever/dossier/project_templates/byline.pt
 msgid "label_by_author"
 msgstr "Federführend: ${author}"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/viewlets/templates/note.pt:55
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/dossier/viewlets/templates/note.pt:61
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_close"
 msgstr "Schliessen"
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:87
-#: ./opengever/dossier/browser/overview.py:68
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "label_comments"
 msgstr "Kommentar"
 
 #. Default: "Contact"
-#: ./opengever/dossier/behaviors/participation.py:93
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_contact"
 msgstr "Person"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:153
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_location"
 msgstr "Behältnis-Standort"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:136
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_type"
 msgstr "Behältnis-Art"
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:110
-#: ./opengever/dossier/templatefolder/form.py:71
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_creator"
 msgstr "Erstellt von"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:253
-#: ./opengever/dossier/templatefolder/tabs.py:140
+#: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/templatefolder/tabs.py
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Destination"
-#: ./opengever/dossier/move_items.py:32
+#: ./opengever/dossier/move_items.py
 msgid "label_destination"
 msgstr "Zielposition / Zieldossier"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:245
-#: ./opengever/dossier/browser/tabbed.py:18
+#: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Create Dossier note"
-#: ./opengever/dossier/viewlets/templates/note.pt:45
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_dossier_note_placeholder"
 msgstr "Kommentar erfassen"
 
 #. Default: "Dossier templates"
-#: ./opengever/dossier/browser/tabbed.py:122
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
 msgstr "Dossiervorlagen"
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatefolder/form.py:92
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
 #. Default: "Edit Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:14
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_edit_note"
 msgstr "Bearbeiten"
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:78
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_email_address"
 msgstr "E-Mail"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:82
-#: ./opengever/dossier/browser/report.py:32
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "to"
-#: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:59
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_end_byline"
 msgstr "Ende"
 
 #. Default: "External Reference"
-#: ./opengever/dossier/behaviors/dossier.py:99
-#: ./opengever/dossier/viewlets/byline.py:84
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_external_reference"
 msgstr "Externe Referenz"
 
 #. Default: "Filing Number"
-#: ./opengever/dossier/filing/byline.py:21
+#: ./opengever/dossier/filing/byline.py
 msgid "label_filing_no"
 msgstr "Ablagenummer"
 
 #. Default: "Filing number"
-#: ./opengever/dossier/filing/advanced_search.py:15
+#: ./opengever/dossier/filing/advanced_search.py
 msgid "label_filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:181
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_former_reference_number"
 msgstr "Früheres Aktenzeichen"
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:38
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_info"
 msgstr "Info"
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:33
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_journal"
 msgstr "Journal"
 
 #. Default: "Keywords"
-#: ./opengever/dossier/behaviors/dossier.py:61
-#: ./opengever/dossier/browser/overview.py:227
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "label_keywords"
 msgstr "Schlagworte"
 
 #. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py:270
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_label"
 msgstr "Label"
 
 #. Default: "Linked Dossiers"
-#: ./opengever/dossier/browser/overview.py:94
+#: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Verlinkte Dossiers"
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py:277
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_mail_address"
 msgstr "Mail Addresse"
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:113
-#: ./opengever/dossier/templatefolder/form.py:74
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_modified"
 msgstr "Zuletzt Bearbeitet"
 
 #. Default: "Reference Number will be generated                 after content creation"
-#: ./opengever/dossier/widget.py:25
+#: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
 msgstr "Die Archivnummer wird erst beim Erstellen generiert."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:146
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_number_of_containers"
 msgstr "Anzahl Behältnisse"
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:13
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_overview"
 msgstr "Übersicht"
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:66
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_participants"
 msgstr "Beteiligungen"
 
 #. Default: "Participation"
-#: ./opengever/dossier/behaviors/participation.py:150
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_participation"
 msgstr "Beteiligung"
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:62
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_participations"
 msgstr "Beteiligungen"
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py:288
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_phonenumber"
 msgstr "Telefonnummer"
 
 #. Default: "Predefined Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:44
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
 msgstr "Schlagworte vorausfüllen"
 
 #. Default: "Proposal Templates"
-#: ./opengever/dossier/browser/tabbed.py:113
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposal_templates"
 msgstr "Antragsvorlagen"
 
 #. Default: "Proposals"
-#: ./opengever/dossier/browser/tabbed.py:53
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposals"
 msgstr "Anträge"
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py:85
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_recipient"
 msgstr "Empfänger"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:188
-#: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:71
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:159
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_related_dossier"
 msgstr "Verwandte Dossiers"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:93
-#: ./opengever/dossier/browser/participants.py:169
-#: ./opengever/dossier/browser/report.py:35
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/participants.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:55
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_restrict_keywords"
 msgstr "Schlagwortkatalog einschränken"
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:38
+#: ./opengever/dossier/browser/report.py
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Roles"
-#: ./opengever/dossier/behaviors/participation.py:100
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_roles"
 msgstr "Rollen"
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:104
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Sablon Vorlagen"
 
 #. Default: "Save"
-#: ./opengever/dossier/viewlets/templates/note.pt:53
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:65
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Show Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:31
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_show_note"
 msgstr "Anzeigen"
 
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:74
-#: ./opengever/dossier/browser/report.py:29
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "from"
-#: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:53
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Beginn"
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:45
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_subdossiers"
 msgstr "Subdossiers"
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:23
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasks"
 msgstr "Aufgaben"
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:91
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasktemplate_folders"
 msgstr "Standardabläufe"
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:102
-#: ./opengever/dossier/templatefolder/form.py:62
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
 msgstr "Vorlage"
 
 #. Default: "Title"
-#: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:107
-#: ./opengever/dossier/templatefolder/form.py:67
+#: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Title help"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:34
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
 msgstr "Titelhilfe"
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:28
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
 msgstr "Papierkorb"
 
 #. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py:299
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_url"
 msgstr "URL"
 
 #. Default: "State"
-#: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:47
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_workflow_state"
 msgstr "Status"
 
 #. Default: "Changes not saved"
-#: ./opengever/dossier/viewlets/comment.py:28
+#: ./opengever/dossier/viewlets/comment.py
 msgid "message_body_error"
 msgstr "Änderungen wurde nicht gespeichert"
 
 #. Default: "Changes saved"
-#: ./opengever/dossier/viewlets/comment.py:27
+#: ./opengever/dossier/viewlets/comment.py
 msgid "message_body_info"
 msgstr "Änderungen gespeichert"
 
 #. Default: "The object `${title}` is not stored inside a dossier."
-#: ./opengever/dossier/browser/redirect_to_maindossier.py:16
+#: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
 msgstr "Das Object `${title}` ist nicht in einem Dossier abgelegt."
 
-#: ./opengever/dossier/resolve.py:24
+#: ./opengever/dossier/resolve.py
 msgid "not all documents and tasks are stored in a subdossier."
 msgstr "Es sind nicht alle Dokumente und Aufgaben in Subdossiers abgelegt."
 
-#: ./opengever/dossier/resolve.py:26
+#: ./opengever/dossier/resolve.py
 msgid "not all documents are checked in"
 msgstr "Es sind nicht alle Dokumente eingecheckt"
 
-#: ./opengever/dossier/resolve.py:27
+#: ./opengever/dossier/resolve.py
 msgid "not all task are closed"
 msgstr "Es sind nicht alle Aufgaben abgeschlossen"
 
 #. Default: "Confirm abbord"
-#: ./opengever/dossier/viewlets/comment.py:24
+#: ./opengever/dossier/viewlets/comment.py
 msgid "note_text_confirm_abord"
 msgstr "Sie haben nicht gespeicherte Änderungen, wollen Sie wirklich abbrechen?"
 
-#: ./opengever/dossier/archive.py:36
+#: ./opengever/dossier/archive.py
 msgid "only resolve, set filing no later"
 msgstr "Nur abschliessen (keine Ablagenummer vergeben)"
 
-#: ./opengever/dossier/archive.py:38
+#: ./opengever/dossier/archive.py
 msgid "resolve and set a new filing no"
 msgstr "Abschliessen und Ablagenummer neu vergeben"
 
-#: ./opengever/dossier/archive.py:35
+#: ./opengever/dossier/archive.py
 msgid "resolve and set filing no"
 msgstr "Abschliessen und Ablagenummer vergeben"
 
-#: ./opengever/dossier/archive.py:37
+#: ./opengever/dossier/archive.py
 msgid "resolve and take the existing filing no"
 msgstr "Abschliessen und die existierende Ablagenummer verwenden"
 
-#: ./opengever/dossier/archive.py:39
+#: ./opengever/dossier/archive.py
 msgid "set a filing no"
 msgstr "Ablagenummer vergeben"
 
@@ -828,30 +828,30 @@ msgid "tasks"
 msgstr "Aufgaben"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "temporary_former_reference_number"
 msgstr "Temporäres früheres Aktenzeichen"
 
-#: ./opengever/dossier/viewlets/templates/note.pt:57
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "text_delete_note"
 msgstr "Kommentar löschen (Löscht den Kommentar und schliesst das Overlay)."
 
-#: ./opengever/dossier/resolve.py:28
+#: ./opengever/dossier/resolve.py
 msgid "the dossier start date is missing."
 msgstr "Es wurde kein Beginn-Datum gesetzt."
 
 #. Default: "expired"
-#: ./opengever/dossier/project_templates/byline.pt:47
+#: ./opengever/dossier/project_templates/byline.pt
 msgid "time_expired"
 msgstr "abgelaufen"
 
 #. Default: "Journal of dossier ${title}, ${timestamp}"
-#: ./opengever/dossier/resolve.py:220
+#: ./opengever/dossier/resolve.py
 msgid "title_dossier_journal"
 msgstr "Dossier Journal ${title}, ${timestamp}"
 
 #. Default: "You didn't select any participants."
-#: ./opengever/dossier/behaviors/participation.py:202
+#: ./opengever/dossier/behaviors/participation.py
 msgid "warning_no_participants_selected"
 msgstr "Sie haben keine Beteiligungen ausgewählt."
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,55 +1,54 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-04 07:40+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-09-03 09:00+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-dossier/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/dossier/move_items.py:170
+#: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
 msgstr "Les éléments ${copied_items} ont été déplacés avec succès."
 
 msgid "Add Business Case Dossier"
 msgstr "Ajouter un dossier d'affaire"
 
-#: ./opengever/dossier/behaviors/dossier.py:241
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:49
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Add Subdossier"
 msgstr "Ajouter un sous-dossier"
 
-#: ./opengever/dossier/dossiertemplate/form.py:127
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "Add dossier"
 msgstr "Ajouter le dossier"
 
-#: ./opengever/dossier/move_items.py:214
+#: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
 msgstr "Seuls les objets de dossiers actifs peuvent être déplacés!"
 
-#: ./opengever/dossier/browser/report.py:75
+#: ./opengever/dossier/browser/report.py
 msgid "Could not generate the report."
 msgstr "Impossible de générer l'affichage."
 
-#: ./opengever/dossier/browser/overview.py:102
+#: ./opengever/dossier/browser/overview.py
 msgid "Description"
 msgstr "Description"
 
-#: ./opengever/dossier/move_items.py:119
+#: ./opengever/dossier/move_items.py
 msgid "Document ${name} is not movable."
 msgstr "Le document «${name}» n'est pas déplaçable."
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+#: ./opengever/dossier/browser/overview_templates/overview.pt
 msgid "Dossier structure"
 msgstr "Structure du dossier"
 
@@ -57,12 +56,12 @@ msgstr "Structure du dossier"
 msgid "Dossier template"
 msgstr "Modèle de dossier"
 
-#: ./opengever/dossier/resolve.py:113
+#: ./opengever/dossier/resolve.py
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été rouvert avec succès."
 
-#: ./opengever/dossier/behaviors/dossier.py:263
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:67
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Edit Subdossier"
 msgstr "Modifier le sous-dossier"
 
@@ -70,62 +69,60 @@ msgstr "Modifier le sous-dossier"
 msgid "Export selection"
 msgstr "Exporter le choix"
 
-#: ./opengever/dossier/move_items.py:176
+#: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr "Impossible de déplacer les éléments suivants: ${failed_objects}"
 
-#: ./opengever/dossier/move_items.py:182
+#: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr "Les objets suivants ne peuvent pas être copiés: ${failed_objects}. Ils sont verrouillés par WebDAV."
 
-#: ./opengever/dossier/move_items.py:246
+#: ./opengever/dossier/move_items.py
 msgid "It isn't allowed to add such items there."
 msgstr "Cet élément ne peut être déplacé vers cette position."
 
-#: ./opengever/dossier/resolve.py:118
+#: ./opengever/dossier/resolve.py
 msgid "It isn't possible to reactivate a sub dossier."
-msgstr ""
-"Il n'est pas possible de rouvrir le sous-dossier, le dossier principal doit "
-"être ouvert à nouveau."
+msgstr "Il n'est pas possible de rouvrir le sous-dossier, le dossier principal doit être ouvert à nouveau."
 
-#: ./opengever/dossier/browser/overview.py:98
+#: ./opengever/dossier/browser/overview.py
 msgid "Newest documents"
 msgstr "Derniers documents"
 
-#: ./opengever/dossier/browser/overview.py:88
+#: ./opengever/dossier/browser/overview.py
 msgid "Newest tasks"
 msgstr "Dernières tâches"
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:28
+#: ./opengever/dossier/browser/overview_templates/overview.pt
 msgid "No Subdossiers"
 msgstr "Aucun sous-dossier"
 
-#: ./opengever/dossier/archive.py:56
+#: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
 msgstr "Un ou plusieurs des champs requis n'ont pas été remplis."
 
-#: ./opengever/dossier/browser/overview.py:83
+#: ./opengever/dossier/browser/overview.py
 msgid "Participants"
 msgstr "Participants"
 
-#: ./opengever/dossier/browser/overview.py:76
+#: ./opengever/dossier/browser/overview.py
 msgid "Participations"
 msgstr "Participations"
 
-#: ./opengever/dossier/templatefolder/form.py:114
+#: ./opengever/dossier/templatefolder/form.py
 msgid "Select document"
 msgstr "Choisir un dossier"
 
-#: ./opengever/dossier/dossiertemplate/form.py:126
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
 msgstr "Choisir un modèle"
 
-#: ./opengever/dossier/templatefolder/form.py:115
+#: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
 msgstr "Choisir l'adresse du destinataire"
 
-#: ./opengever/dossier/dossiertemplate/menu.py:15
-#: ./opengever/dossier/menu.py:19
+#: ./opengever/dossier/dossiertemplate/menu.py
+#: ./opengever/dossier/menu.py
 msgid "Subdossier"
 msgstr "Sous-dossier"
 
@@ -136,93 +133,83 @@ msgstr "Dossier des modèles"
 msgid "Templates"
 msgstr "Modèles"
 
-#: ./opengever/dossier/deactivate.py:58
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Le dossier ne peut pas être annulé, il contient des requêtes actives."
 
-#: ./opengever/dossier/deactivate.py:76
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
-msgstr ""
-"Ce dossier ne peut pas être annulé, il contient encore des tâches non "
-"accomplies."
+msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches non accomplies."
 
-#: ./opengever/dossier/deactivate.py:52
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
-msgstr ""
-"Ce dossier ne peut pas être annulé, parce qu'il contient des documents qui "
-"ne sont pas en statut \"checkin\"."
+msgstr "Ce dossier ne peut pas être annulé, parce qu'il contient des documents qui ne sont pas en statut \"checkin\"."
 
-#: ./opengever/dossier/deactivate.py:66
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
-msgstr ""
-"Impossible d'annuler le dossier, parce que le sous-dossier ${dossier} a déjà "
-"été clôturé. Le sous-dossier doit d'abord être rouvert."
+msgstr "Impossible d'annuler le dossier, parce que le sous-dossier ${dossier} a déjà été clôturé. Le sous-dossier doit d'abord être rouvert."
 
-#: ./opengever/dossier/activate.py:41
+#: ./opengever/dossier/activate.py
 msgid "The Dossier has been activated"
 msgstr "Le dossier a été activé."
 
-#: ./opengever/dossier/deactivate.py:36
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier has been deactivated"
 msgstr "Le dossier a été annulé."
 
-#: ./opengever/dossier/archive.py:288
+#: ./opengever/dossier/archive.py
 msgid "The Dossier has been resolved"
 msgstr "Le dossier a été clôturé avec succès."
 
-#: ./opengever/dossier/resolve.py:76
+#: ./opengever/dossier/resolve.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "La date de clôture du dossier ${dossier} n'est pas valable."
 
-#: ./opengever/dossier/resolve.py:29
+#: ./opengever/dossier/resolve.py
 msgid "The dossier contains active proposals."
 msgstr "Le dossier contient des propositions actives."
 
-#: ./opengever/dossier/resolve.py:94
+#: ./opengever/dossier/resolve.py
 msgid "The dossier has been succesfully resolved."
 msgstr "Le dossier a été clôturé avec succès."
 
-#: ./opengever/dossier/archive.py:259
+#: ./opengever/dossier/archive.py
 msgid "The filing number has been given."
 msgstr "Le numéro d'inventaire a été attribué."
 
-#: ./opengever/dossier/archive.py:71
+#: ./opengever/dossier/archive.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
-msgstr ""
-"La date de clôture n'est pas valable. Elle doit être plus récente ou égale à "
-"la date de l'objet le plus récent y contenu (${date})."
+msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou égale à la date de l'objet le plus récent y contenu (${date})."
 
-#: ./opengever/dossier/archive.py:91
+#: ./opengever/dossier/archive.py
 msgid "The given value is not a valid Year."
 msgstr "L'année d'archivage indiquée n'est pas valable."
 
-#: ./opengever/dossier/move_items.py:111
+#: ./opengever/dossier/move_items.py
 msgid "The selected objects can't be found, please try it again."
 msgstr "Impossible de trouver les objets sélectionnés, merci de réessayer."
 
-#: ./opengever/dossier/behaviors/dossier.py:204
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "The start date must be before the end date."
 msgstr "La date de début doit être plus récente que la date de clôture."
 
-#: ./opengever/dossier/behaviors/dossier.py:270
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
-#: ./opengever/dossier/resolve.py:90
+#: ./opengever/dossier/resolve.py
 msgid "The subdossier has been succesfully resolved."
 msgstr "Le sous-dossier a été clôturé avec succès."
 
-#: ./opengever/dossier/activate.py:28
+#: ./opengever/dossier/activate.py
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
-msgstr ""
-"Ce sous-dossier ne peut pas être réactivé, parce que le dossier principal a "
-"été annulé."
+msgstr "Ce sous-dossier ne peut pas être réactivé, parce que le dossier principal a été annulé."
 
-#: ./opengever/dossier/archive.py:215
+#: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution du numéro d'inventaire, tous les champs sont obligatoires."
 
-#: ./opengever/dossier/move_items.py:224
+#: ./opengever/dossier/move_items.py
 msgid "You have not selected any items"
 msgstr "Aucun élément n'a été sélectionné"
 
@@ -230,123 +217,116 @@ msgid "additional_attributes"
 msgstr "Attributs supplémentaires"
 
 #. Default: "Add"
-#: ./opengever/dossier/behaviors/participation.py:159
+#: ./opengever/dossier/behaviors/participation.py
 msgid "button_add"
 msgstr "Etablir"
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:232
+#: ./opengever/dossier/archive.py
 msgid "button_archive"
 msgstr "Enregistrer"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:291
-#: ./opengever/dossier/behaviors/participation.py:172
-#: ./opengever/dossier/dossiertemplate/form.py:162
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/participation.py
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:150
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Save"
-#: ./opengever/dossier/templatefolder/form.py:173
+#: ./opengever/dossier/templatefolder/form.py
 msgid "button_save"
 msgstr "Enregistrer"
 
 #. Default: "Move"
-#: ./opengever/dossier/move_items.py:96
+#: ./opengever/dossier/move_items.py
 msgid "button_submit"
 msgstr "Déplacer"
 
 #. Default: "Contact"
-#: ./opengever/dossier/browser/participants.py:112
+#: ./opengever/dossier/browser/participants.py
 msgid "column_contact"
 msgstr "Contacts"
 
 #. Default: "role_list"
-#: ./opengever/dossier/browser/participants.py:116
+#: ./opengever/dossier/browser/participants.py
 msgid "column_rolelist"
 msgstr "Rôle"
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatefolder/form.py:107
+#: ./opengever/dossier/templatefolder/form.py
 msgid "create_document_with_template"
 msgstr "Créer un document à partir d'un modèle"
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:122
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "create_dossier_with_template"
 msgstr "Créer un dossier d'affaire à partir du modèle"
 
 #. Default: "The defined keywords will be preselected for new dossies from template."
-#: ./opengever/dossier/dossiertemplate/behaviors.py:45
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
-msgstr ""
-"En activant cette option les mots-clés définis seront présélectionnés quand "
-"vous créez un nouveau dossier à partir du modèle."
+msgstr "En activant cette option les mots-clés définis seront présélectionnés quand vous créez un nouveau dossier à partir du modèle."
 
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:56
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_restrict_keywords"
-msgstr ""
-"En activant cette option lors de la création du nouveau dossier, seuls les "
-"mots-clés figurant dans le modèle peuvent être choisis.<br> Ainsi, "
-"l'utilisateur ne peut pas non plus créer de nouveaux mots-clés."
+msgstr "En activant cette option lors de la création du nouveau dossier, seuls les mots-clés figurant dans le modèle peuvent être choisis.<br> Ainsi, l'utilisateur ne peut pas non plus créer de nouveaux mots-clés."
 
 msgid "documents"
 msgstr "Documents"
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:277
+#: ./opengever/dossier/move_items.py
 msgid "error_NotInContentTypes ${failed_objects}"
-msgstr ""
-"Aucun objet n'a été déplacé. Les objets suivants ne peuvent être insérés "
-"dans le classeur choisi: ${failed_objects}"
+msgstr "Aucun objet n'a été déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi: ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:66
+#: ./opengever/dossier/archive.py
 msgid "error_enddate"
 msgstr "Date de clôture requise"
 
 #. Default: "You have not selected any items."
-#: ./opengever/dossier/browser/report.py:59
+#: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun élément."
 
 #. Default: "Common"
-#: ./opengever/dossier/behaviors/dossier.py:47
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:106
-#: ./opengever/dossier/behaviors/filing.py:17
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/behaviors/filing.py
 msgid "fieldset_filing"
 msgstr "Classeur"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:202
+#: ./opengever/dossier/archive.py
 msgid "filing_action"
 msgstr "Action"
 
 #. Default: "Filing number"
-#: ./opengever/dossier/behaviors/filing.py:23
-#: ./opengever/dossier/filing/report.py:65
+#: ./opengever/dossier/behaviors/filing.py
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no"
 msgstr "Numéro d'inventaire"
 
-#: ./opengever/dossier/filing/report.py:53
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_filing"
 msgstr "Classeur"
 
-#: ./opengever/dossier/filing/report.py:61
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_number"
 msgstr "Numéro d'inventaire"
 
-#: ./opengever/dossier/filing/report.py:57
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_year"
 msgstr "Année de dépôt"
 
@@ -354,488 +334,485 @@ msgid "filing_nr"
 msgstr "Attribuer un numéro d'inventaire"
 
 #. Default: "Filing Number"
-#: ./opengever/dossier/filing/tabs.py:10
+#: ./opengever/dossier/filing/tabs.py
 msgid "filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:118
-#: ./opengever/dossier/browser/overview.py:249
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:195
+#: ./opengever/dossier/archive.py
 msgid "filing_year"
 msgstr "Année de dépôt"
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:224
+#: ./opengever/dossier/archive.py
 msgid "heading_archive_form"
 msgstr "Classer le dossier"
 
 #. Default: "${title} notes / comments"
-#: ./opengever/dossier/viewlets/templates/note.pt:40
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "heading_dossier_note"
 msgstr "Commentaire sur le dossier `${title}`"
 
 #. Default: "Move Items"
-#: ./opengever/dossier/move_items.py:78
+#: ./opengever/dossier/move_items.py
 msgid "heading_move_items"
 msgstr "Déplacer des éléments"
 
-#: ./opengever/dossier/behaviors/participation.py:94
+#: ./opengever/dossier/behaviors/participation.py
 msgid "help_contact"
 msgstr "Choix d'un utilisateur ou d'un contact."
 
-#: ./opengever/dossier/behaviors/dossier.py:154
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_location"
 msgstr "Emplacement du dossier imprimé"
 
-#: ./opengever/dossier/behaviors/dossier.py:137
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_type"
 msgstr "Type de conteneur du dossier imprimé"
 
 #. Default: "Live Search: search the Plone Site"
-#: ./opengever/dossier/move_items.py:33
+#: ./opengever/dossier/move_items.py
 msgid "help_destination"
 msgstr "Recherche en direct: Recherche de ce client"
 
-#: ./opengever/dossier/filing/advanced_search.py:16
+#: ./opengever/dossier/filing/advanced_search.py
 msgid "help_filing_number"
 msgstr "Saisir le numéro d'inventaire complet."
 
-#: ./opengever/dossier/behaviors/dossier.py:62
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
-msgstr ""
-"Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de "
-"classement."
+msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement."
 
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"
 msgstr "Nombre de conteneurs contenant des dossiers imprimés (volumineux)"
 
 #. Default: "Create a new note"
-#: ./opengever/dossier/viewlets/templates/note.pt:19
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_add_note"
 msgstr "Saisir un nouveau commentaire."
 
 #. Default: "There is a note"
-#: ./opengever/dossier/viewlets/templates/note.pt:11
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_edit_note"
 msgstr "Un commentaire a été saisi!"
 
 #. Default: "View note"
-#: ./opengever/dossier/viewlets/templates/note.pt:28
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_view_note"
 msgstr "Afficher le commentaire."
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:35
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_title_help"
 msgstr "Recommandation pour le titre. Affiché comme texte d'aide lors de la saisie d'un nouveau dossier à partir du modèle."
 
 #. Default: "Participation created."
-#: ./opengever/dossier/behaviors/participation.py:167
+#: ./opengever/dossier/behaviors/participation.py
 msgid "info_participation_create"
 msgstr "Participation enregistrée."
 
 #. Default: "Removed participations."
-#: ./opengever/dossier/behaviors/participation.py:212
+#: ./opengever/dossier/behaviors/participation.py
 msgid "info_removed_participations"
 msgstr "Participations enlevées."
 
 #. Default: "Add Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:22
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_add_note"
 msgstr "Saisir"
 
 #. Default: "Addable dossier templates"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:107
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_addable_dossier_templates"
 msgstr "Modèles de dossier autorisés"
 
 #. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py:265
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_address"
 msgstr "Adresse"
 
 #. Default: "by ${author}"
-#: ./opengever/dossier/project_templates/byline.pt:10
+#: ./opengever/dossier/project_templates/byline.pt
 msgid "label_by_author"
 msgstr "Responsable: ${author}"
 
 #. Default: "Cancel"
-#: ./opengever/dossier/viewlets/templates/note.pt:55
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Close"
-#: ./opengever/dossier/viewlets/templates/note.pt:61
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_close"
 msgstr "Clôturer"
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:87
-#: ./opengever/dossier/browser/overview.py:68
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "label_comments"
 msgstr "Commentaire"
 
 #. Default: "Contact"
-#: ./opengever/dossier/behaviors/participation.py:93
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_contact"
 msgstr "Personne"
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:153
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_location"
 msgstr "Emplacement du conteneur"
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:136
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_type"
 msgstr "Type de conteneur"
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:110
-#: ./opengever/dossier/templatefolder/form.py:71
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:253
-#: ./opengever/dossier/templatefolder/tabs.py:140
+#: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/templatefolder/tabs.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Destination"
-#: ./opengever/dossier/move_items.py:32
+#: ./opengever/dossier/move_items.py
 msgid "label_destination"
 msgstr "Destination (position/dossier)"
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:245
-#: ./opengever/dossier/browser/tabbed.py:18
+#: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Create Dossier note"
-#: ./opengever/dossier/viewlets/templates/note.pt:45
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_dossier_note_placeholder"
 msgstr "Saisir un commentaire"
 
 #. Default: "Dossier templates"
-#: ./opengever/dossier/browser/tabbed.py:122
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
 msgstr "Modèles de dossier"
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatefolder/form.py:92
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_edit_after_creation"
 msgstr "Modifier après la création"
 
 #. Default: "Edit Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:14
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_edit_note"
 msgstr "Editer"
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:78
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_email_address"
 msgstr "E-mail"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:82
-#: ./opengever/dossier/browser/report.py:32
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "to"
-#: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:59
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_end_byline"
 msgstr "Jusqu'au"
 
 #. Default: "External Reference"
-#: ./opengever/dossier/behaviors/dossier.py:99
-#: ./opengever/dossier/viewlets/byline.py:84
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_external_reference"
 msgstr "Référence externe"
 
 #. Default: "Filing Number"
-#: ./opengever/dossier/filing/byline.py:21
+#: ./opengever/dossier/filing/byline.py
 msgid "label_filing_no"
 msgstr "Numéro d'inventaire"
 
 #. Default: "Filing number"
-#: ./opengever/dossier/filing/advanced_search.py:15
+#: ./opengever/dossier/filing/advanced_search.py
 msgid "label_filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:181
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_former_reference_number"
 msgstr "Ancien numéro de référence"
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:38
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_info"
 msgstr "Info"
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:33
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_journal"
 msgstr "Historique"
 
 #. Default: "Keywords"
-#: ./opengever/dossier/behaviors/dossier.py:61
-#: ./opengever/dossier/browser/overview.py:227
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "label_keywords"
 msgstr "Mots-clés"
 
 #. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py:270
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_label"
 msgstr "label"
 
 #. Default: "Linked Dossiers"
-#: ./opengever/dossier/browser/overview.py:94
+#: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Dossiers liés"
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py:277
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_mail_address"
 msgstr "Adresse e-mail"
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:113
-#: ./opengever/dossier/templatefolder/form.py:74
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_modified"
 msgstr "Dernière modification"
 
 #. Default: "Reference Number will be generated                 after content creation"
-#: ./opengever/dossier/widget.py:25
+#: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
-msgstr ""
-"Le numéro de classement est seulement généré lors de la création du document."
+msgstr "Le numéro de classement est seulement généré lors de la création du document."
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:146
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_number_of_containers"
 msgstr "Nombre de conteneurs"
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:13
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_overview"
 msgstr "Sommaire"
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:66
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Participation"
-#: ./opengever/dossier/behaviors/participation.py:150
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_participation"
 msgstr "Participation"
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:62
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_participations"
 msgstr "Participations"
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py:288
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_phonenumber"
 msgstr "Numéro de téléphone"
 
 #. Default: "Predefined Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:44
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
 msgstr "Prédéfinition des mots-clés"
 
 #. Default: "Proposal Templates"
-#: ./opengever/dossier/browser/tabbed.py:113
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposal_templates"
 msgstr "Modèles pour la soumission de propositions"
 
 #. Default: "Proposals"
-#: ./opengever/dossier/browser/tabbed.py:53
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposals"
 msgstr "Propositions"
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py:85
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_recipient"
 msgstr "Destinataire"
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:188
-#: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:71
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:159
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_related_dossier"
 msgstr "Dossiers liés"
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:93
-#: ./opengever/dossier/browser/participants.py:169
-#: ./opengever/dossier/browser/report.py:35
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/participants.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:55
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_restrict_keywords"
 msgstr "Restreindre la liste des mots-clés"
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:38
+#: ./opengever/dossier/browser/report.py
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Roles"
-#: ./opengever/dossier/behaviors/participation.py:100
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_roles"
 msgstr "Rôles"
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:104
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Modèles Sablon"
 
 #. Default: "Save"
-#: ./opengever/dossier/viewlets/templates/note.pt:53
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_save"
 msgstr "Sauvegarder"
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:65
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Show Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:31
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_show_note"
 msgstr "Afficher"
 
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:74
-#: ./opengever/dossier/browser/report.py:29
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "from"
-#: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:53
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Début"
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:45
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_subdossiers"
 msgstr "Sous-dossiers"
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:23
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasks"
 msgstr "Tâches"
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:91
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasktemplate_folders"
 msgstr "Déroulements standard"
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:102
-#: ./opengever/dossier/templatefolder/form.py:62
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
 msgstr "Modèle"
 
 #. Default: "Title"
-#: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:107
-#: ./opengever/dossier/templatefolder/form.py:67
+#: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Title help"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:34
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
 msgstr "Aide pour le choix du titre"
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:28
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
 msgstr "Corbeille"
 
 #. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py:299
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_url"
 msgstr "Adresse URL"
 
 #. Default: "State"
-#: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:47
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_workflow_state"
 msgstr "Etat"
 
 #. Default: "Changes not saved"
-#: ./opengever/dossier/viewlets/comment.py:28
+#: ./opengever/dossier/viewlets/comment.py
 msgid "message_body_error"
 msgstr "Les modifications n'ont pas été sauvegardées."
 
 #. Default: "Changes saved"
-#: ./opengever/dossier/viewlets/comment.py:27
+#: ./opengever/dossier/viewlets/comment.py
 msgid "message_body_info"
 msgstr "Modifications sauvegardées"
 
 #. Default: "The object `${title}` is not stored inside a dossier."
-#: ./opengever/dossier/browser/redirect_to_maindossier.py:16
+#: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
 msgstr "L'objet `${title}`n'est déposé dans aucun dossier."
 
-#: ./opengever/dossier/resolve.py:24
+#: ./opengever/dossier/resolve.py
 msgid "not all documents and tasks are stored in a subdossier."
 msgstr "Pas tous les documents ou tâches ont été classés dans un sous-dossier."
 
-#: ./opengever/dossier/resolve.py:26
+#: ./opengever/dossier/resolve.py
 msgid "not all documents are checked in"
 msgstr "Pas tous les documents ont le statut \"checkin\""
 
-#: ./opengever/dossier/resolve.py:27
+#: ./opengever/dossier/resolve.py
 msgid "not all task are closed"
 msgstr "Pas toutes les tâches ont été clôturées."
 
 #. Default: "Confirm abbord"
-#: ./opengever/dossier/viewlets/comment.py:24
+#: ./opengever/dossier/viewlets/comment.py
 msgid "note_text_confirm_abord"
 msgstr "Vous avez des modifications non sauvegardées. Voulez-vous vraiment annuler?"
 
-#: ./opengever/dossier/archive.py:36
+#: ./opengever/dossier/archive.py
 msgid "only resolve, set filing no later"
 msgstr "Clôturer seulement (numéro d'inventaire non attribué)"
 
-#: ./opengever/dossier/archive.py:38
+#: ./opengever/dossier/archive.py
 msgid "resolve and set a new filing no"
 msgstr "Clôturer et attribuer un nouveau numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py:35
+#: ./opengever/dossier/archive.py
 msgid "resolve and set filing no"
 msgstr "Clôturer et attribuer un numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py:37
+#: ./opengever/dossier/archive.py
 msgid "resolve and take the existing filing no"
 msgstr "Clôturer et utiliser le numéro d'inventaire existant"
 
-#: ./opengever/dossier/archive.py:39
+#: ./opengever/dossier/archive.py
 msgid "set a filing no"
 msgstr "Attribuer un numéro d'inventaire"
 
@@ -849,29 +826,30 @@ msgid "tasks"
 msgstr "Tâches"
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "temporary_former_reference_number"
 msgstr "Ancien numéro de référence temporaire"
 
-#: ./opengever/dossier/viewlets/templates/note.pt:57
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "text_delete_note"
 msgstr "Supprimer le commentaire (supprime le commentaire et ferme le Overlay)."
 
-#: ./opengever/dossier/resolve.py:28
+#: ./opengever/dossier/resolve.py
 msgid "the dossier start date is missing."
 msgstr "Aucune date de début n'a été saisie."
 
 #. Default: "expired"
-#: ./opengever/dossier/project_templates/byline.pt:47
+#: ./opengever/dossier/project_templates/byline.pt
 msgid "time_expired"
 msgstr "Périmé"
 
 #. Default: "Journal of dossier ${title}, ${timestamp}"
-#: ./opengever/dossier/resolve.py:220
+#: ./opengever/dossier/resolve.py
 msgid "title_dossier_journal"
 msgstr "Journal du dossier ${title}, ${timestamp}"
 
 #. Default: "You didn't select any participants."
-#: ./opengever/dossier/behaviors/participation.py:202
+#: ./opengever/dossier/behaviors/participation.py
 msgid "warning_no_participants_selected"
 msgstr "Vous n'avez sélectionné aucune participation."
+

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-04 07:40+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,39 +17,39 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.dossier\n"
 
-#: ./opengever/dossier/move_items.py:170
+#: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
 msgstr ""
 
 msgid "Add Business Case Dossier"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:241
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:49
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Add Subdossier"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:127
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "Add dossier"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:214
+#: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
 msgstr ""
 
-#: ./opengever/dossier/browser/report.py:75
+#: ./opengever/dossier/browser/report.py
 msgid "Could not generate the report."
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:102
+#: ./opengever/dossier/browser/overview.py
 msgid "Description"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:119
+#: ./opengever/dossier/move_items.py
 msgid "Document ${name} is not movable."
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:8
+#: ./opengever/dossier/browser/overview_templates/overview.pt
 msgid "Dossier structure"
 msgstr ""
 
@@ -57,12 +57,12 @@ msgstr ""
 msgid "Dossier template"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:113
+#: ./opengever/dossier/resolve.py
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:263
-#: ./opengever/dossier/dossiertemplate/dossiertemplate.py:67
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Edit Subdossier"
 msgstr ""
 
@@ -70,60 +70,60 @@ msgstr ""
 msgid "Export selection"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:176
+#: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:182
+#: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}. Locked via WebDAV"
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:246
+#: ./opengever/dossier/move_items.py
 msgid "It isn't allowed to add such items there."
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:118
+#: ./opengever/dossier/resolve.py
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:98
+#: ./opengever/dossier/browser/overview.py
 msgid "Newest documents"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:88
+#: ./opengever/dossier/browser/overview.py
 msgid "Newest tasks"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview_templates/overview.pt:28
+#: ./opengever/dossier/browser/overview_templates/overview.pt
 msgid "No Subdossiers"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:56
+#: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:83
+#: ./opengever/dossier/browser/overview.py
 msgid "Participants"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py:76
+#: ./opengever/dossier/browser/overview.py
 msgid "Participations"
 msgstr ""
 
-#: ./opengever/dossier/templatefolder/form.py:114
+#: ./opengever/dossier/templatefolder/form.py
 msgid "Select document"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/form.py:126
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
 msgstr ""
 
-#: ./opengever/dossier/templatefolder/form.py:115
+#: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
 msgstr ""
 
-#: ./opengever/dossier/dossiertemplate/menu.py:15
-#: ./opengever/dossier/menu.py:19
+#: ./opengever/dossier/dossiertemplate/menu.py
+#: ./opengever/dossier/menu.py
 msgid "Subdossier"
 msgstr ""
 
@@ -134,83 +134,83 @@ msgstr ""
 msgid "Templates"
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:58
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:76
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:52
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:66
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
 msgstr ""
 
-#: ./opengever/dossier/activate.py:41
+#: ./opengever/dossier/activate.py
 msgid "The Dossier has been activated"
 msgstr ""
 
-#: ./opengever/dossier/deactivate.py:36
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier has been deactivated"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:288
+#: ./opengever/dossier/archive.py
 msgid "The Dossier has been resolved"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:76
+#: ./opengever/dossier/resolve.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:29
+#: ./opengever/dossier/resolve.py
 msgid "The dossier contains active proposals."
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:94
+#: ./opengever/dossier/resolve.py
 msgid "The dossier has been succesfully resolved."
 msgstr ""
 
-#: ./opengever/dossier/archive.py:259
+#: ./opengever/dossier/archive.py
 msgid "The filing number has been given."
 msgstr ""
 
-#: ./opengever/dossier/archive.py:71
+#: ./opengever/dossier/archive.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr ""
 
-#: ./opengever/dossier/archive.py:91
+#: ./opengever/dossier/archive.py
 msgid "The given value is not a valid Year."
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:111
+#: ./opengever/dossier/move_items.py
 msgid "The selected objects can't be found, please try it again."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:204
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "The start date must be before the end date."
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:270
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "The start or end date is invalid"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:90
+#: ./opengever/dossier/resolve.py
 msgid "The subdossier has been succesfully resolved."
 msgstr ""
 
-#: ./opengever/dossier/activate.py:28
+#: ./opengever/dossier/activate.py
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:215
+#: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""
 
-#: ./opengever/dossier/move_items.py:224
+#: ./opengever/dossier/move_items.py
 msgid "You have not selected any items"
 msgstr ""
 
@@ -218,64 +218,64 @@ msgid "additional_attributes"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/dossier/behaviors/participation.py:159
+#: ./opengever/dossier/behaviors/participation.py
 msgid "button_add"
 msgstr ""
 
 #. Default: "Archive"
-#: ./opengever/dossier/archive.py:232
+#: ./opengever/dossier/archive.py
 msgid "button_archive"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/dossier/archive.py:291
-#: ./opengever/dossier/behaviors/participation.py:172
-#: ./opengever/dossier/dossiertemplate/form.py:162
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/participation.py
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/dossier/dossiertemplate/form.py:150
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/dossier/templatefolder/form.py:173
+#: ./opengever/dossier/templatefolder/form.py
 msgid "button_save"
 msgstr ""
 
 #. Default: "Move"
-#: ./opengever/dossier/move_items.py:96
+#: ./opengever/dossier/move_items.py
 msgid "button_submit"
 msgstr ""
 
 #. Default: "Contact"
-#: ./opengever/dossier/browser/participants.py:112
+#: ./opengever/dossier/browser/participants.py
 msgid "column_contact"
 msgstr ""
 
 #. Default: "role_list"
-#: ./opengever/dossier/browser/participants.py:116
+#: ./opengever/dossier/browser/participants.py
 msgid "column_rolelist"
 msgstr ""
 
 #. Default: "Create document from template"
-#: ./opengever/dossier/templatefolder/form.py:107
+#: ./opengever/dossier/templatefolder/form.py
 msgid "create_document_with_template"
 msgstr ""
 
 #. Default: "Create dossier from template"
-#: ./opengever/dossier/dossiertemplate/form.py:122
+#: ./opengever/dossier/dossiertemplate/form.py
 msgid "create_dossier_with_template"
 msgstr ""
 
 #. Default: "The defined keywords will be preselected for new dossies from template."
-#: ./opengever/dossier/dossiertemplate/behaviors.py:45
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
 msgstr ""
 
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:56
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_restrict_keywords"
 msgstr ""
 
@@ -283,51 +283,51 @@ msgid "documents"
 msgstr ""
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
-#: ./opengever/dossier/move_items.py:277
+#: ./opengever/dossier/move_items.py
 msgid "error_NotInContentTypes ${failed_objects}"
 msgstr ""
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py:66
+#: ./opengever/dossier/archive.py
 msgid "error_enddate"
 msgstr ""
 
 #. Default: "You have not selected any items."
-#: ./opengever/dossier/browser/report.py:59
+#: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/dossier/behaviors/dossier.py:47
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Filing"
-#: ./opengever/dossier/behaviors/dossier.py:106
-#: ./opengever/dossier/behaviors/filing.py:17
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/behaviors/filing.py
 msgid "fieldset_filing"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py:202
+#: ./opengever/dossier/archive.py
 msgid "filing_action"
 msgstr ""
 
 #. Default: "Filing number"
-#: ./opengever/dossier/behaviors/filing.py:23
-#: ./opengever/dossier/filing/report.py:65
+#: ./opengever/dossier/behaviors/filing.py
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no"
 msgstr ""
 
-#: ./opengever/dossier/filing/report.py:53
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_filing"
 msgstr ""
 
-#: ./opengever/dossier/filing/report.py:61
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_number"
 msgstr ""
 
-#: ./opengever/dossier/filing/report.py:57
+#: ./opengever/dossier/filing/report.py
 msgid "filing_no_year"
 msgstr ""
 
@@ -335,489 +335,485 @@ msgid "filing_nr"
 msgstr ""
 
 #. Default: "Filing Number"
-#: ./opengever/dossier/filing/tabs.py:10
+#: ./opengever/dossier/filing/tabs.py
 msgid "filing_number"
 msgstr ""
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py:179
-#: ./opengever/dossier/behaviors/dossier.py:118
-#: ./opengever/dossier/browser/overview.py:249
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "filing_prefix"
 msgstr ""
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py:195
+#: ./opengever/dossier/archive.py
 msgid "filing_year"
 msgstr ""
 
 #. Default: "Archive Dossier"
-#: ./opengever/dossier/archive.py:224
+#: ./opengever/dossier/archive.py
 msgid "heading_archive_form"
 msgstr ""
 
 #. Default: "${title} notes / comments"
-#: ./opengever/dossier/viewlets/templates/note.pt:40
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "heading_dossier_note"
 msgstr ""
 
 #. Default: "Move Items"
-#: ./opengever/dossier/move_items.py:78
+#: ./opengever/dossier/move_items.py
 msgid "heading_move_items"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/participation.py:94
+#: ./opengever/dossier/behaviors/participation.py
 msgid "help_contact"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:154
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_location"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:137
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_type"
 msgstr ""
 
 #. Default: "Live Search: search the Plone Site"
-#: ./opengever/dossier/move_items.py:33
+#: ./opengever/dossier/move_items.py
 msgid "help_destination"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:100
-msgid "help_external_reference"
-msgstr ""
-
-#: ./opengever/dossier/filing/advanced_search.py:16
+#: ./opengever/dossier/filing/advanced_search.py
 msgid "help_filing_number"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:62
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
 msgstr ""
 
-#: ./opengever/dossier/behaviors/dossier.py:148
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"
 msgstr ""
 
 #. Default: "Create a new note"
-#: ./opengever/dossier/viewlets/templates/note.pt:19
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_add_note"
 msgstr ""
 
 #. Default: "There is a note"
-#: ./opengever/dossier/viewlets/templates/note.pt:11
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_edit_note"
 msgstr ""
 
 #. Default: "View note"
-#: ./opengever/dossier/viewlets/templates/note.pt:28
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_view_note"
 msgstr ""
 
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:35
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_title_help"
 msgstr ""
 
 #. Default: "Participation created."
-#: ./opengever/dossier/behaviors/participation.py:167
+#: ./opengever/dossier/behaviors/participation.py
 msgid "info_participation_create"
 msgstr ""
 
 #. Default: "Removed participations."
-#: ./opengever/dossier/behaviors/participation.py:212
+#: ./opengever/dossier/behaviors/participation.py
 msgid "info_removed_participations"
 msgstr ""
 
 #. Default: "Add Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:22
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_add_note"
 msgstr ""
 
 #. Default: "Addable dossier templates"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:107
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_addable_dossier_templates"
 msgstr ""
 
 #. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py:265
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_address"
 msgstr ""
 
 #. Default: "by ${author}"
-#: ./opengever/dossier/project_templates/byline.pt:10
+#: ./opengever/dossier/project_templates/byline.pt
 msgid "label_by_author"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/dossier/viewlets/templates/note.pt:55
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/dossier/viewlets/templates/note.pt:61
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_close"
 msgstr ""
 
 #. Default: "Comments"
-#: ./opengever/dossier/behaviors/dossier.py:87
-#: ./opengever/dossier/browser/overview.py:68
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "label_comments"
 msgstr ""
 
 #. Default: "Contact"
-#: ./opengever/dossier/behaviors/participation.py:93
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_contact"
 msgstr ""
 
 #. Default: "Container Location"
-#: ./opengever/dossier/behaviors/dossier.py:153
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_location"
 msgstr ""
 
 #. Default: "Container Type"
-#: ./opengever/dossier/behaviors/dossier.py:136
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_type"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/dossier/dossiertemplate/form.py:110
-#: ./opengever/dossier/templatefolder/form.py:71
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py:253
-#: ./opengever/dossier/templatefolder/tabs.py:140
+#: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/templatefolder/tabs.py
 msgid "label_description"
 msgstr ""
 
 #. Default: "Destination"
-#: ./opengever/dossier/move_items.py:32
+#: ./opengever/dossier/move_items.py
 msgid "label_destination"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/dossier/browser/overview.py:245
-#: ./opengever/dossier/browser/tabbed.py:18
+#: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Create Dossier note"
-#: ./opengever/dossier/viewlets/templates/note.pt:45
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_dossier_note_placeholder"
 msgstr ""
 
 #. Default: "Dossier templates"
-#: ./opengever/dossier/browser/tabbed.py:122
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
 msgstr ""
 
 #. Default: "Edit after creation"
-#: ./opengever/dossier/templatefolder/form.py:92
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_edit_after_creation"
 msgstr ""
 
 #. Default: "Edit Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:14
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_edit_note"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/dossier/viewlets/byline.py:78
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_email_address"
 msgstr ""
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py:189
-#: ./opengever/dossier/behaviors/dossier.py:82
-#: ./opengever/dossier/browser/report.py:32
+#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_end"
 msgstr ""
 
 #. Default: "to"
-#: ./opengever/dossier/project_templates/byline.pt:38
-#: ./opengever/dossier/viewlets/byline.py:59
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_end_byline"
 msgstr ""
 
-#. Default: "External reference"
-#: ./opengever/dossier/behaviors/dossier.py:99
-#: ./opengever/dossier/viewlets/byline.py:84
+#. Default: "External Reference"
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_external_reference"
 msgstr ""
 
 #. Default: "Filing Number"
-#: ./opengever/dossier/filing/byline.py:21
+#: ./opengever/dossier/filing/byline.py
 msgid "label_filing_no"
 msgstr ""
 
 #. Default: "Filing number"
-#: ./opengever/dossier/filing/advanced_search.py:15
+#: ./opengever/dossier/filing/advanced_search.py
 msgid "label_filing_number"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:181
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_former_reference_number"
 msgstr ""
 
 #. Default: "Info"
-#: ./opengever/dossier/browser/tabbed.py:38
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_info"
 msgstr ""
 
 #. Default: "Journal"
-#: ./opengever/dossier/browser/tabbed.py:33
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_journal"
 msgstr ""
 
 #. Default: "Keywords"
-#: ./opengever/dossier/behaviors/dossier.py:61
-#: ./opengever/dossier/browser/overview.py:227
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/overview.py
 msgid "label_keywords"
 msgstr ""
 
 #. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py:270
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_label"
 msgstr ""
 
 #. Default: "Linked Dossiers"
-#: ./opengever/dossier/browser/overview.py:94
+#: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr ""
 
 #. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py:277
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/dossier/dossiertemplate/form.py:113
-#: ./opengever/dossier/templatefolder/form.py:74
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_modified"
 msgstr ""
 
 #. Default: "Reference Number will be generated                 after content creation"
-#: ./opengever/dossier/widget.py:25
+#: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
 msgstr ""
 
 #. Default: "Number of Containers"
-#: ./opengever/dossier/behaviors/dossier.py:146
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_number_of_containers"
 msgstr ""
 
 #. Default: "Overview"
-#: ./opengever/dossier/browser/tabbed.py:13
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_overview"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/dossier/browser/tabbed.py:66
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Participation"
-#: ./opengever/dossier/behaviors/participation.py:150
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_participation"
 msgstr ""
 
 #. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py:62
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_participations"
 msgstr ""
 
 #. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py:288
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_phonenumber"
 msgstr ""
 
 #. Default: "Predefined Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:44
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
 msgstr ""
 
 #. Default: "Proposal Templates"
-#: ./opengever/dossier/browser/tabbed.py:113
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposal_templates"
 msgstr ""
 
 #. Default: "Proposals"
-#: ./opengever/dossier/browser/tabbed.py:53
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposals"
 msgstr ""
 
 #. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py:85
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_recipient"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/dossier/behaviors/dossier.py:188
-#: ./opengever/dossier/browser/report.py:41
-#: ./opengever/dossier/viewlets/byline.py:71
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Related Dossier"
-#: ./opengever/dossier/behaviors/dossier.py:159
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "label_related_dossier"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/dossier/behaviors/dossier.py:93
-#: ./opengever/dossier/browser/participants.py:169
-#: ./opengever/dossier/browser/report.py:35
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/participants.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "Restrict Keywords"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:55
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_restrict_keywords"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/dossier/browser/report.py:38
+#: ./opengever/dossier/browser/report.py
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Roles"
-#: ./opengever/dossier/behaviors/participation.py:100
+#: ./opengever/dossier/behaviors/participation.py
 msgid "label_roles"
 msgstr ""
 
 #. Default: "Sablon Templates"
-#: ./opengever/dossier/browser/tabbed.py:104
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/dossier/viewlets/templates/note.pt:53
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_save"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/dossier/viewlets/byline.py:65
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Show Note"
-#: ./opengever/dossier/viewlets/templates/note.pt:31
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_show_note"
 msgstr ""
 
 #. Default: "Opening Date"
-#: ./opengever/dossier/behaviors/dossier.py:74
-#: ./opengever/dossier/browser/report.py:29
+#: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/browser/report.py
 msgid "label_start"
 msgstr ""
 
 #. Default: "from"
-#: ./opengever/dossier/project_templates/byline.pt:29
-#: ./opengever/dossier/viewlets/byline.py:53
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_start_byline"
 msgstr ""
 
 #. Default: "Subdossiers"
-#: ./opengever/dossier/browser/tabbed.py:45
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_subdossiers"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/dossier/browser/tabbed.py:23
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasks"
 msgstr ""
 
 #. Default: "Tasktemplate Folders"
-#: ./opengever/dossier/browser/tabbed.py:91
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasktemplate_folders"
 msgstr ""
 
 #. Default: "Template"
-#: ./opengever/dossier/dossiertemplate/form.py:102
-#: ./opengever/dossier/templatefolder/form.py:62
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/dossier/browser/report.py:26
-#: ./opengever/dossier/dossiertemplate/form.py:107
-#: ./opengever/dossier/templatefolder/form.py:67
+#: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/dossiertemplate/form.py
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Title help"
-#: ./opengever/dossier/dossiertemplate/behaviors.py:34
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
 msgstr ""
 
 #. Default: "Trash"
-#: ./opengever/dossier/browser/tabbed.py:28
+#: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
 msgstr ""
 
 #. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py:299
+#: ./opengever/dossier/templatefolder/form.py
 msgid "label_url"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/dossier/project_templates/byline.pt:22
-#: ./opengever/dossier/viewlets/byline.py:47
+#: ./opengever/dossier/project_templates/byline.pt
+#: ./opengever/dossier/viewlets/byline.py
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "Changes not saved"
-#: ./opengever/dossier/viewlets/comment.py:28
+#: ./opengever/dossier/viewlets/comment.py
 msgid "message_body_error"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/dossier/viewlets/comment.py:27
+#: ./opengever/dossier/viewlets/comment.py
 msgid "message_body_info"
 msgstr ""
 
 #. Default: "The object `${title}` is not stored inside a dossier."
-#: ./opengever/dossier/browser/redirect_to_maindossier.py:16
+#: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:24
+#: ./opengever/dossier/resolve.py
 msgid "not all documents and tasks are stored in a subdossier."
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:26
+#: ./opengever/dossier/resolve.py
 msgid "not all documents are checked in"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:27
+#: ./opengever/dossier/resolve.py
 msgid "not all task are closed"
 msgstr ""
 
 #. Default: "Confirm abbord"
-#: ./opengever/dossier/viewlets/comment.py:24
+#: ./opengever/dossier/viewlets/comment.py
 msgid "note_text_confirm_abord"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:36
+#: ./opengever/dossier/archive.py
 msgid "only resolve, set filing no later"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:38
+#: ./opengever/dossier/archive.py
 msgid "resolve and set a new filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:35
+#: ./opengever/dossier/archive.py
 msgid "resolve and set filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:37
+#: ./opengever/dossier/archive.py
 msgid "resolve and take the existing filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py:39
+#: ./opengever/dossier/archive.py
 msgid "set a filing no"
 msgstr ""
 
@@ -831,30 +827,30 @@ msgid "tasks"
 msgstr ""
 
 #. Default: "Temporary former reference number"
-#: ./opengever/dossier/behaviors/dossier.py:130
+#: ./opengever/dossier/behaviors/dossier.py
 msgid "temporary_former_reference_number"
 msgstr ""
 
-#: ./opengever/dossier/viewlets/templates/note.pt:57
+#: ./opengever/dossier/viewlets/templates/note.pt
 msgid "text_delete_note"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py:28
+#: ./opengever/dossier/resolve.py
 msgid "the dossier start date is missing."
 msgstr ""
 
 #. Default: "expired"
-#: ./opengever/dossier/project_templates/byline.pt:47
+#: ./opengever/dossier/project_templates/byline.pt
 msgid "time_expired"
 msgstr ""
 
 #. Default: "Journal of dossier ${title}, ${timestamp}"
-#: ./opengever/dossier/resolve.py:220
+#: ./opengever/dossier/resolve.py
 msgid "title_dossier_journal"
 msgstr ""
 
 #. Default: "You didn't select any participants."
-#: ./opengever/dossier/behaviors/participation.py:202
+#: ./opengever/dossier/behaviors/participation.py
 msgid "warning_no_participants_selected"
 msgstr ""
 

--- a/opengever/ech0147/locales/de/LC_MESSAGES/opengever.ech0147.po
+++ b/opengever/ech0147/locales/de/LC_MESSAGES/opengever.ech0147.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-08 09:48+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,218 +14,218 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/ech0147/browser/import.py:60
+#: ./opengever/ech0147/browser/import.py
 msgid "Invalid message. Missing message.xml"
 msgstr "Ungültige eCH-0147 Nachricht. message.xml fehlt."
 
-#: ./opengever/ech0147/browser/import.py:86
+#: ./opengever/ech0147/browser/import.py
 msgid "Message has been imported"
 msgstr "Nachricht wurde importiert."
 
-#: ./opengever/ech0147/browser/import.py:82
+#: ./opengever/ech0147/browser/import.py
 msgid "Message import failed. ${details}"
 msgstr "Import fehlgeschlagen. ${details}"
 
-#: ./opengever/ech0147/browser/import.py:67
+#: ./opengever/ech0147/browser/import.py
 msgid "Messages containing toplevel dossiers and toplevel documents are not supported"
 msgstr "Nachrichten mit Dossiers und Dokumenten ausserhalb von Dossiers werden nicht unterstützt."
 
-#: ./opengever/ech0147/browser/export.py:40
+#: ./opengever/ech0147/browser/export.py
 msgid "help_action"
 msgstr "Fachliche Austauschanweisung für den Empfänger der Nachricht."
 
-#: ./opengever/ech0147/browser/export.py:65
+#: ./opengever/ech0147/browser/export.py
 msgid "help_directive"
 msgstr "Bearbeitungsanweisung für den Empfänger der Nachricht."
 
 #. Default: "A ZIP file containing an eCH-147 message."
-#: ./opengever/ech0147/browser/import.py:26
+#: ./opengever/ech0147/browser/import.py
 msgid "help_message"
 msgstr "Eine eCH-0147 konforme ZIP-Datei"
 
 #. Default: "Recipients of the message. Enter one recipient per line."
-#: ./opengever/ech0147/browser/export.py:31
+#: ./opengever/ech0147/browser/export.py
 msgid "help_recipients"
 msgstr "Empfänger der Nachricht (z.B. E-Mail-Adresse). Pro Zeile ein Empfänger."
 
 #. Default: "Responsible for dossiers created by eCH-0147 import."
-#: ./opengever/ech0147/browser/import.py:35
+#: ./opengever/ech0147/browser/import.py
 msgid "help_responsible"
 msgstr "Federführende Person bei Dossiers, die durch den eCH-0147 Import erstellt werden."
 
 #. Default: "Action"
-#: ./opengever/ech0147/browser/export.py:39
+#: ./opengever/ech0147/browser/export.py
 msgid "label_action"
 msgstr "Aktion"
 
 #. Default: "Cancel"
-#: ./opengever/ech0147/browser/export.py:190
-#: ./opengever/ech0147/browser/import.py:89
+#: ./opengever/ech0147/browser/export.py
+#: ./opengever/ech0147/browser/import.py
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Comment"
-#: ./opengever/ech0147/browser/export.py:59
+#: ./opengever/ech0147/browser/export.py
 msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "Deadline"
-#: ./opengever/ech0147/browser/export.py:102
+#: ./opengever/ech0147/browser/export.py
 msgid "label_deadline"
 msgstr "Frist"
 
 #. Default: "Directive"
-#: ./opengever/ech0147/browser/export.py:64
+#: ./opengever/ech0147/browser/export.py
 msgid "label_directive"
 msgstr "Anweisung"
 
 #. Default: "eCH 0147 Export"
-#: ./opengever/ech0147/browser/export.py:131
+#: ./opengever/ech0147/browser/export.py
 msgid "label_ech0147_export_form"
 msgstr "eCH-0147/eCH-0039 Export"
 
 #. Default: "eCH 0147 Import"
-#: ./opengever/ech0147/browser/import.py:46
+#: ./opengever/ech0147/browser/import.py
 msgid "label_ech0147_import_form"
 msgstr "eCH-0147 Import"
 
 #. Default: "Export"
-#: ./opengever/ech0147/browser/export.py:135
+#: ./opengever/ech0147/browser/export.py
 msgid "label_export"
 msgstr "Exportiern"
 
 #. Default: "Exported as eCH-0147 message"
-#: ./opengever/ech0147/browser/export.py:162
+#: ./opengever/ech0147/browser/export.py
 msgid "label_exported_as_ech0147"
 msgstr "Als eCH-0147 Nachricht exportiert"
 
 #. Default: "Import"
-#: ./opengever/ech0147/browser/import.py:48
+#: ./opengever/ech0147/browser/import.py
 msgid "label_import"
 msgstr "Importieren"
 
 #. Default: "File"
-#: ./opengever/ech0147/browser/import.py:25
+#: ./opengever/ech0147/browser/import.py
 msgid "label_message"
 msgstr "Datei"
 
 #. Default: "Paths"
-#: ./opengever/ech0147/browser/export.py:108
+#: ./opengever/ech0147/browser/export.py
 msgid "label_paths"
 msgstr "Pfade"
 
 #. Default: "Priority"
-#: ./opengever/ech0147/browser/export.py:90
+#: ./opengever/ech0147/browser/export.py
 msgid "label_priority"
 msgstr "Priorität"
 
 #. Default: "Recipient(s)"
-#: ./opengever/ech0147/browser/export.py:30
+#: ./opengever/ech0147/browser/export.py
 msgid "label_recipients"
 msgstr "Empfänger"
 
 #. Default: "Responsible"
-#: ./opengever/ech0147/browser/import.py:34
+#: ./opengever/ech0147/browser/import.py
 msgid "label_reponsible"
 msgstr "Federführend"
 
 #. Default: "Subject"
-#: ./opengever/ech0147/browser/export.py:54
+#: ./opengever/ech0147/browser/export.py
 msgid "label_subject"
 msgstr "Betreff"
 
 #. Default: "new"
-#: ./opengever/ech0147/browser/export.py:42
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_1"
 msgstr "neu"
 
 #. Default: "forwarding"
-#: ./opengever/ech0147/browser/export.py:48
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_10"
 msgstr "Weiterleitung"
 
 #. Default: "reminder"
-#: ./opengever/ech0147/browser/export.py:49
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_12"
 msgstr "Mahnung"
 
 #. Default: "revocation"
-#: ./opengever/ech0147/browser/export.py:43
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_3"
 msgstr "Widerruf"
 
 #. Default: "correction"
-#: ./opengever/ech0147/browser/export.py:44
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_4"
 msgstr "Korrektur"
 
 #. Default: "inquiry"
-#: ./opengever/ech0147/browser/export.py:45
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_5"
 msgstr "Anfrage"
 
 #. Default: "response"
-#: ./opengever/ech0147/browser/export.py:46
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_6"
 msgstr "Antwort"
 
 #. Default: "key exchange"
-#: ./opengever/ech0147/browser/export.py:47
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_7"
 msgstr "Schlüsselaustausch"
 
 #. Default: "approve"
-#: ./opengever/ech0147/browser/export.py:78
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_approve"
 msgstr "zur Genehmigung"
 
 #. Default: "comment"
-#: ./opengever/ech0147/browser/export.py:76
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_comment"
 msgstr "zur Stellungnahme"
 
 #. Default: "complete"
-#: ./opengever/ech0147/browser/export.py:84
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_complete"
 msgstr "zum Abschliessen"
 
 #. Default: "external process"
-#: ./opengever/ech0147/browser/export.py:70
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_external_process"
 msgstr "Externe Bearbeitung"
 
 #. Default: "informationrocess"
-#: ./opengever/ech0147/browser/export.py:73
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_information"
 msgstr "zur Kenntnis"
 
 #. Default: "process"
-#: ./opengever/ech0147/browser/export.py:68
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_process"
 msgstr "zur Bearbeitung"
 
 #. Default: "send"
-#: ./opengever/ech0147/browser/export.py:82
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_send"
 msgstr "zum Versand"
 
 #. Default: "sign"
-#: ./opengever/ech0147/browser/export.py:80
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_sign"
 msgstr "zum Visieren"
 
 #. Default: "high"
-#: ./opengever/ech0147/browser/export.py:97
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_high"
 msgstr "hoch"
 
 #. Default: "medium"
-#: ./opengever/ech0147/browser/export.py:95
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_medium"
 msgstr "mittel"
 
 #. Default: "undefined"
-#: ./opengever/ech0147/browser/export.py:93
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_undefined"
 msgstr "nicht zugewiesen"
 

--- a/opengever/ech0147/locales/fr/LC_MESSAGES/opengever.ech0147.po
+++ b/opengever/ech0147/locales/fr/LC_MESSAGES/opengever.ech0147.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-08 09:48+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,218 +14,218 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/ech0147/browser/import.py:60
+#: ./opengever/ech0147/browser/import.py
 msgid "Invalid message. Missing message.xml"
 msgstr ""
 
-#: ./opengever/ech0147/browser/import.py:86
+#: ./opengever/ech0147/browser/import.py
 msgid "Message has been imported"
 msgstr ""
 
-#: ./opengever/ech0147/browser/import.py:82
+#: ./opengever/ech0147/browser/import.py
 msgid "Message import failed. ${details}"
 msgstr ""
 
-#: ./opengever/ech0147/browser/import.py:67
+#: ./opengever/ech0147/browser/import.py
 msgid "Messages containing toplevel dossiers and toplevel documents are not supported"
 msgstr ""
 
-#: ./opengever/ech0147/browser/export.py:40
+#: ./opengever/ech0147/browser/export.py
 msgid "help_action"
 msgstr ""
 
-#: ./opengever/ech0147/browser/export.py:65
+#: ./opengever/ech0147/browser/export.py
 msgid "help_directive"
 msgstr ""
 
 #. Default: "A ZIP file containing an eCH-147 message."
-#: ./opengever/ech0147/browser/import.py:26
+#: ./opengever/ech0147/browser/import.py
 msgid "help_message"
 msgstr ""
 
 #. Default: "Recipients of the message. Enter one recipient per line."
-#: ./opengever/ech0147/browser/export.py:31
+#: ./opengever/ech0147/browser/export.py
 msgid "help_recipients"
 msgstr ""
 
 #. Default: "Responsible for dossiers created by eCH-0147 import."
-#: ./opengever/ech0147/browser/import.py:35
+#: ./opengever/ech0147/browser/import.py
 msgid "help_responsible"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/ech0147/browser/export.py:39
+#: ./opengever/ech0147/browser/export.py
 msgid "label_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/ech0147/browser/export.py:190
-#: ./opengever/ech0147/browser/import.py:89
+#: ./opengever/ech0147/browser/export.py
+#: ./opengever/ech0147/browser/import.py
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/ech0147/browser/export.py:59
+#: ./opengever/ech0147/browser/export.py
 msgid "label_comment"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/ech0147/browser/export.py:102
+#: ./opengever/ech0147/browser/export.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Directive"
-#: ./opengever/ech0147/browser/export.py:64
+#: ./opengever/ech0147/browser/export.py
 msgid "label_directive"
 msgstr ""
 
 #. Default: "eCH 0147 Export"
-#: ./opengever/ech0147/browser/export.py:131
+#: ./opengever/ech0147/browser/export.py
 msgid "label_ech0147_export_form"
 msgstr ""
 
 #. Default: "eCH 0147 Import"
-#: ./opengever/ech0147/browser/import.py:46
+#: ./opengever/ech0147/browser/import.py
 msgid "label_ech0147_import_form"
 msgstr ""
 
 #. Default: "Export"
-#: ./opengever/ech0147/browser/export.py:135
+#: ./opengever/ech0147/browser/export.py
 msgid "label_export"
 msgstr ""
 
 #. Default: "Exported as eCH-0147 message"
-#: ./opengever/ech0147/browser/export.py:162
+#: ./opengever/ech0147/browser/export.py
 msgid "label_exported_as_ech0147"
 msgstr ""
 
 #. Default: "Import"
-#: ./opengever/ech0147/browser/import.py:48
+#: ./opengever/ech0147/browser/import.py
 msgid "label_import"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/ech0147/browser/import.py:25
+#: ./opengever/ech0147/browser/import.py
 msgid "label_message"
 msgstr ""
 
 #. Default: "Paths"
-#: ./opengever/ech0147/browser/export.py:108
+#: ./opengever/ech0147/browser/export.py
 msgid "label_paths"
 msgstr ""
 
 #. Default: "Priority"
-#: ./opengever/ech0147/browser/export.py:90
+#: ./opengever/ech0147/browser/export.py
 msgid "label_priority"
 msgstr ""
 
 #. Default: "Recipient(s)"
-#: ./opengever/ech0147/browser/export.py:30
+#: ./opengever/ech0147/browser/export.py
 msgid "label_recipients"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/ech0147/browser/import.py:34
+#: ./opengever/ech0147/browser/import.py
 msgid "label_reponsible"
 msgstr ""
 
 #. Default: "Subject"
-#: ./opengever/ech0147/browser/export.py:54
+#: ./opengever/ech0147/browser/export.py
 msgid "label_subject"
 msgstr ""
 
 #. Default: "new"
-#: ./opengever/ech0147/browser/export.py:42
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_1"
 msgstr ""
 
 #. Default: "forwarding"
-#: ./opengever/ech0147/browser/export.py:48
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_10"
 msgstr ""
 
 #. Default: "reminder"
-#: ./opengever/ech0147/browser/export.py:49
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_12"
 msgstr ""
 
 #. Default: "revocation"
-#: ./opengever/ech0147/browser/export.py:43
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_3"
 msgstr ""
 
 #. Default: "correction"
-#: ./opengever/ech0147/browser/export.py:44
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_4"
 msgstr ""
 
 #. Default: "inquiry"
-#: ./opengever/ech0147/browser/export.py:45
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_5"
 msgstr ""
 
 #. Default: "response"
-#: ./opengever/ech0147/browser/export.py:46
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_6"
 msgstr ""
 
 #. Default: "key exchange"
-#: ./opengever/ech0147/browser/export.py:47
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_7"
 msgstr ""
 
 #. Default: "approve"
-#: ./opengever/ech0147/browser/export.py:78
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_approve"
 msgstr ""
 
 #. Default: "comment"
-#: ./opengever/ech0147/browser/export.py:76
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_comment"
 msgstr ""
 
 #. Default: "complete"
-#: ./opengever/ech0147/browser/export.py:84
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_complete"
 msgstr ""
 
 #. Default: "external process"
-#: ./opengever/ech0147/browser/export.py:70
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_external_process"
 msgstr ""
 
 #. Default: "informationrocess"
-#: ./opengever/ech0147/browser/export.py:73
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_information"
 msgstr ""
 
 #. Default: "process"
-#: ./opengever/ech0147/browser/export.py:68
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_process"
 msgstr ""
 
 #. Default: "send"
-#: ./opengever/ech0147/browser/export.py:82
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_send"
 msgstr ""
 
 #. Default: "sign"
-#: ./opengever/ech0147/browser/export.py:80
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_sign"
 msgstr ""
 
 #. Default: "high"
-#: ./opengever/ech0147/browser/export.py:97
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_high"
 msgstr ""
 
 #. Default: "medium"
-#: ./opengever/ech0147/browser/export.py:95
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_medium"
 msgstr ""
 
 #. Default: "undefined"
-#: ./opengever/ech0147/browser/export.py:93
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_undefined"
 msgstr ""
 

--- a/opengever/ech0147/locales/opengever.ech0147.pot
+++ b/opengever/ech0147/locales/opengever.ech0147.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-08 09:48+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,218 +17,218 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.ech0147\n"
 
-#: ./opengever/ech0147/browser/import.py:60
+#: ./opengever/ech0147/browser/import.py
 msgid "Invalid message. Missing message.xml"
 msgstr ""
 
-#: ./opengever/ech0147/browser/import.py:86
+#: ./opengever/ech0147/browser/import.py
 msgid "Message has been imported"
 msgstr ""
 
-#: ./opengever/ech0147/browser/import.py:82
+#: ./opengever/ech0147/browser/import.py
 msgid "Message import failed. ${details}"
 msgstr ""
 
-#: ./opengever/ech0147/browser/import.py:67
+#: ./opengever/ech0147/browser/import.py
 msgid "Messages containing toplevel dossiers and toplevel documents are not supported"
 msgstr ""
 
-#: ./opengever/ech0147/browser/export.py:40
+#: ./opengever/ech0147/browser/export.py
 msgid "help_action"
 msgstr ""
 
-#: ./opengever/ech0147/browser/export.py:65
+#: ./opengever/ech0147/browser/export.py
 msgid "help_directive"
 msgstr ""
 
 #. Default: "A ZIP file containing an eCH-147 message."
-#: ./opengever/ech0147/browser/import.py:26
+#: ./opengever/ech0147/browser/import.py
 msgid "help_message"
 msgstr ""
 
 #. Default: "Recipients of the message. Enter one recipient per line."
-#: ./opengever/ech0147/browser/export.py:31
+#: ./opengever/ech0147/browser/export.py
 msgid "help_recipients"
 msgstr ""
 
 #. Default: "Responsible for dossiers created by eCH-0147 import."
-#: ./opengever/ech0147/browser/import.py:35
+#: ./opengever/ech0147/browser/import.py
 msgid "help_responsible"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/ech0147/browser/export.py:39
+#: ./opengever/ech0147/browser/export.py
 msgid "label_action"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/ech0147/browser/export.py:190
-#: ./opengever/ech0147/browser/import.py:89
+#: ./opengever/ech0147/browser/export.py
+#: ./opengever/ech0147/browser/import.py
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/ech0147/browser/export.py:59
+#: ./opengever/ech0147/browser/export.py
 msgid "label_comment"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/ech0147/browser/export.py:102
+#: ./opengever/ech0147/browser/export.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Directive"
-#: ./opengever/ech0147/browser/export.py:64
+#: ./opengever/ech0147/browser/export.py
 msgid "label_directive"
 msgstr ""
 
 #. Default: "eCH 0147 Export"
-#: ./opengever/ech0147/browser/export.py:131
+#: ./opengever/ech0147/browser/export.py
 msgid "label_ech0147_export_form"
 msgstr ""
 
 #. Default: "eCH 0147 Import"
-#: ./opengever/ech0147/browser/import.py:46
+#: ./opengever/ech0147/browser/import.py
 msgid "label_ech0147_import_form"
 msgstr ""
 
 #. Default: "Export"
-#: ./opengever/ech0147/browser/export.py:135
+#: ./opengever/ech0147/browser/export.py
 msgid "label_export"
 msgstr ""
 
 #. Default: "Exported as eCH-0147 message"
-#: ./opengever/ech0147/browser/export.py:162
+#: ./opengever/ech0147/browser/export.py
 msgid "label_exported_as_ech0147"
 msgstr ""
 
 #. Default: "Import"
-#: ./opengever/ech0147/browser/import.py:48
+#: ./opengever/ech0147/browser/import.py
 msgid "label_import"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/ech0147/browser/import.py:25
+#: ./opengever/ech0147/browser/import.py
 msgid "label_message"
 msgstr ""
 
 #. Default: "Paths"
-#: ./opengever/ech0147/browser/export.py:108
+#: ./opengever/ech0147/browser/export.py
 msgid "label_paths"
 msgstr ""
 
 #. Default: "Priority"
-#: ./opengever/ech0147/browser/export.py:90
+#: ./opengever/ech0147/browser/export.py
 msgid "label_priority"
 msgstr ""
 
 #. Default: "Recipient(s)"
-#: ./opengever/ech0147/browser/export.py:30
+#: ./opengever/ech0147/browser/export.py
 msgid "label_recipients"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/ech0147/browser/import.py:34
+#: ./opengever/ech0147/browser/import.py
 msgid "label_reponsible"
 msgstr ""
 
 #. Default: "Subject"
-#: ./opengever/ech0147/browser/export.py:54
+#: ./opengever/ech0147/browser/export.py
 msgid "label_subject"
 msgstr ""
 
 #. Default: "new"
-#: ./opengever/ech0147/browser/export.py:42
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_1"
 msgstr ""
 
 #. Default: "forwarding"
-#: ./opengever/ech0147/browser/export.py:48
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_10"
 msgstr ""
 
 #. Default: "reminder"
-#: ./opengever/ech0147/browser/export.py:49
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_12"
 msgstr ""
 
 #. Default: "revocation"
-#: ./opengever/ech0147/browser/export.py:43
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_3"
 msgstr ""
 
 #. Default: "correction"
-#: ./opengever/ech0147/browser/export.py:44
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_4"
 msgstr ""
 
 #. Default: "inquiry"
-#: ./opengever/ech0147/browser/export.py:45
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_5"
 msgstr ""
 
 #. Default: "response"
-#: ./opengever/ech0147/browser/export.py:46
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_6"
 msgstr ""
 
 #. Default: "key exchange"
-#: ./opengever/ech0147/browser/export.py:47
+#: ./opengever/ech0147/browser/export.py
 msgid "term_action_7"
 msgstr ""
 
 #. Default: "approve"
-#: ./opengever/ech0147/browser/export.py:78
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_approve"
 msgstr ""
 
 #. Default: "comment"
-#: ./opengever/ech0147/browser/export.py:76
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_comment"
 msgstr ""
 
 #. Default: "complete"
-#: ./opengever/ech0147/browser/export.py:84
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_complete"
 msgstr ""
 
 #. Default: "external process"
-#: ./opengever/ech0147/browser/export.py:70
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_external_process"
 msgstr ""
 
 #. Default: "informationrocess"
-#: ./opengever/ech0147/browser/export.py:73
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_information"
 msgstr ""
 
 #. Default: "process"
-#: ./opengever/ech0147/browser/export.py:68
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_process"
 msgstr ""
 
 #. Default: "send"
-#: ./opengever/ech0147/browser/export.py:82
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_send"
 msgstr ""
 
 #. Default: "sign"
-#: ./opengever/ech0147/browser/export.py:80
+#: ./opengever/ech0147/browser/export.py
 msgid "term_directive_sign"
 msgstr ""
 
 #. Default: "high"
-#: ./opengever/ech0147/browser/export.py:97
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_high"
 msgstr ""
 
 #. Default: "medium"
-#: ./opengever/ech0147/browser/export.py:95
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_medium"
 msgstr ""
 
 #. Default: "undefined"
-#: ./opengever/ech0147/browser/export.py:93
+#: ./opengever/ech0147/browser/export.py
 msgid "term_priority_undefined"
 msgstr ""
 

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: de\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/globalindex/browser/report.py:94
+#: ./opengever/globalindex/browser/report.py
 msgid "Could not generate the report."
 msgstr "Aufgaben-Export konnte nicht erstellt werden."
 
@@ -25,60 +25,61 @@ msgid "Export selection"
 msgstr "Auswahl exportieren"
 
 #. Default: "You have not selected any items."
-#: ./opengever/globalindex/browser/report.py:49
+#: ./opengever/globalindex/browser/report.py
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:23
+#: ./opengever/globalindex/browser/report.py
 msgid "forwarding_task_type"
 msgstr "Weiterleitung"
 
-#: ./opengever/globalindex/browser/report.py:77
+#: ./opengever/globalindex/browser/report.py
 msgid "label_admin_unit_id"
 msgstr "Verwaltungseinheit"
 
-#: ./opengever/globalindex/browser/report.py:66
+#: ./opengever/globalindex/browser/report.py
 msgid "label_completed"
 msgstr "Erledigt am"
 
-#: ./opengever/globalindex/browser/report.py:64
+#: ./opengever/globalindex/browser/report.py
 msgid "label_deadline"
 msgstr "Frist"
 
-#: ./opengever/globalindex/browser/report.py:68
+#: ./opengever/globalindex/browser/report.py
 msgid "label_dossier_title"
 msgstr "Dossier-Titel"
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
-#: ./opengever/globalindex/browser/report.py:72
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
 msgstr "Auftraggeber Mandant"
 
-#: ./opengever/globalindex/browser/report.py:73
+#: ./opengever/globalindex/browser/report.py
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
-#: ./opengever/globalindex/browser/report.py:78
+#: ./opengever/globalindex/browser/report.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
-#: ./opengever/globalindex/browser/report.py:60
+#: ./opengever/globalindex/browser/report.py
 msgid "label_task_title"
 msgstr "Aufgabentitel"
 
-#: ./opengever/globalindex/browser/report.py:75
+#: ./opengever/globalindex/browser/report.py
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:86
+#: ./opengever/globalindex/browser/report.py
 msgid "label_tasks"
 msgstr "Tasks"
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py
 msgid "review_state"
 msgstr "Status"
+

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-06-04 12:57+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/fr/>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/globalindex/browser/report.py:94
+#: ./opengever/globalindex/browser/report.py
 msgid "Could not generate the report."
 msgstr "Impossible de générer l'export de tâches."
 
@@ -25,61 +25,61 @@ msgid "Export selection"
 msgstr "Exporter le choix"
 
 #. Default: "You have not selected any items."
-#: ./opengever/globalindex/browser/report.py:49
+#: ./opengever/globalindex/browser/report.py
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun élément."
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:23
+#: ./opengever/globalindex/browser/report.py
 msgid "forwarding_task_type"
 msgstr "Transmission"
 
-#: ./opengever/globalindex/browser/report.py:77
+#: ./opengever/globalindex/browser/report.py
 msgid "label_admin_unit_id"
 msgstr "Unité administrative"
 
-#: ./opengever/globalindex/browser/report.py:66
+#: ./opengever/globalindex/browser/report.py
 msgid "label_completed"
 msgstr "Accompli le"
 
-#: ./opengever/globalindex/browser/report.py:64
+#: ./opengever/globalindex/browser/report.py
 msgid "label_deadline"
 msgstr "Délai"
 
-#: ./opengever/globalindex/browser/report.py:68
+#: ./opengever/globalindex/browser/report.py
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
 msgstr "Mandataire"
 
-#: ./opengever/globalindex/browser/report.py:72
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
 msgstr "Donneur d'ordre / mandant"
 
-#: ./opengever/globalindex/browser/report.py:73
+#: ./opengever/globalindex/browser/report.py
 msgid "label_responsible"
 msgstr "Mandataire"
 
-#: ./opengever/globalindex/browser/report.py:78
+#: ./opengever/globalindex/browser/report.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
-#: ./opengever/globalindex/browser/report.py:60
+#: ./opengever/globalindex/browser/report.py
 msgid "label_task_title"
 msgstr "Titre de tâche"
 
-#: ./opengever/globalindex/browser/report.py:75
+#: ./opengever/globalindex/browser/report.py
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:86
+#: ./opengever/globalindex/browser/report.py
 msgid "label_tasks"
 msgstr "Mandats"
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py
 msgid "review_state"
 msgstr "Etat"
 

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.globalindex\n"
 
-#: ./opengever/globalindex/browser/report.py:94
+#: ./opengever/globalindex/browser/report.py
 msgid "Could not generate the report."
 msgstr ""
 
@@ -26,61 +26,61 @@ msgid "Export selection"
 msgstr ""
 
 #. Default: "You have not selected any items."
-#: ./opengever/globalindex/browser/report.py:49
+#: ./opengever/globalindex/browser/report.py
 msgid "error_no_items"
 msgstr ""
 
 #. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py:23
+#: ./opengever/globalindex/browser/report.py
 msgid "forwarding_task_type"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:77
+#: ./opengever/globalindex/browser/report.py
 msgid "label_admin_unit_id"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:66
+#: ./opengever/globalindex/browser/report.py
 msgid "label_completed"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:64
+#: ./opengever/globalindex/browser/report.py
 msgid "label_deadline"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:68
+#: ./opengever/globalindex/browser/report.py
 msgid "label_dossier_title"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:69
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:72
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:73
+#: ./opengever/globalindex/browser/report.py
 msgid "label_responsible"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:78
+#: ./opengever/globalindex/browser/report.py
 msgid "label_sequence_number"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:60
+#: ./opengever/globalindex/browser/report.py
 msgid "label_task_title"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:75
+#: ./opengever/globalindex/browser/report.py
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/globalindex/browser/report.py:86
+#: ./opengever/globalindex/browser/report.py
 msgid "label_tasks"
 msgstr ""
 
-#: ./opengever/globalindex/browser/report.py:61
+#: ./opengever/globalindex/browser/report.py
 msgid "review_state"
 msgstr ""
 

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2015-03-30 08:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/inbox/browser/overview.py:41
+#: ./opengever/inbox/browser/overview.py
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -27,90 +27,90 @@ msgid "Inbox Container"
 msgstr "Eingangskorb Ordner"
 
 #. Default: "Close"
-#: ./opengever/inbox/browser/close.py:37
+#: ./opengever/inbox/browser/close.py
 msgid "close"
 msgstr "Abschliessen"
 
 #. Default: "Your not allowed to access the inbox of ${current_org_unit}."
-#: ./opengever/inbox/browser/view.py:15
+#: ./opengever/inbox/browser/view.py
 msgid "current_inbox_not_available"
 msgstr "Sie sind nicht dazu berechtigt auf den Eingangskorb der/des ${current_org_unit} zuzugreifen."
 
 #. Default: "Error: Please select at least one document to forward."
-#: ./opengever/inbox/forwarding.py:118
+#: ./opengever/inbox/forwarding.py
 msgid "error_no_document_selected"
 msgstr "Fehler: Bitte wählen Sie mindestens ein Dokument aus das weitergeleitet werden soll."
 
 #. Default: "Common"
-#: ./opengever/inbox/inbox.py:20
+#: ./opengever/inbox/inbox.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Forwarding"
-#: ./opengever/inbox/forwarding.py:89
+#: ./opengever/inbox/forwarding.py
 msgid "forwarding_task_type"
 msgstr "Weiterleitung"
 
-#: ./opengever/inbox/inbox.py:26
+#: ./opengever/inbox/inbox.py
 msgid "help_inbox_group"
 msgstr "Diese Gruppe wird berechtigt, wenn dem Eingangskorb eine Aufgabe zugewiesen wird."
 
-#: ./opengever/inbox/forwarding.py:59
+#: ./opengever/inbox/forwarding.py
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person bzw. den Eingangskorb des oben gewählten Mandanten aus."
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:31
+#: ./opengever/inbox/browser/overview.py
 msgid "label_assigned_inbox_tasks"
 msgstr "Erhaltene Aufgaben"
 
 #. Default: "Forwarding added"
-#: ./opengever/inbox/activities.py:27
+#: ./opengever/inbox/activities.py
 msgid "label_forwarding_added"
 msgstr "Weiterleitung hinzugefügt"
 
 #. Default: "Inbox Group"
-#: ./opengever/inbox/inbox.py:25
+#: ./opengever/inbox/inbox.py
 msgid "label_inbox_group"
 msgstr "Eingangskorb Gruppe"
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:36
+#: ./opengever/inbox/browser/overview.py
 msgid "label_issued_inbox_tasks"
 msgstr "Erteilte Aufgaben"
 
 #. Default: "Refuse"
-#: ./opengever/inbox/browser/refuse.py:39
+#: ./opengever/inbox/browser/refuse.py
 msgid "label_refuse"
 msgstr "Ablehnen"
 
 #. Default: "Refuse Forwarding"
-#: ./opengever/inbox/browser/refuse.py:36
+#: ./opengever/inbox/browser/refuse.py
 msgid "label_refuse_forwarding"
 msgstr "Weiterleitung ablehnen"
 
 #. Default: "Responsible"
-#: ./opengever/inbox/forwarding.py:58
+#: ./opengever/inbox/forwarding.py
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
 #. Default: "New forwarding added by ${user}"
-#: ./opengever/inbox/activities.py:20
+#: ./opengever/inbox/activities.py
 msgid "msg_forwarding_added"
 msgstr "Neue Weiterleitung hinzugefügt durch ${user}"
 
 #. Default: "Assign Forwarding"
-#: ./opengever/inbox/browser/assign.py:39
+#: ./opengever/inbox/browser/assign.py
 msgid "title_assign_forwarding"
 msgstr "Weiterleitung weiterleiten"
 
 #. Default: "Close orwarding"
-#: ./opengever/inbox/browser/close.py:35
+#: ./opengever/inbox/browser/close.py
 msgid "title_close_forwarding"
 msgstr "Weiterleitung abschliessen"
 
 #. Default: "Closed ${year}"
-#: ./opengever/inbox/yearfolder.py:39
+#: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
 msgstr "Abgeschlossen ${year}"
 

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2016-08-10 04:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-inbox/fr/>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/inbox/browser/overview.py:41
+#: ./opengever/inbox/browser/overview.py
 msgid "Documents"
 msgstr "Documents"
 
@@ -29,90 +29,90 @@ msgid "Inbox Container"
 msgstr "Conteneur de la boîte de réception"
 
 #. Default: "Close"
-#: ./opengever/inbox/browser/close.py:37
+#: ./opengever/inbox/browser/close.py
 msgid "close"
 msgstr "Fermer"
 
 #. Default: "Your not allowed to access the inbox of ${current_org_unit}."
-#: ./opengever/inbox/browser/view.py:15
+#: ./opengever/inbox/browser/view.py
 msgid "current_inbox_not_available"
 msgstr "Vous n'avez pas accès à la boîte de réception de ${current_org_unit}."
 
 #. Default: "Error: Please select at least one document to forward."
-#: ./opengever/inbox/forwarding.py:118
+#: ./opengever/inbox/forwarding.py
 msgid "error_no_document_selected"
 msgstr "Erreur: Choisissez au minimum un document à transmettre."
 
 #. Default: "Common"
-#: ./opengever/inbox/inbox.py:20
+#: ./opengever/inbox/inbox.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Forwarding"
-#: ./opengever/inbox/forwarding.py:89
+#: ./opengever/inbox/forwarding.py
 msgid "forwarding_task_type"
 msgstr "Transmission"
 
-#: ./opengever/inbox/inbox.py:26
+#: ./opengever/inbox/inbox.py
 msgid "help_inbox_group"
 msgstr "Ce goupe est autorisé, dès qu'une tâche est attribuée à la boîte de réception."
 
-#: ./opengever/inbox/forwarding.py:59
+#: ./opengever/inbox/forwarding.py
 msgid "help_responsible"
 msgstr "Choix de la personne responsable ou la boîte de réception du client mentionné ci-dessus."
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:31
+#: ./opengever/inbox/browser/overview.py
 msgid "label_assigned_inbox_tasks"
 msgstr "Tâches reçues"
 
 #. Default: "Forwarding added"
-#: ./opengever/inbox/activities.py:27
+#: ./opengever/inbox/activities.py
 msgid "label_forwarding_added"
 msgstr "Transmission ajoutée"
 
 #. Default: "Inbox Group"
-#: ./opengever/inbox/inbox.py:25
+#: ./opengever/inbox/inbox.py
 msgid "label_inbox_group"
 msgstr "Boîte de réception Groupe"
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:36
+#: ./opengever/inbox/browser/overview.py
 msgid "label_issued_inbox_tasks"
 msgstr "Tâches attribuées"
 
 #. Default: "Refuse"
-#: ./opengever/inbox/browser/refuse.py:39
+#: ./opengever/inbox/browser/refuse.py
 msgid "label_refuse"
 msgstr "Refuser"
 
 #. Default: "Refuse Forwarding"
-#: ./opengever/inbox/browser/refuse.py:36
+#: ./opengever/inbox/browser/refuse.py
 msgid "label_refuse_forwarding"
 msgstr "Refuser le transfert"
 
 #. Default: "Responsible"
-#: ./opengever/inbox/forwarding.py:58
+#: ./opengever/inbox/forwarding.py
 msgid "label_responsible"
 msgstr "Mandataire"
 
 #. Default: "New forwarding added by ${user}"
-#: ./opengever/inbox/activities.py:20
+#: ./opengever/inbox/activities.py
 msgid "msg_forwarding_added"
 msgstr "Nouvelle transmission ajoutée par ${user}"
 
 #. Default: "Assign Forwarding"
-#: ./opengever/inbox/browser/assign.py:39
+#: ./opengever/inbox/browser/assign.py
 msgid "title_assign_forwarding"
 msgstr "Envoyer le transfert"
 
 #. Default: "Close orwarding"
-#: ./opengever/inbox/browser/close.py:35
+#: ./opengever/inbox/browser/close.py
 msgid "title_close_forwarding"
 msgstr "Fermer le transfert"
 
 #. Default: "Closed ${year}"
-#: ./opengever/inbox/yearfolder.py:39
+#: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
 msgstr "Fermé ${year}"
 

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.inbox\n"
 
-#: ./opengever/inbox/browser/overview.py:41
+#: ./opengever/inbox/browser/overview.py
 msgid "Documents"
 msgstr ""
 
@@ -30,90 +30,90 @@ msgid "Inbox Container"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/inbox/browser/close.py:37
+#: ./opengever/inbox/browser/close.py
 msgid "close"
 msgstr ""
 
 #. Default: "Your not allowed to access the inbox of ${current_org_unit}."
-#: ./opengever/inbox/browser/view.py:15
+#: ./opengever/inbox/browser/view.py
 msgid "current_inbox_not_available"
 msgstr ""
 
 #. Default: "Error: Please select at least one document to forward."
-#: ./opengever/inbox/forwarding.py:118
+#: ./opengever/inbox/forwarding.py
 msgid "error_no_document_selected"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/inbox/inbox.py:20
+#: ./opengever/inbox/inbox.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Forwarding"
-#: ./opengever/inbox/forwarding.py:89
+#: ./opengever/inbox/forwarding.py
 msgid "forwarding_task_type"
 msgstr ""
 
-#: ./opengever/inbox/inbox.py:26
+#: ./opengever/inbox/inbox.py
 msgid "help_inbox_group"
 msgstr ""
 
-#: ./opengever/inbox/forwarding.py:59
+#: ./opengever/inbox/forwarding.py
 msgid "help_responsible"
 msgstr ""
 
 #. Default: "Assigned tasks"
-#: ./opengever/inbox/browser/overview.py:31
+#: ./opengever/inbox/browser/overview.py
 msgid "label_assigned_inbox_tasks"
 msgstr ""
 
 #. Default: "Forwarding added"
-#: ./opengever/inbox/activities.py:27
+#: ./opengever/inbox/activities.py
 msgid "label_forwarding_added"
 msgstr ""
 
 #. Default: "Inbox Group"
-#: ./opengever/inbox/inbox.py:25
+#: ./opengever/inbox/inbox.py
 msgid "label_inbox_group"
 msgstr ""
 
 #. Default: "Issued tasks"
-#: ./opengever/inbox/browser/overview.py:36
+#: ./opengever/inbox/browser/overview.py
 msgid "label_issued_inbox_tasks"
 msgstr ""
 
 #. Default: "Refuse"
-#: ./opengever/inbox/browser/refuse.py:39
+#: ./opengever/inbox/browser/refuse.py
 msgid "label_refuse"
 msgstr ""
 
 #. Default: "Refuse Forwarding"
-#: ./opengever/inbox/browser/refuse.py:36
+#: ./opengever/inbox/browser/refuse.py
 msgid "label_refuse_forwarding"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/inbox/forwarding.py:58
+#: ./opengever/inbox/forwarding.py
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "New forwarding added by ${user}"
-#: ./opengever/inbox/activities.py:20
+#: ./opengever/inbox/activities.py
 msgid "msg_forwarding_added"
 msgstr ""
 
 #. Default: "Assign Forwarding"
-#: ./opengever/inbox/browser/assign.py:39
+#: ./opengever/inbox/browser/assign.py
 msgid "title_assign_forwarding"
 msgstr ""
 
 #. Default: "Close orwarding"
-#: ./opengever/inbox/browser/close.py:35
+#: ./opengever/inbox/browser/close.py
 msgid "title_close_forwarding"
 msgstr ""
 
 #. Default: "Closed ${year}"
-#: ./opengever/inbox/yearfolder.py:39
+#: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
 msgstr ""
 

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-07-03 12:27+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,299 +15,299 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Journal"
-#: ./opengever/journal/templates/journalhistory.pt:15
+#: ./opengever/journal/templates/journalhistory.pt
 msgid "heading_journal"
 msgstr "Journal"
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:83
+#: ./opengever/journal/tab.py
 msgid "label_actor"
 msgstr "Geändert von"
 
 #. Default: "Add journal entry"
-#: ./opengever/journal/form.py:59
-#: ./opengever/journal/templates/journal_selection.pt:2
+#: ./opengever/journal/form.py
+#: ./opengever/journal/templates/journal_selection.pt
 msgid "label_add_journal_entry"
 msgstr "Journaleintrag hinzufügen"
 
 #. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py:336
+#: ./opengever/journal/handlers.py
 msgid "label_attachments_deleted"
 msgstr "Attachments gelöscht: ${filenames}"
 
 #. Default: "Category"
-#: ./opengever/journal/form.py:19
+#: ./opengever/journal/form.py
 msgid "label_category"
 msgstr "Kategorie"
 
 #. Default: "Comment"
-#: ./opengever/journal/form.py:25
+#: ./opengever/journal/form.py
 msgid "label_comment"
 msgstr "Kommentar"
 
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:87
+#: ./opengever/journal/tab.py
 msgid "label_comments"
 msgstr "Kommentare"
 
 #. Default: "Contacts"
-#: ./opengever/journal/form.py:30
-#: ./opengever/journal/templates/journal_references.pt:3
+#: ./opengever/journal/form.py
+#: ./opengever/journal/templates/journal_references.pt
 msgid "label_contacts"
 msgstr "Kontakte"
 
 #. Default: "DocProperties updated."
-#: ./opengever/journal/handlers.py:325
+#: ./opengever/journal/handlers.py
 msgid "label_doc_properties_updated"
 msgstr "DocProperties aktualisiert"
 
 #. Default: "Document added: ${title}"
-#: ./opengever/journal/handlers.py:351
+#: ./opengever/journal/handlers.py
 msgid "label_document_added"
 msgstr "Dokument hinzugefügt: ${title}"
 
 #. Default: "Document attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:806
+#: ./opengever/journal/handlers.py
 msgid "label_document_attached"
 msgstr "Dokument mit Mailprogramm versendet"
 
 #. Default: "Document checked in"
-#: ./opengever/journal/handlers.py:466
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkin"
 msgstr "Dokument eingecheckt"
 
 #. Default: "Document checked out"
-#: ./opengever/journal/handlers.py:453
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkout"
 msgstr "Dokument ausgecheckt"
 
 #. Default: "Canceled document checkout"
-#: ./opengever/journal/handlers.py:478
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkout_cancel"
 msgstr "Änderungen an der Datei widerrufen"
 
 #. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py:403
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_and_metadata_modified"
 msgstr "Datei und Metadaten bearbeitet"
 
 #. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py:406
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_and_metadata_modified__parent"
 msgstr "Datei und Metadaten des Dokuments «${title}» bearbeitet"
 
 #. Default: "Changed file"
-#: ./opengever/journal/handlers.py:415
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_modified"
 msgstr "Datei bearbeitet"
 
 #. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py:417
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_modified__parent"
 msgstr "Datei des Dokuments «${title}» bearbeitet"
 
 #. Default: "Reverte document file to version ${version_id}"
-#: ./opengever/journal/handlers.py:496
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_reverted"
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt"
 
 #. Default: "Document in dossier attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:814
+#: ./opengever/journal/handlers.py
 msgid "label_document_in_dossier_attached"
 msgstr "Dokument im Dossier mit Mailprogramm versendet"
 
 #. Default: "Changed metadata"
-#: ./opengever/journal/handlers.py:425
+#: ./opengever/journal/handlers.py
 msgid "label_document_metadata_modified"
 msgstr "Metadaten bearbeitet"
 
 #. Default: "Changed metadata of document ${title}"
-#: ./opengever/journal/handlers.py:427
+#: ./opengever/journal/handlers.py
 msgid "label_document_metadata_modified__parent"
 msgstr "Metadaten des Dokuments «${title}» bearbeitet"
 
 #. Default: "Public trial changed to \"${public_trial}\"."
-#: ./opengever/journal/handlers.py:440
+#: ./opengever/journal/handlers.py
 msgid "label_document_public_trial_modified"
 msgstr "Öffentlichkeitsstatus geändert nach «${public_trial}»."
 
 #. Default: "Document ${title} removed."
-#: ./opengever/journal/handlers.py:647
+#: ./opengever/journal/handlers.py
 msgid "label_document_removed"
 msgstr "Dokument ${title} gelöscht."
 
 #. Default: "Document ${title} restored."
-#: ./opengever/journal/handlers.py:664
+#: ./opengever/journal/handlers.py
 msgid "label_document_restored"
 msgstr "Dokument ${title} wiederhergestellt."
 
 #. Default: "Document sent by Mail: ${subject}"
-#: ./opengever/journal/handlers.py:548
+#: ./opengever/journal/handlers.py
 msgid "label_document_sent"
 msgstr "Dokumentversand per E-Mail: ${subject}"
 
 #. Default: "Attachments: ${documents} | Receivers: ${receiver} | Message: ${message}"
-#: ./opengever/journal/handlers.py:553
+#: ./opengever/journal/handlers.py
 msgid "label_document_sent_comment"
 msgstr "Anhänge: ${documents} | Empfänger: ${receiver} | Nachricht: ${message}"
 
 #. Default: "Document included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:782
+#: ./opengever/journal/handlers.py
 msgid "label_document_zipped"
 msgstr "Dokument in ZIP-Export aufgenommen: ${title}"
 
 #. Default: "Documents"
-#: ./opengever/journal/templates/journal_references.pt:17
+#: ./opengever/journal/templates/journal_references.pt
 msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Dossier added: ${title}"
-#: ./opengever/journal/handlers.py:227
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_added"
 msgstr "Dossier hinzugefügt: ${title}"
 
 #. Default: "Dossier modified: ${title}"
-#: ./opengever/journal/handlers.py:240
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_modified"
 msgstr "Dossier modifiziert: ${title}"
 
 #. Default: "Dossier included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:769
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_zipped"
 msgstr "Dossier in ZIP-Export aufgenommen: ${title}"
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:520
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded"
 msgstr "Download Kopie"
 
 #. Default: "current version (${version_id})"
-#: ./opengever/journal/handlers.py:513
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_actual_version"
 msgstr "aktuelle Version (${version_id})"
 
 #. Default: "version ${version_id}"
-#: ./opengever/journal/handlers.py:516
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_version"
 msgstr "Version ${version_id}"
 
 #. Default: "${title} ${version_string}"
-#: ./opengever/journal/handlers.py:525
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_with_version"
 msgstr "${title} ${version_string}"
 
 #. Default: "Local roles aquistion activated."
-#: ./opengever/journal/handlers.py:296
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_activated"
 msgstr "Vererbung der Berechtigungen aktiviert."
 
 #. Default: "Local roles aquistion activated at ${repository}."
-#: ./opengever/journal/handlers.py:189
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_activated_at"
 msgstr "Vererbung der Berechtigungen aktiviert für ${repository}."
 
 #. Default: "Local roles aquistion blocked."
-#: ./opengever/journal/handlers.py:281
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_blocked"
 msgstr "Vererbung der Berechtigungen unterbrochen."
 
 #. Default: "Local roles aquistion blocked at ${repository}."
-#: ./opengever/journal/handlers.py:171
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_blocked_at"
 msgstr "Vererbung der Berechtigungen für ${repository} unterbrochen."
 
 #. Default: "Local roles modified."
-#: ./opengever/journal/handlers.py:311
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_modified"
 msgstr "Lokale Rollen modifiziert."
 
 #. Default: "Local roles modified at ${repository}."
-#: ./opengever/journal/handlers.py:207
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_modified_at"
 msgstr "Lokale Rollen von ${repository} modifziert."
 
 #. Default: "Manual entry: ${category}"
-#: ./opengever/journal/entry.py:81
+#: ./opengever/journal/entry.py
 msgid "label_manual_journal_entry"
 msgstr "Manueller Eintrag: ${category}"
 
 #. Default: "Object cut: ${title}"
-#: ./opengever/journal/handlers.py:753
+#: ./opengever/journal/handlers.py
 msgid "label_object_cut"
 msgstr "Objekt ausgeschnitten: ${title}"
 
 #. Default: "Object moved: ${title}"
-#: ./opengever/journal/handlers.py:731
+#: ./opengever/journal/handlers.py
 msgid "label_object_moved"
 msgstr "Objekt eingefügt: ${title}"
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
-#: ./opengever/journal/handlers.py:687
+#: ./opengever/journal/handlers.py
 msgid "label_participant_added"
 msgstr "Beteiligung hinzugefügt für ${contact} als ${roles}"
 
 #. Default: "Participant removed: ${contact}"
-#: ./opengever/journal/handlers.py:702
+#: ./opengever/journal/handlers.py
 msgid "label_participant_removed"
 msgstr "Beteiligung von ${contact} entfernt"
 
 #. Default: "PDF downloaded"
-#: ./opengever/journal/handlers.py:517
+#: ./opengever/journal/handlers.py
 msgid "label_pdf_downloaded"
 msgstr "PDF heruntergeladen"
 
 #. Default: "Unlocked prefix ${prefix} in ${repository}."
-#: ./opengever/journal/handlers.py:155
+#: ./opengever/journal/handlers.py
 msgid "label_prefix_unlocked"
 msgstr "Aktenzeichen ${prefix} in ${repository} wurde freigegeben."
 
 #. Default: "References"
-#: ./opengever/journal/tab.py:92
+#: ./opengever/journal/tab.py
 msgid "label_references"
 msgstr "Referenzen"
 
 #. Default: "Related Documents"
-#: ./opengever/journal/form.py:37
+#: ./opengever/journal/form.py
 msgid "label_related_documents"
 msgstr "Dokumentverweise"
 
 #. Default: "Object restored: ${title}"
-#: ./opengever/journal/handlers.py:630
+#: ./opengever/journal/handlers.py
 msgid "label_restore"
 msgstr "Dokument ${title} reaktiviert"
 
 #. Default: "Task added: ${title}"
-#: ./opengever/journal/handlers.py:572
+#: ./opengever/journal/handlers.py
 msgid "label_task_added"
 msgstr "Aufgabe hinzugefügt: ${title}"
 
 #. Default: "Task modified: ${title}"
-#: ./opengever/journal/handlers.py:589
+#: ./opengever/journal/handlers.py
 msgid "label_task_modified"
 msgstr "Aufgabe modifiziert: ${title}"
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:75
+#: ./opengever/journal/tab.py
 msgid "label_time"
 msgstr "Zeitpunkt"
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:79
+#: ./opengever/journal/tab.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Object moved to trash: ${title}"
-#: ./opengever/journal/handlers.py:612
+#: ./opengever/journal/handlers.py
 msgid "label_to_trash"
 msgstr "Dokument ${title} in den Papierkorb verschoben"
 
 #. Default: "Journal"
-#: ./opengever/journal/templates/journalhistory.pt:17
+#: ./opengever/journal/templates/journalhistory.pt
 msgid "summary_journal"
 msgstr "Journal"
 
 #. Default: "${amount} matches"
-#: ./opengever/journal/templates/journal_selection.pt:9
+#: ./opengever/journal/templates/journal_selection.pt
 msgid "tab_matches"
 msgstr "${amount} Treffer"
 

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-03 12:27+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-06-04 12:59+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
@@ -17,299 +17,299 @@ msgstr ""
 "X-Generator: Weblate 2.13.1\n"
 
 #. Default: "Journal"
-#: ./opengever/journal/templates/journalhistory.pt:15
+#: ./opengever/journal/templates/journalhistory.pt
 msgid "heading_journal"
 msgstr "Historique"
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:83
+#: ./opengever/journal/tab.py
 msgid "label_actor"
 msgstr "Modifier par"
 
 #. Default: "Add journal entry"
-#: ./opengever/journal/form.py:59
-#: ./opengever/journal/templates/journal_selection.pt:2
+#: ./opengever/journal/form.py
+#: ./opengever/journal/templates/journal_selection.pt
 msgid "label_add_journal_entry"
 msgstr "Ajouter une entrée de journal"
 
 #. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py:336
+#: ./opengever/journal/handlers.py
 msgid "label_attachments_deleted"
 msgstr "Fichiers attachés effacés: ${filenames}"
 
 #. Default: "Category"
-#: ./opengever/journal/form.py:19
+#: ./opengever/journal/form.py
 msgid "label_category"
 msgstr "Catégorie"
 
 #. Default: "Comment"
-#: ./opengever/journal/form.py:25
+#: ./opengever/journal/form.py
 msgid "label_comment"
 msgstr "commentaire"
 
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:87
+#: ./opengever/journal/tab.py
 msgid "label_comments"
 msgstr "Commentaire"
 
 #. Default: "Contacts"
-#: ./opengever/journal/form.py:30
-#: ./opengever/journal/templates/journal_references.pt:3
+#: ./opengever/journal/form.py
+#: ./opengever/journal/templates/journal_references.pt
 msgid "label_contacts"
 msgstr "Contacts"
 
 #. Default: "DocProperties updated."
-#: ./opengever/journal/handlers.py:325
+#: ./opengever/journal/handlers.py
 msgid "label_doc_properties_updated"
 msgstr "DocProperties actualisé"
 
 #. Default: "Document added: ${title}"
-#: ./opengever/journal/handlers.py:351
+#: ./opengever/journal/handlers.py
 msgid "label_document_added"
 msgstr "Document ajouté: ${title}"
 
 #. Default: "Document attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:806
+#: ./opengever/journal/handlers.py
 msgid "label_document_attached"
 msgstr "Document envoyé par le programme de messagerie"
 
 #. Default: "Document checked in"
-#: ./opengever/journal/handlers.py:466
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkin"
 msgstr "Document avec checkin"
 
 #. Default: "Document checked out"
-#: ./opengever/journal/handlers.py:453
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkout"
 msgstr "Document avec checkout"
 
 #. Default: "Canceled document checkout"
-#: ./opengever/journal/handlers.py:478
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkout_cancel"
 msgstr "Annuler les modification du fichier"
 
 #. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py:403
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_and_metadata_modified"
 msgstr "Fichier et méta-données modifiés"
 
 #. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py:406
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_and_metadata_modified__parent"
 msgstr "Fichier et méta-données du document «${title}» modifiés"
 
 #. Default: "Changed file"
-#: ./opengever/journal/handlers.py:415
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_modified"
 msgstr "Fichier modifié"
 
 #. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py:417
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_modified__parent"
 msgstr "Fichier du document «${title}» modifié"
 
 #. Default: "Reverte document file to version ${version_id}"
-#: ./opengever/journal/handlers.py:496
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_reverted"
 msgstr "Fichier du document remis à la version ${version_id}"
 
 #. Default: "Document in dossier attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:814
+#: ./opengever/journal/handlers.py
 msgid "label_document_in_dossier_attached"
 msgstr "Document du dossier envoyé par le programme de messagerie."
 
 #. Default: "Changed metadata"
-#: ./opengever/journal/handlers.py:425
+#: ./opengever/journal/handlers.py
 msgid "label_document_metadata_modified"
 msgstr "Méta-données modifiées"
 
 #. Default: "Changed metadata of document ${title}"
-#: ./opengever/journal/handlers.py:427
+#: ./opengever/journal/handlers.py
 msgid "label_document_metadata_modified__parent"
 msgstr "Méta-données du document ${title} modifiées"
 
 #. Default: "Public trial changed to \"${public_trial}\"."
-#: ./opengever/journal/handlers.py:440
+#: ./opengever/journal/handlers.py
 msgid "label_document_public_trial_modified"
 msgstr "Statut public modifié en «${public_trial}»."
 
 #. Default: "Document ${title} removed."
-#: ./opengever/journal/handlers.py:647
+#: ./opengever/journal/handlers.py
 msgid "label_document_removed"
 msgstr "Document ${title} effacé."
 
 #. Default: "Document ${title} restored."
-#: ./opengever/journal/handlers.py:664
+#: ./opengever/journal/handlers.py
 msgid "label_document_restored"
 msgstr "Document restoré."
 
 #. Default: "Document sent by Mail: ${subject}"
-#: ./opengever/journal/handlers.py:548
+#: ./opengever/journal/handlers.py
 msgid "label_document_sent"
 msgstr "Envoi de document par Email: ${subject}"
 
 #. Default: "Attachments: ${documents} | Receivers: ${receiver} | Message: ${message}"
-#: ./opengever/journal/handlers.py:553
+#: ./opengever/journal/handlers.py
 msgid "label_document_sent_comment"
 msgstr "Annexes:  ${documents} | Récepteur ${receiver} | Message ${message}"
 
 #. Default: "Document included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:782
+#: ./opengever/journal/handlers.py
 msgid "label_document_zipped"
 msgstr "Document ajouté à l'export ZIP: ${title}"
 
 #. Default: "Documents"
-#: ./opengever/journal/templates/journal_references.pt:17
+#: ./opengever/journal/templates/journal_references.pt
 msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Dossier added: ${title}"
-#: ./opengever/journal/handlers.py:227
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_added"
 msgstr "Dossier ajouté: ${title}"
 
 #. Default: "Dossier modified: ${title}"
-#: ./opengever/journal/handlers.py:240
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_modified"
 msgstr "Dossier modifié: ${title}"
 
 #. Default: "Dossier included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:769
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_zipped"
 msgstr "Dossier ajouté à l'export ZIP: ${title}"
 
 #. Default: "Download copy"
-#: ./opengever/journal/handlers.py:520
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded"
 msgstr "Télécharger une copie"
 
 #. Default: "current version (${version_id})"
-#: ./opengever/journal/handlers.py:513
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_actual_version"
 msgstr "version actuelle (${version_id})"
 
 #. Default: "version ${version_id}"
-#: ./opengever/journal/handlers.py:516
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_version"
 msgstr "version ${version_id}"
 
 #. Default: "${title} ${version_string}"
-#: ./opengever/journal/handlers.py:525
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_with_version"
 msgstr "${title} ${version_string}"
 
 #. Default: "Local roles aquistion activated."
-#: ./opengever/journal/handlers.py:296
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_activated"
 msgstr "Héritage des droits d'accès activé."
 
 #. Default: "Local roles aquistion activated at ${repository}."
-#: ./opengever/journal/handlers.py:189
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_activated_at"
 msgstr "Héritage des droits d'accès activé pour  ${repository}."
 
 #. Default: "Local roles aquistion blocked."
-#: ./opengever/journal/handlers.py:281
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_blocked"
 msgstr "Héritage des droits d'accès désactivé."
 
 #. Default: "Local roles aquistion blocked at ${repository}."
-#: ./opengever/journal/handlers.py:171
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_blocked_at"
 msgstr "Héritage des droits d'accès désactivé pour  ${repository}."
 
 #. Default: "Local roles modified."
-#: ./opengever/journal/handlers.py:311
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_modified"
 msgstr "Rôles à l'intérne modifiés."
 
 #. Default: "Local roles modified at ${repository}."
-#: ./opengever/journal/handlers.py:207
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_modified_at"
 msgstr "Rôles à l'intérne pour ${repository} modifiés."
 
 #. Default: "Manual entry: ${category}"
-#: ./opengever/journal/entry.py:81
+#: ./opengever/journal/entry.py
 msgid "label_manual_journal_entry"
 msgstr "Entrée manuelle: ${category}"
 
 #. Default: "Object cut: ${title}"
-#: ./opengever/journal/handlers.py:753
+#: ./opengever/journal/handlers.py
 msgid "label_object_cut"
 msgstr "Objet coupé: ${title}"
 
 #. Default: "Object moved: ${title}"
-#: ./opengever/journal/handlers.py:731
+#: ./opengever/journal/handlers.py
 msgid "label_object_moved"
 msgstr "Objet collé: ${title}"
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
-#: ./opengever/journal/handlers.py:687
+#: ./opengever/journal/handlers.py
 msgid "label_participant_added"
 msgstr "Participation ajoutée pour ${contact} comme ${roles}"
 
 #. Default: "Participant removed: ${contact}"
-#: ./opengever/journal/handlers.py:702
+#: ./opengever/journal/handlers.py
 msgid "label_participant_removed"
 msgstr "Participation de ${contact} enlevée"
 
 #. Default: "PDF downloaded"
-#: ./opengever/journal/handlers.py:517
+#: ./opengever/journal/handlers.py
 msgid "label_pdf_downloaded"
 msgstr "Télécharger le PDF"
 
 #. Default: "Unlocked prefix ${prefix} in ${repository}."
-#: ./opengever/journal/handlers.py:155
+#: ./opengever/journal/handlers.py
 msgid "label_prefix_unlocked"
 msgstr "Référence ${prefix} dans ${repository} a été débloqué."
 
 #. Default: "References"
-#: ./opengever/journal/tab.py:92
+#: ./opengever/journal/tab.py
 msgid "label_references"
 msgstr "Références"
 
 #. Default: "Related Documents"
-#: ./opengever/journal/form.py:37
+#: ./opengever/journal/form.py
 msgid "label_related_documents"
 msgstr "Références documentaires"
 
 #. Default: "Object restored: ${title}"
-#: ./opengever/journal/handlers.py:630
+#: ./opengever/journal/handlers.py
 msgid "label_restore"
 msgstr "Objet restauré: ${title}"
 
 #. Default: "Task added: ${title}"
-#: ./opengever/journal/handlers.py:572
+#: ./opengever/journal/handlers.py
 msgid "label_task_added"
 msgstr "Tâche ajoutée: ${title}"
 
 #. Default: "Task modified: ${title}"
-#: ./opengever/journal/handlers.py:589
+#: ./opengever/journal/handlers.py
 msgid "label_task_modified"
 msgstr "Tâche modifiée: ${title}"
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:75
+#: ./opengever/journal/tab.py
 msgid "label_time"
 msgstr "Date"
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:79
+#: ./opengever/journal/tab.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Object moved to trash: ${title}"
-#: ./opengever/journal/handlers.py:612
+#: ./opengever/journal/handlers.py
 msgid "label_to_trash"
 msgstr "Objet effacé: ${title}"
 
 #. Default: "Journal"
-#: ./opengever/journal/templates/journalhistory.pt:17
+#: ./opengever/journal/templates/journalhistory.pt
 msgid "summary_journal"
 msgstr "Historique"
 
 #. Default: "${amount} matches"
-#: ./opengever/journal/templates/journal_selection.pt:9
+#: ./opengever/journal/templates/journal_selection.pt
 msgid "tab_matches"
 msgstr "Résultat(s): ${amount}"
 

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-03 12:27+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,299 +17,300 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.journal\n"
 
-#: ./opengever/journal/handlers.py:513
-msgid "label_file_copy_downloaded"
-msgstr ""
-
 #. Default: "Journal"
-#: ./opengever/journal/templates/journalhistory.pt:15
+#: ./opengever/journal/templates/journalhistory.pt
 msgid "heading_journal"
 msgstr ""
 
 #. Default: "Changed by"
-#: ./opengever/journal/tab.py:83
+#: ./opengever/journal/tab.py
 msgid "label_actor"
 msgstr ""
 
 #. Default: "Add journal entry"
-#: ./opengever/journal/form.py:59
-#: ./opengever/journal/templates/journal_selection.pt:2
+#: ./opengever/journal/form.py
+#: ./opengever/journal/templates/journal_selection.pt
 msgid "label_add_journal_entry"
 msgstr ""
 
 #. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py:336
+#: ./opengever/journal/handlers.py
 msgid "label_attachments_deleted"
 msgstr ""
 
 #. Default: "Category"
-#: ./opengever/journal/form.py:19
+#: ./opengever/journal/form.py
 msgid "label_category"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/journal/form.py:25
+#: ./opengever/journal/form.py
 msgid "label_comment"
 msgstr ""
 
 #. Default: "Comments"
-#: ./opengever/journal/tab.py:87
+#: ./opengever/journal/tab.py
 msgid "label_comments"
 msgstr ""
 
 #. Default: "Contacts"
-#: ./opengever/journal/form.py:30
-#: ./opengever/journal/templates/journal_references.pt:3
+#: ./opengever/journal/form.py
+#: ./opengever/journal/templates/journal_references.pt
 msgid "label_contacts"
 msgstr ""
 
 #. Default: "DocProperties updated."
-#: ./opengever/journal/handlers.py:325
+#: ./opengever/journal/handlers.py
 msgid "label_doc_properties_updated"
 msgstr ""
 
 #. Default: "Document added: ${title}"
-#: ./opengever/journal/handlers.py:351
+#: ./opengever/journal/handlers.py
 msgid "label_document_added"
 msgstr ""
 
 #. Default: "Document attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:806
+#: ./opengever/journal/handlers.py
 msgid "label_document_attached"
 msgstr ""
 
 #. Default: "Document checked in"
-#: ./opengever/journal/handlers.py:466
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkin"
 msgstr ""
 
 #. Default: "Document checked out"
-#: ./opengever/journal/handlers.py:453
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkout"
 msgstr ""
 
 #. Default: "Canceled document checkout"
-#: ./opengever/journal/handlers.py:478
+#: ./opengever/journal/handlers.py
 msgid "label_document_checkout_cancel"
 msgstr ""
 
 #. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py:403
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_and_metadata_modified"
 msgstr ""
 
 #. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py:406
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_and_metadata_modified__parent"
 msgstr ""
 
 #. Default: "Changed file"
-#: ./opengever/journal/handlers.py:415
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_modified"
 msgstr ""
 
 #. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py:417
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_modified__parent"
 msgstr ""
 
 #. Default: "Reverte document file to version ${version_id}"
-#: ./opengever/journal/handlers.py:496
+#: ./opengever/journal/handlers.py
 msgid "label_document_file_reverted"
 msgstr ""
 
 #. Default: "Document in dossier attached to email via OfficeConnector"
-#: ./opengever/journal/handlers.py:814
+#: ./opengever/journal/handlers.py
 msgid "label_document_in_dossier_attached"
 msgstr ""
 
 #. Default: "Changed metadata"
-#: ./opengever/journal/handlers.py:425
+#: ./opengever/journal/handlers.py
 msgid "label_document_metadata_modified"
 msgstr ""
 
 #. Default: "Changed metadata of document ${title}"
-#: ./opengever/journal/handlers.py:427
+#: ./opengever/journal/handlers.py
 msgid "label_document_metadata_modified__parent"
 msgstr ""
 
 #. Default: "Public trial changed to \"${public_trial}\"."
-#: ./opengever/journal/handlers.py:440
+#: ./opengever/journal/handlers.py
 msgid "label_document_public_trial_modified"
 msgstr ""
 
 #. Default: "Document ${title} removed."
-#: ./opengever/journal/handlers.py:647
+#: ./opengever/journal/handlers.py
 msgid "label_document_removed"
 msgstr ""
 
 #. Default: "Document ${title} restored."
-#: ./opengever/journal/handlers.py:664
+#: ./opengever/journal/handlers.py
 msgid "label_document_restored"
 msgstr ""
 
 #. Default: "Document sent by Mail: ${subject}"
-#: ./opengever/journal/handlers.py:548
+#: ./opengever/journal/handlers.py
 msgid "label_document_sent"
 msgstr ""
 
 #. Default: "Attachments: ${documents} | Receivers: ${receiver} | Message: ${message}"
-#: ./opengever/journal/handlers.py:553
+#: ./opengever/journal/handlers.py
 msgid "label_document_sent_comment"
 msgstr ""
 
 #. Default: "Document included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:782
+#: ./opengever/journal/handlers.py
 msgid "label_document_zipped"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/journal/templates/journal_references.pt:17
+#: ./opengever/journal/templates/journal_references.pt
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossier added: ${title}"
-#: ./opengever/journal/handlers.py:227
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_added"
 msgstr ""
 
 #. Default: "Dossier modified: ${title}"
-#: ./opengever/journal/handlers.py:240
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_modified"
 msgstr ""
 
 #. Default: "Dossier included in a zip export: ${title}"
-#: ./opengever/journal/handlers.py:769
+#: ./opengever/journal/handlers.py
 msgid "label_dossier_zipped"
 msgstr ""
 
-#. Default: "Download copy ${version_string}"
-#: ./opengever/journal/handlers.py:520
+#. Default: "Download copy"
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded"
 msgstr ""
 
 #. Default: "current version (${version_id})"
-#: ./opengever/journal/handlers.py:513
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_actual_version"
 msgstr ""
 
 #. Default: "version ${version_id}"
-#: ./opengever/journal/handlers.py:516
+#: ./opengever/journal/handlers.py
 msgid "label_file_copy_downloaded_version"
 msgstr ""
 
+#. Default: "${title} ${version_string}"
+#: ./opengever/journal/handlers.py
+msgid "label_file_copy_downloaded_with_version"
+msgstr ""
+
 #. Default: "Local roles aquistion activated."
-#: ./opengever/journal/handlers.py:296
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_activated"
 msgstr ""
 
 #. Default: "Local roles aquistion activated at ${repository}."
-#: ./opengever/journal/handlers.py:189
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_activated_at"
 msgstr ""
 
 #. Default: "Local roles aquistion blocked."
-#: ./opengever/journal/handlers.py:281
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_blocked"
 msgstr ""
 
 #. Default: "Local roles aquistion blocked at ${repository}."
-#: ./opengever/journal/handlers.py:171
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_acquisition_blocked_at"
 msgstr ""
 
 #. Default: "Local roles modified."
-#: ./opengever/journal/handlers.py:311
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_modified"
 msgstr ""
 
 #. Default: "Local roles modified at ${repository}."
-#: ./opengever/journal/handlers.py:207
+#: ./opengever/journal/handlers.py
 msgid "label_local_roles_modified_at"
 msgstr ""
 
 #. Default: "Manual entry: ${category}"
-#: ./opengever/journal/entry.py:81
+#: ./opengever/journal/entry.py
 msgid "label_manual_journal_entry"
 msgstr ""
 
 #. Default: "Object cut: ${title}"
-#: ./opengever/journal/handlers.py:753
+#: ./opengever/journal/handlers.py
 msgid "label_object_cut"
 msgstr ""
 
 #. Default: "Object moved: ${title}"
-#: ./opengever/journal/handlers.py:731
+#: ./opengever/journal/handlers.py
 msgid "label_object_moved"
 msgstr ""
 
 #. Default: "Participant added: ${contact} with roles ${roles}"
-#: ./opengever/journal/handlers.py:687
+#: ./opengever/journal/handlers.py
 msgid "label_participant_added"
 msgstr ""
 
 #. Default: "Participant removed: ${contact}"
-#: ./opengever/journal/handlers.py:702
+#: ./opengever/journal/handlers.py
 msgid "label_participant_removed"
 msgstr ""
 
 #. Default: "PDF downloaded"
-#: ./opengever/journal/handlers.py:517
+#: ./opengever/journal/handlers.py
 msgid "label_pdf_downloaded"
 msgstr ""
 
 #. Default: "Unlocked prefix ${prefix} in ${repository}."
-#: ./opengever/journal/handlers.py:155
+#: ./opengever/journal/handlers.py
 msgid "label_prefix_unlocked"
 msgstr ""
 
 #. Default: "References"
-#: ./opengever/journal/tab.py:92
+#: ./opengever/journal/tab.py
 msgid "label_references"
 msgstr ""
 
 #. Default: "Related Documents"
-#: ./opengever/journal/form.py:37
+#: ./opengever/journal/form.py
 msgid "label_related_documents"
 msgstr ""
 
 #. Default: "Object restored: ${title}"
-#: ./opengever/journal/handlers.py:630
+#: ./opengever/journal/handlers.py
 msgid "label_restore"
 msgstr ""
 
 #. Default: "Task added: ${title}"
-#: ./opengever/journal/handlers.py:572
+#: ./opengever/journal/handlers.py
 msgid "label_task_added"
 msgstr ""
 
 #. Default: "Task modified: ${title}"
-#: ./opengever/journal/handlers.py:589
+#: ./opengever/journal/handlers.py
 msgid "label_task_modified"
 msgstr ""
 
 #. Default: "Time"
-#: ./opengever/journal/tab.py:75
+#: ./opengever/journal/tab.py
 msgid "label_time"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/journal/tab.py:79
+#: ./opengever/journal/tab.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Object moved to trash: ${title}"
-#: ./opengever/journal/handlers.py:612
+#: ./opengever/journal/handlers.py
 msgid "label_to_trash"
 msgstr ""
 
 #. Default: "Journal"
-#: ./opengever/journal/templates/journalhistory.pt:17
+#: ./opengever/journal/templates/journalhistory.pt
 msgid "summary_journal"
 msgstr ""
 
 #. Default: "${amount} matches"
-#: ./opengever/journal/templates/journal_selection.pt:9
+#: ./opengever/journal/templates/journal_selection.pt
 msgid "tab_matches"
 msgstr ""
 

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,128 +15,128 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Deadline"
-#: ./opengever/latex/listing.py:273
+#: ./opengever/latex/listing.py
 msgid "label_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Delivery date"
-#: ./opengever/latex/listing.py:226
+#: ./opengever/latex/listing.py
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Document author"
-#: ./opengever/latex/listing.py:231
+#: ./opengever/latex/listing.py
 msgid "label_document_author"
 msgstr "Autor"
 
 #. Default: "Document date"
-#: ./opengever/latex/listing.py:216
+#: ./opengever/latex/listing.py
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Documents"
-#: ./opengever/latex/dossierdetails.py:79
+#: ./opengever/latex/dossierdetails.py
 msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Journal of dossier ${title} (${reference_number})"
-#: ./opengever/latex/dossierjournal.py:65
+#: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
 msgstr "Journal zu Dossier ${title} (${reference_number})"
 
 #. Default: "End"
-#: ./opengever/latex/dossierdetails.py:128
-#: ./opengever/latex/listing.py:182
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Issuer"
-#: ./opengever/latex/listing.py:253
+#: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "Participants"
-#: ./opengever/latex/dossierdetails.py:131
+#: ./opengever/latex/dossierdetails.py
 msgid "label_participants"
 msgstr "Beteiligung"
 
 #. Default: "Receipt date"
-#: ./opengever/latex/listing.py:221
+#: ./opengever/latex/listing.py
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference number"
-#: ./opengever/latex/dossierdetails.py:106
-#: ./opengever/latex/listing.py:149
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
 
 #. Default: "Repository"
-#: ./opengever/latex/dossierdetails.py:113
+#: ./opengever/latex/dossierdetails.py
 msgid "label_repository"
 msgstr "Ordnungsposition"
 
 #. Default: "Repositoryfolder"
-#: ./opengever/latex/listing.py:157
+#: ./opengever/latex/listing.py
 msgid "label_repository_title"
 msgstr "Ordnungsposition"
 
 #. Default: "Responsible"
-#: ./opengever/latex/dossierdetails.py:122
-#: ./opengever/latex/listing.py:167
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_responsible"
 msgstr "Federführend"
 
 #. Default: "State"
-#: ./opengever/latex/dossierdetails.py:135
-#: ./opengever/latex/listing.py:172
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Sequence number"
-#: ./opengever/latex/dossierdetails.py:110
+#: ./opengever/latex/dossierdetails.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Start"
-#: ./opengever/latex/dossierdetails.py:125
-#: ./opengever/latex/listing.py:177
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "Subdossier Title"
-#: ./opengever/latex/dossierdetails.py:119
+#: ./opengever/latex/dossierdetails.py
 msgid "label_subdossier_title"
 msgstr "Titel Subdossier"
 
 #. Default: "Subdossiers"
-#: ./opengever/latex/dossierdetails.py:71
+#: ./opengever/latex/dossierdetails.py
 msgid "label_subdossiers"
 msgstr "Subdossiers"
 
 #. Default: "Responsible"
-#: ./opengever/latex/listing.py:259
+#: ./opengever/latex/listing.py
 msgid "label_task_responsible"
 msgstr "Auftragnehmer"
 
 #. Default: "Task type"
-#: ./opengever/latex/listing.py:248
+#: ./opengever/latex/listing.py
 msgid "label_task_type"
 msgstr "Art"
 
 #. Default: "Tasks"
-#: ./opengever/latex/dossierdetails.py:87
+#: ./opengever/latex/dossierdetails.py
 msgid "label_tasks"
 msgstr "Aufgaben"
 
 #. Default: "Title"
-#: ./opengever/latex/dossierdetails.py:116
-#: ./opengever/latex/listing.py:162
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "No."
-#: ./opengever/latex/listing.py:153
+#: ./opengever/latex/listing.py
 msgid "short_label_sequence_number"
 msgstr "Nr."
 

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2017-06-04 08:49+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
@@ -17,128 +17,128 @@ msgstr ""
 "X-Generator: Weblate 2.13.1\n"
 
 #. Default: "Deadline"
-#: ./opengever/latex/listing.py:273
+#: ./opengever/latex/listing.py
 msgid "label_deadline"
 msgstr "A réaliser jusqu'au"
 
 #. Default: "Delivery date"
-#: ./opengever/latex/listing.py:226
+#: ./opengever/latex/listing.py
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Document author"
-#: ./opengever/latex/listing.py:231
+#: ./opengever/latex/listing.py
 msgid "label_document_author"
 msgstr "Auteur"
 
 #. Default: "Document date"
-#: ./opengever/latex/listing.py:216
+#: ./opengever/latex/listing.py
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Documents"
-#: ./opengever/latex/dossierdetails.py:79
+#: ./opengever/latex/dossierdetails.py
 msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Journal of dossier ${title} (${reference_number})"
-#: ./opengever/latex/dossierjournal.py:65
+#: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
 msgstr "Journal du dossier ${title} (${reference_number})"
 
 #. Default: "End"
-#: ./opengever/latex/dossierdetails.py:128
-#: ./opengever/latex/listing.py:182
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Issuer"
-#: ./opengever/latex/listing.py:253
+#: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "Participants"
-#: ./opengever/latex/dossierdetails.py:131
+#: ./opengever/latex/dossierdetails.py
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Receipt date"
-#: ./opengever/latex/listing.py:221
+#: ./opengever/latex/listing.py
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference number"
-#: ./opengever/latex/dossierdetails.py:106
-#: ./opengever/latex/listing.py:149
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_reference_number"
 msgstr "Numéro de référence"
 
 #. Default: "Repository"
-#: ./opengever/latex/dossierdetails.py:113
+#: ./opengever/latex/dossierdetails.py
 msgid "label_repository"
 msgstr "Numéro de classement"
 
 #. Default: "Repositoryfolder"
-#: ./opengever/latex/listing.py:157
+#: ./opengever/latex/listing.py
 msgid "label_repository_title"
 msgstr "Numéro de classement"
 
 #. Default: "Responsible"
-#: ./opengever/latex/dossierdetails.py:122
-#: ./opengever/latex/listing.py:167
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_responsible"
 msgstr "Responsable"
 
 #. Default: "State"
-#: ./opengever/latex/dossierdetails.py:135
-#: ./opengever/latex/listing.py:172
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Sequence number"
-#: ./opengever/latex/dossierdetails.py:110
+#: ./opengever/latex/dossierdetails.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Start"
-#: ./opengever/latex/dossierdetails.py:125
-#: ./opengever/latex/listing.py:177
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Subdossier Title"
-#: ./opengever/latex/dossierdetails.py:119
+#: ./opengever/latex/dossierdetails.py
 msgid "label_subdossier_title"
 msgstr "Titre du sous-dossier"
 
 #. Default: "Subdossiers"
-#: ./opengever/latex/dossierdetails.py:71
+#: ./opengever/latex/dossierdetails.py
 msgid "label_subdossiers"
 msgstr "Sous-dossiers"
 
 #. Default: "Responsible"
-#: ./opengever/latex/listing.py:259
+#: ./opengever/latex/listing.py
 msgid "label_task_responsible"
 msgstr "Mandataire"
 
 #. Default: "Task type"
-#: ./opengever/latex/listing.py:248
+#: ./opengever/latex/listing.py
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Tasks"
-#: ./opengever/latex/dossierdetails.py:87
+#: ./opengever/latex/dossierdetails.py
 msgid "label_tasks"
 msgstr "Tâches"
 
 #. Default: "Title"
-#: ./opengever/latex/dossierdetails.py:116
-#: ./opengever/latex/listing.py:162
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "No."
-#: ./opengever/latex/listing.py:153
+#: ./opengever/latex/listing.py
 msgid "short_label_sequence_number"
 msgstr "No."
 

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,128 +18,128 @@ msgstr ""
 "Domain: opengever.latex\n"
 
 #. Default: "Deadline"
-#: ./opengever/latex/listing.py:273
+#: ./opengever/latex/listing.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Delivery date"
-#: ./opengever/latex/listing.py:226
+#: ./opengever/latex/listing.py
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Document author"
-#: ./opengever/latex/listing.py:231
+#: ./opengever/latex/listing.py
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document date"
-#: ./opengever/latex/listing.py:216
+#: ./opengever/latex/listing.py
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/latex/dossierdetails.py:79
+#: ./opengever/latex/dossierdetails.py
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Journal of dossier ${title} (${reference_number})"
-#: ./opengever/latex/dossierjournal.py:65
+#: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/latex/dossierdetails.py:128
-#: ./opengever/latex/listing.py:182
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_end"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/latex/listing.py:253
+#: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/latex/dossierdetails.py:131
+#: ./opengever/latex/dossierdetails.py
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Receipt date"
-#: ./opengever/latex/listing.py:221
+#: ./opengever/latex/listing.py
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference number"
-#: ./opengever/latex/dossierdetails.py:106
-#: ./opengever/latex/listing.py:149
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_reference_number"
 msgstr ""
 
 #. Default: "Repository"
-#: ./opengever/latex/dossierdetails.py:113
+#: ./opengever/latex/dossierdetails.py
 msgid "label_repository"
 msgstr ""
 
 #. Default: "Repositoryfolder"
-#: ./opengever/latex/listing.py:157
+#: ./opengever/latex/listing.py
 msgid "label_repository_title"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/latex/dossierdetails.py:122
-#: ./opengever/latex/listing.py:167
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/latex/dossierdetails.py:135
-#: ./opengever/latex/listing.py:172
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/latex/dossierdetails.py:110
+#: ./opengever/latex/dossierdetails.py
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/latex/dossierdetails.py:125
-#: ./opengever/latex/listing.py:177
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_start"
 msgstr ""
 
 #. Default: "Subdossier Title"
-#: ./opengever/latex/dossierdetails.py:119
+#: ./opengever/latex/dossierdetails.py
 msgid "label_subdossier_title"
 msgstr ""
 
 #. Default: "Subdossiers"
-#: ./opengever/latex/dossierdetails.py:71
+#: ./opengever/latex/dossierdetails.py
 msgid "label_subdossiers"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/latex/listing.py:259
+#: ./opengever/latex/listing.py
 msgid "label_task_responsible"
 msgstr ""
 
 #. Default: "Task type"
-#: ./opengever/latex/listing.py:248
+#: ./opengever/latex/listing.py
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Tasks"
-#: ./opengever/latex/dossierdetails.py:87
+#: ./opengever/latex/dossierdetails.py
 msgid "label_tasks"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/latex/dossierdetails.py:116
-#: ./opengever/latex/listing.py:162
+#: ./opengever/latex/dossierdetails.py
+#: ./opengever/latex/listing.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "No."
-#: ./opengever/latex/listing.py:153
+#: ./opengever/latex/listing.py
 msgid "short_label_sequence_number"
 msgstr ""
 

--- a/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/de/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,27 +15,27 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
-#: ./opengever/locking/templates/meeting_lock.pt:12
+#: ./opengever/locking/templates/meeting_lock.pt
 msgid "description_locked_by_meeting"
 msgstr "Das Protokoll bleibt gesperrt bis die Sitzung ${meeting} abgeschlossen wurde."
 
 #. Default: "This document is a copy of an excerpt from a meeting and cannot be edited directly."
-#: ./opengever/locking/templates/excerpt_document_lock_template.pt:22
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt
 msgid "description_locked_excerpt_document"
 msgstr "Dieses Dokument ist eine Kopie eines Protokollauszugs aus einer Sitzung und kann nicht direkt bearbeitet werden."
 
 #. Default: "This document is a copy of the excerpt ${document} from the meeting ${meeting} and cannot be edited directly."
-#: ./opengever/locking/templates/excerpt_document_lock_template.pt:17
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt
 msgid "description_locked_linked_excerpt_document"
 msgstr "Dieses Dokument ist eine Kopie des Protokollauszugs ${document} aus der Sitzung ${meeting} und kann nicht direkt bearbeitet werden."
 
 #. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
-#: ./opengever/locking/templates/submitted_document_lock_template.pt:12
+#: ./opengever/locking/templates/submitted_document_lock_template.pt
 msgid "description_locked_linked_submitted_document"
 msgstr "Dieses Dokument wurde als Kopie von ${document} eingereicht und kann nicht direkt bearbeitet werden."
 
 #. Default: "This document has been submitted as a copy and cannot be edited directly."
-#: ./opengever/locking/templates/submitted_document_lock_template.pt:17
+#: ./opengever/locking/templates/submitted_document_lock_template.pt
 msgid "description_locked_submitted_document"
 msgstr "Dieses Dokument wurde als Kopie eingereicht und kann nicht direkt bearbeitet werden"
 

--- a/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
+++ b/opengever/locking/locales/fr/LC_MESSAGES/opengever.locking.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: 2016-08-10 05:14+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-locking/fr/>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "X-Generator: Weblate 2.7-dev\n"
 
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
-#: ./opengever/locking/templates/meeting_lock.pt:12
+#: ./opengever/locking/templates/meeting_lock.pt
 msgid "description_locked_by_meeting"
 msgstr "Le protocole reste verrouillé jusqu'à la clôture de la séance ${meeting}."
 
 #. Default: "This document is a copy of an excerpt from a meeting and cannot be edited directly."
-#: ./opengever/locking/templates/excerpt_document_lock_template.pt:22
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt
 msgid "description_locked_excerpt_document"
 msgstr "Ce document est une copie d'un extrait de procès-verbal d'une séance et ne peut être directement modifié."
 
 #. Default: "This document is a copy of the excerpt ${document} from the meeting ${meeting} and cannot be edited directly."
-#: ./opengever/locking/templates/excerpt_document_lock_template.pt:17
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt
 msgid "description_locked_linked_excerpt_document"
 msgstr "Ce document est une copie de l'extrait de procès-verbal ${document} de la séance ${meeting} et ne peut être directement modifié."
 
 #. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
-#: ./opengever/locking/templates/submitted_document_lock_template.pt:12
+#: ./opengever/locking/templates/submitted_document_lock_template.pt
 msgid "description_locked_linked_submitted_document"
 msgstr "Ce document a été déposé en tant que copie de ${document} et ne peut être directement modifié."
 
 #. Default: "This document has been submitted as a copy and cannot be edited directly."
-#: ./opengever/locking/templates/submitted_document_lock_template.pt:17
+#: ./opengever/locking/templates/submitted_document_lock_template.pt
 msgid "description_locked_submitted_document"
 msgstr "Ce document a été déposé en tant que copie et ne peut être directement modifié"
 

--- a/opengever/locking/locales/opengever.locking.pot
+++ b/opengever/locking/locales/opengever.locking.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,27 +18,27 @@ msgstr ""
 "Domain: opengever.locking\n"
 
 #. Default: "This protocol will remain locked until the meeting ${meeting} is closed."
-#: ./opengever/locking/templates/meeting_lock.pt:12
+#: ./opengever/locking/templates/meeting_lock.pt
 msgid "description_locked_by_meeting"
 msgstr ""
 
 #. Default: "This document is a copy of an excerpt from a meeting and cannot be edited directly."
-#: ./opengever/locking/templates/excerpt_document_lock_template.pt:22
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt
 msgid "description_locked_excerpt_document"
 msgstr ""
 
 #. Default: "This document is a copy of the excerpt ${document} from the meeting ${meeting} and cannot be edited directly."
-#: ./opengever/locking/templates/excerpt_document_lock_template.pt:17
+#: ./opengever/locking/templates/excerpt_document_lock_template.pt
 msgid "description_locked_linked_excerpt_document"
 msgstr ""
 
 #. Default: "This document has been submitted as a copy of ${document} and cannot be edited directly."
-#: ./opengever/locking/templates/submitted_document_lock_template.pt:12
+#: ./opengever/locking/templates/submitted_document_lock_template.pt
 msgid "description_locked_linked_submitted_document"
 msgstr ""
 
 #. Default: "This document has been submitted as a copy and cannot be edited directly."
-#: ./opengever/locking/templates/submitted_document_lock_template.pt:17
+#: ./opengever/locking/templates/submitted_document_lock_template.pt
 msgid "description_locked_submitted_document"
 msgstr ""
 

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-31 09:32+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -16,231 +16,232 @@ msgstr ""
 "Language: de\n"
 "X-Generator: Weblate 2.7-dev\n"
 
-#: ./opengever/mail/browser/templates/extract_attachments.pt:109
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ./opengever/mail/browser/send_document.py:55
+#: ./opengever/mail/browser/send_document.py
 msgid "No Mail Address"
 msgstr "Keine E-Mail Adresse"
 
-#: ./opengever/mail/browser/templates/extract_attachments.pt:104
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "Save attachments"
 msgstr "Anhänge speichern"
 
-#: ./opengever/mail/browser/send_document.py:335
+#: ./opengever/mail/browser/send_document.py
 msgid "Sent mail filed as '${title}'."
 msgstr "Versandtes E-Mail wurde als '${title}' abgelegt."
 
-#: ./opengever/mail/validators.py:20
+#: ./opengever/mail/validators.py
 msgid "The files you selected are larger than the maximum size"
 msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maximalgrösse."
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:198
+#: ./opengever/mail/browser/send_document.py
 msgid "button_send"
 msgstr "Senden"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py
 msgid "cancel_back"
 msgstr "Abbrechen"
 
 #. Default: "Filename"
-#: ./opengever/mail/browser/extract_attachments.py:92
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_filename"
 msgstr "Dateiname"
 
 #. Default: "Size"
-#: ./opengever/mail/browser/extract_attachments.py:97
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_size"
 msgstr "Grösse"
 
 #. Default: "Type"
-#: ./opengever/mail/browser/extract_attachments.py:87
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_type"
 msgstr "Typ"
 
 #. Default: "You have not selected any attachments."
-#: ./opengever/mail/browser/extract_attachments.py:122
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "error_no_attachments_selected"
 msgstr "Sie haben keine Anhänge ausgewählt."
 
 #. Default: "This mail has no attachments to extract."
-#: ./opengever/mail/browser/extract_attachments.py:111
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "error_no_attachments_to_extract"
 msgstr "Diese E-Mail hat keine Anhänge, die extrahiert werden könnten."
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:75
+#: ./opengever/mail/browser/send_document.py
 msgid "extern_receiver"
 msgstr "Externer Empfänger"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:188
+#: ./opengever/mail/browser/send_document.py
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(nur für aktive Dossiers möglich)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:161
+#: ./opengever/mail/browser/send_document.py
 msgid "heading_send_as_email"
 msgstr "Dokumente als E-Mail versenden"
 
 #. Default: "Select the attachments that should be saved. From every selected attachment a document in the parent dossier will be created."
-#: ./opengever/mail/browser/templates/extract_attachments.pt:47
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "help_attachments_to_save"
 msgstr "Wählen Sie die Anhänge aus, die gespeichert werden sollen. Aus jedem ausgewähltem Anhang wird ein Dokument im übergeordneten Dossier erzeugt."
 
 #. Default: "Select which attachments should be deleted."
-#: ./opengever/mail/browser/templates/extract_attachments.pt:69
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "help_delete_action"
 msgstr "Wählen Sie aus, ob und welche Anhänge aus dieser E-Mail gelöscht werden sollen."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:76
+#: ./opengever/mail/browser/send_document.py
 msgid "help_extern_receiver"
 msgstr "E-Mail Adressen der externen Empfänger manuell eintragen. Pro Zeile eine Adresse eingeben."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:63
+#: ./opengever/mail/browser/send_document.py
 msgid "help_intern_receiver"
 msgstr "Live Search: Nachname/Vorname der internen Mitarbeiter oder Kontakte eingeben. Mehrauswahl möglich."
 
 #. Default: "Created document ${title}"
-#: ./opengever/mail/browser/extract_attachments.py:143
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "info_extracted_document"
 msgstr "Dokument wurde erstellt: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py
 msgid "info_mail_sent"
 msgstr "E-Mail wurde versendet."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py
 msgid "intern_receiver"
 msgstr "Interne Empfänger"
 
 #. Default: "Attachments to save"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:42
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_attachments_to_save"
 msgstr "Zu speichernde Anhänge"
 
 #. Default: "Delete attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:64
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action"
 msgstr "Anhänge löschen"
 
 #. Default: "Delete all attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:86
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_all"
 msgstr "Alle Anhänge in dieser E-Mail löschen"
 
 #. Default: "Delete nothing"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:77
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_nothing"
 msgstr "Keine Anhänge löschen"
 
 #. Default: "Delete all selected attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:95
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_selected"
 msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Attachments"
-#: ./opengever/mail/browser/mail.py:100
-#: ./opengever/mail/browser/send_document.py:94
-#: ./opengever/mail/browser/templates/previewtab.pt:48
+#: ./opengever/mail/browser/mail.py
+#: ./opengever/mail/browser/send_document.py
+#: ./opengever/mail/browser/templates/previewtab.pt
 msgid "label_documents"
 msgstr "Anhänge"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:113
+#: ./opengever/mail/browser/send_document.py
 msgid "label_documents_as_link"
 msgstr "Dokumente nur als Link versenden"
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:119
+#: ./opengever/mail/browser/send_document.py
 msgid "label_file_copy_in_dossier"
 msgstr "Kopie des versandten Mails in Dossier ablegen"
 
 #. Default: "Journal"
-#: ./opengever/mail/browser/tabbed.py:19
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_journal"
 msgstr "Journal"
 
 #. Default: "Journal initialized"
-#: ./opengever/mail/upgrades/to3406.py:7
+#: ./opengever/mail/upgrades/to3406.py
 msgid "label_journal_initialized"
 msgstr "Dokument migriert"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:89
+#: ./opengever/mail/browser/send_document.py
 msgid "label_message"
 msgstr "Mitteilung"
 
 #. Default: "Message source"
-#: ./opengever/mail/mail.py:114
+#: ./opengever/mail/mail.py
 msgid "label_message_source"
 msgstr "Quelle Originalnachricht"
 
 #. Default: "Drag and drop upload"
-#: ./opengever/mail/mail.py:78
+#: ./opengever/mail/mail.py
 msgid "label_message_source_d_n_d_upload"
 msgstr "Drag & Drop Upload"
 
 #. Default: "Mail-in"
-#: ./opengever/mail/mail.py:75
+#: ./opengever/mail/mail.py
 msgid "label_message_source_mailin"
 msgstr "Mail-In"
 
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:97
+#: ./opengever/mail/browser/mail.py
 msgid "label_org_message"
 msgstr "Originalnachricht"
 
 #. Default: "Raw *.msg message before conversion"
-#: ./opengever/mail/mail.py:105
+#: ./opengever/mail/mail.py
 msgid "label_original_message"
 msgstr "Quelldatei im *.msg Format vor der Konvertierung"
 
 #. Default: "Overview"
-#: ./opengever/mail/browser/tabbed.py:9
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_overview"
 msgstr "Übersicht"
 
 #. Default: "Preview"
-#: ./opengever/mail/browser/tabbed.py:14
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_preview"
 msgstr "Vorschau"
 
 #. Default: "Save attachments"
-#: ./opengever/mail/browser/templates/attachments.pt:17
+#: ./opengever/mail/browser/templates/attachments.pt
 msgid "label_save_attachments"
 msgstr "Anhänge speichern"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:300
+#: ./opengever/mail/browser/send_document.py
 msgid "label_see_attachment"
 msgstr "siehe Anhänge"
 
 #. Default: "Sharing"
-#: ./opengever/mail/browser/tabbed.py:24
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_sharing"
 msgstr "Info"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:84
+#: ./opengever/mail/browser/send_document.py
 msgid "label_subject"
 msgstr "Betreff"
 
-#: ./opengever/mail/browser/send_document.py:67
+#: ./opengever/mail/browser/send_document.py
 msgid "mails"
 msgstr "E-Mails"
 
-#: ./opengever/mail/browser/send_document.py:79
+#: ./opengever/mail/browser/send_document.py
 msgid "receiver"
 msgstr "Empfänger"
+

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,251 +1,247 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-31 09:32+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-09-04 06:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-mail/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/mail/browser/templates/extract_attachments.pt:109
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ./opengever/mail/browser/send_document.py:55
+#: ./opengever/mail/browser/send_document.py
 msgid "No Mail Address"
 msgstr "Pas d'adresse e-mail"
 
-#: ./opengever/mail/browser/templates/extract_attachments.pt:104
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "Save attachments"
 msgstr "Sauvegarder les appendices"
 
-#: ./opengever/mail/browser/send_document.py:335
+#: ./opengever/mail/browser/send_document.py
 msgid "Sent mail filed as '${title}'."
 msgstr "L'e-mail envoyé a été classé sous '${title}'."
 
-#: ./opengever/mail/validators.py:20
+#: ./opengever/mail/validators.py
 msgid "The files you selected are larger than the maximum size"
 msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permise."
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse e-mail interne ou externe."
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:198
+#: ./opengever/mail/browser/send_document.py
 msgid "button_send"
 msgstr "Envoyer"
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py
 msgid "cancel_back"
 msgstr "Annuler"
 
 #. Default: "Filename"
-#: ./opengever/mail/browser/extract_attachments.py:92
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_filename"
 msgstr "Nom du fichier"
 
 #. Default: "Size"
-#: ./opengever/mail/browser/extract_attachments.py:97
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_size"
 msgstr "Taille"
 
 #. Default: "Type"
-#: ./opengever/mail/browser/extract_attachments.py:87
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_type"
 msgstr "Type"
 
 #. Default: "You have not selected any attachments."
-#: ./opengever/mail/browser/extract_attachments.py:122
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "error_no_attachments_selected"
 msgstr "Vous n'avez sélectionné aucune appendice."
 
 #. Default: "This mail has no attachments to extract."
-#: ./opengever/mail/browser/extract_attachments.py:111
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "error_no_attachments_to_extract"
 msgstr "Cet e-mail n'a pas d'annexe à extraire."
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:75
+#: ./opengever/mail/browser/send_document.py
 msgid "extern_receiver"
 msgstr "Destinataire externe"
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:188
+#: ./opengever/mail/browser/send_document.py
 msgid "file_copy_widget_disabled_hint_text"
 msgstr "(possible uniquement pour les dossiers ouverts)"
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:161
+#: ./opengever/mail/browser/send_document.py
 msgid "heading_send_as_email"
 msgstr "Envoyer les documents par e-mail"
 
 #. Default: "Select the attachments that should be saved. From every selected attachment a document in the parent dossier will be created."
-#: ./opengever/mail/browser/templates/extract_attachments.pt:47
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "help_attachments_to_save"
-msgstr ""
-"Sélectionner les annexes à extraire. De chaque appendice sélectionnée un "
-"document sera créé dans le dossier maître."
+msgstr "Sélectionner les annexes à extraire. De chaque appendice sélectionnée un document sera créé dans le dossier maître."
 
 #. Default: "Select which attachments should be deleted."
-#: ./opengever/mail/browser/templates/extract_attachments.pt:69
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "help_delete_action"
 msgstr "Sélectionnez les annexes à effacer."
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:76
+#: ./opengever/mail/browser/send_document.py
 msgid "help_extern_receiver"
-msgstr ""
-"Ajouter les adresses e-mail des destinataires externes. Une adresse par "
-"ligne."
+msgstr "Ajouter les adresses e-mail des destinataires externes. Une adresse par ligne."
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:63
+#: ./opengever/mail/browser/send_document.py
 msgid "help_intern_receiver"
 msgstr "Recherche en direct: Saisir nom et prénom des collaborateurs internes ou des contacts. Séléction multiple possible."
 
 #. Default: "Created document ${title}"
-#: ./opengever/mail/browser/extract_attachments.py:143
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "info_extracted_document"
 msgstr "Document créé: ${title}"
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py
 msgid "info_mail_sent"
 msgstr "E-mail envoyé."
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py
 msgid "intern_receiver"
 msgstr "Destinataires internes"
 
 #. Default: "Attachments to save"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:42
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_attachments_to_save"
 msgstr "Fichiers attachés"
 
 #. Default: "Delete attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:64
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action"
 msgstr "Effacer les fichiers attachés"
 
 #. Default: "Delete all attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:86
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_all"
 msgstr "Effacer tous les fichiers attachés à cet e-mail"
 
 #. Default: "Delete nothing"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:77
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_nothing"
 msgstr "N'effacer aucun fichier attaché"
 
 #. Default: "Delete all selected attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:95
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_selected"
 msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Attachments"
-#: ./opengever/mail/browser/mail.py:100
-#: ./opengever/mail/browser/send_document.py:94
-#: ./opengever/mail/browser/templates/previewtab.pt:48
+#: ./opengever/mail/browser/mail.py
+#: ./opengever/mail/browser/send_document.py
+#: ./opengever/mail/browser/templates/previewtab.pt
 msgid "label_documents"
 msgstr "Fichiers attachés"
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:113
+#: ./opengever/mail/browser/send_document.py
 msgid "label_documents_as_link"
 msgstr "Envoyer seulement le lien du document"
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:119
+#: ./opengever/mail/browser/send_document.py
 msgid "label_file_copy_in_dossier"
 msgstr "Classer une copie de l'e-mail envoyé dans le dossier"
 
 #. Default: "Journal"
-#: ./opengever/mail/browser/tabbed.py:19
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_journal"
 msgstr "Historique"
 
 #. Default: "Journal initialized"
-#: ./opengever/mail/upgrades/to3406.py:7
+#: ./opengever/mail/upgrades/to3406.py
 msgid "label_journal_initialized"
 msgstr "Document migré"
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:89
+#: ./opengever/mail/browser/send_document.py
 msgid "label_message"
 msgstr "Message"
 
 #. Default: "Message source"
-#: ./opengever/mail/mail.py:114
+#: ./opengever/mail/mail.py
 msgid "label_message_source"
 msgstr "Source du message d'origine"
 
 #. Default: "Drag and drop upload"
-#: ./opengever/mail/mail.py:78
+#: ./opengever/mail/mail.py
 msgid "label_message_source_d_n_d_upload"
 msgstr "Téléchargement drag & drop"
 
 #. Default: "Mail-in"
-#: ./opengever/mail/mail.py:75
+#: ./opengever/mail/mail.py
 msgid "label_message_source_mailin"
 msgstr "Mail-In"
 
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:97
+#: ./opengever/mail/browser/mail.py
 msgid "label_org_message"
 msgstr "Message original"
 
 #. Default: "Raw *.msg message before conversion"
-#: ./opengever/mail/mail.py:105
+#: ./opengever/mail/mail.py
 msgid "label_original_message"
 msgstr "Fichier source en format *.msg avant conversion"
 
 #. Default: "Overview"
-#: ./opengever/mail/browser/tabbed.py:9
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_overview"
 msgstr "Sommaire"
 
 #. Default: "Preview"
-#: ./opengever/mail/browser/tabbed.py:14
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_preview"
 msgstr "Aperçu"
 
 #. Default: "Save attachments"
-#: ./opengever/mail/browser/templates/attachments.pt:17
+#: ./opengever/mail/browser/templates/attachments.pt
 msgid "label_save_attachments"
 msgstr "Sauvegarder les appendices"
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:300
+#: ./opengever/mail/browser/send_document.py
 msgid "label_see_attachment"
 msgstr "Voir fichiers attachés"
 
 #. Default: "Sharing"
-#: ./opengever/mail/browser/tabbed.py:24
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_sharing"
 msgstr "Info"
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:84
+#: ./opengever/mail/browser/send_document.py
 msgid "label_subject"
 msgstr "Objet"
 
-#: ./opengever/mail/browser/send_document.py:67
+#: ./opengever/mail/browser/send_document.py
 msgid "mails"
 msgstr "E-mails"
 
-#: ./opengever/mail/browser/send_document.py:79
+#: ./opengever/mail/browser/send_document.py
 msgid "receiver"
 msgstr "Destinataire"
+

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-08-31 09:32+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,232 +17,232 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.mail\n"
 
-#: ./opengever/mail/browser/templates/extract_attachments.pt:109
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "Cancel"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:55
+#: ./opengever/mail/browser/send_document.py
 msgid "No Mail Address"
 msgstr ""
 
-#: ./opengever/mail/browser/templates/extract_attachments.pt:104
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "Save attachments"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:335
+#: ./opengever/mail/browser/send_document.py
 msgid "Sent mail filed as '${title}'."
 msgstr ""
 
-#: ./opengever/mail/validators.py:20
+#: ./opengever/mail/validators.py
 msgid "The files you selected are larger than the maximum size"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:129
+#: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr ""
 
 #. Default: "Send"
-#: ./opengever/mail/browser/send_document.py:198
+#: ./opengever/mail/browser/send_document.py
 msgid "button_send"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/mail/browser/send_document.py:256
+#: ./opengever/mail/browser/send_document.py
 msgid "cancel_back"
 msgstr ""
 
 #. Default: "Filename"
-#: ./opengever/mail/browser/extract_attachments.py:92
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_filename"
 msgstr ""
 
 #. Default: "Size"
-#: ./opengever/mail/browser/extract_attachments.py:97
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_size"
 msgstr ""
 
 #. Default: "Type"
-#: ./opengever/mail/browser/extract_attachments.py:87
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_type"
 msgstr ""
 
 #. Default: "You have not selected any attachments."
-#: ./opengever/mail/browser/extract_attachments.py:122
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "error_no_attachments_selected"
 msgstr ""
 
 #. Default: "This mail has no attachments to extract."
-#: ./opengever/mail/browser/extract_attachments.py:111
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "error_no_attachments_to_extract"
 msgstr ""
 
 #. Default: "Extern receiver"
-#: ./opengever/mail/browser/send_document.py:75
+#: ./opengever/mail/browser/send_document.py
 msgid "extern_receiver"
 msgstr ""
 
 #. Default: "(only possible for open dossiers)"
-#: ./opengever/mail/browser/send_document.py:188
+#: ./opengever/mail/browser/send_document.py
 msgid "file_copy_widget_disabled_hint_text"
 msgstr ""
 
 #. Default: "Send as email"
-#: ./opengever/mail/browser/send_document.py:161
+#: ./opengever/mail/browser/send_document.py
 msgid "heading_send_as_email"
 msgstr ""
 
 #. Default: "Select the attachments that should be saved. From every selected attachment a document in the parent dossier will be created."
-#: ./opengever/mail/browser/templates/extract_attachments.pt:47
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "help_attachments_to_save"
 msgstr ""
 
 #. Default: "Select which attachments should be deleted."
-#: ./opengever/mail/browser/templates/extract_attachments.pt:69
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "help_delete_action"
 msgstr ""
 
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
-#: ./opengever/mail/browser/send_document.py:76
+#: ./opengever/mail/browser/send_document.py
 msgid "help_extern_receiver"
 msgstr ""
 
 #. Default: "Live Search: search for users and contacts"
-#: ./opengever/mail/browser/send_document.py:63
+#: ./opengever/mail/browser/send_document.py
 msgid "help_intern_receiver"
 msgstr ""
 
 #. Default: "Created document ${title}"
-#: ./opengever/mail/browser/extract_attachments.py:143
+#: ./opengever/mail/browser/extract_attachments.py
 msgid "info_extracted_document"
 msgstr ""
 
 #. Default: "E-mail has been sent."
-#: ./opengever/mail/browser/send_document.py:246
+#: ./opengever/mail/browser/send_document.py
 msgid "info_mail_sent"
 msgstr ""
 
 #. Default: "Intern receiver"
-#: ./opengever/mail/browser/send_document.py:62
+#: ./opengever/mail/browser/send_document.py
 msgid "intern_receiver"
 msgstr ""
 
 #. Default: "Attachments to save"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:42
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_attachments_to_save"
 msgstr ""
 
 #. Default: "Delete attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:64
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action"
 msgstr ""
 
 #. Default: "Delete all attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:86
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_all"
 msgstr ""
 
 #. Default: "Delete nothing"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:77
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_nothing"
 msgstr ""
 
 #. Default: "Delete all selected attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt:95
+#: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_delete_action_selected"
 msgstr ""
 
 #. Default: "Attachments"
-#: ./opengever/mail/browser/mail.py:100
-#: ./opengever/mail/browser/send_document.py:94
-#: ./opengever/mail/browser/templates/previewtab.pt:48
+#: ./opengever/mail/browser/mail.py
+#: ./opengever/mail/browser/send_document.py
+#: ./opengever/mail/browser/templates/previewtab.pt
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Send documents only als links"
-#: ./opengever/mail/browser/send_document.py:113
+#: ./opengever/mail/browser/send_document.py
 msgid "label_documents_as_link"
 msgstr ""
 
 #. Default: "File a copy of the sent mail in dossier"
-#: ./opengever/mail/browser/send_document.py:119
+#: ./opengever/mail/browser/send_document.py
 msgid "label_file_copy_in_dossier"
 msgstr ""
 
 #. Default: "Journal"
-#: ./opengever/mail/browser/tabbed.py:19
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_journal"
 msgstr ""
 
 #. Default: "Journal initialized"
-#: ./opengever/mail/upgrades/to3406.py:7
+#: ./opengever/mail/upgrades/to3406.py
 msgid "label_journal_initialized"
 msgstr ""
 
 #. Default: "Message"
-#: ./opengever/mail/browser/send_document.py:89
+#: ./opengever/mail/browser/send_document.py
 msgid "label_message"
 msgstr ""
 
 #. Default: "Message source"
-#: ./opengever/mail/mail.py:114
+#: ./opengever/mail/mail.py
 msgid "label_message_source"
 msgstr ""
 
 #. Default: "Drag and drop upload"
-#: ./opengever/mail/mail.py:78
+#: ./opengever/mail/mail.py
 msgid "label_message_source_d_n_d_upload"
 msgstr ""
 
 #. Default: "Mail-in"
-#: ./opengever/mail/mail.py:75
+#: ./opengever/mail/mail.py
 msgid "label_message_source_mailin"
 msgstr ""
 
 #. Default: "Original message"
-#: ./opengever/mail/browser/mail.py:97
+#: ./opengever/mail/browser/mail.py
 msgid "label_org_message"
 msgstr ""
 
 #. Default: "Raw *.msg message before conversion"
-#: ./opengever/mail/mail.py:105
+#: ./opengever/mail/mail.py
 msgid "label_original_message"
 msgstr ""
 
 #. Default: "Overview"
-#: ./opengever/mail/browser/tabbed.py:9
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_overview"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/mail/browser/tabbed.py:14
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_preview"
 msgstr ""
 
 #. Default: "Save attachments"
-#: ./opengever/mail/browser/templates/attachments.pt:17
+#: ./opengever/mail/browser/templates/attachments.pt
 msgid "label_save_attachments"
 msgstr ""
 
 #. Default: "see attachment"
-#: ./opengever/mail/browser/send_document.py:300
+#: ./opengever/mail/browser/send_document.py
 msgid "label_see_attachment"
 msgstr ""
 
 #. Default: "Sharing"
-#: ./opengever/mail/browser/tabbed.py:24
+#: ./opengever/mail/browser/tabbed.py
 msgid "label_sharing"
 msgstr ""
 
 #. Default: "Subject"
-#: ./opengever/mail/browser/send_document.py:84
+#: ./opengever/mail/browser/send_document.py
 msgid "label_subject"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:67
+#: ./opengever/mail/browser/send_document.py
 msgid "mails"
 msgstr ""
 
-#: ./opengever/mail/browser/send_document.py:79
+#: ./opengever/mail/browser/send_document.py
 msgid "receiver"
 msgstr ""
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-25 11:37+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-09-25 13:37+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,218 +17,218 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/meeting/command.py:540
+#: ./opengever/meeting/command.py
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Eine neu eingereichte Version des Dokuments ${title} wurde erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:319
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Actions"
 msgstr "Aktionen"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:79
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Add Dossier for Meeting"
 msgstr "Sitzungsdossier hinzufügen"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:78
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Add Meeting"
 msgstr "Sitzung hinzufügen"
 
 #. Default: "Add Member"
-#: ./opengever/meeting/browser/members.py:44
+#: ./opengever/meeting/browser/members.py
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
 #. Default: "Add Membership"
-#: ./opengever/meeting/browser/memberships.py:45
+#: ./opengever/meeting/browser/memberships.py
 msgid "Add Membership"
 msgstr "Mitgliedschaft hinzufügen"
 
-#: ./opengever/meeting/browser/committeeforms.py:29
+#: ./opengever/meeting/browser/committeeforms.py
 msgid "Add committee"
 msgstr "Gremium hinzufügen"
 
-#: ./opengever/meeting/browser/periods.py:50
+#: ./opengever/meeting/browser/periods.py
 msgid "Add new period"
 msgstr "Neue Periode hinzufügen"
 
-#: ./opengever/meeting/browser/committeeforms.py:30
-#: ./opengever/meeting/browser/periods.py:137
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/periods.py
 msgid "Add period"
 msgstr "Periode hinzufügen"
 
-#: ./opengever/meeting/command.py:574
+#: ./opengever/meeting/command.py
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
 msgstr "Nach Abschluss kann die Sitzung nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Agenda Items"
 msgstr "Traktanden"
 
-#: ./opengever/meeting/command.py:114
+#: ./opengever/meeting/command.py
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr "Traktandenliste für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Agendaitem list"
 msgstr "Traktandenliste"
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:416
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "An unexpected error has occurred"
 msgstr "Ein unerwarteter Fehler ist aufgetreten"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:68
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:73
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure you want to close this meeting?"
 msgstr "Wollen Sie diese Sitzung wirklich abschliessen?"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr "Wollen Sie diesen Protokollauszug wirklich an den Antragsteller zurücksenden?"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:84
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:89
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr "Sind Sie sicher, dass Sie dieses Traktandum beschliessen möchten?"
 
-#: ./opengever/meeting/browser/memberships.py:53
+#: ./opengever/meeting/browser/memberships.py
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Die Mitgliedschaft kann nicht erstellt werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis ${date_to} überschneidet."
 
-#: ./opengever/meeting/browser/memberships.py:87
+#: ./opengever/meeting/browser/memberships.py
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende Mitgliedschaft vom ${date_from} bis zum ${date_to} überschneidet."
 
-#: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
+#: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Choose Agenda Items"
 msgstr "Traktanden auswählen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Close all proposals."
 msgstr "Alle Anträge werden abgeschlossen."
 
-#: ./opengever/meeting/browser/periods.py:69
+#: ./opengever/meeting/browser/periods.py
 msgid "Close currently active period"
 msgstr "Aktuelle Periode abschliessen"
 
-#: ./opengever/meeting/browser/periods.py:49
+#: ./opengever/meeting/browser/periods.py
 msgid "Close period"
 msgstr "Periode abschliessen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:34
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:36
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete"
 msgstr "Löschen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:31
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:33
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete proposal"
 msgstr "Traktandum löschen"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:18
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ./opengever/meeting/command.py:500
+#: ./opengever/meeting/command.py
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Documents"
 msgstr "Dokumente"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:209
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Download agenda item list"
 msgstr "Traktandenliste herunterladen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:99
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/meeting/command.py:145
+#: ./opengever/meeting/command.py
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich generiert."
 
-#: ./opengever/meeting/command.py:150
+#: ./opengever/meeting/command.py
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "Der Protokollauszug für ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/command.py:214
+#: ./opengever/meeting/command.py
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:219
+#: ./opengever/meeting/command.py
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "Protokollauszug für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:65
-#: ./opengever/meeting/committeecontainer.py:24
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "Excerpt template"
 msgstr "Vorlage Protokollauszug"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Excerpts"
 msgstr "Protokollauszüge"
 
-#: ./opengever/meeting/browser/meetings/templates/excerpt.pt:19
+#: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Export settings"
 msgstr "Export-Einstellungen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Generate excerpts for all proposals."
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt."
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:94
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "History"
 msgstr "Verlauf"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:64
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include \"disclose to\""
 msgstr "\"Zu eröffnen\" an einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:60
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include \"publish in\""
 msgstr "\"Veröffentlichung in\" einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:44
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include considerations"
 msgstr "Überlegungen einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:68
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include copy for attention"
 msgstr "Kopie z.K. einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:56
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include decision"
 msgstr "Entscheid einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:52
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include discussion"
 msgstr "Diskussion einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:36
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include initial position"
 msgstr "Ausgangslage einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:40
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include legal basis"
 msgstr "Rechtsgrundlage einfügen"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:48
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include proposed action"
 msgstr "Antrag einfügen"
 
-#: ./opengever/meeting/committee.py:85
+#: ./opengever/meeting/committee.py
 msgid "Linked repository folder"
 msgstr "Ablageposition"
 
@@ -236,48 +236,48 @@ msgstr "Ablageposition"
 msgid "Meeting Dossier"
 msgstr "Sitzungsdossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:159
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:223
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Meeting on ${date}"
 msgstr "Sitzung vom ${date}"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:63
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Meetinginformation"
 msgstr "Sitzungsangaben"
 
-#: ./opengever/meeting/browser/templates/member.pt:41
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "Memberships"
 msgstr "Mitgliedschaften"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Number"
 msgstr "Nummer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:314
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Order"
 msgstr "Sortierung"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Paragraph:"
 msgstr "Abschnitt:"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:133
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Please select at least one agenda item."
 msgstr "Bitte wählen Sie mindestens ein Traktandum aus."
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:85
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Please select at least one field for the excerpt."
 msgstr "Bitte wählen Sie mindestens ein Feld für den Protokollauszug aus."
 
-#: ./opengever/meeting/browser/templates/member.pt:19
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "Properties"
 msgstr "Eigenschaften"
 
 #. Default: "Proposal"
-#: ./opengever/meeting/browser/documents/submit.py:32
+#: ./opengever/meeting/browser/documents/submit.py
 msgid "Proposal"
 msgstr "Antrag"
 
@@ -285,29 +285,29 @@ msgstr "Antrag"
 msgid "Proposal Template"
 msgstr "Antragsvorlage"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:298
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Proposals:"
 msgstr "Anträge"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/model/meeting.py:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/model/meeting.py
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: ./opengever/meeting/model/meeting.py:275
+#: ./opengever/meeting/model/meeting.py
 msgid "Protocol Excerpt"
 msgstr "Protokollauszug"
 
-#: ./opengever/meeting/command.py:64
+#: ./opengever/meeting/command.py
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich erstellt."
 
-#: ./opengever/meeting/command.py:69
+#: ./opengever/meeting/command.py
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Protokoll für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
-#: ./opengever/meeting/committee.py:59
-#: ./opengever/meeting/committeecontainer.py:18
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "Protocol template"
 msgstr "Vorlage Protokoll"
 
@@ -316,1363 +316,1364 @@ msgid "Sablon Template"
 msgstr "Sablon Vorlage"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:205
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "Save"
 msgstr "Speichern"
 
-#: ./opengever/meeting/browser/meetings/unscheduled_proposals.py:50
+#: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
 msgstr "Erfolgreich traktandiert"
 
-#: ./opengever/meeting/browser/committee_templates/overview.pt:19
+#: ./opengever/meeting/browser/committee_templates/overview.pt
 msgid "Show more"
 msgstr "Mehr anzeigen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:277
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Text:"
 msgstr "Freitext:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:175
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "The meeting and its dossier were created successfully"
 msgstr "Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt."
 
-#: ./opengever/meeting/browser/proposaltransitions.py:80
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "The proposal has been rejected successfully"
 msgstr "Der Antrag wurde erfolgreich zurückgewiesen."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Title"
 msgstr "Titel"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:47
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Unschedule"
 msgstr "Entfernen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:44
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:46
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Unschedule proposal"
 msgstr "Traktandum entfernen"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:66
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Update or create the protocol."
 msgstr "Das Protokoll wird erstellt oder aktualisiert."
 
-#: ./opengever/meeting/browser/submitdocuments.py:215
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
 
-#: ./opengever/meeting/browser/excerpt.py:44
+#: ./opengever/meeting/browser/excerpt.py
 msgid "Updated with a newer excerpt version."
 msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs überschrieben."
 
-#: ./opengever/meeting/command.py:326
+#: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 
 #. Default: "Active"
-#: ./opengever/meeting/browser/documents/proposalstab.py:64
-#: ./opengever/meeting/model/committee.py:29
-#: ./opengever/meeting/model/period.py:21
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/model/committee.py
+#: ./opengever/meeting/model/period.py
 msgid "active"
 msgstr "Aktiv"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:337
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr "Traktandum kann nicht beschlossen werden: das Beschlussdokument ist noch von einer anderen Person ausgecheckt."
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:307
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_decided"
 msgstr "Traktandum wurde beschlossen."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:283
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_deleted"
 msgstr "Traktandum wurde erfolgreich entfernt."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:312
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_meeting_held"
 msgstr "Das Traktandum wurde beschlossen und die Sitzung wurde durchgeführt."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:242
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:304
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_proposal_decided"
 msgstr "Traktandum wurde beschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:353
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_reopened"
 msgstr "Das Traktandum wurde wieder eröffnet."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:366
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_revised"
 msgstr "Das Traktandum wurde erfolgreich überarbeitet."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:255
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_empty_string"
 msgstr "Der Titel eines Traktandums darf nicht leer sein."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:262
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_too_long_title"
 msgstr "Der Traktandums-Titel ist zu lang."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:268
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_updated"
 msgstr "Traktandum erfolgreich aktualisiert."
 
 #. Default: "All"
-#: ./opengever/meeting/browser/documents/proposalstab.py:61
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "all"
 msgstr "Alle"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/committeeforms.py:73
-#: ./opengever/meeting/browser/documents/submit.py:96
-#: ./opengever/meeting/browser/meetings/meeting.py:121
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/documents/submit.py
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:92
+#: ./opengever/meeting/browser/periods.py
 msgid "button_close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Continue"
-#: ./opengever/meeting/browser/committeeforms.py:61
-#: ./opengever/meeting/browser/meetings/meeting.py:105
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Submit Attachments"
-#: ./opengever/meeting/browser/documents/submit.py:82
-#: ./opengever/meeting/browser/submitdocuments.py:83
+#: ./opengever/meeting/browser/documents/submit.py
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "button_submit_attachments"
 msgstr "Anhänge einreichen"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:161
+#: ./opengever/meeting/model/proposal.py
 msgid "cancel"
 msgstr "Stornieren"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py
 msgid "cancelled"
 msgstr "Storniert"
 
 #. Default: "Close meeting"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:58
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:60
-#: ./opengever/meeting/model/meeting.py:83
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+#: ./opengever/meeting/model/meeting.py
 msgid "close_meeting"
 msgstr "Abschliessen"
 
 #. Default: "Close period"
-#: ./opengever/meeting/model/period.py:29
+#: ./opengever/meeting/model/period.py
 msgid "close_period"
 msgstr "Periode abschliessen"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:77
-#: ./opengever/meeting/model/period.py:22
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/model/period.py
 msgid "closed"
 msgstr "Abgeschlossen"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/browser/documents/proposalstab.py:95
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_comittee"
 msgstr "Gremium"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:58
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_date"
 msgstr "Datum"
 
 #. Default: "Date from"
-#: ./opengever/meeting/tabs/membershiplisting.py:32
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_date_from"
 msgstr "Von"
 
 #. Default: "Date to"
-#: ./opengever/meeting/tabs/membershiplisting.py:36
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_date_to"
 msgstr "Bis"
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/tabs/memberlisting.py:36
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_email"
 msgstr "E-Mail"
 
 #. Default: "Firstname"
-#: ./opengever/meeting/tabs/memberlisting.py:26
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_firstname"
 msgstr "Vorname"
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:62
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_from"
 msgstr "Von"
 
 #. Default: "Lastname"
-#: ./opengever/meeting/tabs/memberlisting.py:31
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_lastname"
 msgstr "Nachname"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:55
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_location"
 msgstr "Sitzungsort"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/browser/documents/proposalstab.py:99
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_meeting"
 msgstr "Sitzung"
 
 #. Default: "Member"
-#: ./opengever/meeting/tabs/membershiplisting.py:28
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_member"
 msgstr "Mitglied"
 
 #. Default: "Role"
-#: ./opengever/meeting/tabs/membershiplisting.py:40
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_role"
 msgstr "Rolle"
 
 #. Default: "State"
-#: ./opengever/meeting/browser/documents/proposalstab.py:91
-#: ./opengever/meeting/tabs/meetinglisting.py:51
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_state"
 msgstr "Status"
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/documents/proposalstab.py:87
-#: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:47
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/tabs/committeelisting.py
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_title"
 msgstr "Titel"
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:67
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_to"
 msgstr "Bis"
 
 #. Default: "Create Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:115
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "create_excerpt"
 msgstr "Protokollauszug generieren"
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:51
-#: ./opengever/meeting/model/proposal.py:159
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/proposal.py
 msgid "decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide Agendaitem"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "decide_agendaitem"
 msgstr "Traktandum beschliessen"
 
 #. Default: "Decided"
-#: ./opengever/meeting/browser/documents/proposalstab.py:68
-#: ./opengever/meeting/model/agendaitem.py:45
-#: ./opengever/meeting/model/proposal.py:139
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/proposal.py
 msgid "decided"
 msgstr "Beschlossen"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:129
+#: ./opengever/meeting/committee.py
 msgid "description_group"
 msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium vergeben."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:382
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
 #. Default: "Dossier"
-#: ./opengever/meeting/tabs/meetinglisting.py:72
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:214
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:399
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "empty_paragraph"
 msgstr "Der Abschnitt darf nicht leer sein."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:414
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
-#: ./opengever/meeting/browser/proposaltransitions.py:29
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "error_no_permission_to_add_document"
 msgstr "Ungenügende Berechtigungen zum Hinzufügen eines Dokumentes im Sitzungsdossier."
 
 #. Default: "Only word files (.docx) can be added here."
-#: ./opengever/meeting/proposaltemplate.py:36
+#: ./opengever/meeting/proposaltemplate.py
 msgid "error_prosal_template_not_docx"
 msgstr "Nur Word-Dateien (.docx) sind erlaubt."
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:217
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_document_default_title"
 msgstr "Protokollauszug ${title}"
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:464
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_generated"
 msgstr "Protokollauszug erfolgreich generiert."
 
 #. Default: "Excerpt was returned to proposer."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:484
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
 msgstr "Der Protokollauszug wurde an den Antragsteller zurückgesendet."
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
-#: ./opengever/meeting/browser/toc.py:60
+#: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} alphabetisch"
 
 #. Default: "Repository Toc ${period} ${committee}"
-#: ./opengever/meeting/browser/toc.py:89
+#: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} nach Ordnungsposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:176
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:203
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new agenda item list as word document"
 msgstr "Traktandenliste als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:252
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:208
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:215
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
 #. Default: "Reject proposal"
-#: ./opengever/meeting/browser/proposaltransitions.py:68
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "heading_reject_proposal_form"
 msgstr "Antrag zurückweisen"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:76
+#: ./opengever/meeting/model/meeting.py
 msgid "held"
 msgstr "Durchgeführt"
 
 #. Default: "Describe, why the proposal is rejected"
-#: ./opengever/meeting/browser/proposaltransitions.py:60
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "help_reject_proposal_text"
 msgstr "Beschreiben Sie, warum der Antrag zurückgewiesen wird"
 
 #. Default: "Select the target dossier where the excerpts should be created."
-#: ./opengever/meeting/browser/meetings/excerpt.py:24
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "help_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem der Protokollauszug abgelegt werden soll."
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:85
+#: ./opengever/meeting/model/meeting.py
 msgid "hold"
 msgstr "Sitzung durchführen"
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py
 msgid "inactive"
 msgstr "Inaktiv"
 
-#. Default: "Ad hoc agenda item template"
-#: ./opengever/meeting/committee.py:94
-#: ./opengever/meeting/committeecontainer.py:44
-msgid "label_ad_hoc_template"
-msgstr "Vorlage"
-
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_ad_hoc_delete_action"
 msgstr "Traktandum löschen"
 
+#. Default: "Ad hoc agenda item template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_ad_hoc_template"
+msgstr "Vorlage"
+
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:374
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_agenda_item_number"
 msgstr "Nummer des Traktandums in dieser Sitzung"
 
 #. Default: "Agendaitem list"
-#: ./opengever/meeting/model/meeting.py:279
-#: ./opengever/meeting/protocol.py:160
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/protocol.py
 msgid "label_agendaitem_list"
 msgstr "Traktandenliste"
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:71
-#: ./opengever/meeting/committeecontainer.py:30
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr "Vorlage Traktandenliste"
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:370
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
-#: ./opengever/meeting/browser/submitdocuments.py:40
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "label_attachments"
 msgstr "Anhänge"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:152
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:36
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:38
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:240
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_close"
 msgstr "Schliessen"
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:77
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_deactivated"
 msgstr "Gremium erfolgreich deaktiviert."
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:50
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_reactivated"
 msgstr "Gremium erfolgreich reaktiviert."
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:59
-#: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/templates/member.pt
+#: ./opengever/meeting/proposal.py
 msgid "label_committee"
 msgstr "Gremium"
 
 #. Default: "The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually."
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "label_conflict_changes"
 msgstr "Das Protokoll wurde in der Zwischenzeit bearbeitet. Wenn Sie Ihre Änderungen beibehalten wollen, versuchen Sie die Konflikte manuell zu lösen."
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
-#: ./opengever/meeting/proposal.py:146
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_considerations"
 msgstr "Erwägungen"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:148
-#: ./opengever/meeting/proposal.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_copy_for_attention"
 msgstr "Kopie z.K."
 
 #. Default: "Create Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:127
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_create_excerpt"
 msgstr "Protokollauszug generieren"
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:92
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_creator"
 msgstr "Ersteller"
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:36
+#: ./opengever/meeting/browser/committee.py
 msgid "label_current_members"
 msgstr "Aktuelle Mitglieder"
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:21
+#: ./opengever/meeting/browser/committee.py
 msgid "label_current_period"
 msgstr "Aktuelle Periode"
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/memberships.py:21
-#: ./opengever/meeting/browser/periods.py:37
-#: ./opengever/meeting/browser/templates/member.pt:50
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/periods.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_date_from"
 msgstr "Von"
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/memberships.py:26
-#: ./opengever/meeting/browser/periods.py:43
-#: ./opengever/meeting/browser/templates/member.pt:51
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/periods.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_date_to"
 msgstr "Bis"
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:36
+#: ./opengever/meeting/model/committee.py
 msgid "label_deactivate"
 msgstr "Gremium deaktivieren"
 
 #. Default: "Decide"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:88
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:93
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_decide"
 msgstr "Beschliessen"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_decide_action"
 msgstr "Dieses Traktandum beschliessen"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
-#: ./opengever/meeting/proposal.py:222
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_decision"
 msgstr "Beschluss"
 
 #. Default: "Decision draft"
-#: ./opengever/meeting/proposal.py:100
+#: ./opengever/meeting/proposal.py
 msgid "label_decision_draft"
 msgstr "Beschlussentwurf"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/documents/proposalstab.py:82
-#: ./opengever/meeting/browser/meetings/meeting.py:375
-#: ./opengever/meeting/proposal.py:248
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/proposal.py
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
 #. Default: "remove this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:349
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_delete_action"
 msgstr "Traktandum entfernen"
 
 #. Default: "Are you sure you want to delete this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:32
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:34
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_delete_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich löschen?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:145
-#: ./opengever/meeting/proposal.py:112
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_disclose_to"
 msgstr "\"Zu eröffnen\" an"
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
-#: ./opengever/meeting/proposal.py:379
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_discussion"
 msgstr "Diskussion"
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:359
+#: ./opengever/meeting/proposal.py
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:460
+#: ./opengever/meeting/proposal.py
 msgid "label_dossier_not_available"
 msgstr "Dossier nicht verfügbar"
 
 #. Default: "download TOC alphabetical"
-#: ./opengever/meeting/browser/templates/periods.pt:11
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc"
 msgstr "Inhaltsverzeichnis alphabetisch"
 
 #. Default: "download TOC by repository"
-#: ./opengever/meeting/browser/templates/periods.pt:18
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_toc"
 msgstr "Inhaltsverzeichnis nach Ordnungsposition"
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/templates/member.pt:65
-#: ./opengever/meeting/browser/templates/periods.pt:27
+#: ./opengever/meeting/browser/templates/member.pt
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_edit"
 msgstr "Bearbeiten"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:348
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_action"
 msgstr "Titel bearbeiten"
 
 #. Default: "Edit after creation"
-#: ./opengever/meeting/browser/proposalforms.py:100
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_edit_after_creation"
 msgstr "Nach dem Hinzufügen bearbeiten"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:346
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Checkout and edit word document."
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_document_action"
 msgstr "Word-Dokument auschecken und bearbeiten."
 
 #. Default: "Edit Membership"
-#: ./opengever/meeting/browser/memberships.py:73
+#: ./opengever/meeting/browser/memberships.py
 msgid "label_edit_membership"
 msgstr "Mitgliedschaft bearbeiten"
 
 #. Default: "Edit Period"
-#: ./opengever/meeting/browser/periods.py:204
+#: ./opengever/meeting/browser/periods.py
 msgid "label_edit_period"
 msgstr "Bearbeiten"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:347
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_save"
 msgstr "Speichern"
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/browser/members.py:34
-#: ./opengever/meeting/browser/templates/member.pt:32
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:73
-#: ./opengever/meeting/browser/meetings/protocol.py:73
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:77
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "label_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Excerpts"
-#: ./opengever/meeting/browser/meetings/meeting.py:371
-#: ./opengever/meeting/proposal.py:151
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/proposal.py
 msgid "label_excerpts"
 msgstr "Protokollauszüge"
 
 #. Default: "File"
-#: ./opengever/meeting/proposaltemplate.py:19
+#: ./opengever/meeting/proposaltemplate.py
 msgid "label_file"
 msgstr "Datei"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:300
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:299
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_filter_proposal"
 msgstr "Filtern"
 
 #. Default: "Firstname"
-#: ./opengever/meeting/browser/members.py:24
-#: ./opengever/meeting/browser/templates/member.pt:28
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_firstname"
 msgstr "Vorname"
 
 #. Default: "Generate an excerpt."
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_generate_excerpt"
 msgstr "Protokollauszug generieren."
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:128
+#: ./opengever/meeting/committee.py
 msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
-#: ./opengever/meeting/proposal.py:88
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_initial_position"
 msgstr "Ausgangslage"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:331
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_insert"
 msgstr "Einfügen"
 
 #. Default: "Last Meeting:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:45
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "label_last_meeting"
 msgstr "Letzte Sitzung:"
 
 #. Default: "Lastname"
-#: ./opengever/meeting/browser/members.py:29
-#: ./opengever/meeting/browser/templates/member.pt:24
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
-#: ./opengever/meeting/proposal.py:82
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_legal_basis"
 msgstr "Rechtsgrundlage"
 
 #. Default: "Linked meeting"
-#: ./opengever/meeting/browser/dossier/overview.py:23
+#: ./opengever/meeting/browser/dossier/overview.py
 msgid "label_linked_meeting"
 msgstr "Sitzung"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:86
+#: ./opengever/meeting/committee.py
 msgid "label_linked_repository_folder"
 msgstr "Alle automatisch generierten Sitzungsdossiers und Dokumente werden in dieser Ordnungsposition abgelegt."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:64
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_location"
 msgstr "Sitzungsort"
 
 #. Default: "Main Atrributes"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:12
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "label_main_attributes"
 msgstr "Eigenschaften"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:186
+#: ./opengever/meeting/proposal.py
 msgid "label_meeting"
 msgstr "Sitzung"
 
 #. Default: "Member"
-#: ./opengever/meeting/browser/memberships.py:30
+#: ./opengever/meeting/browser/memberships.py
 msgid "label_member"
 msgstr "Mitglied"
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:95
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_modified"
 msgstr "Zuletzt bearbeitet"
 
 #. Default: "Next Meeting:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:53
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "label_next_meeting"
 msgstr "Nächste Sitzung:"
 
 #. Default: "No agenda item list has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:197
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:193
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_agendaitem_list"
 msgstr "Es wurde noch keine Traktandenliste generiert."
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:257
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "label_no_excerpts"
 msgstr "Es wurden noch keine zusätzlichen Protokollauszüge generiert."
 
 #. Default: "This member has no memberships."
-#: ./opengever/meeting/browser/templates/member.pt:43
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_no_memberships"
 msgstr "Dieser Benutzer hat keine Mitgliedschaften."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:386
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_no_proposals"
 msgstr "Keine Anträge eingereicht"
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:228
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:227
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
 #. Default: "Paragraph template"
-#: ./opengever/meeting/committee.py:101
-#: ./opengever/meeting/committeecontainer.py:51
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_paragraph_template"
 msgstr "Vorlage für Zwischentitel"
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_participants"
 msgstr "Teilnehmende"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_presidency"
 msgstr "Vorsitz"
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/browser/documents/proposalstab.py:78
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "label_proposal_id"
 msgstr "Laufnummer"
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:83
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_proposal_template"
 msgstr "Antragsvorlage"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
-#: ./opengever/meeting/proposal.py:94
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:56
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
-#: ./opengever/meeting/proposal.py:106
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_publish_in"
 msgstr "Veröffentlichung in"
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:40
+#: ./opengever/meeting/model/committee.py
 msgid "label_reactivate"
 msgstr "Gremium reaktivieren"
 
 #. Default: "Comment"
-#: ./opengever/meeting/browser/proposaltransitions.py:59
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "label_reject_proposal_text"
 msgstr "Kommentar"
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/templates/member.pt:70
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_remove"
 msgstr "Löschen"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_reopen_action"
 msgstr "Traktandum wieder eröffnen"
 
 #. Default: "Return excerpt to proposer"
-#: ./opengever/meeting/browser/meetings/meeting.py:372
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_return_action"
 msgstr "Protokollauszug an Antragsteller zurücksenden"
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_return_excerpt"
 msgstr "Protokollauszug zurücksenden"
 
 #. Default: "This excerpt was returned to the dossier"
-#: ./opengever/meeting/browser/meetings/meeting.py:376
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_returned_excerpt"
 msgstr "Dieser Protokollauszug wurde an den Antragsteller zurückgesendet."
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:352
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_revise_action"
 msgstr "Traktandum überarbeiten"
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/memberships.py:35
-#: ./opengever/meeting/browser/templates/member.pt:52
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_role"
 msgstr "Rolle"
 
 #. Default: "File"
-#: ./opengever/meeting/sablontemplate.py:13
+#: ./opengever/meeting/sablontemplate.py
 msgid "label_sablon_template_file"
 msgstr "Vorlage-Datei"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:385
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:280
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:316
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_schedule"
 msgstr "Traktandieren"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:38
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
 msgstr "Protokollführung"
 
 #. Default: "Target dossier"
-#: ./opengever/meeting/browser/meetings/excerpt.py:22
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "label_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:69
-#: ./opengever/meeting/browser/meetings/protocol.py:68
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr "Start"
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:54
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Excerpt title"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:122
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_title_excerpt"
 msgstr "Titel"
 
 #. Default: "Table of contents template"
-#: ./opengever/meeting/committee.py:78
-#: ./opengever/meeting/committeecontainer.py:37
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
 msgstr "Vorlage Inhaltsverzeichnis"
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:373
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_toggle_attachments"
 msgstr "Anhänge anzeigen / ausblenden"
 
 #. Default: "Transition ${transition} executed"
-#: ./opengever/meeting/browser/meetings/transitions.py:24
+#: ./opengever/meeting/browser/meetings/transitions.py
 msgid "label_transition_executed"
 msgstr "Statusänderung ${transition} ausgeführt"
 
 #. Default: "You have unsaved changes."
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:26
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "label_unsaved_changes"
 msgstr "Sie haben nicht gespeicherte lokale Änderungen."
 
 #. Default: "Are you sure you want to unschedule this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:45
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:47
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Wollen Sie dieses Traktandum wirklich aus der Traktandenliste entfernen?"
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:30
+#: ./opengever/meeting/browser/committee.py
 msgid "label_unscheduled_proposals"
 msgstr "Nicht traktandierte Anträge"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:25
+#: ./opengever/meeting/browser/committee.py
 msgid "label_upcoming_meetings"
 msgstr "Kommende Sitzungen"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:244
+#: ./opengever/meeting/proposal.py
 msgid "label_workflow_state"
 msgstr "Status"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:239
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "label_zip_download"
 msgstr "Zip-Datei herunterladen"
 
 #. Default: "Language"
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/proposal.py
 msgid "language"
 msgstr "Sprache"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "location"
 msgstr "Ort"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:151
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
 msgstr "Sitzungsdossier"
 
 #. Default: "Meetings"
-#: ./opengever/meeting/browser/tabbed.py:13
+#: ./opengever/meeting/browser/tabbed.py
 msgid "meetings"
 msgstr "Sitzungen"
 
 #. Default: "Memberships"
-#: ./opengever/meeting/browser/tabbed.py:19
+#: ./opengever/meeting/browser/tabbed.py
 msgid "memberships"
 msgstr "Mitgliedschaften"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:262
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_changes_saved"
 msgstr "Änderungen gespeichert"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:94
-#: ./opengever/meeting/browser/meetings/protocol.py:254
+#: ./opengever/meeting/browser/meetings/edit_meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_locked_by_another_user"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde von ${username} gesperrt."
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:89
-#: ./opengever/meeting/browser/meetings/protocol.py:248
+#: ./opengever/meeting/browser/meetings/edit_meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_write_conflict"
 msgstr "Die Änderungen konnten nicht gespeichert werden, das Protokoll wurde in der Zwischenzeit modifiziert."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:422
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "missing_ad_hoc_template"
 msgstr "Es konnte keine Vorlage für ein Traktandum gefunden werden."
 
 #. Default: "Choose a meaningful title to distinguish the created excerpts better."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_confirm_create_excerpt_dialog"
 msgstr "Wählen Sie einen aussagekräftigen Titel um die Protokollauszüge besser unterscheiden zu können."
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_confirm_return_excerpt_dialog"
 msgstr "Der Protokollauszug wird an den Antragsteller bzw. ins Ursprungsdossier des Antrags zurückgesendet. Es können keine weiteren Protokollauszuge zurückgesendet werden."
 
 #. Default: "The agenda item list for meeting ${title} has already been generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
 msgid "msg_error_agendaitem_list_already_generated"
 msgstr "Die Traktandenliste für die Sitzung ${title} wurde bereits erstellt."
 
 #. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:39
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
 msgid "msg_error_agendaitem_list_missing_template"
 msgstr "Es ist keine Vorlage für die Traktandenliste konfiguriert, die Traktandenliste konnte nicht generiert werden."
 
 #. Default: "The protocol for meeting ${title} has already been generated."
-#: ./opengever/meeting/browser/protocol.py:76
+#: ./opengever/meeting/browser/protocol.py
 msgid "msg_error_protocol_already_generated"
 msgstr "Das Protokoll für die Sitzung ${title} wurde schon erstellt."
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:81
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:86
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_hold_meeting_dialog"
 msgstr "Beim Abschluss dieses Traktandums wird die Sitzung in den Status `Durchgeführt`  versetzt. Anschliessend kann die Traktandenliste nicht mehr bearbeitet werden."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:40
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_inactive_committee_selected"
 msgstr "Das ausgewählte Gremium wurde deaktiviert, der Antrag konnte nicht eingereicht werden."
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/meeting.py
 msgid "msg_meeting_successfully_closed"
 msgstr "Die Sitzung ${title} wurde erfolgreich abgeschlossen, die Protokollauszüge wurden generiert und an die Urprungsdossiers zurückgespielt."
 
 #. Default: "The membership was deleted successfully."
-#: ./opengever/meeting/browser/memberships.py:107
+#: ./opengever/meeting/browser/memberships.py
 msgid "msg_membership_deleted"
 msgstr "Die Mitgliedschaft wurde erfolgreich gelöscht"
 
 #. Default: "There is no toc template configured, toc could not be generated."
-#: ./opengever/meeting/browser/toc.py:25
+#: ./opengever/meeting/browser/toc.py
 msgid "msg_no_toc_template"
 msgstr "Es ist keine Vorlage für das Inhaltsverzeichnis konfiguriert, das Inhaltsverzeichnis konnte nicht generiert werden."
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:58
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_pending_meetings"
 msgstr "Nicht alle Sitzungen sind abgeschlossen."
 
 #. Default: "Proposal cancelled successfully."
-#: ./opengever/meeting/model/proposal.py:68
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_cancelled"
 msgstr "Der Antrag wurde storniert."
 
 #. Default: "Proposal reactivated successfully."
-#: ./opengever/meeting/model/proposal.py:79
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_reactivated"
 msgstr "Der Antrag wurde wieder eröffnet."
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:50
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
 
 #. Default: "The object was deleted successfully."
-#: ./opengever/meeting/browser/views.py:21
+#: ./opengever/meeting/browser/views.py
 msgid "msg_successfully_deleted"
 msgstr "Das Objekt wurde erfolgreich gelöscht."
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:66
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_unscheduled_proposals"
 msgstr "Es gibt nicht traktandierte Anträge, die diesem Gremium zugewiesen sind."
 
 #. Default: "New unscheduled proposals:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:32
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
 
 #. Default: "Overview"
-#: ./opengever/meeting/browser/tabbed.py:10
+#: ./opengever/meeting/browser/tabbed.py
 msgid "overview"
 msgstr "Übersicht"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:403
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "paragraph_added"
 msgstr "Paragraph erfolgreich hinzugefügt."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:141
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "participants"
 msgstr "Teilnehmende"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:44
-#: ./opengever/meeting/model/meeting.py:75
-#: ./opengever/meeting/model/proposal.py:134
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/model/proposal.py
 msgid "pending"
 msgstr "In Bearbeitung"
 
 #. Default: "Periods"
-#: ./opengever/meeting/browser/tabbed.py:22
+#: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr "Perioden"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:127
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "presidency"
 msgstr "Vorsitz"
 
 #. Default: "Proposal document"
-#: ./opengever/meeting/proposal.py:195
+#: ./opengever/meeting/proposal.py
 msgid "proposal_document"
 msgstr "Antragsdokument"
 
 #. Default: "Proposal cancelled by ${user}"
-#: ./opengever/meeting/proposalhistory.py:196
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_cancelled"
 msgstr "Storniert durch ${user}"
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/proposalhistory.py:185
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_created"
 msgstr "Erstellt durch ${user}"
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/proposalhistory.py:312
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
 msgstr "Antrag beschlossen durch ${user}"
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:245
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_submitted"
 msgstr "Dokument ${title} in Version ${version} eingereicht durch ${user}"
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:350
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_updated"
 msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version} durch ${user}"
 
 #. Default: "Proposal reactivated by ${user}"
-#: ./opengever/meeting/proposalhistory.py:207
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reactivated"
 msgstr "Wieder eröffnet durch ${user}"
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/meeting/proposalhistory.py:263
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_rejected"
 msgstr "Zurückgewiesen von ${user}"
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:337
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Von der Traktandenliste der Sitzung ${meeting} entfernt durch ${user}"
 
 #. Default: "Proposal reopened by ${user}"
-#: ./opengever/meeting/proposalhistory.py:275
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reopened"
 msgstr "Antrag zur Überarbeitung wiedereröffnet durch ${user}"
 
 #. Default: "Proposal revised by ${user}"
-#: ./opengever/meeting/proposalhistory.py:324
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_revised"
 msgstr "Antragsbeschluss überarbeitet durch ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:299
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_scheduled"
 msgstr "Geplant für die Sitzung ${meeting} durch ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/proposalhistory.py:218
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"
 
 #. Default: "Protocol"
-#: ./opengever/meeting/protocol.py:58
+#: ./opengever/meeting/protocol.py
 msgid "protocol"
 msgstr "Protokoll"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:146
+#: ./opengever/meeting/protocol.py
 msgid "protocol_excerpt"
 msgstr "Protokollauszug"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:163
+#: ./opengever/meeting/model/proposal.py
 msgid "reactivate"
 msgstr "Wieder eröffnen"
 
 #. Default: "Reject"
-#: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:153
+#: ./opengever/meeting/browser/proposaltransitions.py
+#: ./opengever/meeting/model/proposal.py
 msgid "reject"
 msgstr "Zurückweisen"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:53
-#: ./opengever/meeting/model/meeting.py:89
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/meeting.py
 msgid "reopen"
 msgstr "Wieder eröffnen"
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:101
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "return_excerpt"
 msgstr "Protokollauszug zurücksenden"
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:55
+#: ./opengever/meeting/model/agendaitem.py
 msgid "revise"
 msgstr "Überarbeiten"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:46
+#: ./opengever/meeting/model/agendaitem.py
 msgid "revision"
 msgstr "Überarbeitung"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:155
+#: ./opengever/meeting/model/proposal.py
 msgid "schedule"
 msgstr "traktandieren"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:138
+#: ./opengever/meeting/model/proposal.py
 msgid "scheduled"
 msgstr "Traktandiert"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:134
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "secretary"
 msgstr "Protokollführer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:105
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "status"
 msgstr "Status"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:151
+#: ./opengever/meeting/model/proposal.py
 msgid "submit"
 msgstr "einreichen"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:136
+#: ./opengever/meeting/model/proposal.py
 msgid "submitted"
 msgstr "Eingereicht"
 
 #. Default: "Submitted Proposals"
-#: ./opengever/meeting/browser/tabbed.py:16
+#: ./opengever/meeting/browser/tabbed.py
 msgid "submittedproposals"
 msgstr "Anträge"
 
 #. Default: "${amount} matches"
-#: ./opengever/meeting/browser/templates/no_selection.pt:2
+#: ./opengever/meeting/browser/templates/no_selection.pt
 msgid "tab_matches"
 msgstr "${amount} Treffer"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:437
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
 msgstr "Freitext erfolgreich hinzugefügt"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:118
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "time"
 msgstr "Zeit"
 
 #. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py:377
+#: ./opengever/meeting/model/meeting.py
 msgid "title_ad_hoc_document"
 msgstr "Traktandum ${title}"
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:157
+#: ./opengever/meeting/model/proposal.py
 msgid "un-schedule"
 msgstr "Traktandum entfernen"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_add"
 msgstr "Hinzufügen"
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:325
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_add_section_header"
 msgstr "Zwischentitel einfügen:"
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agendaitem_list"
 msgstr "Traktandenliste:"
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_dossier"
 msgstr "Sitzungsdossier:"
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:135
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_end"
 msgstr "Sitzungsende:"
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_location"
 msgstr "Ort:"
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:145
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_number"
 msgstr "Sitzungsnummer:"
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:129
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_start"
 msgstr "Beginn:"
 
 #. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:121
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_status"
 msgstr "Status:"
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:167
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
 msgstr "Teilnehmer:"
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:153
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_presidency"
 msgstr "Vorsitz:"
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:225
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_protocol"
 msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:310
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_ad_hoc"
 msgstr "Traktandum einfügen:"
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:295
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:160
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
+

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-25 11:37+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -19,218 +19,218 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/meeting/command.py:540
+#: ./opengever/meeting/command.py
 msgid "A new submitted version of document ${title} has been created."
 msgstr "Une nouvelle version soumise du document ${title} a été créée."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:319
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Actions"
 msgstr "Actions"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:79
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Add Dossier for Meeting"
 msgstr "Ajouter le dossier d'une réunion"
 
 #. Default: "Add Meeting"
-#: ./opengever/meeting/browser/meetings/meeting.py:78
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Add Meeting"
 msgstr "Ajouter la réunion"
 
 #. Default: "Add Member"
-#: ./opengever/meeting/browser/members.py:44
+#: ./opengever/meeting/browser/members.py
 msgid "Add Member"
 msgstr "Ajouter un membre"
 
 #. Default: "Add Membership"
-#: ./opengever/meeting/browser/memberships.py:45
+#: ./opengever/meeting/browser/memberships.py
 msgid "Add Membership"
 msgstr "Ajouter une adhésion"
 
-#: ./opengever/meeting/browser/committeeforms.py:29
+#: ./opengever/meeting/browser/committeeforms.py
 msgid "Add committee"
 msgstr "Ajouter un comité"
 
-#: ./opengever/meeting/browser/periods.py:50
+#: ./opengever/meeting/browser/periods.py
 msgid "Add new period"
 msgstr "Ajouter une nouvelle période"
 
-#: ./opengever/meeting/browser/committeeforms.py:30
-#: ./opengever/meeting/browser/periods.py:137
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/periods.py
 msgid "Add period"
 msgstr "Ajouter la période"
 
-#: ./opengever/meeting/command.py:574
+#: ./opengever/meeting/command.py
 msgid "Additional document ${title} has been submitted successfully."
 msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Agenda Items"
 msgstr "Points de l'ordre du jour"
 
-#: ./opengever/meeting/command.py:114
+#: ./opengever/meeting/command.py
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Agendaitem list"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:416
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "An unexpected error has occurred"
 msgstr "Une erreur imprévue est apparue"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:68
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:73
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure you want to close this meeting?"
 msgstr "Êtes-vous sûr de vouloir fermer cette réunion?"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:84
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:89
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr "Êtes-vous sûr de vouloir fixer ce point de l'ordre du jour?"
 
-#: ./opengever/meeting/browser/memberships.py:53
+#: ./opengever/meeting/browser/memberships.py
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Impossible d'ajouter une adhésion, parce qu'elle se chevauche avec une adhésion existante du ${date_from} jusqu'au ${date_to}."
 
-#: ./opengever/meeting/browser/memberships.py:87
+#: ./opengever/meeting/browser/memberships.py
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr "Impossible de changer l'adhésion, parce qu'elle se chevauche avec une adhésion existante du ${date_from} jusqu'au ${date_to}."
 
-#: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
+#: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Choose Agenda Items"
 msgstr "Choisir les points du l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Close all proposals."
 msgstr "Toutes les propositions sont clôturées."
 
-#: ./opengever/meeting/browser/periods.py:69
+#: ./opengever/meeting/browser/periods.py
 msgid "Close currently active period"
 msgstr "Clôturer la période actuellement active"
 
-#: ./opengever/meeting/browser/periods.py:49
+#: ./opengever/meeting/browser/periods.py
 msgid "Close period"
 msgstr "Clôturer la période"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:34
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:36
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:31
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:33
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete proposal"
 msgstr "Supprimer le point de l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:18
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Discard"
 msgstr "Écarter"
 
-#: ./opengever/meeting/command.py:500
+#: ./opengever/meeting/command.py
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Le document ${title} a déjà été soumis dans cette version."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Documents"
 msgstr "Documents"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:209
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Download agenda item list"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:99
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Edit"
 msgstr "Modifier"
 
-#: ./opengever/meeting/command.py:145
+#: ./opengever/meeting/command.py
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr "L'extrait du protocole de ${title} a été généré avec succès."
 
-#: ./opengever/meeting/command.py:150
+#: ./opengever/meeting/command.py
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr "L'extrait du protocole ${title} a été mis à jour avec succès."
 
-#: ./opengever/meeting/command.py:214
+#: ./opengever/meeting/command.py
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été créé avec succès."
 
-#: ./opengever/meeting/command.py:219
+#: ./opengever/meeting/command.py
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr "L'extrait du protocole de la réunion ${title} a été mis à jour avec succès."
 
-#: ./opengever/meeting/committee.py:65
-#: ./opengever/meeting/committeecontainer.py:24
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "Excerpt template"
 msgstr "Modèle du protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Excerpts"
 msgstr "Extraits de protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/excerpt.pt:19
+#: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Export settings"
 msgstr "Paramètres de l'export"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Generate excerpts for all proposals."
 msgstr "Pour toutes les propositions un extrait de protocole sera généré et renvoyé au dossier de proposition."
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:94
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "History"
 msgstr "Historique"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:64
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include \"disclose to\""
 msgstr "Insérer \"à l'information de\""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:60
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include \"publish in\""
 msgstr "Insérer \"publication dans\""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:44
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include considerations"
 msgstr "Insérer des considérations"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:68
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include copy for attention"
 msgstr "Insérer une copie pour information"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:56
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include decision"
 msgstr "Insérer une décision"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:52
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include discussion"
 msgstr "Insérer une discussion"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:36
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include initial position"
 msgstr "Insérer une situation initiale"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:40
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include legal basis"
 msgstr "Insérer des fondements juridiques"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:48
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include proposed action"
 msgstr "Insérer une proposition"
 
-#: ./opengever/meeting/committee.py:85
+#: ./opengever/meeting/committee.py
 msgid "Linked repository folder"
 msgstr "Répertoire d'archivage"
 
@@ -238,48 +238,48 @@ msgstr "Répertoire d'archivage"
 msgid "Meeting Dossier"
 msgstr "Dossier de réunion"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:159
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Meeting number"
 msgstr "Numéro de la réunion"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:223
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Meeting on ${date}"
 msgstr "Réunion du ${date}"
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:63
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Meetinginformation"
 msgstr "Informations concernant la réunion"
 
-#: ./opengever/meeting/browser/templates/member.pt:41
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "Memberships"
 msgstr "Adhésions"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Number"
 msgstr "Numéro"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:314
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Order"
 msgstr "Tri"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Paragraph:"
 msgstr "Paragraphe:"
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:133
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Please select at least one agenda item."
 msgstr "Veuillez choisir au moins un point de l'ordre du jour."
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:85
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Please select at least one field for the excerpt."
 msgstr "Veuillez choisir au moins une case pour l'extrait du protocole."
 
-#: ./opengever/meeting/browser/templates/member.pt:19
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "Properties"
 msgstr "Propriétés"
 
 #. Default: "Proposal"
-#: ./opengever/meeting/browser/documents/submit.py:32
+#: ./opengever/meeting/browser/documents/submit.py
 msgid "Proposal"
 msgstr "Proposition"
 
@@ -287,29 +287,29 @@ msgstr "Proposition"
 msgid "Proposal Template"
 msgstr "Modèle de proposition"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:298
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Proposals:"
 msgstr "Propositions"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/model/meeting.py:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/model/meeting.py
 msgid "Protocol"
 msgstr "Protocole"
 
-#: ./opengever/meeting/model/meeting.py:275
+#: ./opengever/meeting/model/meeting.py
 msgid "Protocol Excerpt"
 msgstr "Extrait du protocole"
 
-#: ./opengever/meeting/command.py:64
+#: ./opengever/meeting/command.py
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr "Le protocole pour la séance ${title} a été créé avec succès."
 
-#: ./opengever/meeting/command.py:69
+#: ./opengever/meeting/command.py
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr "Le protocole pour la séance ${title} a été actualisé avec succès."
 
-#: ./opengever/meeting/committee.py:59
-#: ./opengever/meeting/committeecontainer.py:18
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "Protocol template"
 msgstr "Modèle du protocole"
 
@@ -318,1364 +318,1364 @@ msgid "Sablon Template"
 msgstr "Modèle Sablon"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:205
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: ./opengever/meeting/browser/meetings/unscheduled_proposals.py:50
+#: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
 msgstr "Joint à l'ordre du jour avec succès"
 
-#: ./opengever/meeting/browser/committee_templates/overview.pt:19
+#: ./opengever/meeting/browser/committee_templates/overview.pt
 msgid "Show more"
 msgstr "Afficher plus"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:277
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Text:"
 msgstr "Texte libre:"
 
-#: ./opengever/meeting/browser/meetings/meeting.py:175
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "The meeting and its dossier were created successfully"
 msgstr "La réunion et le dossier y associé ont été créés avec succès."
 
-#: ./opengever/meeting/browser/proposaltransitions.py:80
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "The proposal has been rejected successfully"
 msgstr "La proposition a été rejetée avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Title"
 msgstr "Titre"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:47
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Unschedule"
 msgstr "Enlever de l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:44
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:46
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Unschedule proposal"
 msgstr "Enlever un point de l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:66
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Update or create the protocol."
 msgstr "Le protocole est créé ou mis à jour."
 
-#: ./opengever/meeting/browser/submitdocuments.py:215
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr "Le document a été écrasé par une version plus récente du dossier proposé."
 
-#: ./opengever/meeting/browser/excerpt.py:44
+#: ./opengever/meeting/browser/excerpt.py
 msgid "Updated with a newer excerpt version."
 msgstr "Le document a été écrasé par une version plus récente de l'extrait de protocole."
 
-#: ./opengever/meeting/command.py:326
+#: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé par une nouvelle version de la réunion ${title}."
 
 #. Default: "Active"
-#: ./opengever/meeting/browser/documents/proposalstab.py:64
-#: ./opengever/meeting/model/committee.py:29
-#: ./opengever/meeting/model/period.py:21
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/model/committee.py
+#: ./opengever/meeting/model/period.py
 msgid "active"
 msgstr "Actif"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:337
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:307
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_decided"
 msgstr "Le point de l'ordre du jour a été fixé."
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:283
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_deleted"
 msgstr "Le point a été enlevé avec succès de l'ordre du jour."
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:312
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_meeting_held"
 msgstr "Le point de l'ordre du jour a été fixé et la réunion a eu lieu."
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:242
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
 msgstr "L'ordre des points de l'ordre du jour a été actualisé."
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:304
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_proposal_decided"
 msgstr "Le point de l'ordre du jour a été fixé, l'extrait de protocole a été généré et renvoyé."
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:353
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_reopened"
 msgstr "Le point d'ordre du jour a été rouvert."
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:366
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_revised"
 msgstr "Le point d'ordre du jour a été révisé avec succès."
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:255
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_empty_string"
 msgstr "Le titre d'un point d'ordre du jour ne peut pas être laissé vide."
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:262
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_too_long_title"
 msgstr "Le titre du point de l'ordre du jour est trop long."
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:268
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_updated"
 msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
 
 #. Default: "All"
-#: ./opengever/meeting/browser/documents/proposalstab.py:61
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "all"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/committeeforms.py:73
-#: ./opengever/meeting/browser/documents/submit.py:96
-#: ./opengever/meeting/browser/meetings/meeting.py:121
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/documents/submit.py
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:92
+#: ./opengever/meeting/browser/periods.py
 msgid "button_close_period"
 msgstr "Clôturer une période"
 
 #. Default: "Continue"
-#: ./opengever/meeting/browser/committeeforms.py:61
-#: ./opengever/meeting/browser/meetings/meeting.py:105
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Submit Attachments"
-#: ./opengever/meeting/browser/documents/submit.py:82
-#: ./opengever/meeting/browser/submitdocuments.py:83
+#: ./opengever/meeting/browser/documents/submit.py
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "button_submit_attachments"
 msgstr "Soumettre des appendices"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:161
+#: ./opengever/meeting/model/proposal.py
 msgid "cancel"
 msgstr "Annuler"
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py
 msgid "cancelled"
 msgstr "Annulé"
 
 #. Default: "Close meeting"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:58
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:60
-#: ./opengever/meeting/model/meeting.py:83
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+#: ./opengever/meeting/model/meeting.py
 msgid "close_meeting"
 msgstr "Clôturer"
 
 #. Default: "Close period"
-#: ./opengever/meeting/model/period.py:29
+#: ./opengever/meeting/model/period.py
 msgid "close_period"
 msgstr "Clôturer une période"
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:77
-#: ./opengever/meeting/model/period.py:22
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/model/period.py
 msgid "closed"
 msgstr "clôturé"
 
 #. Default: "Comittee"
-#: ./opengever/meeting/browser/documents/proposalstab.py:95
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_comittee"
 msgstr "Comité"
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:58
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_date"
 msgstr "Date"
 
 #. Default: "Date from"
-#: ./opengever/meeting/tabs/membershiplisting.py:32
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_date_from"
 msgstr "De"
 
 #. Default: "Date to"
-#: ./opengever/meeting/tabs/membershiplisting.py:36
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_date_to"
 msgstr "Jusqu'à"
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/tabs/memberlisting.py:36
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_email"
 msgstr "e-mail"
 
 #. Default: "Firstname"
-#: ./opengever/meeting/tabs/memberlisting.py:26
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_firstname"
 msgstr "Prénom"
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:62
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_from"
 msgstr "De"
 
 #. Default: "Lastname"
-#: ./opengever/meeting/tabs/memberlisting.py:31
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_lastname"
 msgstr "Nom"
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:55
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_location"
 msgstr "Lieu de réunion"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/browser/documents/proposalstab.py:99
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_meeting"
 msgstr "Réunion"
 
 #. Default: "Member"
-#: ./opengever/meeting/tabs/membershiplisting.py:28
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_member"
 msgstr "membre"
 
 #. Default: "Role"
-#: ./opengever/meeting/tabs/membershiplisting.py:40
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_role"
 msgstr "Rôle"
 
 #. Default: "State"
-#: ./opengever/meeting/browser/documents/proposalstab.py:91
-#: ./opengever/meeting/tabs/meetinglisting.py:51
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_state"
 msgstr "Etat"
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/documents/proposalstab.py:87
-#: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:47
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/tabs/committeelisting.py
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_title"
 msgstr "Titre"
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:67
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_to"
 msgstr "Jusqu'à"
 
 #. Default: "Create Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:115
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "create_excerpt"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:51
-#: ./opengever/meeting/model/proposal.py:159
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/proposal.py
 msgid "decide"
 msgstr "Décider"
 
 #. Default: "Decide Agendaitem"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "decide_agendaitem"
 msgstr "Décider d'un point de l'ordre du jour"
 
 #. Default: "Decided"
-#: ./opengever/meeting/browser/documents/proposalstab.py:68
-#: ./opengever/meeting/model/agendaitem.py:45
-#: ./opengever/meeting/model/proposal.py:139
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/proposal.py
 msgid "decided"
 msgstr "Décidé"
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:129
+#: ./opengever/meeting/committee.py
 msgid "description_group"
 msgstr "Pour ce groupe, les autorisations sont attribuées automatiquement au comité."
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:382
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "document_checkout_not_allowed"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/tabs/meetinglisting.py:72
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "dossier"
 msgstr "Dossier"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:214
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "download protocol"
 msgstr "Télécharger le protocole"
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:399
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "empty_paragraph"
 msgstr "Ce paragraphe ne doit pas rester vide."
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:414
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "empty_proposal"
 msgstr "Ce texte libre ne doit pas être vide."
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
-#: ./opengever/meeting/browser/proposaltransitions.py:29
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
 #. Default: "Only word files (.docx) can be added here."
-#: ./opengever/meeting/proposaltemplate.py:36
+#: ./opengever/meeting/proposaltemplate.py
 msgid "error_prosal_template_not_docx"
 msgstr "Seuls les fichiers Word (.docx) sont acceptés."
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:217
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_document_default_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:464
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_generated"
 msgstr ""
 
 #. Default: "Excerpt was returned to proposer."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:484
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
 msgstr ""
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
-#: ./opengever/meeting/browser/toc.py:60
+#: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"
 msgstr "Table de matière ${period} ${committee} alphabétique"
 
 #. Default: "Repository Toc ${period} ${committee}"
-#: ./opengever/meeting/browser/toc.py:89
+#: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
 msgstr "Table de matière ${period} ${committee} selon l'ordre des points"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:176
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:203
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new agenda item list as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:252
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "generate new excerpt"
 msgstr "Générer un nouvel extrait de protocole"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:208
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new protocol as word document"
 msgstr "Générer le protocole comme document Word"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:215
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new version as word document"
 msgstr "Générer une nouvelle version comme document Word"
 
 #. Default: "Reject proposal"
-#: ./opengever/meeting/browser/proposaltransitions.py:68
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "heading_reject_proposal_form"
 msgstr "Rejeter la proposition"
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:76
+#: ./opengever/meeting/model/meeting.py
 msgid "held"
 msgstr "Tenue"
 
 #. Default: "Describe, why the proposal is rejected"
-#: ./opengever/meeting/browser/proposaltransitions.py:60
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "help_reject_proposal_text"
 msgstr "Décrivez la raison pour laquelle la proposition a été rejetée."
 
 #. Default: "Select the target dossier where the excerpts should be created."
-#: ./opengever/meeting/browser/meetings/excerpt.py:24
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "help_select_dossier"
 msgstr "Choisissez le dossier, dans lequel l'extrait de protocole doit être déposé."
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:85
+#: ./opengever/meeting/model/meeting.py
 msgid "hold"
 msgstr "Tenir une réunion"
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py
 msgid "inactive"
 msgstr "Inactif"
 
-#. Default: "Ad hoc agenda item template"
-#: ./opengever/meeting/committee.py:94
-#: ./opengever/meeting/committeecontainer.py:44
-msgid "label_ad_hoc_template"
-msgstr ""
-
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_ad_hoc_delete_action"
 msgstr ""
 
+#. Default: "Ad hoc agenda item template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_ad_hoc_template"
+msgstr ""
+
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:374
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_agenda_item_number"
 msgstr ""
 
 #. Default: "Agendaitem list"
-#: ./opengever/meeting/model/meeting.py:279
-#: ./opengever/meeting/protocol.py:160
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/protocol.py
 msgid "label_agendaitem_list"
 msgstr "Liste des points du jour"
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:71
-#: ./opengever/meeting/committeecontainer.py:30
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr "Modèle de la liste des points du jour"
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:370
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
-#: ./opengever/meeting/browser/submitdocuments.py:40
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "label_attachments"
 msgstr "Appendices"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:152
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:36
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:38
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:240
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_close"
 msgstr "Clôturer"
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:77
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_deactivated"
 msgstr "Comité déactivé avec succès."
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:50
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_reactivated"
 msgstr "Comité réactivé avec succès."
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:59
-#: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/templates/member.pt
+#: ./opengever/meeting/proposal.py
 msgid "label_committee"
 msgstr "Comité"
 
 #. Default: "The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually."
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "label_conflict_changes"
 msgstr "Le protocole a été édité entre-temps. Sie vous voulez garder vos changements, essayer de résoudre les conflits de façon manuelle."
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
-#: ./opengever/meeting/proposal.py:146
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_considerations"
 msgstr "Considérations"
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:148
-#: ./opengever/meeting/proposal.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_copy_for_attention"
 msgstr "Copie pour information"
 
 #. Default: "Create Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:127
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_create_excerpt"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:92
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:36
+#: ./opengever/meeting/browser/committee.py
 msgid "label_current_members"
 msgstr "Membres actuels"
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:21
+#: ./opengever/meeting/browser/committee.py
 msgid "label_current_period"
 msgstr "Période actuelle"
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/memberships.py:21
-#: ./opengever/meeting/browser/periods.py:37
-#: ./opengever/meeting/browser/templates/member.pt:50
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/periods.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_date_from"
 msgstr "De"
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/memberships.py:26
-#: ./opengever/meeting/browser/periods.py:43
-#: ./opengever/meeting/browser/templates/member.pt:51
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/periods.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_date_to"
 msgstr "Jusqu'à"
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:36
+#: ./opengever/meeting/model/committee.py
 msgid "label_deactivate"
 msgstr "Déactiver le comité"
 
 #. Default: "Decide"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:88
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:93
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_decide"
 msgstr "Décider"
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_decide_action"
 msgstr "Fixez ce point de l'ordre du jour"
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
-#: ./opengever/meeting/proposal.py:222
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_decision"
 msgstr "Décision"
 
 #. Default: "Decision draft"
-#: ./opengever/meeting/proposal.py:100
+#: ./opengever/meeting/proposal.py
 msgid "label_decision_draft"
 msgstr "Brouillon de la décision"
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/documents/proposalstab.py:82
-#: ./opengever/meeting/browser/meetings/meeting.py:375
-#: ./opengever/meeting/proposal.py:248
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/proposal.py
 msgid "label_decision_number"
 msgstr "Numéro de décision"
 
 #. Default: "remove this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:349
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_delete_action"
 msgstr "Enlever ce point de l'ordre du jour"
 
 #. Default: "Are you sure you want to delete this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:32
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:34
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_delete_agenda_item_confirm_text"
 msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:145
-#: ./opengever/meeting/proposal.py:112
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_disclose_to"
 msgstr "\"à l'information de\""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
-#: ./opengever/meeting/proposal.py:379
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_discussion"
 msgstr "Discussion"
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:359
+#: ./opengever/meeting/proposal.py
 msgid "label_dossier"
 msgstr "Dossier"
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:460
+#: ./opengever/meeting/proposal.py
 msgid "label_dossier_not_available"
 msgstr "Dossier indisponible"
 
 #. Default: "download TOC alphabetical"
-#: ./opengever/meeting/browser/templates/periods.pt:11
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc"
 msgstr "Table de matière alphabétique"
 
 #. Default: "download TOC by repository"
-#: ./opengever/meeting/browser/templates/periods.pt:18
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_toc"
 msgstr "Table de matière selon l'ordre des points"
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/templates/member.pt:65
-#: ./opengever/meeting/browser/templates/periods.pt:27
+#: ./opengever/meeting/browser/templates/member.pt
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_edit"
 msgstr "Editer"
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:348
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_action"
 msgstr "Editer le titre"
 
 #. Default: "Edit after creation"
-#: ./opengever/meeting/browser/proposalforms.py:100
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_edit_after_creation"
 msgstr "Modifier après la création"
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:346
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_cancel"
 msgstr "Annuler"
 
 #. Default: "Checkout and edit word document."
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_document_action"
 msgstr ""
 
 #. Default: "Edit Membership"
-#: ./opengever/meeting/browser/memberships.py:73
+#: ./opengever/meeting/browser/memberships.py
 msgid "label_edit_membership"
 msgstr "Editer l'adhésion"
 
 #. Default: "Edit Period"
-#: ./opengever/meeting/browser/periods.py:204
+#: ./opengever/meeting/browser/periods.py
 msgid "label_edit_period"
 msgstr "Editer"
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:347
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_save"
 msgstr "Sauvegarder"
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/browser/members.py:34
-#: ./opengever/meeting/browser/templates/member.pt:32
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_email"
 msgstr "e-mail"
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:73
-#: ./opengever/meeting/browser/meetings/protocol.py:73
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:77
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "label_excerpt"
 msgstr "Extrait du protocole"
 
 #. Default: "Excerpts"
-#: ./opengever/meeting/browser/meetings/meeting.py:371
-#: ./opengever/meeting/proposal.py:151
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/proposal.py
 msgid "label_excerpts"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/meeting/proposaltemplate.py:19
+#: ./opengever/meeting/proposaltemplate.py
 msgid "label_file"
 msgstr "Fichier"
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:300
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:299
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_filter_proposal"
 msgstr "Filtrage"
 
 #. Default: "Firstname"
-#: ./opengever/meeting/browser/members.py:24
-#: ./opengever/meeting/browser/templates/member.pt:28
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_firstname"
 msgstr "Prénom"
 
 #. Default: "Generate an excerpt."
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_generate_excerpt"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:128
+#: ./opengever/meeting/committee.py
 msgid "label_group"
 msgstr "Groupe"
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
-#: ./opengever/meeting/proposal.py:88
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_initial_position"
 msgstr "Situation initiale"
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:331
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_insert"
 msgstr "Insérer"
 
 #. Default: "Last Meeting:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:45
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "label_last_meeting"
 msgstr "Dernière séance:"
 
 #. Default: "Lastname"
-#: ./opengever/meeting/browser/members.py:29
-#: ./opengever/meeting/browser/templates/member.pt:24
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
-#: ./opengever/meeting/proposal.py:82
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_legal_basis"
 msgstr "Base légale"
 
 #. Default: "Linked meeting"
-#: ./opengever/meeting/browser/dossier/overview.py:23
+#: ./opengever/meeting/browser/dossier/overview.py
 msgid "label_linked_meeting"
 msgstr "Réunion"
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:86
+#: ./opengever/meeting/committee.py
 msgid "label_linked_repository_folder"
 msgstr "Tous les dossiers de réunion et tous les documents générés automatiquement seront classés sous cette position."
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:64
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_location"
 msgstr "Site"
 
 #. Default: "Main Atrributes"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:12
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "label_main_attributes"
 msgstr "Propriétés"
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:186
+#: ./opengever/meeting/proposal.py
 msgid "label_meeting"
 msgstr "Séance"
 
 #. Default: "Member"
-#: ./opengever/meeting/browser/memberships.py:30
+#: ./opengever/meeting/browser/memberships.py
 msgid "label_member"
 msgstr "Membre"
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:95
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_modified"
 msgstr "Dernière modification"
 
 #. Default: "Next Meeting:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:53
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "label_next_meeting"
 msgstr "Prochaine réunion:"
 
 #. Default: "No agenda item list has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:197
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:193
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_agendaitem_list"
 msgstr ""
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:257
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "label_no_excerpts"
 msgstr "Aucun extrait de protocole supplémentaire n'a été généré encore."
 
 #. Default: "This member has no memberships."
-#: ./opengever/meeting/browser/templates/member.pt:43
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_no_memberships"
 msgstr "Cet utilisateur n'a pas d'adhésion."
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:386
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_no_proposals"
 msgstr "Aucune proposition n'a été soumise."
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:228
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:227
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_protocol"
 msgstr "Aucun protocole n'a été généré encore."
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_other_participants"
 msgstr "Autres participants"
 
 #. Default: "Paragraph template"
-#: ./opengever/meeting/committee.py:101
-#: ./opengever/meeting/committeecontainer.py:51
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_paragraph_template"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_participants"
 msgstr "Participants"
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_presidency"
 msgstr "Présidence"
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/browser/documents/proposalstab.py:78
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "label_proposal_id"
 msgstr "Numéro de référence"
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:83
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_proposal_template"
 msgstr "Modèle de proposition"
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
-#: ./opengever/meeting/proposal.py:94
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:56
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_protocol_start_page_number"
 msgstr "Début de la numérotation des pages du protocole"
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
-#: ./opengever/meeting/proposal.py:106
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_publish_in"
 msgstr "Publication dans"
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:40
+#: ./opengever/meeting/model/committee.py
 msgid "label_reactivate"
 msgstr "Réactiver le comité"
 
 #. Default: "Comment"
-#: ./opengever/meeting/browser/proposaltransitions.py:59
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "label_reject_proposal_text"
 msgstr "Commentaire"
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/templates/member.pt:70
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_remove"
 msgstr "Supprimer"
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_reopen_action"
 msgstr "Rouvrir ce point de l'ordre du jour"
 
 #. Default: "Return excerpt to proposer"
-#: ./opengever/meeting/browser/meetings/meeting.py:372
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_return_action"
 msgstr ""
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_return_excerpt"
 msgstr ""
 
 #. Default: "This excerpt was returned to the dossier"
-#: ./opengever/meeting/browser/meetings/meeting.py:376
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_returned_excerpt"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:352
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_revise_action"
 msgstr "Réviser le point de l'ordre du jour"
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/memberships.py:35
-#: ./opengever/meeting/browser/templates/member.pt:52
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_role"
 msgstr "Rôle"
 
 #. Default: "File"
-#: ./opengever/meeting/sablontemplate.py:13
+#: ./opengever/meeting/sablontemplate.py
 msgid "label_sablon_template_file"
 msgstr "Fichier-modèle"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:385
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:280
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:316
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_schedule"
 msgstr "Mettre à l'ordre du jour"
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:38
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
 msgstr "Secrétaire"
 
 #. Default: "Target dossier"
-#: ./opengever/meeting/browser/meetings/excerpt.py:22
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "label_select_dossier"
 msgstr "Fichier-cible"
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:69
-#: ./opengever/meeting/browser/meetings/protocol.py:68
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:54
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Excerpt title"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:122
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_title_excerpt"
 msgstr ""
 
 #. Default: "Table of contents template"
-#: ./opengever/meeting/committee.py:78
-#: ./opengever/meeting/committeecontainer.py:37
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
 msgstr "Modèle de la table de matière"
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:373
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_toggle_attachments"
 msgstr ""
 
 #. Default: "Transition ${transition} executed"
-#: ./opengever/meeting/browser/meetings/transitions.py:24
+#: ./opengever/meeting/browser/meetings/transitions.py
 msgid "label_transition_executed"
 msgstr "Modification de l'état ${transition} exécutée"
 
 #. Default: "You have unsaved changes."
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:26
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "label_unsaved_changes"
 msgstr "Il y a des modifications locales non sauvegardées."
 
 #. Default: "Are you sure you want to unschedule this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:45
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:47
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_unschedule_agenda_item_confirm_text"
 msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:30
+#: ./opengever/meeting/browser/committee.py
 msgid "label_unscheduled_proposals"
 msgstr "Propositions imprévues"
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:25
+#: ./opengever/meeting/browser/committee.py
 msgid "label_upcoming_meetings"
 msgstr "Prochaines réunions"
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:244
+#: ./opengever/meeting/proposal.py
 msgid "label_workflow_state"
 msgstr "Etat"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:239
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "label_zip_download"
 msgstr "Télécharger le fichier ZIP"
 
 #. Default: "Language"
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/proposal.py
 msgid "language"
 msgstr "Langue"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "location"
 msgstr "Lieu"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:151
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
 msgstr "Dossier de la réunion"
 
 #. Default: "Meetings"
-#: ./opengever/meeting/browser/tabbed.py:13
+#: ./opengever/meeting/browser/tabbed.py
 msgid "meetings"
 msgstr "Réunions"
 
 #. Default: "Memberships"
-#: ./opengever/meeting/browser/tabbed.py:19
+#: ./opengever/meeting/browser/tabbed.py
 msgid "memberships"
 msgstr "Adhésions"
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:262
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_changes_saved"
 msgstr "Modifications sauvegardées"
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:94
-#: ./opengever/meeting/browser/meetings/protocol.py:254
+#: ./opengever/meeting/browser/meetings/edit_meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_locked_by_another_user"
 msgstr "Les modifications n'ont pas pu être sauvegardées; le protocole a été verrouillé par ${username}."
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:89
-#: ./opengever/meeting/browser/meetings/protocol.py:248
+#: ./opengever/meeting/browser/meetings/edit_meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_write_conflict"
 msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été modifié entre-temps."
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:422
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "missing_ad_hoc_template"
 msgstr ""
 
 #. Default: "Choose a meaningful title to distinguish the created excerpts better."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_confirm_create_excerpt_dialog"
 msgstr ""
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_confirm_return_excerpt_dialog"
 msgstr ""
 
 #. Default: "The agenda item list for meeting ${title} has already been generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
 msgid "msg_error_agendaitem_list_already_generated"
 msgstr ""
 
 #. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:39
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
 msgid "msg_error_agendaitem_list_missing_template"
 msgstr ""
 
 #. Default: "The protocol for meeting ${title} has already been generated."
-#: ./opengever/meeting/browser/protocol.py:76
+#: ./opengever/meeting/browser/protocol.py
 msgid "msg_error_protocol_already_generated"
 msgstr "Le protocole pour la réunion ${title} a déjà été créé."
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:81
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:86
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_hold_meeting_dialog"
 msgstr "Lors de la clôture de ce point de l'ordre du jour, la réunion sera mise dans l'état \"réalisé\". Ensuite, l'ordre du jour ne pourra plus être modifié."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:40
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_inactive_committee_selected"
 msgstr "Le comité sélectionné a été désactivé; la proposition n'a pas pu être soumise."
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/meeting.py
 msgid "msg_meeting_successfully_closed"
 msgstr "La réunion ${title} a été clôturée avec succès, les extraits de protocole ont été générés et renvoyés aux dossiers initiaux."
 
 #. Default: "The membership was deleted successfully."
-#: ./opengever/meeting/browser/memberships.py:107
+#: ./opengever/meeting/browser/memberships.py
 msgid "msg_membership_deleted"
 msgstr "L'adhésion a été supprimée avec succès."
 
 #. Default: "There is no toc template configured, toc could not be generated."
-#: ./opengever/meeting/browser/toc.py:25
+#: ./opengever/meeting/browser/toc.py
 msgid "msg_no_toc_template"
 msgstr "Il n'y a pas de modèle configuré pour la table des matières; la table des matières n'a pas pu être générée."
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:58
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_pending_meetings"
 msgstr "Il y a des réunions non clôturées."
 
 #. Default: "Proposal cancelled successfully."
-#: ./opengever/meeting/model/proposal.py:68
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_cancelled"
 msgstr "Proposition annulée avec succès."
 
 #. Default: "Proposal reactivated successfully."
-#: ./opengever/meeting/model/proposal.py:79
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_reactivated"
 msgstr "La proposition a été réactivée."
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:50
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
 msgstr "Proposition soumise avec succès."
 
 #. Default: "The object was deleted successfully."
-#: ./opengever/meeting/browser/views.py:21
+#: ./opengever/meeting/browser/views.py
 msgid "msg_successfully_deleted"
 msgstr "L'objet a été supprimé avec succès."
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:66
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_unscheduled_proposals"
 msgstr "Des propositions qui ne figurent pas à l'ordre du jour ont été attribuées à ce comité."
 
 #. Default: "New unscheduled proposals:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:32
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
 
 #. Default: "Overview"
-#: ./opengever/meeting/browser/tabbed.py:10
+#: ./opengever/meeting/browser/tabbed.py
 msgid "overview"
 msgstr "Sommaire"
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:403
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "paragraph_added"
 msgstr "Paragraphe ajouté avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:141
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "participants"
 msgstr "Participants"
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:44
-#: ./opengever/meeting/model/meeting.py:75
-#: ./opengever/meeting/model/proposal.py:134
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/model/proposal.py
 msgid "pending"
 msgstr "En modification"
 
 #. Default: "Periods"
-#: ./opengever/meeting/browser/tabbed.py:22
+#: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr "Périodes"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:127
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "presidency"
 msgstr "Présidence"
 
 #. Default: "Proposal document"
-#: ./opengever/meeting/proposal.py:195
+#: ./opengever/meeting/proposal.py
 msgid "proposal_document"
 msgstr "Document de proposition"
 
 #. Default: "Proposal cancelled by ${user}"
-#: ./opengever/meeting/proposalhistory.py:196
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_cancelled"
 msgstr "Annulé par ${user}"
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/proposalhistory.py:185
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_created"
 msgstr "Créé par ${user}"
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/proposalhistory.py:312
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
 msgstr "Proposition décidée par ${user}"
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:245
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_submitted"
 msgstr "Document ${title} soumis par ${user} en version ${version}."
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:350
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_updated"
 msgstr "Document soumis ${title} actualisé en version ${version} par ${user}"
 
 #. Default: "Proposal reactivated by ${user}"
-#: ./opengever/meeting/proposalhistory.py:207
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reactivated"
 msgstr "Réactivé par ${user}"
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/meeting/proposalhistory.py:263
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_rejected"
 msgstr "Rejeté par ${user}"
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:337
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Enlevé de l'ordre du jour de la réunion ${meeting} par ${user}"
 
 #. Default: "Proposal reopened by ${user}"
-#: ./opengever/meeting/proposalhistory.py:275
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reopened"
 msgstr "Proposition de révision rouverte par ${user}"
 
 #. Default: "Proposal revised by ${user}"
-#: ./opengever/meeting/proposalhistory.py:324
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_revised"
 msgstr "Décision de proposition révisée par ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:299
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_scheduled"
 msgstr "Prévu pour la séance ${meeting} par ${user}"
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/proposalhistory.py:218
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr "Soumis par ${user}"
 
 #. Default: "Protocol"
-#: ./opengever/meeting/protocol.py:58
+#: ./opengever/meeting/protocol.py
 msgid "protocol"
 msgstr "Protocole"
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:146
+#: ./opengever/meeting/protocol.py
 msgid "protocol_excerpt"
 msgstr "Extrait de protocole"
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:163
+#: ./opengever/meeting/model/proposal.py
 msgid "reactivate"
 msgstr "Réactiver"
 
 #. Default: "Reject"
-#: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:153
+#: ./opengever/meeting/browser/proposaltransitions.py
+#: ./opengever/meeting/model/proposal.py
 msgid "reject"
 msgstr "Rejeter"
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:53
-#: ./opengever/meeting/model/meeting.py:89
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/meeting.py
 msgid "reopen"
 msgstr "Réactiver"
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:101
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "return_excerpt"
 msgstr ""
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:55
+#: ./opengever/meeting/model/agendaitem.py
 msgid "revise"
 msgstr "Réviser"
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:46
+#: ./opengever/meeting/model/agendaitem.py
 msgid "revision"
 msgstr "Révision"
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:155
+#: ./opengever/meeting/model/proposal.py
 msgid "schedule"
 msgstr "Mettre à l'ordre du jour"
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:138
+#: ./opengever/meeting/model/proposal.py
 msgid "scheduled"
 msgstr "Mis à l'ordre du jour"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:134
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "secretary"
 msgstr "Secrétaire"
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:105
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "status"
 msgstr "État"
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:151
+#: ./opengever/meeting/model/proposal.py
 msgid "submit"
 msgstr "soumettre"
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:136
+#: ./opengever/meeting/model/proposal.py
 msgid "submitted"
 msgstr "Soumis"
 
 #. Default: "Submitted Proposals"
-#: ./opengever/meeting/browser/tabbed.py:16
+#: ./opengever/meeting/browser/tabbed.py
 msgid "submittedproposals"
 msgstr "Propositions"
 
 #. Default: "${amount} matches"
-#: ./opengever/meeting/browser/templates/no_selection.pt:2
+#: ./opengever/meeting/browser/templates/no_selection.pt
 msgid "tab_matches"
 msgstr "${amount} résultats"
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:437
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
 msgstr "Texte libre ajouté avec succès."
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:118
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "time"
 msgstr "Temps"
 
 #. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py:377
+#: ./opengever/meeting/model/meeting.py
 msgid "title_ad_hoc_document"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:157
+#: ./opengever/meeting/model/proposal.py
 msgid "un-schedule"
 msgstr "Enlever le point de l'ordre du jour"
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:325
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
 msgstr ""
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:135
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_end"
 msgstr ""
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_location"
 msgstr ""
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:145
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:129
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_start"
 msgstr ""
 
 #. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:121
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_status"
 msgstr ""
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:167
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:153
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:225
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:310
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:295
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_proposal"
 msgstr ""
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:160
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_secretary"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-25 11:37+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,217 +17,217 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.meeting\n"
 
-#: ./opengever/meeting/command.py:540
+#: ./opengever/meeting/command.py
 msgid "A new submitted version of document ${title} has been created."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:319
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Actions"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:79
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Add Dossier for Meeting"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:78
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Add Meeting"
 msgstr ""
 
 #. Default: "Add Member"
-#: ./opengever/meeting/browser/members.py:44
+#: ./opengever/meeting/browser/members.py
 msgid "Add Member"
 msgstr ""
 
 #. Default: "Add Membership"
-#: ./opengever/meeting/browser/memberships.py:45
+#: ./opengever/meeting/browser/memberships.py
 msgid "Add Membership"
 msgstr ""
 
-#: ./opengever/meeting/browser/committeeforms.py:29
+#: ./opengever/meeting/browser/committeeforms.py
 msgid "Add committee"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:50
+#: ./opengever/meeting/browser/periods.py
 msgid "Add new period"
 msgstr ""
 
-#: ./opengever/meeting/browser/committeeforms.py:30
-#: ./opengever/meeting/browser/periods.py:137
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/periods.py
 msgid "Add period"
 msgstr ""
 
-#: ./opengever/meeting/command.py:574
+#: ./opengever/meeting/command.py
 msgid "Additional document ${title} has been submitted successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:59
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:61
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:273
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Agenda Items"
 msgstr ""
 
-#: ./opengever/meeting/command.py:114
+#: ./opengever/meeting/command.py
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:175
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Agendaitem list"
 msgstr ""
 
 #. Default: "An unexpected error has occurred"
-#: ./opengever/meeting/browser/meetings/meeting.py:416
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "An unexpected error has occurred"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:68
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:73
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure you want to close this meeting?"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:106
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure you want to return this excerpt to the proposer?"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:84
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:89
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure, you want to decide this agendaitem?"
 msgstr ""
 
-#: ./opengever/meeting/browser/memberships.py:53
+#: ./opengever/meeting/browser/memberships.py
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
-#: ./opengever/meeting/browser/memberships.py:87
+#: ./opengever/meeting/browser/memberships.py
 msgid "Can't change membership, it overlaps an existing membership from ${date_from} to ${date_to}."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/excerpt.pt:23
+#: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Choose Agenda Items"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:64
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:66
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Close all proposals."
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:69
+#: ./opengever/meeting/browser/periods.py
 msgid "Close currently active period"
 msgstr ""
 
-#: ./opengever/meeting/browser/periods.py:49
+#: ./opengever/meeting/browser/periods.py
 msgid "Close period"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:34
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:36
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:31
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:33
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:18
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Discard"
 msgstr ""
 
-#: ./opengever/meeting/command.py:500
+#: ./opengever/meeting/command.py
 msgid "Document ${title} has already been submitted in that version."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:318
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Documents"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:182
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:209
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Download agenda item list"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:99
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/meeting/command.py:145
+#: ./opengever/meeting/command.py
 msgid "Excerpt for agenda item ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:150
+#: ./opengever/meeting/command.py
 msgid "Excerpt for agenda item ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:214
+#: ./opengever/meeting/command.py
 msgid "Excerpt for meeting ${title} has been generated successfully"
 msgstr ""
 
-#: ./opengever/meeting/command.py:219
+#: ./opengever/meeting/command.py
 msgid "Excerpt for meeting ${title} has been updated successfully"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:65
-#: ./opengever/meeting/committeecontainer.py:24
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "Excerpt template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:250
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Excerpts"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/excerpt.pt:19
+#: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Export settings"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:65
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:67
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Generate excerpts for all proposals."
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:94
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "History"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:64
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include \"disclose to\""
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:60
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include \"publish in\""
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:44
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include considerations"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:68
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include copy for attention"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:56
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include decision"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:52
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include discussion"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:36
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include initial position"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:40
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include legal basis"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:48
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Include proposed action"
 msgstr ""
 
-#: ./opengever/meeting/committee.py:85
+#: ./opengever/meeting/committee.py
 msgid "Linked repository folder"
 msgstr ""
 
@@ -235,48 +235,48 @@ msgstr ""
 msgid "Meeting Dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:159
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Meeting number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:223
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "Meeting on ${date}"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:63
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Meetinginformation"
 msgstr ""
 
-#: ./opengever/meeting/browser/templates/member.pt:41
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "Memberships"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:316
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Number"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:314
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Order"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Paragraph:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:133
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Please select at least one agenda item."
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/excerpt.py:85
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "Please select at least one field for the excerpt."
 msgstr ""
 
-#: ./opengever/meeting/browser/templates/member.pt:19
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "Properties"
 msgstr ""
 
 #. Default: "Proposal"
-#: ./opengever/meeting/browser/documents/submit.py:32
+#: ./opengever/meeting/browser/documents/submit.py
 msgid "Proposal"
 msgstr ""
 
@@ -284,29 +284,29 @@ msgstr ""
 msgid "Proposal Template"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:298
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Proposals:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:207
-#: ./opengever/meeting/model/meeting.py:272
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/model/meeting.py
 msgid "Protocol"
 msgstr ""
 
-#: ./opengever/meeting/model/meeting.py:275
+#: ./opengever/meeting/model/meeting.py
 msgid "Protocol Excerpt"
 msgstr ""
 
-#: ./opengever/meeting/command.py:64
+#: ./opengever/meeting/command.py
 msgid "Protocol for meeting ${title} has been generated successfully."
 msgstr ""
 
-#: ./opengever/meeting/command.py:69
+#: ./opengever/meeting/command.py
 msgid "Protocol for meeting ${title} has been updated successfully."
 msgstr ""
 
-#: ./opengever/meeting/committee.py:59
-#: ./opengever/meeting/committeecontainer.py:18
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "Protocol template"
 msgstr ""
 
@@ -315,1364 +315,1364 @@ msgid "Sablon Template"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/excerpt.py:120
-#: ./opengever/meeting/browser/meetings/protocol.py:205
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "Save"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/unscheduled_proposals.py:50
+#: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/committee_templates/overview.pt:19
+#: ./opengever/meeting/browser/committee_templates/overview.pt
 msgid "Show more"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:277
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Text:"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/meeting.py:175
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "The meeting and its dossier were created successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/proposaltransitions.py:80
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "The proposal has been rejected successfully"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:317
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Title"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:47
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:49
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Unschedule"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:44
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:46
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Unschedule proposal"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:66
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:68
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Update or create the protocol."
 msgstr ""
 
-#: ./opengever/meeting/browser/submitdocuments.py:215
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
 msgstr ""
 
-#: ./opengever/meeting/browser/excerpt.py:44
+#: ./opengever/meeting/browser/excerpt.py
 msgid "Updated with a newer excerpt version."
 msgstr ""
 
-#: ./opengever/meeting/command.py:326
+#: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/meeting/browser/documents/proposalstab.py:64
-#: ./opengever/meeting/model/committee.py:29
-#: ./opengever/meeting/model/period.py:21
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/model/committee.py
+#: ./opengever/meeting/model/period.py
 msgid "active"
 msgstr ""
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:337
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
 msgstr ""
 
 #. Default: "Agenda Item decided."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:307
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_decided"
 msgstr ""
 
 #. Default: "Agenda Item Successfully deleted"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:283
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_deleted"
 msgstr ""
 
 #. Default: "Agendaitem has been decided and the meeting has been held."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:312
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_meeting_held"
 msgstr ""
 
 #. Default: "Agenda Item order updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:242
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
 msgstr ""
 
 #. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:304
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:353
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_reopened"
 msgstr ""
 
 #. Default: "Agenda Item revised successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:366
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_revised"
 msgstr ""
 
 #. Default: "Agenda Item title must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:255
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_empty_string"
 msgstr ""
 
 #. Default: "Agenda Item title is too long."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:262
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_too_long_title"
 msgstr ""
 
 #. Default: "Agenda Item updated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:268
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_updated"
 msgstr ""
 
 #. Default: "All"
-#: ./opengever/meeting/browser/documents/proposalstab.py:61
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "all"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/committeeforms.py:73
-#: ./opengever/meeting/browser/documents/submit.py:96
-#: ./opengever/meeting/browser/meetings/meeting.py:121
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/documents/submit.py
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Close period"
-#: ./opengever/meeting/browser/periods.py:92
+#: ./opengever/meeting/browser/periods.py
 msgid "button_close_period"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/meeting/browser/committeeforms.py:61
-#: ./opengever/meeting/browser/meetings/meeting.py:105
+#: ./opengever/meeting/browser/committeeforms.py
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Submit Attachments"
-#: ./opengever/meeting/browser/documents/submit.py:82
-#: ./opengever/meeting/browser/submitdocuments.py:83
+#: ./opengever/meeting/browser/documents/submit.py
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "button_submit_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/model/proposal.py:161
+#: ./opengever/meeting/model/proposal.py
 msgid "cancel"
 msgstr ""
 
 #. Default: "Cancelled"
-#: ./opengever/meeting/model/proposal.py:141
+#: ./opengever/meeting/model/proposal.py
 msgid "cancelled"
 msgstr ""
 
 #. Default: "Close meeting"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:58
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:60
-#: ./opengever/meeting/model/meeting.py:83
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+#: ./opengever/meeting/model/meeting.py
 msgid "close_meeting"
 msgstr ""
 
 #. Default: "Close period"
-#: ./opengever/meeting/model/period.py:29
+#: ./opengever/meeting/model/period.py
 msgid "close_period"
 msgstr ""
 
 #. Default: "Closed"
-#: ./opengever/meeting/model/meeting.py:77
-#: ./opengever/meeting/model/period.py:22
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/model/period.py
 msgid "closed"
 msgstr ""
 
 #. Default: "Comittee"
-#: ./opengever/meeting/browser/documents/proposalstab.py:95
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_comittee"
 msgstr ""
 
 #. Default: "Date"
-#: ./opengever/meeting/tabs/meetinglisting.py:58
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_date"
 msgstr ""
 
 #. Default: "Date from"
-#: ./opengever/meeting/tabs/membershiplisting.py:32
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_date_from"
 msgstr ""
 
 #. Default: "Date to"
-#: ./opengever/meeting/tabs/membershiplisting.py:36
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_date_to"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/tabs/memberlisting.py:36
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_email"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/meeting/tabs/memberlisting.py:26
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_firstname"
 msgstr ""
 
 #. Default: "From"
-#: ./opengever/meeting/tabs/meetinglisting.py:62
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_from"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/meeting/tabs/memberlisting.py:31
+#: ./opengever/meeting/tabs/memberlisting.py
 msgid "column_lastname"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/tabs/meetinglisting.py:55
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_location"
 msgstr ""
 
 #. Default: "Meeting"
-#: ./opengever/meeting/browser/documents/proposalstab.py:99
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_meeting"
 msgstr ""
 
 #. Default: "Member"
-#: ./opengever/meeting/tabs/membershiplisting.py:28
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_member"
 msgstr ""
 
 #. Default: "Role"
-#: ./opengever/meeting/tabs/membershiplisting.py:40
+#: ./opengever/meeting/tabs/membershiplisting.py
 msgid "column_role"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/meeting/browser/documents/proposalstab.py:91
-#: ./opengever/meeting/tabs/meetinglisting.py:51
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_state"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/documents/proposalstab.py:87
-#: ./opengever/meeting/tabs/committeelisting.py:24
-#: ./opengever/meeting/tabs/meetinglisting.py:47
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/tabs/committeelisting.py
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_title"
 msgstr ""
 
 #. Default: "To"
-#: ./opengever/meeting/tabs/meetinglisting.py:67
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "column_to"
 msgstr ""
 
 #. Default: "Create Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:115
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "create_excerpt"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/model/agendaitem.py:51
-#: ./opengever/meeting/model/proposal.py:159
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/proposal.py
 msgid "decide"
 msgstr ""
 
 #. Default: "Decide Agendaitem"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:80
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:85
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "decide_agendaitem"
 msgstr ""
 
 #. Default: "Decided"
-#: ./opengever/meeting/browser/documents/proposalstab.py:68
-#: ./opengever/meeting/model/agendaitem.py:45
-#: ./opengever/meeting/model/proposal.py:139
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/proposal.py
 msgid "decided"
 msgstr ""
 
 #. Default: "Automatically configure permissions on the committee for this group."
-#: ./opengever/meeting/committee.py:129
+#: ./opengever/meeting/committee.py
 msgid "description_group"
 msgstr ""
 
 #. Default: "You are not allowed to checkout the document."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:382
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "document_checkout_not_allowed"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/tabs/meetinglisting.py:72
+#: ./opengever/meeting/tabs/meetinglisting.py
 msgid "dossier"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:214
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:243
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "download protocol"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:399
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "empty_paragraph"
 msgstr ""
 
 #. Default: "Proposal must not be empty."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:414
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "empty_proposal"
 msgstr ""
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
-#: ./opengever/meeting/browser/proposaltransitions.py:29
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:428
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "error_no_permission_to_add_document"
 msgstr ""
 
 #. Default: "Only word files (.docx) can be added here."
-#: ./opengever/meeting/proposaltemplate.py:36
+#: ./opengever/meeting/proposaltemplate.py
 msgid "error_prosal_template_not_docx"
 msgstr ""
 
 #. Default: "Excerpt ${title}"
-#: ./opengever/meeting/browser/meetings/agendaitem.py:217
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_document_default_title"
 msgstr ""
 
 #. Default: "Excerpt was created successfully."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:464
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_generated"
 msgstr ""
 
 #. Default: "Excerpt was returned to proposer."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:484
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
 msgstr ""
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
-#: ./opengever/meeting/browser/toc.py:60
+#: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"
 msgstr ""
 
 #. Default: "Repository Toc ${period} ${committee}"
-#: ./opengever/meeting/browser/toc.py:89
+#: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:176
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:203
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new agenda item list as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:252
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "generate new excerpt"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:208
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:237
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new protocol as word document"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:188
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:215
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new version as word document"
 msgstr ""
 
 #. Default: "Reject proposal"
-#: ./opengever/meeting/browser/proposaltransitions.py:68
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "heading_reject_proposal_form"
 msgstr ""
 
 #. Default: "Held"
-#: ./opengever/meeting/model/meeting.py:76
+#: ./opengever/meeting/model/meeting.py
 msgid "held"
 msgstr ""
 
 #. Default: "Describe, why the proposal is rejected"
-#: ./opengever/meeting/browser/proposaltransitions.py:60
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "help_reject_proposal_text"
 msgstr ""
 
 #. Default: "Select the target dossier where the excerpts should be created."
-#: ./opengever/meeting/browser/meetings/excerpt.py:24
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "help_select_dossier"
 msgstr ""
 
 #. Default: "Hold meeting"
-#: ./opengever/meeting/model/meeting.py:85
+#: ./opengever/meeting/model/meeting.py
 msgid "hold"
 msgstr ""
 
 #. Default: "Inactive"
-#: ./opengever/meeting/model/committee.py:30
+#: ./opengever/meeting/model/committee.py
 msgid "inactive"
 msgstr ""
 
-#. Default: "Ad hoc agenda item template"
-#: ./opengever/meeting/committee.py:94
-#: ./opengever/meeting/committeecontainer.py:44
-msgid "label_ad_hoc_template"
-msgstr ""
-
 #. Default: "delete this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_ad_hoc_delete_action"
 msgstr ""
 
+#. Default: "Ad hoc agenda item template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_ad_hoc_template"
+msgstr ""
+
 #. Default: "Agenda item number"
-#: ./opengever/meeting/browser/meetings/meeting.py:374
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_agenda_item_number"
 msgstr ""
 
 #. Default: "Agendaitem list"
-#: ./opengever/meeting/model/meeting.py:279
-#: ./opengever/meeting/protocol.py:160
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/protocol.py
 msgid "label_agendaitem_list"
 msgstr ""
 
 #. Default: "Agendaitem list template"
-#: ./opengever/meeting/committee.py:71
-#: ./opengever/meeting/committeecontainer.py:30
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr ""
 
 #. Default: "Attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:370
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:27
-#: ./opengever/meeting/browser/submitdocuments.py:40
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+#: ./opengever/meeting/browser/submitdocuments.py
 msgid "label_attachments"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/excerpt.py:152
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:36
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:38
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_cancel"
 msgstr ""
 
 #. Default: "Close"
-#: ./opengever/meeting/browser/meetings/protocol.py:240
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_close"
 msgstr ""
 
 #. Default: "Committee deactivated successfully"
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:77
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_deactivated"
 msgstr ""
 
 #. Default: "Committee reactivated successfully"
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:50
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_reactivated"
 msgstr ""
 
 #. Default: "Committee"
-#: ./opengever/meeting/browser/meetings/meeting.py:59
-#: ./opengever/meeting/browser/templates/member.pt:49
-#: ./opengever/meeting/proposal.py:54
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/templates/member.pt
+#: ./opengever/meeting/proposal.py
 msgid "label_committee"
 msgstr ""
 
 #. Default: "The protocol has been modified in the meantime. If you want to keep your changes try resolving the conflicts manually."
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:22
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "label_conflict_changes"
 msgstr ""
 
 #. Default: "Considerations"
-#: ./opengever/meeting/browser/meetings/protocol.py:133
-#: ./opengever/meeting/proposal.py:146
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_considerations"
 msgstr ""
 
 #. Default: "Copy for attention"
-#: ./opengever/meeting/browser/meetings/protocol.py:148
-#: ./opengever/meeting/proposal.py:118
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_copy_for_attention"
 msgstr ""
 
 #. Default: "Create Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:127
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_create_excerpt"
 msgstr ""
 
 #. Default: "Creator"
-#: ./opengever/meeting/browser/proposalforms.py:92
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_creator"
 msgstr ""
 
 #. Default: "Current members"
-#: ./opengever/meeting/browser/committee.py:36
+#: ./opengever/meeting/browser/committee.py
 msgid "label_current_members"
 msgstr ""
 
 #. Default: "Current Period"
-#: ./opengever/meeting/browser/committee.py:21
+#: ./opengever/meeting/browser/committee.py
 msgid "label_current_period"
 msgstr ""
 
 #. Default: "Start date"
-#: ./opengever/meeting/browser/memberships.py:21
-#: ./opengever/meeting/browser/periods.py:37
-#: ./opengever/meeting/browser/templates/member.pt:50
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/periods.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_date_from"
 msgstr ""
 
 #. Default: "End date"
-#: ./opengever/meeting/browser/memberships.py:26
-#: ./opengever/meeting/browser/periods.py:43
-#: ./opengever/meeting/browser/templates/member.pt:51
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/periods.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_date_to"
 msgstr ""
 
 #. Default: "Deactivate committee"
-#: ./opengever/meeting/model/committee.py:36
+#: ./opengever/meeting/model/committee.py
 msgid "label_deactivate"
 msgstr ""
 
 #. Default: "Decide"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:88
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:93
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_decide"
 msgstr ""
 
 #. Default: "Decide this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:350
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_decide_action"
 msgstr ""
 
 #. Default: "Decision"
-#: ./opengever/meeting/browser/meetings/protocol.py:139
-#: ./opengever/meeting/proposal.py:222
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_decision"
 msgstr ""
 
 #. Default: "Decision draft"
-#: ./opengever/meeting/proposal.py:100
+#: ./opengever/meeting/proposal.py
 msgid "label_decision_draft"
 msgstr ""
 
 #. Default: "Decision number"
-#: ./opengever/meeting/browser/documents/proposalstab.py:82
-#: ./opengever/meeting/browser/meetings/meeting.py:375
-#: ./opengever/meeting/proposal.py:248
+#: ./opengever/meeting/browser/documents/proposalstab.py
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/proposal.py
 msgid "label_decision_number"
 msgstr ""
 
 #. Default: "remove this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:349
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_delete_action"
 msgstr ""
 
 #. Default: "Are you sure you want to delete this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:32
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:34
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_delete_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Disclose to"
-#: ./opengever/meeting/browser/meetings/protocol.py:145
-#: ./opengever/meeting/proposal.py:112
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_disclose_to"
 msgstr ""
 
 #. Default: "Discussion"
-#: ./opengever/meeting/browser/meetings/protocol.py:136
-#: ./opengever/meeting/proposal.py:379
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_discussion"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/meeting/proposal.py:359
+#: ./opengever/meeting/proposal.py
 msgid "label_dossier"
 msgstr ""
 
 #. Default: "Dossier not available"
-#: ./opengever/meeting/proposal.py:460
+#: ./opengever/meeting/proposal.py
 msgid "label_dossier_not_available"
 msgstr ""
 
 #. Default: "download TOC alphabetical"
-#: ./opengever/meeting/browser/templates/periods.pt:11
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc"
 msgstr ""
 
 #. Default: "download TOC by repository"
-#: ./opengever/meeting/browser/templates/periods.pt:18
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_toc"
 msgstr ""
 
 #. Default: "Edit"
-#: ./opengever/meeting/browser/templates/member.pt:65
-#: ./opengever/meeting/browser/templates/periods.pt:27
+#: ./opengever/meeting/browser/templates/member.pt
+#: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_edit"
 msgstr ""
 
 #. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py:348
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Edit after creation"
-#: ./opengever/meeting/browser/proposalforms.py:100
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_edit_after_creation"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/meeting/browser/meetings/meeting.py:346
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_cancel"
 msgstr ""
 
 #. Default: "Checkout and edit word document."
-#: ./opengever/meeting/browser/meetings/meeting.py:363
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_document_action"
 msgstr ""
 
 #. Default: "Edit Membership"
-#: ./opengever/meeting/browser/memberships.py:73
+#: ./opengever/meeting/browser/memberships.py
 msgid "label_edit_membership"
 msgstr ""
 
 #. Default: "Edit Period"
-#: ./opengever/meeting/browser/periods.py:204
+#: ./opengever/meeting/browser/periods.py
 msgid "label_edit_period"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/meeting/browser/meetings/meeting.py:347
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_edit_save"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./opengever/meeting/browser/members.py:34
-#: ./opengever/meeting/browser/templates/member.pt:32
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_email"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/meeting/browser/meetings/meeting.py:73
-#: ./opengever/meeting/browser/meetings/protocol.py:73
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_end"
 msgstr ""
 
 #. Default: "Excerpt"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:77
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "label_excerpt"
 msgstr ""
 
 #. Default: "Excerpts"
-#: ./opengever/meeting/browser/meetings/meeting.py:371
-#: ./opengever/meeting/proposal.py:151
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/proposal.py
 msgid "label_excerpts"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/meeting/proposaltemplate.py:19
+#: ./opengever/meeting/proposaltemplate.py
 msgid "label_file"
 msgstr ""
 
 #. Default: "Filter"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:300
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:299
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_filter_proposal"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/meeting/browser/members.py:24
-#: ./opengever/meeting/browser/templates/member.pt:28
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_firstname"
 msgstr ""
 
 #. Default: "Generate an excerpt."
-#: ./opengever/meeting/browser/meetings/meeting.py:365
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_generate_excerpt"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/meeting/committee.py:128
+#: ./opengever/meeting/committee.py
 msgid "label_group"
 msgstr ""
 
 #. Default: "Initial position"
-#: ./opengever/meeting/browser/meetings/protocol.py:127
-#: ./opengever/meeting/proposal.py:88
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_initial_position"
 msgstr ""
 
 #. Default: "Insert"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:291
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:331
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_insert"
 msgstr ""
 
 #. Default: "Last Meeting:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:45
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "label_last_meeting"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/meeting/browser/members.py:29
-#: ./opengever/meeting/browser/templates/member.pt:24
+#: ./opengever/meeting/browser/members.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_lastname"
 msgstr ""
 
 #. Default: "Legal basis"
-#: ./opengever/meeting/browser/meetings/protocol.py:124
-#: ./opengever/meeting/proposal.py:82
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_legal_basis"
 msgstr ""
 
 #. Default: "Linked meeting"
-#: ./opengever/meeting/browser/dossier/overview.py:23
+#: ./opengever/meeting/browser/dossier/overview.py
 msgid "label_linked_meeting"
 msgstr ""
 
 #. Default: "Contains automatically generated dossiers and documents for this committee."
-#: ./opengever/meeting/committee.py:86
+#: ./opengever/meeting/committee.py
 msgid "label_linked_repository_folder"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/meeting/browser/meetings/meeting.py:64
-#: ./opengever/meeting/browser/meetings/protocol.py:62
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_location"
 msgstr ""
 
 #. Default: "Main Atrributes"
-#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt:12
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
 msgid "label_main_attributes"
 msgstr ""
 
 #. Default: "Meeting"
-#: ./opengever/meeting/proposal.py:186
+#: ./opengever/meeting/proposal.py
 msgid "label_meeting"
 msgstr ""
 
 #. Default: "Member"
-#: ./opengever/meeting/browser/memberships.py:30
+#: ./opengever/meeting/browser/memberships.py
 msgid "label_member"
 msgstr ""
 
 #. Default: "Modified"
-#: ./opengever/meeting/browser/proposalforms.py:95
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_modified"
 msgstr ""
 
 #. Default: "Next Meeting:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:53
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "label_next_meeting"
 msgstr ""
 
 #. Default: "No agenda item list has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:197
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:193
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_agendaitem_list"
 msgstr ""
 
 #. Default: "No additional excerpts have been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:257
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "label_no_excerpts"
 msgstr ""
 
 #. Default: "This member has no memberships."
-#: ./opengever/meeting/browser/templates/member.pt:43
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_no_memberships"
 msgstr ""
 
 #. Default: "No proposals submitted"
-#: ./opengever/meeting/browser/meetings/meeting.py:386
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_no_proposals"
 msgstr ""
 
 #. Default: "No protocol has been generated yet."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:228
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:227
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_protocol"
 msgstr ""
 
 #. Default: "Other Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:52
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_other_participants"
 msgstr ""
 
 #. Default: "Paragraph template"
-#: ./opengever/meeting/committee.py:101
-#: ./opengever/meeting/committeecontainer.py:51
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_paragraph_template"
 msgstr ""
 
 #. Default: "Participants"
-#: ./opengever/meeting/browser/meetings/protocol.py:44
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_participants"
 msgstr ""
 
 #. Default: "Presidency"
-#: ./opengever/meeting/browser/meetings/protocol.py:33
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_presidency"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/meeting/browser/documents/proposalstab.py:78
+#: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "label_proposal_id"
 msgstr ""
 
 #. Default: "Proposal template"
-#: ./opengever/meeting/browser/proposalforms.py:83
+#: ./opengever/meeting/browser/proposalforms.py
 msgid "label_proposal_template"
 msgstr ""
 
 #. Default: "Proposed action"
-#: ./opengever/meeting/browser/meetings/protocol.py:130
-#: ./opengever/meeting/proposal.py:94
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol start-page"
-#: ./opengever/meeting/browser/meetings/protocol.py:56
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Publish in"
-#: ./opengever/meeting/browser/meetings/protocol.py:142
-#: ./opengever/meeting/proposal.py:106
+#: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/proposal.py
 msgid "label_publish_in"
 msgstr ""
 
 #. Default: "Reactivate committee"
-#: ./opengever/meeting/model/committee.py:40
+#: ./opengever/meeting/model/committee.py
 msgid "label_reactivate"
 msgstr ""
 
 #. Default: "Comment"
-#: ./opengever/meeting/browser/proposaltransitions.py:59
+#: ./opengever/meeting/browser/proposaltransitions.py
 msgid "label_reject_proposal_text"
 msgstr ""
 
 #. Default: "Remove"
-#: ./opengever/meeting/browser/templates/member.pt:70
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_remove"
 msgstr ""
 
 #. Default: "Reopen this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:351
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_reopen_action"
 msgstr ""
 
 #. Default: "Return excerpt to proposer"
-#: ./opengever/meeting/browser/meetings/meeting.py:372
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_return_action"
 msgstr ""
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_return_excerpt"
 msgstr ""
 
 #. Default: "This excerpt was returned to the dossier"
-#: ./opengever/meeting/browser/meetings/meeting.py:376
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_returned_excerpt"
 msgstr ""
 
 #. Default: "Revise this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py:352
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_revise_action"
 msgstr ""
 
 #. Default: "Role"
-#: ./opengever/meeting/browser/memberships.py:35
-#: ./opengever/meeting/browser/templates/member.pt:52
+#: ./opengever/meeting/browser/memberships.py
+#: ./opengever/meeting/browser/templates/member.pt
 msgid "label_role"
 msgstr ""
 
 #. Default: "File"
-#: ./opengever/meeting/sablontemplate.py:13
+#: ./opengever/meeting/sablontemplate.py
 msgid "label_sablon_template_file"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/browser/meetings/meeting.py:385
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:280
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:316
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_schedule"
 msgstr ""
 
 #. Default: "Secretary"
-#: ./opengever/meeting/browser/meetings/protocol.py:38
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
 msgstr ""
 
 #. Default: "Target dossier"
-#: ./opengever/meeting/browser/meetings/excerpt.py:22
+#: ./opengever/meeting/browser/meetings/excerpt.py
 msgid "label_select_dossier"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/meeting/browser/meetings/meeting.py:69
-#: ./opengever/meeting/browser/meetings/protocol.py:68
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/meeting/browser/meetings/excerpt.py:31
-#: ./opengever/meeting/browser/meetings/meeting.py:54
-#: ./opengever/meeting/browser/meetings/protocol.py:29
+#: ./opengever/meeting/browser/meetings/excerpt.py
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Excerpt title"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:122
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_title_excerpt"
 msgstr ""
 
 #. Default: "Table of contents template"
-#: ./opengever/meeting/committee.py:78
-#: ./opengever/meeting/committeecontainer.py:37
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
 msgstr ""
 
 #. Default: "Toggle attachments"
-#: ./opengever/meeting/browser/meetings/meeting.py:373
+#: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_toggle_attachments"
 msgstr ""
 
 #. Default: "Transition ${transition} executed"
-#: ./opengever/meeting/browser/meetings/transitions.py:24
+#: ./opengever/meeting/browser/meetings/transitions.py
 msgid "label_transition_executed"
 msgstr ""
 
 #. Default: "You have unsaved changes."
-#: ./opengever/meeting/browser/meetings/templates/protocol.pt:26
+#: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "label_unsaved_changes"
 msgstr ""
 
 #. Default: "Are you sure you want to unschedule this agendaitem?"
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:45
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:47
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_unschedule_agenda_item_confirm_text"
 msgstr ""
 
 #. Default: "Unscheduled proposals"
-#: ./opengever/meeting/browser/committee.py:30
+#: ./opengever/meeting/browser/committee.py
 msgid "label_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Upcoming meetings"
-#: ./opengever/meeting/browser/committee.py:25
+#: ./opengever/meeting/browser/committee.py
 msgid "label_upcoming_meetings"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/meeting/proposal.py:244
+#: ./opengever/meeting/proposal.py
 msgid "label_workflow_state"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:239
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "label_zip_download"
 msgstr ""
 
 #. Default: "Language"
-#: ./opengever/meeting/proposal.py:59
+#: ./opengever/meeting/proposal.py
 msgid "language"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:110
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "location"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:151
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
 msgstr ""
 
 #. Default: "Meetings"
-#: ./opengever/meeting/browser/tabbed.py:13
+#: ./opengever/meeting/browser/tabbed.py
 msgid "meetings"
 msgstr ""
 
 #. Default: "Memberships"
-#: ./opengever/meeting/browser/tabbed.py:19
+#: ./opengever/meeting/browser/tabbed.py
 msgid "memberships"
 msgstr ""
 
 #. Default: "Changes saved"
-#: ./opengever/meeting/browser/meetings/protocol.py:262
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_changes_saved"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:94
-#: ./opengever/meeting/browser/meetings/protocol.py:254
+#: ./opengever/meeting/browser/meetings/edit_meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_locked_by_another_user"
 msgstr ""
 
 #. Default: "Your changes were not saved, the protocol has been modified in the meantime."
-#: ./opengever/meeting/browser/meetings/edit_meeting.py:89
-#: ./opengever/meeting/browser/meetings/protocol.py:248
+#: ./opengever/meeting/browser/meetings/edit_meeting.py
+#: ./opengever/meeting/browser/meetings/protocol.py
 msgid "message_write_conflict"
 msgstr ""
 
 #. Default: "No ad-hoc agenda-item template has been configured."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:422
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "missing_ad_hoc_template"
 msgstr ""
 
-#. Default: "Chose a meaningful title to distinguish the created excerpts better."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:116
+#. Default: "Choose a meaningful title to distinguish the created excerpts better."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_confirm_create_excerpt_dialog"
 msgstr ""
 
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:102
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_confirm_return_excerpt_dialog"
 msgstr ""
 
 #. Default: "The agenda item list for meeting ${title} has already been generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:47
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
 msgid "msg_error_agendaitem_list_already_generated"
 msgstr ""
 
 #. Default: "There is no agendaitem list template configured, agendaitem list could not be generated."
-#: ./opengever/meeting/browser/meetings/agendaitem_list.py:39
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
 msgid "msg_error_agendaitem_list_missing_template"
 msgstr ""
 
 #. Default: "The protocol for meeting ${title} has already been generated."
-#: ./opengever/meeting/browser/protocol.py:76
+#: ./opengever/meeting/browser/protocol.py
 msgid "msg_error_protocol_already_generated"
 msgstr ""
 
 #. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:81
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:86
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_hold_meeting_dialog"
 msgstr ""
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
-#: ./opengever/meeting/model/proposal.py:40
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_inactive_committee_selected"
 msgstr ""
 
 #. Default: "The meeting ${title} has been successfully closed, the excerpts have been generated and sent back to the initial dossier."
-#: ./opengever/meeting/model/meeting.py:63
+#: ./opengever/meeting/model/meeting.py
 msgid "msg_meeting_successfully_closed"
 msgstr ""
 
 #. Default: "The membership was deleted successfully."
-#: ./opengever/meeting/browser/memberships.py:107
+#: ./opengever/meeting/browser/memberships.py
 msgid "msg_membership_deleted"
 msgstr ""
 
 #. Default: "There is no toc template configured, toc could not be generated."
-#: ./opengever/meeting/browser/toc.py:25
+#: ./opengever/meeting/browser/toc.py
 msgid "msg_no_toc_template"
 msgstr ""
 
 #. Default: "Not all meetings are closed."
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:58
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_pending_meetings"
 msgstr ""
 
 #. Default: "Proposal cancelled successfully."
-#: ./opengever/meeting/model/proposal.py:68
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_cancelled"
 msgstr ""
 
 #. Default: "Proposal reactivated successfully."
-#: ./opengever/meeting/model/proposal.py:79
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_reactivated"
 msgstr ""
 
 #. Default: "Proposal successfully submitted."
-#: ./opengever/meeting/model/proposal.py:50
+#: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
 msgstr ""
 
 #. Default: "The object was deleted successfully."
-#: ./opengever/meeting/browser/views.py:21
+#: ./opengever/meeting/browser/views.py
 msgid "msg_successfully_deleted"
 msgstr ""
 
 #. Default: "There are unscheduled proposals submitted to this committee."
-#: ./opengever/meeting/browser/committeetransitioncontroller.py:66
+#: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_unscheduled_proposals"
 msgstr ""
 
 #. Default: "New unscheduled proposals:"
-#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt:32
+#: ./opengever/meeting/browser/committeecontainertabs_templates/committee.pt
 msgid "new_unscheduled_proposals"
 msgstr ""
 
 #. Default: "Overview"
-#: ./opengever/meeting/browser/tabbed.py:10
+#: ./opengever/meeting/browser/tabbed.py
 msgid "overview"
 msgstr ""
 
 #. Default: "Paragraph successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:403
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "paragraph_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:141
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "participants"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/meeting/model/agendaitem.py:44
-#: ./opengever/meeting/model/meeting.py:75
-#: ./opengever/meeting/model/proposal.py:134
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/meeting.py
+#: ./opengever/meeting/model/proposal.py
 msgid "pending"
 msgstr ""
 
 #. Default: "Periods"
-#: ./opengever/meeting/browser/tabbed.py:22
+#: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:127
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "presidency"
 msgstr ""
 
 #. Default: "Proposal document"
-#: ./opengever/meeting/proposal.py:195
+#: ./opengever/meeting/proposal.py
 msgid "proposal_document"
 msgstr ""
 
 #. Default: "Proposal cancelled by ${user}"
-#: ./opengever/meeting/proposalhistory.py:196
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_cancelled"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/meeting/proposalhistory.py:185
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_created"
 msgstr ""
 
 #. Default: "Proposal decided by ${user}"
-#: ./opengever/meeting/proposalhistory.py:312
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
 msgstr ""
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:245
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_submitted"
 msgstr ""
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:350
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_updated"
 msgstr ""
 
 #. Default: "Proposal reactivated by ${user}"
-#: ./opengever/meeting/proposalhistory.py:207
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reactivated"
 msgstr ""
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/meeting/proposalhistory.py:263
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_rejected"
 msgstr ""
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:337
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_remove_scheduled"
 msgstr ""
 
 #. Default: "Proposal reopened by ${user}"
-#: ./opengever/meeting/proposalhistory.py:275
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reopened"
 msgstr ""
 
 #. Default: "Proposal revised by ${user}"
-#: ./opengever/meeting/proposalhistory.py:324
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_revised"
 msgstr ""
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
-#: ./opengever/meeting/proposalhistory.py:299
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_scheduled"
 msgstr ""
 
 #. Default: "Submitted by ${user}"
-#: ./opengever/meeting/proposalhistory.py:218
+#: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr ""
 
 #. Default: "Protocol"
-#: ./opengever/meeting/protocol.py:58
+#: ./opengever/meeting/protocol.py
 msgid "protocol"
 msgstr ""
 
 #. Default: "Protocol-Excerpt"
-#: ./opengever/meeting/protocol.py:146
+#: ./opengever/meeting/protocol.py
 msgid "protocol_excerpt"
 msgstr ""
 
 #. Default: "Reactivate"
-#: ./opengever/meeting/model/proposal.py:163
+#: ./opengever/meeting/model/proposal.py
 msgid "reactivate"
 msgstr ""
 
 #. Default: "Reject"
-#: ./opengever/meeting/browser/proposaltransitions.py:70
-#: ./opengever/meeting/model/proposal.py:153
+#: ./opengever/meeting/browser/proposaltransitions.py
+#: ./opengever/meeting/model/proposal.py
 msgid "reject"
 msgstr ""
 
 #. Default: "Reopen"
-#: ./opengever/meeting/model/agendaitem.py:53
-#: ./opengever/meeting/model/meeting.py:89
+#: ./opengever/meeting/model/agendaitem.py
+#: ./opengever/meeting/model/meeting.py
 msgid "reopen"
 msgstr ""
 
 #. Default: "Return Excerpt"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:101
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "return_excerpt"
 msgstr ""
 
 #. Default: "Revise"
-#: ./opengever/meeting/model/agendaitem.py:55
+#: ./opengever/meeting/model/agendaitem.py
 msgid "revise"
 msgstr ""
 
 #. Default: "Revision"
-#: ./opengever/meeting/model/agendaitem.py:46
+#: ./opengever/meeting/model/agendaitem.py
 msgid "revision"
 msgstr ""
 
 #. Default: "Schedule"
-#: ./opengever/meeting/model/proposal.py:155
+#: ./opengever/meeting/model/proposal.py
 msgid "schedule"
 msgstr ""
 
 #. Default: "Scheduled"
-#: ./opengever/meeting/model/proposal.py:138
+#: ./opengever/meeting/model/proposal.py
 msgid "scheduled"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:134
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "secretary"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:105
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "status"
 msgstr ""
 
 #. Default: "Submit"
-#: ./opengever/meeting/model/proposal.py:151
+#: ./opengever/meeting/model/proposal.py
 msgid "submit"
 msgstr ""
 
 #. Default: "Submitted"
-#: ./opengever/meeting/model/proposal.py:136
+#: ./opengever/meeting/model/proposal.py
 msgid "submitted"
 msgstr ""
 
 #. Default: "Submitted Proposals"
-#: ./opengever/meeting/browser/tabbed.py:16
+#: ./opengever/meeting/browser/tabbed.py
 msgid "submittedproposals"
 msgstr ""
 
 #. Default: "${amount} matches"
-#: ./opengever/meeting/browser/templates/no_selection.pt:2
+#: ./opengever/meeting/browser/templates/no_selection.pt
 msgid "tab_matches"
 msgstr ""
 
 #. Default: "Text successfully added."
-#: ./opengever/meeting/browser/meetings/agendaitem.py:437
+#: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
 msgstr ""
 
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt:118
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "time"
 msgstr ""
 
 #. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py:377
+#: ./opengever/meeting/model/meeting.py
 msgid "title_ad_hoc_document"
 msgstr ""
 
 #. Default: "Remove from schedule"
-#: ./opengever/meeting/model/proposal.py:157
+#: ./opengever/meeting/model/proposal.py
 msgid "un-schedule"
 msgstr ""
 
 #. Default: "Add"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:288
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_add"
 msgstr ""
 
 #. Default: "Add section header:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:325
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_add_section_header"
 msgstr ""
 
 #. Default: "Agenda items"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:268
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
 msgstr ""
 
 #. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:191
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:181
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_dossier"
 msgstr ""
 
 #. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:135
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_end"
 msgstr ""
 
 #. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:140
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_location"
 msgstr ""
 
 #. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:145
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:129
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_start"
 msgstr ""
 
 #. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:121
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_status"
 msgstr ""
 
 #. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:167
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:153
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:225
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:310
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_ad_hoc"
 msgstr ""
 
 #. Default: "Schedule proposal:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:295
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_proposal"
 msgstr ""
 
 #. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:160
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_secretary"
 msgstr ""
 

--- a/opengever/officeatwork/locales/de/LC_MESSAGES/opengever.officeatwork.po
+++ b/opengever/officeatwork/locales/de/LC_MESSAGES/opengever.officeatwork.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,15 +14,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:29
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Add document from officeatwork"
 msgstr "Dokument mit officeatwork hinzufügen"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:41
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Create with officeatwork"
 msgstr "Mit officeatwork erstellen"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:54
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Creation with officeatwork initiated successfully"
 msgstr "Inhaltserstellung mit officeatwork erfolgreich gestartet"
 

--- a/opengever/officeatwork/locales/fr/LC_MESSAGES/opengever.officeatwork.po
+++ b/opengever/officeatwork/locales/fr/LC_MESSAGES/opengever.officeatwork.po
@@ -1,31 +1,30 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-06 08:42+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-officeatwork/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-officeatwork/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:29
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Add document from officeatwork"
 msgstr "Ajouter le document avec officeatwork"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:41
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Create with officeatwork"
 msgstr "Créer avec officeatwork"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:54
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Creation with officeatwork initiated successfully"
-msgstr ""
-"Création du contenu a été démarrée avec succès par le biais d'officeatwork"
+msgstr "Création du contenu a été démarrée avec succès par le biais d'officeatwork"
+

--- a/opengever/officeatwork/locales/opengever.officeatwork.pot
+++ b/opengever/officeatwork/locales/opengever.officeatwork.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.officeatwork\n"
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:29
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Add document from officeatwork"
 msgstr ""
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:41
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Create with officeatwork"
 msgstr ""
 
-#: ./opengever/officeatwork/browser/documentfromofficeatwork.py:54
+#: ./opengever/officeatwork/browser/documentfromofficeatwork.py
 msgid "Creation with officeatwork initiated successfully"
 msgstr ""
 

--- a/opengever/officeconnector/locales/de/LC_MESSAGES/opengever.officeconnector.po
+++ b/opengever/officeconnector/locales/de/LC_MESSAGES/opengever.officeconnector.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-01 15:07+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Unfortunately it's not currently possible to attach this many documents. Please try again with fewer documents selected."
-#: ./opengever/officeconnector/service.py:31
+#: ./opengever/officeconnector/service.py
 msgid "error_oc_url_too_long"
 msgstr "Die ausgewählte Anzahl Dokumente ist zu gross, um sie auf einmal als Attachments zu versenden. Bitte versuchen Sie es erneut mit weniger Dokumenten."
+

--- a/opengever/officeconnector/locales/fr/LC_MESSAGES/opengever.officeconnector.po
+++ b/opengever/officeconnector/locales/fr/LC_MESSAGES/opengever.officeconnector.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-01 15:07+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #. Default: "Unfortunately it's not currently possible to attach this many documents. Please try again with fewer documents selected."
-#: ./opengever/officeconnector/service.py:31
+#: ./opengever/officeconnector/service.py
 msgid "error_oc_url_too_long"
 msgstr ""
 

--- a/opengever/officeconnector/locales/opengever.officeconnector.pot
+++ b/opengever/officeconnector/locales/opengever.officeconnector.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-01 15:07+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.officeconnector\n"
 
 #. Default: "Unfortunately it's not currently possible to attach this many documents. Please try again with fewer documents selected."
-#: ./opengever/officeconnector/service.py:31
+#: ./opengever/officeconnector/service.py
 msgid "error_oc_url_too_long"
 msgstr ""
 

--- a/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-09-26 11:54+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2016-07-22 16:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/de/>\n"
@@ -21,112 +21,113 @@ msgid "Toggle orgunit selector"
 msgstr "Amtswechsler umschalten"
 
 #. Default: "No"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:36
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "active_no"
 msgstr "Nein"
 
 #. Default: "Yes"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:35
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "active_yes"
 msgstr "Ja"
 
 #. Default: "Inbox: ${client}"
-#: ./opengever/ogds/base/actor.py:152
-#: ./opengever/ogds/base/sources.py:103
+#: ./opengever/ogds/base/actor.py
+#: ./opengever/ogds/base/sources.py
 msgid "inbox_label"
 msgstr "Eingangskorb: ${client}"
 
 #. Default: "Active"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:34
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_active"
 msgstr "Aktiv"
 
 #. Default: "Address"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:104
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_address"
 msgstr "Adresse"
 
 #. Default: "Assigned org unit"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:22
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_assigned_orgunit"
 msgstr "Zugehörige Organisationseinheit"
 
 #. Default: "Department"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:60
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_department"
 msgstr "Amt"
 
 #. Default: "Description"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:45
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Directorate"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:50
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_directorate"
 msgstr "Direktion"
 
 #. Default: "Email"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:70
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email"
 msgstr "E-Mail Adresse"
 
 #. Default: "Email 2"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:76
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email2"
 msgstr "Alternative E-Mail Adresse"
 
 #. Default: "Name"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:29
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_fullname"
 msgstr "Name"
 
 #. Default: "Group"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:27
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_group"
 msgstr "Gruppe"
 
 #. Default: "Groups"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:117
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_groups"
 msgstr "Gruppen"
 
 #. Default: "Members"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:32
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_members"
 msgstr "Mitglieder"
 
 #. Default: "Fax"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:94
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_fax"
 msgstr "Fax"
 
 #. Default: "Mobile phone"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:99
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_mobile"
 msgstr "Mobiltelefon"
 
 #. Default: "Office phone"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:89
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_office"
 msgstr "Telefon Büro"
 
 #. Default: "Salutation"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:40
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_salutation"
 msgstr "Anrede"
 
 #. Default: "Teams"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:128
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_teams"
 msgstr "Teams"
 
 #. Default: "URL"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:82
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_url"
 msgstr "Homepage"
 
 #. Default: "Show all users"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:23
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr "Alle Benutzer anzeigen"
+

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-26 11:54+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-04 13:05+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/fr/>\n"
@@ -21,112 +21,113 @@ msgid "Toggle orgunit selector"
 msgstr "commuter l'agent public"
 
 #. Default: "No"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:36
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "active_no"
 msgstr "Non"
 
 #. Default: "Yes"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:35
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "active_yes"
 msgstr "Oui"
 
 #. Default: "Inbox: ${client}"
-#: ./opengever/ogds/base/actor.py:152
-#: ./opengever/ogds/base/sources.py:103
+#: ./opengever/ogds/base/actor.py
+#: ./opengever/ogds/base/sources.py
 msgid "inbox_label"
 msgstr "Boîte de réception"
 
 #. Default: "Active"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:34
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_active"
 msgstr "Actif"
 
 #. Default: "Address"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:104
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_address"
 msgstr "Adresse"
 
 #. Default: "Assigned org unit"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:22
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_assigned_orgunit"
 msgstr ""
 
 #. Default: "Department"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:60
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_department"
 msgstr "Service"
 
 #. Default: "Description"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:45
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Directorate"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:50
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_directorate"
 msgstr "Direction"
 
 #. Default: "Email"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:70
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email"
 msgstr "Adresse email"
 
 #. Default: "Email 2"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:76
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email2"
 msgstr "Adresse email 2"
 
 #. Default: "Name"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:29
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_fullname"
 msgstr "Nom"
 
 #. Default: "Group"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:27
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_group"
 msgstr ""
 
 #. Default: "Groups"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:117
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_groups"
 msgstr "Groupes"
 
 #. Default: "Members"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:32
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_members"
 msgstr ""
 
 #. Default: "Fax"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:94
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_fax"
 msgstr "Fax"
 
 #. Default: "Mobile phone"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:99
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_mobile"
 msgstr "Mobile"
 
 #. Default: "Office phone"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:89
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_office"
 msgstr "Téléphone professionnel"
 
 #. Default: "Salutation"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:40
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_salutation"
 msgstr "Titre"
 
 #. Default: "Teams"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:128
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_teams"
 msgstr ""
 
 #. Default: "URL"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:82
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_url"
 msgstr "Site Internet"
 
 #. Default: "Show all users"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:23
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr "Afficher tous les utilisateurs"
+

--- a/opengever/ogds/base/locales/opengever.ogds.base.pot
+++ b/opengever/ogds/base/locales/opengever.ogds.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-09-26 11:54+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,113 +22,113 @@ msgid "Toggle orgunit selector"
 msgstr ""
 
 #. Default: "No"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:36
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "active_no"
 msgstr ""
 
 #. Default: "Yes"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:35
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "active_yes"
 msgstr ""
 
 #. Default: "Inbox: ${client}"
-#: ./opengever/ogds/base/actor.py:152
-#: ./opengever/ogds/base/sources.py:103
+#: ./opengever/ogds/base/actor.py
+#: ./opengever/ogds/base/sources.py
 msgid "inbox_label"
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:34
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_active"
 msgstr ""
 
 #. Default: "Address"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:104
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_address"
 msgstr ""
 
 #. Default: "Assigned org unit"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:22
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_assigned_orgunit"
 msgstr ""
 
 #. Default: "Department"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:60
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_department"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:45
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_description"
 msgstr ""
 
 #. Default: "Directorate"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:50
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_directorate"
 msgstr ""
 
 #. Default: "Email"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:70
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email"
 msgstr ""
 
 #. Default: "Email 2"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:76
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email2"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:29
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_fullname"
 msgstr ""
 
 #. Default: "Group"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:27
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_group"
 msgstr ""
 
 #. Default: "Groups"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:117
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_groups"
 msgstr ""
 
 #. Default: "Members"
-#: ./opengever/ogds/base/browser/templates/teamdetails.pt:32
+#: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_members"
 msgstr ""
 
 #. Default: "Fax"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:94
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_fax"
 msgstr ""
 
 #. Default: "Mobile phone"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:99
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_mobile"
 msgstr ""
 
 #. Default: "Office phone"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:89
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_phone_office"
 msgstr ""
 
 #. Default: "Salutation"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:40
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_salutation"
 msgstr ""
 
 #. Default: "Teams"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:128
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_teams"
 msgstr ""
 
 #. Default: "URL"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:82
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_url"
 msgstr ""
 
 #. Default: "Show all users"
-#: ./opengever/ogds/base/browser/templates/userdetails.pt:23
+#: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr ""
 

--- a/opengever/portlets/tree/locales/de/LC_MESSAGES/opengever.portlets.tree.po
+++ b/opengever/portlets/tree/locales/de/LC_MESSAGES/opengever.portlets.tree.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,45 +14,45 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/portlets/tree/treeportlet.pt:15
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "Favorites"
 msgstr "Favoriten"
 
-#: ./opengever/portlets/tree/treeportlet.pt:1
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_add_to_favorites"
 msgstr "Als Favorit markieren"
 
 #. Default: "Help"
-#: ./opengever/portlets/tree/treeportlet.pt:36
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_help"
 msgstr "Hilfe"
 
-#: ./opengever/portlets/tree/treeportlet.pt:1
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_remove_from_favorites"
 msgstr "Aus Favoriten entfernen"
 
 #. Default: "No favorites set yet."
-#: ./opengever/portlets/tree/treeportlet.pt:28
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_empty"
 msgstr "Es wurden noch keine Ordnungspositionen als Favorit markiert."
 
 #. Default: "When hovering over a repository folder, the icon for marking folders as favorites (${icon}) appears at the right side. Clicking this icon adds the folder as favorite here."
-#: ./opengever/portlets/tree/treeportlet.pt:45
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_adding"
 msgstr "Wird der Mauszeiger im Ordnungssystem über Ordnungspositionen bewegt, so erscheint auf der rechten Seite das Symbol zum Markieren von Favoriten (${icon}). Wird auf dieses Symbol geklickt, so erscheint diese Ordnungsposition im Reiter \"Favoriten\"."
 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
-#: ./opengever/portlets/tree/treeportlet.pt:53
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_marked"
 msgstr "Die von Ihnen als Favoriten markierten Ordnungspositionen werden im Ordnungssystem-Reiter mit einem entsprechenden Symbol (${icon}) markiert."
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
-#: ./opengever/portlets/tree/treeportlet.pt:60
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_removing"
 msgstr "Um einen Favoriten zu entfernen, wechseln Sie zurück in den Reiter «Ordnungssystem» und klicken Sie auf das Symbol zum Entfernen von Favoriten (${icon})."
 
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
-#: ./opengever/portlets/tree/treeportlet.pt:39
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_summary"
 msgstr "Das Markieren und Entfernen von Favoriten geschieht über den Ordnungssystem-Reiter."
 

--- a/opengever/portlets/tree/locales/fr/LC_MESSAGES/opengever.portlets.tree.po
+++ b/opengever/portlets/tree/locales/fr/LC_MESSAGES/opengever.portlets.tree.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,45 +14,45 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/portlets/tree/treeportlet.pt:15
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "Favorites"
 msgstr "Favoris"
 
-#: ./opengever/portlets/tree/treeportlet.pt:1
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_add_to_favorites"
 msgstr "Ajouter aux favoris"
 
 #. Default: "Help"
-#: ./opengever/portlets/tree/treeportlet.pt:36
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_help"
 msgstr "Aide"
 
-#: ./opengever/portlets/tree/treeportlet.pt:1
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_remove_from_favorites"
 msgstr "Effacer des favoris"
 
 #. Default: "No favorites set yet."
-#: ./opengever/portlets/tree/treeportlet.pt:28
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_empty"
 msgstr "Il n'y a encore aucun numéro de classement épinglé en favoris."
 
 #. Default: "When hovering over a repository folder, the icon for marking folders as favorites (${icon}) appears at the right side. Clicking this icon adds the folder as favorite here."
-#: ./opengever/portlets/tree/treeportlet.pt:45
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_adding"
 msgstr "En survolant les numéros de classement dans le plan de classement avec le pointeur de la souris, le symbole pour marquer les favoris (${icon}) s'affiche à droite. En cliquant sur ce symbole, ce numéro de classement apparaît dans l'onglet \"Favoris\"."
 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
-#: ./opengever/portlets/tree/treeportlet.pt:53
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_marked"
 msgstr "Vos numéros de classement choisis comme favoris sont épinglés dans l'onglet du plan de classement avec le symbole correspondant (${icon})."
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
-#: ./opengever/portlets/tree/treeportlet.pt:60
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_removing"
 msgstr "Pour effacer un favori, retournez sur l'onglet \"Plan de classement\" et cliquez sur le symbole pour effacer les favoris (${icon})."
 
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
-#: ./opengever/portlets/tree/treeportlet.pt:39
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_summary"
 msgstr "L'ajout ou la suppression des favoris se fait dans l'onglet plan de classement."
 

--- a/opengever/portlets/tree/locales/opengever.portlets.tree.pot
+++ b/opengever/portlets/tree/locales/opengever.portlets.tree.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,45 +17,45 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.portlets.tree\n"
 
-#: ./opengever/portlets/tree/treeportlet.pt:15
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "Favorites"
 msgstr ""
 
-#: ./opengever/portlets/tree/treeportlet.pt:1
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_add_to_favorites"
 msgstr ""
 
 #. Default: "Help"
-#: ./opengever/portlets/tree/treeportlet.pt:36
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_help"
 msgstr ""
 
-#: ./opengever/portlets/tree/treeportlet.pt:1
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "label_remove_from_favorites"
 msgstr ""
 
 #. Default: "No favorites set yet."
-#: ./opengever/portlets/tree/treeportlet.pt:28
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_empty"
 msgstr ""
 
 #. Default: "When hovering over a repository folder, the icon for marking folders as favorites (${icon}) appears at the right side. Clicking this icon adds the folder as favorite here."
-#: ./opengever/portlets/tree/treeportlet.pt:45
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_adding"
 msgstr ""
 
 #. Default: "Your favorite folders are marked with the favorites icon (${icon}) in the repository tree."
-#: ./opengever/portlets/tree/treeportlet.pt:53
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_marked"
 msgstr ""
 
 #. Default: "For removing a favorite, switch back to the repository tree tab and click on the icon for removing a favorite (${icon})."
-#: ./opengever/portlets/tree/treeportlet.pt:60
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_removing"
 msgstr ""
 
 #. Default: "Adding and removing of favorites is done in the repository tree tab."
-#: ./opengever/portlets/tree/treeportlet.pt:39
+#: ./opengever/portlets/tree/treeportlet.pt
 msgid "tree_favorites_help_summary"
 msgstr ""
 

--- a/opengever/private/locales/de/LC_MESSAGES/opengever.private.po
+++ b/opengever/private/locales/de/LC_MESSAGES/opengever.private.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,15 +14,16 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/private/viewlets/quotawarning.py:31
+#: ./opengever/private/viewlets/quotawarning.py
 msgid "The quota of your private folder has exceeded, you can not add any new files or mails."
 msgstr "Der Ihnen zur Verfügung stehende Speicherplatz für die persönlichen Ablage ist überschritten: es können keine Dateien oder E-Mails mehr hinzugefügt werden."
 
-#: ./opengever/private/viewlets/quotawarning.py:37
+#: ./opengever/private/viewlets/quotawarning.py
 msgid "The quota of your private folder will exceed soon."
 msgstr "Der Ihnen zur Verfügung stehende Speicherplatz für die persönlichen Ablage ist nächstens ausgeschöpft. Löschen Sie Dateien, um mehr freien Speicherplatz zu schaffen."
 
 #. Default: "Dossiers"
-#: ./opengever/private/browser/tabbed.py:15
+#: ./opengever/private/browser/tabbed.py
 msgid "label_dossiers"
 msgstr "Dossiers"
+

--- a/opengever/private/locales/fr/LC_MESSAGES/opengever.private.po
+++ b/opengever/private/locales/fr/LC_MESSAGES/opengever.private.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-04 16:00+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-private/fr/>\n"
@@ -16,16 +16,16 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/private/viewlets/quotawarning.py:31
+#: ./opengever/private/viewlets/quotawarning.py
 msgid "The quota of your private folder has exceeded, you can not add any new files or mails."
 msgstr "Vous avez dépassé l'espace de mémoire disponible pour le stockage de vos documents personnels: il n'est pas possible d'ajouter d'autres données ou e-mails."
 
-#: ./opengever/private/viewlets/quotawarning.py:37
+#: ./opengever/private/viewlets/quotawarning.py
 msgid "The quota of your private folder will exceed soon."
 msgstr "L'espace de mémoire disponible pour le stockage de vos documents personnels est bientôt saturé. Créez plus d'espace libre en supprimant des fichiers."
 
 #. Default: "Dossiers"
-#: ./opengever/private/browser/tabbed.py:15
+#: ./opengever/private/browser/tabbed.py
 msgid "label_dossiers"
 msgstr "Dossiers"
 

--- a/opengever/private/locales/opengever.private.pot
+++ b/opengever/private/locales/opengever.private.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,16 +17,16 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.private\n"
 
-#: ./opengever/private/viewlets/quotawarning.py:31
+#: ./opengever/private/viewlets/quotawarning.py
 msgid "The quota of your private folder has exceeded, you can not add any new files or mails."
 msgstr ""
 
-#: ./opengever/private/viewlets/quotawarning.py:37
+#: ./opengever/private/viewlets/quotawarning.py
 msgid "The quota of your private folder will exceed soon."
 msgstr ""
 
 #. Default: "Dossiers"
-#: ./opengever/private/browser/tabbed.py:15
+#: ./opengever/private/browser/tabbed.py
 msgid "label_dossiers"
 msgstr ""
 

--- a/opengever/quota/locales/de/LC_MESSAGES/opengever.quota.po
+++ b/opengever/quota/locales/de/LC_MESSAGES/opengever.quota.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,32 +14,32 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/quota/browser/templates/usage.pt:35
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Back"
 msgstr "Zurück"
 
-#: ./opengever/quota/sizequota.py:87
+#: ./opengever/quota/sizequota.py
 msgid "Can not add this item because it exhausts the quota."
 msgstr "Dieser Inhalt kann nicht hinzugefügt werden, weil damit der Ihnen zur Verfügung stehende Speicherplatz überschritten würde."
 
-#: ./opengever/quota/browser/templates/usage.pt:27
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Hard limit"
 msgstr "Hard-Limit"
 
-#: ./opengever/quota/browser/templates/usage.pt:23
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Soft limit"
 msgstr "Soft-Limit"
 
-#: ./opengever/quota/browser/templates/usage.pt:19
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Usage"
 msgstr "Nutzung"
 
-#: ./opengever/quota/browser/usage.py:18
+#: ./opengever/quota/browser/usage.py
 msgid "unlimited"
 msgstr "unlimitiert"
 
 #. Default: "Usage of «${title}»"
-#: ./opengever/quota/browser/templates/usage.pt:12
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "usage_title"
 msgstr "Nutzung in «${title}»"
 

--- a/opengever/quota/locales/fr/LC_MESSAGES/opengever.quota.po
+++ b/opengever/quota/locales/fr/LC_MESSAGES/opengever.quota.po
@@ -1,49 +1,47 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-04 16:13+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-quota/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-quota/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/quota/browser/templates/usage.pt:35
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Back"
 msgstr "Retour"
 
-#: ./opengever/quota/sizequota.py:87
+#: ./opengever/quota/sizequota.py
 msgid "Can not add this item because it exhausts the quota."
-msgstr ""
-"Ce contenu ne peut pas être ajouté, parce que cela mènerait à un dépassement "
-"de l'espace de mémoire à votre disposition."
+msgstr "Ce contenu ne peut pas être ajouté, parce que cela mènerait à un dépassement de l'espace de mémoire à votre disposition."
 
-#: ./opengever/quota/browser/templates/usage.pt:27
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Hard limit"
 msgstr "limite stricte"
 
-#: ./opengever/quota/browser/templates/usage.pt:23
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Soft limit"
 msgstr "limite non stricte"
 
-#: ./opengever/quota/browser/templates/usage.pt:19
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Usage"
 msgstr "Usage"
 
-#: ./opengever/quota/browser/usage.py:18
+#: ./opengever/quota/browser/usage.py
 msgid "unlimited"
 msgstr "illimité"
 
 #. Default: "Usage of «${title}»"
-#: ./opengever/quota/browser/templates/usage.pt:12
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "usage_title"
 msgstr "Usage en «${title}»"
+

--- a/opengever/quota/locales/opengever.quota.pot
+++ b/opengever/quota/locales/opengever.quota.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.quota\n"
 
-#: ./opengever/quota/browser/templates/usage.pt:35
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Back"
 msgstr ""
 
-#: ./opengever/quota/sizequota.py:87
+#: ./opengever/quota/sizequota.py
 msgid "Can not add this item because it exhausts the quota."
 msgstr ""
 
-#: ./opengever/quota/browser/templates/usage.pt:27
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Hard limit"
 msgstr ""
 
-#: ./opengever/quota/browser/templates/usage.pt:23
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Soft limit"
 msgstr ""
 
-#: ./opengever/quota/browser/templates/usage.pt:19
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "Usage"
 msgstr ""
 
-#: ./opengever/quota/browser/usage.py:18
+#: ./opengever/quota/browser/usage.py
 msgid "unlimited"
 msgstr ""
 
 #. Default: "Usage of «${title}»"
-#: ./opengever/quota/browser/templates/usage.pt:12
+#: ./opengever/quota/browser/templates/usage.pt
 msgid "usage_title"
 msgstr ""
 

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:40
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "In use"
 msgstr "Wird verwendet"
 
@@ -30,171 +30,171 @@ msgid "Unlock unused repository prefixes."
 msgstr "Freigabe von ungebrauchten Aktenzeichen Prefixen."
 
 #. Default: "Allow add businesscase dossier"
-#: ./opengever/repository/repositoryfolder.py:84
+#: ./opengever/repository/repositoryfolder.py
 msgid "allow_add_businesscase_dossier"
 msgstr "Hinzufügen von Geschäftsdossiers erlauben"
 
 #. Default: "Choose if the user is allowed to add businesscase dossiers or only dossiers from a  dossiertemplate."
-#: ./opengever/repository/repositoryfolder.py:86
+#: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Wählen Sie, ob es in dieser Ordnungsposition erlaubt ist, Geschäftsdossiers hinzuzufügen. Ist diese Option deaktiviert, kann der Benutzer nur Dossiers aus einer Vorlage oder Spezialdossiers erstellen."
 
 #. Default: "No nested repositorys available."
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:29
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "empty_repository"
 msgstr "Keine untergeordnete Ordnungspositionen verfügbar."
 
 #. Default: "A Sibling with the same reference number is existing."
-#: ./opengever/repository/behaviors/referenceprefix.py:69
+#: ./opengever/repository/behaviors/referenceprefix.py
 msgid "error_sibling_reference_number_existing"
 msgstr "Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf gleicher Stufe."
 
 #. Default: "Common"
-#: ./opengever/repository/behaviors/referenceprefix.py:32
-#: ./opengever/repository/behaviors/responsibleorg.py:12
-#: ./opengever/repository/repositoryfolder.py:26
+#: ./opengever/repository/behaviors/referenceprefix.py
+#: ./opengever/repository/behaviors/responsibleorg.py
+#: ./opengever/repository/repositoryfolder.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:76
+#: ./opengever/repository/repositoryfolder.py
 msgid "help_addable_dossier_types"
 msgstr "Wählen Sie die Spezialdossiers aus, die in dieser Ordnungsposition erlaubt sind."
 
 #. Default: "A short summary of the content."
-#: ./opengever/repository/repositoryfolder.py:39
+#: ./opengever/repository/repositoryfolder.py
 msgid "help_description"
 msgstr "Eine kurze Beschreibung des Inhalts."
 
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:74
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_addable_dossier_types"
 msgstr "Erlaubte Spezialdossiers"
 
 #. Default: "Delete"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:32
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete"
 msgstr "Löschen"
 
 #. Default: "Delete repository"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:20
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete_repository"
 msgstr "Ordnungsposition löschen"
 
 #. Default: "Description"
-#: ./opengever/repository/repositoryfolder.py:38
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:68
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_former_reference"
 msgstr "Früheres Zeichen"
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:56
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_location"
 msgstr "Standort"
 
 #. Default: "Reference Prefix"
-#: ./opengever/repository/behaviors/referenceprefix.py:39
+#: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
 msgstr "Präfix des Aktenzeichens"
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:61
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_referenced_activity"
 msgstr "Leistung"
 
 #. Default: "The repository have been successfully deleted."
-#: ./opengever/repository/browser/deletion.py:38
+#: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
 msgstr "Die Ordnungsposition wurde erfolgreich gelöscht."
 
 #. Default: "Valid from"
-#: ./opengever/repository/repositoryfolder.py:46
-#: ./opengever/repository/repositoryroot.py:22
+#: ./opengever/repository/repositoryfolder.py
+#: ./opengever/repository/repositoryroot.py
 msgid "label_valid_from"
 msgstr "Gültig ab"
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:51
-#: ./opengever/repository/repositoryroot.py:27
+#: ./opengever/repository/repositoryfolder.py
+#: ./opengever/repository/repositoryroot.py
 msgid "label_valid_until"
 msgstr "Gültig bis"
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:32
+#: ./opengever/repository/repositoryroot.py
 msgid "label_version"
 msgstr "Version"
 
 #. Default: "Warning"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:25
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_warning"
 msgstr "Warnung"
 
 #. Default: "State"
-#: ./opengever/repository/viewlets/byline.py:29
+#: ./opengever/repository/viewlets/byline.py
 msgid "label_workflow_state"
 msgstr "Status"
 
 #. Default: "Do you really want to delete the current repository?"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:26
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "msg_delete_confirmation"
 msgstr "Möchten Sie die aktuelle Ordnungsposition wirklich löschen?"
 
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
-#: ./opengever/repository/repositoryfolder.py:142
+#: ./opengever/repository/browser/repositoryfolder_forms.py
 msgid "msg_leafnode_warning"
 msgstr "Sie fügen eine Ordnungsposition einem Blattknoten hinzu, der bereits Dossiers enthält. Dies ist nur vorübergehend erlaubt und darin enthaltene Dossiers müssen anschliessend wieder in einen Blattknoten verschoben werden."
 
 #. Default: "Name"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:24
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "name"
 msgstr "Name"
 
 #. Default: "Position"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:23
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "position"
 msgstr "Position"
 
 #. Default: "Reference Prefix Manager"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:15
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "prefman_title"
 msgstr "Aktenzeichen Präfix Manager"
 
 #. Default: "Responsible organisation unit"
-#: ./opengever/repository/behaviors/responsibleorg.py:17
+#: ./opengever/repository/behaviors/responsibleorg.py
 msgid "responsible_org_unit"
 msgstr "Federführendes Amt"
 
 #. Default: "The reference you try to unlock is still in use."
-#: ./opengever/repository/browser/referenceprefix_manager.py:23
+#: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlock_failure"
 msgstr "Das Aktenzeichen Präfix wird noch verwendet."
 
 #. Default: "Reference prefix has been unlocked."
-#: ./opengever/repository/browser/referenceprefix_manager.py:32
+#: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlocked"
 msgstr "Aktenzeichen Präfix wurde freigegeben."
 
 #. Default: "Documents:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:16
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_documents"
 msgstr "Dokumente"
 
 #. Default: "Dossiers:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:6
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Tasks:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:11
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_task"
 msgstr "Aufgaben"
 
 #. Default: "Unlock"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:25
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "unlock"
 msgstr "Freigeben"
 

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-04 17:05+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-repository/fr/>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:40
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "In use"
 msgstr "Est utilisé"
 
@@ -29,171 +29,171 @@ msgid "Unlock unused repository prefixes."
 msgstr "Déblocage de préfixes de référence inutilisés."
 
 #. Default: "Allow add businesscase dossier"
-#: ./opengever/repository/repositoryfolder.py:84
+#: ./opengever/repository/repositoryfolder.py
 msgid "allow_add_businesscase_dossier"
 msgstr "Permettre l'ajout de dossiers commerciaux"
 
 #. Default: "Choose if the user is allowed to add businesscase dossiers or only dossiers from a  dossiertemplate."
-#: ./opengever/repository/repositoryfolder.py:86
+#: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Déterminez s'il est permis d'ajouter des dossiers commerciaux à ce niveau. Si cette option est désactivée, l'utilisateur ne peut créer que des dossiers spéciaux ou bien des dossiers à partir d'un modèle."
 
 #. Default: "No nested repositorys available."
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:29
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "empty_repository"
 msgstr "Pas de numéros de classement disponible dans cette subdivison."
 
 #. Default: "A Sibling with the same reference number is existing."
-#: ./opengever/repository/behaviors/referenceprefix.py:69
+#: ./opengever/repository/behaviors/referenceprefix.py
 msgid "error_sibling_reference_number_existing"
 msgstr "A ce niveau du classement ce numéro de référence existe déjà."
 
 #. Default: "Common"
-#: ./opengever/repository/behaviors/referenceprefix.py:32
-#: ./opengever/repository/behaviors/responsibleorg.py:12
-#: ./opengever/repository/repositoryfolder.py:26
+#: ./opengever/repository/behaviors/referenceprefix.py
+#: ./opengever/repository/behaviors/responsibleorg.py
+#: ./opengever/repository/repositoryfolder.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:76
+#: ./opengever/repository/repositoryfolder.py
 msgid "help_addable_dossier_types"
 msgstr "Sélectionnez les types de dossiers à ajouter pour cette position du classeur."
 
 #. Default: "A short summary of the content."
-#: ./opengever/repository/repositoryfolder.py:39
+#: ./opengever/repository/repositoryfolder.py
 msgid "help_description"
 msgstr "Brève description du contenu."
 
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:74
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_addable_dossier_types"
 msgstr "Types de dossiers à ajouter"
 
 #. Default: "Delete"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:32
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete"
 msgstr "Effacer"
 
 #. Default: "Delete repository"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:20
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete_repository"
 msgstr "Effacer le numéro de la position"
 
 #. Default: "Description"
-#: ./opengever/repository/repositoryfolder.py:38
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:68
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_former_reference"
 msgstr "Ancien numéro de référence"
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:56
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_location"
 msgstr "Site"
 
 #. Default: "Reference Prefix"
-#: ./opengever/repository/behaviors/referenceprefix.py:39
+#: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
 msgstr "Préfixe référence"
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:61
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_referenced_activity"
 msgstr "Performance"
 
 #. Default: "The repository have been successfully deleted."
-#: ./opengever/repository/browser/deletion.py:38
+#: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
 msgstr "Le numéro de la position a été effacé avec succès."
 
 #. Default: "Valid from"
-#: ./opengever/repository/repositoryfolder.py:46
-#: ./opengever/repository/repositoryroot.py:22
+#: ./opengever/repository/repositoryfolder.py
+#: ./opengever/repository/repositoryroot.py
 msgid "label_valid_from"
 msgstr "Valable de :"
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:51
-#: ./opengever/repository/repositoryroot.py:27
+#: ./opengever/repository/repositoryfolder.py
+#: ./opengever/repository/repositoryroot.py
 msgid "label_valid_until"
 msgstr "Valable jusqu'à :"
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:32
+#: ./opengever/repository/repositoryroot.py
 msgid "label_version"
 msgstr "Version"
 
 #. Default: "Warning"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:25
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_warning"
 msgstr "Avertissement"
 
 #. Default: "State"
-#: ./opengever/repository/viewlets/byline.py:29
+#: ./opengever/repository/viewlets/byline.py
 msgid "label_workflow_state"
 msgstr "Etat"
 
 #. Default: "Do you really want to delete the current repository?"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:26
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "msg_delete_confirmation"
 msgstr "Voulez-vous vraiment effacer le numéro de la position actuel?"
 
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
-#: ./opengever/repository/repositoryfolder.py:142
+#: ./opengever/repository/browser/repositoryfolder_forms.py
 msgid "msg_leafnode_warning"
 msgstr "Vous ajoutez un dossier du référentiel à un nœud feuille contenant déjà des dossiers. Ceci n'est permis que temporairement et les dossiers s'y trouvant doivent ensuite être déplacés dans un nœud feuille."
 
 #. Default: "Name"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:24
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "name"
 msgstr "Nom"
 
 #. Default: "Position"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:23
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "position"
 msgstr "Position"
 
 #. Default: "Reference Prefix Manager"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:15
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "prefman_title"
 msgstr "Gestionnaire de préfixes de référence"
 
 #. Default: "Responsible organisation unit"
-#: ./opengever/repository/behaviors/responsibleorg.py:17
+#: ./opengever/repository/behaviors/responsibleorg.py
 msgid "responsible_org_unit"
 msgstr "Service responsable"
 
 #. Default: "The reference you try to unlock is still in use."
-#: ./opengever/repository/browser/referenceprefix_manager.py:23
+#: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlock_failure"
 msgstr "La référence que vous essayez de déverrouiller est toujours utilisée."
 
 #. Default: "Reference prefix has been unlocked."
-#: ./opengever/repository/browser/referenceprefix_manager.py:32
+#: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlocked"
 msgstr "Le préfixe de référence à été débloqué."
 
 #. Default: "Documents:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:16
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_documents"
 msgstr "Documents"
 
 #. Default: "Dossiers:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:6
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_dossiers"
 msgstr "Dossiers"
 
 #. Default: "Tasks:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:11
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_task"
 msgstr "Tâches"
 
 #. Default: "Unlock"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:25
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "unlock"
 msgstr "Libérer"
 

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.repository\n"
 
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:40
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "In use"
 msgstr ""
 
@@ -30,171 +30,171 @@ msgid "Unlock unused repository prefixes."
 msgstr ""
 
 #. Default: "Allow add businesscase dossier"
-#: ./opengever/repository/repositoryfolder.py:84
+#: ./opengever/repository/repositoryfolder.py
 msgid "allow_add_businesscase_dossier"
 msgstr ""
 
 #. Default: "Choose if the user is allowed to add businesscase dossiers or only dossiers from a  dossiertemplate."
-#: ./opengever/repository/repositoryfolder.py:86
+#: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
 msgstr ""
 
 #. Default: "No nested repositorys available."
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:29
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "empty_repository"
 msgstr ""
 
 #. Default: "A Sibling with the same reference number is existing."
-#: ./opengever/repository/behaviors/referenceprefix.py:69
+#: ./opengever/repository/behaviors/referenceprefix.py
 msgid "error_sibling_reference_number_existing"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/repository/behaviors/referenceprefix.py:32
-#: ./opengever/repository/behaviors/responsibleorg.py:12
-#: ./opengever/repository/repositoryfolder.py:26
+#: ./opengever/repository/behaviors/referenceprefix.py
+#: ./opengever/repository/behaviors/responsibleorg.py
+#: ./opengever/repository/repositoryfolder.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
-#: ./opengever/repository/repositoryfolder.py:76
+#: ./opengever/repository/repositoryfolder.py
 msgid "help_addable_dossier_types"
 msgstr ""
 
 #. Default: "A short summary of the content."
-#: ./opengever/repository/repositoryfolder.py:39
+#: ./opengever/repository/repositoryfolder.py
 msgid "help_description"
 msgstr ""
 
 #. Default: "Addable dossier types"
-#: ./opengever/repository/repositoryfolder.py:74
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_addable_dossier_types"
 msgstr ""
 
 #. Default: "Delete"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:32
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete"
 msgstr ""
 
 #. Default: "Delete repository"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:20
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete_repository"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/repository/repositoryfolder.py:38
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_description"
 msgstr ""
 
 #. Default: "Former reference"
-#: ./opengever/repository/repositoryfolder.py:68
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_former_reference"
 msgstr ""
 
 #. Default: "Location"
-#: ./opengever/repository/repositoryfolder.py:56
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_location"
 msgstr ""
 
 #. Default: "Reference Prefix"
-#: ./opengever/repository/behaviors/referenceprefix.py:39
+#: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
 msgstr ""
 
 #. Default: "Referenced activity"
-#: ./opengever/repository/repositoryfolder.py:61
+#: ./opengever/repository/repositoryfolder.py
 msgid "label_referenced_activity"
 msgstr ""
 
 #. Default: "The repository have been successfully deleted."
-#: ./opengever/repository/browser/deletion.py:38
+#: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
 msgstr ""
 
 #. Default: "Valid from"
-#: ./opengever/repository/repositoryfolder.py:46
-#: ./opengever/repository/repositoryroot.py:22
+#: ./opengever/repository/repositoryfolder.py
+#: ./opengever/repository/repositoryroot.py
 msgid "label_valid_from"
 msgstr ""
 
 #. Default: "Valid until"
-#: ./opengever/repository/repositoryfolder.py:51
-#: ./opengever/repository/repositoryroot.py:27
+#: ./opengever/repository/repositoryfolder.py
+#: ./opengever/repository/repositoryroot.py
 msgid "label_valid_until"
 msgstr ""
 
 #. Default: "Version"
-#: ./opengever/repository/repositoryroot.py:32
+#: ./opengever/repository/repositoryroot.py
 msgid "label_version"
 msgstr ""
 
 #. Default: "Warning"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:25
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_warning"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/repository/viewlets/byline.py:29
+#: ./opengever/repository/viewlets/byline.py
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "Do you really want to delete the current repository?"
-#: ./opengever/repository/browser/deletion_templates/deletion.pt:26
+#: ./opengever/repository/browser/templates/deletion.pt
 msgid "msg_delete_confirmation"
 msgstr ""
 
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
-#: ./opengever/repository/repositoryfolder.py:142
+#: ./opengever/repository/browser/repositoryfolder_forms.py
 msgid "msg_leafnode_warning"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:24
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "name"
 msgstr ""
 
 #. Default: "Position"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:23
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "position"
 msgstr ""
 
 #. Default: "Reference Prefix Manager"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:15
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "prefman_title"
 msgstr ""
 
 #. Default: "Responsible organisation unit"
-#: ./opengever/repository/behaviors/responsibleorg.py:17
+#: ./opengever/repository/behaviors/responsibleorg.py
 msgid "responsible_org_unit"
 msgstr ""
 
 #. Default: "The reference you try to unlock is still in use."
-#: ./opengever/repository/browser/referenceprefix_manager.py:23
+#: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlock_failure"
 msgstr ""
 
 #. Default: "Reference prefix has been unlocked."
-#: ./opengever/repository/browser/referenceprefix_manager.py:32
+#: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlocked"
 msgstr ""
 
 #. Default: "Documents:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:16
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_documents"
 msgstr ""
 
 #. Default: "Dossiers:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:6
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_dossiers"
 msgstr ""
 
 #. Default: "Tasks:"
-#: ./opengever/repository/browser/overview_templates/repositoryrootoverview.pt:11
+#: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_task"
 msgstr ""
 
 #. Default: "Unlock"
-#: ./opengever/repository/browser/templates/referenceprefixmanager.pt:25
+#: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "unlock"
 msgstr ""
 

--- a/opengever/setup/locales/de/LC_MESSAGES/opengever.setup.po
+++ b/opengever/setup/locales/de/LC_MESSAGES/opengever.setup.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/setup/locales/fr/LC_MESSAGES/opengever.setup.po
+++ b/opengever/setup/locales/fr/LC_MESSAGES/opengever.setup.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/setup/locales/opengever.setup.pot
+++ b/opengever/setup/locales/opengever.setup.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/sharing/locales/de/LC_MESSAGES/opengever.sharing.po
+++ b/opengever/sharing/locales/de/LC_MESSAGES/opengever.sharing.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,49 +14,39 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/sharing/browser/sharing.py:35
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_contributor"
 msgstr "Hinzufügen"
 
-#: ./opengever/sharing/browser/sharing.py:27
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_contributor"
 msgstr "Dossiers hinzufügen"
 
-#: ./opengever/sharing/browser/sharing.py:28
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_editor"
 msgstr "Dossiers bearbeiten"
 
-#: ./opengever/sharing/browser/sharing.py:30
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_publisher"
 msgstr "Dossiers reaktivieren"
 
-#: ./opengever/sharing/browser/sharing.py:26
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reader"
 msgstr "Lesen"
 
-#: ./opengever/sharing/browser/sharing.py:29
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reviewer"
 msgstr "Dossiers abschliessen"
 
-#: ./opengever/sharing/browser/sharing.py:36
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_editor"
 msgstr "Bearbeiten"
 
-#: ./opengever/sharing/browser/sharing.py:34
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_reader"
 msgstr "Lesen"
 
-#: ./opengever/sharing/browser/sharing.py:37
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_role_manager"
 msgstr "Rollen verwalten"
-
-#. Default: "Can administrate"
-#: ./opengever/sharing/utilities.py:12
-msgid "title_can_administrate"
-msgstr "Administrieren"
-
-#. Default: "Can publish"
-#: ./opengever/sharing/utilities.py:20
-msgid "title_can_publish"
-msgstr "Publizieren"
 

--- a/opengever/sharing/locales/fr/LC_MESSAGES/opengever.sharing.po
+++ b/opengever/sharing/locales/fr/LC_MESSAGES/opengever.sharing.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,49 +14,39 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/sharing/browser/sharing.py:35
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_contributor"
 msgstr "Ajouter"
 
-#: ./opengever/sharing/browser/sharing.py:27
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_contributor"
 msgstr "Ajouter les dossiers"
 
-#: ./opengever/sharing/browser/sharing.py:28
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_editor"
 msgstr "Modifier les dossiers"
 
-#: ./opengever/sharing/browser/sharing.py:30
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_publisher"
 msgstr "Réactiver les dossiers"
 
-#: ./opengever/sharing/browser/sharing.py:26
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reader"
 msgstr "Lire les dossiers"
 
-#: ./opengever/sharing/browser/sharing.py:29
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reviewer"
 msgstr "Fermer les dossiers"
 
-#: ./opengever/sharing/browser/sharing.py:36
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_editor"
 msgstr "Modifier"
 
-#: ./opengever/sharing/browser/sharing.py:34
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_reader"
 msgstr "Lire"
 
-#: ./opengever/sharing/browser/sharing.py:37
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_role_manager"
 msgstr "Gérer les rôles"
-
-#. Default: "Can administrate"
-#: ./opengever/sharing/utilities.py:12
-msgid "title_can_administrate"
-msgstr "Administrer"
-
-#. Default: "Can publish"
-#: ./opengever/sharing/utilities.py:20
-msgid "title_can_publish"
-msgstr "Publier"
 

--- a/opengever/sharing/locales/opengever.sharing.pot
+++ b/opengever/sharing/locales/opengever.sharing.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-27 11:21+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,49 +17,39 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.sharing\n"
 
-#: ./opengever/sharing/browser/sharing.py:35
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_contributor"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:27
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_contributor"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:28
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_editor"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:30
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_publisher"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:26
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reader"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:29
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reviewer"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:36
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_editor"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:34
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_reader"
 msgstr ""
 
-#: ./opengever/sharing/browser/sharing.py:37
+#: ./opengever/sharing/browser/sharing.py
 msgid "sharing_role_manager"
-msgstr ""
-
-#. Default: "Can administrate"
-#: ./opengever/sharing/utilities.py:12
-msgid "title_can_administrate"
-msgstr ""
-
-#. Default: "Can publish"
-#: ./opengever/sharing/utilities.py:20
-msgid "title_can_publish"
 msgstr ""
 

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-07-19 08:51+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -14,12 +14,12 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:282
-#: ./opengever/tabbedview/browser/users.py:62
+#: ./opengever/tabbedview/browser/tabs.py
+#: ./opengever/tabbedview/browser/users.py
 msgid "Active"
 msgstr "Aktiv"
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr "Alle Sichtbaren ausgewählt <a href=\"#\">x</a>"
 
@@ -30,16 +30,16 @@ msgstr "Auswählen"
 msgid "Creator"
 msgstr "Ersteller"
 
-#: ./opengever/tabbedview/browser/batching.pt:68
+#: ./opengever/tabbedview/browser/batching.pt
 msgid "Hits per site"
 msgstr "Treffer pro Seite"
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "Show all in this Folder"
 msgstr "Alle in diesem Ordner anzeigen"
 
-#: ./opengever/tabbedview/browser/generic_with_filters.pt:54
-#: ./opengever/tabbedview/browser/selection_with_filters.pt:19
+#: ./opengever/tabbedview/browser/generic_with_filters.pt
+#: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "State"
 msgstr "Status"
 
@@ -61,7 +61,7 @@ msgid "all_orgunits"
 msgstr "Alle Gremien"
 
 #. Default: "More actions &#9660;"
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:40
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "button_more_actions"
 msgstr "Weitere Aktionen &#9660;"
 
@@ -72,42 +72,42 @@ msgid "checkout_and_edit"
 msgstr "Auschecken / Bearbeiten"
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:92
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_date_of_completion"
 msgstr "Erledigt am"
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:88
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:105
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_issued_at"
 msgstr "Erstellt am"
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:113
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_issuing_org_unit"
 msgstr "Organisationseinheit"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:76
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_review_state"
 msgstr "Status"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:119
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:84
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:80
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_title"
 msgstr "Titel"
 
@@ -122,7 +122,7 @@ msgid "contact"
 msgstr "Beteiligter"
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:109
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "containing_dossier"
 msgstr "Dossier"
 
@@ -145,7 +145,7 @@ msgid "document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:139
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "document_sequence_number"
 msgstr "Laufnummer"
 
@@ -154,19 +154,19 @@ msgid "documents"
 msgstr "Dokumente"
 
 #. Default: "Show more"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:17
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
 msgid "documentsShowMore"
 msgstr "Mehr anzeigen"
 
 #. Default: "Gallery"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:3
-#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:11
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 msgid "documents_pill_documents"
 msgstr "Galerieansicht"
 
 #. Default: "List"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:4
-#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:17
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 msgid "documents_pill_list"
 msgstr "Listenansicht"
 
@@ -184,7 +184,7 @@ msgstr "Ende"
 msgid "events"
 msgstr "Termine"
 
-#: ./opengever/tabbedview/browser/tabs.py:285
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "expired"
 msgstr "Abgelaufen"
 
@@ -199,158 +199,158 @@ msgid "journal"
 msgstr "Journal"
 
 #. Default: "Active"
-#: ./opengever/tabbedview/browser/users.py:99
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_active"
 msgstr "Aktiv"
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:166
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_checked_out"
 msgstr "In Bearbeitung"
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:162
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Department"
-#: ./opengever/tabbedview/browser/users.py:90
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_department_user"
 msgstr "Amt"
 
 #. Default: "Directorate"
-#: ./opengever/tabbedview/browser/users.py:95
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_directorate_user"
 msgstr "Direktion"
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:149
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_author"
 msgstr "Autor"
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:154
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_date"
 msgstr "Dokumentdatum"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:178
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_reference"
 msgstr "Aktenzeichen"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:255
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_dossier_responsible"
 msgstr "Federführung"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:264
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_end"
 msgstr "Ende"
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:101
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "My notifications"
-#: ./opengever/tabbedview/browser/personal_overview.py:113
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "label_my_notifications"
 msgstr "Meine Benachrichtigungen"
 
 #. Default: "My proposals"
-#: ./opengever/tabbedview/browser/personal_overview.py:124
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "label_my_proposals"
 msgstr "Meine Anträge"
 
 #. Default: "No contents"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:23
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
 msgid "label_no_contents"
 msgstr "Keine Inhalte"
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:66
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_pending"
 msgstr "Pendent"
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:198
+#: ./opengever/tabbedview/helper.py
 msgid "label_preview"
 msgstr "Vorschau"
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:174
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_public_trial"
 msgstr "Öffentlichkeitsstatus"
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:158
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:243
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_reference"
 msgstr "Aktenzeichen"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:97
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_responsible_task"
 msgstr "Auftragnehmer"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:251
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:188
+#: ./opengever/tabbedview/helper.py
 msgid "label_showroom_version_title"
 msgstr "Version ${version} vom ${timestamp}"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:260
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_start"
 msgstr "Beginn"
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:170
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_subdossier"
 msgstr "Subdossier"
 
-#: ./opengever/tabbedview/browser/tabs.py:280
-#: ./opengever/tabbedview/browser/tasklisting.py:64
-#: ./opengever/tabbedview/browser/users.py:61
+#: ./opengever/tabbedview/browser/tabs.py
+#: ./opengever/tabbedview/browser/tasklisting.py
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_tabbedview_filter_all"
 msgstr "Alle"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:144
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Email"
-#: ./opengever/tabbedview/browser/users.py:81
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_email"
 msgstr "E-Mail"
 
 #. Default: "Firstname"
-#: ./opengever/tabbedview/browser/users.py:71
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_firstname"
 msgstr "Vorname"
 
 #. Default: "Lastname"
-#: ./opengever/tabbedview/browser/users.py:66
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_lastname"
 msgstr "Nachname"
 
 #. Default: "Office Phone"
-#: ./opengever/tabbedview/browser/users.py:86
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_phone_office"
 msgstr "Telefon Geschäft"
 
 #. Default: "Userid"
-#: ./opengever/tabbedview/browser/users.py:76
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_userid"
 msgstr "Benutzerid"
 
@@ -361,7 +361,7 @@ msgstr "Änderungsdatum"
 msgid "mytasks"
 msgstr "Meine Aufgaben"
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "none"
 msgstr "Keine"
 
@@ -376,7 +376,7 @@ msgid "participants"
 msgstr "Beteiligte"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:94
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "personal_overview_title"
 msgstr "Persönliche Übersicht: ${user_name}"
 
@@ -430,7 +430,7 @@ msgid "subdossiers"
 msgstr "Subdossiers"
 
 #. Default: "${amount} matches"
-#: ./opengever/tabbedview/browser/no_selection_amount.pt:3
+#: ./opengever/tabbedview/browser/no_selection_amount.pt
 msgid "tab_matches"
 msgstr "${amount} Treffer"
 
@@ -448,3 +448,4 @@ msgstr "Titel"
 
 msgid "trash"
 msgstr "Papierkorb"
+

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-07-19 08:51+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-06-04 17:01+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tabbedview/fr/>\n"
@@ -16,12 +16,12 @@ msgstr ""
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:282
-#: ./opengever/tabbedview/browser/users.py:62
+#: ./opengever/tabbedview/browser/tabs.py
+#: ./opengever/tabbedview/browser/users.py
 msgid "Active"
 msgstr "Actif"
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr "Choix de toutes les entrées visibles <a href=\"#\">x</a>"
 
@@ -31,16 +31,16 @@ msgstr "Choix"
 msgid "Creator"
 msgstr "Créateur"
 
-#: ./opengever/tabbedview/browser/batching.pt:68
+#: ./opengever/tabbedview/browser/batching.pt
 msgid "Hits per site"
 msgstr "Résultats par page"
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "Show all in this Folder"
 msgstr "Tout afficher dans ce classeur"
 
-#: ./opengever/tabbedview/browser/generic_with_filters.pt:54
-#: ./opengever/tabbedview/browser/selection_with_filters.pt:19
+#: ./opengever/tabbedview/browser/generic_with_filters.pt
+#: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "State"
 msgstr "Etat"
 
@@ -60,7 +60,7 @@ msgid "all_orgunits"
 msgstr "Toutes les unités d'organisation"
 
 #. Default: "More actions &#9660;"
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:40
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "button_more_actions"
 msgstr "Autres actions"
 
@@ -71,42 +71,42 @@ msgid "checkout_and_edit"
 msgstr "Checkout et modifier"
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:92
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_date_of_completion"
 msgstr "Accompli le"
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:88
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_deadline"
 msgstr "A accomplir jusqu'au"
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:105
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_issued_at"
 msgstr "Créé le"
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:113
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_issuing_org_unit"
 msgstr "Unité d'organisation"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:76
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_review_state"
 msgstr "Etat"
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:119
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:84
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:80
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_title"
 msgstr "Titre"
 
@@ -120,7 +120,7 @@ msgid "contact"
 msgstr "Participant"
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:109
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "containing_dossier"
 msgstr "Dossier"
 
@@ -143,7 +143,7 @@ msgid "document_date"
 msgstr "Date du document"
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:139
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "document_sequence_number"
 msgstr "Numéro courant"
 
@@ -151,19 +151,19 @@ msgid "documents"
 msgstr "Documents "
 
 #. Default: "Show more"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:17
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
 msgid "documentsShowMore"
 msgstr "Montre plus"
 
 #. Default: "Gallery"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:3
-#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:11
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 msgid "documents_pill_documents"
 msgstr "Galerie"
 
 #. Default: "List"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:4
-#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:17
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 msgid "documents_pill_list"
 msgstr "Liste"
 
@@ -179,7 +179,7 @@ msgstr "Fin"
 msgid "events"
 msgstr "Rendez-vous"
 
-#: ./opengever/tabbedview/browser/tabs.py:285
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "expired"
 msgstr "Expiré"
 
@@ -193,158 +193,158 @@ msgid "journal"
 msgstr "Historique"
 
 #. Default: "Active"
-#: ./opengever/tabbedview/browser/users.py:99
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_active"
 msgstr "Actif"
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:166
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_checked_out"
 msgstr "En traitement"
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:162
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Department"
-#: ./opengever/tabbedview/browser/users.py:90
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_department_user"
 msgstr "Service"
 
 #. Default: "Directorate"
-#: ./opengever/tabbedview/browser/users.py:95
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_directorate_user"
 msgstr "Direction"
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:149
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_author"
 msgstr "Auteur"
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:154
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_date"
 msgstr "Date du document"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:178
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_reference"
 msgstr "Numéro de référence"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:255
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_dossier_responsible"
 msgstr "Responsable"
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:264
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_end"
 msgstr "Fin"
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:101
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "My notifications"
-#: ./opengever/tabbedview/browser/personal_overview.py:113
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "label_my_notifications"
 msgstr "Mes notifications"
 
 #. Default: "My proposals"
-#: ./opengever/tabbedview/browser/personal_overview.py:124
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "label_my_proposals"
 msgstr "Mes requêtes"
 
 #. Default: "No contents"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:23
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
 msgid "label_no_contents"
 msgstr "Aucun contenu"
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:66
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_pending"
 msgstr "En suspens"
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:198
+#: ./opengever/tabbedview/helper.py
 msgid "label_preview"
 msgstr "Aperçu"
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:174
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_public_trial"
 msgstr "Statut public"
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:158
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:243
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_reference"
 msgstr "Numéro de référence"
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:97
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_responsible_task"
 msgstr "Mandataire"
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:251
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:188
+#: ./opengever/tabbedview/helper.py
 msgid "label_showroom_version_title"
 msgstr "Version ${version} de ${timestamp}"
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:260
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_start"
 msgstr "Début"
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:170
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_subdossier"
 msgstr "Sous-dossier"
 
-#: ./opengever/tabbedview/browser/tabs.py:280
-#: ./opengever/tabbedview/browser/tasklisting.py:64
-#: ./opengever/tabbedview/browser/users.py:61
+#: ./opengever/tabbedview/browser/tabs.py
+#: ./opengever/tabbedview/browser/tasklisting.py
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_tabbedview_filter_all"
 msgstr "Tous"
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:144
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Email"
-#: ./opengever/tabbedview/browser/users.py:81
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_email"
 msgstr "Email"
 
 #. Default: "Firstname"
-#: ./opengever/tabbedview/browser/users.py:71
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_firstname"
 msgstr "Prénom"
 
 #. Default: "Lastname"
-#: ./opengever/tabbedview/browser/users.py:66
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_lastname"
 msgstr "Nom"
 
 #. Default: "Office Phone"
-#: ./opengever/tabbedview/browser/users.py:86
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_phone_office"
 msgstr "Téléphone professionnel"
 
 #. Default: "Userid"
-#: ./opengever/tabbedview/browser/users.py:76
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_userid"
 msgstr "N° d'utilisateur"
 
@@ -354,7 +354,7 @@ msgstr "Date de modification"
 msgid "mytasks"
 msgstr "Mes tâches"
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "none"
 msgstr "Aucun"
 
@@ -368,7 +368,7 @@ msgid "participants"
 msgstr "Participants"
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:94
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "personal_overview_title"
 msgstr "Vue d'ensemble personnelle: ${user_name}"
 
@@ -415,7 +415,7 @@ msgid "subdossiers"
 msgstr "Sous-dossiers"
 
 #. Default: "${amount} matches"
-#: ./opengever/tabbedview/browser/no_selection_amount.pt:3
+#: ./opengever/tabbedview/browser/no_selection_amount.pt
 msgid "tab_matches"
 msgstr "Résultat(s): ${amount}"
 
@@ -430,3 +430,4 @@ msgstr "Titre"
 
 msgid "trash"
 msgstr "Corbeille"
+

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-07-19 08:51+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,12 +15,12 @@ msgstr ""
 "Domain: opengever.tabbedview\n"
 "X-Poedit-Language: German\n"
 
-#: ./opengever/tabbedview/browser/tabs.py:282
-#: ./opengever/tabbedview/browser/users.py:62
+#: ./opengever/tabbedview/browser/tabs.py
+#: ./opengever/tabbedview/browser/users.py
 msgid "Active"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr ""
 
@@ -30,16 +30,16 @@ msgstr ""
 msgid "Creator"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/batching.pt:68
+#: ./opengever/tabbedview/browser/batching.pt
 msgid "Hits per site"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "Show all in this Folder"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/generic_with_filters.pt:54
-#: ./opengever/tabbedview/browser/selection_with_filters.pt:19
+#: ./opengever/tabbedview/browser/generic_with_filters.pt
+#: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "State"
 msgstr ""
 
@@ -59,7 +59,7 @@ msgid "all_orgunits"
 msgstr ""
 
 #. Default: "More actions &#9660;"
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:40
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "button_more_actions"
 msgstr ""
 
@@ -70,42 +70,42 @@ msgid "checkout_and_edit"
 msgstr ""
 
 #. Default: "Date of completion"
-#: ./opengever/tabbedview/browser/tasklisting.py:92
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_date_of_completion"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/tabbedview/browser/tasklisting.py:88
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_deadline"
 msgstr ""
 
 #. Default: "Issued at"
-#: ./opengever/tabbedview/browser/tasklisting.py:105
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_issued_at"
 msgstr ""
 
 #. Default: "Organisational Unit"
-#: ./opengever/tabbedview/browser/tasklisting.py:113
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_issuing_org_unit"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tasklisting.py:76
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_review_state"
 msgstr ""
 
 #. Default: "Sequence number"
-#: ./opengever/tabbedview/browser/tasklisting.py:119
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_sequence_number"
 msgstr ""
 
 #. Default: "Task type"
-#: ./opengever/tabbedview/browser/tasklisting.py:84
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_task_type"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tasklisting.py:80
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "column_title"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgid "contact"
 msgstr ""
 
 #. Default: "Dossier"
-#: ./opengever/tabbedview/browser/tasklisting.py:109
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "containing_dossier"
 msgstr ""
 
@@ -142,7 +142,7 @@ msgid "document_date"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/tabbedview/browser/tabs.py:139
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "document_sequence_number"
 msgstr ""
 
@@ -150,19 +150,19 @@ msgid "documents"
 msgstr ""
 
 #. Default: "Show more"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:17
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
 msgid "documentsShowMore"
 msgstr ""
 
 #. Default: "Gallery"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:3
-#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:11
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 msgid "documents_pill_documents"
 msgstr ""
 
 #. Default: "List"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:4
-#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt:17
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 msgid "documents_pill_list"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "events"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:285
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "expired"
 msgstr ""
 
@@ -192,158 +192,158 @@ msgid "journal"
 msgstr ""
 
 #. Default: "Active"
-#: ./opengever/tabbedview/browser/users.py:99
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_active"
 msgstr ""
 
 #. Default: "Checked out by"
-#: ./opengever/tabbedview/browser/tabs.py:166
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_checked_out"
 msgstr ""
 
 #. Default: "Delivery Date"
-#: ./opengever/tabbedview/browser/tabs.py:162
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Department"
-#: ./opengever/tabbedview/browser/users.py:90
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_department_user"
 msgstr ""
 
 #. Default: "Directorate"
-#: ./opengever/tabbedview/browser/users.py:95
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_directorate_user"
 msgstr ""
 
 #. Default: "Document Author"
-#: ./opengever/tabbedview/browser/tabs.py:149
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_author"
 msgstr ""
 
 #. Default: "Document Date"
-#: ./opengever/tabbedview/browser/tabs.py:154
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_date"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:178
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_reference"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tabs.py:255
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_dossier_responsible"
 msgstr ""
 
 #. Default: "End"
-#: ./opengever/tabbedview/browser/tabs.py:264
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_end"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/tabbedview/browser/tasklisting.py:101
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_issuer"
 msgstr ""
 
 #. Default: "My notifications"
-#: ./opengever/tabbedview/browser/personal_overview.py:113
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "label_my_notifications"
 msgstr ""
 
 #. Default: "My proposals"
-#: ./opengever/tabbedview/browser/personal_overview.py:124
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "label_my_proposals"
 msgstr ""
 
 #. Default: "No contents"
-#: ./opengever/tabbedview/browser/bumblebee_gallery.pt:23
+#: ./opengever/tabbedview/browser/bumblebee_gallery.pt
 msgid "label_no_contents"
 msgstr ""
 
 #. Default: "Pending"
-#: ./opengever/tabbedview/browser/tasklisting.py:66
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_pending"
 msgstr ""
 
 #. Default: "Preview"
-#: ./opengever/tabbedview/helper.py:198
+#: ./opengever/tabbedview/helper.py
 msgid "label_preview"
 msgstr ""
 
 #. Default: "Public Trial"
-#: ./opengever/tabbedview/browser/tabs.py:174
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_public_trial"
 msgstr ""
 
 #. Default: "Receipt Date"
-#: ./opengever/tabbedview/browser/tabs.py:158
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference Number"
-#: ./opengever/tabbedview/browser/tabs.py:243
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_reference"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tabbedview/browser/tasklisting.py:97
+#: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_responsible_task"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tabbedview/browser/tabs.py:251
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Version ${version} of ${timestamp}"
-#: ./opengever/tabbedview/helper.py:188
+#: ./opengever/tabbedview/helper.py
 msgid "label_showroom_version_title"
 msgstr ""
 
 #. Default: "Start"
-#: ./opengever/tabbedview/browser/tabs.py:260
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_start"
 msgstr ""
 
 #. Default: "Subdossier"
-#: ./opengever/tabbedview/browser/tabs.py:170
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_subdossier"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs.py:280
-#: ./opengever/tabbedview/browser/tasklisting.py:64
-#: ./opengever/tabbedview/browser/users.py:61
+#: ./opengever/tabbedview/browser/tabs.py
+#: ./opengever/tabbedview/browser/tasklisting.py
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_tabbedview_filter_all"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tabbedview/browser/tabs.py:144
+#: ./opengever/tabbedview/browser/tabs.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Email"
-#: ./opengever/tabbedview/browser/users.py:81
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_email"
 msgstr ""
 
 #. Default: "Firstname"
-#: ./opengever/tabbedview/browser/users.py:71
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_firstname"
 msgstr ""
 
 #. Default: "Lastname"
-#: ./opengever/tabbedview/browser/users.py:66
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_lastname"
 msgstr ""
 
 #. Default: "Office Phone"
-#: ./opengever/tabbedview/browser/users.py:86
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_phone_office"
 msgstr ""
 
 #. Default: "Userid"
-#: ./opengever/tabbedview/browser/users.py:76
+#: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_userid"
 msgstr ""
 
@@ -353,7 +353,7 @@ msgstr ""
 msgid "mytasks"
 msgstr ""
 
-#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
+#: ./opengever/tabbedview/browser/tabs_templates/generic.pt
 msgid "none"
 msgstr ""
 
@@ -367,7 +367,7 @@ msgid "participants"
 msgstr ""
 
 #. Default: "Personal Overview: ${user_name}"
-#: ./opengever/tabbedview/browser/personal_overview.py:94
+#: ./opengever/tabbedview/browser/personal_overview.py
 msgid "personal_overview_title"
 msgstr ""
 
@@ -414,7 +414,7 @@ msgid "subdossiers"
 msgstr ""
 
 #. Default: "${amount} matches"
-#: ./opengever/tabbedview/browser/no_selection_amount.pt:3
+#: ./opengever/tabbedview/browser/no_selection_amount.pt
 msgid "tab_matches"
 msgstr ""
 

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -14,333 +14,333 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./opengever/task/browser/close.py:256
+#: ./opengever/task/browser/close.py
 msgid "${num} documents were copied."
 msgstr "${num} Dokumente wurden kopiert."
 
-#: ./opengever/task/browser/delegate/metadata.py:83
+#: ./opengever/task/browser/delegate/metadata.py
 msgid "${subtask_num} subtasks were create."
 msgstr "${subtask_num} Unteraufgaben wurden erstellt."
 
-#: ./opengever/task/response.py:395
+#: ./opengever/task/response.py
 msgid "Changes saved to response id ${response_id}."
 msgstr "Änderungen an der Antwort ${response_id} wurden gespeichert"
 
-#: ./opengever/task/viewlets/response_templates/responseview.pt:22
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "Delete"
 msgstr "Löschen"
 
-#: ./opengever/task/viewlets/response_templates/responseview.pt:18
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ./opengever/task/response.py:300
-#: ./opengever/task/response_syncer/workflow.py:79
-#: ./opengever/task/util.py:164
+#: ./opengever/task/response.py
+#: ./opengever/task/response_syncer/workflow.py
+#: ./opengever/task/util.py
 msgid "Issue state"
 msgstr "Status"
 
-#: ./opengever/task/response.py:423
+#: ./opengever/task/response.py
 msgid "No response selected for removal."
 msgstr "Es wurde keine Antwort fürs Löschen selektiert"
 
-#: ./opengever/task/response.py:386
+#: ./opengever/task/response.py
 msgid "No response selected for saving."
 msgstr "Es wurde keine Antwort fürs Speichern selektiert"
 
-#: ./opengever/task/response.py:445
+#: ./opengever/task/response.py
 msgid "Removed response id ${response_id}."
 msgstr "Antwort ${response_id} gelöscht"
 
-#: ./opengever/task/response.py:438
+#: ./opengever/task/response.py
 msgid "Response id ${response_id} does not exist so it cannot be removed."
 msgstr "Antowrt ${response_id} existiert nicht und konnte deshalb nicht gelöscht werden"
 
-#: ./opengever/task/response.py:430
+#: ./opengever/task/response.py
 msgid "Response id ${response_id} is no integer so it cannot be removed."
 msgstr "Antwort id ${response_id} ist keine Zahl und konnte deshalb nicht gelöscht werden"
 
-#: ./opengever/task/browser/delegate/recipients.py:37
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "Select the related documents you wish to attach to the new subtasks."
 msgstr "Wählen Sie die mit der Aufgabe verknüpften Dokumente aus, die Sie an die neuen Unteraufgaben anhängen wollen."
 
-#: ./opengever/task/menu.py:22
+#: ./opengever/task/menu.py
 msgid "Subtask"
 msgstr "Unteraufgabe"
 
-#: ./opengever/task/browser/complete.py:136
+#: ./opengever/task/browser/complete.py
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr "Die Dokumente wurde an den Auftraggeber geliefert und die Aufgaben wurden abgeschlossen."
 
-#: ./opengever/task/browser/accept/inbox.py:33
+#: ./opengever/task/browser/accept/inbox.py
 msgid "The forwarding has been stored in the local inbox"
 msgstr "Die Weiterleitung wurde im lokalen Eingangskorb gespeichert."
 
-#: ./opengever/task/browser/accept/existingdossier.py:119
-#: ./opengever/task/browser/accept/newdossier.py:319
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The forwarding has been stored in the local inbox and the succesor task has been created"
 msgstr "Die Weiterleitung wurde im lokalen Eingangskorb abgelegt und die Kopierte Aufgabe erstellt."
 
-#: ./opengever/task/browser/accept/existingdossier.py:110
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "The forwarding is now assigned to the dossier"
 msgstr "Die Weiterleitung wurde nun dem Dossier zugewiesen."
 
-#: ./opengever/task/browser/accept/newdossier.py:304
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The forwarding is now assigned to the new dossier"
 msgstr "Die Weiterleitung wurde nun dem neuen Dossier zugewiesen."
 
-#: ./opengever/task/browser/accept/newdossier.py:334
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The new dossier has been created and the task has been copied to the new dossier."
 msgstr "Das neue Dossier wurde erstellt und die akzeptierte Aufgabe wurde in das neue Dossier kopiert."
 
-#: ./opengever/task/browser/accept/main.py:169
+#: ./opengever/task/browser/accept/main.py
 msgid "The task has been accepted."
 msgstr "Die Aufgabe wurde akzeptiert."
 
-#: ./opengever/task/browser/accept/existingdossier.py:130
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "The task has been copied to the selected dossier and accepted."
 msgstr "Die Aufgabe wurde kopiert und akzeptiert."
 
-#: ./opengever/task/response.py:417
+#: ./opengever/task/response.py
 msgid "You are not allowed to delete responses."
 msgstr "Sie haben keine Berechtigung Antworten zu löschen"
 
-#: ./opengever/task/response.py:380
+#: ./opengever/task/response.py
 msgid "You are not allowed to edit responses."
 msgstr "Sie haben keine Berechtigung Antworten zu editieren"
 
-#: ./opengever/task/browser/accept/main.py:120
+#: ./opengever/task/browser/accept/main.py
 msgid "You are not assigned to the responsible client (${client}). You can only process the task in the issuers dossier."
 msgstr "Sie sind nicht dem Auftragnehmer-Mandanten (${client}) zugewiesen. Sie können die Aufgabe nur direkt im Dossier des Auftraggebers behandeln."
 
-#: ./opengever/task/browser/close.py:191
+#: ./opengever/task/browser/close.py
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr "Sie haben nicht genügend Berechtigungen um Dokumente im ausgewählten Dossier hinzuzfügen. Möglicherweise ist das Dossier bereits abgeschlossen."
 
-#: ./opengever/task/browser/accept/existingdossier.py:71
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "You cannot add tasks in the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr "In dem ausgewählten Dossier können Sie keine Aufgaben erstellen. Entweder wurde das Dossier bereits abgeschlossen oder Sie besitzen nicht die erforderlichen Berechtigungen."
 
 #. Default: "file in existing dossier in ${client}"
-#: ./opengever/task/browser/accept/main.py:81
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_existing_dossier"
 msgstr "in einem bestehenden Dossier auf ${client} bearbeiten"
 
 #. Default: "... store in  ${client}'s inbox and process in an existing dossier on ${client}"
-#: ./opengever/task/browser/accept/main.py:62
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_existing_dossier"
 msgstr "... im Eingangskorb von ${client} ablegen und in bestehendem Dossier auf ${client} bearbeiten"
 
 #. Default: "... store in  ${client}'s inbox and process in a new dossier on ${client}"
-#: ./opengever/task/browser/accept/main.py:68
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_new_dossier"
 msgstr "... im Eingangskorb von ${client} ablegen und in neuem Dossier auf ${client} bearbeiten"
 
 #. Default: "... store in ${client}'s inbox"
-#: ./opengever/task/browser/accept/main.py:56
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_participate"
 msgstr "... im Eingangskorb von ${client} ablegen"
 
 #. Default: "file in new dossier in ${client}"
-#: ./opengever/task/browser/accept/main.py:87
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_new_dossier"
 msgstr "in einem neuen Dossier auf ${client} bearbeiten"
 
 #. Default: "process in issuer's dossier"
-#: ./opengever/task/browser/accept/main.py:76
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_participate"
 msgstr "direkt im Dossier des Auftraggebers bearbeiten"
 
 #. Default: "RE"
-#: ./opengever/task/browser/complete.py:309
+#: ./opengever/task/browser/complete.py
 msgid "answer_prefix"
 msgstr "AW"
 
 #. Default: "Assign"
-#: ./opengever/task/browser/assign.py:69
+#: ./opengever/task/browser/assign.py
 msgid "button_assign"
 msgstr "Zuweisen"
 
 #. Default: "Cancel"
-#: ./opengever/task/browser/accept/existingdossier.py:134
-#: ./opengever/task/browser/accept/main.py:208
-#: ./opengever/task/browser/accept/newdossier.py:138
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
-#: ./opengever/task/browser/accept/main.py:144
-#: ./opengever/task/browser/accept/newdossier.py:115
-#: ./opengever/task/browser/assign_dossier.py:73
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/assign_dossier.py
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Save"
-#: ./opengever/task/browser/accept/existingdossier.py:93
-#: ./opengever/task/browser/accept/newdossier.py:276
-#: ./opengever/task/browser/close.py:205
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/close.py
 msgid "button_save"
 msgstr "Speichern"
 
 #. Default: "Cancel"
-#: ./opengever/task/response.py:177
+#: ./opengever/task/response.py
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: ./opengever/task/response.py:260
+#: ./opengever/task/response.py
 msgid "date_of_completion"
 msgstr "Erledigungsdatum"
 
 #. Default: "Select one or more responsibles. For each selected responsible a subtask will be created and assigned."
-#: ./opengever/task/browser/delegate/recipients.py:27
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_help_responsible"
 msgstr "Wählen Sie einen oder mehrere Verantwortliche aus, an welche Sie die Aufgabe delegieren wollen. Es wird für jeden ausgewählten Verantwortlichen eine Unteraufgabe erstellt."
 
 #. Default: "Attach documents"
-#: ./opengever/task/browser/delegate/recipients.py:36
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_label_documents"
 msgstr "Anzuhängende Dokumente"
 
 #. Default: "Responsibles"
-#: ./opengever/task/browser/delegate/recipients.py:26
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_label_responsibles"
 msgstr "Verantwortliche"
 
 #. Default: "The documents (${title}) are still checked out.                                 Please checkin them in bevore deliver"
-#: ./opengever/task/validators.py:33
+#: ./opengever/task/validators.py
 msgid "error_checked_out_document"
 msgstr "Die folgenden Dokumente (${title}) müssen noch eingecheckt werden."
 
 #. Default: "No changes: same responsible selected"
-#: ./opengever/task/browser/assign.py:78
+#: ./opengever/task/browser/assign.py
 msgid "error_same_responsible"
 msgstr "Keine Änderung, da kein anderer Auftragnehmer ausgewählt wurde"
 
 #. Default: "existing dossier"
-#: ./opengever/task/browser/assign_dossier.py:44
+#: ./opengever/task/browser/assign_dossier.py
 msgid "existing_dossier"
 msgstr "bestehendes Dossier"
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:77
+#: ./opengever/task/task.py
 msgid "fieldset_additional"
 msgstr "Erweitert"
 
 #. Default: "Common"
-#: ./opengever/task/task.py:62
+#: ./opengever/task/task.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
 #. Default: "Forwarding"
-#: ./opengever/task/helper.py:15
+#: ./opengever/task/helper.py
 msgid "forwarding_task_type"
 msgstr "Weiterleitung"
 
 #. Default: "Select the target dossier where you like to handle the task."
-#: ./opengever/task/browser/accept/existingdossier.py:37
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "help_accept_select_dossier"
 msgstr "Wählen Sie das Dossier aus, in welchem Sie die Aufgabe bearbeiten wollen."
 
 #. Default: "Select the type for the new dossier"
-#: ./opengever/task/browser/accept/newdossier.py:213
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "help_accept_select_dossier_type"
 msgstr "Wählen Sie den Typ des neuen Dossiers aus"
 
 #. Default: "Select the repository folder within the dossier should be created."
-#: ./opengever/task/browser/accept/newdossier.py:84
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "help_accept_select_repositoryfolder"
 msgstr "Wählen Sie die Ordnungsposition aus, in welchem das neue Dossier erstellt werden soll."
 
 #. Default: "Enter a answer text which will be shown as response when the task is accepted."
-#: ./opengever/task/browser/accept/main.py:102
-#: ./opengever/task/browser/close.py:80
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/close.py
 msgid "help_accept_task_response"
 msgstr "Geben Sie einen Text für die automatisch erstellte Antwort ein."
 
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
-#: ./opengever/task/browser/assign_dossier.py:61
+#: ./opengever/task/browser/assign_dossier.py
 msgid "help_assign_to_dossier_task_response"
 msgstr "Geben sie einen Antwort text ein, dieser wird bei der Aufgabenkopie als Antwort hinzugefügt."
 
 #. Default: "Choose the target dossier where the documents should be filed."
-#: ./opengever/task/browser/close.py:157
+#: ./opengever/task/browser/close.py
 msgid "help_close_choose_dossier"
 msgstr "Wählen Sie das Dossier aus, in welche Sie die ausgewählten Dokumente kopieren möchten."
 
 #. Default: "You can copy attached documents to your client by selecting here the documents to copy."
-#: ./opengever/task/browser/close.py:88
+#: ./opengever/task/browser/close.py
 msgid "help_close_documents"
 msgstr "Wählen Sie hier bei Bedarf die Dokumente aus, die Sie in ein eigenes Dossier kopieren möchten."
 
 #. Default: "Select the documents you want to deliver to the issuer of the task. They will be attached to the original task of the issuer."
-#: ./opengever/task/browser/complete.py:87
+#: ./opengever/task/browser/complete.py
 msgid "help_complete_documents"
 msgstr "Wählen Sie die Dokumente aus, die Sie dem Auftraggeber liefern wollen. Sie werden dann automatisch an die Originalaufgabe des Auftraggebers angehängt."
 
 #. Default: "Enter a answer text which will be shown as response when the task is completed."
-#: ./opengever/task/browser/complete.py:99
+#: ./opengever/task/browser/complete.py
 msgid "help_complete_task_response"
 msgstr "Der hier eingegebene Text erscheint in der Antwort, die die Aufgabe abschliesst."
 
-#: ./opengever/task/response.py:67
-#: ./opengever/task/task.py:143
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "help_date_of_completion"
 msgstr "Das Datum an dem die Aufgabe beendet wurde"
 
 #. Default: "Deadline"
-#: ./opengever/task/browser/delegate/metadata.py:35
-#: ./opengever/task/task.py:134
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_deadline"
 msgstr "Tragen Sie ein Datum ein, bis wann die Aufgabe erledigt werden muss"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:200
+#: ./opengever/task/task.py
 msgid "help_effectiveCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:194
+#: ./opengever/task/task.py
 msgid "help_effectiveDuration"
 msgstr "Dauer in h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:188
+#: ./opengever/task/task.py
 msgid "help_expectedCost"
 msgstr "Kosten in CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:182
+#: ./opengever/task/task.py
 msgid "help_expectedDuration"
 msgstr "Dauer in h"
 
-#: ./opengever/task/task.py:126
+#: ./opengever/task/task.py
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortliche Person aus."
 
-#: ./opengever/task/task.py:118
+#: ./opengever/task/task.py
 msgid "help_responsible_client"
 msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer."
 
-#: ./opengever/task/task.py:220
+#: ./opengever/task/task.py
 msgid "help_responsible_multiple"
 msgstr "Wählen Sie die verantwortlichen Personen aus."
 
-#: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/form.py:130
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/form.py
 msgid "help_responsible_single_client_setup"
 msgstr "Wählen Sie die verantwortliche Person aus"
 
-#: ./opengever/task/task.py:106
+#: ./opengever/task/task.py
 msgid "help_task_type"
 msgstr "Wählen Sie den Auftragstyp"
 
-#: ./opengever/task/browser/delegate/metadata.py:40
-#: ./opengever/task/task.py:151
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_text"
 msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein"
 
-#: ./opengever/task/browser/delegate/metadata.py:25
-#: ./opengever/task/task.py:91
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_title"
 msgstr "Der Name der Aufgabe"
 
@@ -348,272 +348,272 @@ msgid "issuedtasks"
 msgstr "In Auftrag gegebene Aufgaben"
 
 #. Default: "Accept the task and ..."
-#: ./opengever/task/browser/accept/main.py:95
+#: ./opengever/task/browser/accept/main.py
 msgid "label_accept_choose_method"
 msgstr "Diese Aufgabe akzeptieren und ..."
 
 #. Default: "Accept forwarding and ..."
-#: ./opengever/task/browser/accept/main.py:227
+#: ./opengever/task/browser/accept/main.py
 msgid "label_accept_forwarding_choose_method"
 msgstr "Weiterleitung akzeptieren und ..."
 
 #. Default: "Target dossier"
-#: ./opengever/task/browser/accept/existingdossier.py:35
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "label_accept_select_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Dossier type"
-#: ./opengever/task/browser/accept/newdossier.py:212
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "label_accept_select_dossier_type"
 msgstr "Dossier Typ"
 
 #. Default: "Repository folder"
-#: ./opengever/task/browser/accept/newdossier.py:82
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "label_accept_select_repositoryfolder"
 msgstr "Ordnungsposition"
 
 #. Default: "Agency"
-#: ./opengever/task/viewlets/actionmenu_templates/actionmenuviewlet.pt:23
+#: ./opengever/task/viewlets/actionmenu_templates/actionmenuviewlet.pt
 msgid "label_agency"
 msgstr "Stellvertretung"
 
 #. Default: "Assign to a ..."
-#: ./opengever/task/browser/assign_dossier.py:54
+#: ./opengever/task/browser/assign_dossier.py
 msgid "label_assign_choose_method"
 msgstr "Weiterleitung zuweisen an ein ..."
 
 #. Default: "by"
-#: ./opengever/task/viewlets/byline.py:28
+#: ./opengever/task/viewlets/byline.py
 msgid "label_by_author"
 msgstr "Auftragnehmer"
 
 #. Default: "Target dossier"
-#: ./opengever/task/browser/close.py:155
+#: ./opengever/task/browser/close.py
 msgid "label_close_choose_dossier"
 msgstr "Zieldossier"
 
 #. Default: "Documents to copy"
-#: ./opengever/task/browser/close.py:86
+#: ./opengever/task/browser/close.py
 msgid "label_close_documents"
 msgstr "Dokumente kopieren"
 
 #. Default: "Documents to deliver"
-#: ./opengever/task/browser/complete.py:85
+#: ./opengever/task/browser/complete.py
 msgid "label_complete_documents"
 msgstr "Dokumente"
 
 #. Default: "Containing tasks"
-#: ./opengever/task/browser/overview_templates/overview.pt:47
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_containing_task"
 msgstr "Hauptaufgabe"
 
 #. Default: "created"
-#: ./opengever/task/viewlets/byline.py:46
+#: ./opengever/task/viewlets/byline.py
 msgid "label_created"
 msgstr "erstellt am"
 
 #. Default: "Date of completion"
-#: ./opengever/task/browser/overview.py:104
-#: ./opengever/task/response.py:66
-#: ./opengever/task/task.py:142
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "label_date_of_completion"
 msgstr "Erledigungsdatum"
 
 #. Default: "Deadline"
-#: ./opengever/task/activities.py:57
-#: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/browser/overview.py:88
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
 msgid "label_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Documents"
-#: ./opengever/task/browser/overview_templates/overview.pt:34
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_documents"
 msgstr "Dokumente"
 
 #. Default: "Dossier title"
-#: ./opengever/task/activities.py:61
+#: ./opengever/task/activities.py
 msgid "label_dossier_title"
 msgstr "Dossiertitel"
 
 #. Default: "You are not allowed to edit this response."
-#: ./opengever/task/templates/edit_response.pt:44
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_edit_response_not_allowed"
 msgstr "Sie sind nicht berechtigt diese Antwort zu löschen"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:199
+#: ./opengever/task/task.py
 msgid "label_effectiveCost"
 msgstr "Effektive Kosten (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:193
+#: ./opengever/task/task.py
 msgid "label_effectiveDuration"
 msgstr "Effektive Dauer (h)"
 
 #. Default: "Please enter your response below"
-#: ./opengever/task/templates/edit_response.pt:59
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_enter_response"
 msgstr "Bitte tragen sie ihre Antwort unten ein"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:187
+#: ./opengever/task/task.py
 msgid "label_expectedCost"
 msgstr "Geschätzte Kosten (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:181
+#: ./opengever/task/task.py
 msgid "label_expectedDuration"
 msgstr "Geschätzte Dauer (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:176
+#: ./opengever/task/task.py
 msgid "label_expectedStartOfWork"
 msgstr "Beginn der Arbeit"
 
 #. Default: "Issuer"
-#: ./opengever/task/browser/delegate/metadata.py:29
-#: ./opengever/task/browser/overview.py:93
-#: ./opengever/task/task.py:98
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/task.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "last modified"
-#: ./opengever/task/viewlets/byline.py:40
+#: ./opengever/task/viewlets/byline.py
 msgid "label_last_modified"
 msgstr "zuletzt verändert"
 
 #. Default: "Main Atrributes"
-#: ./opengever/task/browser/overview_templates/overview.pt:16
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_main_attributes"
 msgstr "Eigenschaften"
 
 #. Default: "New Deadline"
-#: ./opengever/task/browser/modify_deadline.py:29
+#: ./opengever/task/browser/modify_deadline.py
 msgid "label_new_deadline"
 msgstr "Neue Frist"
 
 #. Default: "Dossiertitle"
-#: ./opengever/task/browser/overview.py:71
+#: ./opengever/task/browser/overview.py
 msgid "label_parent_dossier_title"
 msgstr "Dossiertitel"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:206
+#: ./opengever/task/task.py
 msgid "label_predecessor"
 msgstr "Vorgänger"
 
 #. Default: "Predecessor task"
-#: ./opengever/task/browser/overview_templates/overview.pt:63
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_predecessor_task"
 msgstr "Ursprüngliche Aufgabe"
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py:218
-#: ./opengever/task/response.py:72
-#: ./opengever/task/task.py:156
+#: ./opengever/task/browser/complete.py
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "label_related_items"
 msgstr "Verweise"
 
 #. Default: "Responsible Client"
-#: ./opengever/task/task.py:116
+#: ./opengever/task/task.py
 msgid "label_resonsible_client"
 msgstr "Mandant des Auftragnehmers"
 
 #. Default: "Response"
-#: ./opengever/task/browser/accept/main.py:101
-#: ./opengever/task/browser/assign.py:45
-#: ./opengever/task/browser/assign_dossier.py:60
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/assign_dossier.py
 msgid "label_response"
 msgstr "Antworttext"
 
 #. Default: "Responsible"
-#: ./opengever/task/browser/assign.py:38
-#: ./opengever/task/browser/overview.py:99
-#: ./opengever/task/response_syncer/workflow.py:70
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/response_syncer/workflow.py
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
 #. Default: "Return to issue."
-#: ./opengever/task/templates/edit_response.pt:32
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_return_to_issue"
 msgstr "Zurück zur Aufgabe"
 
 #. Default: "Sequence Number"
-#: ./opengever/task/viewlets/byline.py:52
+#: ./opengever/task/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Sub tasks"
-#: ./opengever/task/browser/overview_templates/overview.pt:54
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_sub_task"
 msgstr "Unteraufgaben"
 
 #. Default: "Successor task"
-#: ./opengever/task/browser/overview_templates/overview.pt:70
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_successor_task"
 msgstr "Kopierte Aufgabe"
 
 #. Default: "New task added by ${user}"
-#: ./opengever/task/activities.py:31
+#: ./opengever/task/activities.py
 msgid "label_task_added"
 msgstr "Neue Aufgabe hinzugefügt durch ${user}"
 
 #. Default: "Task commented"
-#: ./opengever/task/response_description.py:333
+#: ./opengever/task/response_description.py
 msgid "label_task_commented"
 msgstr "Aufgabe wurde kommentiert"
 
 #. Default: "Task title"
-#: ./opengever/task/activities.py:56
-#: ./opengever/task/browser/overview.py:67
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/overview.py
 msgid "label_task_title"
 msgstr "Aufgabentitel"
 
 #. Default: "Task Type"
-#: ./opengever/task/activities.py:59
-#: ./opengever/task/browser/overview.py:79
-#: ./opengever/task/task.py:105
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/task.py
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Text"
-#: ./opengever/task/activities.py:63
-#: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/browser/overview.py:75
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
 msgid "label_text"
 msgstr "Beschreibung"
 
 #. Default: "Title"
-#: ./opengever/task/browser/delegate/metadata.py:24
-#: ./opengever/task/task.py:90
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Transition"
-#: ./opengever/task/browser/assign.py:32
-#: ./opengever/task/browser/complete.py:106
-#: ./opengever/task/browser/modify_deadline.py:23
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/complete.py
+#: ./opengever/task/browser/modify_deadline.py
 msgid "label_transition"
 msgstr "Aktion"
 
 #. Default: "State"
-#: ./opengever/task/browser/overview.py:83
+#: ./opengever/task/browser/overview.py
 msgid "label_workflow_state"
 msgstr "Status"
 
 #. Default: "State"
-#: ./opengever/task/viewlets/byline.py:34
+#: ./opengever/task/viewlets/byline.py
 msgid "label_workflow_state_byline"
 msgstr "Status"
 
 #. Default: "Deadline successfully changed."
-#: ./opengever/task/browser/modify_deadline.py:69
+#: ./opengever/task/browser/modify_deadline.py
 msgid "msg_deadline_change_successfull"
 msgstr "Frist wurde erfolgreich angepasst."
 
 #. Default: "Commented by ${user}"
-#: ./opengever/task/response_description.py:329
+#: ./opengever/task/response_description.py
 msgid "msg_task_commented"
 msgstr "Kommentiert von ${user}"
 
@@ -621,278 +621,278 @@ msgid "mytasks"
 msgstr "Meine Aufgaben"
 
 #. Default: "new dossier"
-#: ./opengever/task/browser/assign_dossier.py:47
+#: ./opengever/task/browser/assign_dossier.py
 msgid "new_dossier"
 msgstr "neues Dossier"
 
 #. Default: "Progress:"
-#: ./opengever/task/viewlets/response_templates/responseview.pt:3
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "progress"
 msgstr "Verlauf"
 
 #. Default: "Response"
-#: ./opengever/task/templates/edit_response.pt:56
+#: ./opengever/task/templates/edit_response.pt
 msgid "response_label_response"
 msgstr "Antwort"
 
 #. Default: "The given deadline, is the current one."
-#: ./opengever/task/browser/modify_deadline.py:61
+#: ./opengever/task/browser/modify_deadline.py
 msgid "same_deadline_error"
 msgstr "Die angegebene Frist ist die aktuelle."
 
 #. Default: "Save"
-#: ./opengever/task/response.py:164
+#: ./opengever/task/response.py
 msgid "save"
 msgstr "Speichern"
 
 #. Default: "Step 1"
-#: ./opengever/task/browser/accept/existingdossier.py:87
-#: ./opengever/task/browser/accept/main.py:37
-#: ./opengever/task/browser/accept/newdossier.py:55
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_1"
 msgstr "Schritt 1"
 
 #. Default: "Step 2"
-#: ./opengever/task/browser/accept/existingdossier.py:90
-#: ./opengever/task/browser/accept/newdossier.py:58
-#: ./opengever/task/browser/close.py:53
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/close.py
 msgid "step_2"
 msgstr "Schritt 2"
 
 #. Default: "Step 3"
-#: ./opengever/task/browser/accept/newdossier.py:61
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_3"
 msgstr "Schritt 3"
 
 #. Default: "Step 4"
-#: ./opengever/task/browser/accept/newdossier.py:64
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_4"
 msgstr "Schritt 4"
 
 #. Default: "Accept forwarding"
-#: ./opengever/task/browser/accept/main.py:140
+#: ./opengever/task/browser/accept/main.py
 msgid "title_accept_forwarding"
 msgstr "Weiterleitung akkzeptieren"
 
 #. Default: "Accept task"
-#: ./opengever/task/browser/accept/main.py:42
+#: ./opengever/task/browser/accept/main.py
 msgid "title_accept_task"
 msgstr "Aufgabe akzeptieren"
 
 #. Default: "Assign task"
-#: ./opengever/task/browser/assign.py:63
+#: ./opengever/task/browser/assign.py
 msgid "title_assign_task"
 msgstr "Neu zuweisen"
 
 #. Default: "Assign to Dossier"
-#: ./opengever/task/browser/assign_dossier.py:34
+#: ./opengever/task/browser/assign_dossier.py
 msgid "title_assign_to_dossier"
 msgstr "Einem Dossier zuweisen"
 
 #. Default: "Close task"
-#: ./opengever/task/browser/close.py:55
+#: ./opengever/task/browser/close.py
 msgid "title_close_task"
 msgstr "Aufgabe abschliessen"
 
 #. Default: "Complete task"
-#: ./opengever/task/browser/complete.py:121
+#: ./opengever/task/browser/complete.py
 msgid "title_complete_task"
 msgstr "Aufgabe erledigen / abschliessen"
 
 #. Default: "Delegate task"
-#: ./opengever/task/browser/delegate/main.py:23
+#: ./opengever/task/browser/delegate/main.py
 msgid "title_delegate_task"
 msgstr "Aufgabe delegieren"
 
 #. Default: "Edit response"
-#: ./opengever/task/templates/edit_response.pt:41
+#: ./opengever/task/templates/edit_response.pt
 msgid "title_edit_response"
 msgstr "Antwort bearbeiten"
 
 #. Default: "Error: no response found for editing"
-#: ./opengever/task/templates/edit_response.pt:30
+#: ./opengever/task/templates/edit_response.pt
 msgid "title_error_no_response"
 msgstr "Fehler: keine Antworten zum editieren gefunden"
 
 #. Default: "Modify deadline"
-#: ./opengever/task/browser/modify_deadline.py:47
+#: ./opengever/task/browser/modify_deadline.py
 msgid "title_modify_deadline"
 msgstr "Frist ändern"
 
 #. Default: "Document ${doc} added by ${user}"
-#: ./opengever/task/response_description.py:311
+#: ./opengever/task/response_description.py
 msgid "transition_add_document"
 msgstr "Dokument ${doc} hinzugefügt durch ${user}"
 
 #. Default: "Subtask ${task} added by ${user}"
-#: ./opengever/task/response_description.py:291
+#: ./opengever/task/response_description.py
 msgid "transition_add_subtask"
 msgstr "Unteraufgabe ${task} hinzugefügt durch ${user}"
 
 #. Default: "Task accepted"
-#: ./opengever/task/response_description.py:146
+#: ./opengever/task/response_description.py
 msgid "transition_label_accept"
 msgstr "Aufgabe akzeptiert"
 
 #. Default: "Document added to Task"
-#: ./opengever/task/response_description.py:317
+#: ./opengever/task/response_description.py
 msgid "transition_label_add_document"
 msgstr "Dokument zur Aufgabe hinzugefügt"
 
 #. Default: "Subtask added to task"
-#: ./opengever/task/response_description.py:297
+#: ./opengever/task/response_description.py
 msgid "transition_label_add_subtask"
 msgstr "Unteraufgabe zur Aufgabe hinzugefügt"
 
 #. Default: "Forwarding assigned to Dossier"
-#: ./opengever/task/response_description.py:274
+#: ./opengever/task/response_description.py
 msgid "transition_label_assign_to_dossier"
 msgstr "Weiterleitung zu einem Dossier hinzugefügt"
 
 #. Default: "Task cancelled"
-#: ./opengever/task/response_description.py:130
+#: ./opengever/task/response_description.py
 msgid "transition_label_cancelled"
 msgstr "Aufgabe storniert"
 
 #. Default: "Task closed"
-#: ./opengever/task/response_description.py:116
+#: ./opengever/task/response_description.py
 msgid "transition_label_close"
 msgstr "Aufgabe abgeschlossen"
 
 #. Default: "Created by ${user}"
-#: ./opengever/task/viewlets/response.py:68
+#: ./opengever/task/viewlets/response.py
 msgid "transition_label_created"
 msgstr "Erstellt durch ${user}"
 
 #. Default: "Task added"
-#: ./opengever/task/activities.py:26
-#: ./opengever/task/response_description.py:49
+#: ./opengever/task/activities.py
+#: ./opengever/task/response_description.py
 msgid "transition_label_default"
 msgstr "Aufgabe hinzugefügt"
 
 #. Default: "Task deadline modified"
-#: ./opengever/task/response_description.py:224
+#: ./opengever/task/response_description.py
 msgid "transition_label_modify_deadline"
 msgstr "Aufgabenfrist verändert"
 
 #. Default: "Task reactivated"
-#: ./opengever/task/response_description.py:68
+#: ./opengever/task/response_description.py
 msgid "transition_label_reactivate"
 msgstr "Aufgabe reaktiviert"
 
 #. Default: "Task reassigned"
-#: ./opengever/task/response_description.py:199
+#: ./opengever/task/response_description.py
 msgid "transition_label_reassign"
 msgstr "Aufgabe neu zugewiesen"
 
 #. Default: "Forwarding refused"
-#: ./opengever/task/response_description.py:254
+#: ./opengever/task/response_description.py
 msgid "transition_label_refuse"
 msgstr "Weiterleitung abgelehnt"
 
 #. Default: "Task rejected"
-#: ./opengever/task/response_description.py:82
+#: ./opengever/task/response_description.py
 msgid "transition_label_reject"
 msgstr "Aufgabe abgelehnt"
 
 #. Default: "Task reopened"
-#: ./opengever/task/response_description.py:161
+#: ./opengever/task/response_description.py
 msgid "transition_label_reopen"
 msgstr "Aufgaben wieder eröffnet"
 
 #. Default: "Task resolved"
-#: ./opengever/task/response_description.py:98
+#: ./opengever/task/response_description.py
 msgid "transition_label_resolve"
 msgstr "Aufgabe erledigt"
 
 #. Default: "Task revised"
-#: ./opengever/task/response_description.py:176
+#: ./opengever/task/response_description.py
 msgid "transition_label_revise"
 msgstr "Überarbeitung der Aufgabe angefordert"
 
 #. Default: "Accepted by ${user}"
-#: ./opengever/task/response_description.py:142
+#: ./opengever/task/response_description.py
 msgid "transition_msg_accept"
 msgstr "Akzeptiert durch ${user}"
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
-#: ./opengever/task/response_description.py:268
+#: ./opengever/task/response_description.py
 msgid "transition_msg_assign_to_dossier"
 msgstr "Einem Dossier zugewiesen durch ${user} Nachfolgeaufgabe=${successor}"
 
 #. Default: "Cancelled by ${user}"
-#: ./opengever/task/response_description.py:126
+#: ./opengever/task/response_description.py
 msgid "transition_msg_cancel"
 msgstr "Storniert durch ${user}"
 
 #. Default: "Closed by ${user}"
-#: ./opengever/task/response_description.py:112
+#: ./opengever/task/response_description.py
 msgid "transition_msg_close"
 msgstr "Abgeschlossen durch ${user}"
 
 #. Default: "Response added"
-#: ./opengever/task/response_description.py:44
+#: ./opengever/task/response_description.py
 msgid "transition_msg_default"
 msgstr "Antwort hinzugefügt"
 
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
-#: ./opengever/task/response_description.py:216
+#: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
 msgstr "Frist geändert von ${deadline_old} zu ${deadline_new} durch ${user}"
 
 #. Default: "Reactivate by ${user}"
-#: ./opengever/task/response_description.py:64
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reactivate"
 msgstr "Reaktiviert durch ${user}"
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
-#: ./opengever/task/response_description.py:191
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reassign"
 msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new} durch ${user}"
 
 #. Default: "Refused by ${user}"
-#: ./opengever/task/response_description.py:250
+#: ./opengever/task/response_description.py
 msgid "transition_msg_refuse"
 msgstr "Abgelehnt durch ${user}"
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/task/response_description.py:78
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reject"
 msgstr "Abgelehnt durch ${user}"
 
 #. Default: "Reopened by ${user}"
-#: ./opengever/task/response_description.py:157
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reopen"
 msgstr "Wieder eröffnet durch ${user}"
 
 #. Default: "Resolved by ${user}"
-#: ./opengever/task/response_description.py:94
+#: ./opengever/task/response_description.py
 msgid "transition_msg_resolve"
 msgstr "Erledigt durch ${user}"
 
 #. Default: "Revised by ${user}"
-#: ./opengever/task/response_description.py:172
+#: ./opengever/task/response_description.py
 msgid "transition_msg_revise"
 msgstr "Überarbeitung angefordert durch ${user}"
 
 #. Default: "Document copied from forwarding (forwarding accepted)"
-#: ./opengever/task/browser/accept/utils.py:94
+#: ./opengever/task/browser/accept/utils.py
 msgid "version_message_accept_forwarding"
 msgstr "Dokument von Weiterleitung kopiert (Weiterleitung akzeptiert)"
 
 #. Default: "Document copied from task (task accepted)"
-#: ./opengever/task/browser/accept/utils.py:259
+#: ./opengever/task/browser/accept/utils.py
 msgid "version_message_accept_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe akzeptiert)"
 
 #. Default: "Document copied from task (task closed)"
-#: ./opengever/task/browser/close.py:249
-#: ./opengever/task/browser/complete.py:298
+#: ./opengever/task/browser/close.py
+#: ./opengever/task/browser/complete.py
 msgid "version_message_closed_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe abgeschlossen)"
 
 #. Default: "Document copied from task (task resolved)"
-#: ./opengever/task/browser/complete.py:292
+#: ./opengever/task/browser/complete.py
 msgid "version_message_resolved_task"
 msgstr "Dokument von Aufgabe kopiert (Aufgabe erledigt)"
 

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,349 +1,348 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-09-03 09:19+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-task/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/task/browser/close.py:256
+#: ./opengever/task/browser/close.py
 msgid "${num} documents were copied."
 msgstr "${num} document(s) a (ont) été copié(s)."
 
-#: ./opengever/task/browser/delegate/metadata.py:83
+#: ./opengever/task/browser/delegate/metadata.py
 msgid "${subtask_num} subtasks were create."
 msgstr "${subtask_num} sous-tâche(s) a (ont) été créé(es)."
 
-#: ./opengever/task/response.py:395
+#: ./opengever/task/response.py
 msgid "Changes saved to response id ${response_id}."
 msgstr "Modifications de la réponse ${response_id} ont été sauvegardées"
 
-#: ./opengever/task/viewlets/response_templates/responseview.pt:22
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ./opengever/task/viewlets/response_templates/responseview.pt:18
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "Edit"
 msgstr "Modifier"
 
-#: ./opengever/task/response.py:300
-#: ./opengever/task/response_syncer/workflow.py:79
-#: ./opengever/task/util.py:164
+#: ./opengever/task/response.py
+#: ./opengever/task/response_syncer/workflow.py
+#: ./opengever/task/util.py
 msgid "Issue state"
 msgstr "Etat"
 
-#: ./opengever/task/response.py:423
+#: ./opengever/task/response.py
 msgid "No response selected for removal."
 msgstr "Aucune réponse séléctionnée pour l'effaçement"
 
-#: ./opengever/task/response.py:386
+#: ./opengever/task/response.py
 msgid "No response selected for saving."
 msgstr "Aucune réponse séléctionnée pour la sauvegarde"
 
-#: ./opengever/task/response.py:445
+#: ./opengever/task/response.py
 msgid "Removed response id ${response_id}."
 msgstr "Réponse ${response_id} effacée"
 
-#: ./opengever/task/response.py:438
+#: ./opengever/task/response.py
 msgid "Response id ${response_id} does not exist so it cannot be removed."
 msgstr "Réponse ${response_id} inexistante et ne peut être effacée"
 
-#: ./opengever/task/response.py:430
+#: ./opengever/task/response.py
 msgid "Response id ${response_id} is no integer so it cannot be removed."
 msgstr "Réponse ${response_id} n'est pas un chiffre et ne peut être effacé"
 
-#: ./opengever/task/browser/delegate/recipients.py:37
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "Select the related documents you wish to attach to the new subtasks."
 msgstr "Choix de la tâche liée aux documents qui vont être liés à une nouvelle sous-tâches."
 
-#: ./opengever/task/menu.py:22
+#: ./opengever/task/menu.py
 msgid "Subtask"
 msgstr "Sous-tâche"
 
-#: ./opengever/task/browser/complete.py:136
+#: ./opengever/task/browser/complete.py
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr "Les documents sont transmis au mandataire et les tâches sont fermées."
 
-#: ./opengever/task/browser/accept/inbox.py:33
+#: ./opengever/task/browser/accept/inbox.py
 msgid "The forwarding has been stored in the local inbox"
 msgstr "L'acheminement est sauvegardé dans la boîte de réception locale."
 
-#: ./opengever/task/browser/accept/existingdossier.py:119
-#: ./opengever/task/browser/accept/newdossier.py:319
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The forwarding has been stored in the local inbox and the succesor task has been created"
 msgstr "L'acheminement est déposé dans la boîte de réception locale et une copie de la tâche est créée."
 
-#: ./opengever/task/browser/accept/existingdossier.py:110
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "The forwarding is now assigned to the dossier"
 msgstr "L'acheminement a été attribué au dossier."
 
-#: ./opengever/task/browser/accept/newdossier.py:304
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The forwarding is now assigned to the new dossier"
 msgstr "L'acheminement a été attribué à un noveau dossier."
 
-#: ./opengever/task/browser/accept/newdossier.py:334
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The new dossier has been created and the task has been copied to the new dossier."
 msgstr "Le nouveau dossier a été créé. La tâche acceptée a été copiée dans le nouveau dossier."
 
-#: ./opengever/task/browser/accept/main.py:169
+#: ./opengever/task/browser/accept/main.py
 msgid "The task has been accepted."
 msgstr "La tâche a été accepté."
 
-#: ./opengever/task/browser/accept/existingdossier.py:130
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "The task has been copied to the selected dossier and accepted."
 msgstr "La tâche a été copiée et acceptée."
 
-#: ./opengever/task/response.py:417
+#: ./opengever/task/response.py
 msgid "You are not allowed to delete responses."
 msgstr "Vous n'étes pas l'autorisation d'effacer ces réponses"
 
-#: ./opengever/task/response.py:380
+#: ./opengever/task/response.py
 msgid "You are not allowed to edit responses."
 msgstr "Vous n'étes pas l'autorisation pour éditer ces réponses"
 
-#: ./opengever/task/browser/accept/main.py:120
+#: ./opengever/task/browser/accept/main.py
 msgid "You are not assigned to the responsible client (${client}). You can only process the task in the issuers dossier."
 msgstr "Vous n'avez pas été désigné comme client. Vous ne pouvez traiter la tâche que dans le dossier du mandataire."
 
-#: ./opengever/task/browser/close.py:191
+#: ./opengever/task/browser/close.py
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr "Vos droits ne sont pas suffisants pour ajouter des documents dans le dossier choisi. Le dossier est probablement déjà fermé."
 
-#: ./opengever/task/browser/accept/existingdossier.py:71
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "You cannot add tasks in the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr "Dans le dossier choisi, vous ne pouvez créer aucune tâche. Soit parce que le dossier est déjà fermé; soit parce que vous n'avez pas les droits suffisants pour effectuer cette tâche."
 
 #. Default: "file in existing dossier in ${client}"
-#: ./opengever/task/browser/accept/main.py:81
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_existing_dossier"
 msgstr "modifier dans un dossier existant dans ${client}"
 
 #. Default: "... store in  ${client}'s inbox and process in an existing dossier on ${client}"
-#: ./opengever/task/browser/accept/main.py:62
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_existing_dossier"
 msgstr "… déposer dans la boîte de réception de ${client} et modifier dans un dossier existant de ${client}"
 
 #. Default: "... store in  ${client}'s inbox and process in a new dossier on ${client}"
-#: ./opengever/task/browser/accept/main.py:68
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_new_dossier"
 msgstr "… déposer dans la boîte de réception de ${client} et modifier dans un nouveau dossier de ${client}"
 
 #. Default: "... store in ${client}'s inbox"
-#: ./opengever/task/browser/accept/main.py:56
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_participate"
 msgstr "… déposer dans la boîte de réception de ${client}"
 
 #. Default: "file in new dossier in ${client}"
-#: ./opengever/task/browser/accept/main.py:87
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_new_dossier"
 msgstr "Modifier dans un nouveau dossier dans ${client}"
 
 #. Default: "process in issuer's dossier"
-#: ./opengever/task/browser/accept/main.py:76
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_participate"
 msgstr "Modifier directement dans le dossier du mandataire"
 
 #. Default: "RE"
-#: ./opengever/task/browser/complete.py:309
+#: ./opengever/task/browser/complete.py
 msgid "answer_prefix"
 msgstr "Rép"
 
 #. Default: "Assign"
-#: ./opengever/task/browser/assign.py:69
+#: ./opengever/task/browser/assign.py
 msgid "button_assign"
 msgstr "Attribuer"
 
 #. Default: "Cancel"
-#: ./opengever/task/browser/accept/existingdossier.py:134
-#: ./opengever/task/browser/accept/main.py:208
-#: ./opengever/task/browser/accept/newdossier.py:138
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Continue"
-#: ./opengever/task/browser/accept/main.py:144
-#: ./opengever/task/browser/accept/newdossier.py:115
-#: ./opengever/task/browser/assign_dossier.py:73
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/assign_dossier.py
 msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Save"
-#: ./opengever/task/browser/accept/existingdossier.py:93
-#: ./opengever/task/browser/accept/newdossier.py:276
-#: ./opengever/task/browser/close.py:205
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/close.py
 msgid "button_save"
 msgstr "Enregistrer"
 
 #. Default: "Cancel"
-#: ./opengever/task/response.py:177
+#: ./opengever/task/response.py
 msgid "cancel"
 msgstr "Annuler"
 
-#: ./opengever/task/response.py:260
+#: ./opengever/task/response.py
 msgid "date_of_completion"
 msgstr "Date d'accomplissement"
 
 #. Default: "Select one or more responsibles. For each selected responsible a subtask will be created and assigned."
-#: ./opengever/task/browser/delegate/recipients.py:27
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_help_responsible"
 msgstr "Choix d'un ou plusieurs responsable(s) pour déléguer la tâche. Une sous-tâche est créée pour chaque responsable choisi."
 
 #. Default: "Attach documents"
-#: ./opengever/task/browser/delegate/recipients.py:36
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_label_documents"
 msgstr "Documents à attacher"
 
 #. Default: "Responsibles"
-#: ./opengever/task/browser/delegate/recipients.py:26
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_label_responsibles"
 msgstr "Responsable"
 
 #. Default: "The documents (${title}) are still checked out.                                 Please checkin them in bevore deliver"
-#: ./opengever/task/validators.py:33
+#: ./opengever/task/validators.py
 msgid "error_checked_out_document"
 msgstr "Les documents suivants (${title}) sont en checkout. Vous devez faire un checkin pour pouvoir les déposer."
 
 #. Default: "No changes: same responsible selected"
-#: ./opengever/task/browser/assign.py:78
+#: ./opengever/task/browser/assign.py
 msgid "error_same_responsible"
 msgstr "Pas de changement: mandataire identique séléctionné"
 
 #. Default: "existing dossier"
-#: ./opengever/task/browser/assign_dossier.py:44
+#: ./opengever/task/browser/assign_dossier.py
 msgid "existing_dossier"
 msgstr "Dossier existant"
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:77
+#: ./opengever/task/task.py
 msgid "fieldset_additional"
 msgstr "Avancé"
 
 #. Default: "Common"
-#: ./opengever/task/task.py:62
+#: ./opengever/task/task.py
 msgid "fieldset_common"
 msgstr "En général"
 
 #. Default: "Forwarding"
-#: ./opengever/task/helper.py:15
+#: ./opengever/task/helper.py
 msgid "forwarding_task_type"
 msgstr "Transmission"
 
 #. Default: "Select the target dossier where you like to handle the task."
-#: ./opengever/task/browser/accept/existingdossier.py:37
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "help_accept_select_dossier"
 msgstr "Choix du dossier dans lequel vous voulez modifier la tâche."
 
 #. Default: "Select the type for the new dossier"
-#: ./opengever/task/browser/accept/newdossier.py:213
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "help_accept_select_dossier_type"
 msgstr "Choix du type du nouveau dossier."
 
 #. Default: "Select the repository folder within the dossier should be created."
-#: ./opengever/task/browser/accept/newdossier.py:84
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "help_accept_select_repositoryfolder"
 msgstr "Choix du numéro de classement où le dossier doit être créé."
 
 #. Default: "Enter a answer text which will be shown as response when the task is accepted."
-#: ./opengever/task/browser/accept/main.py:102
-#: ./opengever/task/browser/close.py:80
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/close.py
 msgid "help_accept_task_response"
 msgstr "Saisie d'un texte pour la réponse créée automatiquement."
 
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
-#: ./opengever/task/browser/assign_dossier.py:61
+#: ./opengever/task/browser/assign_dossier.py
 msgid "help_assign_to_dossier_task_response"
 msgstr "Saisie d'un texte pour la réponse; ce texte apparaîtra dans le message qui suivra."
 
 #. Default: "Choose the target dossier where the documents should be filed."
-#: ./opengever/task/browser/close.py:157
+#: ./opengever/task/browser/close.py
 msgid "help_close_choose_dossier"
 msgstr "Choix du dossier dans lequel vous voulez copier les documents."
 
 #. Default: "You can copy attached documents to your client by selecting here the documents to copy."
-#: ./opengever/task/browser/close.py:88
+#: ./opengever/task/browser/close.py
 msgid "help_close_documents"
 msgstr "En cas de besoin, choix des documents à copier dans un autre dossier."
 
 #. Default: "Select the documents you want to deliver to the issuer of the task. They will be attached to the original task of the issuer."
-#: ./opengever/task/browser/complete.py:87
+#: ./opengever/task/browser/complete.py
 msgid "help_complete_documents"
 msgstr "Choix des documents à livrer au mandataire. Ils seront ensuite attachés automatiquement à la tâche originale."
 
 #. Default: "Enter a answer text which will be shown as response when the task is completed."
-#: ./opengever/task/browser/complete.py:99
+#: ./opengever/task/browser/complete.py
 msgid "help_complete_task_response"
 msgstr "Le texte saisi ici apparaît dans la réponse qui clôture cette tâche."
 
-#: ./opengever/task/response.py:67
-#: ./opengever/task/task.py:143
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "help_date_of_completion"
 msgstr "Date d'achèvement de la tâche"
 
-#: ./opengever/task/browser/delegate/metadata.py:35
-#: ./opengever/task/task.py:134
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_deadline"
 msgstr "Saisissez la date d'achèvement de la tâche"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:200
+#: ./opengever/task/task.py
 msgid "help_effectiveCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:194
+#: ./opengever/task/task.py
 msgid "help_effectiveDuration"
 msgstr "Durée effective en h"
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:188
+#: ./opengever/task/task.py
 msgid "help_expectedCost"
 msgstr "Coûts effectifs en CHF"
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:182
+#: ./opengever/task/task.py
 msgid "help_expectedDuration"
 msgstr "Durée effective en h"
 
 #. Default: "Select the responsible user from the client chosen above, or the corresponding inbox."
-#: ./opengever/task/task.py:126
+#: ./opengever/task/task.py
 msgid "help_responsible"
 msgstr "Sélectionnez la personne responsable."
 
-#: ./opengever/task/task.py:118
+#: ./opengever/task/task.py
 msgid "help_responsible_client"
 msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire."
 
-#: ./opengever/task/task.py:220
+#: ./opengever/task/task.py
 msgid "help_responsible_multiple"
 msgstr "Sélectionnez les personnes responsables."
 
-#: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/form.py:130
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/form.py
 msgid "help_responsible_single_client_setup"
 msgstr "Choix de la personne responsable"
 
-#: ./opengever/task/task.py:106
+#: ./opengever/task/task.py
 msgid "help_task_type"
 msgstr "Choix du type de mandat"
 
-#: ./opengever/task/browser/delegate/metadata.py:40
-#: ./opengever/task/task.py:151
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_text"
 msgstr "Saisissez une instruction de travail détaillée ou un commentaire"
 
-#: ./opengever/task/browser/delegate/metadata.py:25
-#: ./opengever/task/task.py:91
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_title"
 msgstr "Nom de la tâche"
 
@@ -351,272 +350,272 @@ msgid "issuedtasks"
 msgstr "Tâches mandatées"
 
 #. Default: "Accept the task and ..."
-#: ./opengever/task/browser/accept/main.py:95
+#: ./opengever/task/browser/accept/main.py
 msgid "label_accept_choose_method"
 msgstr "Accepter cette tâche et…"
 
 #. Default: "Accept forwarding and ..."
-#: ./opengever/task/browser/accept/main.py:227
+#: ./opengever/task/browser/accept/main.py
 msgid "label_accept_forwarding_choose_method"
 msgstr "Accepter l'acheminement et…"
 
 #. Default: "Target dossier"
-#: ./opengever/task/browser/accept/existingdossier.py:35
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "label_accept_select_dossier"
 msgstr "Dossier de destination"
 
 #. Default: "Dossier type"
-#: ./opengever/task/browser/accept/newdossier.py:212
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "label_accept_select_dossier_type"
 msgstr "Type de dossier"
 
 #. Default: "Repository folder"
-#: ./opengever/task/browser/accept/newdossier.py:82
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "label_accept_select_repositoryfolder"
 msgstr "Numéro de classement"
 
 #. Default: "Agency"
-#: ./opengever/task/viewlets/actionmenu_templates/actionmenuviewlet.pt:23
+#: ./opengever/task/viewlets/actionmenu_templates/actionmenuviewlet.pt
 msgid "label_agency"
 msgstr "Remplacement"
 
 #. Default: "Assign to a ..."
-#: ./opengever/task/browser/assign_dossier.py:54
+#: ./opengever/task/browser/assign_dossier.py
 msgid "label_assign_choose_method"
 msgstr "Acheminement attribué à un/une.."
 
 #. Default: "by"
-#: ./opengever/task/viewlets/byline.py:28
+#: ./opengever/task/viewlets/byline.py
 msgid "label_by_author"
 msgstr "Mandataire"
 
 #. Default: "Target dossier"
-#: ./opengever/task/browser/close.py:155
+#: ./opengever/task/browser/close.py
 msgid "label_close_choose_dossier"
 msgstr "Dossier de destination"
 
 #. Default: "Documents to copy"
-#: ./opengever/task/browser/close.py:86
+#: ./opengever/task/browser/close.py
 msgid "label_close_documents"
 msgstr "Copier documents"
 
 #. Default: "Documents to deliver"
-#: ./opengever/task/browser/complete.py:85
+#: ./opengever/task/browser/complete.py
 msgid "label_complete_documents"
 msgstr "Documents"
 
 #. Default: "Containing tasks"
-#: ./opengever/task/browser/overview_templates/overview.pt:47
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_containing_task"
 msgstr "Tâche principale"
 
 #. Default: "created"
-#: ./opengever/task/viewlets/byline.py:46
+#: ./opengever/task/viewlets/byline.py
 msgid "label_created"
 msgstr "Créé le"
 
 #. Default: "Date of completion"
-#: ./opengever/task/browser/overview.py:104
-#: ./opengever/task/response.py:66
-#: ./opengever/task/task.py:142
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "label_date_of_completion"
 msgstr "Date de réalisation"
 
 #. Default: "Deadline"
-#: ./opengever/task/activities.py:57
-#: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/browser/overview.py:88
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
 msgid "label_deadline"
 msgstr "A réaliser jusqu'au"
 
 #. Default: "Documents"
-#: ./opengever/task/browser/overview_templates/overview.pt:34
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_documents"
 msgstr "Documents"
 
 #. Default: "Dossier title"
-#: ./opengever/task/activities.py:61
+#: ./opengever/task/activities.py
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
 
 #. Default: "You are not allowed to edit this response."
-#: ./opengever/task/templates/edit_response.pt:44
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_edit_response_not_allowed"
 msgstr "Vous n'avez pas les droits pour effacer cette réponse"
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:199
+#: ./opengever/task/task.py
 msgid "label_effectiveCost"
 msgstr "Coûts effectifs (CHF)"
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:193
+#: ./opengever/task/task.py
 msgid "label_effectiveDuration"
 msgstr "Durée effective (h)"
 
 #. Default: "Please enter your response below"
-#: ./opengever/task/templates/edit_response.pt:59
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_enter_response"
 msgstr "Saisissez votre réponse ci-dessous"
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:187
+#: ./opengever/task/task.py
 msgid "label_expectedCost"
 msgstr "Coûts estimés (CHF)"
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:181
+#: ./opengever/task/task.py
 msgid "label_expectedDuration"
 msgstr "Durée estimées (h)"
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:176
+#: ./opengever/task/task.py
 msgid "label_expectedStartOfWork"
 msgstr "Début du travail"
 
 #. Default: "Issuer"
-#: ./opengever/task/browser/delegate/metadata.py:29
-#: ./opengever/task/browser/overview.py:93
-#: ./opengever/task/task.py:98
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/task.py
 msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "last modified"
-#: ./opengever/task/viewlets/byline.py:40
+#: ./opengever/task/viewlets/byline.py
 msgid "label_last_modified"
 msgstr "Dernière modification"
 
 #. Default: "Main Atrributes"
-#: ./opengever/task/browser/overview_templates/overview.pt:16
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_main_attributes"
 msgstr "Attributs"
 
 #. Default: "New Deadline"
-#: ./opengever/task/browser/modify_deadline.py:29
+#: ./opengever/task/browser/modify_deadline.py
 msgid "label_new_deadline"
 msgstr "Nouveau délai"
 
 #. Default: "Dossiertitle"
-#: ./opengever/task/browser/overview.py:71
+#: ./opengever/task/browser/overview.py
 msgid "label_parent_dossier_title"
 msgstr "Titre de la dossier"
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:206
+#: ./opengever/task/task.py
 msgid "label_predecessor"
 msgstr "Prédécesseur"
 
 #. Default: "Predecessor task"
-#: ./opengever/task/browser/overview_templates/overview.pt:63
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_predecessor_task"
 msgstr "Tâche initiale"
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py:218
-#: ./opengever/task/response.py:72
-#: ./opengever/task/task.py:156
+#: ./opengever/task/browser/complete.py
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "label_related_items"
 msgstr "Renvois"
 
 #. Default: "Responsible Client"
-#: ./opengever/task/task.py:116
+#: ./opengever/task/task.py
 msgid "label_resonsible_client"
 msgstr "Mandataire du client"
 
 #. Default: "Response"
-#: ./opengever/task/browser/accept/main.py:101
-#: ./opengever/task/browser/assign.py:45
-#: ./opengever/task/browser/assign_dossier.py:60
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/assign_dossier.py
 msgid "label_response"
 msgstr "Response"
 
 #. Default: "Responsible"
-#: ./opengever/task/browser/assign.py:38
-#: ./opengever/task/browser/overview.py:99
-#: ./opengever/task/response_syncer/workflow.py:70
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/response_syncer/workflow.py
 msgid "label_responsible"
 msgstr "Mandataire"
 
 #. Default: "Return to issue."
-#: ./opengever/task/templates/edit_response.pt:32
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_return_to_issue"
 msgstr "Retour à la tâche"
 
 #. Default: "Sequence Number"
-#: ./opengever/task/viewlets/byline.py:52
+#: ./opengever/task/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Sub tasks"
-#: ./opengever/task/browser/overview_templates/overview.pt:54
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_sub_task"
 msgstr "Sous-tâche"
 
 #. Default: "Successor task"
-#: ./opengever/task/browser/overview_templates/overview.pt:70
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_successor_task"
 msgstr "Tâche copiée"
 
 #. Default: "New task added by ${user}"
-#: ./opengever/task/activities.py:31
+#: ./opengever/task/activities.py
 msgid "label_task_added"
 msgstr "Nouvelle tâche ajoutée par ${user}"
 
 #. Default: "Task commented"
-#: ./opengever/task/response_description.py:333
+#: ./opengever/task/response_description.py
 msgid "label_task_commented"
 msgstr "La tâche a été commentée"
 
 #. Default: "Task title"
-#: ./opengever/task/activities.py:56
-#: ./opengever/task/browser/overview.py:67
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/overview.py
 msgid "label_task_title"
 msgstr "Titre de la tâche"
 
 #. Default: "Task Type"
-#: ./opengever/task/activities.py:59
-#: ./opengever/task/browser/overview.py:79
-#: ./opengever/task/task.py:105
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/task.py
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Text"
-#: ./opengever/task/activities.py:63
-#: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/browser/overview.py:75
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
 msgid "label_text"
 msgstr "Description"
 
 #. Default: "Title"
-#: ./opengever/task/browser/delegate/metadata.py:24
-#: ./opengever/task/task.py:90
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Transition"
-#: ./opengever/task/browser/assign.py:32
-#: ./opengever/task/browser/complete.py:106
-#: ./opengever/task/browser/modify_deadline.py:23
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/complete.py
+#: ./opengever/task/browser/modify_deadline.py
 msgid "label_transition"
 msgstr "Action"
 
 #. Default: "State"
-#: ./opengever/task/browser/overview.py:83
+#: ./opengever/task/browser/overview.py
 msgid "label_workflow_state"
 msgstr "Etat"
 
 #. Default: "State"
-#: ./opengever/task/viewlets/byline.py:34
+#: ./opengever/task/viewlets/byline.py
 msgid "label_workflow_state_byline"
 msgstr "Etat"
 
 #. Default: "Deadline successfully changed."
-#: ./opengever/task/browser/modify_deadline.py:69
+#: ./opengever/task/browser/modify_deadline.py
 msgid "msg_deadline_change_successfull"
 msgstr "Le délai a été modifié avec succès."
 
 #. Default: "Commented by ${user}"
-#: ./opengever/task/response_description.py:329
+#: ./opengever/task/response_description.py
 msgid "msg_task_commented"
 msgstr "Commenté par ${user}"
 
@@ -624,277 +623,278 @@ msgid "mytasks"
 msgstr "Mes tâches"
 
 #. Default: "new dossier"
-#: ./opengever/task/browser/assign_dossier.py:47
+#: ./opengever/task/browser/assign_dossier.py
 msgid "new_dossier"
 msgstr "Nouveau Dossier"
 
 #. Default: "Progress:"
-#: ./opengever/task/viewlets/response_templates/responseview.pt:3
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "progress"
 msgstr "Progrès"
 
 #. Default: "Response"
-#: ./opengever/task/templates/edit_response.pt:56
+#: ./opengever/task/templates/edit_response.pt
 msgid "response_label_response"
 msgstr "Réponse"
 
 #. Default: "The given deadline, is the current one."
-#: ./opengever/task/browser/modify_deadline.py:61
+#: ./opengever/task/browser/modify_deadline.py
 msgid "same_deadline_error"
 msgstr "Le délai saisi est celui qui court actuellement."
 
 #. Default: "Save"
-#: ./opengever/task/response.py:164
+#: ./opengever/task/response.py
 msgid "save"
 msgstr "Enregistrer"
 
 #. Default: "Step 1"
-#: ./opengever/task/browser/accept/existingdossier.py:87
-#: ./opengever/task/browser/accept/main.py:37
-#: ./opengever/task/browser/accept/newdossier.py:55
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_1"
 msgstr "Premier étape"
 
 #. Default: "Step 2"
-#: ./opengever/task/browser/accept/existingdossier.py:90
-#: ./opengever/task/browser/accept/newdossier.py:58
-#: ./opengever/task/browser/close.py:53
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/close.py
 msgid "step_2"
 msgstr "Deuxième étape"
 
 #. Default: "Step 3"
-#: ./opengever/task/browser/accept/newdossier.py:61
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_3"
 msgstr "Troisième étape"
 
 #. Default: "Step 4"
-#: ./opengever/task/browser/accept/newdossier.py:64
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_4"
 msgstr "Quatrième étape"
 
 #. Default: "Accept forwarding"
-#: ./opengever/task/browser/accept/main.py:140
+#: ./opengever/task/browser/accept/main.py
 msgid "title_accept_forwarding"
 msgstr "Accepter l'acheminement"
 
 #. Default: "Accept task"
-#: ./opengever/task/browser/accept/main.py:42
+#: ./opengever/task/browser/accept/main.py
 msgid "title_accept_task"
 msgstr "Accepter la tâche"
 
 #. Default: "Assign task"
-#: ./opengever/task/browser/assign.py:63
+#: ./opengever/task/browser/assign.py
 msgid "title_assign_task"
 msgstr "Attribuer à nouveau"
 
 #. Default: "Assign to Dossier"
-#: ./opengever/task/browser/assign_dossier.py:34
+#: ./opengever/task/browser/assign_dossier.py
 msgid "title_assign_to_dossier"
 msgstr "Attribuer à un dossier"
 
 #. Default: "Close task"
-#: ./opengever/task/browser/close.py:55
+#: ./opengever/task/browser/close.py
 msgid "title_close_task"
 msgstr "Fermer la tâche"
 
 #. Default: "Complete task"
-#: ./opengever/task/browser/complete.py:121
+#: ./opengever/task/browser/complete.py
 msgid "title_complete_task"
 msgstr "Accomplir / Fermer la tâche"
 
 #. Default: "Delegate task"
-#: ./opengever/task/browser/delegate/main.py:23
+#: ./opengever/task/browser/delegate/main.py
 msgid "title_delegate_task"
 msgstr "Déléguer la tâche"
 
 #. Default: "Edit response"
-#: ./opengever/task/templates/edit_response.pt:41
+#: ./opengever/task/templates/edit_response.pt
 msgid "title_edit_response"
 msgstr "Editer la réponse"
 
 #. Default: "Error: no response found for editing"
-#: ./opengever/task/templates/edit_response.pt:30
+#: ./opengever/task/templates/edit_response.pt
 msgid "title_error_no_response"
 msgstr "Erreur: Aucune réponse à éditer n'a été trouvée"
 
 #. Default: "Modify deadline"
-#: ./opengever/task/browser/modify_deadline.py:47
+#: ./opengever/task/browser/modify_deadline.py
 msgid "title_modify_deadline"
 msgstr "Changer le délai"
 
 #. Default: "Document ${doc} added by ${user}"
-#: ./opengever/task/response_description.py:311
+#: ./opengever/task/response_description.py
 msgid "transition_add_document"
 msgstr "Document ${doc} ajouté par ${user}"
 
 #. Default: "Subtask ${task} added by ${user}"
-#: ./opengever/task/response_description.py:291
+#: ./opengever/task/response_description.py
 msgid "transition_add_subtask"
 msgstr "Sous-tâche ${task} ajoutée par ${user}"
 
 #. Default: "Task accepted"
-#: ./opengever/task/response_description.py:146
+#: ./opengever/task/response_description.py
 msgid "transition_label_accept"
 msgstr "Tâche accéptée"
 
 #. Default: "Document added to Task"
-#: ./opengever/task/response_description.py:317
+#: ./opengever/task/response_description.py
 msgid "transition_label_add_document"
 msgstr "Document ajouté à la tâche"
 
 #. Default: "Subtask added to task"
-#: ./opengever/task/response_description.py:297
+#: ./opengever/task/response_description.py
 msgid "transition_label_add_subtask"
 msgstr "Sous-tâche ajoutée à la tâche"
 
 #. Default: "Forwarding assigned to Dossier"
-#: ./opengever/task/response_description.py:274
+#: ./opengever/task/response_description.py
 msgid "transition_label_assign_to_dossier"
 msgstr "Transmission assignée au dossier"
 
 #. Default: "Task cancelled"
-#: ./opengever/task/response_description.py:130
+#: ./opengever/task/response_description.py
 msgid "transition_label_cancelled"
 msgstr "Tâche annulée"
 
 #. Default: "Task closed"
-#: ./opengever/task/response_description.py:116
+#: ./opengever/task/response_description.py
 msgid "transition_label_close"
 msgstr "Täche fermée"
 
 #. Default: "Created by ${user}"
-#: ./opengever/task/viewlets/response.py:68
+#: ./opengever/task/viewlets/response.py
 msgid "transition_label_created"
 msgstr "Créé par ${user}"
 
 #. Default: "Task added"
-#: ./opengever/task/activities.py:26
-#: ./opengever/task/response_description.py:49
+#: ./opengever/task/activities.py
+#: ./opengever/task/response_description.py
 msgid "transition_label_default"
 msgstr "Tâche ajoutée"
 
 #. Default: "Task deadline modified"
-#: ./opengever/task/response_description.py:224
+#: ./opengever/task/response_description.py
 msgid "transition_label_modify_deadline"
 msgstr "Délai de la tâche modifié"
 
 #. Default: "Task reactivated"
-#: ./opengever/task/response_description.py:68
+#: ./opengever/task/response_description.py
 msgid "transition_label_reactivate"
 msgstr "Tâche réactivée"
 
 #. Default: "Task reassigned"
-#: ./opengever/task/response_description.py:199
+#: ./opengever/task/response_description.py
 msgid "transition_label_reassign"
 msgstr "Tâche réassignée"
 
 #. Default: "Forwarding refused"
-#: ./opengever/task/response_description.py:254
+#: ./opengever/task/response_description.py
 msgid "transition_label_refuse"
 msgstr "Transmission refusée"
 
 #. Default: "Task rejected"
-#: ./opengever/task/response_description.py:82
+#: ./opengever/task/response_description.py
 msgid "transition_label_reject"
 msgstr "Tâche refusée"
 
 #. Default: "Task reopened"
-#: ./opengever/task/response_description.py:161
+#: ./opengever/task/response_description.py
 msgid "transition_label_reopen"
 msgstr "Tâche réouverte"
 
 #. Default: "Task resolved"
-#: ./opengever/task/response_description.py:98
+#: ./opengever/task/response_description.py
 msgid "transition_label_resolve"
 msgstr "Tâche accomplie"
 
 #. Default: "Task revised"
-#: ./opengever/task/response_description.py:176
+#: ./opengever/task/response_description.py
 msgid "transition_label_revise"
 msgstr "Révision de la tâche demandée"
 
 #. Default: "Accepted by ${user}"
-#: ./opengever/task/response_description.py:142
+#: ./opengever/task/response_description.py
 msgid "transition_msg_accept"
 msgstr "Accepté par ${user}"
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
-#: ./opengever/task/response_description.py:268
+#: ./opengever/task/response_description.py
 msgid "transition_msg_assign_to_dossier"
 msgstr "Attribué à un dossier par ${user} Tâche suivante=${successor}"
 
 #. Default: "Cancelled by ${user}"
-#: ./opengever/task/response_description.py:126
+#: ./opengever/task/response_description.py
 msgid "transition_msg_cancel"
 msgstr "Annulé par ${user}"
 
 #. Default: "Closed by ${user}"
-#: ./opengever/task/response_description.py:112
+#: ./opengever/task/response_description.py
 msgid "transition_msg_close"
 msgstr "Fermé par ${user}"
 
 #. Default: "Response added"
-#: ./opengever/task/response_description.py:44
+#: ./opengever/task/response_description.py
 msgid "transition_msg_default"
 msgstr "Réponse ajouté"
 
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
-#: ./opengever/task/response_description.py:216
+#: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
 msgstr "Délai modifié de ${deadline_old} à ${deadline_new} par ${user}"
 
 #. Default: "Reactivate by ${user}"
-#: ./opengever/task/response_description.py:64
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reactivate"
 msgstr "Réactivé par ${user}"
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
-#: ./opengever/task/response_description.py:191
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reassign"
 msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new} par ${user}"
 
 #. Default: "Refused by ${user}"
-#: ./opengever/task/response_description.py:250
+#: ./opengever/task/response_description.py
 msgid "transition_msg_refuse"
 msgstr "Refusé par ${user}"
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/task/response_description.py:78
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reject"
 msgstr "Refusé par ${user}"
 
 #. Default: "Reopened by ${user}"
-#: ./opengever/task/response_description.py:157
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reopen"
 msgstr "Réouvert par ${user}"
 
 #. Default: "Resolved by ${user}"
-#: ./opengever/task/response_description.py:94
+#: ./opengever/task/response_description.py
 msgid "transition_msg_resolve"
 msgstr "Accompli par ${user}"
 
 #. Default: "Revised by ${user}"
-#: ./opengever/task/response_description.py:172
+#: ./opengever/task/response_description.py
 msgid "transition_msg_revise"
 msgstr "Révision demandée par ${user}"
 
 #. Default: "Document copied from forwarding (forwarding accepted)"
-#: ./opengever/task/browser/accept/utils.py:94
+#: ./opengever/task/browser/accept/utils.py
 msgid "version_message_accept_forwarding"
 msgstr "Document copié de l'acheminement (Acheminement accepté)"
 
 #. Default: "Document copied from task (task accepted)"
-#: ./opengever/task/browser/accept/utils.py:259
+#: ./opengever/task/browser/accept/utils.py
 msgid "version_message_accept_task"
 msgstr "Document copié de la tâche (Tâche accepté)"
 
 #. Default: "Document copied from task (task closed)"
-#: ./opengever/task/browser/close.py:249
-#: ./opengever/task/browser/complete.py:298
+#: ./opengever/task/browser/close.py
+#: ./opengever/task/browser/complete.py
 msgid "version_message_closed_task"
 msgstr "Document copié de la tâche (tâche finie)"
 
 #. Default: "Document copied from task (task resolved)"
-#: ./opengever/task/browser/complete.py:292
+#: ./opengever/task/browser/complete.py
 msgid "version_message_resolved_task"
 msgstr "Document copié de la tâche (tâche achevée)"
+

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,332 +15,332 @@ msgstr ""
 "Domain: opengever.task\n"
 "X-Poedit-Language: German\n"
 
-#: ./opengever/task/browser/close.py:256
+#: ./opengever/task/browser/close.py
 msgid "${num} documents were copied."
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:83
+#: ./opengever/task/browser/delegate/metadata.py
 msgid "${subtask_num} subtasks were create."
 msgstr ""
 
-#: ./opengever/task/response.py:395
+#: ./opengever/task/response.py
 msgid "Changes saved to response id ${response_id}."
 msgstr ""
 
-#: ./opengever/task/viewlets/response_templates/responseview.pt:22
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "Delete"
 msgstr ""
 
-#: ./opengever/task/viewlets/response_templates/responseview.pt:18
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "Edit"
 msgstr ""
 
-#: ./opengever/task/response.py:300
-#: ./opengever/task/response_syncer/workflow.py:79
-#: ./opengever/task/util.py:164
+#: ./opengever/task/response.py
+#: ./opengever/task/response_syncer/workflow.py
+#: ./opengever/task/util.py
 msgid "Issue state"
 msgstr ""
 
-#: ./opengever/task/response.py:423
+#: ./opengever/task/response.py
 msgid "No response selected for removal."
 msgstr ""
 
-#: ./opengever/task/response.py:386
+#: ./opengever/task/response.py
 msgid "No response selected for saving."
 msgstr ""
 
-#: ./opengever/task/response.py:445
+#: ./opengever/task/response.py
 msgid "Removed response id ${response_id}."
 msgstr ""
 
-#: ./opengever/task/response.py:438
+#: ./opengever/task/response.py
 msgid "Response id ${response_id} does not exist so it cannot be removed."
 msgstr ""
 
-#: ./opengever/task/response.py:430
+#: ./opengever/task/response.py
 msgid "Response id ${response_id} is no integer so it cannot be removed."
 msgstr ""
 
-#: ./opengever/task/browser/delegate/recipients.py:37
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "Select the related documents you wish to attach to the new subtasks."
 msgstr ""
 
-#: ./opengever/task/menu.py:22
+#: ./opengever/task/menu.py
 msgid "Subtask"
 msgstr ""
 
-#: ./opengever/task/browser/complete.py:136
+#: ./opengever/task/browser/complete.py
 msgid "The documents were delivered to the issuer and the tasks were completed."
 msgstr ""
 
-#: ./opengever/task/browser/accept/inbox.py:33
+#: ./opengever/task/browser/accept/inbox.py
 msgid "The forwarding has been stored in the local inbox"
 msgstr ""
 
-#: ./opengever/task/browser/accept/existingdossier.py:119
-#: ./opengever/task/browser/accept/newdossier.py:319
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The forwarding has been stored in the local inbox and the succesor task has been created"
 msgstr ""
 
-#: ./opengever/task/browser/accept/existingdossier.py:110
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "The forwarding is now assigned to the dossier"
 msgstr ""
 
-#: ./opengever/task/browser/accept/newdossier.py:304
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The forwarding is now assigned to the new dossier"
 msgstr ""
 
-#: ./opengever/task/browser/accept/newdossier.py:334
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "The new dossier has been created and the task has been copied to the new dossier."
 msgstr ""
 
-#: ./opengever/task/browser/accept/main.py:169
+#: ./opengever/task/browser/accept/main.py
 msgid "The task has been accepted."
 msgstr ""
 
-#: ./opengever/task/browser/accept/existingdossier.py:130
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "The task has been copied to the selected dossier and accepted."
 msgstr ""
 
-#: ./opengever/task/response.py:417
+#: ./opengever/task/response.py
 msgid "You are not allowed to delete responses."
 msgstr ""
 
-#: ./opengever/task/response.py:380
+#: ./opengever/task/response.py
 msgid "You are not allowed to edit responses."
 msgstr ""
 
-#: ./opengever/task/browser/accept/main.py:120
+#: ./opengever/task/browser/accept/main.py
 msgid "You are not assigned to the responsible client (${client}). You can only process the task in the issuers dossier."
 msgstr ""
 
-#: ./opengever/task/browser/close.py:191
+#: ./opengever/task/browser/close.py
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr ""
 
-#: ./opengever/task/browser/accept/existingdossier.py:71
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "You cannot add tasks in the selected dossier. Either the dossier is closed or you do not have the privileges."
 msgstr ""
 
 #. Default: "file in existing dossier in ${client}"
-#: ./opengever/task/browser/accept/main.py:81
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_existing_dossier"
 msgstr ""
 
 #. Default: "... store in  ${client}'s inbox and process in an existing dossier on ${client}"
-#: ./opengever/task/browser/accept/main.py:62
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_existing_dossier"
 msgstr ""
 
 #. Default: "... store in  ${client}'s inbox and process in a new dossier on ${client}"
-#: ./opengever/task/browser/accept/main.py:68
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_new_dossier"
 msgstr ""
 
 #. Default: "... store in ${client}'s inbox"
-#: ./opengever/task/browser/accept/main.py:56
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_forwarding_participate"
 msgstr ""
 
 #. Default: "file in new dossier in ${client}"
-#: ./opengever/task/browser/accept/main.py:87
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_new_dossier"
 msgstr ""
 
 #. Default: "process in issuer's dossier"
-#: ./opengever/task/browser/accept/main.py:76
+#: ./opengever/task/browser/accept/main.py
 msgid "accept_method_participate"
 msgstr ""
 
 #. Default: "RE"
-#: ./opengever/task/browser/complete.py:309
+#: ./opengever/task/browser/complete.py
 msgid "answer_prefix"
 msgstr ""
 
 #. Default: "Assign"
-#: ./opengever/task/browser/assign.py:69
+#: ./opengever/task/browser/assign.py
 msgid "button_assign"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/task/browser/accept/existingdossier.py:134
-#: ./opengever/task/browser/accept/main.py:208
-#: ./opengever/task/browser/accept/newdossier.py:138
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/task/browser/accept/main.py:144
-#: ./opengever/task/browser/accept/newdossier.py:115
-#: ./opengever/task/browser/assign_dossier.py:73
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/assign_dossier.py
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/task/browser/accept/existingdossier.py:93
-#: ./opengever/task/browser/accept/newdossier.py:276
-#: ./opengever/task/browser/close.py:205
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/close.py
 msgid "button_save"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/task/response.py:177
+#: ./opengever/task/response.py
 msgid "cancel"
 msgstr ""
 
-#: ./opengever/task/response.py:260
+#: ./opengever/task/response.py
 msgid "date_of_completion"
 msgstr ""
 
 #. Default: "Select one or more responsibles. For each selected responsible a subtask will be created and assigned."
-#: ./opengever/task/browser/delegate/recipients.py:27
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_help_responsible"
 msgstr ""
 
 #. Default: "Attach documents"
-#: ./opengever/task/browser/delegate/recipients.py:36
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_label_documents"
 msgstr ""
 
 #. Default: "Responsibles"
-#: ./opengever/task/browser/delegate/recipients.py:26
+#: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_label_responsibles"
 msgstr ""
 
 #. Default: "The documents (${title}) are still checked out.                                 Please checkin them in bevore deliver"
-#: ./opengever/task/validators.py:33
+#: ./opengever/task/validators.py
 msgid "error_checked_out_document"
 msgstr ""
 
 #. Default: "No changes: same responsible selected"
-#: ./opengever/task/browser/assign.py:78
+#: ./opengever/task/browser/assign.py
 msgid "error_same_responsible"
 msgstr ""
 
 #. Default: "existing dossier"
-#: ./opengever/task/browser/assign_dossier.py:44
+#: ./opengever/task/browser/assign_dossier.py
 msgid "existing_dossier"
 msgstr ""
 
 #. Default: "Additional"
-#: ./opengever/task/task.py:77
+#: ./opengever/task/task.py
 msgid "fieldset_additional"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/task/task.py:62
+#: ./opengever/task/task.py
 msgid "fieldset_common"
 msgstr ""
 
 #. Default: "Forwarding"
-#: ./opengever/task/helper.py:15
+#: ./opengever/task/helper.py
 msgid "forwarding_task_type"
 msgstr ""
 
 #. Default: "Select the target dossier where you like to handle the task."
-#: ./opengever/task/browser/accept/existingdossier.py:37
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "help_accept_select_dossier"
 msgstr ""
 
 #. Default: "Select the type for the new dossier"
-#: ./opengever/task/browser/accept/newdossier.py:213
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "help_accept_select_dossier_type"
 msgstr ""
 
 #. Default: "Select the repository folder within the dossier should be created."
-#: ./opengever/task/browser/accept/newdossier.py:84
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "help_accept_select_repositoryfolder"
 msgstr ""
 
 #. Default: "Enter a answer text which will be shown as response when the task is accepted."
-#: ./opengever/task/browser/accept/main.py:102
-#: ./opengever/task/browser/close.py:80
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/close.py
 msgid "help_accept_task_response"
 msgstr ""
 
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
-#: ./opengever/task/browser/assign_dossier.py:61
+#: ./opengever/task/browser/assign_dossier.py
 msgid "help_assign_to_dossier_task_response"
 msgstr ""
 
 #. Default: "Choose the target dossier where the documents should be filed."
-#: ./opengever/task/browser/close.py:157
+#: ./opengever/task/browser/close.py
 msgid "help_close_choose_dossier"
 msgstr ""
 
 #. Default: "You can copy attached documents to your client by selecting here the documents to copy."
-#: ./opengever/task/browser/close.py:88
+#: ./opengever/task/browser/close.py
 msgid "help_close_documents"
 msgstr ""
 
 #. Default: "Select the documents you want to deliver to the issuer of the task. They will be attached to the original task of the issuer."
-#: ./opengever/task/browser/complete.py:87
+#: ./opengever/task/browser/complete.py
 msgid "help_complete_documents"
 msgstr ""
 
 #. Default: "Enter a answer text which will be shown as response when the task is completed."
-#: ./opengever/task/browser/complete.py:99
+#: ./opengever/task/browser/complete.py
 msgid "help_complete_task_response"
 msgstr ""
 
-#: ./opengever/task/response.py:67
-#: ./opengever/task/task.py:143
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "help_date_of_completion"
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:35
-#: ./opengever/task/task.py:134
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_deadline"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:200
+#: ./opengever/task/task.py
 msgid "help_effectiveCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:194
+#: ./opengever/task/task.py
 msgid "help_effectiveDuration"
 msgstr ""
 
 #. Default: "Cost in CHF"
-#: ./opengever/task/task.py:188
+#: ./opengever/task/task.py
 msgid "help_expectedCost"
 msgstr ""
 
 #. Default: "Duration in h"
-#: ./opengever/task/task.py:182
+#: ./opengever/task/task.py
 msgid "help_expectedDuration"
 msgstr ""
 
-#: ./opengever/task/task.py:126
+#: ./opengever/task/task.py
 msgid "help_responsible"
 msgstr ""
 
-#: ./opengever/task/task.py:118
+#: ./opengever/task/task.py
 msgid "help_responsible_client"
 msgstr ""
 
-#: ./opengever/task/task.py:220
+#: ./opengever/task/task.py
 msgid "help_responsible_multiple"
 msgstr ""
 
-#: ./opengever/task/browser/assign.py:39
-#: ./opengever/task/form.py:130
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/form.py
 msgid "help_responsible_single_client_setup"
 msgstr ""
 
-#: ./opengever/task/task.py:106
+#: ./opengever/task/task.py
 msgid "help_task_type"
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:40
-#: ./opengever/task/task.py:151
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_text"
 msgstr ""
 
-#: ./opengever/task/browser/delegate/metadata.py:25
-#: ./opengever/task/task.py:91
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "help_title"
 msgstr ""
 
@@ -348,270 +348,270 @@ msgid "issuedtasks"
 msgstr ""
 
 #. Default: "Accept the task and ..."
-#: ./opengever/task/browser/accept/main.py:95
+#: ./opengever/task/browser/accept/main.py
 msgid "label_accept_choose_method"
 msgstr ""
 
 #. Default: "Accept forwarding and ..."
-#: ./opengever/task/browser/accept/main.py:227
+#: ./opengever/task/browser/accept/main.py
 msgid "label_accept_forwarding_choose_method"
 msgstr ""
 
 #. Default: "Target dossier"
-#: ./opengever/task/browser/accept/existingdossier.py:35
+#: ./opengever/task/browser/accept/existingdossier.py
 msgid "label_accept_select_dossier"
 msgstr ""
 
 #. Default: "Dossier type"
-#: ./opengever/task/browser/accept/newdossier.py:212
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "label_accept_select_dossier_type"
 msgstr ""
 
 #. Default: "Repository folder"
-#: ./opengever/task/browser/accept/newdossier.py:82
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "label_accept_select_repositoryfolder"
 msgstr ""
 
 #. Default: "Agency"
-#: ./opengever/task/viewlets/actionmenu_templates/actionmenuviewlet.pt:23
+#: ./opengever/task/viewlets/actionmenu_templates/actionmenuviewlet.pt
 msgid "label_agency"
 msgstr ""
 
 #. Default: "Assign to a ..."
-#: ./opengever/task/browser/assign_dossier.py:54
+#: ./opengever/task/browser/assign_dossier.py
 msgid "label_assign_choose_method"
 msgstr ""
 
 #. Default: "by"
-#: ./opengever/task/viewlets/byline.py:28
+#: ./opengever/task/viewlets/byline.py
 msgid "label_by_author"
 msgstr ""
 
 #. Default: "Target dossier"
-#: ./opengever/task/browser/close.py:155
+#: ./opengever/task/browser/close.py
 msgid "label_close_choose_dossier"
 msgstr ""
 
 #. Default: "Documents to copy"
-#: ./opengever/task/browser/close.py:86
+#: ./opengever/task/browser/close.py
 msgid "label_close_documents"
 msgstr ""
 
 #. Default: "Documents to deliver"
-#: ./opengever/task/browser/complete.py:85
+#: ./opengever/task/browser/complete.py
 msgid "label_complete_documents"
 msgstr ""
 
 #. Default: "Containing tasks"
-#: ./opengever/task/browser/overview_templates/overview.pt:47
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_containing_task"
 msgstr ""
 
 #. Default: "created"
-#: ./opengever/task/viewlets/byline.py:46
+#: ./opengever/task/viewlets/byline.py
 msgid "label_created"
 msgstr ""
 
 #. Default: "Date of completion"
-#: ./opengever/task/browser/overview.py:104
-#: ./opengever/task/response.py:66
-#: ./opengever/task/task.py:142
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "label_date_of_completion"
 msgstr ""
 
 #. Default: "Deadline"
-#: ./opengever/task/activities.py:57
-#: ./opengever/task/browser/delegate/metadata.py:34
-#: ./opengever/task/browser/overview.py:88
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Documents"
-#: ./opengever/task/browser/overview_templates/overview.pt:34
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossier title"
-#: ./opengever/task/activities.py:61
+#: ./opengever/task/activities.py
 msgid "label_dossier_title"
 msgstr ""
 
 #. Default: "You are not allowed to edit this response."
-#: ./opengever/task/templates/edit_response.pt:44
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_edit_response_not_allowed"
 msgstr ""
 
 #. Default: "effective cost"
-#: ./opengever/task/task.py:199
+#: ./opengever/task/task.py
 msgid "label_effectiveCost"
 msgstr ""
 
 #. Default: "effective duration"
-#: ./opengever/task/task.py:193
+#: ./opengever/task/task.py
 msgid "label_effectiveDuration"
 msgstr ""
 
 #. Default: "Please enter your response below"
-#: ./opengever/task/templates/edit_response.pt:59
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_enter_response"
 msgstr ""
 
 #. Default: "expected cost"
-#: ./opengever/task/task.py:187
+#: ./opengever/task/task.py
 msgid "label_expectedCost"
 msgstr ""
 
 #. Default: "Expected duration"
-#: ./opengever/task/task.py:181
+#: ./opengever/task/task.py
 msgid "label_expectedDuration"
 msgstr ""
 
 #. Default: "Start with work"
-#: ./opengever/task/task.py:176
+#: ./opengever/task/task.py
 msgid "label_expectedStartOfWork"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/task/browser/delegate/metadata.py:29
-#: ./opengever/task/browser/overview.py:93
-#: ./opengever/task/task.py:98
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/task.py
 msgid "label_issuer"
 msgstr ""
 
 #. Default: "last modified"
-#: ./opengever/task/viewlets/byline.py:40
+#: ./opengever/task/viewlets/byline.py
 msgid "label_last_modified"
 msgstr ""
 
 #. Default: "Main Atrributes"
-#: ./opengever/task/browser/overview_templates/overview.pt:16
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_main_attributes"
 msgstr ""
 
 #. Default: "New Deadline"
-#: ./opengever/task/browser/modify_deadline.py:29
+#: ./opengever/task/browser/modify_deadline.py
 msgid "label_new_deadline"
 msgstr ""
 
-#: ./opengever/task/browser/overview.py:71
+#: ./opengever/task/browser/overview.py
 msgid "label_parent_dossier_title"
 msgstr ""
 
 #. Default: "Predecessor"
-#: ./opengever/task/task.py:206
+#: ./opengever/task/task.py
 msgid "label_predecessor"
 msgstr ""
 
 #. Default: "Predecessor task"
-#: ./opengever/task/browser/overview_templates/overview.pt:63
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_predecessor_task"
 msgstr ""
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py:218
-#: ./opengever/task/response.py:72
-#: ./opengever/task/task.py:156
+#: ./opengever/task/browser/complete.py
+#: ./opengever/task/response.py
+#: ./opengever/task/task.py
 msgid "label_related_items"
 msgstr ""
 
 #. Default: "Responsible Client"
-#: ./opengever/task/task.py:116
+#: ./opengever/task/task.py
 msgid "label_resonsible_client"
 msgstr ""
 
 #. Default: "Response"
-#: ./opengever/task/browser/accept/main.py:101
-#: ./opengever/task/browser/assign.py:45
-#: ./opengever/task/browser/assign_dossier.py:60
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/assign_dossier.py
 msgid "label_response"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/task/browser/assign.py:38
-#: ./opengever/task/browser/overview.py:99
-#: ./opengever/task/response_syncer/workflow.py:70
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/response_syncer/workflow.py
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "Return to issue."
-#: ./opengever/task/templates/edit_response.pt:32
+#: ./opengever/task/templates/edit_response.pt
 msgid "label_return_to_issue"
 msgstr ""
 
 #. Default: "Sequence Number"
-#: ./opengever/task/viewlets/byline.py:52
+#: ./opengever/task/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Sub tasks"
-#: ./opengever/task/browser/overview_templates/overview.pt:54
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_sub_task"
 msgstr ""
 
 #. Default: "Successor task"
-#: ./opengever/task/browser/overview_templates/overview.pt:70
+#: ./opengever/task/browser/overview_templates/overview.pt
 msgid "label_successor_task"
 msgstr ""
 
 #. Default: "New task added by ${user}"
-#: ./opengever/task/activities.py:31
+#: ./opengever/task/activities.py
 msgid "label_task_added"
 msgstr ""
 
 #. Default: "Task commented"
-#: ./opengever/task/response_description.py:333
+#: ./opengever/task/response_description.py
 msgid "label_task_commented"
 msgstr ""
 
 #. Default: "Task title"
-#: ./opengever/task/activities.py:56
-#: ./opengever/task/browser/overview.py:67
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/overview.py
 msgid "label_task_title"
 msgstr ""
 
 #. Default: "Task Type"
-#: ./opengever/task/activities.py:59
-#: ./opengever/task/browser/overview.py:79
-#: ./opengever/task/task.py:105
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/overview.py
+#: ./opengever/task/task.py
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Text"
-#: ./opengever/task/activities.py:63
-#: ./opengever/task/browser/delegate/metadata.py:39
-#: ./opengever/task/browser/overview.py:75
+#: ./opengever/task/activities.py
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/browser/overview.py
 msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/task/browser/delegate/metadata.py:24
-#: ./opengever/task/task.py:90
+#: ./opengever/task/browser/delegate/metadata.py
+#: ./opengever/task/task.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Transition"
-#: ./opengever/task/browser/assign.py:32
-#: ./opengever/task/browser/complete.py:106
-#: ./opengever/task/browser/modify_deadline.py:23
+#: ./opengever/task/browser/assign.py
+#: ./opengever/task/browser/complete.py
+#: ./opengever/task/browser/modify_deadline.py
 msgid "label_transition"
 msgstr ""
 
-#: ./opengever/task/browser/overview.py:83
+#: ./opengever/task/browser/overview.py
 msgid "label_workflow_state"
 msgstr ""
 
 #. Default: "State"
-#: ./opengever/task/viewlets/byline.py:34
+#: ./opengever/task/viewlets/byline.py
 msgid "label_workflow_state_byline"
 msgstr ""
 
 #. Default: "Deadline successfully changed."
-#: ./opengever/task/browser/modify_deadline.py:69
+#: ./opengever/task/browser/modify_deadline.py
 msgid "msg_deadline_change_successfull"
 msgstr ""
 
 #. Default: "Commented by ${user}"
-#: ./opengever/task/response_description.py:329
+#: ./opengever/task/response_description.py
 msgid "msg_task_commented"
 msgstr ""
 
@@ -619,278 +619,278 @@ msgid "mytasks"
 msgstr ""
 
 #. Default: "new dossier"
-#: ./opengever/task/browser/assign_dossier.py:47
+#: ./opengever/task/browser/assign_dossier.py
 msgid "new_dossier"
 msgstr ""
 
 #. Default: "Progress:"
-#: ./opengever/task/viewlets/response_templates/responseview.pt:3
+#: ./opengever/task/viewlets/response_templates/responseview.pt
 msgid "progress"
 msgstr ""
 
 #. Default: "Response"
-#: ./opengever/task/templates/edit_response.pt:56
+#: ./opengever/task/templates/edit_response.pt
 msgid "response_label_response"
 msgstr ""
 
 #. Default: "The given deadline, is the current one."
-#: ./opengever/task/browser/modify_deadline.py:61
+#: ./opengever/task/browser/modify_deadline.py
 msgid "same_deadline_error"
 msgstr ""
 
 #. Default: "Save"
-#: ./opengever/task/response.py:164
+#: ./opengever/task/response.py
 msgid "save"
 msgstr ""
 
 #. Default: "Step 1"
-#: ./opengever/task/browser/accept/existingdossier.py:87
-#: ./opengever/task/browser/accept/main.py:37
-#: ./opengever/task/browser/accept/newdossier.py:55
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/main.py
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_1"
 msgstr ""
 
 #. Default: "Step 2"
-#: ./opengever/task/browser/accept/existingdossier.py:90
-#: ./opengever/task/browser/accept/newdossier.py:58
-#: ./opengever/task/browser/close.py:53
+#: ./opengever/task/browser/accept/existingdossier.py
+#: ./opengever/task/browser/accept/newdossier.py
+#: ./opengever/task/browser/close.py
 msgid "step_2"
 msgstr ""
 
 #. Default: "Step 3"
-#: ./opengever/task/browser/accept/newdossier.py:61
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_3"
 msgstr ""
 
 #. Default: "Step 4"
-#: ./opengever/task/browser/accept/newdossier.py:64
+#: ./opengever/task/browser/accept/newdossier.py
 msgid "step_4"
 msgstr ""
 
 #. Default: "Accept forwarding"
-#: ./opengever/task/browser/accept/main.py:140
+#: ./opengever/task/browser/accept/main.py
 msgid "title_accept_forwarding"
 msgstr ""
 
 #. Default: "Accept task"
-#: ./opengever/task/browser/accept/main.py:42
+#: ./opengever/task/browser/accept/main.py
 msgid "title_accept_task"
 msgstr ""
 
 #. Default: "Assign task"
-#: ./opengever/task/browser/assign.py:63
+#: ./opengever/task/browser/assign.py
 msgid "title_assign_task"
 msgstr ""
 
 #. Default: "Assign to Dossier"
-#: ./opengever/task/browser/assign_dossier.py:34
+#: ./opengever/task/browser/assign_dossier.py
 msgid "title_assign_to_dossier"
 msgstr ""
 
 #. Default: "Close task"
-#: ./opengever/task/browser/close.py:55
+#: ./opengever/task/browser/close.py
 msgid "title_close_task"
 msgstr ""
 
 #. Default: "Complete task"
-#: ./opengever/task/browser/complete.py:121
+#: ./opengever/task/browser/complete.py
 msgid "title_complete_task"
 msgstr ""
 
 #. Default: "Delegate task"
-#: ./opengever/task/browser/delegate/main.py:23
+#: ./opengever/task/browser/delegate/main.py
 msgid "title_delegate_task"
 msgstr ""
 
 #. Default: "Edit response"
-#: ./opengever/task/templates/edit_response.pt:41
+#: ./opengever/task/templates/edit_response.pt
 msgid "title_edit_response"
 msgstr ""
 
 #. Default: "Error: no response found for editing"
-#: ./opengever/task/templates/edit_response.pt:30
+#: ./opengever/task/templates/edit_response.pt
 msgid "title_error_no_response"
 msgstr ""
 
 #. Default: "Modify deadline"
-#: ./opengever/task/browser/modify_deadline.py:47
+#: ./opengever/task/browser/modify_deadline.py
 msgid "title_modify_deadline"
 msgstr ""
 
 #. Default: "Document ${doc} added by ${user}"
-#: ./opengever/task/response_description.py:311
+#: ./opengever/task/response_description.py
 msgid "transition_add_document"
 msgstr ""
 
 #. Default: "Subtask ${task} added by ${user}"
-#: ./opengever/task/response_description.py:291
+#: ./opengever/task/response_description.py
 msgid "transition_add_subtask"
 msgstr ""
 
 #. Default: "Task accepted"
-#: ./opengever/task/response_description.py:146
+#: ./opengever/task/response_description.py
 msgid "transition_label_accept"
 msgstr ""
 
 #. Default: "Document added to Task"
-#: ./opengever/task/response_description.py:317
+#: ./opengever/task/response_description.py
 msgid "transition_label_add_document"
 msgstr ""
 
 #. Default: "Subtask added to task"
-#: ./opengever/task/response_description.py:297
+#: ./opengever/task/response_description.py
 msgid "transition_label_add_subtask"
 msgstr ""
 
 #. Default: "Forwarding assigned to Dossier"
-#: ./opengever/task/response_description.py:274
+#: ./opengever/task/response_description.py
 msgid "transition_label_assign_to_dossier"
 msgstr ""
 
 #. Default: "Task cancelled"
-#: ./opengever/task/response_description.py:130
+#: ./opengever/task/response_description.py
 msgid "transition_label_cancelled"
 msgstr ""
 
 #. Default: "Task closed"
-#: ./opengever/task/response_description.py:116
+#: ./opengever/task/response_description.py
 msgid "transition_label_close"
 msgstr ""
 
 #. Default: "Created by ${user}"
-#: ./opengever/task/viewlets/response.py:68
+#: ./opengever/task/viewlets/response.py
 msgid "transition_label_created"
 msgstr ""
 
 #. Default: "Task added"
-#: ./opengever/task/activities.py:26
-#: ./opengever/task/response_description.py:49
+#: ./opengever/task/activities.py
+#: ./opengever/task/response_description.py
 msgid "transition_label_default"
 msgstr ""
 
 #. Default: "Task deadline modified"
-#: ./opengever/task/response_description.py:224
+#: ./opengever/task/response_description.py
 msgid "transition_label_modify_deadline"
 msgstr ""
 
 #. Default: "Task reactivated"
-#: ./opengever/task/response_description.py:68
+#: ./opengever/task/response_description.py
 msgid "transition_label_reactivate"
 msgstr ""
 
 #. Default: "Task reassigned"
-#: ./opengever/task/response_description.py:199
+#: ./opengever/task/response_description.py
 msgid "transition_label_reassign"
 msgstr ""
 
 #. Default: "Forwarding refused"
-#: ./opengever/task/response_description.py:254
+#: ./opengever/task/response_description.py
 msgid "transition_label_refuse"
 msgstr ""
 
 #. Default: "Task rejected"
-#: ./opengever/task/response_description.py:82
+#: ./opengever/task/response_description.py
 msgid "transition_label_reject"
 msgstr ""
 
 #. Default: "Task reopened"
-#: ./opengever/task/response_description.py:161
+#: ./opengever/task/response_description.py
 msgid "transition_label_reopen"
 msgstr ""
 
 #. Default: "Task resolved"
-#: ./opengever/task/response_description.py:98
+#: ./opengever/task/response_description.py
 msgid "transition_label_resolve"
 msgstr ""
 
 #. Default: "Task revised"
-#: ./opengever/task/response_description.py:176
+#: ./opengever/task/response_description.py
 msgid "transition_label_revise"
 msgstr ""
 
 #. Default: "Accepted by ${user}"
-#: ./opengever/task/response_description.py:142
+#: ./opengever/task/response_description.py
 msgid "transition_msg_accept"
 msgstr ""
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
-#: ./opengever/task/response_description.py:268
+#: ./opengever/task/response_description.py
 msgid "transition_msg_assign_to_dossier"
 msgstr ""
 
 #. Default: "Cancelled by ${user}"
-#: ./opengever/task/response_description.py:126
+#: ./opengever/task/response_description.py
 msgid "transition_msg_cancel"
 msgstr ""
 
 #. Default: "Closed by ${user}"
-#: ./opengever/task/response_description.py:112
+#: ./opengever/task/response_description.py
 msgid "transition_msg_close"
 msgstr ""
 
 #. Default: "Response added"
-#: ./opengever/task/response_description.py:44
+#: ./opengever/task/response_description.py
 msgid "transition_msg_default"
 msgstr ""
 
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
-#: ./opengever/task/response_description.py:216
+#: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
 msgstr ""
 
 #. Default: "Reactivate by ${user}"
-#: ./opengever/task/response_description.py:64
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reactivate"
 msgstr ""
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
-#: ./opengever/task/response_description.py:191
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reassign"
 msgstr ""
 
 #. Default: "Refused by ${user}"
-#: ./opengever/task/response_description.py:250
+#: ./opengever/task/response_description.py
 msgid "transition_msg_refuse"
 msgstr ""
 
 #. Default: "Rejected by ${user}"
-#: ./opengever/task/response_description.py:78
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reject"
 msgstr ""
 
 #. Default: "Reopened by ${user}"
-#: ./opengever/task/response_description.py:157
+#: ./opengever/task/response_description.py
 msgid "transition_msg_reopen"
 msgstr ""
 
 #. Default: "Resolved by ${user}"
-#: ./opengever/task/response_description.py:94
+#: ./opengever/task/response_description.py
 msgid "transition_msg_resolve"
 msgstr ""
 
 #. Default: "Revised by ${user}"
-#: ./opengever/task/response_description.py:172
+#: ./opengever/task/response_description.py
 msgid "transition_msg_revise"
 msgstr ""
 
 #. Default: "Document copied from forwarding (forwarding accepted)"
-#: ./opengever/task/browser/accept/utils.py:94
+#: ./opengever/task/browser/accept/utils.py
 msgid "version_message_accept_forwarding"
 msgstr ""
 
 #. Default: "Document copied from task (task accepted)"
-#: ./opengever/task/browser/accept/utils.py:259
+#: ./opengever/task/browser/accept/utils.py
 msgid "version_message_accept_task"
 msgstr ""
 
 #. Default: "Document copied from task (task closed)"
-#: ./opengever/task/browser/close.py:249
-#: ./opengever/task/browser/complete.py:298
+#: ./opengever/task/browser/close.py
+#: ./opengever/task/browser/complete.py
 msgid "version_message_closed_task"
 msgstr ""
 
 #. Default: "Document copied from task (task resolved)"
-#: ./opengever/task/browser/complete.py:292
+#: ./opengever/task/browser/complete.py
 msgid "version_message_resolved_task"
 msgstr ""
 

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -20,209 +20,209 @@ msgstr "Beschreibung"
 msgid "Title"
 msgstr "Titel"
 
-#: ./opengever/tasktemplates/browser/form.pt:29
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "add tasktemplate"
 msgstr "Aufgabenvorlage hinzufügen"
 
 #. Default: "Cancel"
-#: ./opengever/tasktemplates/browser/trigger.py:127
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/trigger.py:115
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_continue"
 msgstr "Weiter"
 
 #. Default: "Trigger"
-#: ./opengever/tasktemplates/browser/trigger.py:207
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_trigger"
 msgstr "Auslösen"
 
-#: ./opengever/tasktemplates/browser/form.pt:32
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "choose template"
 msgstr "Vorlage auswählen"
 
 #. Default: "Interactive users"
-#: ./opengever/tasktemplates/vocabularies.py:25
+#: ./opengever/tasktemplates/vocabularies.py
 msgid "client_interactive_users"
 msgstr "Interaktiver Benutzer"
 
 #. Default: "Common"
-#: ./opengever/tasktemplates/content/tasktemplate.py:22
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "fieldset_common"
 msgstr "Allgemein"
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:79
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
 msgstr "Frist in Tagen ab Startdatum der Aufgabe."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:44
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_issuer"
 msgstr "Wählen Sie einen Auftraggeber aus. Sie können auch die interaktiven Benutzer \"Federführender\" oder \"Sachbearbeiter\" auswählen."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:93
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_preselected"
 msgstr "Diese Vorlage gehört zur Standardauswahl des Standardablaufs."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:72
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible"
 msgstr "Wählen Sie einen Auftragnehmer aus. Sie können auch die interaktiven Benutzer \"Federführender\" oder \"Sachbearbeiter\" auswählen."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:64
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible_client"
 msgstr "Wählen Sie den Mandanten des Auftragnehmers aus oder wählen Sie \"Interaktiver Benutzer\"."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:52
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
 msgstr "Wählen Sie den Typ der Aufgabe aus."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:86
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_text"
 msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:37
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_title"
 msgstr "Der Name der Aufgabe."
 
 #. Default: "Current user"
-#: ./opengever/tasktemplates/sources.py:18
+#: ./opengever/tasktemplates/sources.py
 msgid "interactive_user_current_user"
 msgstr "Sachbearbeiter"
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/sources.py:14
+#: ./opengever/tasktemplates/sources.py
 msgid "interactive_user_responsible"
 msgstr "Federführender"
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/form.pt:40
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "label_continue"
 msgstr "Weiter"
 
 #. Default: "Created"
-#: ./opengever/tasktemplates/browser/form.py:121
+#: ./opengever/tasktemplates/browser/form.py
 msgid "label_created"
 msgstr "Erstelldatum"
 
 #. Default: "Deadline in Days"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:54
-#: ./opengever/tasktemplates/content/tasktemplate.py:78
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"
 msgstr "Frist in Tagen"
 
 #. Default: "Issuer"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:46
-#: ./opengever/tasktemplates/content/tasktemplate.py:43
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "Preselect"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:57
-#: ./opengever/tasktemplates/content/tasktemplate.py:92
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_preselected"
 msgstr "Vorselektiert"
 
 #. Default: "Related documents"
-#: ./opengever/tasktemplates/browser/trigger.py:73
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_related_documents"
 msgstr "Verweise"
 
 #. Default: "Responsible Client"
-#: ./opengever/tasktemplates/content/tasktemplate.py:62
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_resonsible_client"
 msgstr "Mandant des Auftragnehmers"
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/content/tasktemplate.py:71
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_responsible"
 msgstr "Auftragnehmer"
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:50
+#: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "label_responsible_task"
 msgstr "Auftragnehmer"
 
 #. Default: "Review state"
-#: ./opengever/tasktemplates/browser/templatefolders.py:28
+#: ./opengever/tasktemplates/browser/templatefolders.py
 msgid "label_review_state"
 msgstr "Status"
 
 #. Default: "Select tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:94
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplatefolder"
 msgstr "Auswahl Standardablauf"
 
 #. Default: "Select tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:175
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplates"
 msgstr "Auswahl Aufgabenvorlagen"
 
 #. Default: "Task Type"
-#: ./opengever/tasktemplates/content/tasktemplate.py:51
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_task_type"
 msgstr "Auftragstyp"
 
 #. Default: "Tasktemplate selection"
-#: ./opengever/tasktemplates/browser/trigger.py:48
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplate_selection"
 msgstr "Auswahl Aufgabenvorlagen"
 
 #. Default: "Tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:67
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder"
 msgstr "Standardablauf"
 
 #. Default: "Tasktemplatefolder selection"
-#: ./opengever/tasktemplates/browser/trigger.py:44
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder_selection"
 msgstr "Auswahl Standardablauf"
 
 #. Default: "Tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:164
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplates"
 msgstr "Aufgabenvorlage"
 
 #. Default: "Text"
-#: ./opengever/tasktemplates/content/tasktemplate.py:85
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_text"
 msgstr "Kommentar"
 
 #. Default: "Title"
-#: ./opengever/tasktemplates/browser/form.py:119
-#: ./opengever/tasktemplates/browser/tasktemplates.py:37
-#: ./opengever/tasktemplates/browser/templatefolders.py:24
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/browser/templatefolders.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Yes"
-#: ./opengever/tasktemplates/browser/tasktemplates_templates/view.pt:39
+#: ./opengever/tasktemplates/browser/templates/view.pt
 msgid "label_yes"
 msgstr "Ja"
 
 #. Default: "You have not selected any templates"
-#: ./opengever/tasktemplates/browser/form.py:230
+#: ./opengever/tasktemplates/browser/form.py
 msgid "message_no_templates_selected"
 msgstr "Sie haben keine Vorlagen ausgewählt."
 
 #. Default: "tasks created"
-#: ./opengever/tasktemplates/browser/form.py:310
-#: ./opengever/tasktemplates/browser/trigger.py:221
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "message_tasks_created"
 msgstr "Alle Aufgaben aus gewähltem Standardablauf wurden erstellt."
 
 #. Default: "Currently there are no active task template folders registered."
-#: ./opengever/tasktemplates/browser/form.py:144
-#: ./opengever/tasktemplates/browser/trigger.py:107
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
 msgstr "Zurzeit sind keine aktiven Standardabläufe hinterlegt."
 
 #. Default: "Yes"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:19
+#: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
 msgstr "Ja"
 
-#: ./opengever/tasktemplates/browser/form.pt:33
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "select tasks"
 msgstr "Aufgaben auswählen"
 

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2016-09-20 21:23+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tasktemplates/fr/>\n"
@@ -22,209 +22,209 @@ msgstr "Description"
 msgid "Title"
 msgstr "Titre"
 
-#: ./opengever/tasktemplates/browser/form.pt:29
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "add tasktemplate"
 msgstr "Ajouter un modèle de tâches"
 
 #. Default: "Cancel"
-#: ./opengever/tasktemplates/browser/trigger.py:127
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_cancel"
 msgstr "Annuler"
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/trigger.py:115
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_continue"
 msgstr "Continuer"
 
 #. Default: "Trigger"
-#: ./opengever/tasktemplates/browser/trigger.py:207
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_trigger"
 msgstr "Enclencher"
 
-#: ./opengever/tasktemplates/browser/form.pt:32
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "choose template"
 msgstr "Choix du modèle"
 
 #. Default: "Interactive users"
-#: ./opengever/tasktemplates/vocabularies.py:25
+#: ./opengever/tasktemplates/vocabularies.py
 msgid "client_interactive_users"
 msgstr "Utilisateur interactif"
 
 #. Default: "Common"
-#: ./opengever/tasktemplates/content/tasktemplate.py:22
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "fieldset_common"
 msgstr "En général"
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:79
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
 msgstr "Délai en jours à partir de la date de début de la tâche."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:44
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_issuer"
 msgstr "Choix du client. Vous pouvez aussi choisir les utilisateurs interactifs \"responsables\" ou \"collaborateurs\"."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:93
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_preselected"
 msgstr "Ce modèle fait parti du choix standard des procédés standards."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:72
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible"
 msgstr "Choix du mandataire. Vous pouvez aussi choisir les utilisateurs interactifs \"responsables\" ou \"collaborateurs\"."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:64
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible_client"
 msgstr "Choix du client du mandataire ou choisissez \"utilisateur interactif\"."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:52
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
 msgstr "Choix le type de tâche."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:86
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_text"
 msgstr "Saisie d'une  instruction de travail détaillée ou d'un commentaire."
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:37
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_title"
 msgstr "Nom de la tâche."
 
 #. Default: "Current user"
-#: ./opengever/tasktemplates/sources.py:18
+#: ./opengever/tasktemplates/sources.py
 msgid "interactive_user_current_user"
 msgstr "Collaborateur"
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/sources.py:14
+#: ./opengever/tasktemplates/sources.py
 msgid "interactive_user_responsible"
 msgstr "Responsable"
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/form.pt:40
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "label_continue"
 msgstr "Continuer"
 
 #. Default: "Created"
-#: ./opengever/tasktemplates/browser/form.py:121
+#: ./opengever/tasktemplates/browser/form.py
 msgid "label_created"
 msgstr "Date de création"
 
 #. Default: "Deadline in Days"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:54
-#: ./opengever/tasktemplates/content/tasktemplate.py:78
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"
 msgstr "Délai en jours"
 
 #. Default: "Issuer"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:46
-#: ./opengever/tasktemplates/content/tasktemplate.py:43
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_issuer"
 msgstr "Mandataire"
 
 #. Default: "Preselect"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:57
-#: ./opengever/tasktemplates/content/tasktemplate.py:92
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_preselected"
 msgstr "Préséléctionné"
 
 #. Default: "Related documents"
-#: ./opengever/tasktemplates/browser/trigger.py:73
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_related_documents"
 msgstr "Renvois"
 
 #. Default: "Responsible Client"
-#: ./opengever/tasktemplates/content/tasktemplate.py:62
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_resonsible_client"
 msgstr "Mandataire du client"
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/content/tasktemplate.py:71
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_responsible"
 msgstr "Mandataire"
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:50
+#: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "label_responsible_task"
 msgstr "Mandataire"
 
 #. Default: "Review state"
-#: ./opengever/tasktemplates/browser/templatefolders.py:28
+#: ./opengever/tasktemplates/browser/templatefolders.py
 msgid "label_review_state"
 msgstr "Etat"
 
 #. Default: "Select tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:94
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplatefolder"
 msgstr "Sélectionner le processus standard"
 
 #. Default: "Select tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:175
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplates"
 msgstr "Sélectionner les modèles de tâches"
 
 #. Default: "Task Type"
-#: ./opengever/tasktemplates/content/tasktemplate.py:51
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_task_type"
 msgstr "Type de mandat"
 
 #. Default: "Tasktemplate selection"
-#: ./opengever/tasktemplates/browser/trigger.py:48
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplate_selection"
 msgstr "Sélectionner les modèles de tâches"
 
 #. Default: "Tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:67
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder"
 msgstr "Processus standard"
 
 #. Default: "Tasktemplatefolder selection"
-#: ./opengever/tasktemplates/browser/trigger.py:44
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder_selection"
 msgstr "Sélectionner le processus standard"
 
 #. Default: "Tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:164
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplates"
 msgstr "Modèles de tâches"
 
 #. Default: "Text"
-#: ./opengever/tasktemplates/content/tasktemplate.py:85
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_text"
 msgstr "commentaire"
 
 #. Default: "Title"
-#: ./opengever/tasktemplates/browser/form.py:119
-#: ./opengever/tasktemplates/browser/tasktemplates.py:37
-#: ./opengever/tasktemplates/browser/templatefolders.py:24
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/browser/templatefolders.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Yes"
-#: ./opengever/tasktemplates/browser/tasktemplates_templates/view.pt:39
+#: ./opengever/tasktemplates/browser/templates/view.pt
 msgid "label_yes"
 msgstr "Oui"
 
 #. Default: "You have not selected any templates"
-#: ./opengever/tasktemplates/browser/form.py:230
+#: ./opengever/tasktemplates/browser/form.py
 msgid "message_no_templates_selected"
 msgstr "Vous n'avez sélectionné aucun modèle."
 
 #. Default: "tasks created"
-#: ./opengever/tasktemplates/browser/form.py:310
-#: ./opengever/tasktemplates/browser/trigger.py:221
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "message_tasks_created"
 msgstr "Toutes les tâches du procédé standard ont été créées."
 
 #. Default: "Currently there are no active task template folders registered."
-#: ./opengever/tasktemplates/browser/form.py:144
-#: ./opengever/tasktemplates/browser/trigger.py:107
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
 msgstr "Aucun processus standard actif n'est enregistré pour le moment."
 
 #. Default: "Yes"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:19
+#: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
 msgstr "Oui"
 
-#: ./opengever/tasktemplates/browser/form.pt:33
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "select tasks"
 msgstr "Choix des tâches"
 

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,209 +23,209 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: ./opengever/tasktemplates/browser/form.pt:29
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "add tasktemplate"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./opengever/tasktemplates/browser/trigger.py:127
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_cancel"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/trigger.py:115
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_continue"
 msgstr ""
 
 #. Default: "Trigger"
-#: ./opengever/tasktemplates/browser/trigger.py:207
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "button_trigger"
 msgstr ""
 
-#: ./opengever/tasktemplates/browser/form.pt:32
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "choose template"
 msgstr ""
 
 #. Default: "Interactive users"
-#: ./opengever/tasktemplates/vocabularies.py:25
+#: ./opengever/tasktemplates/vocabularies.py
 msgid "client_interactive_users"
 msgstr ""
 
 #. Default: "Common"
-#: ./opengever/tasktemplates/content/tasktemplate.py:22
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "fieldset_common"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:79
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:44
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_issuer"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:93
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_preselected"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:72
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:64
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible_client"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:52
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:86
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_text"
 msgstr ""
 
-#: ./opengever/tasktemplates/content/tasktemplate.py:37
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_title"
 msgstr ""
 
 #. Default: "Current user"
-#: ./opengever/tasktemplates/sources.py:18
+#: ./opengever/tasktemplates/sources.py
 msgid "interactive_user_current_user"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/sources.py:14
+#: ./opengever/tasktemplates/sources.py
 msgid "interactive_user_responsible"
 msgstr ""
 
 #. Default: "Continue"
-#: ./opengever/tasktemplates/browser/form.pt:40
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "label_continue"
 msgstr ""
 
 #. Default: "Created"
-#: ./opengever/tasktemplates/browser/form.py:121
+#: ./opengever/tasktemplates/browser/form.py
 msgid "label_created"
 msgstr ""
 
 #. Default: "Deadline in Days"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:54
-#: ./opengever/tasktemplates/content/tasktemplate.py:78
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Issuer"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:46
-#: ./opengever/tasktemplates/content/tasktemplate.py:43
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_issuer"
 msgstr ""
 
 #. Default: "Preselect"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:57
-#: ./opengever/tasktemplates/content/tasktemplate.py:92
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_preselected"
 msgstr ""
 
 #. Default: "Related documents"
-#: ./opengever/tasktemplates/browser/trigger.py:73
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_related_documents"
 msgstr ""
 
 #. Default: "Responsible Client"
-#: ./opengever/tasktemplates/content/tasktemplate.py:62
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_resonsible_client"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/content/tasktemplate.py:71
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_responsible"
 msgstr ""
 
 #. Default: "Responsible"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:50
+#: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "label_responsible_task"
 msgstr ""
 
 #. Default: "Review state"
-#: ./opengever/tasktemplates/browser/templatefolders.py:28
+#: ./opengever/tasktemplates/browser/templatefolders.py
 msgid "label_review_state"
 msgstr ""
 
 #. Default: "Select tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:94
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Select tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:175
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplates"
 msgstr ""
 
 #. Default: "Task Type"
-#: ./opengever/tasktemplates/content/tasktemplate.py:51
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_task_type"
 msgstr ""
 
 #. Default: "Tasktemplate selection"
-#: ./opengever/tasktemplates/browser/trigger.py:48
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplate_selection"
 msgstr ""
 
 #. Default: "Tasktemplatefolder"
-#: ./opengever/tasktemplates/browser/trigger.py:67
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Tasktemplatefolder selection"
-#: ./opengever/tasktemplates/browser/trigger.py:44
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder_selection"
 msgstr ""
 
 #. Default: "Tasktemplates"
-#: ./opengever/tasktemplates/browser/trigger.py:164
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplates"
 msgstr ""
 
 #. Default: "Text"
-#: ./opengever/tasktemplates/content/tasktemplate.py:85
+#: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/tasktemplates/browser/form.py:119
-#: ./opengever/tasktemplates/browser/tasktemplates.py:37
-#: ./opengever/tasktemplates/browser/templatefolders.py:24
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/tasktemplates.py
+#: ./opengever/tasktemplates/browser/templatefolders.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Yes"
-#: ./opengever/tasktemplates/browser/tasktemplates_templates/view.pt:39
+#: ./opengever/tasktemplates/browser/templates/view.pt
 msgid "label_yes"
 msgstr ""
 
 #. Default: "You have not selected any templates"
-#: ./opengever/tasktemplates/browser/form.py:230
+#: ./opengever/tasktemplates/browser/form.py
 msgid "message_no_templates_selected"
 msgstr ""
 
 #. Default: "tasks created"
-#: ./opengever/tasktemplates/browser/form.py:310
-#: ./opengever/tasktemplates/browser/trigger.py:221
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "message_tasks_created"
 msgstr ""
 
 #. Default: "Currently there are no active task template folders registered."
-#: ./opengever/tasktemplates/browser/form.py:144
-#: ./opengever/tasktemplates/browser/trigger.py:107
+#: ./opengever/tasktemplates/browser/form.py
+#: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./opengever/tasktemplates/browser/tasktemplates.py:19
+#: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
 msgstr ""
 
-#: ./opengever/tasktemplates/browser/form.pt:33
+#: ./opengever/tasktemplates/browser/form.pt
 msgid "select tasks"
 msgstr ""
 

--- a/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: opengever.trash 1.0\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-05-03 09:38+0200\n"
 "Last-Translator: Julian Infanger <julian.infangner.@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -15,83 +15,83 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
-#: ./opengever/trash/trash.py:119
+#: ./opengever/trash/browser/trash.py
 msgid "Trashing ${title} is forbidden"
 msgstr "Das Objekt ${title} darf nicht in den Papierkorb verschoben werden."
 
-#: ./opengever/trash/trash.py:158
+#: ./opengever/trash/browser/trash.py
 msgid "Untrashing ${title} is forbidden"
 msgstr "Das Objekt ${title} darf nicht aus dem Papierkorb reaktiviert werden."
 
-#: ./opengever/trash/trash.py:134
+#: ./opengever/trash/browser/trash.py
 msgid "You have not selected any items."
 msgstr "Sie haben keine Objekte ausgewählt"
 
-#: ./opengever/trash/trash.py:100
+#: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "Das Objekt ${obj} wurde bereits in den Papierkorb verschoben"
 
-#: ./opengever/trash/trash.py:109
+#: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is checked out."
 msgstr "Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist ausgecheckt."
 
 #. Default: "You have not selected any items."
-#: ./opengever/trash/browser/remove_confirmation.py:35
+#: ./opengever/trash/browser/remove_confirmation.py
 msgid "error_no_documents_selected"
 msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "Delete"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:55
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_delete"
 msgstr "Löschen"
 
 #. Default: "Delete documents"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:19
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_delete_documents"
 msgstr "Dokumente löschen"
 
 #. Default: "Error"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:31
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_errror"
 msgstr "Fehler"
 
 #. Default: "The documents have been successfully deleted"
-#: ./opengever/trash/browser/remove_confirmation.py:26
+#: ./opengever/trash/browser/remove_confirmation.py
 msgid "label_successfully_deleted"
 msgstr "Die Dokumente wurden efolgreich gelöscht"
 
 #. Default: "Warning"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:24
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_warning"
 msgstr "Warnung"
 
 #. Default: "Do you really want to delete the selected documents?"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:25
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "msg_delete_confirmation"
 msgstr "Möchten Sie die selektierten Dokumente wirklich löschen?"
 
 #. Default: "The selected documents can't be removed, see error messages below."
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:32
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "msg_delete_not_possible"
 msgstr "Die selektierten Dokumente können nicht gelöscht werden."
 
 #. Default: "The document is referred by the document(s) ${links}."
-#: ./opengever/trash/remover.py:70
+#: ./opengever/trash/remover.py
 msgid "msg_document_has_backreferences"
 msgstr "Auf das Dokument existiert noch eine Referenz von Dokument ${links}."
 
 #. Default: "The document contains relations."
-#: ./opengever/trash/remover.py:60
+#: ./opengever/trash/remover.py
 msgid "msg_document_has_relations"
 msgstr "Das Dokument referenziert andere Dokumente."
 
 #. Default: "The document is still checked out."
-#: ./opengever/trash/remover.py:52
+#: ./opengever/trash/remover.py
 msgid "msg_document_is_checked_out"
 msgstr "Das Dokument ist noch ausgecheckt."
 
 #. Default: "The document is not trashed."
-#: ./opengever/trash/remover.py:77
+#: ./opengever/trash/remover.py
 msgid "msg_is_not_trashed"
 msgstr "Das Dokument ist noch nicht im Papierkorb."
 
@@ -99,7 +99,7 @@ msgstr "Das Dokument ist noch nicht im Papierkorb."
 msgid "remove"
 msgstr "Löschen"
 
-#: ./opengever/trash/trash.py:128
+#: ./opengever/trash/browser/trash.py
 msgid "the object ${obj} trashed"
 msgstr "Das Objekt ${obj} wurde in den Papierkorb verschoben."
 

--- a/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
@@ -1,99 +1,98 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: 2017-09-03 09:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-trash/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-trash/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
-#: ./opengever/trash/trash.py:119
+#: ./opengever/trash/browser/trash.py
 msgid "Trashing ${title} is forbidden"
 msgstr ""
 
-#: ./opengever/trash/trash.py:158
+#: ./opengever/trash/browser/trash.py
 msgid "Untrashing ${title} is forbidden"
 msgstr ""
 
-#: ./opengever/trash/trash.py:134
+#: ./opengever/trash/browser/trash.py
 msgid "You have not selected any items."
 msgstr ""
 
-#: ./opengever/trash/trash.py:100
+#: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "L'objet a été déplacé vers la corbeille"
 
-#: ./opengever/trash/trash.py:109
+#: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is checked out."
 msgstr "L'objet ${obj} a un checkout. Vous ne pouvez pas le supprimer."
 
 #. Default: "You have not selected any items."
-#: ./opengever/trash/browser/remove_confirmation.py:35
+#: ./opengever/trash/browser/remove_confirmation.py
 msgid "error_no_documents_selected"
 msgstr "Vous n'avez sélectionné aucun élément."
 
 #. Default: "Delete"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:55
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_delete"
 msgstr "Effacer"
 
 #. Default: "Delete documents"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:19
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_delete_documents"
 msgstr "Effacer les documents"
 
 #. Default: "Error"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:31
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_errror"
 msgstr "Erreur"
 
 #. Default: "The documents have been successfully deleted"
-#: ./opengever/trash/browser/remove_confirmation.py:26
+#: ./opengever/trash/browser/remove_confirmation.py
 msgid "label_successfully_deleted"
 msgstr "Les documents ont été effacés avec succès"
 
 #. Default: "Warning"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:24
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_warning"
 msgstr "Avertissement"
 
 #. Default: "Do you really want to delete the selected documents?"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:25
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "msg_delete_confirmation"
 msgstr "Voulez-vous vraiment effacer les documents selectionnés?"
 
 #. Default: "The selected documents can't be removed, see error messages below."
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:32
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "msg_delete_not_possible"
 msgstr "Les documents selectionnés ne peuvent pas être effacés."
 
 #. Default: "The document is referred by the document(s) ${links}."
-#: ./opengever/trash/remover.py:70
+#: ./opengever/trash/remover.py
 msgid "msg_document_has_backreferences"
 msgstr "Le document ${links} fait encore référence à ce document."
 
 #. Default: "The document contains relations."
-#: ./opengever/trash/remover.py:60
+#: ./opengever/trash/remover.py
 msgid "msg_document_has_relations"
 msgstr "Le document fait réference à d'autres documents."
 
 #. Default: "The document is still checked out."
-#: ./opengever/trash/remover.py:52
+#: ./opengever/trash/remover.py
 msgid "msg_document_is_checked_out"
 msgstr "Le document est encore en checkout."
 
 #. Default: "The document is not trashed."
-#: ./opengever/trash/remover.py:77
+#: ./opengever/trash/remover.py
 msgid "msg_is_not_trashed"
 msgstr "Le document n'est pas encore dans la corbeille."
 
@@ -101,6 +100,7 @@ msgstr "Le document n'est pas encore dans la corbeille."
 msgid "remove"
 msgstr "Effacer"
 
-#: ./opengever/trash/trash.py:128
+#: ./opengever/trash/browser/trash.py
 msgid "the object ${obj} trashed"
 msgstr "L'objet ${obj} a été déplacé dans la corbeille."
+

--- a/opengever/trash/locales/opengever.trash.pot
+++ b/opengever/trash/locales/opengever.trash.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-07 12:34+0000\n"
+"POT-Creation-Date: 2017-10-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,83 +17,83 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.trash\n"
 
-#: ./opengever/trash/trash.py:119
+#: ./opengever/trash/browser/trash.py
 msgid "Trashing ${title} is forbidden"
 msgstr ""
 
-#: ./opengever/trash/trash.py:158
+#: ./opengever/trash/browser/trash.py
 msgid "Untrashing ${title} is forbidden"
 msgstr ""
 
-#: ./opengever/trash/trash.py:134
+#: ./opengever/trash/browser/trash.py
 msgid "You have not selected any items."
 msgstr ""
 
-#: ./opengever/trash/trash.py:100
+#: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr ""
 
-#: ./opengever/trash/trash.py:109
+#: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is checked out."
 msgstr ""
 
 #. Default: "You have not selected any items."
-#: ./opengever/trash/browser/remove_confirmation.py:35
+#: ./opengever/trash/browser/remove_confirmation.py
 msgid "error_no_documents_selected"
 msgstr ""
 
 #. Default: "Delete"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:55
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_delete"
 msgstr ""
 
 #. Default: "Delete documents"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:19
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_delete_documents"
 msgstr ""
 
 #. Default: "Error"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:31
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_errror"
 msgstr ""
 
 #. Default: "The documents have been successfully deleted"
-#: ./opengever/trash/browser/remove_confirmation.py:26
+#: ./opengever/trash/browser/remove_confirmation.py
 msgid "label_successfully_deleted"
 msgstr ""
 
 #. Default: "Warning"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:24
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "label_warning"
 msgstr ""
 
 #. Default: "Do you really want to delete the selected documents?"
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:25
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "msg_delete_confirmation"
 msgstr ""
 
 #. Default: "The selected documents can't be removed, see error messages below."
-#: ./opengever/trash/browser/remove_confirmation_templates/remove_confirmation.pt:32
+#: ./opengever/trash/browser/templates/remove_confirmation.pt
 msgid "msg_delete_not_possible"
 msgstr ""
 
 #. Default: "The document is referred by the document(s) ${links}."
-#: ./opengever/trash/remover.py:70
+#: ./opengever/trash/remover.py
 msgid "msg_document_has_backreferences"
 msgstr ""
 
 #. Default: "The document contains relations."
-#: ./opengever/trash/remover.py:60
+#: ./opengever/trash/remover.py
 msgid "msg_document_has_relations"
 msgstr ""
 
 #. Default: "The document is still checked out."
-#: ./opengever/trash/remover.py:52
+#: ./opengever/trash/remover.py
 msgid "msg_document_is_checked_out"
 msgstr ""
 
 #. Default: "The document is not trashed."
-#: ./opengever/trash/remover.py:77
+#: ./opengever/trash/remover.py
 msgid "msg_is_not_trashed"
 msgstr ""
 
@@ -101,7 +101,7 @@ msgstr ""
 msgid "remove"
 msgstr ""
 
-#: ./opengever/trash/trash.py:128
+#: ./opengever/trash/browser/trash.py
 msgid "the object ${obj} trashed"
 msgstr ""
 


### PR DESCRIPTION
**Motivation:**
The translation files often have a lot of changes when moving code around.  These changes are very noisy in the diffs.

**Change:**
Let bin/i18n-build remove the line numbers from comments in the generated pot files. These changes are then synced to the po files. This only applies to automatically generated pot files (primary package domain).