### PR TITLE
Fixed default_value for hidden responsible_client field on tasktemplates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -528,6 +528,8 @@ Objects
   - self.templates
     - self.proposal_template
     - self.sablon_template
+    - self.tasktemplatefolder
+      - self.tasktemplate
 
 .. </fixture:objects>
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
+- Fix responsible_client default value for tasktemplates. [phgross]
 - SPV word: In proposal forms, move the title to the top. [jone]
 - SPV word: Update proposal workflow translations to be consistent capitalized. [jone]
 - SPV word: Fix protocol zip export. [tarnap]

--- a/opengever/tasktemplates/content/configure.zcml
+++ b/opengever/tasktemplates/content/configure.zcml
@@ -3,6 +3,11 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="opengever.tasktemplates">
 
+  <adapter
+      factory=".tasktemplate.default_responsible_client"
+      name="default"
+      />
+
   <browser:page
       for=".tasktemplate.ITaskTemplate"
       name="edit"

--- a/opengever/tasktemplates/content/tasktemplate.py
+++ b/opengever/tasktemplates/content/tasktemplate.py
@@ -10,6 +10,7 @@ from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.browser.edit import DefaultEditForm
 from plone.dexterity.content import Item
 from plone.directives import form
+from z3c.form import widget
 from z3c.form.browser import checkbox
 from zope import schema
 from zope.interface import implements
@@ -99,12 +100,13 @@ class TaskTemplate(Item):
     implements(ITaskTemplate)
 
 
-@form.default_value(field=ITaskTemplate['responsible_client'])
-def responsible_client_default_value(data):
-    return get_current_org_unit().id()
+default_responsible_client = widget.ComputedWidgetAttribute(
+    lambda adapter: get_current_org_unit().id(),
+    field=ITaskTemplate['responsible_client'])
 
 
 class TaskTemplateAddForm(DefaultAddForm):
+
     def createAndAdd(self, data):
         update_reponsible_field_data(data)
         return super(TaskTemplateAddForm, self).createAndAdd(data)

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -1,8 +1,11 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFCore.utils import getToolByName
 from zope.component import createObject
@@ -86,3 +89,35 @@ class TestTaskTemplates(FunctionalTestCase):
         browser.login().visit(templatefolder, view='@@edit')
         browser.find_button_by_label('Save').click()
         self.assertEquals(templatefolder.absolute_url(), browser.url)
+
+
+class TestTaskTemplatesIntegration(IntegrationTestCase):
+
+    @browsing
+    def test_adding_a_tasktemplate(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        templatefolder = create(Builder('tasktemplatefolder')
+                                .within(self.templates)
+                                .titled(u'Verfahren Neuanstellung'))
+
+        browser.open(templatefolder)
+        factoriesmenu.add('TaskTemplate')
+        browser.fill(
+            {'Title': 'Arbeitsplatz einrichten.',
+             'Task Type': 'comment',
+             'Deadline in Days': u'10'})
+
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill('fa:robert.ziegler')
+        form.find_widget('Issuer').fill(u'responsible')
+
+        browser.click_on('Save')
+        self.assertEquals(['Item created'], info_messages())
+
+        tasktemplate = templatefolder.listFolderContents()[0]
+        self.assertEquals(u'Arbeitsplatz einrichten.', tasktemplate.title)
+        self.assertEquals(u'robert.ziegler', tasktemplate.responsible)
+        self.assertEquals('fa', tasktemplate.responsible_client)
+        self.assertEquals(u'responsible', tasktemplate.issuer)
+        self.assertEquals(10, tasktemplate.deadline)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -189,7 +189,9 @@ class OpengeverContentFixture(object):
             .titled(u'Vorlagen')
             .having(id='vorlagen')))
         templates.manage_setLocalRoles(self.org_unit.users_group_id,
-                                       ('Reader',))
+                                       ('Reader', ))
+        templates.manage_setLocalRoles(self.administrator.getId(),
+                                       ('Reader', 'Contributor', 'Editor'))
         templates.reindexObjectSecurity()
 
         self.sablon_template = self.register('sablon_template', create(

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -206,6 +206,20 @@ class OpengeverContentFixture(object):
                 .with_asset_file(u'vertragsentwurf.docx')
                 .within(templates)))
 
+        self.tasktemplatefolder = self.register('tasktemplatefolder', create(
+            Builder('tasktemplatefolder')
+            .titled(u'Verfahren Neuanstellung')
+            .within(templates)))
+
+        self.tasktemplate = self.register('tasktemplate', create(
+            Builder('tasktemplate')
+            .titled(u'Arbeitsplatz einrichten.')
+            .having(**{'issuer': 'responsible',
+                       'responsible_client': 'fa',
+                       'responsible': 'robert.ziegler',
+                       'deadline': 10})
+            .within(self.tasktemplatefolder)))
+
     @staticuid()
     def create_committees(self):
         self.committee_container = self.register('committee_container', create(


### PR DESCRIPTION
Without grokking the subpackage the `plone.directives.form.default_value` decorator is not working. Therefore the creation of a tasktemplate failed with a validation error for a
hidden field (see https://github.com/4teamwork/opengever.ftw/issues/46). We now register the default_value adapter directly without the help of the decorator. (see https://community.plone.org/t/howto-default-value-for-datetime-field-in-plone5-without-using-plone-directives/2014/6 for further information)

Closes https://github.com/4teamwork/opengever.ftw/issues/46

Backport to `2017.5-stable` needed.