### PR TITLE
UI/UX for officeatwork state recovery and shadow document deletion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -517,6 +517,7 @@ Objects
           - self.mail_eml
           - self.mail_msg
           - self.proposal
+          - self.shadow_document
           - self.subdossier
             - self.subdocument
           - self.subdossier2

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.1 (unreleased)
 ---------------------
 
+- Add a HTTP DELETE endpoint for shadow documents. [Rotonen]
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add a HTTP DELETE endpoint for shadow documents. [Rotonen]
+- Add modal dialogs in JS for handling officeatwork failure states. [Rotonen]
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -64,8 +64,8 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
         self.login(self.regular_user)
 
         adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
-        self.assertEqual(
-            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12/bumblebee-open-pdf?filename=die-burgschaft.pdf',
+        self.assertIn(
+            '/bumblebee-open-pdf?filename=die-burgschaft.pdf',
             adapter.get_open_as_pdf_url())
 
     def test_handles_non_ascii_characters_in_filename(self):
@@ -74,9 +74,10 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
         IMail(self.mail).message.filename = u'GEVER - \xdcbernahme.msg'
 
         adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
-        self.assertEqual(
-            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
-            adapter.get_open_as_pdf_url())
+        self.assertIn(
+            u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
+            adapter.get_open_as_pdf_url(),
+            )
 
 
 class TestGetCheckoutUrl(IntegrationTestCase):

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -161,14 +161,14 @@ class TestContentStatsIntegration(IntegrationTestCase):
             (self.portal, self.portal.REQUEST),
             IStatsProvider, name='checked_out_docs')
 
