### PR TITLE
Fix missing response-variable due to ungrok opengever.document.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Fix missing response-variable due to ungrok opengever.document. [elioschmutz]
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: prevent reader user from returning excerpts. [jone]
 - SPV word: always show excerpts in meeting view. [jone]

--- a/opengever/document/browser/edit.py
+++ b/opengever/document/browser/edit.py
@@ -47,7 +47,7 @@ class EditCheckerView(BrowserView):
         mtool = getToolByName(self.context, 'portal_membership')
         if mtool.checkPermission(
             'Modify portal content', self.context):
-            return self.response.redirect(
+            return self.request.RESPONSE.redirect(
                 '%s/edit' % (self.context.absolute_url()))
         else:
             msg = _(


### PR DESCRIPTION
This PR accesses the response-variable the default-way instead the grok-way.

Related to #3205