### PR TITLE
Add indexer for bundle GUIDs and create index upon bundle import

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Add indexer for bundle GUIDs and create index upon bundle import. [lgraf]
 - Fix missing response-variable due to ungrok opengever.document. [elioschmutz]
 - Ungrok opengever.base. [elioschmutz]
 - SPV word: prevent reader user from returning excerpts. [jone]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -238,6 +238,11 @@
       name="title_fr"
       />
 
+  <adapter
+      factory=".indexes.bundle_guid_indexer"
+      name="bundle_guid"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -3,6 +3,8 @@ from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.interfaces import IReferenceNumber
 from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer import indexer
+from zope.annotation import IAnnotations
+from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 
 
 @indexer(IDexterityContent)
@@ -23,3 +25,13 @@ def title_fr_indexer(obj):
     if ITranslatedTitleSupport.providedBy(obj):
         return ITranslatedTitle(obj).title_fr
     return None
+
+
+@indexer(IDexterityContent)
+def bundle_guid_indexer(obj):
+    """Indexes the GUID of an item imported from an OGGBundle.
+
+    The corresponding index will only exist temporarily during migrations.
+    See openever.bundle.console.add_guid_index()
+    """
+    return IAnnotations(obj).get(BUNDLE_GUID_KEY)

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -2,10 +2,12 @@ from collective.transmogrifier.transmogrifier import Transmogrifier
 from opengever.base.interfaces import INoSeparateConnectionForSequenceNumbers
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.bundle.ldap import DisabledLDAP
+from opengever.bundle.loader import GUID_INDEX_NAME
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
+from plone import api
 from zope.annotation import IAnnotations
 from zope.interface import alsoProvides
 import logging
@@ -33,6 +35,9 @@ def import_oggbundle(app, args):
     # order to avoid conflict errors during OGGBundle import
     alsoProvides(plone.REQUEST, INoSeparateConnectionForSequenceNumbers)
 
+    # Add index to track imported GUIDs (if it doesn't exist yet)
+    add_guid_index()
+
     transmogrifier = Transmogrifier(plone)
     IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = bundle_path
 
@@ -50,6 +55,25 @@ def import_oggbundle(app, args):
     transaction.get().note("Finished import of OGGBundle %r" % bundle_path)
     transaction.commit()
     log.info("Done.")
+
+
+def add_guid_index():
+    """Adds a FieldIndex 'bundle_guid' if it doesn't exist yet.
+
+    This index is only used by OGGBundle imports, and is used to track GUIDs
+    of already imported objects and efficiently query them. This is necessary
+    to enable partial / delta imports, and to accurately query the catalog to
+    build reports about imported objects.
+
+    This index will likely be removed after successful migrations, so code
+    outside the bundle import MUST NOT rely on it being present.
+    """
+    catalog = api.portal.get_tool('portal_catalog')
+    if GUID_INDEX_NAME not in catalog.indexes():
+        log.info("Adding GUID index %r" % GUID_INDEX_NAME)
+        catalog.addIndex(GUID_INDEX_NAME, 'FieldIndex')
+    else:
+        log.info("GUID index %r already exists" % GUID_INDEX_NAME)
 
 
 def setup_logging():

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -22,6 +22,8 @@ BUNDLE_JSON_TYPES = OrderedDict([
     ('documents.json', 'opengever.document.document'),   # document or mail
 ])
 
