### PR TITLE
Change markup for document icons (removed, no access).

### DIFF
--- a/opengever/document/widgets/document_link.pt
+++ b/opengever/document/widgets/document_link.pt
@@ -9,9 +9,6 @@
     <div class="linkWrapper tooltip-trigger"
          tal:attributes="data-tooltip-url string:${view/get_url}/tooltip">
 
-      <span tal:condition="context/is_removed"
-            class="removed_document" />
-
       <a tal:content="view/get_title"
          tal:attributes="class view/get_css_class;
                          href view/get_url;" />
@@ -29,11 +26,8 @@
   <tal:NO_VIEW_PERMISSION tal:condition="not:view_allowed">
     <div class="linkWrapper">
 
-      <span tal:condition="context/is_removed"
-            class="removed_document" />
-
       <span tal:content="view/get_title"
-            tal:attributes="class string:${view/get_css_class} no-access"
+            tal:attributes="class string:${view/get_css_class} no_access"
             title="You are not allowed to view this document."
             i18n:attributes="title" />
 

--- a/opengever/document/widgets/document_link.py
+++ b/opengever/document/widgets/document_link.py
@@ -21,6 +21,9 @@ class DocumentLinkWidget(object):
 
     def get_css_class(self):
         classes = ['document_link', self.document.ContentTypeClass()]
+        if self.context.is_removed:
+            classes.append('removed_document')
+
         return ' '.join(classes)
 
     def get_title(self):


### PR DESCRIPTION
- Remove the "span.removed_document": the markup was wrong, resulting in
  a standalone tag and a HTML syntax error. It was fixed by wrapping
  the link, which coincidentally was what we wanted.
- Add the "removed_document" as regular class to <a> / <span>.
- Rename the "no-access" class to "no_access" in order to be consistent.
- ⚠️ This requires https://github.com/4teamwork/plonetheme.teamraum/pull/592

**Before:**
<img width="966" alt="bildschirmfoto 2017-10-18 um 10 03 27" src="https://user-images.githubusercontent.com/7469/31716580-d8a0a388-b408-11e7-8a0a-75c52b5a13c6.png">
**After:**
<img width="967" alt="bildschirmfoto 2017-10-18 um 13 34 58" src="https://user-images.githubusercontent.com/7469/31716659-2c4d67f0-b409-11e7-9b8c-476b5000d304.png">
