### PR TITLE
SPV word: provide meeting docproperties in proposal document and excerpt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - SPV word: Fix protocol zip export. [tarnap]
 - Create missing SQL sequences. [jone]
 - Ungrok opengever.inbox. [elioschmutz]
+- SPV word: Provide meeting doc properties in proposal documents and excerpts. [jone]
 - Bundle import: Fix deactivation of LDAP plugin during import. [lgraf]
 - SPV word: Register excerpt relations properly in the relation catalog. [jone]
 - Update Plone version to 4.3.15. [lgraf]

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -315,3 +315,15 @@ class Document(Item, BaseDocumentMixin):
                 '%s/external_edit' % self.absolute_url(),
                 target='_self',
                 timeout=1000)
+
+    def get_proposal(self):
+        """Return the proposal to which this document belongs.
+
+        This may return a "proposal" or a "submitted proposal".
+        """
+
+        parent = aq_parent(aq_inner(self))
+        if IProposal.providedBy(parent):
+            return parent
+
+        return None

--- a/opengever/document/tests/test_document_word.py
+++ b/opengever/document/tests/test_document_word.py
@@ -1,0 +1,19 @@
+from opengever.testing import IntegrationTestCase
+
+
+class TestDocumentProposal(IntegrationTestCase):
+    features = ('meeting', 'word-meeting')
+
+    def test_get_proposal_returns_None_for_regular_document(self):
+        self.login(self.dossier_responsible)
+        self.assertIsNone(self.document.get_proposal())
+
+    def test_get_proposal_of_proposal_document_in_case_dossier(self):
+        self.login(self.dossier_responsible)
+        proposal = self.word_proposal
+        self.assertEquals(proposal, proposal.get_proposal_document().get_proposal())
+
+    def test_get_proposal_of_proposal_document_in_committee(self):
+        self.login(self.committee_responsible)
+        proposal = self.submitted_word_proposal
+        self.assertEquals(proposal, proposal.get_proposal_document().get_proposal())

--- a/opengever/document/tests/test_document_word.py
+++ b/opengever/document/tests/test_document_word.py
@@ -17,3 +17,29 @@ class TestDocumentProposal(IntegrationTestCase):
         self.login(self.committee_responsible)
         proposal = self.submitted_word_proposal
         self.assertEquals(proposal, proposal.get_proposal_document().get_proposal())
+
+    def test_get_proposal_of_excerpt_document_in_committee(self):
+        self.login(self.committee_responsible)
+        agenda_item = self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        agenda_item.decide()
+        with self.observe_children(self.meeting_dossier) as children:
+            agenda_item.generate_excerpt(title='Excerpt \xc3\x84nderungen')
+
+        excerpt_document, = children['added']
+        self.assertEquals(self.submitted_word_proposal, excerpt_document.get_proposal())
+
+    def test_get_proposal_of_excerpt_document_in_case_dossier(self):
+        self.login(self.committee_responsible)
+        agenda_item = self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        agenda_item.decide()
+        with self.observe_children(self.meeting_dossier) as children:
+            agenda_item.generate_excerpt(title='Excerpt \xc3\x84nderungen')
+
+        meeting_dossier_excerpt, = children['added']
+        with self.observe_children(self.dossier) as children:
+            self.submitted_word_proposal.load_model().return_excerpt(
+                meeting_dossier_excerpt)
+
+        case_dossier_excerpt, = children['added']
+        with self.login(self.dossier_responsible):
+            self.assertEquals(self.word_proposal, case_dossier_excerpt.get_proposal())

--- a/opengever/dossier/docprops.py
+++ b/opengever/dossier/docprops.py
@@ -320,9 +320,10 @@ class DefaultDocProperties(grok.MultiAdapter):
         repo = self.get_repo(dossier)
         site = self.get_site(dossier)
         member = self.get_member(self.request)
+        proposal = document.get_proposal()
 
         properties = {}
-        for obj in [document, dossier, repofolder, repo, site, member]:
+        for obj in [document, dossier, repofolder, repo, site, member, proposal]:
             property_provider = queryAdapter(obj, IDocPropertyProvider)
             obj_properties = {}
             if property_provider is not None:

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -62,4 +62,7 @@
   <adapter factory=".tabs.membershiplisting.MembershipTableSource" />
 
   <adapter factory=".menu.CommitteePostFactoryMenu" />
+
+  <adapter factory=".docprops.ProposalDocPropertyProvider" />
+
 </configure>

--- a/opengever/meeting/docprops.py
+++ b/opengever/meeting/docprops.py
@@ -11,8 +11,21 @@ class ProposalDocPropertyProvider(object):
     def __init__(self, context):
         self.context = context
 
