### PR TITLE
Do not render document link without View permission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Do not render document link without View permission. [jone]
 - Refactor JSON schema generation and dumping, add tests. [lgraf]
 - Ungrok opengever.document. [elioschmutz]
 - SPV word: Selectable proposal templates can be configured per committee. [jone]

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-09 13:21+0000\n"
-"PO-Revision-Date: 2013-03-27 10:44+0100\n"
+"POT-Creation-Date: 2017-10-13 12:25+0000\n"
+"PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
 "MIME-Version: 1.0\n"
@@ -116,6 +116,10 @@ msgstr "Das Dokument ist bereits von ${userid} ausgecheckt."
 #: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"
 msgstr "Eingereichte Version aktualisieren"
+
+#: ./opengever/document/widgets/document_link.pt
+msgid "You are not allowed to view this document."
+msgstr "Sie haben nicht die nötigen Rechte, um dieses Dokument anzusehen."
 
 #: ./opengever/document/browser/edit.py
 msgid "You are not authorized to edit the document ${title}."
@@ -310,7 +314,7 @@ msgstr "Archivdatei ändern"
 
 #. Default: "Checked out"
 #: ./opengever/document/browser/overview.py
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "label_checked_out"
 msgstr "Ausgecheckt"
 
@@ -513,7 +517,7 @@ msgid "label_yes"
 msgstr "Ja"
 
 #. Default: "This item is being checked out by ${creator}."
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr "Dieses Dokument wurde von ${creator} ausgecheckt."
 
@@ -545,4 +549,3 @@ msgstr "Mit Kommentar"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Ohne Kommentar"
-

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-09 13:21+0000\n"
+"POT-Creation-Date: 2017-10-13 12:25+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -118,6 +118,10 @@ msgstr "Le document a déjà un checkout par ${userid}."
 #: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"
 msgstr "Actualiser la version soumise"
+
+#: ./opengever/document/widgets/document_link.pt
+msgid "You are not allowed to view this document."
+msgstr ""
 
 #: ./opengever/document/browser/edit.py
 msgid "You are not authorized to edit the document ${title}."
@@ -307,7 +311,7 @@ msgstr "Modifier le fichier d'archivage"
 
 #. Default: "Checked out"
 #: ./opengever/document/browser/overview.py
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "label_checked_out"
 msgstr "Avec check-out"
 
@@ -510,7 +514,7 @@ msgid "label_yes"
 msgstr "Oui"
 
 #. Default: "This item is being checked out by ${creator}."
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr "Ce document a été verrouillé par ${creator}."
 
@@ -542,4 +546,3 @@ msgstr "Avec commentaire"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr "Sans commentaire"
-

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-09 13:21+0000\n"
+"POT-Creation-Date: 2017-10-13 12:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,6 +118,10 @@ msgstr ""
 
 #: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"
+msgstr ""
+
+#: ./opengever/document/widgets/document_link.pt
+msgid "You are not allowed to view this document."
 msgstr ""
 
 #: ./opengever/document/browser/edit.py
@@ -308,7 +312,7 @@ msgstr ""
 
 #. Default: "Checked out"
 #: ./opengever/document/browser/overview.py
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "label_checked_out"
 msgstr ""
 
@@ -511,7 +515,7 @@ msgid "label_yes"
 msgstr ""
 
 #. Default: "This item is being checked out by ${creator}."
-#: ./opengever/document/checkout/viewlets_templates/checkedoutviewlet.pt
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr ""
 
@@ -543,4 +547,3 @@ msgstr ""
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "without comment"
 msgstr ""
-

--- a/opengever/document/tests/test_document_link_widget.py
+++ b/opengever/document/tests/test_document_link_widget.py
@@ -49,6 +49,21 @@ class TestDocumentLinkWidget(FunctionalTestCase):
         browser.open_html(DocumentLinkWidget(document_b).render())
         self.assertEquals(1, len(browser.css('.removed_document')))
 
+    @browsing
+    def test_omits_link_when_user_has_no_View_permission(self, browser):
+        document = create(Builder('document')
+                          .titled('Anfrage Meier')
+                          .with_dummy_content())
+        document.manage_permission('View', roles=[], acquire=False)
+
+        browser.open_html(DocumentLinkWidget(document).render())
+
+        self.assertFalse(browser.css('a'))
+        link = browser.css('span.document_link').first
+        self.assertEquals('Anfrage Meier', link.text)
+        self.assertEquals('You are not allowed to view this document.',
+                          link.get('title'))
+
 
 class TestDocumentLinkWidgetWithActivatedBumblebee(FunctionalTestCase):
 

--- a/opengever/document/widgets/document_link.pt
+++ b/opengever/document/widgets/document_link.pt
@@ -1,15 +1,44 @@
-<div i18n:domain="opengever.document" class="linkWrapper tooltip-trigger"
-     tal:attributes="data-tooltip-url string:${view/get_url}/tooltip">
+<html xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="python: True"
+      i18n:domain="opengever.document"
+      tal:define="view_allowed view/is_view_allowed">
 
-  <span tal:condition="context/is_removed" class='removed_document' />
+  <tal:HAS_VIEW_PERMISSION tal:condition="view_allowed">
+    <div class="linkWrapper tooltip-trigger"
+         tal:attributes="data-tooltip-url string:${view/get_url}/tooltip">
 
-  <a tal:content="view/get_title"
-     tal:attributes="class view/get_css_class; href view/get_url;" />
+      <span tal:condition="context/is_removed"
+            class="removed_document" />
 
-</div>
+      <a tal:content="view/get_title"
+         tal:attributes="class view/get_css_class;
+                         href view/get_url;" />
 
-<a href="#" class="hidden-link showroom-item"
-   tal:condition="context/is_bumblebeeable"
-   tal:attributes="data-showroom-target context/get_overlay_url;
-                   data-showroom-title context/get_overlay_title;
-                   data-showroom-id string:showroom-id-${context/uuid}" />
+    </div>
+
+    <a href="#" class="hidden-link showroom-item"
+       tal:condition="context/is_bumblebeeable"
+       tal:attributes="data-showroom-target context/get_overlay_url;
+                       data-showroom-title context/get_overlay_title;
+                       data-showroom-id string:showroom-id-${context/uuid}" />
+  </tal:HAS_VIEW_PERMISSION>
+
+
+  <tal:NO_VIEW_PERMISSION tal:condition="not:view_allowed">
+    <div class="linkWrapper">
+
+      <span tal:condition="context/is_removed"
+            class="removed_document" />
+
+      <span tal:content="view/get_title"
+            tal:attributes="class string:${view/get_css_class} no-access"
+            title="You are not allowed to view this document."
+            i18n:attributes="title" />
+
+    </div>
+  </tal:NO_VIEW_PERMISSION>
+
+
+</html>

--- a/opengever/document/widgets/document_link.py
+++ b/opengever/document/widgets/document_link.py
@@ -28,3 +28,6 @@ class DocumentLinkWidget(object):
 
     def render(self):
         return self.template(self, self.request)
+
+    def is_view_allowed(self):
+        return api.user.has_permission('View', obj=self.context.getObject())


### PR DESCRIPTION
When a user does not have the permission to view a document, the DocumentLinkWidget should not render a link (which will lead to unsufficient privileges), but render a text instead.

This does not affect regular listings, where the users doesnt see such documents anyway, but explicit relations where the user must know that a document exists, but may not have access to the document.

<img width="863" alt="bildschirmfoto 2017-10-13 um 14 30 38" src="https://user-images.githubusercontent.com/7469/31546368-516d915c-b023-11e7-97da-94cb409f781a.png">
