### PR TITLE
Add protocol suffix template

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -31,6 +31,7 @@ Changelog
 - SPV word: Introduce successor proposals. [jone]
 - Ungrok proposal add form. [jone]
 - Reworked initial version creation: do not create a initial version until the file will be changed. [phgross]
+- SPV word: Add protocol header and suffix templates. [tarnap]
 - SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]
 - SPV word: Hide excerpt template from form when word feature enabled. [tarnap]

--- a/opengever/meeting/browser/committeecontainer_forms.py
+++ b/opengever/meeting/browser/committeecontainer_forms.py
@@ -9,20 +9,25 @@ from zope.component import adapter
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
-class AddForm(TranslatedTitleAddForm):
-    """Add form for opengever.meeting.committeecontainer."""
+class CommitteContainerFieldConfigurationMixin(object):
+    """Form mixin, configuring the avialable fields of committe container
+    forms according to the feature flag configuration.
+    """
 
-    def updateWidgets(self):
-        super(AddForm, self).updateWidgets()
-
-        if not is_word_meeting_implementation_enabled():
-            self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
-            self.widgets['paragraph_template'].mode = HIDDEN_MODE
-            self.widgets['protocol_header_template'].mode = HIDDEN_MODE
-            self.widgets['protocol_suffix_template'].mode = HIDDEN_MODE
+    def updateFields(self):
+        super(CommitteContainerFieldConfigurationMixin, self).updateFields()
+        if is_word_meeting_implementation_enabled():
+            self.fields = self.fields.omit('excerpt_template',
+                                           'protocol_template')
         else:
-            self.widgets['excerpt_template'].mode = HIDDEN_MODE
-            self.widgets['protocol_template'].mode = HIDDEN_MODE
+            self.fields = self.fields.omit('ad_hoc_template',
+                                           'paragraph_template',
+                                           'protocol_header_template',
+                                           'protocol_suffix_template')
+
+
+class AddForm(CommitteContainerFieldConfigurationMixin, TranslatedTitleAddForm):
+    """Add form for opengever.meeting.committeecontainer."""
 
 
 @adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
@@ -30,17 +35,5 @@ class AddView(DefaultAddView):
     form = AddForm
 
 
-class EditForm(TranslatedTitleEditForm):
+class EditForm(CommitteContainerFieldConfigurationMixin, TranslatedTitleEditForm):
     """Edit form for opengever.meeting.committeecontainer."""
