### PR TITLE
Fix send as attachment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -503,6 +503,7 @@ Objects
   - self.contactfolder
     - self.franz_meier
     - self.hanspeter_duerr
+  - self.inbox
   - self.repository_root
     - self.branch_repofolder
       - self.leaf_repofolder

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: prevent reader user from returning excerpts. [jone]
 - SPV word: remove double excerpt entry when word feature activated. [tarnap]
+- Fix send as attachment action by providing a default service. [tarnap]
 - SPV word: always show excerpts in meeting view. [jone]
 - Extract bumblebee preview generation into standalone component. [jone]
 - Do not render document link without View permission. [jone]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -105,6 +105,16 @@
       permission="zope2.View"
       />
 
+  <!-- JSON endpoint for send as attachment action -->
+  <plone:service
+      method="GET"
+      for="*"
+      accept="application/json"
+      factory=".service.DefaultEmailAttributes"
+      name="attributes"
+      permission="zope2.View"
+      />
+
   <adapter
       for="*
            opengever.base.interfaces.IOpengeverBaseLayer"

--- a/opengever/base/service.py
+++ b/opengever/base/service.py
@@ -30,3 +30,10 @@ class DocumentStatus(Service):
             payload['locked_by'] = None
 
         return json.dumps(payload)
+
+
+class DefaultEmailAttributes(Service):
+    """Prevent action send as attachment to fail."""
+
+    def render(self):
+        return json.dumps({})

--- a/opengever/base/tests/test_email_attributes_service.py
+++ b/opengever/base/tests/test_email_attributes_service.py
@@ -1,0 +1,13 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestEmailAttributesService(IntegrationTestCase):
+
+    @browsing
+    def test_service_is_available_for_inbox(self, browser):
+        self.login(self.secretariat_user, browser)
+        browser.open(self.inbox,
+                     view='attributes',
+                     headers={'Accept': 'application/json'})
+        self.assertEquals({}, browser.json)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -50,6 +50,7 @@ class OpengeverContentFixture(object):
                 self.create_templates()
                 with self.features('meeting'):
                     self.create_committees()
+                self.create_inbox()
 
         with self.freeze_at_hour(14):
             with self.login(self.dossier_responsible):
@@ -299,6 +300,18 @@ class OpengeverContentFixture(object):
                           self.empty_committee.load_model().committee_id)
         self.empty_committee.manage_setLocalRoles(
             self.meeting_user.getId(), ('CommitteeMember',))
+
+    @staticuid()
+    def create_inbox(self):
+        self.inbox = self.register('inbox', create(
+            Builder('inbox')
+            .titled(u'Eingangsk\xf6rbli')
+            .having(id='eingangskorb',
+                    responsible_org_unit='fa',
+                    inbox_group=self.org_unit.inbox_group)))
+        self.inbox.manage_setLocalRoles(
+            self.secretariat_user.getId(), ('Contributor', 'Editor', 'Reader'))
+        self.inbox.reindexObjectSecurity()
 
     @staticuid()
     def create_treaty_dossiers(self):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -300,6 +300,7 @@ class OpengeverContentFixture(object):
                           self.empty_committee.load_model().committee_id)
         self.empty_committee.manage_setLocalRoles(
             self.meeting_user.getId(), ('CommitteeMember',))
+        self.empty_committee.reindexObjectSecurity()
 
     @staticuid()
     def create_inbox(self):


### PR DESCRIPTION
The action "send as attachment" in the inbox raised a javascript error,
because the service, which is needed to fill the attributes of the email
was not available.
This commit adds a default service which provides an empty set of values for the
resulting email.

![no_error_message](https://user-images.githubusercontent.com/194114/31653176-f6416914-b321-11e7-96b0-961327b23d39.gif)

Also add inbox fixture and add missing reindex after changing roles.

Resolves #3443