### PR TITLE
Add upgrade step to fix proposal history

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Update Plone version to 4.3.15. [lgraf]
+- SPV: Fix proposal history. [tarnap]
 - SPV word: Improve visual feedback when scheduling text or paragraph. [jone]
 - SPV word: Remove proposal document's title prefix. [tarnap]
 - SPV word: Hide excerpt template from form when word feature enabled. [tarnap]

--- a/opengever/core/upgrades/20171003084150_fix_history_entries/upgrade.py
+++ b/opengever/core/upgrades/20171003084150_fix_history_entries/upgrade.py
@@ -1,0 +1,18 @@
+from BTrees.OOBTree import OOBTree
+from ftw.upgrade import UpgradeStep
+from zope.annotation.interfaces import IAnnotations
+
+
+class FixProposalHistoryEntries(UpgradeStep):
+    """Fix proposal history entries.
+    """
+
+    def __call__(self):
+        query = {'portal_type': 'opengever.meeting.proposal'}
+        for proposal in self.objects(query, 'Fix proposal history'):
+
+            history = IAnnotations(proposal).get('object_history', OOBTree())
+
+            for key, value in history.items():
+                if value.get('name') and not value.get('history_type'):
+                    value.update({'history_type': value.get('name')})


### PR DESCRIPTION
Fixes proposal history.

The history of an object is stored in IAnnotations.
The type of the entry (ex. submitted) is used to filter the entries in
the proposal history. (See https://github.com/4teamwork/opengever.core/blob/master/opengever/meeting/proposalhistory.py#L42)
The key under which the type is stored is called 'history_type'.

Previously the key used was 'name', but changed in 21f89be.
There was no upgrade step (data migration) to change these keys for
existing data.

## Screenshots

Before the upgrade:
![before](https://user-images.githubusercontent.com/194114/31119387-1fa8f20a-a831-11e7-8536-b4f89850f67e.png)

The upgrade:
![upgrade](https://user-images.githubusercontent.com/194114/31119393-25ea5834-a831-11e7-8271-c42ed7b5ba89.png)

After the upgrade:
![after](https://user-images.githubusercontent.com/194114/31119397-2d64013c-a831-11e7-8df0-c9e9e5eeddfe.png)

Resolves #3462