### PR TITLE
Add add and edit forms for teams and a team listing to contactfolder

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -29,6 +29,8 @@ Changelog
 - SPV word: trash documents of removed ad hoc agenda items. [tarnap]
 - SPV word: Represent paragraphs in the generated protocol. [jone]
 - SPV word: Allow to set custom excerpt titles. [tarnap]
+- Add new tab teams to contactfolder. [phgross]
+- Add add and edit forms for teams. [phgross]
 - OGDS update: Truncate purely descriptive user fields. [lgraf]
 - Include ftw.usermigration and implement additional user migrations:
 

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -172,4 +172,14 @@
       class=".contactfolder_forms.EditForm"
       permission="cmf.ModifyPortalContent"
       />
+
+  <browser:page
+      name="tabbedview_view-teams"
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      class=".tabs.TeamsListing"
+      permission="zope2.View"
+      />
+
+  <adapter factory=".tabs.TeamsListingTableSource" />
+
 </configure>

--- a/opengever/contact/browser/tabbed.py
+++ b/opengever/contact/browser/tabbed.py
@@ -33,6 +33,12 @@ class ContactFolderTabbedView(TabbedView):
              'title': _(u'label_users', default=u'Users'),
              'icon': None,
              'url': '#',
+             'class': None},
+
+            {'id': 'teams',
+             'title': _(u'label_teams', default=u'Teams'),
+             'icon': None,
+             'url': '#',
              'class': None}]
 
         return tabs

--- a/opengever/contact/browser/tabs.py
+++ b/opengever/contact/browser/tabs.py
@@ -1,0 +1,89 @@
+from ftw.table.interfaces import ITableSource
+from ftw.table.interfaces import ITableSourceConfig
+from opengever.base.model import create_session
+from opengever.contact import _
+from opengever.contact.utils import get_contactfolder_url
+from opengever.ogds.models.team import Team
+from opengever.tabbedview import BaseListingTab
+from opengever.tabbedview import SqlTableSource
+from opengever.tabbedview.filters import Filter
+from opengever.tabbedview.filters import FilterList
+from opengever.tabbedview.helper import boolean_helper
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import implements
+from zope.interface import Interface
+
+
+def linked_title_helper(item, value):
+    """Helper for linking the value with the team details view.
+    """
+    url = '{}/team-{}/view'.format(get_contactfolder_url(), item.team_id)
+    return u'<a href="{}">{}</a>'.format(url, value)
+
+
+class ITeamListingTableSourceConfig(ITableSourceConfig):
+    """Marker interface for table source configuration using the OGDS team
+    model as source.
+    """
+
+
+class ActiveOnlyFilter(Filter):
+    """Filter to only display active teams."""
+
+    def update_query(self, query):
+        return query.filter(Team.active == True)  # noqa
+
+
+class TeamsListing(BaseListingTab):
+    """Tab registered on contacts folder listing all teams.
+    """
+
+    implements(ITeamListingTableSourceConfig)
+
+    sort_on = 'title'
+    sort_order = ''
+
+    # the model attributes is used for a dynamic textfiltering functionality
+    model = Team
+    show_selects = False
+
+    filterlist_name = 'team_state_filter'
+    filterlist_available = True
+    filterlist = FilterList(
+        Filter('filter_all', _('label_tabbedview_filter_all')),
+        ActiveOnlyFilter('filter_active', _('Active'), default=True))
+
+    columns = (
+        {'column': 'title',
+         'column_title': _(u'label_title', default=u'Title'),
+         'transform': linked_title_helper},
+
+        {'column': 'groupid',
+         'column_title': _(u'label_group', default=u'Group'),
+         'transform': lambda item, value: item.group.label()},
+
+        {'column': 'org_unit_id',
+         'column_title': _(u'label_org_unit', default=u'Org Unit'),
+         'transform': lambda item, value: item.org_unit.title},
+
+        {'column': 'active',
+         'column_title': _(u'label_active', default=u'Active'),
+         'transform': boolean_helper}
+
+        )
+
+    def get_base_query(self):
+        """Returns the base search query (sqlalchemy)
+        """
+        session = create_session()
+        return session.query(Team)
+
+
+@implementer(ITableSource)
+@adapter(ITeamListingTableSourceConfig, Interface)
+class TeamsListingTableSource(SqlTableSource):
+    """Table source teams.
+    """
+
+    searchable_columns = [Team.title]

--- a/opengever/contact/contactfolder.py
+++ b/opengever/contact/contactfolder.py
@@ -1,6 +1,8 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Contact
+from opengever.ogds.base.wrapper import TeamWrapper
+from opengever.ogds.models.team import Team
 from plone.dexterity.content import Container
 from zope.interface import implements
 
