### PR TITLE
SPV: prevent incorrect meeting traversal in committees.

### DIFF
--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -171,19 +171,19 @@ class Committee(ModelContainer):
         if id_.startswith('meeting'):
             meeting_id = int(id_.split('-')[-1])
             meeting = Meeting.query.get(meeting_id)
-            if meeting:
+            if meeting and meeting.committee == self.load_model():
                 return MeetingWrapper.wrap(self, meeting)
 
         elif id_.startswith('period'):
             period_id = int(id_.split('-')[-1])
             period = Period.query.get(period_id)
-            if period:
+            if period and period.committee == self.load_model():
                 return PeriodWrapper.wrap(self, period)
 
         elif id_.startswith('membership'):
             membership_id = int(id_.split('-')[-1])
             membership = Membership.query.get(membership_id)
-            if membership:
+            if membership and membership.committee == self.load_model():
                 return MembershipWrapper.wrap(self, membership)
 
         if default is _marker:

--- a/opengever/meeting/tests/test_committee_traversal.py
+++ b/opengever/meeting/tests/test_committee_traversal.py
@@ -1,0 +1,27 @@
+from opengever.testing import IntegrationTestCase
+
+
+class TestCommitteeTraversal(IntegrationTestCase):
+    features = ('meeting',)
+
+    def test_can_only_access_contained_meetings(self):
+        self.login(self.meeting_user)
+        self.assertEquals(self.meeting.model.committee, self.committee.load_model())
+        meeting_path_segment = 'meeting-{}'.format(self.meeting.model.meeting_id)
+        self.assertEquals(self.meeting.model,
+                          self.committee.get(meeting_path_segment).model)
+        self.assertIsNone(self.empty_committee.get(meeting_path_segment))
+
+    def test_can_only_access_contained_periods(self):
+        self.login(self.meeting_user)
+        period = self.committee.load_model().periods[0]
+        period_path_segment = 'period-{}'.format(period.period_id)
+        self.assertEquals(period, self.committee.get(period_path_segment).model)
+        self.assertIsNone(self.empty_committee.get(period_path_segment))
+
+    def test_can_only_access_contained_memberships(self):
+        self.login(self.meeting_user)
+        membership = self.committee.load_model().memberships[0]
+        membership_path_segment = 'membership-{}'.format(membership.membership_id)
+        self.assertEquals(membership, self.committee.get(membership_path_segment).model)
+        self.assertIsNone(self.empty_committee.get(membership_path_segment))


### PR DESCRIPTION
Make sure that a meeting can only be accessed in the correct committee.