### PR TITLE
SPV word: configure available proposal templates for committee.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Refactor JSON schema generation and dumping, add tests. [lgraf]
 - Ungrok opengever.document. [elioschmutz]
+- SPV word: Selectable proposal templates can be configured per committee. [jone]
 - Ungrok opengever.task. [elioschmutz]
 - Ungrok opengever.officeatwork. [elioschmutz]
 - SPV: Let CommitteeMember only have read-access on meeting view. [jone]

--- a/opengever/base/browser/resources/SelectAutocomplete.js
+++ b/opengever/base/browser/resources/SelectAutocomplete.js
@@ -45,6 +45,7 @@
 
       this.sync = $.proxy(function() {
         target.val(this.selected);
+        target.trigger("change");
         this.element.val($(":selected", target).text());
         this.element.blur();
       }, this);

--- a/opengever/base/browser/resources/TableRadioWidget.js
+++ b/opengever/base/browser/resources/TableRadioWidget.js
@@ -1,0 +1,32 @@
+$(function() {
+  $('.tableradio-widget-wrapper[data-vocabulary-depends-on]').each(function() {
+    /** When a table radio widget has a list of fieldnames configured
+        in  "vocabulary-depends-on", the widget should be re-rendered
+        whenever one of those fields change, so that the vocabulary
+        can reduce its selectable terms. **/
+
+    var widget = $(this);
+    var fieldname = widget.parent('.field').data('fieldname');
+    var form = widget.parents('form:first');
+    var dependency_fields_selector = widget.data('vocabulary-depends-on').map(function(fieldname) {
+      return '[name="' + fieldname + '"], [name="' + fieldname + ':list"]'; }).join(',');
+    var dependency_fields = $(dependency_fields_selector);
+
+    var update_widget = function() {
+      var selection = widget.find('input[type=radio]:checked').val();
+      var widget_render_url = [location.protocol, '//', location.host,
+                               location.pathname,
+                               '/++widget++' + fieldname,
+                               '/ajax_render'].join('');
+      $.get(widget_render_url,
+            form.serialize(),
+            function(result) {
+              widget.html($(result).find('.tableradio-widget-wrapper'));
+              widget.find('input[value="' + selection + '"]').prop('checked', true);
+            });
+    };
+
+    $(dependency_fields).change(update_widget);
+    update_widget();
+  });
+});

--- a/opengever/base/schema.py
+++ b/opengever/base/schema.py
@@ -45,9 +45,14 @@ class TableChoice(schema.Choice):
     The column configuration must be in the format that is required by
     ftw.table's ITableGenerator.
 
