### PR TITLE
SPV word: do not decide agenda items when closing the meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]
+- SPV word: Do not automatically decide agenda items when closing meetings. [jone]
 - SPV word: Prevent meetings with undecided agenda items from closing. [jone]
 - SPV word: In proposal forms, move the title to the top. [jone]
 - SPV word: Update proposal workflow translations to be consistent capitalized. [jone]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]
+- SPV word: Prevent meetings with undecided agenda items from closing. [jone]
 - SPV word: In proposal forms, move the title to the top. [jone]
 - SPV word: Update proposal workflow translations to be consistent capitalized. [jone]
 - SPV word: Fix protocol zip export. [tarnap]

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -59,18 +59,15 @@
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
           <h2 i18n:translate="close_meeting">Close meeting</h2>
-          <p i18n:translate="">
-            After closing the meeting it can no longer be edited.
-            The following tasks will be performed:
+          <p tal:condition="view/will_closing_regenerate_protocol"
+             i18n:translate="">
+            Closing the meeting the first time will automatically (re-)create the protocol.
           </p>
-          <ul>
-            <li i18n:translate="">Close all proposals.</li>
-            <li i18n:translate="">Generate excerpts for all proposals.</li>
-            <li i18n:translate=""
-                tal:condition="view/will_closing_regenerate_protocol">
-              Update or create the protocol.
-            </li>
-          </ul>
+          <p tal:condition="not:view/will_closing_regenerate_protocol"
+             i18n:translate="">
+            Closing the meeting will not update the protocol automatically. <br />
+            Make sure to transfer your changes or recreate the protocol.
+          </p>
           <p i18n:translate="">
             Are you sure you want to close this meeting?
           </p>

--- a/opengever/meeting/browser/meetings/transitions.py
+++ b/opengever/meeting/browser/meetings/transitions.py
@@ -2,7 +2,7 @@ from opengever.base.response import JSONResponse
 from opengever.meeting import _
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
-from zExceptions import NotFound
+from zExceptions import BadRequest
 from zope.interface import implements
 from zope.publisher.interfaces.browser import IBrowserView
 
@@ -17,21 +17,35 @@ class MeetingTransitionController(BrowserView):
 
     def __call__(self):
         transition = self.request.get('transition')
-        if not self.is_valid_transition(transition):
-            raise NotFound
+        response = JSONResponse(self.request)
 
-        self.execute_transition(transition)
-        msg = _('label_transition_executed',
-                default='Transition ${transition} executed',
-                mapping={'transition': self.model.workflow.transitions.get(transition).title})
+        errors = self.get_transition_validation_errors(transition)
+        if errors:
+            map(response.error, errors)
+            response.remain()
 
-        return JSONResponse(self.request).redirect(self.model.get_url()).info(msg).dump()
+        elif not self.is_valid_transition(transition):
+            raise BadRequest()
+
+        else:
+            self.execute_transition(transition)
+            response.info(_('label_transition_executed',
+                            default='Transition ${transition} executed',
+                            mapping={'transition': self.model.workflow.transitions.get(
+                                transition).title}))
+            response.redirect(self.model.get_url())
+
+        return response.dump()
 
     @classmethod
     def url_for(cls, context, meeting, transition):
         url = '{}?transition={}'.format(
             meeting.get_url(view='meetingtransitioncontroller'), transition)
         return addTokenToUrl(url)