-        self.assertEqual({'checked_out': 0, 'checked_in': 16},
+        self.assertEqual({'checked_out': 0, 'checked_in': 17},
                          stats_provider.get_raw_stats())
 
         # Check out a document
         getMultiAdapter((self.document, self.document.REQUEST),
                         ICheckinCheckoutManager).checkout()
 
-        self.assertEqual({'checked_out': 1, 'checked_in': 15},
+        self.assertEqual({'checked_out': 1, 'checked_in': 16},
                          stats_provider.get_raw_stats())
 
     def test_file_mimetypes_provider(self):
@@ -177,12 +177,32 @@ class TestContentStatsIntegration(IntegrationTestCase):
             (self.portal, self.portal.REQUEST),
             IStatsProvider, name='file_mimetypes')
 
-        self.assertEqual({
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 1,
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 10,
-            'message/rfc822': 2,
-            'text/plain': 1},
-            stats_provider.get_raw_stats())
+        raw_mimetype_stats = stats_provider.get_raw_stats()
+
+        # Shadow documents
+        self.assertIn(
+            '',
+            raw_mimetype_stats,
+        )
+        self.assertEquals(1, raw_mimetype_stats.get('', None))
+
+        self.assertIn(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            raw_mimetype_stats,
+        )
+        self.assertEquals(1, raw_mimetype_stats.get('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', None))
+
+        self.assertIn(
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            raw_mimetype_stats,
+        )
+        self.assertEquals(10, raw_mimetype_stats.get('application/vnd.openxmlformats-officedocument.wordprocessingml.document', None))
+
+        self.assertIn(
+            'message/rfc822',
+            raw_mimetype_stats,
+        )
+        self.assertEquals(2, raw_mimetype_stats.get('message/rfc822', None))
 
     @browsing
     def test_file_mimetypes_provider_in_view(self, browser):
@@ -191,12 +211,26 @@ class TestContentStatsIntegration(IntegrationTestCase):
         browser.open(self.portal, view='@@content-stats')
         table = browser.css('#content-stats-file_mimetypes').first
 
-        self.assertEquals([
+        # Shadow documents
+        self.assertIn(
+            ['', '', '1'],
+            table.lists(),
+            )
+
+        self.assertIn(
             ['', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '1'],
+            table.lists(),
+            )
+
+        self.assertIn(
             ['', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', '10'],
+            table.lists(),
+            )
+
+        self.assertIn(
             ['', 'message/rfc822', '2'],
-            ['', 'text/plain', '1']],
-            table.lists())
+            table.lists(),
+            )
 
     @browsing
     def test_checked_out_docs_stats_provider_in_view(self, browser):
@@ -206,7 +240,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-checked_out_docs').first
 
         self.assertEquals(
-            [['', 'checked_in', '16'], ['', 'checked_out', '0']],
+            [['', 'checked_in', '17'], ['', 'checked_out', '0']],
             table.lists())
 
         # Check out a document
@@ -217,5 +251,5 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-checked_out_docs').first
 
         self.assertEquals(
-            [['', 'checked_in', '15'], ['', 'checked_out', '1']],
+            [['', 'checked_in', '16'], ['', 'checked_out', '1']],
             table.lists())

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -80,7 +80,7 @@ class FieldRow(BaseRow):
         value = widget.items[0]['checked']
         yes = _('label_yes', default='yes')
         no = _('label_no', default='no')
-        return bool(value) and yes or no
+        return yes if bool(value) else no
 
 
 class CustomRow(BaseRow):
@@ -194,7 +194,6 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
     def linked_documents(self):
         """Returns a list documents related to the context document.
         """
-
         return [{
             'class': self.get_css_class(obj),
             'title': obj.Title(),

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -265,4 +265,13 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="GET"
+      for="opengever.document.document.IDocumentSchema"
+      accept="application/json"
+      factory=".service.ShadowDocumentDeleteConfirmMessage"
+      name="delete_confirm"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -246,4 +246,14 @@
 
   <adapter factory=".document.UploadValidator" />
 
+  <!-- plone.rest services -->
+  <plone:service
+      method="GET"
+      for="opengever.document.document.IDocumentSchema"
+      accept="application/json"
+      factory=".service.OfficeatworkInitializationLabels"
+      name="oaw_init_labels"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -274,4 +274,13 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="DELETE"
+      for="opengever.document.document.IDocumentSchema"
+      accept="application/json"
+      factory=".service.DeleteShadowDocument"
+      name="delete_shadow_document"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -256,4 +256,13 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="GET"
+      for="opengever.document.document.IDocumentSchema"
+      accept="application/json"
+      factory=".service.OfficeatworkRetryAbortLabels"
+      name="oaw_retry_abort_labels"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-13 12:25+0000\n"
-"PO-Revision-Date: 2017-10-13 14:27+0200\n"
+"POT-Creation-Date: 2017-10-12 13:53+0000\n"
+"PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
 "MIME-Version: 1.0\n"
@@ -267,6 +267,7 @@ msgstr "Datum, an dem das Dokument über den Korrespondenzweg angekommen ist"
 #. Default: "Initial version"
 #: ./opengever/document/browser/versions_tab.py
 #: ./opengever/document/versioner.py
+#: ./opengever/document/checkout/handlers.py
 msgid "initial_document_version_change_note"
 msgstr "Dokument erstellt (Initialversion)"
 
@@ -425,6 +426,11 @@ msgstr "Schlagworte"
 msgid "label_no"
 msgstr "Nein"
 
+#. Default: "Initializing officeatwork"
+#: ./opengever/document/service.py
+msgid "label_officeatwork_init_title"
+msgstr "Officeatwork wird initialisiert"
+
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_ok"
 msgstr "OK"
@@ -525,6 +531,11 @@ msgstr "Dieses Dokument wurde von ${creator} ausgecheckt."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Das Dokument `${title}` konnte nicht ausgecheckt werden, da Mails den Check-in-/Check-out-Prozess nicht unterstützen."
+
+#. Default: "Please wait."
+#: ./opengever/document/service.py
+msgid "msg_officeatwork_init"
+msgstr "Bitte warten."
 
 #. Default: "No file"
 #: ./opengever/document/browser/templates/archiv_file.pt

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -271,6 +271,11 @@ msgstr "Datum, an dem das Dokument über den Korrespondenzweg angekommen ist"
 msgid "initial_document_version_change_note"
 msgstr "Dokument erstellt (Initialversion)"
 
+#. Default: "Abort"
+#: ./opengever/document/service.py
+msgid "label_abort"
+msgstr "Abbrechen"
+
 #. Default: "Changed by"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
@@ -485,6 +490,11 @@ msgstr "Aktenzeichen"
 #: ./opengever/document/browser/overview.py
 msgid "label_related_documents"
 msgstr "Verwandte Dokumente"
+
+#. Default: "Retry"
+#: ./opengever/document/service.py
+msgid "label_retry"
+msgstr "Erneut versuchen"
 
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -410,6 +410,11 @@ msgstr "Herunterladen"
 msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
+#. Default: "Failed to delete the shadow document."
+#: ./opengever/document/service.py
+msgid "label_failed_shadow_document_deletion"
+msgstr "Das temporäre Schatten-Dokument konnte nicht gelöscht werden."
+
 #. Default: "File"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/document.py
@@ -516,6 +521,11 @@ msgstr "Dokument löschen"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Dokumentdatum"
+
+#. Default: "Succesfully deleted the shadow document."
+#: ./opengever/document/service.py
+msgid "label_succesful_shadow_document_deletion"
+msgstr "Das Schatten-Dokument wurde erfolgreich entfernt."
 
 #. Default: "Thumbnail"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -428,6 +428,7 @@ msgstr "Schlagworte"
 
 #. Default: "no"
 #: ./opengever/document/browser/overview.py
+#: ./opengever/document/service.py
 msgid "label_no"
 msgstr "Nein"
 
@@ -506,6 +507,11 @@ msgstr "Zurücksetzen"
 msgid "label_sequence_number"
 msgstr "Laufnummer"
 
+#. Default: "Delete document"
+#: ./opengever/document/service.py
+msgid "label_shadow_document_delete_confirm_title"
+msgstr "Dokument löschen"
+
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
@@ -529,6 +535,7 @@ msgstr "Version"
 
 #. Default: "yes"
 #: ./opengever/document/browser/overview.py
+#: ./opengever/document/service.py
 msgid "label_yes"
 msgstr "Ja"
 
@@ -546,6 +553,11 @@ msgstr "Das Dokument `${title}` konnte nicht ausgecheckt werden, da Mails den Ch
 #: ./opengever/document/service.py
 msgid "msg_officeatwork_init"
 msgstr "Bitte warten."
+
+#. Default: "Do you really want to delete this document?"
+#: ./opengever/document/service.py
+msgid "msg_shadow_document_delete_confirm_message"
+msgstr "Möchten Sie das Dokument wirklich löschen?"
 
 #. Default: "No file"
 #: ./opengever/document/browser/templates/archiv_file.pt

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -407,6 +407,11 @@ msgstr "Télécharger"
 msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
+#. Default: "Failed to delete the shadow document."
+#: ./opengever/document/service.py
+msgid "label_failed_shadow_document_deletion"
+msgstr ""
+
 #. Default: "File"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/document.py
@@ -513,6 +518,11 @@ msgstr ""
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Date du document"
+
+#. Default: "Succesfully deleted the shadow document."
+#: ./opengever/document/service.py
+msgid "label_succesful_shadow_document_deletion"
+msgstr ""
 
 #. Default: "Thumbnail"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -268,6 +268,11 @@ msgstr "Date de réception du document écrit"
 msgid "initial_document_version_change_note"
 msgstr "Document créé (version initiale)"
 
+#. Default: "Abort"
+#: ./opengever/document/service.py
+msgid "label_abort"
+msgstr ""
+
 #. Default: "Changed by"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
@@ -482,6 +487,11 @@ msgstr "Numéro de référence"
 #: ./opengever/document/browser/overview.py
 msgid "label_related_documents"
 msgstr "Documents liés"
+
+#. Default: "Retry"
+#: ./opengever/document/service.py
+msgid "label_retry"
+msgstr ""
 
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-13 12:25+0000\n"
+"POT-Creation-Date: 2017-10-12 13:53+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -264,6 +264,7 @@ msgstr "Date de réception du document écrit"
 #. Default: "Initial version"
 #: ./opengever/document/browser/versions_tab.py
 #: ./opengever/document/versioner.py
+#: ./opengever/document/checkout/handlers.py
 msgid "initial_document_version_change_note"
 msgstr "Document créé (version initiale)"
 
@@ -422,6 +423,11 @@ msgstr "Mots-clés"
 msgid "label_no"
 msgstr "Non"
 
+#. Default: "Initializing officeatwork"
+#: ./opengever/document/service.py
+msgid "label_officeatwork_init_title"
+msgstr ""
+
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_ok"
 msgstr "OK"
@@ -522,6 +528,11 @@ msgstr "Ce document a été verrouillé par ${creator}."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Le document `${title}` n'a pas pu être verrouillé, car les e-mails ne sont pas supportés par le processus de check-in / check-out."
+
+#. Default: "Please wait."
+#: ./opengever/document/service.py
+msgid "msg_officeatwork_init"
+msgstr ""
 
 #. Default: "No file"
 #: ./opengever/document/browser/templates/archiv_file.pt

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -425,6 +425,7 @@ msgstr "Mots-clés"
 
 #. Default: "no"
 #: ./opengever/document/browser/overview.py
+#: ./opengever/document/service.py
 msgid "label_no"
 msgstr "Non"
 
@@ -503,6 +504,11 @@ msgstr "Reculer"
 msgid "label_sequence_number"
 msgstr "Numéro courant"
 
+#. Default: "Delete document"
+#: ./opengever/document/service.py
+msgid "label_shadow_document_delete_confirm_title"
+msgstr ""
+
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
@@ -526,6 +532,7 @@ msgstr "Version"
 
 #. Default: "yes"
 #: ./opengever/document/browser/overview.py
+#: ./opengever/document/service.py
 msgid "label_yes"
 msgstr "Oui"
 
@@ -542,6 +549,11 @@ msgstr "Le document `${title}` n'a pas pu être verrouillé, car les e-mails ne 
 #. Default: "Please wait."
 #: ./opengever/document/service.py
 msgid "msg_officeatwork_init"
+msgstr ""
+
+#. Default: "Do you really want to delete this document?"
+#: ./opengever/document/service.py
+msgid "msg_shadow_document_delete_confirm_message"
 msgstr ""
 
 #. Default: "No file"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -269,6 +269,11 @@ msgstr ""
 msgid "initial_document_version_change_note"
 msgstr ""
 
+#. Default: "Abort"
+#: ./opengever/document/service.py
+msgid "label_abort"
+msgstr ""
+
 #. Default: "Changed by"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
@@ -482,6 +487,11 @@ msgstr ""
 #: ./opengever/document/behaviors/related_docs.py
 #: ./opengever/document/browser/overview.py
 msgid "label_related_documents"
+msgstr ""
+
+#. Default: "Retry"
+#: ./opengever/document/service.py
+msgid "label_retry"
 msgstr ""
 
 #. Default: "Revert"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -408,6 +408,11 @@ msgstr ""
 msgid "label_download_copy"
 msgstr ""
 
+#. Default: "Failed to delete the shadow document."
+#: ./opengever/document/service.py
+msgid "label_failed_shadow_document_deletion"
+msgstr ""
+
 #. Default: "File"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/document.py
@@ -513,6 +518,11 @@ msgstr ""
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
+msgstr ""
+
+#. Default: "Succesfully deleted the shadow document."
+#: ./opengever/document/service.py
+msgid "label_succesful_shadow_document_deletion"
 msgstr ""
 
 #. Default: "Thumbnail"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -426,6 +426,7 @@ msgstr ""
 
 #. Default: "no"
 #: ./opengever/document/browser/overview.py
+#: ./opengever/document/service.py
 msgid "label_no"
 msgstr ""
 
@@ -504,6 +505,11 @@ msgstr ""
 msgid "label_sequence_number"
 msgstr ""
 
+#. Default: "Delete document"
+#: ./opengever/document/service.py
+msgid "label_shadow_document_delete_confirm_title"
+msgstr ""
+
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
@@ -527,6 +533,7 @@ msgstr ""
 
 #. Default: "yes"
 #: ./opengever/document/browser/overview.py
+#: ./opengever/document/service.py
 msgid "label_yes"
 msgstr ""
 
@@ -543,6 +550,11 @@ msgstr ""
 #. Default: "Please wait."
 #: ./opengever/document/service.py
 msgid "msg_officeatwork_init"
+msgstr ""
+
+#. Default: "Do you really want to delete this document?"
+#: ./opengever/document/service.py
+msgid "msg_shadow_document_delete_confirm_message"
 msgstr ""
 
 #. Default: "No file"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-13 12:25+0000\n"
+"POT-Creation-Date: 2017-10-12 13:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -265,6 +265,7 @@ msgstr ""
 #. Default: "Initial version"
 #: ./opengever/document/browser/versions_tab.py
 #: ./opengever/document/versioner.py
+#: ./opengever/document/checkout/handlers.py
 msgid "initial_document_version_change_note"
 msgstr ""
 
@@ -423,6 +424,11 @@ msgstr ""
 msgid "label_no"
 msgstr ""
 
+#. Default: "Initializing officeatwork"
+#: ./opengever/document/service.py
+msgid "label_officeatwork_init_title"
+msgstr ""
+
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "label_ok"
 msgstr ""
@@ -522,6 +528,11 @@ msgstr ""
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
+msgstr ""
+
+#. Default: "Please wait."
+#: ./opengever/document/service.py
+msgid "msg_officeatwork_init"
 msgstr ""
 
 #. Default: "No file"

--- a/opengever/document/service.py
+++ b/opengever/document/service.py
@@ -58,3 +58,42 @@ class OfficeatworkRetryAbortLabels(Service):
         # Fail per default
         raise Forbidden
 
+
+class ShadowDocumentDeleteConfirmMessage(Service):
+    """Provide an HTTP GET endpoint for shadow document deletion information."""
+
+    def render(self):
+        """Provide i18ns label for a user facing alert box for confirming shadow document deletion."""
+        if self.context.is_shadow_document():
+            message = translate(
+                _(u'msg_shadow_document_delete_confirm_message', default=u'Do you really want to delete this document?'),
+                context=self.request,
+                )
+
+            title = translate(
+                _(u'label_shadow_document_delete_confirm_title', default=u'Delete document'),
+                context=self.request,
+                )
+
+            label_yes = translate(
+                _(u'label_yes', default=u'yes'),
+                context=self.request,
+                )
+
+            label_no = translate(
+                _(u'label_no', default=u'no'),
+                context=self.request,
+                )
+
+            payload = dict(
+                message=message,
+                title=title,
+                label_yes=label_yes,
+                label_no=label_no,
+                )
+
+            return json.dumps(payload)
+
+        # Fail per default
+        raise Forbidden
+

--- a/opengever/document/service.py
+++ b/opengever/document/service.py
@@ -1,0 +1,33 @@
+from opengever.document import _
+from plone.rest import Service
+from zExceptions import Forbidden
+from zope.i18n import translate
+import json
+
+
+class OfficeatworkInitializationLabels(Service):
+    """Provide an HTTP GET endpoint for officeatwork initialization related labels for shadow documents."""
+
+    def render(self):
+        """Provide i18n labels for officeatwork initialization for shadow documents."""
+        if self.context.is_shadow_document():
+            title = translate(
+                _(u'label_officeatwork_init_title', default=u'Initializing officeatwork'),
+                context=self.request,
+                )
+
+            message = translate(
+                _(u'msg_officeatwork_init', default=u'Please wait.'),
+                context=self.request,
+            )
+
+            payload = dict(
+                title=title,
+                message=message,
+            )
+
+            return json.dumps(payload)
+
+        # Fail per default
+        raise Forbidden
+

--- a/opengever/document/service.py
+++ b/opengever/document/service.py
@@ -123,7 +123,7 @@ class DeleteShadowDocument(Service):
                 # The document does not yet have a file
                 if not self.context.file:
                     # The document does not yet have versions
-                    if self.context.version_id == 0:
+                    if self.context.get_current_version_id(missing_as_zero=True) == 0:
                         parent_dossier = self.context.get_parent_dossier()
                         parent_dossier_url = parent_dossier.absolute_url() if parent_dossier else None
 

--- a/opengever/document/service.py
+++ b/opengever/document/service.py
@@ -1,4 +1,5 @@
 from opengever.document import _
+from plone import api
 from plone.rest import Service
 from zExceptions import Forbidden
 from zope.i18n import translate
@@ -97,3 +98,48 @@ class ShadowDocumentDeleteConfirmMessage(Service):
         # Fail per default
         raise Forbidden
 
+
+class DeleteShadowDocument(Service):
+    """Provide a HTTP DELETE endpoint for shadow documents."""
+
+    def render(self):
+        """Delete a shadow document.
+
+        Preconditions:
+        * Only the document owner or a Manager may delete a shadow document
+        * Only a document still in the shadow state may be deleted
+        * Only a document without a file may be deleted
+        * Only a document without versions beyond the initial version may be deleted
+        """
+        document_owner_id = self.context.owner_info().get('id', None)
+
+        current_user = api.user.get_current()
+        current_user_id = current_user.id
+
+        # The creator or someone with a Manager role is trying to delete the document
+        if (document_owner_id and current_user_id == document_owner_id) or api.user.has_permission('Manage portal', obj=self.context):
+            # The document is still in a shadow state
+            if self.context.is_shadow_document():
+                # The document does not yet have a file
+                if not self.context.file:
+                    # The document does not yet have versions
+                    if self.context.version_id == 0:
+                        parent_dossier = self.context.get_parent_dossier()
+                        parent_dossier_url = parent_dossier.absolute_url() if parent_dossier else None
+
+                        parent_inbox = self.context.get_parent_inbox()
+                        parent_inbox_url = parent_inbox.absolute_url() if parent_inbox else None
+
+                        parent_url = parent_dossier_url if parent_dossier_url else parent_inbox_url
+
+                        api.content.delete(obj=self.context)
+
+                        success_message = _(u'label_succesful_shadow_document_deletion', default='Succesfully deleted the shadow document.')
+                        api.portal.show_message(message=success_message, type='info', request=self.request)
+
+                        return json.dumps(dict(parent_url=parent_url))
+
+        # Fail per default
+        failure_message = _(u'label_failed_shadow_document_deletion', default='Failed to delete the shadow document.')
+        api.portal.show_message(message=failure_message, type='error', request=self.request)
+        raise Forbidden

--- a/opengever/document/service.py
+++ b/opengever/document/service.py
@@ -31,3 +31,30 @@ class OfficeatworkInitializationLabels(Service):
         # Fail per default
         raise Forbidden
 
+
+class OfficeatworkRetryAbortLabels(Service):
+    """Provide an HTTP GET endpoint for officeatwork retry/abort logic related labels for shadow documents."""
+
+    def render(self):
+        """Provide i18n labels for officeatwork retry/abort logic for shadow documents."""
+        if self.context.is_shadow_document():
+            retry = translate(
+                _(u'label_retry', default=u'Retry'),
+                context=self.request,
+            )
+
+            abort = translate(
+                _(u'label_abort', default=u'Abort'),
+                context=self.request,
+            )
+
+            payload = dict(
+                retry=retry,
+                abort=abort,
+            )
+
+            return json.dumps(payload)
+
+        # Fail per default
+        raise Forbidden
+

--- a/opengever/document/static/officeconnector.js
+++ b/opengever/document/static/officeconnector.js
@@ -2,7 +2,10 @@
 
     "use strict";
 
-    var OFFICE_CONNECTOR_TIMEOUT = 5 * 1000;
+    var APPLICATION_TIMEOUTS = {
+        officeconnector: 5 * 1000,
+        officeatwork: 45 * 1000,
+    };
 
     function poll(fn, options) {
 
@@ -31,93 +34,208 @@
         return promise;
     }
 
-    function requestJSON(url) {
+    function requestJSON(url, method) {
+        method = method || 'GET';
+
         return $.ajax(url, {
             headers: {
                 Accept: "application/json",
-            }
+            },
+            type: method,
         });
+
     }
 
     function isDocumentLocked(documentURL) {
         return requestJSON(documentURL + "/status").pipe(function(data) {
-            return JSON.parse(data)["locked"];
+            return JSON.parse(data).locked;
         });
     }
 
     function checkout(documentURL) {
         return poll(function() {
-            return isDocumentLocked(documentURL)
+            return isDocumentLocked(documentURL);
         });
     }
 
-    function edit() {
+    function edit(application) {
         var promise = $.Deferred();
+
         setTimeout(function() {
             promise.reject();
-        }, OFFICE_CONNECTOR_TIMEOUT);
+        }, APPLICATION_TIMEOUTS[application]);
+
         return promise;
+    }
+
+    function delete_confirmation_modal(data, documentURL) {
+        var labels = JSON.parse(data);
+        var title = labels.title;
+        var message = labels.message;
+        var label_yes = labels.label_yes;
+        var label_no = labels.label_no;
+
+        // IE11 does not support computed properties
+        // The introduction order of the buttons dictionary is left to right
+        var buttons = {};
+        buttons[label_no] = function() { $(this).dialog('close'); };
+        buttons[label_yes] = function() { delete_shadow_document(documentURL); };
+
+        $('<div id="dialog">' + JSON.parse(data).message + '</div>').dialog({
+            draggable: false,
+            modal: true,
+            title: title,
+            buttons: buttons,
+        });
+    }
+
+    function delete_shadow_document(documentURL) {
+        var delete_status = requestJSON(documentURL + '/delete_shadow_document', 'DELETE');
+        $.when(delete_status.done(), delete_status.fail())
+        .then(function(data) { window.location.replace(JSON.parse(data[0]).parent_url); })
+        // There should be a portal message set
+        .fail(function(){ location.reload(); });
+    }
+
+    function show_status_modal(data) {
+        var labels = JSON.parse(data);
+        var title = labels.title;
+        var message = labels.message;
+
+        $('<div id="dialog" class="officeatwork-status oc-loading">' + message + '</div>').dialog({
+            draggable: false,
+            modal: true,
+            title: title,
+        });
+    }
+
+    function handle_officeatwork_timeout(documentURL) {
+        var retry_abort_labels = requestJSON(documentURL + '/oaw_retry_abort_labels');
+        $.when(retry_abort_labels.done()).then(function(data) { render_retry_abort_labels(data); });
+    }
+
+    function render_retry_abort_labels(data) {
+        var labels = JSON.parse(data);
+        var retry = labels.retry;
+        var abort = labels.abort;
+
+        var officeatworkStatusDiv = $('div.officeatwork-status');
+        officeatworkStatusDiv.removeClass('oc-loading');
+        officeatworkStatusDiv.empty();
+        officeatworkStatusDiv.append('<a class="officeatwork-retry" href="">'+ retry + '</a>');
+        officeatworkStatusDiv.append('<a class="officeatwork-abort" href="">' + abort + '</a>');
     }
 
     $(document).on("click", ".oc-checkout", function(event) {
         var checkoutButton = $(event.currentTarget);
         var documentURL = checkoutButton.data("document-url");
+
         if(checkoutButton.hasClass('oc-loading')) {
             return false;
         }
+
         checkoutButton.addClass("oc-loading");
+
         isDocumentLocked(documentURL).pipe(function(status) {
             if(status) {
-                return edit();
+                return edit('officeconnector');
             } else {
                 return checkout(documentURL);
             }
         })
         .done(function() { location.reload(); })
-        .fail(function() {
-            checkoutButton.removeClass("oc-loading");
-        });
+        .fail(function() { checkoutButton.removeClass("oc-loading"); });
+    });
+
+    $(document).on("click", ".officeatwork-abort", function(event) {
+        var loc = document.location;
+        var documentURL = loc.protocol + '//' + loc.hostname + ':' + loc.port + loc.pathname;
+
+        var delete_confirmation = requestJSON(documentURL + '/delete_confirm');
+        $.when(delete_confirmation.done()).then(function(data) { delete_confirmation_modal(data, documentURL); });
+
+        return false;
+    });
+
+    $(document).on("click", ".officeatwork-retry", function(event) {
+        // This relies on the query string as the element will not be there otherwise
+        location.reload();
+        return false;
+    });
+
+    $(document).on('reload', '.tabbedview_view', function(event) {
+        var loc = document.location;
+        var params = new URLSearchParams(loc.search);
+        if ( params.get('oaw_init') ) {
+            var documentURL = loc.protocol + '//' + loc.hostname + ':' + loc.port + loc.pathname;
+
+            var oaw_dialog_labels = requestJSON(documentURL + '/oaw_init_labels');
+
+            $.when(oaw_dialog_labels.done()).then(function(data) { show_status_modal(data); });
+
+            var document_lock = isDocumentLocked(documentURL).pipe(function(status) {
+                if(!status) {
+                    return edit('officeatwork');
+                }
+
+                else {
+                    return checkout(documentURL);
+                }
+            });
+
+            /*
+            Office Connector has succesfully:
+            1) Initiated the template chooser
+            2) Generated a document
+            3) Uploaded the document
+            4) Initiated a checkout
+            5) Locked the document
+            */
+            $.when(document_lock.done(), document_lock.fail())
+            .then(function() { location.reload(); })
+            .fail(function() { handle_officeatwork_timeout(documentURL); } );
+        }
     });
 
 })(window.jQuery);
 
 function openOfficeconnector(data) {
     // URLs the browser does not handle get passed onto the OS
-    window.location = data['url'];
+    window.location = data.url;
 }
 
 function alertUser(data) {
-    alert(JSON.parse(data["responseText"])["error"]["message"]);
+    alert(JSON.parse(data.responseText.error.message));
 }
 
 function officeConnectorCheckout(url) {
-    var officeconnector_config = {}
+    var officeconnector_config = {};
 
     officeconnector_config.url = url;
     officeconnector_config.headers = {};
-    officeconnector_config.headers['Accept'] = 'application/json';
+    officeconnector_config.headers.accept = 'application/json';
 
     $.ajax(officeconnector_config).error(alertUser).done(openOfficeconnector);
 }
 
 function officeConnectorAttach(url) {
-    var officeconnector_config = {}
+    var officeconnector_config = {};
 
     officeconnector_config.url = url;
     officeconnector_config.headers = {};
-    officeconnector_config.headers['Accept'] = 'application/json';
+    officeconnector_config.headers.accept = 'application/json';
 
     $.ajax(officeconnector_config).error(alertUser).done(openOfficeconnector);
 }
 
 function officeConnectorMultiAttach(url) {
-    var officeconnector_config = {}
+    var officeconnector_config = {};
 
     officeconnector_config.data = {};
     officeconnector_config.data.documents = [];
     officeconnector_config.dataType = 'json';
     officeconnector_config.headers = {};
-    officeconnector_config.headers['Accept'] = 'application/json';
+    officeconnector_config.headers.accept = 'application/json';
     officeconnector_config.headers['Content-Type'] = 'application/json';
     officeconnector_config.type = 'POST';
     officeconnector_config.url = url;
@@ -129,21 +247,19 @@ function officeConnectorMultiAttach(url) {
     });
 
     if (officeconnector_config.data.documents.length > 0) {
-        var dossier_config = {}
+        var dossier_config = {};
 
         dossier_config.dataType = 'json';
         dossier_config.headers = {};
-        dossier_config.headers['Accept'] = 'application/json';
+        dossier_config.headers.accept = 'application/json';
         dossier_config.type = 'GET';
         dossier_config.url = window.location.pathname + '/attributes';
 
         dossier_attributes = $.ajax(dossier_config);
 
-        $.when(dossier_attributes.done()).then(function(attributes){
-            officeconnector_config.data.bcc = attributes.email;
-        });
+        $.when(dossier_attributes.done()).then(function(attributes){ officeconnector_config.data.bcc = attributes.email; });
 
-        $.when(dossier_attributes.complete()).then(function(){
+        $.when(dossier_attributes.always()).then(function(){
             officeconnector_config.data = JSON.stringify(officeconnector_config.data);
             $.ajax(officeconnector_config).error(alertUser).done(openOfficeconnector);
         });

--- a/opengever/document/tests/test_api.py
+++ b/opengever/document/tests/test_api.py
@@ -85,3 +85,50 @@ class TestDocumentAPI(IntegrationTestCase):
                     'Accept': 'application/json',
                 },
             )
+
+    @browsing
+    def test_get_shadow_document_deletion_message_on_shadow_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        label_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'delete_confirm',
+            ))
+
+        browser.open(
+            label_url,
+            headers={
+                'Accept': 'application/json',
+            },
+        )
+
+        labels = browser.json
+
+        self.assertIn(u'label_no', labels)
+        self.assertTrue(labels.get(u'label_no', None))
+
+        self.assertIn(u'label_yes', labels)
+        self.assertTrue(labels.get(u'label_yes', None))
+
+        self.assertIn(u'message', labels)
+        self.assertTrue(labels.get(u'message', None))
+
+        self.assertIn(u'title', labels)
+        self.assertTrue(labels.get(u'title', None))
+
+    @browsing
+    def test_get_shadow_document_deletion_message_on_normal_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        label_url = '/'.join((
+            self.document.absolute_url(),
+            'delete_confirm',
+            ))
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                label_url,
+                headers={
+                    'Accept': 'application/json',
+                },
+            )

