### PR TITLE
SPV word: prevent reader user from returning excerpts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Ungrok opengever.base. [elioschmutz]
+- SPV word: prevent reader user from returing excerpts. [jone]
 - SPV word: always show excerpts in meeting view. [jone]
 - Do not render document link without View permission. [jone]
 - Refactor JSON schema generation and dumping, add tests. [lgraf]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -151,9 +151,10 @@ class AgendaItemsView(BrowserView):
         for doc in docs:
             data = {'link': doc.render_link()}
             if not source_dossier_excerpt and item.has_proposal:
-                data['return_link'] = meeting.get_url(
-                    view='agenda_items/{}/return_excerpt?document={}'.format(
-                        item.agenda_item_id, doc.uuid()))
+                if self.meeting.is_editable():
+                    data['return_link'] = meeting.get_url(
+                        view='agenda_items/{}/return_excerpt?document={}'.format(
+                            item.agenda_item_id, doc.uuid()))
             elif source_dossier_excerpt and doc == source_dossier_excerpt:
                 data['is_excerpt_in_source_dossier'] = True
             excerpt_data.append(data)

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -54,3 +54,17 @@ class TestWordMeetingView(IntegrationTestCase):
         browser.open(self.meeting)
         editbar.menu_option('Actions', 'Close meeting').click()
         self.assertEquals('closed', self.meeting.model.get_state().name)
+
+    @browsing
+    def test_meeting_member_cannot_return_excerpt(self, browser):
+        with self.login(self.committee_responsible, browser):
+            agenda_item = self.schedule_proposal(self.meeting,
+                                                 self.submitted_word_proposal)
+            agenda_item.decide()
+            agenda_item.generate_excerpt(title='The Excerpt')
+            browser.open(self.meeting, view='agenda_items/list')
+            self.assertIn('return_link', browser.json['items'][0]['excerpts'][0])
+
+        self.login(self.meeting_user, browser)
+        browser.open(self.meeting, view='agenda_items/list')
+        self.assertNotIn('return_link', browser.json['items'][0]['excerpts'][0])


### PR DESCRIPTION
Reguler committee members should not be able to return excerpts.

<img width="1408" alt="bildschirmfoto 2017-10-13 um 16 02 05" src="https://user-images.githubusercontent.com/7469/31549993-296e1fd4-b030-11e7-95aa-c7cd7f1a729b.png">
