### PR TITLE
Remove bcc from attributes for resolved dossiers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add indexer for bundle GUIDs and create index upon bundle import. [lgraf]
 - Fix missing response-variable due to ungrok opengever.document. [elioschmutz]
 - Removes groked plone.directives. [elioschmutz]
+- Remove bcc from email attributes in send as attachment action if the dossier is resolved. [tarnap]
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: prevent reader user from returning excerpts. [jone]
 - SPV word: remove double excerpt entry when word feature activated. [tarnap]

--- a/opengever/dossier/service.py
+++ b/opengever/dossier/service.py
@@ -1,4 +1,5 @@
 from ftw.mail.interfaces import IEmailAddress
+from plone import api
 from plone.rest import Service
 
 import json
@@ -9,6 +10,7 @@ class DossierAttributes(Service):
 
     def render(self):
         payload = {}
-        payload['email'] = IEmailAddress(
-            self.request).get_email_for_object(self.context)
+        if api.user.has_permission('Modify portal content', obj=self.context):
+            payload['email'] = IEmailAddress(
+                self.request).get_email_for_object(self.context)
         return json.dumps(payload)

--- a/opengever/dossier/tests/test_email_attributes_service.py
+++ b/opengever/dossier/tests/test_email_attributes_service.py
@@ -1,0 +1,37 @@
+from ftw.mail.interfaces import IEmailAddress
+from ftw.testbrowser import browsing
+from plone import api
+from opengever.testing import IntegrationTestCase
+from zope.globalrequest import getRequest
+
+
+class TestEmailAttributesService(IntegrationTestCase):
+
+    @browsing
+    def test_service_contains_bcc_if_user_has_modify_portal_content_permission(
+            self, browser):
+        self.login(self.regular_user, browser)
+        self.assertTrue(api.user.has_permission(
+            'Modify portal content',
+            self.regular_user.getId(),
+            obj=self.dossier))
+        browser.open(self.dossier,
+                     view='attributes',
+                     headers={'Accept': 'application/json'})
+        email = IEmailAddress(getRequest()).get_email_for_object(self.dossier) 
+
+        self.assertEquals({u'email': email}, browser.json)
+
+    @browsing
+    def test_service_contains_no_bcc_if_dossier_is_resolved(
+            self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.assertFalse(api.user.has_permission(
+            'Modify portal content',
+            self.regular_user.getId(),
+            obj=self.dossier))
+        browser.open(self.dossier,
+                     view='attributes',
+                     headers={'Accept': 'application/json'})
+        self.assertEquals({}, browser.json)


### PR DESCRIPTION
When a dossier is resolved, the user does not have the permission to
modify its content.
The send as attachment action adds a bcc email address, such that the
document is added to the dossier again.
This should not happen when the dossier is resolved.
Therefore the bcc is removed when the user has no permission to modify
its content.

Resolves #3457