### PR TITLE
Provide a body.feature-word-meeting class.

### DIFF
--- a/opengever/base/browser/layout.py
+++ b/opengever/base/browser/layout.py
@@ -1,4 +1,5 @@
 from opengever.bumblebee import is_bumblebee_feature_enabled
+from opengever.meeting import is_word_meeting_implementation_enabled
 from plone.app.layout.globals.layout import LayoutPolicy
 
 
@@ -14,5 +15,8 @@ class GeverLayoutPolicy(LayoutPolicy):
 
         if is_bumblebee_feature_enabled():
             body_class = ' '.join((body_class, 'feature-bumblebee'))
+
+        if is_word_meeting_implementation_enabled():
+            body_class = ' '.join((body_class, 'feature-word-meeting'))
 
         return body_class

--- a/opengever/base/tests/test_layout.py
+++ b/opengever/base/tests/test_layout.py
@@ -1,6 +1,8 @@
 from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.testing import FunctionalTestCase
+from plone import api
+import transaction
 
 
 class TestGeverLayoutPolicy(FunctionalTestCase):
@@ -10,6 +12,25 @@ class TestGeverLayoutPolicy(FunctionalTestCase):
         self.assertNotIn(
             'feature-bumblebee',
             browser.css('body').first.get('class').split(' '))
+
+    @browsing
+    def test_word_meeting_feature_presence(self, browser):
+        browser.login()
+        prefix = 'opengever.meeting.interfaces.IMeetingSettings'
+        meeting_feature = prefix + '.is_feature_enabled'
+        api.portal.set_registry_record(meeting_feature, True)
+
+        word_feature = prefix + '.is_word_implementation_enabled'
+
+        api.portal.set_registry_record(word_feature, False)
+        transaction.commit()
+        self.assertNotIn('feature-word-meeting',
+                         browser.open().css('body').first.classes)
+
+        api.portal.set_registry_record(word_feature, True)
+        transaction.commit()
+        self.assertIn('feature-word-meeting',
+                      browser.open().css('body').first.classes)
 
 
 class TestGeverLayoutPolicyBumblebeeFeature(FunctionalTestCase):


### PR DESCRIPTION
When the meeting and its word implementation is enabled, provide a class "body.feature-word-meeting" so that we can use it in CSS.