@@ -31,6 +33,13 @@ class ContactFolder(Container, TranslatedTitleMixin):
             contact = Contact.query.get(contact_id)
             if contact:
                 return contact.get_wrapper(self)
+
+        if id_.startswith('team-'):
+            team_id = int(id_.split('-')[-1])
+            team = Team.query.get(team_id)
+            if team:
+                return TeamWrapper.wrap(self, team)
+
 
         if default is _marker:
             raise KeyError(id_)

--- a/opengever/contact/contactfolder.py
+++ b/opengever/contact/contactfolder.py
@@ -40,7 +40,6 @@ class ContactFolder(Container, TranslatedTitleMixin):
             if team:
                 return TeamWrapper.wrap(self, team)
 
-
         if default is _marker:
             raise KeyError(id_)
         return default

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-10-05 17:31+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/contact/browser/tabs.py
+msgid "Active"
+msgstr "Aktiv"
 
 #. Default: "Add Person"
 #: ./opengever/contact/browser/person.py
@@ -153,6 +157,7 @@ msgstr "Titel"
 
 #. Default: "Active"
 #: ./opengever/contact/browser/byline.py
+#: ./opengever/contact/browser/tabs.py
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_active"
 msgstr "Aktiv"
@@ -281,6 +286,11 @@ msgstr "Vorname"
 msgid "label_former_contact_id"
 msgstr "Frühere Kontakt ID"
 
+#. Default: "Group"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_group"
+msgstr "Gruppe"
+
 #. Default: "Inactive"
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_inactive"
@@ -329,6 +339,11 @@ msgstr "Keine Beteiligungen"
 #: ./opengever/contact/ogdsuser.py
 msgid "label_office"
 msgstr "Büro"
+
+#. Default: "Org Unit"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_org_unit"
+msgstr "Organisationseinheit"
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py
@@ -411,6 +426,20 @@ msgstr "Laufnummer"
 msgid "label_show_all"
 msgstr "Alle ${total} Beteiligungen anzeigen"
 
+#: ./opengever/contact/browser/tabs.py
+msgid "label_tabbedview_filter_all"
+msgstr "Alle"
+
+#. Default: "Teams"
+#: ./opengever/contact/browser/tabbed.py
+msgid "label_teams"
+msgstr "Teams"
+
+#. Default: "Title"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_title"
+msgstr "Titel"
+
 #. Default: "Url"
 #: ./opengever/contact/contact.py
 msgid "label_url"
@@ -461,4 +490,3 @@ msgstr "${amount} Treffer"
 #: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr "Telefon"
-

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-10-05 17:31+0000\n"
 "PO-Revision-Date: 2017-06-02 16:00+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#: ./opengever/contact/browser/tabs.py
+msgid "Active"
+msgstr ""
 
 #. Default: "Add Person"
 #: ./opengever/contact/browser/person.py
@@ -155,6 +159,7 @@ msgstr "Titre"
 
 #. Default: "Active"
 #: ./opengever/contact/browser/byline.py
+#: ./opengever/contact/browser/tabs.py
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_active"
 msgstr "Actif"
@@ -283,6 +288,11 @@ msgstr "Prénom"
 msgid "label_former_contact_id"
 msgstr "Contact ID antérieur"
 
+#. Default: "Group"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_group"
+msgstr ""
+
 #. Default: "Inactive"
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_inactive"
@@ -331,6 +341,11 @@ msgstr "Pas de participations"
 #: ./opengever/contact/ogdsuser.py
 msgid "label_office"
 msgstr "Bureau"
+
+#. Default: "Org Unit"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_org_unit"
+msgstr ""
 
 #. Default: "Organizations"
 #: ./opengever/contact/browser/tabbed.py
@@ -412,6 +427,20 @@ msgstr "Numéro courant"
 #: ./opengever/contact/browser/participations.py
 msgid "label_show_all"
 msgstr "Indiquer toutes les participations ${total}"
+
+#: ./opengever/contact/browser/tabs.py
+msgid "label_tabbedview_filter_all"
+msgstr ""
+
+#. Default: "Teams"
+#: ./opengever/contact/browser/tabbed.py
+msgid "label_teams"
+msgstr ""
+
+#. Default: "Title"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_title"
+msgstr ""
 
 #. Default: "Url"
 #: ./opengever/contact/contact.py

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-10-05 17:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.contact\n"
+
+#: ./opengever/contact/browser/tabs.py
+msgid "Active"
+msgstr ""
 
 #. Default: "Add Person"
 #: ./opengever/contact/browser/person.py
