### PR TITLE
 List team-tasks in team member's MyTask tab of the personal overview

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - SPV word: Protect proposal transitions to require modify permission. [jone]
 - SPV word: Update document- and mail-workflow to support committee roles. [jone]
 - SPV: Update and fix proposal tabs. [jone]
+- Link and prefix task responsibles and issuers with an icon in tasklistings. [phgross]
 - List also team-tasks in team member's MyTask tab of the personal overview. [phgross]
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - SPV word: Protect proposal transitions to require modify permission. [jone]
 - SPV word: Update document- and mail-workflow to support committee roles. [jone]
 - SPV: Update and fix proposal tabs. [jone]
+- List also team-tasks in team member's MyTask tab of the personal overview. [phgross]
 - Fix default_documents_as_links default value for opengever.mail. [elioschmutz]
 - Fix responsible_client default value for tasktemplates. [phgross]
 - SPV word: Do not automatically decide agenda items when closing meetings. [jone]

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -75,7 +75,7 @@ class TaskQuery(BaseQuery):
     def by_brain(self, brain):
         relative_content_path = '/'.join(brain.getPath().split('/')[2:])
         return self.by_admin_unit(get_current_admin_unit())\
-                   .filter(Task.physical_path==relative_content_path).one()
+                   .filter(Task.physical_path == relative_content_path).one()
 
     def subtasks_by_task(self, task):
         """Queries all subtask of the given task sql object."""
@@ -87,5 +87,6 @@ class TaskQuery(BaseQuery):
 
     def in_pending_state(self):
         return self.filter(Task.review_state.in_(Task.PENDING_STATES))
+
 
 Task.query_cls = TaskQuery

--- a/opengever/globalindex/model/query.py
+++ b/opengever/globalindex/model/query.py
@@ -13,6 +13,9 @@ class TaskQuery(BaseQuery):
         """
         return self.filter(Task.responsible == userid)
 
+    def by_responsibles(self, responsibles):
+        return self.filter(Task.responsible.in_(responsibles))
+
     def users_issued_tasks(self, userid):
         """Returns query which list all tasks where the given user
         is the issuer. It queries all admin units.

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -38,6 +38,8 @@ from zope.i18n import translate
 
 class Actor(object):
 
+    css_class = 'actor-user'
+
     def __init__(self, identifier):
         self.identifier = identifier
 
@@ -89,10 +91,15 @@ class Actor(object):
         label = escape_html(self.get_label())
 
         if not url:
+            if with_icon:
+                return u'<span class="actor-label {}">{}</span>'.format(
+                    self.css_class, label)
+
             return label
 
         if with_icon:
-            link = u'<a href="{}" class="contenttype-opengever-actor">{}</a>'.format(url, label)
+            link = u'<a href="{}" class="actor-label {}">{}</a>'.format(
+                url, self.css_class, label)
         else:
             link = u'<a href="{}">{}</a>'.format(url, label)
 
@@ -135,6 +142,8 @@ class NullActor(object):
 
 class InboxActor(Actor):
 
+    css_class = 'actor-inbox'
+
     def __init__(self, identifier, org_unit=None):
         super(InboxActor, self).__init__(identifier)
         self.org_unit = org_unit
@@ -165,6 +174,8 @@ class InboxActor(Actor):
 
 class TeamActor(Actor):
 
+    css_class = 'actor-team'
+
     def __init__(self, identifier, team=None):
         super(TeamActor, self).__init__(identifier)
         self.team = team
@@ -188,6 +199,8 @@ class TeamActor(Actor):
 
 
 class ContactActor(Actor):
+
+    css_class = 'actor-contact'
 
     def __init__(self, identifier, contact=None):
         super(ContactActor, self).__init__(identifier)

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -17,6 +17,9 @@ class TestActorLookup(IntegrationTestCase):
         self.assertIsNone(actor.get_profile_url())
         self.assertEqual('Inbox: Finanzamt', actor.get_link())
         self.assertEqual(u'fa_inbox_users', actor.permission_identifier)
+        self.assertEqual(
+            u'<span class="actor-label actor-inbox">Inbox: Finanzamt</span>',
+            actor.get_link(with_icon=True))
 
     def test_contact_actor_lookup(self):
         self.login(self.regular_user)
@@ -27,9 +30,10 @@ class TestActorLookup(IntegrationTestCase):
         self.assertEqual(self.franz_meier.absolute_url(),
                          actor.get_profile_url())
 
