### PR TITLE
Fix "stale association proxy" error.

### DIFF
--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -80,11 +80,16 @@ class NotificationCenter(object):
                 self.session.delete(subscription)
 
     def get_watchers(self, oguid):
+        """Returns a read-only tuple of watchers for a given oguid.
+        """
         resource = Resource.query.get_by_oguid(oguid)
         if not resource:
-            return []
+            return ()
 
-        return resource.watchers
+        # resources.watchers is an association_proxy. When not consumed properly
+        # the GC will remove things, resulting in a "stale association proxy"
+        # error. In order to avoid that we consume it by making a tuple.
+        return tuple(resource.watchers)
 
     def add_activity(self, oguid, kind, title, label, summary, actor_id, description):
         if description is None:

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -131,12 +131,12 @@ class TestWatcherHandling(ActivityTestCase):
         self.assertEquals(123, resource_1.int_id)
         self.assertEquals(456, resource_2.int_id)
 
-        self.assertEquals([hugo, fritz], self.center.get_watchers(Oguid('fd', '123')))
-        self.assertEquals([peter],
+        self.assertEquals((hugo, fritz), self.center.get_watchers(Oguid('fd', '123')))
+        self.assertEquals((peter,),
                           self.center.get_watchers(Oguid('fd', '456')))
 
     def test_get_watchers_returns_empty_list_when_resource_not_exists(self):
-        self.assertEquals([], self.center.get_watchers(Oguid('fd', '123')))
+        self.assertEquals((), self.center.get_watchers(Oguid('fd', '123')))
 
     def test_remove_watcher_from_resource_will_be_ignored_when_watcher_not_exists(self):
         create(Builder('resource').oguid('fd:123'))


### PR DESCRIPTION
Fixes a flaky bug where the use of get_watchers sometimes threw a "InvalidRequestError: stale association proxy, parent object has gone out of scope"

The reason for this error is that resource.watchers is an association proxy, which is implemented lazy. This leads to situations where the garbage collector removes objects which are parts of lambdas within the association proxy object, because the GC believes there are no references to those objects (refcount is 0).

This means we need to consume the watchers within the same scope we access the watchers attribute. Thus the get_watchers method cannot return a lazy association proxy object but must resolve it first.

This is achieved by putting the watchers into a tuple. This resolves lazyness while making sure that no user of get_watchers tries to add new watchers (expecting an association proxy).

Traceback:
```python
Error in test test_all_team_members_are_notified_for_a_new_team_task (opengever.task.tests.test_team_tasks.TestTeamTasks)
Traceback (most recent call last):
  File "/var/lib/jenkins/zope/eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
    testMethod()
  File "/var/lib/jenkins/zope/eggs/ftw.testbrowser-1.27.0-py2.7.egg/ftw/testbrowser/__init__.py", line 42, in test_function
    return func(self, *args, **kwargs)
  File "/var/lib/jenkins/jobs/opengever.core/workspace@2/opengever/task/tests/test_team_tasks.py", line 76, in test_all_team_members_are_notified_for_a_new_team_task
    [watcher.actorid for watcher in center.get_watchers(task)]
  File "/var/lib/jenkins/zope/eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/ext/associationproxy.py", line 604, in __iter__
    for member in self.col:
  File "/var/lib/jenkins/zope/eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/ext/associationproxy.py", line 509, in <lambda>
    col = property(lambda self: self.lazy_collection())
  File "/var/lib/jenkins/zope/eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/ext/associationproxy.py", line 465, in __call__
    "stale association proxy, parent object has gone out of "
InvalidRequestError: stale association proxy, parent object has gone out of scope
```

Related attempt to fix this problem: #3434