### PR TITLE
Add missing protocol header template error message

### DIFF
--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -14,6 +14,7 @@ from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.exceptions import AgendaItemListAlreadyGenerated
 from opengever.meeting.exceptions import AgendaItemListMissingTemplate
 from opengever.meeting.exceptions import MissingParagraphTemplate
+from opengever.meeting.exceptions import MissingProtocolHeaderTemplate
 from opengever.meeting.exceptions import ProtocolAlreadyGenerated
 from opengever.meeting.interfaces import IHistory
 from opengever.meeting.mergetool import DocxMergeTool
@@ -351,7 +352,10 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
             return merge_tool()
 
     def get_header_sablon(self):
-        return Sablon(self.meeting.get_protocol_header_template()).process(
+        template = self.meeting.get_protocol_header_template()
+        if template is None:
+            raise MissingProtocolHeaderTemplate()
+        return Sablon(template).process(
             self.document_operations.get_meeting_data(self.meeting).as_json())
 
     def get_suffix_sablon(self):

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -65,7 +65,7 @@ class ICommitteeContainer(form.Schema):
         title=_('label_paragraph_template',
                 default=u'Paragraph template'),
         source=sablon_template_source,
-        required=False,
+        required=True,
     )
 
 
@@ -100,7 +100,9 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
         return self.protocol_template.to_object
 
     def get_protocol_header_template(self):
-        return self.protocol_header_template.to_object
+        if self.protocol_header_template:
+            return self.protocol_header_template.to_object
+        return None
 
     def get_protocol_suffix_template(self):
         return getattr(self.protocol_suffix_template, 'to_object', None)

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -34,6 +34,11 @@ class MissingAdHocTemplate(Exception):
     """
 
 
+class MissingProtocolHeaderTemplate(Exception):
+    """No protocol header template could be found for the committee or its container.
+    """
+
+
 class MissingParagraphTemplate(Exception):
     """No paragraph template could be found for the committee or its container.
     """

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -33,6 +33,7 @@ class TestCommitteeContainer(IntegrationTestCase):
         browser.fill({'Title': u'Sitzungen',
                       'Protocol header template': self.sablon_template,
                       'Protocol suffix template': self.sablon_template,
+                      'Paragraph template': self.sablon_template,
                       'Ad hoc agenda item template': self.proposal_template}).save()
         statusmessages.assert_no_error_messages()
 


### PR DESCRIPTION
... also make the paragraph template required for the committee container; resolves https://github.com/4teamwork/opengever.core/issues/3459
... also adapt test to include all required templates in the tests.