+GUID_INDEX_NAME = 'bundle_guid'
+
 
 class Bundle(object):
     """An iterable OGGBundle.

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -5,11 +5,15 @@ from ftw.testing import freeze
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.security import elevated_privileges
+from opengever.bundle.console import add_guid_index
+from opengever.bundle.loader import GUID_INDEX_NAME
 from opengever.bundle.sections.bundlesource import BUNDLE_INGESTION_SETTINGS_KEY  # noqa
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
+from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix  # noqa
+from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
 from pkg_resources import resource_filename
 from plone import api
@@ -32,6 +36,10 @@ class TestOggBundlePipeline(IntegrationTestCase):
         # test its data.
 
         self.login(self.manager)
+
+        # Create the 'bundle_guid' index. In production, this will be done
+        # by the "bin/instance import" command in opengever.bundle.console
+        add_guid_index()
 
         # load pipeline
         transmogrifier = Transmogrifier(api.portal.get())
@@ -69,6 +77,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(date(2099, 12, 31), root.valid_until)
         self.assertIsNone(getattr(root, 'guid', None))
         self.assert_navigation_portlet_assigned(root)
+        self.assertEqual(
+            IAnnotations(root)[BUNDLE_GUID_KEY],
+            index_data_for(root)[GUID_INDEX_NAME])
         return root
 
     def assert_repo_folders_created(self, root):
@@ -141,6 +152,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
             api.content.get_state(folder_organisation))
         self.assertIsNone(getattr(folder_organisation, 'guid', None))
         self.assertIsNone(getattr(folder_organisation, 'parent_guid', None))
+        self.assertEqual(
+            IAnnotations(folder_organisation)[BUNDLE_GUID_KEY],
+            index_data_for(folder_organisation)[GUID_INDEX_NAME])
         return folder_organisation
 
     def assert_processes_folder_created(self, parent):
@@ -187,6 +201,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
             api.content.get_state(folder_process))
         self.assertIsNone(getattr(folder_process, 'guid', None))
         self.assertIsNone(getattr(folder_process, 'parent_guid', None))
+        self.assertEqual(
+            IAnnotations(folder_process)[BUNDLE_GUID_KEY],
+            index_data_for(folder_process)[GUID_INDEX_NAME])
         return folder_process
 
     def assert_staff_folder_created(self, parent):
@@ -242,6 +259,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
             api.content.get_state(folder_staff))
         self.assertIsNone(getattr(folder_staff, 'guid', None))
         self.assertIsNone(getattr(folder_staff, 'parent_guid', None))
+        self.assertEqual(
+            IAnnotations(folder_staff)[BUNDLE_GUID_KEY],
+            index_data_for(folder_staff)[GUID_INDEX_NAME])
 
         self.assertDictContainsSubset(
             {'privileged_users':
@@ -271,6 +291,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
                          api.content.get_state(dossier_peter))
         self.assertEqual(date(2010, 11, 11), IDossier(dossier_peter).start)
         self.assertEqual(u'Dossier Peter Schneider', dossier_peter.title)
+        self.assertEqual(
+            IAnnotations(dossier_peter)[BUNDLE_GUID_KEY],
+            index_data_for(dossier_peter)[GUID_INDEX_NAME])
 
     def assert_dossier_vreni_created(self, parent):
         dossier = self.leaf_repofolder.get('dossier-10')
@@ -284,6 +307,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(date(2010, 11, 11), IDossier(dossier).start)
         self.assertEqual(
             u'Dossier in bestehendem Examplecontent Repository', dossier.title)
+        self.assertEqual(
+            IAnnotations(dossier)[BUNDLE_GUID_KEY],
+            index_data_for(dossier)[GUID_INDEX_NAME])
 
     def assert_dossier_hanspeter_created(self, parent):
         dossier_peter = parent.get('dossier-9')
@@ -343,6 +369,10 @@ class TestOggBundlePipeline(IntegrationTestCase):
             dossier_peter.__ac_local_roles__)
         self.assertTrue(dossier_peter.__ac_local_roles_block__)
 
+        self.assertEqual(
+            IAnnotations(dossier_peter)[BUNDLE_GUID_KEY],
+            index_data_for(dossier_peter)[GUID_INDEX_NAME])
+
         return dossier_peter
 
     def assert_documents_created(self, parent):
@@ -381,6 +411,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(
             u'Bewerbung Hanspeter M\xfcller',
             document_1.title)
+        self.assertEqual(
+            IAnnotations(document_1)[BUNDLE_GUID_KEY],
+            index_data_for(document_1)[GUID_INDEX_NAME])
 
     def assert_document_2_created(self, parent):
         document_2 = parent.objectValues()[1]
@@ -421,6 +454,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(
             u'Entlassung Hanspeter M\xfcller',
             document_2.title)
+        self.assertEqual(
+            IAnnotations(document_2)[BUNDLE_GUID_KEY],
+            index_data_for(document_2)[GUID_INDEX_NAME])
 
     def assert_document_5_created(self, parent):
         document_5 = parent.objectValues()[4]
@@ -435,6 +471,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(
             u'Document referenced via UNC-Path',
             document_5.title)
+        self.assertEqual(
+            IAnnotations(document_5)[BUNDLE_GUID_KEY],
+            index_data_for(document_5)[GUID_INDEX_NAME])
 
     def assert_document_6_created(self):
         document_6 = self.dossier.objectValues()[-2]
@@ -446,6 +485,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
             'document-state-draft', api.content.get_state(document_6))
         self.assertEqual(u'Dokument in bestehendem Examplecontent Dossier',
                          document_6.title)
+        self.assertEqual(
+            IAnnotations(document_6)[BUNDLE_GUID_KEY],
+            index_data_for(document_6)[GUID_INDEX_NAME])
 
     def assert_mail_1_created(self, parent):
         mail = parent.objectValues()[2]
@@ -484,6 +526,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(
             u'Ein Mail',
             mail.title)
+        self.assertEqual(
+            IAnnotations(mail)[BUNDLE_GUID_KEY],
+            index_data_for(mail)[GUID_INDEX_NAME])
 
     def assert_mail_2_created(self, parent):
         mail = parent.objectValues()[3]
@@ -491,6 +536,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertIsNotNone(mail.message)
         self.assertEqual(920, len(mail.message.data))
         self.assertEqual(u'Lorem Ipsum', mail.title)
+        self.assertEqual(
+            IAnnotations(mail)[BUNDLE_GUID_KEY],
+            index_data_for(mail)[GUID_INDEX_NAME])
 
     def assert_mail_3_created(self):
         mail = self.dossier.objectValues()[-1]
@@ -499,6 +547,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(920, len(mail.message.data))
         self.assertEqual(
             u'Mail in bestehendem Examplecontent Dossier', mail.title)
+        self.assertEqual(
+            IAnnotations(mail)[BUNDLE_GUID_KEY],
+            index_data_for(mail)[GUID_INDEX_NAME])
 
     def assert_report_data_collected(self, bundle):
         report_data = bundle.report_data


### PR DESCRIPTION
Adds an indexer that indexes the bundle GUID from `IAnnotations(obj)['guid']`. In a standard GEVER, there will no corresponding index, and this indexer won't be called.

For bundle imports however, a FieldIndex `bundle_guid` will be created, so that the imported items' GUIDs will get indexed for efficent querying (future partial/delta imports, and import report generation). This index probably will be removed again after the migration.