### PR TITLE
SPV: Let CommitteeMember only have read-access on meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Ungrok opengever.task. [elioschmutz]
 - Ungrok opengever.officeatwork. [elioschmutz]
+- SPV: Let CommitteeMember only have read-access on meeting view. [jone]
 - SPV: Fix ad hoc agenda item template label translation. [tarnap]
 - SPV: Meeting end date is not set when start date is selected. [tarnap]
 - SPV word: Update document- and mail-workflow to support committee roles. [jone]

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -269,9 +269,14 @@ class Meeting(Base, SQLFormSupport):
         return 'contenttype-opengever-meeting-meeting'
 
     def is_editable(self):
+        committee = self.committee.resolve_committee()
+        if not api.user.has_permission('Modify portal content', obj=committee):
+            return False
         return self.get_state() in [self.STATE_PENDING, self.STATE_HELD]
 
     def is_agendalist_editable(self):
+        if not self.is_editable():
+            return False
         return self.get_state() == self.STATE_PENDING
 
     def has_protocol_document(self):

--- a/opengever/meeting/tests/test_meeting_word.py
+++ b/opengever/meeting/tests/test_meeting_word.py
@@ -118,3 +118,28 @@ class TestWordMeeting(IntegrationTestCase):
             browser.json)
 
         self.assertEquals(u'pending', self.meeting.model.workflow_state)
+
+    def test_is_editable_for_pending_meeting(self):
+        with self.login(self.administrator):
+            meeting = self.meeting.model
+            self.assertEquals('pending', meeting.get_state().title)
+            self.assertTrue(meeting.is_editable())
+
+        with self.login(self.committee_responsible):
+            self.assertTrue(meeting.is_editable())
+
+        with self.login(self.meeting_user):
+            self.assertFalse(meeting.is_editable())
+
+    def test_is_editable_for_decided_meeting(self):
+        with self.login(self.administrator):
+            meeting = self.decided_meeting.model
+            self.assertEquals('closed', meeting.get_state().title)
+            self.assertFalse(meeting.is_editable())
+
+        with self.login(self.committee_responsible):
+            self.assertFalse(meeting.is_editable())
+
+        with self.login(self.meeting_user):
+            self.assertFalse(
+                meeting.is_editable())

--- a/opengever/meeting/tests/test_unit_meeting.py
+++ b/opengever/meeting/tests/test_unit_meeting.py
@@ -26,24 +26,6 @@ class TestUnitMeeting(TestCase):
         self.assertEqual(
             '<Meeting at "2010-01-01 10:30:00+00:00">', repr(self.meeting))
 
-    def test_is_editable(self):
-        self.assertTrue(self.meeting.is_editable())
-
-        self.meeting.workflow_state = 'held'
-        self.assertTrue(self.meeting.is_editable())
-
-        self.meeting.workflow_state = 'closed'
-        self.assertFalse(self.meeting.is_editable())
-
-    def test_is_agendalist_editable(self):
-        self.assertTrue(self.meeting.is_agendalist_editable())
-
-        self.meeting.workflow_state = 'held'
-        self.assertFalse(self.meeting.is_agendalist_editable())
-
-        self.meeting.workflow_state = 'closed'
-        self.assertFalse(self.meeting.is_agendalist_editable())
-
     def test_has_protocol_document(self):
         self.assertFalse(self.meeting.has_protocol_document())
         self.meeting.protocol_document = GeneratedProtocol(


### PR DESCRIPTION
The CommitteeMember should only allow users to access the content for reading and not to shange any things.
Since meetings have no Plone content object yet, we require the user to have the "Modify portal content" on the committee object.

This change removes these components for read-only users:
- Generate / update agenda item and protocol documents.
- Reorder agenda items.
- Change agenda items (edit, decide, remove, etc)
- Add new agenda items or paragraphs.

<img width="1408" alt="bildschirmfoto 2017-10-10 um 15 14 19" src="https://user-images.githubusercontent.com/7469/31388425-44c9d5ac-adce-11e7-948c-03fa93aaabfd.png">

Closes https://github.com/4teamwork/gever/issues/128
Closes https://github.com/4teamwork/gever/issues/127