--- a/opengever/document/tests/test_api.py
+++ b/opengever/document/tests/test_api.py
@@ -231,7 +231,7 @@ class TestDocumentAPI(IntegrationTestCase):
         uploaded_file = NamedBlobFile('bla bla', filename=u'test.txt')
         field.set(self.shadow_document, uploaded_file)
 
-        self.assertEquals(0, self.shadow_document.version_id)
+        self.assertEquals(None, self.shadow_document.get_current_version_id())
 
         deletion_url = '/'.join((
             self.shadow_document.absolute_url(),
@@ -261,7 +261,7 @@ class TestDocumentAPI(IntegrationTestCase):
 
         getMultiAdapter((self.shadow_document, self.shadow_document.REQUEST), ICheckinCheckoutManager).checkin()
 
-        self.assertNotEquals(0, self.shadow_document.version_id)
+        self.assertEquals(0, self.shadow_document.get_current_version_id())
 
         deletion_url = '/'.join((
             self.shadow_document.absolute_url(),

--- a/opengever/document/tests/test_api.py
+++ b/opengever/document/tests/test_api.py
@@ -1,0 +1,46 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestDocumentAPI(IntegrationTestCase):
+
+    @browsing
+    def test_get_oaw_init_labels_on_shadow_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        label_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'oaw_init_labels',
+            ))
+
+        browser.open(
+            label_url,
+            headers={
+                'Accept': 'application/json',
+            },
+        )
+
+        labels = browser.json
+
+        self.assertIn(u'message', labels)
+        self.assertTrue(labels.get(u'message', None))
+
+        self.assertIn(u'title', labels)
+        self.assertTrue(labels.get(u'title', None))
+
+    @browsing
+    def test_get_oaw_init_labels_on_normal_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        label_url = '/'.join((
+            self.document.absolute_url(),
+            'oaw_init_labels',
+            ))
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                label_url,
+                headers={
+                    'Accept': 'application/json',
+                },
+            )

--- a/opengever/document/tests/test_api.py
+++ b/opengever/document/tests/test_api.py
@@ -44,3 +44,44 @@ class TestDocumentAPI(IntegrationTestCase):
                     'Accept': 'application/json',
                 },
             )
