### PR TITLE
SPV word: In proposal forms, move the title to the top.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- SPV word: In proposal forms, move the title to the top. [jone]
 - SPV word: Fix protocol zip export. [tarnap]
 - Bundle import: Fix deactivation of LDAP plugin during import. [lgraf]
 - Update Plone version to 4.3.15. [lgraf]

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -49,6 +49,7 @@ class FieldConfigurationMixin(object):
         map(self.use_trix, textfields)
         if is_word_meeting_implementation_enabled():
             map(self.omit_field, textfields)
+            move(self, 'title', before='*')
 
     def omit_field(self, fieldname):
         self.fields = self.fields.omit(fieldname)


### PR DESCRIPTION
Lets be consistent with the other GEVER forms.

![bildschirmfoto 2017-10-04 um 17 03 37](https://user-images.githubusercontent.com/7469/31183172-1afe9dcc-a926-11e7-8046-d5047ec1e150.png)
![bildschirmfoto 2017-10-04 um 17 03 25](https://user-images.githubusercontent.com/7469/31183171-1af1e988-a926-11e7-8f58-7d07a4f73e97.png)
