### PR TITLE
Use new protocol command if word feature enabled

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- SPV word: Fix protocol zip export. [tarnap]
 - Bundle import: Fix deactivation of LDAP plugin during import. [lgraf]
 - Update Plone version to 4.3.15. [lgraf]
 - SPV: Fix proposal history. [tarnap]

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -3,6 +3,7 @@ from ftw.zipexport.utils import normalize_path
 from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.command import AgendaItemListOperations
 from opengever.meeting.command import CreateGeneratedDocumentCommand
+from opengever.meeting.command import MergeDocxProtocolCommand
 from opengever.meeting.command import ProtocolOperations
 from opengever.meeting.interfaces import IMeetingWrapper
 from Products.CMFPlone.utils import safe_unicode
@@ -76,7 +77,11 @@ class MeetingZipExport(BrowserView):
 
         # Create new protocol
         operations = ProtocolOperations()
-        command = CreateGeneratedDocumentCommand(
+        if is_word_meeting_implementation_enabled():
+            command_class = MergeDocxProtocolCommand
+        else:
+            command_class = CreateGeneratedDocumentCommand
+        command = command_class(
             self.context,
             self.model,
             operations,

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -1,7 +1,6 @@
 from ftw.zipexport.generation import ZipGenerator
 from ftw.zipexport.utils import normalize_path
 from opengever.meeting import is_word_meeting_implementation_enabled
-from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.command import AgendaItemListOperations
 from opengever.meeting.command import CreateGeneratedDocumentCommand
 from opengever.meeting.command import ProtocolOperations


### PR DESCRIPTION
There are two command classes:

`CreateGeneratedDocumentCommand` - used when the word feature is disabled
`MergeDocxProtocolCommand` - used when the word feature is enabled.

This affects the content of the protocol word file when exported in a ZIP.

Resolves: https://github.com/4teamwork/gever/issues/112

### Testing
We don't have (yet) testing infrastructure for exact comparison of the content of word files. Therefore this change cannot be reliably tested at this point.

### Manual testing
When a meeting doesn't yet have a protocol, and I export the ZIP file, the protocol generated in the ZIP should use the new protocol generating mechanism. This can be verified by making sure that the agenda item document / proposal document is merged into the protocol. We didn't do that in the non-word implementation.

Steps in order to test it manually:
- Create a meeting.
- Create an agenda item (proposal or ad-hoc, doesn't matter).
- Edit the proposal document of a the agenda item and add distinctive content.
- The protocol of the meeting must NOT be generated (otherwise the ZIP would just use that and not go to the affected code part).
- Export the ZIP file.
- Ensure that the protocol word file contains the content of the proposal document.

![bildschirmfoto 2017-10-04 um 11 57 00](https://user-images.githubusercontent.com/7469/31170354-0a901b84-a8fc-11e7-911b-3159c3e81ba5.png)
![bildschirmfoto 2017-10-04 um 11 57 56](https://user-images.githubusercontent.com/7469/31170364-111fab2c-a8fc-11e7-97eb-487d73b50cb2.png)