+
+    @browsing
+    def test_get_oaw_retry_abort_labels_on_shadow_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        label_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'oaw_retry_abort_labels',
+            ))
+
+        browser.open(
+            label_url,
+            headers={
+                'Accept': 'application/json',
+            },
+        )
+
+        labels = browser.json
+
+        self.assertIn(u'abort', labels)
+        self.assertTrue(labels.get(u'abort', None))
+
+        self.assertIn(u'retry', labels)
+        self.assertTrue(labels.get(u'retry', None))
+
+    @browsing
+    def test_get_oaw_retry_abort_labels_on_normal_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        label_url = '/'.join((
+            self.document.absolute_url(),
+            'oaw_retry_abort_labels',
+            ))
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                label_url,
+                headers={
+                    'Accept': 'application/json',
+                },
+            )

--- a/opengever/document/tests/test_api.py
+++ b/opengever/document/tests/test_api.py
@@ -1,5 +1,10 @@
 from ftw.testbrowser import browsing
+from opengever.document.document import Document
+from opengever.document.document import IDocumentSchema
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
+from plone.namedfile.file import NamedBlobFile
+from zope.component import getMultiAdapter
 
 
 class TestDocumentAPI(IntegrationTestCase):
@@ -132,3 +137,144 @@ class TestDocumentAPI(IntegrationTestCase):
                     'Accept': 'application/json',
                 },
             )
