### PR TITLE
SPV word: Protect proposal transitions to require modify permission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Ungrok opengever.officeatwork. [elioschmutz]
 - SPV: Fix ad hoc agenda item template label translation. [tarnap]
 - SPV: Meeting end date is not set when start date is selected. [tarnap]
+- SPV word: Protect proposal transitions to require modify permission. [jone]
 - SPV word: Update document- and mail-workflow to support committee roles. [jone]
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]

--- a/opengever/meeting/browser/proposaltransitions.py
+++ b/opengever/meeting/browser/proposaltransitions.py
@@ -42,6 +42,9 @@ class ProposalTransitionController(grok.View):
         return self.redirect_to_proposal()
 
     def is_valid_transition(self, transition_name):
+        if not api.user.has_permission('Modify portal content', obj=self.context):
+            return False
+
         return self.context.can_execute_transition(transition_name)
 
     def execute_transition(self, transition_name):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -286,12 +286,18 @@ class ProposalBase(ModelContainer):
         return attributes
 
     def can_execute_transition(self, name):
+        if not api.user.has_permission('Modify portal content', obj=self):
+            return False
+
         return self.workflow.can_execute_transition(self.load_model(), name)
 
     def execute_transition(self, name):
         self.workflow.execute_transition(self, self.load_model(), name)
 
     def get_transitions(self):
+        if not api.user.has_permission('Modify portal content', obj=self):
+            return []
+
         return self.workflow.get_transitions(self.get_state())
 
     def get_state(self):

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -409,3 +409,12 @@ class TestProposalWithWord(IntegrationTestCase):
         with self.login(self.meeting_user):
             self.assert_has_permissions(VIEW_PERMISSIONS, mail,
                                         '(CommitteeMember)')
+
+    @browsing
+    def test_committee_member_should_not_be_able_to_reject_a_proposal(self, browser):
+        """Regression test: committee members did see the "Reject" button,
+        although it did not work.
+        """
+        self.login(self.meeting_user, browser)
+        browser.open(self.submitted_word_proposal, view='tabbedview_view-overview')
+        self.assertFalse(browser.find('Reject'))


### PR DESCRIPTION
Executing a proposal transition requires the "Modify protal content" permission, but the transitions were listed for users without this permissions.

With this change we no longer show transitions to users without the "Modify portal content" permission.

This cannot be soled within the workflow implementation because the workflow object has no reference to the Plone object (which knows about security).
It has a reference to the so-called "model"-object, but this object does not know about security and the Plone object may or may not be  resolvable (e.g. multi client setup where proposal and submitted proposal are stored in different admin units).

Closes https://github.com/4teamwork/gever/issues/124