### PR TITLE
Ungrok opengever.officeatwork.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Ungrok opengever.task. [elioschmutz]
+- Ungrok opengever.officeatwork. [elioschmutz]
 - SPV: Fix ad hoc agenda item template label translation. [tarnap]
 - SPV: Meeting end date is not set when start date is selected. [tarnap]
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]

--- a/opengever/officeatwork/configure.zcml
+++ b/opengever/officeatwork/configure.zcml
@@ -1,14 +1,11 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.officeatwork">
 
   <include package=".browser" />
-
-  <grok:grok package="." />
 
   <i18n:registerTranslations directory="locales" />
 


### PR DESCRIPTION
This PR ungroks `opengever.officeatwork`.

related to #3205 