+
+    @browsing
+    def test_shadow_document_can_be_deleted_by_owner(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        deletion_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'delete_shadow_document',
+            ))
+
+        browser.open(
+            deletion_url,
+            method='DELETE',
+            headers={
+                'Accept': 'application/json',
+            },
+        )
+
+        self.assertFalse([doc for doc in self.dossier.objectValues() if isinstance(doc, Document) and doc.is_shadow_document()])
+
+    @browsing
+    def test_shadow_document_cannot_be_deleted_by_another_user(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        deletion_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'delete_shadow_document',
+            ))
+
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=401, reason='Unauthorized'):
+            browser.open(
+                deletion_url,
+                method='DELETE',
+                headers={
+                    'Accept': 'application/json',
+                },
+            )
+
+        self.login(self.dossier_responsible, browser)
+        self.assertTrue(self.shadow_document)
+
+    @browsing
+    def test_shadow_document_can_be_deleted_by_portal_manager(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        deletion_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'delete_shadow_document',
+            ))
+
+        self.login(self.manager, browser)
+
+        browser.open(
+            deletion_url,
+            method='DELETE',
+            headers={
+                'Accept': 'application/json',
+            },
+        )
+
+        self.assertFalse([doc for doc in self.dossier.objectValues() if isinstance(doc, Document) and doc.is_shadow_document()])
+
+    @browsing
+    def test_normal_document_cannot_be_deleted(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        deletion_url = '/'.join((
+            self.document.absolute_url(),
+            'delete_shadow_document',
+            ))
+
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                deletion_url,
+                method='DELETE',
+                headers={
+                    'Accept': 'application/json',
+                },
+            )
+
+        self.assertTrue(self.document)
+
+    @browsing
+    def test_shadow_document_with_a_file_cannot_be_deleted(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        field = IDocumentSchema['file']
+        uploaded_file = NamedBlobFile('bla bla', filename=u'test.txt')
+        field.set(self.shadow_document, uploaded_file)
+
+        self.assertEquals(0, self.shadow_document.version_id)
+
+        deletion_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'delete_shadow_document',
+            ))
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                deletion_url,
+                method='DELETE',
+                headers={
+                    'Accept': 'application/json',
+                },
+            )
+
+        self.assertTrue(self.shadow_document)
+
+    @browsing
+    def test_shadow_document_with_versions_cannot_be_deleted(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        getMultiAdapter((self.shadow_document, self.shadow_document.REQUEST), ICheckinCheckoutManager).checkout()
+
+        field = IDocumentSchema['file']
+        uploaded_file = NamedBlobFile('bla bla', filename=u'test.txt')
+        field.set(self.shadow_document, uploaded_file)
+
+        getMultiAdapter((self.shadow_document, self.shadow_document.REQUEST), ICheckinCheckoutManager).checkin()
+
+        self.assertNotEquals(0, self.shadow_document.version_id)
+
+        deletion_url = '/'.join((
+            self.shadow_document.absolute_url(),
+            'delete_shadow_document',
+            ))
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                deletion_url,
+                method='DELETE',
+                headers={
+                    'Accept': 'application/json',
+                },
+            )
+
+        self.assertTrue(self.shadow_document)

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -110,10 +110,11 @@ class TestDossierModel(IntegrationTestCase):
     def test_dossier_contains_documents_and_mails(self):
         documentish_types = ['opengever.document.document', 'ftw.mail.mail']
         dossier = Dossier(self.dossier, u'files')
