### PR TITLE
Remove the first element of the pathbar...

### DIFF
--- a/opengever/base/tests/test_pathbar.py
+++ b/opengever/base/tests/test_pathbar.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 
@@ -5,13 +7,18 @@ from opengever.testing import IntegrationTestCase
 class TestPathBar(IntegrationTestCase):
 
     @browsing
-    def test_first_part_is_org_unit_title(self, browser):
+    def test_first_part_is_admin_unit_title_if_multiple_admin_units(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.dossier)
+        create(Builder('admin_unit')
+               .having(title=u'Nebenmandant',
+                       unit_id=u'plonez',
+                       public_url='http://nohost/plonez'))
 
+        browser.open(self.dossier)
         first_part = browser.css('#portal-breadcrumbs li a')[0]
         self.assertEquals('Hauptmandant', first_part.text)
         self.assertEquals(self.portal.absolute_url(), first_part.get('href'))
+
 
     @browsing
     def test_contains_contenttype_icon_class(self, browser):
@@ -19,8 +26,7 @@ class TestPathBar(IntegrationTestCase):
         browser.open(self.document)
 
         self.assertEquals(
-            ['contenttype-plone-site',
-             'contenttype-opengever-repository-repositoryfolder',
+            ['contenttype-opengever-repository-repositoryfolder',
              'contenttype-opengever-repository-repositoryfolder',
              'contenttype-opengever-repository-repositoryroot',
              'contenttype-opengever-dossier-businesscasedossier',
@@ -34,8 +40,7 @@ class TestPathBar(IntegrationTestCase):
         browser.open(self.dossier)
 
         self.assertEquals(
-            [u'Hauptmandant',
-             u'1.1. Vertr\xe4ge und Vereinbarungen',
+            [u'1.1. Vertr\xe4ge und Vereinbarungen',
              u'1. F\xfchrung',
              u'Ordnungssystem',
              u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'],

--- a/opengever/base/viewlets/pathbar.pt
+++ b/opengever/base/viewlets/pathbar.pt
@@ -2,10 +2,11 @@
      i18n:domain="plone"
      tal:define="breadcrumbs view/obj_chain;
                  repository_chain view/repository_chain;
-                 leaf_node view/leaf_node">
+                 leaf_node view/leaf_node;
+                 multiple_admin_units view/has_multiple_admin_units">
 
   <ul class="breadcrumb">
-    <li>
+    <li tal:condition="multiple_admin_units">
       <a href=""
          tal:attributes="href context/@@plone_portal_state/portal_url">
         <i class="contenttype-plone-site" />

--- a/opengever/base/viewlets/pathbar.py
+++ b/opengever/base/viewlets/pathbar.py
@@ -2,6 +2,7 @@ from Acquisition import aq_chain
 from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import ISQLObjectWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import ogds_service
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryroot import IRepositoryRoot
 from plone.app.layout.navigation.interfaces import INavigationRoot
@@ -63,4 +64,8 @@ class PathBar(common.PathBarViewlet):
                 chain.append(data)
 
         chain.reverse()
+
         return repository, chain
+
+    def has_multiple_admin_units(self):
+        return ogds_service().has_multiple_admin_units()

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -107,7 +107,7 @@ class TestParticipationWrapper(FunctionalTestCase):
             [u'Edit Participation of M\xfcller Hans'],
             browser.css('h1').text)
         self.assertEqual(
-            ['Client1', u'Dossier', u'Participation of M\xfcller Hans'],
+            [u'Dossier', u'Participation of M\xfcller Hans'],
             browser.css('#portal-breadcrumbs li').text)
 
     @browsing

--- a/opengever/meeting/tests/test_pathbar.py
+++ b/opengever/meeting/tests/test_pathbar.py
@@ -26,7 +26,7 @@ class TestPathBar(FunctionalTestCase):
 
         breadcrumb_links = browser.css('#portal-breadcrumbs a')
         self.assertEquals(
-            ['Client1', '1. Testposition', 'Repository', 'Dossier 1'],
+            ['1. Testposition', 'Repository', 'Dossier 1'],
             breadcrumb_links.text)
 
     @browsing

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -80,7 +80,7 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
     def test_private_root_is_hidden_from_breadcrumbs(self, browser):
         browser.login().open(self.folder)
         self.assertEqual(
-            ['Client1', 'Test User (test_user_1_)'],
+            ['Test User (test_user_1_)'],
             browser.css('#portal-breadcrumbs li').text)
 
     @browsing


### PR DESCRIPTION
... if there is only one admin unit.

Also rename the test, which tests if the admin unit is displayed
correctly.

# Setup with multiple admin units

![multiple_admin_unit_ordnungssystem](https://user-images.githubusercontent.com/194114/31336142-da6d5766-acf5-11e7-990d-6a0af65d4352.png)
![multiple_admin_unit_root](https://user-images.githubusercontent.com/194114/31336143-da88e92c-acf5-11e7-9b81-1386cf352bf1.png)

# Setup with single admin unit

![single_admin_unit_ordnungssystem](https://user-images.githubusercontent.com/194114/31336145-da9ba0ee-acf5-11e7-9761-4ff0a7f726c1.png)
![single_admin_unit_root](https://user-images.githubusercontent.com/194114/31336144-da968c9e-acf5-11e7-8608-6c72618d75e0.png)


Resolves #3449