-        link = actor.get_link()
+        link = actor.get_link(with_icon=True)
         self.assertIn(actor.get_label(), link)
         self.assertIn(actor.get_profile_url(), link)
+        self.assertIn('class="actor-label actor-contact"', link)
 
     def test_team_actor_lookup(self):
         self.login(self.regular_user)
@@ -39,6 +43,17 @@ class TestActorLookup(IntegrationTestCase):
                          actor.get_label())
         self.assertEqual('http://nohost/plone/kontakte/team-1/view',
                          actor.get_profile_url())
+
+        self.assertEqual(
+            u'<a href="http://nohost/plone/kontakte/team-1/view" '
+            u'class="actor-label actor-team">Projekt \xdcberbaung Dorfmatte '
+            u'(Finanzamt)</a>',
+            actor.get_link(with_icon=True))
+
+        self.assertEqual(
+            u'<a href="http://nohost/plone/kontakte/team-1/view">'
+            u'Projekt \xdcberbaung Dorfmatte (Finanzamt)</a>',
+            actor.get_link())
 
     def test_user_actor_ogds_user(self):
         actor = Actor.lookup('jurgen.konig')
@@ -56,7 +71,7 @@ class TestActorLookup(IntegrationTestCase):
 
         self.assertEqual(
             u'<a href="http://nohost/plone/@@user-details/jurgen.konig" '
-            u'class="contenttype-opengever-actor">K\xf6nig J\xfcrgen '
+            u'class="actor-label actor-user">K\xf6nig J\xfcrgen '
             u'(jurgen.konig)</a>',
             actor.get_link(with_icon=True))
 

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -9,6 +9,9 @@ from opengever.meeting.model.proposal import Proposal
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models.group import Group
+from opengever.ogds.models.group import groups_users
+from opengever.ogds.models.team import Team
 from opengever.tabbedview import _
 from opengever.tabbedview import LOG
 from opengever.tabbedview.browser.tabs import Documents
@@ -229,11 +232,13 @@ class MyTasks(GlobalTaskListingTab):
         ]
 
     def get_base_query(self):
-        portal_state = self.context.unrestrictedTraverse(
-            '@@plone_portal_state')
-        userid = portal_state.member().getId()
+        userid = api.user.get_current().getId()
+        responsibles = [
+            team.actor_id() for team in
+            Team.query.join(Group).join(groups_users).filter_by(userid=userid)]
+        responsibles.append(userid)
 
-        return Task.query.users_tasks(userid)
+        return Task.query.by_responsibles(responsibles)
 
 
 class IssuedTasks(GlobalTaskListingTab):

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -35,8 +35,8 @@ def remove_subdossier_column(columns):
     """
 
     def _filterer(item):
-        if isinstance(
-            item, dict) and item['column'] == 'containing_subdossier':
+        if isinstance(item, dict) and \
+           item['column'] == 'containing_subdossier':
             return False
         return True
 
@@ -111,7 +111,8 @@ class PersonalOverview(TabbedView):
         if is_activity_feature_enabled():
             tabs.append(
                 {'id': 'mynotifications',
-                 'title': _('label_my_notifications', default=u'My notifications'),
+                 'title': _('label_my_notifications',
+                            default=u'My notifications'),
                  'icon': None, 'url': '#', 'class': None})
 
         return tabs

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -2,6 +2,7 @@ from ftw.table import helper
 from ftw.table.interfaces import ITableSource, ITableSourceConfig
 from opengever.globalindex.model.task import Task
 from opengever.globalindex.utils import indexed_task_link_helper
+from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.tabbedview import _
 from opengever.tabbedview import BaseListingTab
@@ -9,20 +10,28 @@ from opengever.tabbedview import SqlTableSource
 from opengever.tabbedview.filters import Filter
 from opengever.tabbedview.filters import FilterList
 from opengever.tabbedview.filters import PendingTasksFilter
+from opengever.tabbedview.helper import author_cache_key
 from opengever.tabbedview.helper import display_org_unit_title_condition
 from opengever.tabbedview.helper import linked_containing_maindossier
 from opengever.tabbedview.helper import org_unit_title_helper
 from opengever.tabbedview.helper import readable_date_set_invisibles
-from opengever.tabbedview.helper import readable_ogds_author
 from opengever.tabbedview.helper import task_id_checkbox_helper
 from opengever.tabbedview.helper import workflow_state
 from opengever.task.helper import task_type_helper
+from plone.memoize import ram
+from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import and_, or_
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import implements
 from zope.interface import Interface
+
+
+@ram.cache(author_cache_key)
+def linked_task_actor(item, actor):
+    actor = safe_unicode(actor) or u''
+    return Actor.lookup(actor).get_link(with_icon=True)
 
 
 class IGlobalTaskTableSourceConfig(ITableSourceConfig):
@@ -92,11 +101,11 @@ class GlobalTaskListingTab(BaseListingTab):
 
         {'column': 'responsible',
          'column_title': _(u'label_responsible_task', default=u'Responsible'),
-         'transform': readable_ogds_author},
+         'transform': linked_task_actor},
 
         {'column': 'issuer',
          'column_title': _(u'label_issuer', default=u'Issuer'),
-         'transform': readable_ogds_author},
+         'transform': linked_task_actor},
 
         {'column': 'created',
          'column_title': _(u'column_issued_at', default=u'Issued at'),

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -53,7 +53,7 @@ class GlobalTaskListingTab(BaseListingTab):
 
     sort_on = 'modified'
     sort_reverse = False
-    #lazy must be false otherwise there will be no correct batching
+    # lazy must be false otherwise there will be no correct batching
     lazy = False
 
     # the model attribute is used for a dynamic textfiltering functionality
@@ -154,6 +154,6 @@ class GlobalTaskTableSource(SqlTableSource):
         """
         query = query.filter(
             or_(
-                and_(Task.predecessor == None, Task.successors == None),
+                and_(Task.predecessor == None, Task.successors == None),  # noqa
                 Task.admin_unit_id == get_current_admin_unit().id()))
         return query

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -60,7 +60,8 @@ def author_cache_key(m, i, author):
         userid = author.getId()
     else:
         userid = author