+
         self.assertItemsEqual(
-            [d for d in self.dossier.objectValues()
-             if d.portal_type in documentish_types],
-            [d.obj for d in dossier.documents])
+            [d for d in self.dossier.objectValues() if d.portal_type in documentish_types and d.get_file()],
+            [d.obj for d in dossier.documents],
+            )
 
     def test_documents_without_a_file_are_skipped(self):
         self.document.file = None

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -33,9 +33,8 @@ class TestMailIndexers(IntegrationTestCase):
     def test_checked_out(self):
         self.assertEqual(checked_out(None)(), '')
 
-    def test_reference_number(self):
+    def test_mail_reference_number(self):
         self.login(self.regular_user)
-        extender = getAdapter(
-            self.mail_eml, IDynamicTextIndexExtender, u'IOGMail')
+        extender = getAdapter(self.mail_eml, IDynamicTextIndexExtender, u'IOGMail')
 
-        self.assertEquals('Client1 1.1 / 1 / 12 12', extender())
+        self.assertEquals('Client1 1.1 / 1 / 13 13', extender())

--- a/opengever/officeatwork/browser/documentfromofficeatwork.py
+++ b/opengever/officeatwork/browser/documentfromofficeatwork.py
@@ -58,7 +58,7 @@ class DocumentFromOfficeatwork(WizzardWrappedAddForm):
                 redirector.redirect(target_url)
 
                 return self.request.RESPONSE.redirect(
-                    '{}#documents'.format(self.context.absolute_url()))
+                    '{}?oaw_init=1'.format(aq_wrapped_doc.absolute_url()))
 
             def create(self, data):
                 document = super(WrappedForm, self).create(data)

