### PR TITLE
Remove link to dossier if permission is missing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Ungrok opengever.task. [elioschmutz]
 - Ungrok opengever.officeatwork. [elioschmutz]
 - SPV: Let CommitteeMember only have read-access on meeting view. [jone]
+- SPV: Remove link to dossier in listings when user has no view permission on the dossier. [tarnap]
 - SPV: Fix ad hoc agenda item template label translation. [tarnap]
 - SPV: Meeting end date is not set when start date is selected. [tarnap]
 - SPV word: Protect proposal transitions to require modify permission. [jone]

--- a/opengever/meeting/tests/test_meeting_listings.py
+++ b/opengever/meeting/tests/test_meeting_listings.py
@@ -1,0 +1,42 @@
+from AccessControl import Unauthorized
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.meeting.tabs.meetinglisting import dossier_link_or_title
+
+
+class TestMeetingListing(IntegrationTestCase):
+    features = ('meeting',)
+
+    maxDiff = None
+
+    @browsing
+    def test_span_appears_if_no_view_permission_on_dossier(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        self.meeting_dossier.__ac_local_roles_block__ = True
+        self.meeting_dossier.reindexObjectSecurity()
+
+        self.login(self.meeting_user, browser)
+        with self.assertRaises(Unauthorized):
+            self.meeting_dossier
+
+        result = dossier_link_or_title(self.meeting.model, None)
+
+        self.assertEquals(
+            '<span title="Sitzungsdossier 9/2017" '
+            'class="contenttype-opengever-meeting-meetingdossier">'
+            'Sitzungsdossier 9/2017</span>',
+            result)
+
+    @browsing
+    def test_link_appears_if_view_permission_on_dossier(self, browser):
+        self.login(self.meeting_user, browser)
+        result = dossier_link_or_title(self.meeting.model, None)
+
+        self.assertEquals(
+            '<a href="http://nohost/plone/ordnungssystem/fuhrung/'
+            'vertrage-und-vereinbarungen/dossier-6" '
+            'title="Sitzungsdossier 9/2017" '
+            'class="contenttype-opengever-meeting-meetingdossier"'
+            '>Sitzungsdossier 9/2017</a>',
+            result)


### PR DESCRIPTION
If a user does not have the permission to view the dossier a link to the
dossier is not reasonable.
Therefore when the dossiers are listed, the view permissions are checked
and if the user is missing the permission to view the dossier only the
title of the dossier is rendered.

![dossier_title_without_link_when_no_permission](https://user-images.githubusercontent.com/194114/31391395-af2e3976-add6-11e7-8e6f-22c35c711c44.png)

Resolves https://github.com/4teamwork/gever/issues/125