-    def get_properties(self):
-        proposal_model = self.context.load_model()
-        return {
-            'ogg.meeting.decision_number': proposal_model.get_decision_number() or '',
+    def get_meeting_properties(self):
+        properties = {
+            'decision_number': '',
+            'agenda_item_number': '',
         }
+
+        proposal_model = self.context.load_model()
+        agenda_item = proposal_model.agenda_item
+        if agenda_item:
+            properties['decision_number'] = agenda_item.get_decision_number()
+            properties['agenda_item_number'] = agenda_item.number
+
+        return properties
+
+    def get_properties(self):
+        return {'ogg.meeting.' + key: value or ''
+                for key, value
+                in self.get_meeting_properties().items()}

--- a/opengever/meeting/docprops.py
+++ b/opengever/meeting/docprops.py
@@ -1,6 +1,7 @@
 from opengever.dossier.interfaces import IDocPropertyProvider
 from opengever.meeting.proposal import IProposal
 from zope.component import adapter
+from zope.i18n import translate
 from zope.interface import implementer
 
 
@@ -18,6 +19,8 @@ class ProposalDocPropertyProvider(object):
             'decision_number': '',
             'agenda_item_number': '',
             'proposal_title': proposal.Title(),
+            'proposal_state': translate(proposal.get_state().title,
+                                        context=self.context.REQUEST),
         }
 
         agenda_item = proposal.load_model().agenda_item

