### PR TITLE
Fix send as attachment action

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: prevent reader user from returning excerpts. [jone]
+- Fix send as attachment action by providing a default service. [tarnap]
 - SPV word: always show excerpts in meeting view. [jone]
 - Extract bumblebee preview generation into standalone component. [jone]
 - Do not render document link without View permission. [jone]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -105,6 +105,16 @@
       permission="zope2.View"
       />
 
+  <!-- JSON endpoint for send as attachment action -->
+  <plone:service
+      method="GET"
+      for="*"
+      accept="application/json"
+      factory=".service.DefaultEmailAttributes"
+      name="attributes"
+      permission="zope2.View"
+      />
+
   <adapter
       for="*
            opengever.base.interfaces.IOpengeverBaseLayer"

--- a/opengever/base/service.py
+++ b/opengever/base/service.py
@@ -30,3 +30,10 @@ class DocumentStatus(Service):
             payload['locked_by'] = None
 
         return json.dumps(payload)
+
+
+class DefaultEmailAttributes(Service):
+    """Prevent action send as attachment to fail."""
+
+    def render(self):
+        return json.dumps({})


### PR DESCRIPTION
The action "send as attachment" in the inbox raised a javascript error,
because the service, which is needed to fill the attributes of the email
was not available.
This commit adds a default service which provides an empty set of values for the
resulting email.

![no_error_message](https://user-images.githubusercontent.com/194114/31653176-f6416914-b321-11e7-96b0-961327b23d39.gif)

Resolves #3443