### PR TITLE
Remove double excerpt entries when word activated

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: prevent reader user from returning excerpts. [jone]
+- SPV word: remove double excerpt entry when word feature activated. [tarnap]
 - SPV word: always show excerpts in meeting view. [jone]
 - Extract bumblebee preview generation into standalone component. [jone]
 - Do not render document link without View permission. [jone]

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -67,11 +67,6 @@
       {{/if}}
 
       {{/if}}
-      {{#if excerpt}}
-      <div class="summary">
-        {{{excerpt}}}
-      </div>
-      {{/if}}
     </td>
     {{#if ../editable}}
     <td class="actions">


### PR DESCRIPTION
Previously:
<img width="646" alt="skizze 4" src="https://user-images.githubusercontent.com/1231822/31096777-6d6c13a6-a7bd-11e7-8ce3-c664a53db3f2.png">

Now:
![fix_double_excerpt_entry](https://user-images.githubusercontent.com/194114/31659658-2b972dc0-b335-11e7-8839-d37e1fea5298.png)


Resolves https://github.com/4teamwork/gever/issues/118