### PR TITLE
SPV word: fix closing meetings with paragraphs.

### DIFF
--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -386,9 +386,13 @@ class Meeting(Base, SQLFormSupport):
         """Return a filtered list of this meetings agenda items,
         containing only the items which are not in a "decided" workflow state.
         """
+        def is_not_paragraph(agenda_item):
+            return not agenda_item.is_paragraph
+
         def is_not_decided(agenda_item):
             return agenda_item.workflow_state != 'decided'
-        return filter(is_not_decided, self.agenda_items)
+
+        return filter(is_not_decided, filter(is_not_paragraph, self.agenda_items))
 
     def _get_localized_time(self, date):
         if not date:

--- a/opengever/meeting/tests/test_meeting_word.py
+++ b/opengever/meeting/tests/test_meeting_word.py
@@ -143,3 +143,16 @@ class TestWordMeeting(IntegrationTestCase):
         with self.login(self.meeting_user):
             self.assertFalse(
                 meeting.is_editable())
+
+    def test_get_undecided_agenda_items(self):
+        self.login(self.committee_responsible)
+        meeting = self.meeting.model
+        self.schedule_paragraph(meeting, u'A-Gesch\xe4fte')
+        item1 = self.schedule_proposal(meeting, self.submitted_word_proposal)
+        item2 = self.schedule_ad_hoc(meeting, u'Ad-Hoc Agenda Item')
+
+        self.assertEquals([item1, item2], meeting.get_undecided_agenda_items())
+        item1.decide()
+        self.assertEquals([item2], meeting.get_undecided_agenda_items())
+        item2.decide()
+        self.assertEquals([], meeting.get_undecided_agenda_items())


### PR DESCRIPTION
Fixes a bug where meetings with paragraphs could not be closed because the paragraph is considered not yet "decided" because of its review state. Paragraphs should be skipped in this check, because it is not possible to decide paragraphs.

ℹ️ No changelog entry because the bug was introduced in a feature in the unreleased master ( #3475). 

Fixes https://github.com/4teamwork/gever/issues/139