+    The optional configuration argument "vocabulary_depends_on" accepts
+    a list of field names which influence the result of the table.
+    This allows the widget to be reloaded automatically when the here
+    listed fields change its values.
     """
     implements(ITableChoice)
 
-    def __init__(self, columns=tuple(), **kwargs):
+    def __init__(self, columns=tuple(), vocabulary_depends_on=(), **kwargs):
         self.columns = columns
+        self.vocabulary_depends_on = vocabulary_depends_on
         super(TableChoice, self).__init__(**kwargs)

--- a/opengever/base/templates/tableradio_input.pt
+++ b/opengever/base/templates/tableradio_input.pt
@@ -3,6 +3,7 @@
       tal:omit-tag="">
 
 <div tal:content="structure view/render_table" tal:condition="view/has_items"
+     tal:attributes="data-vocabulary-depends-on view/get_vocabulary_depends_on"
      class="tableradio-widget-wrapper" />
 <div class="empty_message" tal:content="view/empty_message" tal:condition="not: view/has_items" />
 

--- a/opengever/base/widgets.py
+++ b/opengever/base/widgets.py
@@ -27,6 +27,7 @@ from zope.schema.interfaces import IField
 from zope.schema.interfaces import ISequence
 from zope.schema.interfaces import ITextLine
 from zope.schema.interfaces import ITitledTokenizedTerm
+import json
 import re
 
 
@@ -109,6 +110,16 @@ class TableRadioWidget(widget.HTMLInputWidget, SequenceWidget):
             [term.value for term in self.terms],
             radio_column + (self.field.columns or default_title_colum))
 
+    def ajax_render(self):
+        """Render and return the widget HTML so that it can be replaced
+        in an existing browser page with an AJAX call.
+        """
+        self.form.update()
+        self.update()
+        self.terms = None
+        self.updateTerms()
+        return self()
+
     def render_token_radiobutton(self, item, value):
         """Render the radio-button input element for an item."""
 
@@ -137,6 +148,11 @@ class TableRadioWidget(widget.HTMLInputWidget, SequenceWidget):
         else:
             label = util.toUnicode(term.value)
         return label
+
+    def get_vocabulary_depends_on(self):
+        if not self.field.vocabulary_depends_on:
+            return None
+        return json.dumps(self.field.vocabulary_depends_on)
 
     def update(self):
         """See z3c.form.interfaces.IWidget."""

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -74,13 +74,24 @@
 
   <javascript
       cacheable="True"
+      compression="safe"
+      cookable="True"
+      enabled="True"
+      expression=""
+      id="++resource++opengever.base/TableRadioWidget.js"
+      inline="False"
+      insert-after="++resource++opengever.base/Synchronizer.js"
+      />
+
+  <javascript
+      cacheable="True"
       compression="none"
       cookable="True"
       enabled="on"
       expression=""
       id="++resource++opengever.base/handlebars.js"
       inline="False"
-      insert-after="++resource++opengever.base/Synchronizer.js"
+      insert-after="++resource++opengever.base/TableRadioWidget.js"
       />
 
   <javascript

--- a/opengever/core/upgrades/20171012114615_register_table_radio_widget_js/jsregistry.xml
+++ b/opengever/core/upgrades/20171012114615_register_table_radio_widget_js/jsregistry.xml
@@ -1,0 +1,14 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      enabled="True"
+      expression=""
+      id="++resource++opengever.base/TableRadioWidget.js"
+      inline="False"
+      insert-after="++resource++opengever.base/Synchronizer.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20171012114615_register_table_radio_widget_js/upgrade.py
+++ b/opengever/core/upgrades/20171012114615_register_table_radio_widget_js/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RegisterTableRadioWidgetJs(UpgradeStep):
+    """Register TableRadioWidget.js.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -20,7 +20,6 @@ from plone.z3cform.layout import FormWrapper
 from z3c.form import field
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
-from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import IDataConverter
 from zope.component import getUtility
 