+
+    def get_transition_validation_errors(self, transition_name):
+        transition = self.model.workflow.get_transition(transition_name)
+        return transition.get_validation_errors(self.model)
 
     def is_valid_transition(self, transition_name):
         return self.model.can_execute_transition(transition_name)

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -20,8 +20,12 @@
     };
 
     this.closeMeeting = function() {
-      return $.post(self.currentItem.attr("href")).done(function() {
-        location.reload();
+      return $.post(self.currentItem.attr("href")).always(function(){
+        dialog.close();
+      }).done(function(data) {
+        if (data.redirectUrl){
+          window.location = data.redirectUrl;
+        }
       });
     };
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-05 06:38+0000\n"
-"PO-Revision-Date: 2017-10-04 17:58+0200\n"
+"POT-Creation-Date: 2017-10-05 16:15+0000\n"
+"PO-Revision-Date: 2017-10-05 17:49+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -763,6 +763,11 @@ msgstr "Abbrechen"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_close"
 msgstr "Schliessen"
+
+#. Default: "The meeting cannot be closed because it has undecided agenda items."
+#: ./opengever/meeting/model/meeting.py
+msgid "label_close_error_has_undecided_agenda_items"
+msgstr "Die Sitzung kann nicht abgeschlossen werden solange noch nicht alle Traktanden abgeschlossen sind."
 
 #. Default: "Committee deactivated successfully"
 #: ./opengever/meeting/browser/committeetransitioncontroller.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-10-05 16:15+0000\n"
-"PO-Revision-Date: 2017-10-05 17:49+0200\n"
+"PO-Revision-Date: 2017-10-10 09:01+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -63,7 +63,6 @@ msgid "Additional document ${title} has been submitted successfully."
 msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
 msgstr "Nach Abschluss kann die Sitzung nicht mehr bearbeitet werden. Die folgenden Aktionen werden beim Abschliessen ausgeführt:"
 
@@ -111,7 +110,6 @@ msgid "Choose Agenda Items"
 msgstr "Traktanden auswählen"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Close all proposals."
 msgstr "Alle Anträge werden abgeschlossen."
 
@@ -122,6 +120,14 @@ msgstr "Aktuelle Periode abschliessen"
 #: ./opengever/meeting/browser/periods.py
 msgid "Close period"
 msgstr "Periode abschliessen"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Closing the meeting the first time will automatically (re-)create the protocol."
+msgstr "Das Protokoll wird automatisch neu generiert, da die Sitzung das erste Mal abgeschlossen wird."
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Closing the meeting will not update the protocol automatically. <br /> Make sure to transfer your changes or recreate the protocol."
+msgstr "Das Protokoll wird beim erneuten Sitzungsabschluss nicht automatisch aktualisiert. <br /> Bitte übertragen Sie allfällige Änderungen manuell oder generieren Sie das Protokoll neu."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -184,7 +190,6 @@ msgid "Export settings"
 msgstr "Export-Einstellungen"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Generate excerpts for all proposals."
 msgstr "Für alle Anträge wird ein Protokollauszug generiert und ins Antragsdossier zurückgespielt."
 
@@ -356,7 +361,6 @@ msgid "Unschedule proposal"
 msgstr "Traktandum entfernen"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Update or create the protocol."
 msgstr "Das Protokoll wird erstellt oder aktualisiert."
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -65,7 +65,6 @@ msgid "Additional document ${title} has been submitted successfully."
 msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
 msgstr ""
 
@@ -113,7 +112,6 @@ msgid "Choose Agenda Items"
 msgstr "Choisir les points du l'ordre du jour"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Close all proposals."
 msgstr "Toutes les propositions sont clôturées."
 
@@ -124,6 +122,14 @@ msgstr "Clôturer la période actuellement active"
 #: ./opengever/meeting/browser/periods.py
 msgid "Close period"
 msgstr "Clôturer la période"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Closing the meeting the first time will automatically (re-)create the protocol."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Closing the meeting will not update the protocol automatically. <br /> Make sure to transfer your changes or recreate the protocol."
+msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -186,7 +192,6 @@ msgid "Export settings"
 msgstr "Paramètres de l'export"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Generate excerpts for all proposals."
 msgstr "Pour toutes les propositions un extrait de protocole sera généré et renvoyé au dossier de proposition."
 
@@ -358,7 +363,6 @@ msgid "Unschedule proposal"
 msgstr "Enlever un point de l'ordre du jour"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Update or create the protocol."
 msgstr "Le protocole est créé ou mis à jour."
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-05 06:38+0000\n"
+"POT-Creation-Date: 2017-10-05 16:15+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -765,6 +765,11 @@ msgstr "Annuler"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_close"
 msgstr "Clôturer"
+
+#. Default: "The meeting cannot be closed because it has undecided agenda items."
+#: ./opengever/meeting/model/meeting.py
+msgid "label_close_error_has_undecided_agenda_items"
+msgstr ""
 
 #. Default: "Committee deactivated successfully"
 #: ./opengever/meeting/browser/committeetransitioncontroller.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -62,7 +62,6 @@ msgid "Additional document ${title} has been submitted successfully."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "After closing the meeting it can no longer be edited. The following tasks will be performed:"
 msgstr ""
 
@@ -110,7 +109,6 @@ msgid "Choose Agenda Items"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Close all proposals."
 msgstr ""
 
@@ -120,6 +118,14 @@ msgstr ""
 
 #: ./opengever/meeting/browser/periods.py
 msgid "Close period"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Closing the meeting the first time will automatically (re-)create the protocol."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Closing the meeting will not update the protocol automatically. <br /> Make sure to transfer your changes or recreate the protocol."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -183,7 +189,6 @@ msgid "Export settings"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Generate excerpts for all proposals."
 msgstr ""
 
@@ -355,7 +360,6 @@ msgid "Unschedule proposal"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Update or create the protocol."
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-05 06:38+0000\n"
+"POT-Creation-Date: 2017-10-05 16:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -761,6 +761,11 @@ msgstr ""
 #. Default: "Close"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_close"
+msgstr ""
+
+#. Default: "The meeting cannot be closed because it has undecided agenda items."
+#: ./opengever/meeting/model/meeting.py
+msgid "label_close_error_has_undecided_agenda_items"
 msgstr ""
 
 #. Default: "Committee deactivated successfully"

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -256,8 +256,9 @@ class Meeting(Base, SQLFormSupport):
             assert not self.get_undecided_agenda_items(), \
                 'All agenda items must be decided before a meeting is closed.'
 
-        for agenda_item in self.agenda_items:
-            agenda_item.close()
+        else:
+            for agenda_item in self.agenda_items:
+                agenda_item.close()
 
         self.update_protocol_document()
         self.unlock_protocol_document()

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -55,6 +55,17 @@ class CloseTransition(Transition):
     """Used by pending-closed and held-closed transitions.
     """
 
+    def get_validation_errors(self, model):
+        if not is_word_meeting_implementation_enabled():
+            return ()
+
+        if model.get_undecided_agenda_items():
+            return [_(u'label_close_error_has_undecided_agenda_items',
+                      u'The meeting cannot be closed because it has undecided'
+                      u' agenda items.')]
+
+        return ()
+
     def execute(self, obj, model):
         assert self.can_execute(model)
 
@@ -240,6 +251,11 @@ class Meeting(Base, SQLFormSupport):
         - update and unlock the protocol document
         """
         self.hold()
+
+        if is_word_meeting_implementation_enabled():
+            assert not self.get_undecided_agenda_items(), \
+                'All agenda items must be decided before a meeting is closed.'
+
         for agenda_item in self.agenda_items:
             agenda_item.close()
 
@@ -353,6 +369,14 @@ class Meeting(Base, SQLFormSupport):
             return ''
 
         return self._get_localized_time(self.end)
+
+    def get_undecided_agenda_items(self):
+        """Return a filtered list of this meetings agenda items,
+        containing only the items which are not in a "decided" workflow state.
+        """
+        def is_not_decided(agenda_item):
+            return agenda_item.workflow_state != 'decided'
+        return filter(is_not_decided, self.agenda_items)
 
     def _get_localized_time(self, date):
         if not date:

--- a/opengever/meeting/tests/test_meeting_word.py
+++ b/opengever/meeting/tests/test_meeting_word.py
@@ -67,12 +67,10 @@ class TestWordMeeting(IntegrationTestCase):
         # When closing the meeting, we should end up with a new version
         browser.open(self.meeting)
         self.assertEquals(
-            [
-                'Close all proposals.',
-                'Generate excerpts for all proposals.',
-                'Update or create the protocol.',
-            ],
-            browser.css('#confirm_close_meeting > ul > li').text)
+            ['Closing the meeting the first time will automatically'
+             ' (re-)create the protocol.',
+             'Are you sure you want to close this meeting?'],
+            browser.css('#confirm_close_meeting p').text)
         model.close()
         self.assertEquals(1, model.protocol_document.generated_version)
 
@@ -93,12 +91,10 @@ class TestWordMeeting(IntegrationTestCase):
         # it would potentially overwrite user-changes.
         browser.open(self.meeting)
         self.assertEquals(
-            [
-                'Close all proposals.',
-                'Generate excerpts for all proposals.',
-                # 'Update or create the protocol.',
-            ],
-            browser.css('#confirm_close_meeting > ul > li').text)
+            ['Closing the meeting will not update the protocol automatically.'
+             '\nMake sure to transfer your changes or recreate the protocol.',
+             'Are you sure you want to close this meeting?'],
+            browser.css('#confirm_close_meeting p').text)
         model.close()
         self.assertEquals(0, model.protocol_document.generated_version)
 

--- a/opengever/meeting/tests/test_meeting_word.py
+++ b/opengever/meeting/tests/test_meeting_word.py
@@ -101,3 +101,24 @@ class TestWordMeeting(IntegrationTestCase):
             browser.css('#confirm_close_meeting > ul > li').text)
         model.close()
         self.assertEquals(0, model.protocol_document.generated_version)
+
+    @browsing
+    def test_closing_meeting_with_undecided_items_is_not_allowed(self, browser):
+        """The user must decide all agenda items before the meeting can be closed.
+        """
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        self.assertEquals(u'pending', self.meeting.model.workflow_state)
+
+        browser.open(self.meeting)
+        editbar.menu_option('Actions', 'Close meeting').click()
+        self.assertEquals(
+            {u'messages': [
+                {u'messageTitle': u'Error',
+                 u'message': u'The meeting cannot be closed because it'
+                 u' has undecided agenda items.',
+                 u'messageClass': u'error'}],
+             u'proceed': False},
+            browser.json)
+
+        self.assertEquals(u'pending', self.meeting.model.workflow_state)

--- a/opengever/meeting/tests/test_protocol_word.py
+++ b/opengever/meeting/tests/test_protocol_word.py
@@ -39,7 +39,7 @@ class TestProtocolWithWord(IntegrationTestCase):
     @browsing
     def test_protocol_is_generated_when_closing_meetings(self, browser):
         self.login(self.committee_responsible, browser)
-        self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        self.schedule_proposal(self.meeting, self.submitted_word_proposal).decide()
         meeting = self.meeting.model
 
         self.assertIsNone(meeting.protocol_document)

--- a/opengever/meeting/workflow.py
+++ b/opengever/meeting/workflow.py
@@ -53,8 +53,17 @@ class Transition(object):
         assert self.can_execute(model)
         model.workflow_state = self.state_to
 
+    def get_validation_errors(self, model):
+        """Run custom validation and return a list or tuple of errors.
+
+        If the return value is an empty list or tuple, the validation passed.
+        Otherwise it must be a list or tuple of message strings containing
+        errors which prevent this transition from beeing executed.
+        """
+        return ()
+
     def can_execute(self, model):
-        if not self.condition():
+        if not self.condition() and not self.get_validation_errors(model):
             return False
         return model.workflow_state == self.state_from
 
@@ -108,6 +117,9 @@ class Workflow(object):
 
     def get_transitions(self, state):
         return self.get_state(state.name).get_transitions()
+
+    def get_transition(self, transition_name, **kwargs):
+        return self.transitions.get(transition_name, **kwargs)
 
     def with_visible_transitions(self, transitions):
         copied_states = [each.copy() for each in self.states.values()]


### PR DESCRIPTION
**Goal:**
We want to give the user control over the state of the agenda items. It should be a conscious decision to decide each single agenda items.

**Changes:**
- Closing a meeting does no longer automatically decide agenda items.
- Closing a meeting is not allowed when there are undecided agenda items.

**Implementation details:**
- The transition controller endpoint can now also return a JSON error message.
- The frontend is updated to handle JSON error messages for transitions.
- The transition controller does no longer raise `NotFound` when a request is unexpected, but `BadRequest`.
- Transitions can now implement a `get_validation_errors` method.
- Because we've removed content from the confirmation dialog, the dialog is rewritten to be more expressive about what exactly happens and what that means.

**Background infos:**
The protocol is locked until the meeting is closed for the first time. When the meeting is closed, the meeting lock is removed for further manual changes.
In order to not overwrite the user's potential changes, the protocol will not be locked / updated when the user reopens the meeting. Therefore the different messages below.

**Screenshots:**

![bildschirmfoto 2017-10-05 um 18 07 06](https://user-images.githubusercontent.com/7469/31238758-272e704c-a9fb-11e7-8082-bb3a8510ca62.png)

![bildschirmfoto 2017-10-05 um 18 06 15](https://user-images.githubusercontent.com/7469/31238740-1b0abd66-a9fb-11e7-8fbc-6a53e5ba5f9b.png)

![bildschirmfoto 2017-10-05 um 18 07 20](https://user-images.githubusercontent.com/7469/31238654-e54a4ed0-a9fa-11e7-9635-3be8790d4b26.png)

Resolves https://github.com/4teamwork/gever/issues/111