-    return (userid, hostname)
+
+    return '{}.{}:{}.{}'.format(m.__module__, m.__name__, userid, hostname)
 
 
 @ram.cache(author_cache_key)

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -1,64 +1,37 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
-from opengever.testing import create_plone_user
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
-import transaction
+from opengever.testing import IntegrationTestCase
 
 
-class TestPersonalOverview(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestPersonalOverview, self).setUp()
-
-        create_plone_user(self.portal, 'hugo.boss')
-        self.hugo = create(Builder('ogds_user')
-                           .having(userid='hugo.boss',
-                                   firstname='Hugo',
-                                   lastname='Boss')
-                           .assign_to_org_units([self.org_unit]))
-        transaction.commit()
+class TestPersonalOverview(IntegrationTestCase):
 
     @browsing
     def test_redirects_to_repository_root_on_a_foreign_admin_unit(self, browser):
-        create_plone_user(self.portal, 'peter')
-        setRoles(self.portal, 'hugo.boss', ['Reader'])
-        transaction.commit()
+        foreign_user = create(Builder('user')
+                              .named('Peter', 'Schneider')
+                              .with_roles('Reader'))
+        create(Builder('ogds_user')
+               .id(foreign_user.getId())
+               .having(firstname='Peter', lastname='Schneider'))
 
-        admin_unit = create(Builder('admin_unit')
-                            .id('additional'))
-        additional = create(Builder('org_unit')
-                            .id('additional')
-                            .having(admin_unit=admin_unit)
-                            .with_default_groups())
-
-        self.hugo = create(Builder('ogds_user')
-                           .having(userid='peter')
-                           .assign_to_org_units([additional]))
-
-        repo_root = create(Builder('repository_root'))
-
-        browser.login(username='peter', password='demo09').open(
-            view='personal_overview')
-        self.assertEqual(repo_root.absolute_url(), browser.url)
+        self.login(foreign_user, browser=browser)
+        browser.open(self.portal, view='personal_overview')
+        self.assertEqual(self.repository_root.absolute_url(), browser.url)
 
     @browsing
     def test_personal_overview_displays_username_in_title(self, browser):
-        browser.login().open(view='personal_overview')
-        self.assertEquals(u'Personal Overview: Test User',
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(view='personal_overview')
+        self.assertEquals(u'Personal Overview: B\xe4rfuss K\xe4thi',
                           browser.css('h1.documentFirstHeading').first.text)
 
     @browsing
     def test_additional_tabs_are_shown_for_admins(self, browser):
-        setRoles(self.portal, 'hugo.boss', ['Administrator'])
-        transaction.commit()
+        self.login(self.administrator, browser=browser)
+        browser.open(view='personal_overview')
 
-        browser.login(username='hugo.boss', password='demo09').open(
-            view='personal_overview')
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy', 'mytasks', 'myissuedtasks',
              'alltasks', 'allissuedtasks'],
