### PR TITLE
SPV word: Register excerpt relations properly in the relation catalog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - SPV word: Fix protocol zip export. [tarnap]
 - Bundle import: Fix deactivation of LDAP plugin during import. [lgraf]
+- SPV word: Register excerpt relations properly in the relation catalog. [jone]
 - Update Plone version to 4.3.15. [lgraf]
 - SPV: Fix proposal history. [tarnap]
 - SPV: Fix deleting ad-hoc agenda items. [tarnap]

--- a/opengever/core/upgrades/20171004160937_update_relation_catalog_for_proposal_excerpts/upgrade.py
+++ b/opengever/core/upgrades/20171004160937_update_relation_catalog_for_proposal_excerpts/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+from opengever.meeting import is_word_meeting_implementation_enabled
+from z3c.relationfield.event import addRelations
+
+
+class UpdateRelationCatalogForProposalExcerpts(UpgradeStep):
+    """Register excerpt relations of submitted proposals in relation catalog.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        if is_word_meeting_implementation_enabled():
+            query = {'object_provides': 'opengever.meeting.proposal.ISubmittedProposal'}
+            for obj in self.objects(query, self.__class__.__doc__):
+                addRelations(obj, None)

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -31,6 +31,7 @@ from plone.directives import form
 from plone.formwidget.contenttree import ObjPathSourceBinder
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
+from z3c.relationfield.event import addRelations
 from z3c.relationfield.relation import RelationValue
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
@@ -531,6 +532,7 @@ class SubmittedProposal(ProposalBase):
         intid = getUtility(IIntIds).getId(excerpt_document)
         excerpts.append(RelationValue(intid))
         self.excerpts = excerpts
+        addRelations(self, None)
 
 
 class Proposal(ProposalBase):

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -8,6 +8,8 @@ from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.testing import IntegrationTestCase
 from plone import api
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
 
 
 class TestProposalWithWord(IntegrationTestCase):
@@ -227,6 +229,11 @@ class TestProposalWithWord(IntegrationTestCase):
         self.assertEquals(1, len(excerpts))
         relation, = excerpts
         self.assertEquals(excerpt_document, relation.to_object)
+
+        # The relation catalog should have catalogued the new relation.
+        self.assertIn(relation,
+                      tuple(getUtility(ICatalog).findRelations(
+                          {'to_id': relation.to_id})))
 
     @browsing
     def test_create_successor_proposal(self, browser):


### PR DESCRIPTION
The relation from the submitted proposal to the excerpt were not registred properly in the relation catalog.

- Make sure that `addRelations` is called, which registers all relations in the relation catalog.
- Do the same for existing submitted proposals in an upgrade step.

The `excerpts` relation list is only available in submitted proposals.