@@ -50,7 +49,8 @@ class CommitteeFieldConfigurationMixin(object):
             self.fields = self.fields.omit('ad_hoc_template',
                                            'paragraph_template',
                                            'protocol_header_template',
-                                           'protocol_suffix_template')
+                                           'protocol_suffix_template',
+                                           'allowed_proposal_templates')
 
 
 class AddForm(CommitteeFieldConfigurationMixin,

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -12,7 +12,6 @@ from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.proposal import Proposal
 from opengever.meeting.proposal import SubmittedProposal
-from opengever.meeting.vocabulary import get_proposal_template_vocabulary
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
@@ -91,8 +90,9 @@ class IAddProposal(IProposal):
 
     proposal_template = TableChoice(
         title=_('label_proposal_template', default=u'Proposal template'),
-        source=get_proposal_template_vocabulary,
+        vocabulary='opengever.meeting.ProposalTemplatesForCommitteeVocabulary',
         required=True,
+        vocabulary_depends_on=['form.widgets.committee'],
         columns=(
             {'column': 'title',
              'column_title': _(u'label_title', default=u'Title'),

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -21,6 +21,7 @@ from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.directives import form
 from plone.i18n.normalizer.interfaces import IIDNormalizer
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from z3c.form.validator import WidgetValidatorDiscriminators
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
@@ -117,6 +118,20 @@ class ICommittee(form.Schema):
         source=sablon_template_source,
         required=False,
     )
+
+    form.widget('allowed_proposal_templates', CheckBoxFieldWidget)
+    allowed_proposal_templates = schema.List(
+        title=_(u'label_allowed_proposal_templates',
+                default=u'Allowed proposal templates'),
+        description=_(u'help_allowed_proposal_templates',
+                      default=u'Select the proposal templates allowed for'
+                      u' this commitee, or select no templates for allowing'
+                      u' all templates.'),
+        value_type=schema.Choice(
+            source='opengever.meeting.ProposalTemplatesVocabulary'),
+        required=False,
+        default=None,
+        missing_value=None)
 
 
 class RepositoryfolderValidator(BaseRepositoryfolderValidator):

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -66,6 +66,11 @@
   <adapter factory=".docprops.ProposalDocPropertyProvider" />
 
   <utility
+      factory=".vocabulary.ProposalTemplatesForCommitteeVocabulary"
+      name="opengever.meeting.ProposalTemplatesForCommitteeVocabulary"
+      />
+
+  <utility
       factory=".vocabulary.ProposalTemplatesVocabulary"
       name="opengever.meeting.ProposalTemplatesVocabulary"
       />

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -65,4 +65,9 @@
 
   <adapter factory=".docprops.ProposalDocPropertyProvider" />
 
+  <utility
+      factory=".vocabulary.ProposalTemplatesVocabulary"
+      name="opengever.meeting.ProposalTemplatesVocabulary"
+      />
+
 </configure>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-05 16:15+0000\n"
-"PO-Revision-Date: 2017-10-10 09:01+0200\n"
+"POT-Creation-Date: 2017-10-12 10:36+0000\n"
+"PO-Revision-Date: 2017-10-11 09:21+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -701,6 +701,11 @@ msgstr "Antrag zurückweisen"
 msgid "held"
 msgstr "Durchgeführt"
 
+#. Default: "Select the proposal templates allowed for this commitee, or select no templates for allowing all templates."
+#: ./opengever/meeting/committee.py
+msgid "help_allowed_proposal_templates"
+msgstr "Wählen Sie alle Antragsvorlagen aus, die in diesem Gremium erlaubt sind. Wählen Sie keine Antragsvorlagen aus, um alle Vorlagen zu erlauben."
+
 #. Default: "Describe, why the proposal is rejected"
 #: ./opengever/meeting/browser/proposaltransitions.py
 msgid "help_reject_proposal_text"
@@ -748,6 +753,11 @@ msgstr "Traktandenliste"
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr "Vorlage Traktandenliste"
+
+#. Default: "Allowed proposal templates"
+#: ./opengever/meeting/committee.py
+msgid "label_allowed_proposal_templates"
+msgstr "Erlaubte Antragsvorlagen"
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -1149,7 +1159,8 @@ msgid "label_proposed_action"
 msgstr "Antrag"
 
 #. Default: "Protocol header template"
-#: ./opengever/meeting/committee.py:65
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_header_template"
 msgstr "Vorlage Protokollkopf"
 
@@ -1159,7 +1170,8 @@ msgid "label_protocol_start_page_number"
 msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Protocol suffix template"
-#: ./opengever/meeting/committee.py:72
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_suffix_template"
 msgstr "Vorlage Schlussteil des Protokolls"
 

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-05 16:15+0000\n"
+"POT-Creation-Date: 2017-10-12 10:36+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -703,6 +703,11 @@ msgstr "Rejeter la proposition"
 msgid "held"
 msgstr "Tenue"
 
+#. Default: "Select the proposal templates allowed for this commitee, or select no templates for allowing all templates."
+#: ./opengever/meeting/committee.py
+msgid "help_allowed_proposal_templates"
+msgstr ""
+
 #. Default: "Describe, why the proposal is rejected"
 #: ./opengever/meeting/browser/proposaltransitions.py
 msgid "help_reject_proposal_text"
@@ -750,6 +755,11 @@ msgstr "Liste des points du jour"
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr "Modèle de la liste des points du jour"
+
+#. Default: "Allowed proposal templates"
+#: ./opengever/meeting/committee.py
+msgid "label_allowed_proposal_templates"
+msgstr ""
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -1151,7 +1161,8 @@ msgid "label_proposed_action"
 msgstr "Proposition"
 
 #. Default: "Protocol header template"
-#: ./opengever/meeting/committee.py:65
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_header_template"
 msgstr ""
 
@@ -1161,7 +1172,8 @@ msgid "label_protocol_start_page_number"
 msgstr "Début de la numérotation des pages du protocole"
 
 #. Default: "Protocol suffix template"
-#: ./opengever/meeting/committee.py:72
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_suffix_template"
 msgstr ""
 

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-05 16:15+0000\n"
+"POT-Creation-Date: 2017-10-12 10:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -700,6 +700,11 @@ msgstr ""
 msgid "held"
 msgstr ""
 
+#. Default: "Select the proposal templates allowed for this commitee, or select no templates for allowing all templates."
+#: ./opengever/meeting/committee.py
+msgid "help_allowed_proposal_templates"
+msgstr ""
+
 #. Default: "Describe, why the proposal is rejected"
 #: ./opengever/meeting/browser/proposaltransitions.py
 msgid "help_reject_proposal_text"
@@ -746,6 +751,11 @@ msgstr ""
 #: ./opengever/meeting/committee.py
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
+msgstr ""
+
+#. Default: "Allowed proposal templates"
+#: ./opengever/meeting/committee.py
+msgid "label_allowed_proposal_templates"
 msgstr ""
 
 #. Default: "Attachments"
@@ -1148,7 +1158,8 @@ msgid "label_proposed_action"
 msgstr ""
 
 #. Default: "Protocol header template"
-#: ./opengever/meeting/committee.py:65
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_header_template"
 msgstr ""
 
@@ -1158,7 +1169,8 @@ msgid "label_protocol_start_page_number"
 msgstr ""
 
 #. Default: "Protocol suffix template"
-#: ./opengever/meeting/committee.py:72
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_suffix_template"
 msgstr ""
 

--- a/opengever/meeting/tests/test_vocabulary.py
+++ b/opengever/meeting/tests/test_vocabulary.py
@@ -1,5 +1,8 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.testing import IntegrationTestCase
 from plone.uuid.interfaces import IUUID
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
 
@@ -43,3 +46,57 @@ class TestProposalTemplatesVocabulary(IntegrationTestCase):
         self.assertItemsEqual(
             [IUUID(self.proposal_template)],
             [term.value for term in factory(context=None)])
+
+
+class TestProposalTemplatesForCommitteeVocabulary(IntegrationTestCase):
+    features = ('meeting', 'word-meeting')
+
+    def test_consists_of_all_templates_by_default(self):
+        self.login(self.committee_responsible)
+        baubewilligungen = create(
+            Builder('proposaltemplate')
+            .titled(u'Baubewilligung')
+            .within(self.templates))
+
+        factory = getUtility(
+            IVocabularyFactory,
+            name='opengever.meeting.ProposalTemplatesForCommitteeVocabulary')
+        self.assertItemsEqual(
+            [self.proposal_template, baubewilligungen],
+            [term.value for term in factory(context=self.dossier)])
+
+    def test_reduce_allowed_templates_with_committee_settings(self):
+        self.login(self.committee_responsible)
+        baubewilligungen = create(
+            Builder('proposaltemplate')
+            .titled(u'Baubewilligung')
+            .within(self.templates))
+
+        factory = getUtility(
+            IVocabularyFactory,
+            name='opengever.meeting.ProposalTemplatesForCommitteeVocabulary')
+        self.assertItemsEqual(
+            [self.proposal_template, baubewilligungen],
+            [term.value for term in factory(context=self.dossier)])
+
+        self.committee.allowed_proposal_templates = [IUUID(baubewilligungen)]
+        self.request.form['form.widgets.committee'] = [
+            unicode(self.committee.load_model().committee_id)]
+        self.assertItemsEqual(
+            [baubewilligungen],
+            [term.value for term in factory(context=self.dossier)])
+
+    def test_offer_predecessor_proposal_document(self):
+        self.login(self.committee_responsible)
+        factory = getUtility(
+            IVocabularyFactory,
+            name='opengever.meeting.ProposalTemplatesForCommitteeVocabulary')
+        self.assertEquals(
+            [self.proposal_template],
+            [term.value for term in factory(context=self.dossier)])
+
+        self.request.form['form.widgets.predecessor_proposal'] = '/'.join(
+            self.word_proposal.getPhysicalPath()).replace('/plone', '')
+        self.assertEquals(
+            [self.word_proposal.get_proposal_document(), self.proposal_template],
+            [term.value for term in factory(context=self.dossier)])

--- a/opengever/meeting/tests/test_vocabulary.py
+++ b/opengever/meeting/tests/test_vocabulary.py
@@ -1,4 +1,5 @@
 from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
 
@@ -26,4 +27,19 @@ class TestCommitteeVocabularies(IntegrationTestCase):
         self.empty_committee.load_model().deactivate()
         self.assertItemsEqual(
             [self.committee.load_model()],
+            [term.value for term in factory(context=None)])
+
+
+class TestProposalTemplatesVocabulary(IntegrationTestCase):
+
+    def test_contains_proposal_templates(self):
+        self.login(self.regular_user)
+        factory = getUtility(IVocabularyFactory,
+                             name='opengever.meeting.ProposalTemplatesVocabulary')
+        self.assertItemsEqual(
+            [self.proposal_template.Title()],
+            [term.title for term in factory(context=None)])
+
+        self.assertItemsEqual(
+            [IUUID(self.proposal_template)],
             [term.value for term in factory(context=None)])

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -69,37 +69,87 @@ def get_committee_member_vocabulary(meetingwrapper):
     return SimpleVocabulary(members)
 
 
-@provider(IContextSourceBinder)
-def get_proposal_template_vocabulary(context):
-    template_folder = get_template_folder()
-    if template_folder is None:
-        # this may happen when the user does not have permissions to
-        # view templates and/or during ++widget++ traversal
-        return SimpleVocabulary([])
+@implementer(IVocabularyFactory)
+class ProposalTemplatesForCommitteeVocabulary(object):
+    """The ProposalTemplatesForCommitteeVocabulary is used in the
+    proposal add form for selecting a proposal template.
 
-    templates = [brain.getObject() for brain in api.content.find(
-        context=template_folder,
-        depth=-1,
-        portal_type="opengever.meeting.proposaltemplate",
-        sort_on='sortable_title', sort_order='ascending')]
+    The proposal template field is configured so that the list of templates
+    is re-rendered whenever the user changes the committee.
+    This allows this vocubulary to ask the selected committee whether the
+    list of templates is limited. If so, the templates are reduced to the
+    allowed templates.
 
-    predecessor_path = context.REQUEST.form.get(
-        'form.widgets.predecessor_proposal', None)
-    if predecessor_path and predecessor_path != u'--NOVALUE--':
-        # The ++add++opengever.meeting.proposal was opened with a predecessor.
-        # We should also offer to use the predecessor proposal document as
-        # "template".
-        predecessor_path = safe_unicode(predecessor_path).encode('utf-8')
-        predecessor = api.content.get(path=predecessor_path)
-        templates.insert(0, predecessor.get_proposal_document())
+    Additional, when a successor proposal is created, the vocabulary allows
+    the user to select the proposal document of the predecess as template
+    for the new proposal.
+    """
 
-    terms = []
-    for template in templates:
-        terms.append(SimpleVocabulary.createTerm(
-            template,
-            IUUID(template),
-            safe_unicode(template.Title())))
-    return SimpleVocabulary(terms)
+    def __call__(self, context):
+        template_folder = get_template_folder()
+        if template_folder is None:
+            # this may happen when the user does not have permissions to
+            # view templates and/or during ++widget++ traversal
+            return SimpleVocabulary([])
+
+        allowed_uids = self.get_allowed_proposal_templates_UIDS(context)
+        objects = self.get_predecessor_proposal_documents(context.REQUEST)
+        objects.extend(self.get_proposal_templates(template_folder, allowed_uids))
+        return self.make_vocabulary_from_objects(objects)
+
+    def get_predecessor_proposal_documents(self, request):
+        """Return a list of documents from the predecessor proposal.
+        The returned documents can additionally be selected as proposal template.
+        """
+        predecessor_path = request.form.get('form.widgets.predecessor_proposal', None)
+        if predecessor_path and predecessor_path != u'--NOVALUE--':
+            # The ++add++opengever.meeting.proposal was opened with a predecessor.
+            # We should also offer to use the predecessor proposal document as
+            # "template".
+            predecessor_path = safe_unicode(predecessor_path).encode('utf-8')
+            predecessor = api.content.get(path=predecessor_path)
+            return [predecessor.get_proposal_document()]
+        return []
+
+    def get_proposal_templates(self, template_folder, allowed_uids):
+        """Return a list of regular proposal templates.
+        This list includes all visible proposal templates.
+        When a list of "allowed_uids" is passed in, it is used as filter
+        so that documents without a listed UID are removed.
+        """
+        query = {'context': template_folder,
+                 'depth': -1,
+                 'portal_type': "opengever.meeting.proposaltemplate",
+                 'sort_on': 'sortable_title',
+                 'sort_order': 'ascending'}
+
+        if allowed_uids:
+            query['UID'] = allowed_uids
+
+        return [brain.getObject() for brain in api.content.find(**query)]
+
+    def get_allowed_proposal_templates_UIDS(self, context):
+        committee = self.get_committee(context)
+        if not committee:
+            return None
+
+        return committee.resolve_committee().allowed_proposal_templates
+
+    def get_committee(self, context):
+        committees = context.REQUEST.form.get('form.widgets.committee', None)
+        if committees:
+            return Committee.query.filter_by(committee_id=int(committees[0])).one()
+
+        return None
+
+    def make_vocabulary_from_objects(self, objects):
+        terms = []
+        for template in objects:
+            terms.append(SimpleVocabulary.createTerm(
+                template,
+                IUUID(template),
+                safe_unicode(template.Title())))
+        return SimpleVocabulary(terms)
 
 
 class LanguagesVocabulary(grok.GlobalUtility):

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -3,9 +3,12 @@ from opengever.dossier.templatefolder import get_template_folder
 from opengever.meeting.model import Committee
 from opengever.meeting.model import Member
 from opengever.meeting.model import Membership
+from opengever.meeting.proposaltemplate import IProposalTemplate
+from operator import attrgetter
 from plone import api
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
+from zope.interface import implementer
 from zope.interface import provider
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.interfaces import IVocabularyFactory
@@ -110,3 +113,17 @@ class LanguagesVocabulary(grok.GlobalUtility):
 
         return SimpleVocabulary(
             [SimpleTerm(language) for language in languages])
+
+
+@implementer(IVocabularyFactory)
+class ProposalTemplatesVocabulary(object):
+
+    def __call__(self, context):
+        terms = []
+        for brain in api.content.find(object_provides=IProposalTemplate):
+            terms.append(SimpleTerm(value=brain.UID,
+                                    token=brain.UID,
+                                    title=brain.Title))
+
+        terms.sort(key=attrgetter('title'))
+        return SimpleVocabulary(terms)


### PR DESCRIPTION
Resolves https://github.com/4teamwork/gever/issues/80

**Goal:**
The selection of available proposal templates should be configurable for each committee.

**Changes:**
- Add new field `allowed_proposal_templates` to committees, storing the UID of each enabled proposal template. When empty, all templates are allowed.
- Extend the `TableRadioWidget` and its field so that it can be configured to automatically reload (via AJAX) when one ore more defined fields change.
- Rewrite proposal template vocabulary (so that we have a class and make methods) and extend it so that it filters the allowed templates when a commitee is given.
- Configure proposal add form so that it updates the proposal template table whenever the committee is changed.
- Make sure we preveserve successor proposal support.

**Multi admin unit setups:**
I have realized that the current proposal adding process does not support a multi admin-unit setup: for that to work properly, add proposals would have to work even when the proposal template is stored in a different admin unit (=plone site).
Because this was not the case and I'm trying to solve a different problem, I did not further do anything in the direction of a multi admin-unit setup. I think this needs more work which is currently out of scope.

**Screenshots:**
<img width="1408" alt="bildschirmfoto 2017-10-12 um 15 27 06" src="https://user-images.githubusercontent.com/7469/31498304-e114789c-af61-11e7-81d3-b344bdfd1149.png">
<img width="1408" alt="bildschirmfoto 2017-10-12 um 13 56 42" src="https://user-images.githubusercontent.com/7469/31498600-b38b6740-af62-11e7-9364-fd2ad4b0c561.png">