@@ -66,7 +39,9 @@ class TestPersonalOverview(FunctionalTestCase):
 
     @browsing
     def test_additional_tabs_are_shown_for_inbox_users(self, browser):
-        browser.login().open(view='personal_overview')
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(view='personal_overview')
+
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy', 'mytasks', 'myissuedtasks',
              'alltasks', 'allissuedtasks'],
@@ -74,40 +49,32 @@ class TestPersonalOverview(FunctionalTestCase):
 
     @browsing
     def test_additional_tabs_are_hidden_for_regular_users(self, browser):
-        browser.login(username='hugo.boss', password='demo09').open(
-            view='personal_overview')
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='personal_overview')
+
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy', 'mytasks', 'myissuedtasks'],
             browser.css('li.formTab a').text)
 
     @browsing
     def test_notification_tab_is_hidden_when_activity_feature_is_disabled(self, browser):
-        browser.login(username='hugo.boss', password='demo09').open(
-            view='personal_overview')
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='personal_overview')
+
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy', 'mytasks', 'myissuedtasks'],
             browser.css('li.formTab a').text)
 
 
-class TestPersonalOverviewActivitySupport(FunctionalTestCase):
+class TestPersonalOverviewActivitySupport(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-
-
-    def setUp(self):
-        super(TestPersonalOverviewActivitySupport, self).setUp()
-
-        create_plone_user(self.portal, 'hugo.boss')
-        self.hugo = create(Builder('ogds_user')
-                           .having(userid='hugo.boss',
-                                   firstname='Hugo',
-                                   lastname='Boss')
-                           .assign_to_org_units([self.org_unit]))
-        transaction.commit()
+    features = ('activity', )
 
     @browsing
     def test_notification_tab_is_displayed_when_activity_feature_is_enabled(self, browser):
-        browser.login().open(view='personal_overview')
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(view='personal_overview')
+
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy',
              'mytasks',
@@ -117,21 +84,24 @@ class TestPersonalOverviewActivitySupport(FunctionalTestCase):
              'allissuedtasks'],
             browser.css('li.formTab a').text)
 
-        browser.login(username='hugo.boss', password='demo09').open(
-            view='personal_overview')
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='personal_overview')
+
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy', 'mytasks',
              'myissuedtasks', 'My notifications'],
             browser.css('li.formTab a').text)
 
 
