### PR TITLE
Fix removal of agenda items

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Update Plone version to 4.3.15. [lgraf]
 - SPV: Fix proposal history. [tarnap]
+- SPV: Fix deleting ad-hoc agenda items. [tarnap]
 - SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]
 - SPV word: Hide excerpt template from form when word feature enabled. [tarnap]

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -183,8 +183,12 @@
     this.closeModal = function() {
       unscheduleDialog.close();
       deleteDialog.close();
-      returnExcerptDialog.close();
-      createExcerptDialog.close();
+      if (typeof(returnExcerptDialog) !== 'undefined') {
+        returnExcerptDialog.close();
+      }
+      if (typeof(createExcerptDialog) !== 'undefined') {
+        createExcerptDialog.close();
+      }
     };
 
     this.updateSortOrder = function() {


### PR DESCRIPTION
Some modals (dialogs) exist only in the no-word version.
Trying to close them leads to a javascript error.
Make sure the dialogs are not undefined before trying to close them.

Resolves #3407 

Needs backport to: `2017.5-stable` 