### PR TITLE
SPV: Create successor proposals

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - SPV: Fix proposal history. [tarnap]
 - SPV: Fix deleting ad-hoc agenda items. [tarnap]
 - SPV word: Display other participants in meeting view. [tarnap]
+- SPV word: Introduce successor proposals. [jone]
 - Ungrok proposal add form. [jone]
 - SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -5,6 +5,7 @@ from opengever.base.widgets import TrixFieldWidget
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.meeting import _
 from opengever.meeting import is_word_meeting_implementation_enabled
+from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.form import ModelProxyAddForm
 from opengever.meeting.form import ModelProxyEditForm
 from opengever.meeting.proposal import IProposal
@@ -15,6 +16,7 @@ from opengever.meeting.vocabulary import get_proposal_template_vocabulary
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
+from plone.app.uuid.utils import uuidToObject
 from plone.dexterity.browser.add import DefaultAddForm
 from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.interfaces import IDexterityFTI
@@ -22,6 +24,7 @@ from plone.directives import dexterity
 from plone.directives.form import widget
 from plone.z3cform.fieldsets.utils import move
 from Products.CMFCore.interfaces import IFolderish
+from Products.CMFPlone.utils import safe_unicode
 from z3c.form import field
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
 from z3c.form.interfaces import HIDDEN_MODE
