### PR TITLE
Create missing SQL sequences.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - SPV word: Fix protocol zip export. [tarnap]
+- Create missing SQL sequences. [jone]
 - Bundle import: Fix deactivation of LDAP plugin during import. [lgraf]
 - Update Plone version to 4.3.15. [lgraf]
 - SPV: Fix proposal history. [tarnap]

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -3,11 +3,13 @@ from alembic.operations import Operations
 from decorator import decorator
 from ftw.upgrade import UpgradeStep
 from opengever.base.model import create_session
-from sqlalchemy import Column
 from sqlalchemy import BigInteger
+from sqlalchemy import Column
 from sqlalchemy import MetaData
 from sqlalchemy import select
 from sqlalchemy import String
+from sqlalchemy.schema import CreateSequence
+from sqlalchemy.schema import Sequence
 from zope.sqlalchemy.datamanager import mark_changed
 import logging
 
@@ -313,6 +315,14 @@ class SchemaMigration(SQLUpgradeStep):
     @property
     def supports_sequences(self):
         return self.op.impl.dialect.supports_sequences
+
+    def ensure_sequence_exists(self, sequence_name):
+        if not self.supports_sequences:
+            return None
+        if self.op.impl.dialect.has_sequence(self.connection, sequence_name):
+            return False
+        self.op.execute(CreateSequence(Sequence(sequence_name)))
+        return True
 
     @property
     def is_oracle(self):

--- a/opengever/core/upgrades/20170907161431_add_team_model/upgrade.py
+++ b/opengever/core/upgrades/20170907161431_add_team_model/upgrade.py
@@ -29,3 +29,4 @@ class AddTeamModel(SchemaMigration):
                    ForeignKey('groups.groupid'), nullable=False),
             Column('org_unit_id', String(UNIT_ID_LENGTH),
                    ForeignKey('org_units.unit_id'), nullable=False))
+        self.ensure_sequence_exists('teams_id_seq')

--- a/opengever/core/upgrades/20170920143453_add_excerpts_table/upgrade.py
+++ b/opengever/core/upgrades/20170920143453_add_excerpts_table/upgrade.py
@@ -24,3 +24,4 @@ class AddExcerptsTable(SchemaMigration):
                    String(UNIT_ID_LENGTH), nullable=False),
             Column('excerpt_int_id', Integer, nullable=False)
         )
+        self.ensure_sequence_exists('excerpts_id_seq')

--- a/opengever/core/upgrades/20171004145231_add_missing_sequences/upgrade.py
+++ b/opengever/core/upgrades/20171004145231_add_missing_sequences/upgrade.py
@@ -1,0 +1,42 @@
+from opengever.core.upgrade import SchemaMigration
+
+
+class AddMissingSequences(SchemaMigration):
+    """Add missing sequences.
+    """
+
+    def migrate(self):
+        known_sequences = (
+            'activities_id_seq',
+            'adresses_id_seq',
+            'agendaitems_id_seq',
+            'archived_address_id_seq',
+            'archived_contact_id_seq',
+            'archived_mail_address_id_seq',
+            'archived_phonenumber_id_seq',
+            'archived_url_id_seq',
+            'committee_id_seq',
+            'contacts_id_seq',
+            'excerpts_id_seq',
+            'generateddocument_id_seq',
+            'locks_id_seq',
+            'mail_adresses_id_seq',
+            'meeting_id_seq',
+            'member_id_seq',
+            'membership_id_seq',
+            'notification_defaults_id_seq',
+            'notifications_id_seq',
+            'org_roles_id_seq',
+            'participation_roles_id_seq',
+            'participations_id_seq',
+            'periods_id_seq',
+            'phonenumber_id_seq',
+            'proposal_history_id_seq',
+            'proposal_id_seq',
+            'resources_id_seq',
+            'submitteddocument_id_seq',
+            'task_id_seq',
+            'teams_id_seq',
+            'urls_id_seq',
+            'watchers_id_seq')
+        map(self.ensure_sequence_exists, known_sequences)


### PR DESCRIPTION
When creating a new table with a sequence in a schema migration, the sequence is not created automatically. We haven't done that up to now.

- This change introduces a helper "ensure_sequence_exists", which safely creates a sequences when it is missing.
- An upgrade step makes sure all currently known sequences exist. The list is created with:
  `git grep "Sequence(" | sed -e 's:.*Sequence(.::' -e 's:.).*::' | sort | uniq`
- The last two upgrade steps were updated to ensure the their sequences exist in order to improve the copy/paste experience for future migrations.

⚠️ Please do a careful review as I am no SQL / SQLAlchemy master.

Fixes https://github.com/4teamwork/gever/issues/114