### PR TITLE
SPV: Update and fix proposal tabs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - SPV: Meeting end date is not set when start date is selected. [tarnap]
 - SPV word: Protect proposal transitions to require modify permission. [jone]
 - SPV word: Update document- and mail-workflow to support committee roles. [jone]
+- SPV: Update and fix proposal tabs. [jone]
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]
 - SPV word: Do not automatically decide agenda items when closing meetings. [jone]

--- a/opengever/meeting/browser/documents/proposalstab.py
+++ b/opengever/meeting/browser/documents/proposalstab.py
@@ -74,30 +74,37 @@ class ProposalListingTab(FilteredListingTab):
     @property
     def columns(self):
         return (
-            {'column': 'proposal_id',
-             'column_title': _(u'label_proposal_id',
-                               default=u'Reference Number')},
-
             {'column': 'decision_number',
              'column_title': _(u'label_decision_number',
                                default=u'Decision number'),
-             'transform': lambda item, value: item.get_decision_number()},
+             'transform': lambda item, value: item.get_decision_number(),
+             'sortable': False,
+             'groupable': False,
+             'width': 80},
 
             {'column': 'title',
              'column_title': _(u'column_title', default=u'Title'),
-             'transform': proposal_link},
+             'transform': proposal_link,
+             'sortable': False,
+             'groupable': False,
+             'width': 350},
 
             {'column': 'workflow_state',
              'column_title': _(u'column_state', default=u'State'),
-             'transform': translated_state},
+             'transform': translated_state,
+             'width': 120},
 
             {'column': 'committee_id',
              'column_title': _(u'column_comittee', default=u'Comittee'),
-             'transform': lambda item, value: item.committee.get_link()},
+             'transform': lambda item, value: item.committee.get_link(),
+             'width': 180},
 
             {'column': 'generated_meeting_link',
              'column_title': _(u'column_meeting', default=u'Meeting'),
-             'transform': lambda item, value: item.get_meeting_link()},
+             'transform': lambda item, value: item.get_meeting_link(),
+             'sortable': False,
+             'groupable': False,
+             'width': 180},
 
         )
 

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -4,7 +4,6 @@ from opengever.testing import IntegrationTestCase
 
 
 SUBMITTED_PROPOSAL = {
-    'Reference Number': '1',
     'Decision number': '',
     'Meeting': '',
     'State': 'Submitted',
@@ -12,7 +11,6 @@ SUBMITTED_PROPOSAL = {
     'Title': u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen'}
 
 DRAFT_PROPOSAL = {
-     'Reference Number': '2',
      'Decision number': '',
      'Meeting': '',
      'State': 'Pending',
@@ -20,7 +18,6 @@ DRAFT_PROPOSAL = {
      'Title': u'Antrag f\xfcr Kreiselbau'}
 
 DECIDED_PROPOSAL = {
-    'Reference Number': '3',
     'Decision number': '1',
     'Meeting': u'8. Sitzung der Rechnungspr\xfcfungskommission',
     'State': 'Decided',
@@ -28,7 +25,6 @@ DECIDED_PROPOSAL = {
     'Title': u'Initialvertrag f\xfcr Bearbeitung'}
 
 SUBMITTED_WORD_PROPOSAL = {
-    'Reference Number': '4',
     'Decision number': '',
     'Meeting': '',
     'State': 'Submitted',
@@ -36,7 +32,6 @@ SUBMITTED_WORD_PROPOSAL = {
     'Title': u'\xc4nderungen am Personalreglement'}
 
 DRAFT_WORD_PROPOSAL = {
-    'Reference Number': '5',
     'Decision number': '',
     'Meeting': '',
     'State': 'Pending',


### PR DESCRIPTION
The proposal tab configuration had these problems:
- Sorting by various columns, such as title, did not work.
- Grouping does not make sense when sorting does not work.
- The default width of columns was not configured well.
- The Proposal-ID column did not help and therefore we want to get rid
of it.

Changes:
- Remove Proposal-ID column.
- Disable sorting and grouping on generated columns.
- Configure sane default widths.

<img width="1552" alt="bildschirmfoto 2017-10-10 um 12 21 59" src="https://user-images.githubusercontent.com/7469/31381858-0d04ce3c-adb6-11e7-8f0d-cef68b734712.png">

Fixes https://github.com/4teamwork/gever/issues/137, where sorting by title did not work.
Withs are optimized for my 15" display.