### PR TITLE
SPV word: always show excerpts in meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- SPV word: always show excerpts in meeting view. [jone]
 - Do not render document link without View permission. [jone]
 - Refactor JSON schema generation and dumping, add tests. [lgraf]
 - Ungrok opengever.document. [elioschmutz]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -144,7 +144,8 @@ class AgendaItemsView(BrowserView):
     @require_word_meeting_feature
     def _serialize_excerpts(self, meeting, item):
         excerpt_data = []
-        docs = IContentListing(item.get_excerpt_documents())
+
+        docs = IContentListing(item.get_excerpt_documents(unrestricted=True))
         source_dossier_excerpt = item.get_source_dossier_excerpt()
 
         for doc in docs:

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -500,7 +500,7 @@ class SubmittedProposal(ProposalBase):
             dossier.title)
 
     @require_word_meeting_feature
-    def get_excerpts(self):
+    def get_excerpts(self, unrestricted=False):
         """Return a restricted list of document objects which are excerpts
         of the current proposal.
         """
@@ -508,7 +508,7 @@ class SubmittedProposal(ProposalBase):
         checkPermission = getSecurityManager().checkPermission
         for relation_value in getattr(self, 'excerpts', ()):
             obj = relation_value.to_object
-            if checkPermission('View', obj):
+            if unrestricted or checkPermission('View', obj):
                 excerpts.append(obj)
 
         return excerpts


### PR DESCRIPTION
Always list the excerpts in the meeting view, even when the user has no access to the documents.
This is important in order to let the user know that there are documents.
The user usually has no access because of an incorrect configuration.

Fixes https://github.com/4teamwork/gever/issues/131
Fixes https://github.com/4teamwork/gever/issues/129