-class TestPersonalOverviewMeetingSupport(FunctionalTestCase):
+class TestPersonalOverviewMeetingSupport(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
+    features = ('meeting', )
 
     @browsing
     def test_myproposal_tab_is_displayed_when_meeting_feature_is_enabled(self, browser):
-        browser.login().open(view='personal_overview')
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(view='personal_overview')
+
         self.assertEqual(
             ['mydossiers', 'mydocuments-proxy',
              'mytasks',
@@ -142,69 +112,85 @@ class TestPersonalOverviewMeetingSupport(FunctionalTestCase):
             browser.css('li.formTab a').text)
 
 
-class TestGlobalTaskListings(FunctionalTestCase):
+class TestGlobalTaskListings(IntegrationTestCase):
 
-    use_default_fixture = False
+    @browsing
+    def test_my_tasks_list_task_assigned_to_current_user(self, browser):
+        self.login(self.regular_user, browser=browser)
 
-    def setUp(self):
-        super(TestGlobalTaskListings, self).setUp()
+        browser.open(view='tabbedview_view-mytasks')
+        self.assertEquals(
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
 
-        self.user, self.org_unit, self.admin_unit = create(
-            Builder('fixture').with_all_unit_setup())
+        self.task.get_sql_object().responsible = 'robert.ziegler'
 
-        self.hugo = create(Builder('ogds_user')
-                           .having(userid='hugo.boss',
-                                   firstname='Hugo',
-                                   lastname='Boss')
-                           .assign_to_org_units([self.org_unit]))
+        browser.open(view='tabbedview_view-mytasks')
+        self.assertEquals(
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
 
-        self.task1 = create(Builder('task')
-                            .having(responsible_client='client1',
-                                    responsible=TEST_USER_ID,
-                                    issuer=TEST_USER_ID))
-        self.task2 = create(Builder('task')
-                            .having(responsible_client='client2',
-                                    responsible='hugo.boss',
-                                    issuer=TEST_USER_ID))
-        self.task3 = create(Builder('task')
-                            .having(responsible_client='client1',
-                                    responsible=TEST_USER_ID,
-                                    issuer='hugo.boss'))
-
-    def test_my_tasks(self):
-        view = self.portal.unrestrictedTraverse(
-            'tabbedview_view-mytasks')
-        view.update()
+    @browsing
+    def test_my_tasks_list_task_issued_by_the_current_user(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(view='tabbedview_view-myissuedtasks')
 
         self.assertEquals(
-            [self.task1.get_sql_object(), self.task3.get_sql_object()],
-            view.contents)
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
 
-    def test_my_issued_tasks(self):
-        view = self.portal.unrestrictedTraverse(
-            'tabbedview_view-myissuedtasks')
-        view.update()
+        self.task.get_sql_object().issuer = 'kathi.barfuss'
+
+        browser.open(view='tabbedview_view-myissuedtasks')
+        self.assertEquals(
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
+
+    @browsing
+    def test_all_task_list_all_task_assigned_to_current_org_unit(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(view='tabbedview_view-alltasks')
 
         self.assertEquals(
-            [self.task1.get_sql_object(), self.task2.get_sql_object()],
-            view.contents)
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
 
-    def test_all_tasks(self):
-        view = self.portal.unrestrictedTraverse(
-            'tabbedview_view-alltasks')
-        view.update()
+        self.task.get_sql_object().assigned_org_unit = 'additional'
 
-        expected = [self.task1, self.task3]
+        browser.open(view='tabbedview_view-alltasks')
         self.assertEquals(
-            [task.get_sql_object() for task in expected],
-            view.contents)
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
 
-    def test_all_issued_tasks(self):
-        view = self.portal.unrestrictedTraverse(
-            'tabbedview_view-allissuedtasks')
-        view.update()
+    @browsing
+    def test_all_issued_tasks_list_all_task_issued_by_the_current_org_unit(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(view='tabbedview_view-allissuedtasks')
 
-        expected = [self.task1, self.task2, self.task3]
         self.assertEquals(
-            [task.get_sql_object() for task in expected],
-            view.contents)
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
+
+        create(Builder('org_unit')
+               .id('stv')
+               .having(title=u'Steuerverwaltung',
+                       admin_unit_id='plone'))
+
+        self.task.get_sql_object().issuing_org_unit = 'stv'
+
+        browser.open(view='tabbedview_view-allissuedtasks')
+        self.assertEquals(
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -130,6 +131,34 @@ class TestGlobalTaskListings(IntegrationTestCase):
         browser.open(view='tabbedview_view-mytasks')
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in browser.css('.listing').first.dicts()]
+        )
+
+    @browsing
+    def test_my_tasks_list_also_tasks_assigned_to_my_teams(self, browser):
+        self.login(self.meeting_user, browser=browser)
+
+        create(Builder('task')
+               .within(self.dossier)
+               .titled(u'Anfrage 1')
+               .having(responsible_client='fa',
+                       responsible='team:1',
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction',
+                       deadline=date(2016, 11, 1)))
+
+        create(Builder('task')
+               .within(self.dossier)
+               .titled(u'Anfrage 2')
+               .having(responsible_client='fa',
+                       responsible='team:2',
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction',
+                       deadline=date(2016, 11, 1)))
+
+        browser.open(view='tabbedview_view-mytasks')
+        self.assertEquals(
+            [u'Anfrage 2'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 

--- a/opengever/tabbedview/tests/test_tasklisting.py
+++ b/opengever/tabbedview/tests/test_tasklisting.py
@@ -1,58 +1,48 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.globalindex.handlers.task import TaskSqlSyncer
+from opengever.testing import IntegrationTestCase
 
 
-class TestTaskListing(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestTaskListing, self).setUp()
-
-        self.dossier = create(Builder('dossier')
-                              .titled(u'<b>B\xf6ld title</b>'))
-        self.subdossier = create(Builder('dossier')
-                                 .within(self.dossier)
-                                 .titled(u'S\xfcb'))
-        self.task1 = create(Builder('task')
-                            .within(self.dossier)
-                            .in_state('task-state-open')
-                            .titled('Task 1'))
-        self.task2 = create(Builder('task')
-                            .within(self.dossier)
-                            .in_state('task-state-tested-and-closed')
-                            .titled('Task 2'))
-        self.task3 = create(Builder('task')
-                            .within(self.subdossier)
-                            .in_state('task-state-in-progress')
-                            .titled('Task 3'))
+class TestTaskListing(IntegrationTestCase):
 
     @browsing
     def test_shows_only_pending_tasks_by_default(self, browser):
-        browser.login().open(
-            self.dossier, view='tabbedview_view-tasks')
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('task-state-tested-and-closed', self.subtask)
+
+        browser.open(self.dossier, view='tabbedview_view-tasks')
 
         table = browser.css('.listing').first
-        self.assertEquals(['Task 1', 'Task 3'],
+        self.assertEquals([u'Vertragsentwurf \xdcberpr\xfcfen'],
                           [row.get('Title') for row in table.dicts()])
 
     @browsing
     def test_list_every_dossiers_with_the_all_filter(self, browser):
-        browser.login().open(
-            self.dossier, view='tabbedview_view-tasks',
-            data={'task_state_filter': 'filter_all'})
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('task-state-tested-and-closed', self.subtask)
+
+        browser.open(self.dossier, view='tabbedview_view-tasks',
+                     data={'task_state_filter': 'filter_all'})
 
         table = browser.css('.listing').first
-        self.assertEquals(['Task 1', 'Task 2', 'Task 3'],
-                          [row.get('Title') for row in table.dicts()])
+        self.assertEquals(
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertragsentwurf \xdcberpr\xfcfen'],
+            [row.get('Title') for row in table.dicts()])
 
     @browsing
     def test_escape_dossier_title_to_prevent_xss(self, browser):
-        browser.login().open(
-            self.dossier, view='tabbedview_view-tasks')
-        table = browser.css('.listing').first
-        second_row_dossier_cell = table.rows[1].css('td:nth-child(10) .maindossierLink').first
+        self.login(self.regular_user, browser=browser)
 
+        self.dossier.title = u'<b>B\xf6ld title</b>'
+        TaskSqlSyncer(self.subtask, None).sync()
+        TaskSqlSyncer(self.task, None).sync()
+
+        browser.open(self.dossier, view='tabbedview_view-tasks')
+
+        table = browser.css('.listing').first
+        second_row_dossier_cell = table.rows[1].css(
+            'td:nth-child(10) .maindossierLink').first
         self.assertEquals(
             u'&lt;b&gt;B\xf6ld title&lt;/b&gt;',
             second_row_dossier_cell.innerHTML.strip().strip('\n'))

--- a/opengever/tabbedview/tests/test_tasklisting.py
+++ b/opengever/tabbedview/tests/test_tasklisting.py
@@ -46,3 +46,33 @@ class TestTaskListing(IntegrationTestCase):
         self.assertEquals(
             u'&lt;b&gt;B\xf6ld title&lt;/b&gt;',
             second_row_dossier_cell.innerHTML.strip().strip('\n'))
+
+    @browsing
+    def test_responsible_is_linked_and_prefixed_with_icon(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier, view='tabbedview_view-tasks')
+
+        self.assertEquals(
+            u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+            browser.css('.listing').first.dicts()[0].get('Responsible'))
+
+        link = browser.find(u'B\xe4rfuss K\xe4thi (kathi.barfuss)')
+        self.assertEquals(
+            'http://nohost/plone/@@user-details/kathi.barfuss',
+            link.get('href'))
+        self.assertEquals('actor-label actor-user', link.get('class'))
+
+    @browsing
+    def test_issuer_is_linked_and_prefixed_with_icon(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier, view='tabbedview_view-tasks')
+
+        self.assertEquals(
+            u'Ziegler Robert (robert.ziegler)',
+            browser.css('.listing').first.dicts()[0].get('Issuer'))
+
+        link = browser.find(u'Ziegler Robert (robert.ziegler)')
+        self.assertEquals(
+            'http://nohost/plone/@@user-details/robert.ziegler',
+            link.get('href'))
+        self.assertEquals('actor-label actor-user', link.get('class'))


### PR DESCRIPTION
The MyTask tab in the personal overview now shows also tasks, which are assigned to a team, where the current user is a team member.

Besides that, the `responsible` and `issuer` column in tasklistings is now linked and prefixed with a icon to differ the different actors (user, inbox, team).

![bildschirmfoto 2017-10-11 um 11 57 28](https://user-images.githubusercontent.com/485755/31436764-3494c362-ae83-11e7-8308-6db5b2e23a20.png)

Styling in a separate PR: https://github.com/4teamwork/plonetheme.teamraum/pull/590

Closes #3415 