--- a/opengever/officeatwork/browser/documentfromofficeatwork.py
+++ b/opengever/officeatwork/browser/documentfromofficeatwork.py
@@ -67,7 +67,6 @@ class DocumentFromOfficeatwork(WizzardWrappedAddForm):
 
             def initialize_in_shadow_state(self, document):
                 """Force the initial state to be document-state-shadow."""
-
                 document.as_shadow_document()
 
             @buttonAndHandler(pd_mf(u'Cancel'), name='cancel')

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -43,11 +43,13 @@ class DossierBuilder(DexterityBuilder):
 
         return self
 
+
 builder_registry.register('dossier', DossierBuilder)
 
 
 class MeetingDossierBuilder(DossierBuilder):
     portal_type = 'opengever.meeting.meetingdossier'
+
 
 builder_registry.register('meeting_dossier', MeetingDossierBuilder)
 
@@ -55,17 +57,20 @@ builder_registry.register('meeting_dossier', MeetingDossierBuilder)
 class TemplateFolderBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.dossier.templatefolder'
 
+
 builder_registry.register('templatefolder', TemplateFolderBuilder)
 
 
 class DossierTemplateBuilder(DexterityBuilder):
     portal_type = 'opengever.dossier.dossiertemplate'
 
+
 builder_registry.register('dossiertemplate', DossierTemplateBuilder)
 
 
 class InboxBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.inbox.inbox'
+
 
 builder_registry.register('inbox', InboxBuilder)
 
@@ -145,12 +150,14 @@ class DocumentBuilder(DexterityBuilder):
         self.arguments['relatedItems'] = documents
         return self
 
+
 builder_registry.register('document', DocumentBuilder, force=True)
 
 
 class SablonTemplateBuilder(DocumentBuilder):
 
     portal_type = 'opengever.meeting.sablontemplate'
+
 
 builder_registry.register('sablontemplate', SablonTemplateBuilder)
 
@@ -205,12 +212,14 @@ class TaskBuilder(DexterityBuilder):
         super(TaskBuilder, self).set_modification_date(obj)
         sync_task(obj, None)
 