@@ -156,6 +160,7 @@ msgstr ""
 
 #. Default: "Active"
 #: ./opengever/contact/browser/byline.py
+#: ./opengever/contact/browser/tabs.py
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_active"
 msgstr ""
@@ -284,6 +289,11 @@ msgstr ""
 msgid "label_former_contact_id"
 msgstr ""
 
+#. Default: "Group"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_group"
+msgstr ""
+
 #. Default: "Inactive"
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_inactive"
@@ -331,6 +341,11 @@ msgstr ""
 #. Default: "Office"
 #: ./opengever/contact/ogdsuser.py
 msgid "label_office"
+msgstr ""
+
+#. Default: "Org Unit"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_org_unit"
 msgstr ""
 
 #. Default: "Organizations"
@@ -412,6 +427,20 @@ msgstr ""
 #. Default: "Show all ${total} participations"
 #: ./opengever/contact/browser/participations.py
 msgid "label_show_all"
+msgstr ""
+
+#: ./opengever/contact/browser/tabs.py
+msgid "label_tabbedview_filter_all"
+msgstr ""
+
+#. Default: "Teams"
+#: ./opengever/contact/browser/tabbed.py
+msgid "label_teams"
+msgstr ""
+
+#. Default: "Title"
+#: ./opengever/contact/browser/tabs.py
+msgid "label_title"
 msgstr ""
 
 #. Default: "Url"

--- a/opengever/contact/tests/test_tabbed.py
+++ b/opengever/contact/tests/test_tabbed.py
@@ -18,7 +18,7 @@ class TestContactFolderTabbedView(FunctionalTestCase):
         browser.login().open(self.contactfolder, view='tabbed_view')
 
         self.assertEquals(
-            ['Local', 'Users'],
+            ['Local', 'Users', 'Teams'],
             browser.css('.formTab').text)
 
     @browsing
@@ -27,5 +27,5 @@ class TestContactFolderTabbedView(FunctionalTestCase):
         browser.login().open(self.contactfolder, view='tabbed_view')
 
         self.assertEquals(
-            ['Persons', 'Organizations', 'Users'],
+            ['Persons', 'Organizations', 'Users', 'Teams'],
             browser.css('.formTab').text)

--- a/opengever/contact/tests/test_team_listing.py
+++ b/opengever/contact/tests/test_team_listing.py
@@ -1,0 +1,70 @@
+from ftw.testbrowser import browsing
+from opengever.base.model import create_session
+from opengever.ogds.models.team import Team
+from opengever.testing import IntegrationTestCase
+
+
+class TestTeamListing(IntegrationTestCase):
+
+    @browsing
+    def test_team_listing(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder, view='tabbedview_view-teams')
+
+        row = browser.css('.listing').first.dicts()[0]
+        self.assertEquals(
+            {'Active': 'Yes',
+             'Org Unit': 'Finanzamt',
+             'Group': 'Projekt A',
+             'Title': u'Projekt \xdcberbaung Dorfmatte'},
+            row)
+
+        link = browser.css('.listing tr')[1].css('a').first
+        self.assertEquals(
+            u'Projekt \xdcberbaung Dorfmatte', link.text)
+        self.assertEquals('http://nohost/plone/kontakte/team-1/view',
+                          link.get('href'))
+
+    @browsing
+    def test_lists_only_active_teams_by_default(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder, view='tabbedview_view-teams')
+
+        self.assertEquals(
+            [u'Projekt \xdcberbaung Dorfmatte', 'Sekretariat Abteilung XY'],
+            [team.get('Title') for team in
+             browser.css('.listing').first.dicts()])
+
+        Team.get('1').active = False
+        create_session().flush()
+
+        browser.open(self.contactfolder, view='tabbedview_view-teams')
+        self.assertEquals(
+            ['Sekretariat Abteilung XY'],
+            [team.get('Title') for team in
+             browser.css('.listing').first.dicts()])
+
+    @browsing
+    def test_lists_also_inactive_teams_with_all_filter(self, browser):
+        Team.get('1').active = False
+        create_session().flush()
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder, view='tabbedview_view-teams',
+                     data={'team_state_filter': 'filter_all'})
+
+        self.assertEquals(
+            [u'Projekt \xdcberbaung Dorfmatte', 'Sekretariat Abteilung XY'],
+            [team.get('Title') for team in
+             browser.css('.listing').first.dicts()])
+
+    @browsing
+    def test_filtering_on_title(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder, view='tabbedview_view-teams',
+                     data={'searchable_text': 'abteilung',})
+
+        self.assertEquals(
+            [u'Sekretariat Abteilung XY'],
+            [team.get('Title') for team in
+             browser.css('.listing').first.dicts()])

