### PR TITLE
Do not link meeting dossier if no view permission

### DIFF
--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -260,6 +260,9 @@ class MeetingView(BrowserView):
             return IContentListingObject(
                 self.model.agendaitem_list_document.resolve_document())
 
+    def has_dossier_view_permission(self):
+        return api.user.has_permission('View', obj=self.context.model.get_dossier())
+
     def url_protocol(self):
         return self.model.get_url(view='protocol')
 

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -210,9 +210,13 @@
             <tr>
               <th i18n:translate="view_label_dossier">Meeting dossier:</th>
               <td tal:define="dossier meeting/get_dossier">
-                <a tal:attributes="href dossier/absolute_url;
+                <a tal:condition="view/has_dossier_view_permission"
+                   tal:attributes="href dossier/absolute_url;
                                    class python: view.get_css_class(dossier)"
                    tal:content="dossier/title" />
+                <span tal:condition="not: view/has_dossier_view_permission"
+                      tal:attributes="class python: view.get_css_class(dossier)"
+                      tal:content="dossier/title" />
               </td>
               <td></td>
             </tr>

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.pages import editbar
 from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
@@ -34,6 +35,17 @@ class TestWordMeetingView(IntegrationTestCase):
         browser.open(self.meeting)
         browser.click_on('Sitzungsdossier 9/2017')
         self.assertEquals(self.meeting_dossier.absolute_url(), browser.url)
+
+    @browsing
+    def test_no_meeting_dossier_link_if_no_permission(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.meeting_dossier.__ac_local_roles_block__ = True
+        self.meeting_dossier.reindexObjectSecurity()
+
+        self.login(self.meeting_user, browser)
+        browser.open(self.meeting)
+        with self.assertRaises(NoElementFound):
+            browser.click_on('Sitzungsdossier 9/2017')
 
     @browsing
     def test_agenda_item_url(self, browser):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -252,6 +252,7 @@ class OpengeverContentFixture(object):
         self.register_raw('committee_id', self.committee.load_model().committee_id)
         self.committee.manage_setLocalRoles(
             self.meeting_user.getId(), ('CommitteeMember',))
+        self.committee.reindexObjectSecurity()
 
         self.committee_president = self.create_committee_membership(
             self.committee,


### PR DESCRIPTION
If a user tries to access a view he has no permission to, the
application raises an error.
There should be no link to a view to which a user has no permission,
therefore the link should only be displayed if the user has the required
permission.

![dossier_title_without_link_when_no_permission_2](https://user-images.githubusercontent.com/194114/31765324-47ffff88-b4c4-11e7-94de-7d52df24de54.png)

Resolves https://github.com/4teamwork/gever/issues/126