### PR TITLE
Testing: use long assertion messages.

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -38,6 +38,7 @@ from plone.testing import z2
 from plone.transformchain.interfaces import ITransform
 from Products.CMFCore.utils import getToolByName
 from Testing.ZopeTestCase.utils import setupCoreSessions
+from unittest import TestCase
 from zope.component import getGlobalSiteManager
 from zope.component import getMultiAdapter
 from zope.component import getSiteManager
@@ -62,6 +63,7 @@ for name, level in {'plone.protect': logging.INFO,
 
 
 snapshots.disable()
+TestCase.longMessage = True
 
 
 def clear_transmogrifier_registry():

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -19,7 +19,7 @@ from opengever.core.cached_testing import CACHE_GEVER_FIXTURE
 from opengever.core.cached_testing import CACHE_GEVER_INSTALLATION
 from opengever.core.cached_testing import CACHED_COMPONENT_REGISTRY_ISOLATION
 from opengever.core.cached_testing import DB_CACHE_MANAGER
-from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings # noqa
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings  # noqa
 from opengever.meeting.interfaces import IMeetingSettings
 from opengever.officeatwork.interfaces import IOfficeatworkSettings
 from opengever.private import enable_opengever_private
@@ -428,7 +428,6 @@ class ContentFixtureLayer(OpengeverFixture):
     a new transaction.
     """
 
-
     defaultBases = (CACHED_COMPONENT_REGISTRY_ISOLATION, )
 
     def __init__(self):
@@ -516,9 +515,9 @@ class GEVERIntegrationTesting(IntegrationTesting):
         # changes we need to mark the session as changed first.
         mark_changed(create_session())
         self.savepoint = transaction.savepoint()
-        self.interceptor.intercept(self.interceptor.BEGIN
-                                   | self.interceptor.COMMIT
-                                   | self.interceptor.ABORT)
+        self.interceptor.intercept(self.interceptor.BEGIN |
+                                   self.interceptor.COMMIT |
+                                   self.interceptor.ABORT)
         self.interceptor.begin_savepoint_simulation()
         self.interceptor.begin()
         logout()


### PR DESCRIPTION
We switched from unittest2 to unittest. One difference is that unittest2 has the longMessage set to True be default, but unittest does not. We want long messages, which include a repr of the compared objects, since used to have that and a lot of assertions depend on that.

Before:
```
AssertionError: Object <Proposal at /plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/proposal-4> has an incorrect workflow state.
```
After:
```
AssertionError: {'catalog metadata': 'asdf', 'object': 'asdf', 'catalog index': 'asdf'} != {'catalog metadata': 'proposal-state-submitted', 'object': 'proposal-state-submi [truncated]...
- {'catalog index': 'asdf', 'catalog metadata': 'asdf', 'object': 'asdf'}
+ {'catalog index': 'proposal-state-submitted',
+  'catalog metadata': 'proposal-state-submitted',
+  'object': 'proposal-state-submitted'} : Object <Proposal at /plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/proposal-4> has an incorrect workflow state
```

Discussion:
https://4teamwork.slack.com/archives/C062G6FGT/p1506590346000121