--- a/opengever/meeting/docprops.py
+++ b/opengever/meeting/docprops.py
@@ -1,0 +1,18 @@
+from opengever.dossier.interfaces import IDocPropertyProvider
+from opengever.meeting.proposal import IProposal
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IDocPropertyProvider)
+@adapter(IProposal)
+class ProposalDocPropertyProvider(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def get_properties(self):
+        proposal_model = self.context.load_model()
+        return {
+            'ogg.meeting.decision_number': proposal_model.get_decision_number() or '',
+        }

--- a/opengever/meeting/docprops.py
+++ b/opengever/meeting/docprops.py
@@ -12,13 +12,15 @@ class ProposalDocPropertyProvider(object):
         self.context = context
 
     def get_meeting_properties(self):
+        proposal = self.context
+
         properties = {
             'decision_number': '',
             'agenda_item_number': '',
+            'proposal_title': proposal.Title(),
         }
 
-        proposal_model = self.context.load_model()
-        agenda_item = proposal_model.agenda_item
+        agenda_item = proposal.load_model().agenda_item
         if agenda_item:
             properties['decision_number'] = agenda_item.get_decision_number()
             properties['agenda_item_number'] = agenda_item.number

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -25,7 +25,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
         self.assertEquals('pending', self.draft_word_proposal.get_state().title)
         self.assertEquals(
             {'ogg.meeting.decision_number': '',
-             'ogg.meeting.agenda_item_number': ''},
+             'ogg.meeting.agenda_item_number': '',
+             'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
             get_doc_properties(self.word_proposal.get_proposal_document()))
 
     def test_submitted_proposal_document(self):
@@ -33,14 +34,16 @@ class TestMeetingDocxProperties(IntegrationTestCase):
             self.assertEquals('submitted', self.word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
-                 'ogg.meeting.agenda_item_number': ''},
+                 'ogg.meeting.agenda_item_number': '',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
             self.assertEquals('submitted', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
-                 'ogg.meeting.agenda_item_number': ''},
+                 'ogg.meeting.agenda_item_number': '',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
 
     def test_scheduled_proposal_document(self):
@@ -51,14 +54,16 @@ class TestMeetingDocxProperties(IntegrationTestCase):
             self.assertEquals('scheduled', self.word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
-                 'ogg.meeting.agenda_item_number': '1.'},
+                 'ogg.meeting.agenda_item_number': '1.',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
             self.assertEquals('scheduled', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
-                 'ogg.meeting.agenda_item_number': '1.'},
+                 'ogg.meeting.agenda_item_number': '1.',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
 
     def test_decided_proposal_document(self):
@@ -69,12 +74,14 @@ class TestMeetingDocxProperties(IntegrationTestCase):
             self.assertEquals('decided', self.word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '2016 / 2',
-                 'ogg.meeting.agenda_item_number': '1.'},
+                 'ogg.meeting.agenda_item_number': '1.',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
             self.assertEquals('decided', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '2016 / 2',
-                 'ogg.meeting.agenda_item_number': '1.'},
+                 'ogg.meeting.agenda_item_number': '1.',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -24,20 +24,23 @@ class TestMeetingDocxProperties(IntegrationTestCase):
         self.login(self.dossier_responsible)
         self.assertEquals('pending', self.draft_word_proposal.get_state().title)
         self.assertEquals(
-            {'ogg.meeting.decision_number': ''},
+            {'ogg.meeting.decision_number': '',
+             'ogg.meeting.agenda_item_number': ''},
             get_doc_properties(self.word_proposal.get_proposal_document()))
 
     def test_submitted_proposal_document(self):
         with self.login(self.dossier_responsible):
             self.assertEquals('submitted', self.word_proposal.get_state().title)
             self.assertEquals(
-                {'ogg.meeting.decision_number': ''},
+                {'ogg.meeting.decision_number': '',
+                 'ogg.meeting.agenda_item_number': ''},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
             self.assertEquals('submitted', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
-                {'ogg.meeting.decision_number': ''},
+                {'ogg.meeting.decision_number': '',
+                 'ogg.meeting.agenda_item_number': ''},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
 
     def test_scheduled_proposal_document(self):
@@ -47,13 +50,15 @@ class TestMeetingDocxProperties(IntegrationTestCase):
         with self.login(self.dossier_responsible):
             self.assertEquals('scheduled', self.word_proposal.get_state().title)
             self.assertEquals(
-                {'ogg.meeting.decision_number': ''},
+                {'ogg.meeting.decision_number': '',
+                 'ogg.meeting.agenda_item_number': '1.'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
             self.assertEquals('scheduled', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
-                {'ogg.meeting.decision_number': ''},
+                {'ogg.meeting.decision_number': '',
+                 'ogg.meeting.agenda_item_number': '1.'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
 
     def test_decided_proposal_document(self):
@@ -63,11 +68,13 @@ class TestMeetingDocxProperties(IntegrationTestCase):
         with self.login(self.dossier_responsible):
             self.assertEquals('decided', self.word_proposal.get_state().title)
             self.assertEquals(
-                {'ogg.meeting.decision_number': '2016 / 2'},
+                {'ogg.meeting.decision_number': '2016 / 2',
+                 'ogg.meeting.agenda_item_number': '1.'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
             self.assertEquals('decided', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
-                {'ogg.meeting.decision_number': '2016 / 2'},
+                {'ogg.meeting.decision_number': '2016 / 2',
+                 'ogg.meeting.agenda_item_number': '1.'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -1,0 +1,73 @@
+from opengever.dossier.interfaces import IDocProperties
+from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
+
+
+def get_doc_properties(document, prefix='ogg.meeting.'):
+    docprops = getMultiAdapter((document, document.REQUEST), IDocProperties)
+    return {key: value for key, value in docprops.get_properties().items()
+            if key.startswith(prefix)}
+
+
+class TestMeetingDocxProperties(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    def test_non_meeting_document_should_not_have_meeting_properties(self):
+        self.login(self.dossier_responsible)
+        self.assertEquals(
+            {},
+            get_doc_properties(self.document),
+            'A regular document should not contain meeting doc properties.')
+
+    def test_pending_proposal_document(self):
+        self.login(self.dossier_responsible)
+        self.assertEquals('pending', self.draft_word_proposal.get_state().title)
+        self.assertEquals(
+            {'ogg.meeting.decision_number': ''},
+            get_doc_properties(self.word_proposal.get_proposal_document()))
+
+    def test_submitted_proposal_document(self):
+        with self.login(self.dossier_responsible):
+            self.assertEquals('submitted', self.word_proposal.get_state().title)
+            self.assertEquals(
+                {'ogg.meeting.decision_number': ''},
+                get_doc_properties(self.word_proposal.get_proposal_document()))
+
+        with self.login(self.committee_responsible):
+            self.assertEquals('submitted', self.submitted_word_proposal.get_state().title)
+            self.assertEquals(
+                {'ogg.meeting.decision_number': ''},
+                get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
+
+    def test_scheduled_proposal_document(self):
+        with self.login(self.committee_responsible):
+            self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+
+        with self.login(self.dossier_responsible):
+            self.assertEquals('scheduled', self.word_proposal.get_state().title)
+            self.assertEquals(
+                {'ogg.meeting.decision_number': ''},
+                get_doc_properties(self.word_proposal.get_proposal_document()))
+
+        with self.login(self.committee_responsible):
+            self.assertEquals('scheduled', self.submitted_word_proposal.get_state().title)
+            self.assertEquals(
+                {'ogg.meeting.decision_number': ''},
+                get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
+
+    def test_decided_proposal_document(self):
+        with self.login(self.committee_responsible):
+            self.schedule_proposal(self.meeting, self.submitted_word_proposal).decide()
+
+        with self.login(self.dossier_responsible):
+            self.assertEquals('decided', self.word_proposal.get_state().title)
+            self.assertEquals(
+                {'ogg.meeting.decision_number': '2016 / 2'},
+                get_doc_properties(self.word_proposal.get_proposal_document()))
+
+        with self.login(self.committee_responsible):
+            self.assertEquals('decided', self.submitted_word_proposal.get_state().title)
+            self.assertEquals(
+                {'ogg.meeting.decision_number': '2016 / 2'},
+                get_doc_properties(self.submitted_word_proposal.get_proposal_document()))

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -10,7 +10,6 @@ def get_doc_properties(document, prefix='ogg.meeting.'):
 
 
 class TestMeetingDocxProperties(IntegrationTestCase):
-
     features = ('meeting', 'word-meeting')
 
     def test_non_meeting_document_should_not_have_meeting_properties(self):
@@ -22,28 +21,28 @@ class TestMeetingDocxProperties(IntegrationTestCase):
 
     def test_pending_proposal_document(self):
         self.login(self.dossier_responsible)
-        self.assertEquals('pending', self.draft_word_proposal.get_state().title)
         self.assertEquals(
             {'ogg.meeting.decision_number': '',
              'ogg.meeting.agenda_item_number': '',
-             'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
-            get_doc_properties(self.word_proposal.get_proposal_document()))
+             'ogg.meeting.proposal_title': '\xc3\x9cberarbeitung der GAV',
+             'ogg.meeting.proposal_state': 'Pending'},
+            get_doc_properties(self.draft_word_proposal.get_proposal_document()))
 
     def test_submitted_proposal_document(self):
         with self.login(self.dossier_responsible):
-            self.assertEquals('submitted', self.word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '',
-                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Submitted'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
-            self.assertEquals('submitted', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '',
-                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Submitted'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
 
     def test_scheduled_proposal_document(self):
@@ -51,19 +50,19 @@ class TestMeetingDocxProperties(IntegrationTestCase):
             self.schedule_proposal(self.meeting, self.submitted_word_proposal)
 
         with self.login(self.dossier_responsible):
-            self.assertEquals('scheduled', self.word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '1.',
-                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Scheduled'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
-            self.assertEquals('scheduled', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '1.',
-                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Scheduled'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
 
     def test_decided_proposal_document(self):
@@ -71,17 +70,17 @@ class TestMeetingDocxProperties(IntegrationTestCase):
             self.schedule_proposal(self.meeting, self.submitted_word_proposal).decide()
 
         with self.login(self.dossier_responsible):
-            self.assertEquals('decided', self.word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '2016 / 2',
                  'ogg.meeting.agenda_item_number': '1.',
-                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Decided'},
                 get_doc_properties(self.word_proposal.get_proposal_document()))
 
         with self.login(self.committee_responsible):
-            self.assertEquals('decided', self.submitted_word_proposal.get_state().title)
             self.assertEquals(
                 {'ogg.meeting.decision_number': '2016 / 2',
                  'ogg.meeting.agenda_item_number': '1.',
-                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement'},
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Decided'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -84,3 +84,34 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                  'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
                  'ogg.meeting.proposal_state': 'Decided'},
                 get_doc_properties(self.submitted_word_proposal.get_proposal_document()))
+
+    def test_excerpt_document(self):
+        with self.login(self.committee_responsible):
+            agenda_item = self.schedule_proposal(self.meeting,
+                                                 self.submitted_word_proposal)
+            agenda_item.decide()
+            with self.observe_children(self.meeting_dossier) as children:
+                agenda_item.generate_excerpt(title='Excerpt')
+
+            meeting_dossier_excerpt, = children['added']
+
+            self.assertEquals(
+                {'ogg.meeting.decision_number': '2016 / 2',
+                 'ogg.meeting.agenda_item_number': '1.',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Decided'},
+                get_doc_properties(meeting_dossier_excerpt))
+
+            with self.observe_children(self.dossier) as children:
+                self.submitted_word_proposal.load_model().return_excerpt(
+                    meeting_dossier_excerpt)
+
+            case_dossier_excerpt, = children['added']
+
+        with self.login(self.dossier_responsible):
+            self.assertEquals(
+                {'ogg.meeting.decision_number': '2016 / 2',
+                 'ogg.meeting.agenda_item_number': '1.',
+                 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
+                 'ogg.meeting.proposal_state': 'Decided'},
+                get_doc_properties(case_dossier_excerpt))


### PR DESCRIPTION
When a document belongs to a proposal in any way, meeting docproperties are provided for this document.
Example:
```python
{'ogg.meeting.decision_number': '2016 / 2',
 'ogg.meeting.agenda_item_number': '1.',
 'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
 'ogg.meeting.proposal_state': 'Decided'}
```

**The docproperties are provided for these documents:**

- Proposal documents which are stored within the case dossier.
- Submitted proposal documents which are stored within the committee.
- Excerpt documents which are created in the committed (and stored within the meeting dossier).
- Excerpt documents which were sent back to the proposer and thus stored in the case dossier.

Resolves https://github.com/4teamwork/gever/issues/77