-
-    def updateWidgets(self):
-        super(EditForm, self).updateWidgets()
-
-        if not is_word_meeting_implementation_enabled():
-            self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
-            self.widgets['paragraph_template'].mode = HIDDEN_MODE
-            self.widgets['protocol_header_template'].mode = HIDDEN_MODE
-            self.widgets['protocol_suffix_template'].mode = HIDDEN_MODE
-        else:
-            self.widgets['excerpt_template'].mode = HIDDEN_MODE
-            self.widgets['protocol_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/browser/committeecontainer_forms.py
+++ b/opengever/meeting/browser/committeecontainer_forms.py
@@ -18,8 +18,11 @@ class AddForm(TranslatedTitleAddForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_header_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_suffix_template'].mode = HIDDEN_MODE
         else:
             self.widgets['excerpt_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_template'].mode = HIDDEN_MODE
 
 
 @adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
@@ -36,5 +39,8 @@ class EditForm(TranslatedTitleEditForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_header_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_suffix_template'].mode = HIDDEN_MODE
         else:
             self.widgets['excerpt_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -57,8 +57,11 @@ class AddForm(BaseWizardStepForm, dexterity.AddForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_header_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_suffix_template'].mode = HIDDEN_MODE
         else:
             self.widgets['excerpt_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_template'].mode = HIDDEN_MODE
 
     @buttonAndHandler(_(u'button_continue', default=u'Continue'), name='save')
     def handle_continue(self, action):
@@ -180,5 +183,8 @@ class EditForm(ModelProxyEditForm, dexterity.EditForm):
         if not is_word_meeting_implementation_enabled():
             self.widgets['ad_hoc_template'].mode = HIDDEN_MODE
             self.widgets['paragraph_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_header_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_suffix_template'].mode = HIDDEN_MODE
         else:
             self.widgets['excerpt_template'].mode = HIDDEN_MODE
+            self.widgets['protocol_template'].mode = HIDDEN_MODE

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -1,5 +1,3 @@
-from docx import Document
-from docxcompose.composer import Composer
 from opengever.base import advancedjson
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.interfaces import IDataCollector
@@ -18,6 +16,7 @@ from opengever.meeting.exceptions import AgendaItemListMissingTemplate
 from opengever.meeting.exceptions import MissingParagraphTemplate
 from opengever.meeting.exceptions import ProtocolAlreadyGenerated
 from opengever.meeting.interfaces import IHistory
+from opengever.meeting.mergetool import DocxMergeTool
 from opengever.meeting.model.generateddocument import GeneratedAgendaItemList
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.model.generateddocument import GeneratedProtocol
@@ -27,10 +26,10 @@ from opengever.meeting.protocol import ExcerptProtocolData
 from opengever.meeting.protocol import ProtocolData
 from opengever.meeting.sablon import Sablon
 from opengever.ogds.base.utils import decode_for_json
-from os.path import join
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.locking.interfaces import ILockable
+from plone.memoize import instance
 from plone.namedfile.file import NamedBlobFile
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -38,8 +37,6 @@ from zope.globalrequest import getRequest
 from zope.i18n import translate
 import base64
 import json
-import shutil
-import tempfile
 
 
 MIME_DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
@@ -338,73 +335,40 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
         return document
 
     def generate_file_data(self):
-        header_sablon = Sablon(self.meeting.get_protocol_header_template())
-        header_sablon.process(self.document_operations.get_meeting_data(
-            self.meeting).as_json())
+        with DocxMergeTool() as merge_tool:
+            merge_tool.add_sablon(self.get_header_sablon())
 
-        suffix = self.meeting.get_protocol_suffix_template()
-        if suffix is not None:
-            suffix_sablon = Sablon(self.meeting.get_protocol_suffix_template())
-            suffix_sablon.process(self.document_operations.get_meeting_data(
-                self.meeting).as_json())
-
-        tmpdir_path = tempfile.mkdtemp(prefix='opengever.core.doxcmerge_')
-        master_path = join(tmpdir_path, 'master.docx')
-        suffix_path = join(tmpdir_path, 'suffix.docx')
-        output_path = join(tmpdir_path, 'protocol.docx')
-
-        try:
-            # XXX: this is a bit dumb since sablon would already have generated
-            # a temporary file
-            with open(master_path, 'wb') as master_file:
-                master_file.write(header_sablon.file_data)
-
-            composer = Composer(Document(master_path))
-
-            for index, agenda_item in enumerate(self.meeting.agenda_items):
-                target_path = join(tmpdir_path, 'agenda_item_{}.docx'.format(index))
+            for agenda_item in self.meeting.agenda_items:
                 if agenda_item.is_paragraph:
-                    self._export_paragraph_as_document(agenda_item, target_path)
-                    composer.append(Document(target_path))
+                    merge_tool.add_sablon(self.get_sablon_for_paragraph(agenda_item))
 
                 elif agenda_item.has_document:
-                    self._export_regular_agenda_item_document(agenda_item, target_path)
-                    composer.append(Document(target_path))
+                    merge_tool.add_document(agenda_item.resolve_document())
 
-            if suffix is not None:
-                with open(suffix_path, 'wb') as suffix_file:
-                    suffix_file.write(suffix_sablon.file_data)
-                composer.append(suffix_file)
+            if self.meeting.get_protocol_suffix_template():
+                merge_tool.add_sablon(self.get_suffix_sablon())
 
-            composer.save(output_path)
+            return merge_tool()
 
-            with open(output_path, 'rb') as merged_file:
-                data = merged_file.read()
-        finally:
-            shutil.rmtree(tmpdir_path)
+    def get_header_sablon(self):
+        return Sablon(self.meeting.get_protocol_header_template()).process(
+            self.document_operations.get_meeting_data(self.meeting).as_json())
 
-        return data
+    def get_suffix_sablon(self):
+        return Sablon(self.meeting.get_protocol_suffix_template()).process(
+            self.document_operations.get_meeting_data(self.meeting).as_json())
 
-    def _export_regular_agenda_item_document(self, agenda_item, target_path):
-        document = agenda_item.resolve_document()
-        with open(target_path, 'wb') as fio:
-            fio.write(document.file.data)
+    def get_sablon_for_paragraph(self, agenda_item):
+        return Sablon(self._get_paragraph_template()).process(
+            ProtocolData(self.meeting, [agenda_item]).as_json())
 
-    def _export_paragraph_as_document(self, agenda_item, target_path):
-        sablon = Sablon(self._get_paragraph_template())
-        sablon.process(ProtocolData(self.meeting, [agenda_item]).as_json())
-        with open(target_path, 'wb') as fio:
-            fio.write(sablon.file_data)
-
+    @instance.memoize
     def _get_paragraph_template(self):
-        if hasattr(self, '_paragraph_template'):
-            return self._paragraph_template
-
         committee = self.meeting.committee.resolve_committee()
-        self._paragraph_template = committee.get_paragraph_template()
-        if self._paragraph_template is None:
+        template = committee.get_paragraph_template()
+        if template is None:
             raise MissingParagraphTemplate()
-        return self._paragraph_template
+        return template
 
 
 class UpdateGeneratedDocumentCommand(object):

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -61,6 +61,20 @@ class ICommittee(form.Schema):
         required=False,
     )
 
+    protocol_header_template = RelationChoice(
+        title=_('label_protocol_header_template',
+                default='Protocol header template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
+    protocol_suffix_template = RelationChoice(
+        title=_('label_protocol_suffix_template',
+                default='Protocol suffix template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
     excerpt_template = RelationChoice(
         title=_('Excerpt template'),
         source=sablon_template_source,
@@ -232,6 +246,18 @@ class Committee(ModelContainer):
             return self.protocol_template.to_object
 
         return self.get_committee_container().get_protocol_template()
+
+    def get_protocol_header_template(self):
+        if self.protocol_header_template:
+            return self.protocol_header_template.to_object
+
+        return self.get_committee_container().get_protocol_header_template()
+
+    def get_protocol_suffix_template(self):
+        if self.protocol_suffix_template:
+            return self.protocol_suffix_template.to_object
+
+        return self.get_committee_container().get_protocol_suffix_template()
 
     def get_excerpt_template(self):
         if self.excerpt_template:

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,6 +1,5 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.meeting import _
-from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.model import Member
 from opengever.meeting.sources import proposal_template_source
@@ -9,26 +8,6 @@ from opengever.meeting.wrapper import MemberWrapper
 from plone.dexterity.content import Container
 from plone.directives import form
 from z3c.relationfield.schema import RelationChoice
-from zope.interface import Invalid
-
-
-def required_with_word_feature(value):
-    if is_word_meeting_implementation_enabled():
-        # The excerpt template is not used when word-meeting feature is enabled
-        return True
-    if not value:
-        raise Invalid()
-    return True
-
-
-def required_without_word_feature(value):
-    if not is_word_meeting_implementation_enabled():
-        # protocol header template and protocol suffix template are only used
-        # when the word-meeting feature is enabled
-        return True
-    if not value:
-        raise Invalid()
-    return True
 
 
 class ICommitteeContainer(form.Schema):
@@ -38,16 +17,14 @@ class ICommitteeContainer(form.Schema):
     protocol_template = RelationChoice(
         title=_('Protocol template'),
         source=sablon_template_source,
-        required=False,
-        constraint=required_without_word_feature,
+        required=True,
     )
 
     protocol_header_template = RelationChoice(
         title=_('label_protocol_header_template',
                 default='Protocol header template'),
         source=sablon_template_source,
-        required=False,
-        constraint=required_with_word_feature,
+        required=True,
     )
 
     protocol_suffix_template = RelationChoice(
@@ -60,8 +37,7 @@ class ICommitteeContainer(form.Schema):
     excerpt_template = RelationChoice(
         title=_('Excerpt template'),
         source=sablon_template_source,
-        required=False,
-        constraint=required_without_word_feature,
+        required=True,
     )
 
     agendaitem_list_template = RelationChoice(

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -12,9 +12,19 @@ from z3c.relationfield.schema import RelationChoice
 from zope.interface import Invalid
 
 
-def excerpt_template_constraint(value):
+def required_with_word_feature(value):
     if is_word_meeting_implementation_enabled():
         # The excerpt template is not used when word-meeting feature is enabled
+        return True
+    if not value:
+        raise Invalid()
+    return True
+
+
+def required_without_word_feature(value):
+    if not is_word_meeting_implementation_enabled():
+        # protocol header template and protocol suffix template are only used
+        # when the word-meeting feature is enabled
         return True
     if not value:
         raise Invalid()
@@ -28,14 +38,30 @@ class ICommitteeContainer(form.Schema):
     protocol_template = RelationChoice(
         title=_('Protocol template'),
         source=sablon_template_source,
-        required=True,
+        required=False,
+        constraint=required_without_word_feature,
+    )
+
+    protocol_header_template = RelationChoice(
+        title=_('label_protocol_header_template',
+                default='Protocol header template'),
+        source=sablon_template_source,
+        required=False,
+        constraint=required_with_word_feature,
+    )
+
+    protocol_suffix_template = RelationChoice(
+        title=_('label_protocol_suffix_template',
+                default='Protocol suffix template'),
+        source=sablon_template_source,
+        required=False,
     )
 
     excerpt_template = RelationChoice(
         title=_('Excerpt template'),
         source=sablon_template_source,
         required=False,
-        constraint=excerpt_template_constraint,
+        constraint=required_without_word_feature,
     )
 
     agendaitem_list_template = RelationChoice(
@@ -96,6 +122,12 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
 
     def get_protocol_template(self):
         return self.protocol_template.to_object
+
+    def get_protocol_header_template(self):
+        return self.protocol_header_template.to_object
+
+    def get_protocol_suffix_template(self):
+        return getattr(self.protocol_suffix_template, 'to_object', None)
 
     def get_excerpt_template(self):
         return self.excerpt_template.to_object

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1148,10 +1148,20 @@ msgstr "Antragsvorlage"
 msgid "label_proposed_action"
 msgstr "Antrag"
 
+#. Default: "Protocol header template"
+#: ./opengever/meeting/committee.py:65
+msgid "label_protocol_header_template"
+msgstr "Vorlage Protokollkopf"
+
 #. Default: "Protocol start-page"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
+
+#. Default: "Protocol suffix template"
+#: ./opengever/meeting/committee.py:72
+msgid "label_protocol_suffix_template"
+msgstr "Vorlage Schlussteil des Protokolls"
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1150,10 +1150,20 @@ msgstr "Modèle de proposition"
 msgid "label_proposed_action"
 msgstr "Proposition"
 
+#. Default: "Protocol header template"
+#: ./opengever/meeting/committee.py:65
+msgid "label_protocol_header_template"
+msgstr ""
+
 #. Default: "Protocol start-page"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_protocol_start_page_number"
 msgstr "Début de la numérotation des pages du protocole"
+
+#. Default: "Protocol suffix template"
+#: ./opengever/meeting/committee.py:72
+msgid "label_protocol_suffix_template"
+msgstr ""
 
 #. Default: "Publish in"
 #: ./opengever/meeting/browser/meetings/protocol.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -1147,9 +1147,19 @@ msgstr ""
 msgid "label_proposed_action"
 msgstr ""
 
+#. Default: "Protocol header template"
+#: ./opengever/meeting/committee.py:65
+msgid "label_protocol_header_template"
+msgstr ""
+
 #. Default: "Protocol start-page"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_protocol_start_page_number"
+msgstr ""
+
+#. Default: "Protocol suffix template"
+#: ./opengever/meeting/committee.py:72
+msgid "label_protocol_suffix_template"
 msgstr ""
 
 #. Default: "Publish in"

--- a/opengever/meeting/mergetool.py
+++ b/opengever/meeting/mergetool.py
@@ -1,0 +1,50 @@
+from docx import Document
+from docxcompose.composer import Composer
+from path import Path
+import tempfile
+
+
+class DocxMergeTool(object):
+    """The docx merge tool merges docx documents with the docxcompose composer.
+
+    It is used as a context manager and accepts GEVER documents (add_document)
+    or Sablon instances (add_sablon).
+    Calling the DocxMergeTool object merges the documents and returns the resulting
+    bytes.
+    The files are merged in the order they were added.
+    """
+
+    def __enter__(self):
+        self._tempdir_path = Path(tempfile.mkdtemp(prefix='opengever.core.doxcmerge_'))
+        self._file_paths = []
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self._tempdir_path.rmtree_p()
+
+    def add_document(self, document):
+        """Add a opengever.document.document.
+        """
+        self._get_file().write_bytes(document.file.data)
+
+    def add_sablon(self, sablon):
+        """Add the document of a sablon instance, which is already processed.
+        """
+        self._get_file().write_bytes(sablon.file_data)
+
+    def __call__(self):
+        """Merge the registered docx files and return the resulting bytes.
+        """
+        if len(self._file_paths) == 0:
+            raise ValueError('No files to merge.')
+
+        composer = Composer(Document(self._file_paths[0]))
+        map(composer.append, map(Document, self._file_paths[1:]))
+        result_path = self._tempdir_path.joinpath('result.docx')
+        composer.save(result_path)
+        return result_path.bytes()
+
+    def _get_file(self):
+        path = self._tempdir_path.joinpath('{0}.docx'.format(len(self._file_paths)))
+        self._file_paths.append(path)
+        return path

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -90,6 +90,12 @@ class Committee(Base):
     def get_protocol_template(self):
         return self.resolve_committee().get_protocol_template()
 
+    def get_protocol_header_template(self):
+        return self.resolve_committee().get_protocol_header_template()
+
+    def get_protocol_suffix_template(self):
+        return self.resolve_committee().get_protocol_suffix_template()
+
     def get_excerpt_template(self):
         return self.resolve_committee().get_excerpt_template()
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -322,6 +322,12 @@ class Meeting(Base, SQLFormSupport):
     def get_protocol_template(self):
         return self.committee.get_protocol_template()
 
+    def get_protocol_header_template(self):
+        return self.committee.get_protocol_header_template()
+
+    def get_protocol_suffix_template(self):
+        return self.committee.get_protocol_suffix_template()
+
     def get_excerpt_template(self):
         return self.committee.get_excerpt_template()
 

--- a/opengever/meeting/sablon.py
+++ b/opengever/meeting/sablon.py
@@ -37,5 +37,7 @@ class Sablon(object):
         finally:
             shutil.rmtree(tmpdir_path)
 
+        return self
+
     def is_processed_successfully(self):
         return self.returncode == 0

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -4,10 +4,12 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import dexterity
 from ftw.testbrowser.pages import editbar
+from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
 from opengever.base.oguid import Oguid
 from opengever.meeting.model import Committee
 from opengever.testing import IntegrationTestCase
+from operator import methodcaller
 
 
 class TestCommittee(IntegrationTestCase):
@@ -231,3 +233,31 @@ class TestCommitteeWorkflow(IntegrationTestCase):
 
         editbar.menu_option('Actions', 'deactivate').click()
         self.assertEqual([u'Actions'], editbar.menus())
+
+    @browsing
+    def test_visible_fields_in_forms(self, browser):
+        """Some fields should only be displayed when the word feature is
+        disabled.
+        Therefore we test the appearance of all fields.
+        """
+        fields = ['Title',
+                  'Group',
+                  'Protocol template',
+                  'Excerpt template',
+                  'Agendaitem list template',
+                  'Table of contents template',
+                  'Linked repository folder']
+        with self.login(self.administrator, browser):
+            browser.open(self.committee_container)
+            factoriesmenu.add('Committee')
+            self.assertEquals(
+                fields,
+                map(methodcaller('normalized_text', recursive=False),
+                    browser.css('form#form > div.field > label')))
+
+        with self.login(self.committee_responsible, browser):
+            browser.open(self.committee, view='edit')
+            self.assertEquals(
+                fields,
+                map(methodcaller('normalized_text', recursive=False),
+                    browser.css('form#form > div.field > label')))

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -63,6 +63,62 @@ class TestCommittee(IntegrationTestCase):
         self.assertEqual(
             self.sablon_template, self.committee.get_excerpt_template())
 
+    def test_get_protocol_template_returns_committee_template_if_available(self):
+        self.login(self.administrator)
+        self.committee.protocol_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_protocol_template())
+
+    def test_get_protocol_template_falls_back_to_container(self):
+        self.login(self.administrator)
+
+        self.assertIsNone(self.committee.protocol_template)
+        self.assertIsNotNone(self.committee_container.protocol_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_protocol_template())
+
+    def test_get_protocol_header_template_returns_committee_template_if_available(self):
+        self.login(self.administrator)
+        self.activate_feature('word-meeting')
+        self.committee.protocol_header_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_protocol_header_template())
+
+    def test_get_protocol_header_template_falls_back_to_container(self):
+        self.login(self.administrator)
+        self.activate_feature('word-meeting')
+        self.assertIsNone(self.committee.protocol_header_template)
+        self.assertIsNotNone(self.committee_container.protocol_header_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_protocol_header_template())
+
+    def test_get_protocol_suffix_template_returns_committee_template_if_available(self):
+        self.login(self.administrator)
+        self.activate_feature('word-meeting')
+        self.committee.protocol_suffix_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_protocol_suffix_template())
+
+    def test_get_protocol_suffix_template_falls_back_to_container_if_available(self):
+        self.login(self.administrator)
+        self.activate_feature('word-meeting')
+        self.committee_container.protocol_suffix_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertIsNone(self.committee.protocol_suffix_template)
+        self.assertIsNotNone(self.committee_container.protocol_suffix_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_protocol_suffix_template())
+
     @browsing
     def test_committee_repository_is_validated(self, browser):
         self.login(self.administrator, browser)

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
+from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages import factoriesmenu
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.testing import add_languages
@@ -23,8 +24,8 @@ class TestCommitteeContainer(IntegrationTestCase):
                       'Title (French)': u's\xe9ance',
                       'Protocol template': self.sablon_template,
                       'Excerpt template': self.sablon_template,
-                      'Table of contents template': self.sablon_template})
-        browser.find('Save').click()
+                      'Table of contents template': self.sablon_template}).save()
+        statusmessages.assert_no_error_messages()
 
         browser.find(u'Fran\xe7ais').click()
         self.assertEquals(u's\xe9ance', browser.css('h1').first.text)

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -234,3 +234,23 @@ class TestCommitteesTab(IntegrationTestCase):
         self.assertEquals(self.meeting.model.get_url(),
                           last_meeting.get('href'))
         self.assertEquals(meeting.get_url(), next_meeting.get('href'))
+
+    @browsing
+    def test_visible_fields_in_forms(self, browser):
+        """Some fields should only be displayed when the word feature is
+        disabled.
+        Therefore we test the appearance of all fields.
+        """
+        fields = [u'Title',
+                  u'Protocol template',
+                  u'Excerpt template',
+                  u'Agendaitem list template',
+                  u'Table of contents template']
+        self.login(self.manager, browser)
+
+        browser.open()
+        factoriesmenu.add('Committee Container')
+        self.assertEquals(fields, browser.css('form#form > div.field > label').text)
+
+        browser.open(self.committee_container, view='edit')
+        self.assertEquals(fields, browser.css('form#form > div.field > label').text)

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -31,7 +31,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         browser.open()
         factoriesmenu.add('Committee Container')
         browser.fill({'Title': u'Sitzungen',
-                      'Protocol template': self.sablon_template,
+                      'Protocol header template': self.sablon_template,
+                      'Protocol suffix template': self.sablon_template,
                       'Ad hoc agenda item template': self.proposal_template}).save()
         statusmessages.assert_no_error_messages()
 
@@ -61,7 +62,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         browser.open()
         factoriesmenu.add('Committee Container')
         browser.fill({'Title': u'Sitzungen',
-                      'Protocol template': self.sablon_template,
+                      'Protocol header template': self.sablon_template,
+                      'Protocol suffix template': self.sablon_template,
                       'Paragraph template': self.sablon_template}).save()
         statusmessages.assert_no_error_messages()
 

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -71,34 +71,23 @@ class TestCommitteeContainer(IntegrationTestCase):
                          browser.context.get_paragraph_template())
 
     @browsing
-    def test_paragraph_template_for_nonword_in_add_form_is_hidden(self, browser):
-        """The "Paragraph template" field only makes sense when
-        the word-meeting feature is enabled.
-        Make sure that it does not appear in the forms when disabling
-        the word-meeting feature.
+    def test_visible_fields_in_forms(self, browser):
+        """Some fields should only be displayed when the word feature is
+        enabled.
+        Therefore we test the appearance of all fields.
         """
+        fields = [u'Title',
+                  u'Protocol header template',
+                  u'Protocol suffix template',
+                  u'Agendaitem list template',
+                  u'Table of contents template',
+                  u'Ad hoc agenda item template',
+                  u'Paragraph template']
         self.login(self.manager, browser)
+
         browser.open()
         factoriesmenu.add('Committee Container')
-        field_label = 'Paragraph template'
-        self.assertTrue(browser.find(field_label))
+        self.assertEquals(fields, browser.css('form#form > div.field > label').text)
 
-        self.deactivate_feature('word-meeting')
-        browser.reload()
-        self.assertFalse(browser.find(field_label))
-
-    @browsing
-    def test_paragraph_template_for_nonword_in_edit_form_is_hidden(self, browser):
-        """The "Paragraph template" field only makes sense when
-        the word-meeting feature is enabled.
-        Make sure that it does not appear in the forms when disabling
-        the word-meeting feature.
-        """
-        self.login(self.manager, browser)
         browser.open(self.committee_container, view='edit')
-        field_label = 'Paragraph template'
-        self.assertTrue(browser.find(field_label))
-
-        self.deactivate_feature('word-meeting')
-        browser.reload()
-        self.assertFalse(browser.find(field_label))
+        self.assertEquals(fields, browser.css('form#form > div.field > label').text)

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -71,7 +71,7 @@ class TestCommitteeContainer(IntegrationTestCase):
                          browser.context.get_paragraph_template())
 
     @browsing
-    def test_hide_paragraph_template_for_nonword_in_add_form(self, browser):
+    def test_paragraph_template_for_nonword_in_add_form_is_hidden(self, browser):
         """The "Paragraph template" field only makes sense when
         the word-meeting feature is enabled.
         Make sure that it does not appear in the forms when disabling
@@ -88,7 +88,7 @@ class TestCommitteeContainer(IntegrationTestCase):
         self.assertFalse(browser.find(field_label))
 
     @browsing
-    def test_hide_paragraph_template_for_nonword_in_edit_form(self, browser):
+    def test_paragraph_template_for_nonword_in_edit_form_is_hidden(self, browser):
         """The "Paragraph template" field only makes sense when
         the word-meeting feature is enabled.
         Make sure that it does not appear in the forms when disabling

--- a/opengever/meeting/tests/test_protocol_word.py
+++ b/opengever/meeting/tests/test_protocol_word.py
@@ -37,6 +37,36 @@ class TestProtocolWithWord(IntegrationTestCase):
         self.assertEqual(1, meeting.protocol_document.generated_version)
 
     @browsing
+    def test_word_protocols_with_suffix_template_in_committee_can_be_created_and_updated(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.committee.protocol_suffix_template = self.committee.protocol_header_template
+        self.schedule_paragraph(self.meeting, u'A-Gesch\xe4fte')
+        self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        meeting = self.meeting.model
+
+        self.assertIsNone(meeting.protocol_document)
+
+        browser.open(meeting.get_url())
+        # generate first protocol
+        browser.css('.generate-protocol').first.click()
+
+        statusmessages.assert_message(
+            u'Protocol for meeting 9. Sitzung der '
+            u'Rechnungspr\xfcfungskommission has been generated '
+            u'successfully.')
+        self.assertIsNotNone(meeting.protocol_document)
+        self.assertEqual(0, meeting.protocol_document.generated_version)
+
+        # update already generated protocol
+        browser.css('.refresh-protocol').first.click()
+
+        statusmessages.assert_message(
+            u'Protocol for meeting 9. Sitzung der '
+            u'Rechnungspr\xfcfungskommission has been updated successfully.')
+        self.assertIsNotNone(meeting.protocol_document)
+        self.assertEqual(1, meeting.protocol_document.generated_version)
+
+    @browsing
     def test_protocol_is_generated_when_closing_meetings(self, browser):
         self.login(self.committee_responsible, browser)
         self.schedule_proposal(self.meeting, self.submitted_word_proposal).decide()

--- a/opengever/meeting/tests/test_protocol_word.py
+++ b/opengever/meeting/tests/test_protocol_word.py
@@ -46,6 +46,7 @@ class TestProtocolWithWord(IntegrationTestCase):
 
         browser.open(meeting.get_url())
         browser.find('Close meeting').click()
+        statusmessages.assert_no_error_messages()
 
         self.assertIsNotNone(meeting.protocol_document)
         self.assertEqual(0, meeting.protocol_document.generated_version)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -230,6 +230,7 @@ class OpengeverContentFixture(object):
                 agendaitem_list_template=self.sablon_template,
                 excerpt_template=self.sablon_template,
                 protocol_template=self.sablon_template,
+                protocol_header_template=self.sablon_template,
                 paragraph_template=self.sablon_template,
                 )
             ))


### PR DESCRIPTION
Protocols are usually stored in a physical medium with a signature.
With these changes it is possible to add a template which is appended to the protocol, intended for the signatures.

Resolves https://github.com/4teamwork/gever/issues/103