### PR TITLE
Do not fill end date when start is selected...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - SPV: Fix ad hoc agenda item template label translation. [tarnap]
+- SPV: Meeting end date is not set when start date is selected. [tarnap]
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]
 - SPV word: Do not automatically decide agenda items when closing meetings. [jone]

--- a/opengever/meeting/browser/resources/datetimepicker.js
+++ b/opengever/meeting/browser/resources/datetimepicker.js
@@ -34,15 +34,30 @@
       this.start.val(this.startwidget.str(roundedStartDateTime));
     }
 
+    self.getMinTime = function () {
+      var start = self.startwidget.getCurrentTime();
+      var end = self.endwidget.getCurrentTime();
+      if (end.getDayOfYear() <= start.getDayOfYear()) {
+        return start.format2();
+      } else {
+        return false;
+      }
+    }
+
     // make sure no date is selected before the start of the range by looking
     // up the earliest valid time in the startwidget
     self.end.datetimepicker({
       onShow: function (current_time, input) {
                 this.setOptions({
                   minDate: self.startwidget.getCurrentTime(),
-                  minTime: self.startwidget.getCurrentTime()
+                  minTime: self.getMinTime()
                 });
-              }
+              },
+      onSelectDate: function(current_time, input) {
+                      this.setOptions({
+                        minTime: self.getMinTime()
+                      });
+                    }
     });
 
     // avoid ftw.datetimepicker destroying our end datetime picker 

--- a/opengever/meeting/browser/resources/datetimepicker.js
+++ b/opengever/meeting/browser/resources/datetimepicker.js
@@ -5,7 +5,6 @@
   var Rangetimepicker = function(options) {
 
     options = $.extend({
-      minRange: 1,  // in hours
       precision: 5, // in minutes
       target: {
         start: ".datetimepicker-start",
@@ -18,7 +17,8 @@
     this.start = options.target.start;
     this.end = options.target.end;
 
-    if (!this.start.length || !this.start.length) {
+    if (!this.start.length || !this.end.length) {
+      // Rangetimepicker is only used in some views, namely when there's a start _and_ an end field.
       return;
     }
 
@@ -29,38 +29,24 @@
       return new Date(date.setMinutes(Math.ceil(date.getMinutes() / options.precision) * options.precision));
     };
 
-    var updateSelectableDates = $.proxy(function(){
-      self.end.datetimepicker({minDate: self.startwidget.getCurrentTime(),
-                               minTime: self.startwidget.getCurrentTime()})
-    });
-
-    var adjustEndtime = $.proxy(function(start) {
-      var end = new Date(start.setHours(start.getHours() + options.minRange));
-      this.endwidget.setCurrentTime(end);
-      this.end.val(this.endwidget.str(end));
-    }, this);
-
-    var updateDate = $.proxy(function(date) {
-      if(options.minRange && (this.endwidget.getCurrentTime() - date) < (options.minRange * 60 * 60 * 1000)) {
-        adjustEndtime(date);
-      } else if (!this.end.val()) {
-        adjustEndtime(date);
-      }
-    }, this);
-
     if (!this.start.val()) {
       var roundedStartDateTime = roundMinutes(this.startwidget.getCurrentTime());
       this.start.val(this.startwidget.str(roundedStartDateTime));
     }
-    updateSelectableDates();
 
-    this.start.on('change', function(event) {
-        // Bug in dateptimeicker - the internal state is not updated after clearing the field.
-        var date = self.startwidget.strToDateTime($(this).val());
-        self.startwidget.setCurrentTime(date);
-        updateDate(date);
-        updateSelectableDates();
-      });
+    // make sure no date is selected before the start of the range by looking
+    // up the earliest valid time in the startwidget
+    self.end.datetimepicker({
+      onShow: function (current_time, input) {
+                this.setOptions({
+                  minDate: self.startwidget.getCurrentTime(),
+                  minTime: self.startwidget.getCurrentTime()
+                });
+              }
+    });
+
+    // avoid ftw.datetimepicker destroying our end datetime picker 
+    $(document).off('change', '.datetimepicker-widget');
   };
 
   $(function() {
@@ -78,6 +64,5 @@
     var range = new Rangetimepicker(options);
 
   });
-
 
 }(window, window.jQuery));


### PR DESCRIPTION
... yet keep the allowed min date and min time.

This also refactors the datetimepicker resource:
The earliest possible end date is set when the widget is shown.

![end_time](https://user-images.githubusercontent.com/194114/31371259-2adcc21e-ad90-11e7-902e-846c501510e8.gif)


Resolves https://github.com/4teamwork/gever/issues/91