### PR TITLE
Display other participants

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Update Plone version to 4.3.15. [lgraf]
 - SPV: Fix proposal history. [tarnap]
 - SPV: Fix deleting ad-hoc agenda items. [tarnap]
+- SPV word: Display other participants in meeting view. [tarnap]
 - SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]
 - SPV word: Hide excerpt template from form when word feature enabled. [tarnap]

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -196,6 +196,16 @@
               </td>
             </tr>
 
+            <tr tal:condition="meeting/get_other_participants_list">
+              <th></th>
+              <td>
+                <ul>
+                  <li tal:repeat="participant meeting/get_other_participants_list"
+                      tal:content="structure participant"></li>
+                </ul>
+              </td>
+            </tr>
+
           </table>
 
           <table class="meeting-metadata">

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1650,7 +1650,7 @@ msgstr "Status:"
 #. Default: "Other participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
 msgid "view_label_other_participants"
-msgstr ""
+msgstr "Weitere Teilnehmende"
 
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1647,6 +1647,11 @@ msgstr "Beginn:"
 msgid "view_label_meeting_status"
 msgstr "Status:"
 
+#. Default: "Other participants:"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
+msgid "view_label_other_participants"
+msgstr ""
+
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1649,6 +1649,11 @@ msgstr ""
 msgid "view_label_meeting_status"
 msgstr ""
 
+#. Default: "Other participants:"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
+msgid "view_label_other_participants"
+msgstr ""
+
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -1646,6 +1646,11 @@ msgstr ""
 msgid "view_label_meeting_status"
 msgstr ""
 
+#. Default: "Other participants:"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt:200
+msgid "view_label_other_participants"
+msgstr ""
+
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -147,6 +147,13 @@ class Meeting(Base, SQLFormSupport):
     excerpt_documents = relationship('GeneratedExcerpt',
                                      secondary=meeting_excerpts,)
 
+    def get_other_participants_list(self):
+        if self.other_participants is not None:
+            return filter(len, map(lambda value: value.strip(),
+                                   self.other_participants.split('\n')))
+        else:
+            return []
+
     def initialize_participants(self):
         """Set all active members of our committee as participants of
         this meeting.

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -72,6 +72,7 @@ class TestEditMeeting(IntegrationTestCase):
              ['Presidency:', u'W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
              ['Secretary:', 'Wendler Jens (jens-wendler@gmail.com)'],
              ['Participants:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
+             ['', 'Staatsanwalt'],
              ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
              ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
              ['Protocol:', 'No protocol has been generated yet.', '']],


### PR DESCRIPTION
Displays "other participants" in the meeting view (if any available).

Adding some "other participants":
![weitere_teilnehmer_1](https://user-images.githubusercontent.com/194114/31125929-669fd2dc-a84a-11e7-9359-3a9ced7feaf2.png)

Displaying "other participants":
![weitere_teilnehmer_without_labels](https://user-images.githubusercontent.com/194114/31127318-d985a598-a84e-11e7-8d59-a37963097787.png)

Resolves https://github.com/4teamwork/gever/issues/85