+
 builder_registry.register('task', TaskBuilder)
 
 
 class ForwardingBuilder(TaskBuilder):
 
     portal_type = 'opengever.inbox.forwarding'
+
 
 builder_registry.register('forwarding', ForwardingBuilder)
 
@@ -257,10 +266,10 @@ class MailBuilder(DexterityBuilder):
         """Fire ObjectCreatedEvent (again) to trigger setting of initial
         attribute values extracted from the message.
         """
-
         super(MailBuilder, self).set_missing_values_for_empty_fields(obj)
 
         notify(ObjectCreatedEvent(obj))
+
 
 builder_registry.register('mail', MailBuilder)
 
@@ -268,17 +277,20 @@ builder_registry.register('mail', MailBuilder)
 class RepositoryBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.repository.repositoryfolder'
 
+
 builder_registry.register('repository', RepositoryBuilder)
 
 
 class ContactFolderBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.contact.contactfolder'
 
+
 builder_registry.register('contactfolder', ContactFolderBuilder)
 
 
 class ContactBuilder(DexterityBuilder):
     portal_type = 'opengever.contact.contact'
+
 
 builder_registry.register('contact', ContactBuilder)
 
@@ -292,17 +304,20 @@ class RepositoryRootBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
             'title_de': u'Ordnungssystem',
         }
 
+
 builder_registry.register('repository_root', RepositoryRootBuilder)
 
 
 class YearFolderbuilder(DexterityBuilder):
     portal_type = 'opengever.inbox.yearfolder'
 
+
 builder_registry.register('yearfolder', YearFolderbuilder)
 
 
 class InboxContainerBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.inbox.container'
+
 
 builder_registry.register('inbox_container', InboxContainerBuilder)
 
@@ -374,10 +389,10 @@ class ProposalBuilder(TransparentModelLoader, DexterityBuilder):
 
     def with_submitted(self):
         """Will return proposal and submitted proposal after creating."""
-
         self.as_submitted()
         self._also_return_submitted_proposal = True
         return self
+
 
 builder_registry.register('proposal', ProposalBuilder)
 
@@ -412,11 +427,13 @@ class SubmittedProposalBuilder(TransparentModelLoader, DexterityBuilder):
         obj.sync_model(proposal_model=model)
         super(SubmittedProposalBuilder, self).after_create(obj)
 
+
 builder_registry.register('submitted_proposal', SubmittedProposalBuilder)
 
 
 class CommitteeContainerBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
     portal_type = 'opengever.meeting.committeecontainer'
+
 
 builder_registry.register('committee_container', CommitteeContainerBuilder)
 
@@ -455,6 +472,7 @@ class CommitteeBuilder(DexterityBuilder):
 
         if self.session.auto_commit:
             db_session.flush()
+
 
 builder_registry.register('committee', CommitteeBuilder)
 
@@ -524,5 +542,6 @@ class ProposalTemplateBuilder(DocumentBuilder):
     def __init__(self, *args, **kwargs):
         super(ProposalTemplateBuilder, self).__init__(*args, **kwargs)
         self.with_dummy_content()
+
 
 builder_registry.register('proposaltemplate', ProposalTemplateBuilder)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -127,6 +127,8 @@ class DocumentBuilder(DexterityBuilder):
 
         if self._is_shadow:
             obj.as_shadow_document()
+            # Normally a form takes care of this for us, but we need to do this in our builders
+            obj.reindexObjectSecurity()
 
         super(DocumentBuilder, self).after_create(obj)
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -449,6 +449,12 @@ class OpengeverContentFixture(object):
                     responsible='hugo.boss')
             .in_state('dossier-state-resolved')))
 
+        self.register('shadow_document', create(
+            Builder('document').within(self.dossier)
+            .titled(u'Schade')
+            .as_shadow_document()
+            ))
+
     @staticuid()
     def create_empty_dossier(self):
         self.register('empty_dossier', create(


### PR DESCRIPTION
Officeatwork general overview on what the reality against which this was tackled:

1) GEVER creates an OC payload and passes that to the OS (not implemented)
2) Office Connector creates the document based on a template choice (not implemented)
3) Office Connector uploads the file to the shadow document (not implemented)
4) Gever unshadows the document upon a file upload (not implemented)
5) Office Connector checks out and WebDAV LOCKs the document
6) Gever reloads the document page or times out and offers a retry / abort choice

Implementing step 6 required planning and implementing the GEVER-side UI/UX for the most part to a state where the everything else will just neatly slot in. The DELETE endpoint got implemented at the same time.

Overview on the UX happy path to managed failure state (as in what got implemented here):

1) A portal action on a dossier (or equivalent) lands the user onto a form
2) Upon successfully POSTing the form, the user gets redirected to the newly created shadow document with the querystring parametre `?oaw_init=1`
3) Javascript will initiate Office Connector (not implemented)
4) Javascript spawns a localized JQuery UI modal dialog with a spinner to entertain the user
5) Javascript polls the document lock status until a timeout (45s, officeatwork is SLOW) is reached
6) Javascript replaces the modal contents with localized retry and abort links (retry just reloads the page and restarts this process)
7) Clicking on the abort link will fetch localizations for a new JQuery UI modal for deletion confirmation
8) Confirming the deletion will HTTP DELETE the shadow document and redirect the user to the parent dossier

As we do not have JS integration tests I thoroughly recommend everyone who reviews this to actually deploy this branch and go through the clickety clickety paths. You can manually LOCK the file to see the page reload fire. If possible, a wider swath of people should do this as we probably want more pairs of eyes on this early on. @phgross 

The JS is restructured into a neater structure. @bierik 

On the architecture side, I'm not very happy about the many trivial HTTP GET this causes just to grab the i18n labels for dynamic UX bits, but could not figure out how else to do this either. Ultimately we'd probably want to have some JS label manager using browser local storage for managing a syllabus of translations and using standard `plone.restapi` endpoints for translations, but this is way beyond the scope of this pull request.

What happened to `document_version` in the meanwhile? I rebased and that changed.

The theming is not yet done for any officeatwork stuff. I will do this in a single step at the end of the development cycle.

Missing a changelog entry on purpose as this is still more of a feedback round at this point.

I am still missing translations as well. Help is welcome on those.

Closes #2166 
Closes #3383 