### PR TITLE
Bundle import: Fix deactivation of LDAP plugin during import

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Bundle import: Fix deactivation of LDAP plugin during import. [lgraf]
 - Update Plone version to 4.3.15. [lgraf]
 - SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]


### PR DESCRIPTION
Bundle import: Fix deactivation of LDAP plugin during import:

The previous approach, where a reference to the persistent plugin registry was kept around and later restored, was causing errors in combination with the recent memory optimizations:

Since we regularly re-set the Plone site and garbage collect the cPickleCache, we might hold on to a reference to a persistent object (the plugin registry) that has become detached from the ZODB connection it was retrieved from.

This lead to POSKey errors in cases where the plugin registry had to be restored by the context manager.

Instead, we now keep a **simple mapping** (without any persistent data structures whatsoever) of the plugins that were enabled (per plugin-type) at the beginning of the import, and re-enable those that got deactivated based on that mapping of the original plugin registry contents.