--- a/opengever/core/profiles/default/types/opengever.contact.contactfolder.xml
+++ b/opengever/core/profiles/default/types/opengever.contact.contactfolder.xml
@@ -52,4 +52,16 @@
     <permission value="View" />
   </action>
 
+  <action
+      action_id="add_team"
+      visible="True"
+      title="Team"
+      category="folder_factories"
+      url_expr="string:${object_url}/add-team"
+      icon_expr=""
+      condition_expr=""
+      i18n:domain="opengever.core">
+    <permission value="Manage portal content" />
+  </action>
+
 </object>

--- a/opengever/core/upgrades/20170926141120_add_team_folder_factory_action_to_contactfolder/types/opengever.contact.contactfolder.xml
+++ b/opengever/core/upgrades/20170926141120_add_team_folder_factory_action_to_contactfolder/types/opengever.contact.contactfolder.xml
@@ -1,0 +1,15 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.contact.contactfolder" meta_type="Dexterity FTI" >
+
+  <action
+      action_id="add_team"
+      visible="True"
+      title="Team"
+      category="folder_factories"
+      url_expr="string:${object_url}/add-team"
+      icon_expr=""
+      condition_expr=""
+      i18n:domain="opengever.core">
+    <permission value="Manage portal content" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20170926141120_add_team_folder_factory_action_to_contactfolder/upgrade.py
+++ b/opengever/core/upgrades/20170926141120_add_team_folder_factory_action_to_contactfolder/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddTeamFolderFactoryActionToContactfolder(UpgradeStep):
+    """Add team folder factory action to contactfolder.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -22,12 +22,12 @@ For known actor types use:
 """
 
 from opengever.base.utils import escape_html
+from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base import _
 from opengever.ogds.base.browser.userdetails import UserDetails
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models.team import Team
-from plone import api
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFCore.utils import getToolByName
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
@@ -170,8 +170,8 @@ class TeamActor(Actor):
         self.team = team
 
     def get_profile_url(self):
-        return '/'.join((api.portal.get().absolute_url(),
-                         '@@team-details', str(self.team.team_id)))
+        return '{}/team-{}/view'.format(
+            get_contactfolder_url(), self.team.team_id)
 
     def corresponds_to(self, user):
         return user in self.team.group.users

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -62,4 +62,11 @@
       template="templates/teamdetails.pt"
       />
 
+  <browser:page
+      for="opengever.contact.contactfolder.IContactFolder"
+      name="add-team"
+      class=".team_forms.TeamAddForm"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -69,4 +69,11 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      name="edit"
+      for="opengever.ogds.base.interfaces.ITeam"
+      class=".team_forms.TeamEditForm"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -55,8 +55,8 @@
       />
 
   <browser:page
-      for="*"
-      name="team-details"
+      for="opengever.ogds.base.interfaces.ITeam"
+      name="view"
       class=".teamdetails.TeamDetails"
       permission="zope2.View"
       template="templates/teamdetails.pt"

--- a/opengever/ogds/base/browser/team_forms.py
+++ b/opengever/ogds/base/browser/team_forms.py
@@ -1,11 +1,16 @@
 from ftw.keywordwidget.widget import KeywordFieldWidget
+from ftw.keywordwidget.widget import KeywordWidget
 from opengever.base.browser.modelforms import ModelAddForm
+from opengever.base.browser.modelforms import ModelEditForm
+from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base import _
 from opengever.ogds.base.sources import AllGroupsSourceBinder
 from opengever.ogds.base.sources import AllOrgUnitsSourceBinder
 from opengever.ogds.models import UNIT_TITLE_LENGTH
 from opengever.ogds.models.team import Team
+from plone.autoform.widgets import ParameterizedWidget
 from plone.directives import form
+from z3c.form import field
 from zope import schema
 
 
@@ -40,3 +45,28 @@ class TeamAddForm(ModelAddForm):
     model_class = Team
 
     label = _('label_add_team', default=u'Add team')
+
+
+class TeamEditForm(ModelEditForm):
+
+    fields = field.Fields(ITeam)
+    model_class = Team
+
+    label = _('label_edit_team', default=u'Edit team')
+
+    fields['groupid'].widgetFactory = ParameterizedWidget(
+        KeywordWidget,
+        async=True)
+
+    fields['org_unit_id'].widgetFactory = ParameterizedWidget(
+        KeywordWidget,
+        async=True)
+
+    def __init__(self, context, request):
+        super(TeamEditForm, self).__init__(context, request, context.model)
+
+    def nextURL(self):
+        return get_contactfolder_url()
+
+    def updateWidgets(self):
+        super(TeamEditForm, self).updateWidgets()