@@ -127,6 +130,12 @@ class ProposalAddForm(FieldConfigurationMixin, ModelProxyAddForm, DefaultAddForm
         # attribute.
         return self.instance_schema
 
+    def update(self):
+        if is_word_meeting_implementation_enabled():
+            self.prefillPredecessorDefaults()
+
+        return super(ProposalAddForm, self).update()
+
     def updateFields(self):
         try:
             return super(ProposalAddForm, self).updateFields()
@@ -139,6 +148,44 @@ class ProposalAddForm(FieldConfigurationMixin, ModelProxyAddForm, DefaultAddForm
         ltool = api.portal.get_tool('portal_languages')
         if len(ltool.getSupportedLanguages()) <= 1:
             self.widgets['language'].mode = HIDDEN_MODE
+
+    @require_word_meeting_feature
+    def prefillPredecessorDefaults(self):
+        """When we create a successor proposal, the defaults change to
+        be based on the predecessor.
+        Since the relation widgets do not support changing values we must
+        prefill the values in the request.
+        """
+
+        # When the "Create successor proposal" button is clicked on a
+        # decided proposal, the "predecessor" is submitted in a POST
+        # request to this form, with the UID of the predecessor as value.
+        if 'predecessor' not in self.request.form:
+            # Either we are not creating a successor, but a regular proposal,
+            # or the successor form is already submitted.
+            # In both cases we don't want prefill defaults.
+            return
+
+        predecessor = uuidToObject(self.request.form['predecessor'])
+        related_items_paths = []
+        excerpt = predecessor.get_excerpt()
+        if excerpt:
+            related_items_paths.append('/'.join(excerpt.getPhysicalPath()))
+
+        related_items_paths.extend(
+            [safe_unicode(relation.to_path)
+             for relation in predecessor.relatedItems])
+
+        defaults = {
+            'predecessor_proposal': '/'.join(predecessor.getPhysicalPath()),
+            'title': safe_unicode(predecessor.Title()),
+            'committee': [unicode(
+                predecessor.get_committee().load_model().committee_id)],
+            'language': predecessor.load_model().language,
+            'relatedItems': related_items_paths}
+
+        for name, value in defaults.items():
+            self.request.form['form.widgets.' + name] = value
 
     def createAndAdd(self, data):
         if not is_word_meeting_implementation_enabled():

--- a/opengever/meeting/browser/proposaloverview.py
+++ b/opengever/meeting/browser/proposaloverview.py
@@ -66,6 +66,16 @@ class OverviewBase(object):
         return '{}/@@bumblebee-overlay-document'.format(
             self.context.get_proposal_document().absolute_url())
 
+    def is_create_successor_proposal_button_visible(self):
+        """Returns True when the "Create successor proposal" should be
+        displayed.
+        """
+        if ISubmittedProposal.providedBy(self.context):
+            return False
+
+        model = self.context.load_model()
+        return model.get_state() == model.STATE_DECIDED
+
 
 class ProposalOverview(OverviewBase, DisplayForm, GeverTabMixin):
     grok.context(IProposal)

--- a/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+++ b/opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
@@ -62,6 +62,24 @@
           </table>
           <metal:use use-macro="context/@@meeting-macros/workflow_actions" />
 
+          <div class="actionButtons">
+            <ul class="regular_buttons">
+
+              <li tal:condition="view/is_create_successor_proposal_button_visible">
+                <form method="POST"
+                      tal:attributes="action string:${context/aq_parent/absolute_url}/++add++opengever.meeting.proposal">
+                  <input type="hidden" name="predecessor"
+                         tal:attributes="value here/UID" />
+                  <input type="submit"
+                         class="create-successor-proposal-button button"
+                         value="Create successor proposal"
+                         i18n:attributes="value button_create_successor_proposal" />
+                </form>
+              </li>
+
+            </ul>
+          </div>
+
       </div>
       <div tal:condition="view/show_preview" class="documentPreview">
         <img class="showroom-item"

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 13:51+0000\n"
-"PO-Revision-Date: 2017-10-02 15:13+0200\n"
+"POT-Creation-Date: 2017-10-04 14:04+0000\n"
+"PO-Revision-Date: 2017-10-04 16:05+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -1502,6 +1502,11 @@ msgstr "Geplant für die Sitzung ${meeting} durch ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"
+
+#. Default: "Successor proposal ${successor_link} created by ${user}"
+#: ./opengever/meeting/proposalhistory.py
+msgid "proposal_history_label_successor_created"
+msgstr "Folgeantrag «${successor_link}» erstellt durch ${user}"
 
 #. Default: "Protocol"
 #: ./opengever/meeting/protocol.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 14:04+0000\n"
-"PO-Revision-Date: 2017-10-04 16:05+0200\n"
+"POT-Creation-Date: 2017-10-04 14:05+0000\n"
+"PO-Revision-Date: 2017-10-02 16:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -1113,6 +1113,11 @@ msgstr "Vorlage für Zwischentitel"
 msgid "label_participants"
 msgstr "Teilnehmende"
 
+#. Default: "Predecessor"
+#: ./opengever/meeting/proposal.py
+msgid "label_predecessor"
+msgstr "Vorgänger"
+
 #. Default: "Presidency"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_presidency"
@@ -1218,6 +1223,11 @@ msgstr "Zieldossier"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr "Start"
+
+#. Default: "Successors"
+#: ./opengever/meeting/proposal.py
+msgid "label_successors"
+msgstr "Folgeanträge"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 13:45+0000\n"
-"PO-Revision-Date: 2017-09-25 13:37+0200\n"
+"POT-Creation-Date: 2017-10-04 13:51+0000\n"
+"PO-Revision-Date: 2017-10-02 15:13+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -456,6 +456,11 @@ msgstr "Periode abschliessen"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_continue"
 msgstr "Weiter"
+
+#. Default: "Create successor proposal"
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+msgid "button_create_successor_proposal"
+msgstr "Folgeantrag erstellen"
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py
@@ -1676,4 +1681,3 @@ msgstr "Antrag traktandieren:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_secretary"
 msgstr "Protokollführung:"
-

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 14:04+0000\n"
+"POT-Creation-Date: 2017-10-04 14:05+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1115,6 +1115,11 @@ msgstr ""
 msgid "label_participants"
 msgstr "Participants"
 
+#. Default: "Predecessor"
+#: ./opengever/meeting/proposal.py
+msgid "label_predecessor"
+msgstr ""
+
 #. Default: "Presidency"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_presidency"
@@ -1220,6 +1225,11 @@ msgstr "Fichier-cible"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr "Début"
+
+#. Default: "Successors"
+#: ./opengever/meeting/proposal.py
+msgid "label_successors"
+msgstr ""
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/excerpt.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 13:51+0000\n"
+"POT-Creation-Date: 2017-10-04 14:04+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1504,6 +1504,11 @@ msgstr "Prévu pour la séance ${meeting} par ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr "Soumis par ${user}"
+
+#. Default: "Successor proposal ${successor_link} created by ${user}"
+#: ./opengever/meeting/proposalhistory.py
+msgid "proposal_history_label_successor_created"
+msgstr ""
 
 #. Default: "Protocol"
 #: ./opengever/meeting/protocol.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 13:45+0000\n"
+"POT-Creation-Date: 2017-10-04 13:51+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -458,6 +458,11 @@ msgstr "Clôturer une période"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_continue"
 msgstr "Continuer"
+
+#. Default: "Create successor proposal"
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+msgid "button_create_successor_proposal"
+msgstr ""
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py
@@ -1678,4 +1683,3 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_secretary"
 msgstr ""
-

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 14:04+0000\n"
+"POT-Creation-Date: 2017-10-04 14:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1112,6 +1112,11 @@ msgstr ""
 msgid "label_participants"
 msgstr ""
 
+#. Default: "Predecessor"
+#: ./opengever/meeting/proposal.py
+msgid "label_predecessor"
+msgstr ""
+
 #. Default: "Presidency"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_presidency"
@@ -1216,6 +1221,11 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
+msgstr ""
+
+#. Default: "Successors"
+#: ./opengever/meeting/proposal.py
+msgid "label_successors"
 msgstr ""
 
 #. Default: "Title"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 13:45+0000\n"
+"POT-Creation-Date: 2017-10-04 13:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -454,6 +454,11 @@ msgstr ""
 #: ./opengever/meeting/browser/committeeforms.py
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "button_continue"
+msgstr ""
+
+#. Default: "Create successor proposal"
+#: ./opengever/meeting/browser/proposaloverview_templates/proposaloverview.pt
+msgid "button_create_successor_proposal"
 msgstr ""
 
 #. Default: "Submit Attachments"
@@ -1675,4 +1680,3 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_secretary"
 msgstr ""
-

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-04 13:51+0000\n"
+"POT-Creation-Date: 2017-10-04 14:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1500,6 +1500,11 @@ msgstr ""
 #. Default: "Submitted by ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
+msgstr ""
+
+#. Default: "Successor proposal ${successor_link} created by ${user}"
+#: ./opengever/meeting/proposalhistory.py
+msgid "proposal_history_label_successor_created"
 msgstr ""
 
 #. Default: "Protocol"

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -36,7 +36,6 @@ from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import getUtility
-from zope.i18n import translate
 from zope.interface import implements
 from zope.interface import Interface
 from zope.interface import provider
@@ -526,6 +525,12 @@ class Proposal(ProposalBase):
 
     def _after_model_created(self, model_instance):
         IHistory(self).append_record(u'created')
+
+        if self.predecessor_proposal is not None:
+            predecessor = self.predecessor_proposal.to_object
+            IHistory(predecessor).append_record(
+                u'successor_created',
+                successor_oguid=Oguid.for_object(self).id)
 
     def is_editable(self):
         """A proposal in a dossier is only editable while not submitted.

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -26,7 +26,9 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.app.uuid.utils import uuidToObject
+from plone.autoform.directives import mode
 from plone.directives import form
+from plone.formwidget.contenttree import ObjPathSourceBinder
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
 from z3c.relationfield.relation import RelationValue
@@ -137,6 +139,14 @@ class IProposal(form.Schema):
             ),
         required=False,
         )
+
+    mode(predecessor_proposal='hidden')
+    predecessor_proposal = RelationChoice(
+        title=u'Predecessor proposal',
+        default=None,
+        missing_value=None,
+        required=False,
+        source=ObjPathSourceBinder(portal_type='opengever.meeting.proposal'))
 
 
 class ISubmittedProposal(IProposal):

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -227,3 +227,62 @@ class TestProposalWithWord(IntegrationTestCase):
         self.assertEquals(1, len(excerpts))
         relation, = excerpts
         self.assertEquals(excerpt_document, relation.to_object)
+
+    @browsing
+    def test_create_successor_proposal(self, browser):
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.word_proposal, view='tabbedview_view-overview')
+        button_label = 'Create successor proposal'
+
+        self.assertEquals('submitted', self.word_proposal.get_state().title)
+        self.assertFalse(browser.find(button_label))
+
+        with self.login(self.committee_responsible):
+            agenda_item = self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+            self.assertEquals('scheduled', self.submitted_word_proposal.get_state().title)
+
+        self.assertEquals('scheduled', self.word_proposal.get_state().title)
+        self.assertFalse(browser.reload().find(button_label))
+
+        with self.login(self.committee_responsible):
+            agenda_item.decide()
+            self.assertEquals('decided', self.submitted_word_proposal.get_state().title)
+
+        self.assertEquals('decided', self.word_proposal.get_state().title)
+        self.assertTrue(browser.reload().find(button_label))
+
+        browser.click_on(button_label)
+
+        self.assertEquals(
+            self.word_proposal.Title().decode('utf-8'),
+            browser.find('Title').value)
+        self.assertEquals(
+            str(self.word_proposal.get_committee().load_model().committee_id),
+            browser.find('Committee').value)
+        self.assertEquals(
+            [rel.to_path for rel in self.word_proposal.relatedItems],
+            [node.value for node
+             in browser.find('Attachments').css('input[type=checkbox]')])
+
+        self.assertIn(
+            self.word_proposal.get_proposal_document().UID(),
+            browser.find('Proposal template').options,
+            'The proposal document of the predecessor should be selectable'
+            ' as proposal template.')
+
+        browser.fill({
+            'Proposal template': self.word_proposal.get_proposal_document().Title(),
+        }).save()
+        statusmessages.assert_no_error_messages()
+
+        proposal = browser.context
+        browser.open(proposal, view='tabbedview_view-overview')
+        self.assertEquals(
+            [['Title', u'\xc4nderungen am Personalreglement'],
+             ['Committee', u'Rechnungspr\xfcfungskommission'],
+             ['Meeting', ''],
+             ['Proposal document', u'\xc4nderungen am Personalreglement'],
+             ['State', 'Pending'],
+             ['Decision number', ''],
+             ['Attachments', u'Vertr\xe4gsentwurf']],
+            browser.css('table.listing').first.lists())

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -271,6 +271,7 @@ class TestProposalWithWord(IntegrationTestCase):
             ' as proposal template.')
 
         browser.fill({
+            'Title': u'\xc4nderungen am Personalreglement zur Nachpr\xfcfung',
             'Proposal template': self.word_proposal.get_proposal_document().Title(),
         }).save()
         statusmessages.assert_no_error_messages()
@@ -278,16 +279,29 @@ class TestProposalWithWord(IntegrationTestCase):
         proposal = browser.context
         browser.open(proposal, view='tabbedview_view-overview')
         self.assertEquals(
-            [['Title', u'\xc4nderungen am Personalreglement'],
+            [['Title', u'\xc4nderungen am Personalreglement zur Nachpr\xfcfung'],
              ['Committee', u'Rechnungspr\xfcfungskommission'],
              ['Meeting', ''],
-             ['Proposal document', u'\xc4nderungen am Personalreglement'],
+             ['Proposal document',
+              u'\xc4nderungen am Personalreglement zur Nachpr\xfcfung'],
              ['State', 'Pending'],
              ['Decision number', ''],
+             ['Predecessor', u'\xc4nderungen am Personalreglement'],
              ['Attachments', u'Vertr\xe4gsentwurf']],
             browser.css('table.listing').first.lists())
 
         browser.open(self.word_proposal, view='tabbedview_view-overview')
-        self.assertIn(u'Successor proposal \xc4nderungen am Personalreglement '
+        self.assertIn(u'Successor proposal '
+                      u'\xc4nderungen am Personalreglement zur Nachpr\xfcfung '
                       u'created by Ziegler Robert (robert.ziegler)',
                       browser.css('.answers .answerBody h3').text)
+        self.assertEquals(
+            [['Title', u'\xc4nderungen am Personalreglement'],
+             ['Committee', u'Rechnungspr\xfcfungskommission'],
+             ['Meeting', u'9. Sitzung der Rechnungspr\xfcfungskommission'],
+             ['Proposal document', u'\xc4nderungen am Personalreglement'],
+             ['State', 'Decided'],
+             ['Decision number', '2016 / 2'],
+             ['Successors', u'\xc4nderungen am Personalreglement zur Nachpr\xfcfung'],
+             ['Attachments', u'Vertr\xe4gsentwurf']],
+            browser.css('table.listing').first.lists())

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -286,3 +286,8 @@ class TestProposalWithWord(IntegrationTestCase):
              ['Decision number', ''],
              ['Attachments', u'Vertr\xe4gsentwurf']],
             browser.css('table.listing').first.lists())
+
+        browser.open(self.word_proposal, view='tabbedview_view-overview')
+        self.assertIn(u'Successor proposal \xc4nderungen am Personalreglement '
+                      u'created by Ziegler Robert (robert.ziegler)',
+                      browser.css('.answers .answerBody h3').text)

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -74,19 +74,28 @@ def get_proposal_template_vocabulary(context):
         # view templates and/or during ++widget++ traversal
         return SimpleVocabulary([])
 
-    templates = api.content.find(
+    templates = [brain.getObject() for brain in api.content.find(
         context=template_folder,
         depth=-1,
         portal_type="opengever.meeting.proposaltemplate",
-        sort_on='sortable_title', sort_order='ascending')
+        sort_on='sortable_title', sort_order='ascending')]
+
+    predecessor_path = context.REQUEST.form.get(
+        'form.widgets.predecessor_proposal', None)
+    if predecessor_path and predecessor_path != u'--NOVALUE--':
+        # The ++add++opengever.meeting.proposal was opened with a predecessor.
+        # We should also offer to use the predecessor proposal document as
+        # "template".
+        predecessor_path = safe_unicode(predecessor_path).encode('utf-8')
+        predecessor = api.content.get(path=predecessor_path)
+        templates.insert(0, predecessor.get_proposal_document())
 
     terms = []
-    for brain in templates:
-        template = brain.getObject()
+    for template in templates:
         terms.append(SimpleVocabulary.createTerm(
             template,
             IUUID(template),
-            safe_unicode(brain.Title)))
+            safe_unicode(template.Title())))
     return SimpleVocabulary(terms)
 
 


### PR DESCRIPTION
### Goal
The goal is to make it possible to create successor proposal based on decided proposals.
On one hand it should be visible in the proposals that they depend on each other,
on the other hand it should make it easier for the user to reuse / base on a proposal document.

Closes https://github.com/4teamwork/gever/issues/99

### Implementation Details
- A `Create successor proposal` button appears on decided proposals (but not on a submitted proposal).
- The idea is that a business case is in one dossier, therefore all its proposal shall be in the same proposals.
- The button leads to the proposal addform, which has prefille defaults:
  - The fields are filled with the defaults from the predecessor.
  - The predecessor proposal document can be used as template for the successor proposal; a copy is created.
  - The excerpt of the predecessor is proposed to be used as attachment; can be deselected.
  - The original attachments are proposed to be attached as well.

### Screenshots

![bildschirmfoto 2017-10-02 um 16 58 54](https://user-images.githubusercontent.com/7469/31084929-0a3c8d00-a796-11e7-8463-d981edf54c50.png)
![bildschirmfoto 2017-10-02 um 17 00 01](https://user-images.githubusercontent.com/7469/31084931-0b38f20c-a796-11e7-9547-4d09cb2bd68c.png)
![bildschirmfoto 2017-10-02 um 17 11 08](https://user-images.githubusercontent.com/7469/31084934-0ced1786-a796-11e7-8658-7e46f341c80b.png)
![bildschirmfoto 2017-10-02 um 17 12 20](https://user-images.githubusercontent.com/7469/31084937-0da3357a-a796-11e7-89da-83dfdbaa0ecc.png)