--- a/opengever/ogds/base/browser/team_forms.py
+++ b/opengever/ogds/base/browser/team_forms.py
@@ -1,0 +1,42 @@
+from ftw.keywordwidget.widget import KeywordFieldWidget
+from opengever.base.browser.modelforms import ModelAddForm
+from opengever.ogds.base import _
+from opengever.ogds.base.sources import AllGroupsSourceBinder
+from opengever.ogds.base.sources import AllOrgUnitsSourceBinder
+from opengever.ogds.models import UNIT_TITLE_LENGTH
+from opengever.ogds.models.team import Team
+from plone.directives import form
+from zope import schema
+
+
+class ITeam(form.Schema):
+
+    title = schema.TextLine(
+        title=_(u"label_title", default=u"Title"),
+        required=True,
+        max_length=UNIT_TITLE_LENGTH)
+
+    active = schema.Bool(
+        title=_(u"label_active", default=u"Active"),
+        required=True,
+        default=True)
+
+    form.widget('groupid', KeywordFieldWidget, async=True)
+    groupid = schema.Choice(
+        title=_('label_group', default=u'Group'),
+        source=AllGroupsSourceBinder(),
+        required=True)
+
+    form.widget('org_unit_id', KeywordFieldWidget, async=True)
+    org_unit_id = schema.Choice(
+        title=_('label_org_unit', default=u'Org Unit'),
+        source=AllOrgUnitsSourceBinder(),
+        required=True)
+
+
+class TeamAddForm(ModelAddForm):
+
+    schema = ITeam
+    model_class = Team
+
+    label = _('label_add_team', default=u'Add team')

--- a/opengever/ogds/base/browser/teamdetails.py
+++ b/opengever/ogds/base/browser/teamdetails.py
@@ -1,4 +1,5 @@
 from opengever.ogds.base.actor import Actor
+from plone import api
 from Products.Five import BrowserView
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
@@ -15,6 +16,14 @@ class TeamDetails(BrowserView):
         super(TeamDetails, self).__init__(context, request)
         self.model = self.context.model
         self.request = request
+
+    def prepare_model_tabs(self, viewlet):
+        if api.user.has_permission('cmf.ManagePortal', obj=self.context):
+            url = u'{}/team-{}/edit'.format(
+                self.context.parent.absolute_url(), self.model.team_id)
+            return viewlet.prepare_edit_tab(url)
+
+        return tuple()
 
     def get_team_members(self):
         return [Actor.user(user.userid)

--- a/opengever/ogds/base/browser/teamdetails.py
+++ b/opengever/ogds/base/browser/teamdetails.py
@@ -1,35 +1,21 @@
 from opengever.ogds.base.actor import Actor
-from opengever.ogds.models.team import Team
 from Products.Five import BrowserView
-from zExceptions import NotFound
-from zope.component.hooks import getSite
-from zope.interface import implementer
+from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
+from zope.publisher.interfaces.browser import IBrowserView
 
 
-@implementer(IPublishTraverse)
 class TeamDetails(BrowserView):
     """Displays infos about a team.
     """
 
-    @classmethod
-    def url_for(cls, team_id):
-        portal = getSite()
-        return '/'.join((portal.portal_url(), '@@team-details', str(team_id)))
+    implements(IBrowserView, IPublishTraverse)
 
-    def get_team(self):
-        team = Team.get(int(self.team_id))
-        if not team:
-            raise NotFound
-
-        return team
+    def __init__(self, context, request):
+        super(TeamDetails, self).__init__(context, request)
+        self.model = self.context.model
+        self.request = request
 
     def get_team_members(self):
         return [Actor.user(user.userid)
-                for user in self.get_team().group.users]
-
-    def publishTraverse(self, request, name):  # noqa
-        """The name is the teamid of the team who should be displayed.
-        """
-        self.team_id = name
-        return self
+                for user in self.model.group.users]

--- a/opengever/ogds/base/browser/templates/teamdetails.pt
+++ b/opengever/ogds/base/browser/templates/teamdetails.pt
@@ -9,7 +9,7 @@
   <body>
     <metal:main fill-slot="main">
       <tal:main-macro metal:define-macro="main"
-                      tal:define="team view/get_team">
+                      tal:define="team view/model">
 
         <div tal:replace="structure provider:plone.abovecontenttitle" />
         <h1 class="documentFirstHeading" tal:content="team/title"/>

--- a/opengever/ogds/base/browser/templates/userdetails.pt
+++ b/opengever/ogds/base/browser/templates/userdetails.pt
@@ -130,7 +130,7 @@
                   <ul class="teams">
                       <li tal:repeat="team teams">
                         <a class="team"
-                           tal:attributes="href string:${portal_url}/@@team-details/${team/team_id}"
+                           tal:attributes="href string:${view/contactfolder_url}/team-${team/team_id}/view"
                            tal:content="team/title"></a>
                       </li>
                   </ul>

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -1,3 +1,4 @@
+from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models.exceptions import RecordNotFound
 from Products.Five import BrowserView
@@ -37,3 +38,6 @@ class UserDetails(BrowserView):
         """
         self.userid = name
         return self
+
+    def contactfolder_url(team_id):
+        return get_contactfolder_url()

--- a/opengever/ogds/base/interfaces.py
+++ b/opengever/ogds/base/interfaces.py
@@ -121,3 +121,7 @@ class IInternalOpengeverRequestLayer(Interface):
     """This request layer is activated on interal requests which are
     authenticated with the OGDS PAS plugin.
     """
+
+
+class ITeam(Interface):
+    """Marker interface for team object wrappers."""

--- a/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-02 12:52+0000\n"
+"POT-Creation-Date: 2017-10-05 18:17+0000\n"
 "PO-Revision-Date: 2016-07-22 16:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/de/>\n"
@@ -37,9 +37,15 @@ msgid "inbox_label"
 msgstr "Eingangskorb: ${client}"
 
 #. Default: "Active"
+#: ./opengever/ogds/base/browser/team_forms.py
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_active"
 msgstr "Aktiv"
+
+#. Default: "Add team"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_add_team"
+msgstr "Team hinzufügen"
 
 #. Default: "Address"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
@@ -66,6 +72,11 @@ msgstr "Beschreibung"
 msgid "label_directorate"
 msgstr "Direktion"
 
+#. Default: "Edit team"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_edit_team"
+msgstr "Team bearbeiten"
+
 #. Default: "Email"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email"
@@ -82,6 +93,7 @@ msgid "label_fullname"
 msgstr "Name"
 
 #. Default: "Group"
+#: ./opengever/ogds/base/browser/team_forms.py
 #: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_group"
 msgstr "Gruppe"
@@ -95,6 +107,11 @@ msgstr "Gruppen"
 #: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_members"
 msgstr "Mitglieder"
+
+#. Default: "Org Unit"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_org_unit"
+msgstr "Organisationseinheit"
 
 #. Default: "Fax"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
@@ -121,6 +138,11 @@ msgstr "Anrede"
 msgid "label_teams"
 msgstr "Teams"
 
+#. Default: "Title"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_title"
+msgstr "Titel"
+
 #. Default: "URL"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_url"
@@ -130,4 +152,3 @@ msgstr "Homepage"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr "Alle Benutzer anzeigen"
-

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:52+0000\n"
+"POT-Creation-Date: 2017-10-05 18:17+0000\n"
 "PO-Revision-Date: 2017-06-04 13:05+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/fr/>\n"
@@ -37,9 +37,15 @@ msgid "inbox_label"
 msgstr "Boîte de réception"
 
 #. Default: "Active"
+#: ./opengever/ogds/base/browser/team_forms.py
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_active"
 msgstr "Actif"
+
+#. Default: "Add team"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_add_team"
+msgstr ""
 
 #. Default: "Address"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
@@ -66,6 +72,11 @@ msgstr "Description"
 msgid "label_directorate"
 msgstr "Direction"
 
+#. Default: "Edit team"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_edit_team"
+msgstr ""
+
 #. Default: "Email"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email"
@@ -82,6 +93,7 @@ msgid "label_fullname"
 msgstr "Nom"
 
 #. Default: "Group"
+#: ./opengever/ogds/base/browser/team_forms.py
 #: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_group"
 msgstr ""
@@ -94,6 +106,11 @@ msgstr "Groupes"
 #. Default: "Members"
 #: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_members"
+msgstr ""
+
+#. Default: "Org Unit"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_org_unit"
 msgstr ""
 
 #. Default: "Fax"
@@ -119,6 +136,11 @@ msgstr "Titre"
 #. Default: "Teams"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_teams"
+msgstr ""
+
+#. Default: "Title"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_title"
 msgstr ""
 
 #. Default: "URL"

--- a/opengever/ogds/base/locales/opengever.ogds.base.pot
+++ b/opengever/ogds/base/locales/opengever.ogds.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:52+0000\n"
+"POT-Creation-Date: 2017-10-05 18:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,8 +38,14 @@ msgid "inbox_label"
 msgstr ""
 
 #. Default: "Active"
+#: ./opengever/ogds/base/browser/team_forms.py
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_active"
+msgstr ""
+
+#. Default: "Add team"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_add_team"
 msgstr ""
 
 #. Default: "Address"
@@ -67,6 +73,11 @@ msgstr ""
 msgid "label_directorate"
 msgstr ""
 
+#. Default: "Edit team"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_edit_team"
+msgstr ""
+
 #. Default: "Email"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_email"
@@ -83,6 +94,7 @@ msgid "label_fullname"
 msgstr ""
 
 #. Default: "Group"
+#: ./opengever/ogds/base/browser/team_forms.py
 #: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_group"
 msgstr ""
@@ -95,6 +107,11 @@ msgstr ""
 #. Default: "Members"
 #: ./opengever/ogds/base/browser/templates/teamdetails.pt
 msgid "label_members"
+msgstr ""
+
+#. Default: "Org Unit"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_org_unit"
 msgstr ""
 
 #. Default: "Fax"
@@ -120,6 +137,11 @@ msgstr ""
 #. Default: "Teams"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_teams"
+msgstr ""
+
+#. Default: "Title"
+#: ./opengever/ogds/base/browser/team_forms.py
+msgid "label_title"
 msgstr ""
 
 #. Default: "URL"

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -37,7 +37,7 @@ class TestActorLookup(IntegrationTestCase):
 
         self.assertEqual(u'Projekt \xdcberbaung Dorfmatte (Finanzamt)',
                          actor.get_label())
-        self.assertEqual('http://nohost/plone/@@team-details/1',
+        self.assertEqual('http://nohost/plone/kontakte/team-1/view',
                          actor.get_profile_url())
 
     def test_user_actor_ogds_user(self):

--- a/opengever/ogds/base/tests/test_team_details.py
+++ b/opengever/ogds/base/tests/test_team_details.py
@@ -7,7 +7,7 @@ class TestTeamDetails(IntegrationTestCase):
     @browsing
     def test_title(self, browser):
         self.login(self.administrator, browser=browser)
-        browser.open(self.portal, view='team-details/1')
+        browser.open(self.contactfolder, view='team-1/view')
 
         self.assertEquals(
             [u'Projekt \xdcberbaung Dorfmatte'], browser.css('h1').text)
@@ -17,12 +17,13 @@ class TestTeamDetails(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
 
         with browser.expect_http_error(code=404):
-            browser.open(self.portal, view='team-details/123')
+            browser.open(self.contactfolder, view='team-123/view')
 
     @browsing
     def test_metadata_table(self, browser):
         self.login(self.administrator, browser=browser)
-        browser.open(self.portal, view='team-details/1')
+        browser.raise_http_errors = False
+        browser.open(self.contactfolder, view='team-1/view')
 
         items = browser.css('.listing').first.lists()
         self.assertEquals(
@@ -33,7 +34,7 @@ class TestTeamDetails(IntegrationTestCase):
     @browsing
     def test_list_and_link_team_members(self, browser):
         self.login(self.administrator, browser=browser)
-        browser.open(self.portal, view='team-details/1')
+        browser.open(self.contactfolder, view='team-1/view')
 
         links = browser.css('.members a')
         self.assertEquals(

--- a/opengever/ogds/base/tests/test_team_forms.py
+++ b/opengever/ogds/base/tests/test_team_forms.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.ogds.models.team import Team
 from opengever.testing import IntegrationTestCase
 
@@ -34,3 +35,51 @@ class TestTeamAddForm(IntegrationTestCase):
         self.assertEquals('projekt_a', team.groupid)
         self.assertEquals(u'Projekt \xdcberbaung Dorfmatte', team.title)
         self.assertEquals('fa', team.org_unit_id)
+
+
+class TestTeamEditForm(IntegrationTestCase):
+
+    @browsing
+    def test_editing_a_team(self, browser):
+        self.login(self.manager, browser=browser)
+        browser.open(self.contactfolder, view='team-1/edit')
+
+        browser.fill({'Title': u'Projekt \xdcberbaung Dorf S\xfcd'})
+        browser.click_on('Save')
+
+        self.assertEquals(['Changes saved'], info_messages())
+        self.assertEquals(
+            u'Projekt \xdcberbaung Dorf S\xfcd', Team.get('1').title)
+
+    @browsing
+    def test_editing_is_only_available_for_managers(self, browser):
+        with browser.expect_unauthorized():
+            self.login(self.regular_user, browser=browser)
+            browser.open(self.contactfolder, view='team-1/edit')
+
+        with browser.expect_unauthorized():
+            self.login(self.administrator, browser=browser)
+            browser.open(self.contactfolder, view='team-1/edit')
+
+        self.login(self.manager, browser=browser)
+        browser.open(self.contactfolder, view='team-1/edit')
+
+
+class TestTeamEditAction(IntegrationTestCase):
+
+    @browsing
+    def test_edit_link_is_visible_for_managers(self, browser):
+        self.login(self.manager, browser=browser)
+        browser.open(self.contactfolder, view='team-1/view')
+
+        self.assertEquals(['Edit'], browser.css('#content-views').text)
+        url = browser.css('#content-views a')[0].get('href')
+        self.assertTrue(
+            url.startswith('http://nohost/plone/kontakte/team-1/edit'))
+
+    @browsing
+    def test_edit_link_is_not_visible_for_regular_users(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder, view='team-1/view')
+
+        self.assertEquals([''], browser.css('#content-views').text)

--- a/opengever/ogds/base/tests/test_team_forms.py
+++ b/opengever/ogds/base/tests/test_team_forms.py
@@ -1,0 +1,36 @@
+from ftw.testbrowser import browsing
+from opengever.ogds.models.team import Team
+from opengever.testing import IntegrationTestCase
+
+
+class TestTeamAddForm(IntegrationTestCase):
+
+    @browsing
+    def test_add_new_team_form_is_only_available_for_manager(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_unauthorized():
+            browser.open(self.contactfolder, view='add-team')
+
+        self.login(self.manager, browser)
+        browser.open(self.contactfolder, view='add-team')
+
+    @browsing
+    def test_add_new_team(self, browser):
+        self.login(self.manager, browser)
+
+        browser.raise_http_errors = False
+
+        browser.open(self.contactfolder, view='add-team')
+        browser.fill({'Title': u'Projekt \xdcberbaung Dorfmatte'})
+
+        form = browser.find_form_by_field('Group')
+        form.find_widget('Org Unit').fill('fa')
+        form.find_widget('Group').fill('projekt_a')
+        browser.find('Save').click()
+
+        self.assertEquals(3, len(Team.query.all()))
+        team = Team.query.get(3)
+        self.assertEquals('projekt_a', team.groupid)
+        self.assertEquals(u'Projekt \xdcberbaung Dorfmatte', team.title)
+        self.assertEquals('fa', team.org_unit_id)

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -32,5 +32,5 @@ class TestUserDetails(IntegrationTestCase):
 
         self.assertEquals(
             [u'Projekt \xdcberbaung Dorfmatte'], browser.css('.teams li').text)
-        self.assertEquals('http://nohost/plone/@@team-details/1',
+        self.assertEquals('http://nohost/plone/kontakte/team-1/view',
                           browser.css('.teams a').first.get('href'))

--- a/opengever/ogds/base/wrapper.py
+++ b/opengever/ogds/base/wrapper.py
@@ -1,0 +1,18 @@
+from opengever.base.wrapper import SQLWrapperBase
+from opengever.contact.utils import get_contactfolder_url
+from opengever.ogds.base.interfaces import ITeam
+from zope.interface import implements
+
+
+class TeamWrapper(SQLWrapperBase):
+    """Wrapper object for Teams (only stored in the OGDS database).
+    """
+
+    implements(ITeam)
+
+    def absolute_url(self):
+        return '{}/team-{}/view'.format(
+            get_contactfolder_url(), self.model.team_id)
+
+    def get_title(self):
+        return self.model.label()


### PR DESCRIPTION
Uses:
 - https://github.com/4teamwork/opengever.ogds.models/pull/49
 - https://github.com/4teamwork/plonetheme.teamraum/pull/588

Description:
 - The add and edit forms are only available for managers.
 - The new tab `Teams` on contactfolder is always visible and not protected with a feature flag or something similar.
 - Some of the code can be removed as soon we move opengever.ogds.models in to opengever.core. But I'll to that later.

![bildschirmfoto 2017-10-05 um 19 38 32](https://user-images.githubusercontent.com/485755/31268247-bcd36492-aa7b-11e7-91e2-da5546215de0.png)

![bildschirmfoto 2017-10-06 um 09 52 11](https://user-images.githubusercontent.com/485755/31268330-0890d8ba-aa7c-11e7-869c-74f9bcfb0d38.png)
<img width="168" alt="bildschirmfoto 2017-10-05 um 20 12 51" src="https://user-images.githubusercontent.com/485755/31268233-acaa5c9c-aa7b-11e7-9836-b4ddea87638d.png">
<img width="1217" alt="bildschirmfoto 2017-10-05 um 20 15 42" src="https://user-images.githubusercontent.com/485755/31268232-a94215f4-aa7b-11e7-8896-dfea0624315d.png">

Closes #3411
