### PR TITLE
Add dossiertemplates configuration flag `respect_dossier_depth`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -526,6 +526,8 @@ Objects
         - self.meeting_dossier
     - self.empty_repofolder
   - self.templates
+    - self.dossiertemplate
+      - self.subdossiertemplate
     - self.proposal_template
     - self.sablon_template
     - self.tasktemplatefolder

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Extract bumblebee preview generation into standalone component. [jone]
 - Do not render document link without View permission. [jone]
 - Optimise reindexing for document checkout/checkin cycles. [Rotonen]
+- Add dossiertemplates configuration flag `respect_dossier_depth`. [phgross]
 - Refactor JSON schema generation and dumping, add tests. [lgraf]
 - Ungrok opengever.dossier. [elioschmutz]
 - Ungrok opengever.document. [elioschmutz]

--- a/opengever/core/upgrades/20171017223630_add_respect_max_depth_registry_entry_for_dossiertemplates/registry.xml
+++ b/opengever/core/upgrades/20171017223630_add_respect_max_depth_registry_entry_for_dossiertemplates/registry.xml
@@ -1,0 +1,3 @@
+<records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" purge="False">
+  <value key="respect_max_depth">False</value>
+</records>

--- a/opengever/core/upgrades/20171017223630_add_respect_max_depth_registry_entry_for_dossiertemplates/upgrade.py
+++ b/opengever/core/upgrades/20171017223630_add_respect_max_depth_registry_entry_for_dossiertemplates/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddRespectMaxDepthRegistryEntryForDossiertemplates(UpgradeStep):
+    """Add respect_max_depth registry entry for dossiertemplates.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/dossiertemplate/interfaces.py
+++ b/opengever/dossier/dossiertemplate/interfaces.py
@@ -8,3 +8,9 @@ class IDossierTemplateSettings(Interface):
         title=u'Enable dossier template feature',
         description=u'Whether dossier template feature is enabled or not.',
         default=False)
+
+    respect_max_depth = schema.Bool(
+        title=u'Should be dossiertemplates respect the max dossier depth',
+        description=u'Should the max dossier depth be strictly respected also '
+        'for dossiertemplates.',
+        default=False)

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -1,25 +1,21 @@
-from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.core.testing import activate_bumblebee_feature
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
 from opengever.core.testing import toggle_feature
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
-from opengever.ogds.base.interfaces import ISyncStamp
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from zExceptions import Unauthorized
-from zope.component import getUtility
 
 
-class TestIsDossierTemplateFeatureEnabled(FunctionalTestCase):
+class TestIsDossierTemplateFeatureEnabled(IntegrationTestCase):
 
     def test_true_if_registry_entry_is_true(self):
         api.portal.set_registry_record(
@@ -34,32 +30,30 @@ class TestIsDossierTemplateFeatureEnabled(FunctionalTestCase):
         self.assertFalse(is_dossier_template_feature_enabled())
 
 
-class TestDossierTemplate(FunctionalTestCase):
+class TestDossierTemplate(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
-
-    def setUp(self):
-        super(TestDossierTemplate, self).setUp()
-        self.templatefolder = create(Builder('templatefolder'))
+    features = ('dossiertemplate', )
 
     def test_templatedosisers_does_not_provide_dossier_interface(self):
-        dossiertemplate = create(Builder('dossiertemplate'))
-        self.assertFalse(IDossierMarker.providedBy(dossiertemplate))
+        self.login(self.administrator)
+
+        self.assertFalse(IDossierMarker.providedBy(self.dossiertemplate))
 
     def test_id_is_sequence_number_prefixed_with_dossiertemplate(self):
-        dossiertemplate1 = create(Builder("dossiertemplate"))
-        dossiertemplate2 = create(Builder("dossiertemplate"))
+        self.login(self.administrator)
 
-        self.assertEquals("dossiertemplate-1", dossiertemplate1.id)
-        self.assertEquals("dossiertemplate-2", dossiertemplate2.id)
+        self.assertEquals("dossiertemplate-1", self.dossiertemplate.id)
 
     def test_dossiertemplate_provides_the_IDossierTemplate_behavior(self):
-        dossiertemplate = create(Builder('dossiertemplate'))
-        self.assertTrue(IDossierTemplateSchema.providedBy(dossiertemplate))
+        self.login(self.administrator)
+
+        self.assertTrue(IDossierTemplateSchema.providedBy(self.dossiertemplate))
 
     @browsing
     def test_adding_dossiertemplate_works_properly(self, browser):
-        browser.login().open(self.portal)
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.templates)
         factoriesmenu.add('Dossier template')
         browser.fill({'Title': 'Template'}).submit()
 
@@ -68,11 +62,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_edit_dossiertemplate_works_properly(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
-        browser.login().open(dossiertemplate)
-
+        browser.open(self.dossiertemplate)
         browser.find('Edit').click()
         browser.fill({'Title': 'Edited Template'}).submit()
 
@@ -81,21 +73,16 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_addable_types(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .within(self.templatefolder))
-
-        browser.login().open(dossiertemplate)
+        self.login(self.administrator, browser=browser)
+        browser.open(self.dossiertemplate)
 
         self.assertEquals(
-            ['Document', 'Subdossier'],
-            factoriesmenu.addable_types())
+            ['Document', 'Subdossier'], factoriesmenu.addable_types())
 
     @browsing
     def test_a_subdossiers_is_a_dossiertemplate(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .within(self.templatefolder))
-
-        browser.login().open(dossiertemplate)
+        self.login(self.administrator, browser=browser)
+        browser.open(self.dossiertemplate)
 
         factoriesmenu.add('Subdossier')
         browser.fill({'Title': 'Template'}).submit()
@@ -104,7 +91,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_add_form_title_of_dossiertemplate_is_the_default_title(self, browser):
-        browser.login().open(self.templatefolder)
+        self.login(self.administrator, browser=browser)
+        browser.open(self.templates)
+
         factoriesmenu.add('Dossier template')
 
         self.assertEqual(
@@ -113,10 +102,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_add_form_title_of_dossiertemplate_as_a_subdossier_contains_subdossier(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
-        browser.login().open(dossiertemplate)
+        browser.open(self.dossiertemplate)
         factoriesmenu.add('Subdossier')
 
         self.assertEqual(
@@ -125,10 +113,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_edit_form_title_of_dossiertemplate_is_the_default_title(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
-        browser.login().visit(dossiertemplate, view="edit")
+        browser.open(self.dossiertemplate, view="edit")
 
         self.assertEqual(
             'Edit Dossier template',
@@ -136,13 +123,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_edit_form_title_of_dossiertemplate_as_a_subdossier_contains_subdossier(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
-        subdossiertemplate = create(Builder('dossiertemplate')
-                                    .within(dossiertemplate))
-
-        browser.login().visit(subdossiertemplate, view="edit")
+        browser.open(self.subdossiertemplate, view="edit")
 
         self.assertEqual(
             'Edit Subdossier',
@@ -150,47 +133,36 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_dossiertemplates_tab_lists_only_dossiertemplates_without_subdossiers(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .titled(u'My Dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
-        create(Builder('dossiertemplate')
-               .titled(u'A Subdossiertemplate')
-               .within(dossiertemplate))
-
-        create(Builder('document')
-               .titled('Template A')
-               .within(self.templatefolder))
-
-        browser.login().visit(self.templatefolder, view="tabbedview_view-dossiertemplates")
+        browser.login().visit(self.templates, view="tabbedview_view-dossiertemplates")
 
         self.assertEqual(
-            ['My Dossiertemplate'],
+            ['Bauvorhaben klein'],
             browser.css('.listing td .linkWrapper').text)
 
     @browsing
     def test_documents_inside_a_dossiertemplate_will_not_be_listed_in_documents_tab(self, browser):
-        create(Builder('document')
-               .titled('Good document')
-               .within(self.templatefolder))
-
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .titled(u'My Dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
         create(Builder('document')
-               .titled('Bad document')
-               .within(dossiertemplate))
+               .titled(u'Template document')
+               .within(self.templates))
+        create(Builder('document')
+               .titled(u'Dossiertemplate document')
+               .within(self.dossiertemplate))
 
-        browser.login().visit(self.templatefolder, view="tabbedview_view-documents-proxy")
+        browser.open(
+            self.templates, view="tabbedview_view-documents-proxy")
 
         self.assertEqual(
-            ['Good document'],
+            ['Template document'],
             browser.css('.listing td .linkWrapper').text)
 
     @browsing
     def test_show_only_whitelisted_schema_fields_in_add_form(self, browser):
-        browser.login().open(self.templatefolder)
+        self.login(self.administrator, browser=browser)
+        browser.open(self.templates)
         factoriesmenu.add('Dossier template')
 
         # browser.css('').text will return the text of the current node an all
@@ -220,11 +192,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_show_only_whitelisted_schema_fields_in_edit_form(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .titled(u'My Dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
+        browser.open(self.dossiertemplate, view="edit")
 
-        browser.login().visit(dossiertemplate, view="edit")
         self.assertEqual([
             u'Title help Recommendation for the title. Will be displayed as a'
             u' help text if you create a dossier from template',
@@ -244,11 +214,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_dossiertemplate_predefined_keywords_is_there(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .titled(u'My Dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
+        browser.open(self.dossiertemplate, view="edit")
 
-        browser.login().visit(dossiertemplate, view='@@edit')
         self.assertTrue(browser.find_field_by_text('Predefined Keywords'),
                         'Expect the "Predefined Keywords" field')
 
@@ -259,11 +227,9 @@ class TestDossierTemplate(FunctionalTestCase):
 
     @browsing
     def test_dossiertemplate_restrict_keywords_is_there(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate')
-                                 .titled(u'My Dossiertemplate')
-                                 .within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
+        browser.open(self.dossiertemplate, view="edit")
 
-        browser.login().visit(dossiertemplate, view='@@edit')
         self.assertTrue(browser.find_field_by_text('Restrict Keywords'),
                         'Expect the "Restrict Keywords" field')
 
@@ -274,185 +240,141 @@ class TestDossierTemplate(FunctionalTestCase):
                            'Keywords"')
 
 
-class TestDossierTemplateAddWizard(FunctionalTestCase):
+class TestDossierTemplateAddWizard(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
-
-    def setUp(self):
-        super(TestDossierTemplateAddWizard, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.branch_node = create(Builder('repository').within(self.root))
-        self.leaf_node = create(Builder('repository').within(self.branch_node))
-
-        self.templatefolder = create(Builder('templatefolder'))
+    features = ('dossiertemplate', )
 
     def test_is_not_available_if_dossiertempalte_feature_is_disabled(self):
+        self.login(self.regular_user)
+
         toggle_feature(IDossierTemplateSettings, enabled=False)
 
         self.assertFalse(
-            self.leaf_node.restrictedTraverse('@@dossier_with_template/is_available')())
+            self.leaf_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
 
     def test_is_not_available_on_branch_node(self):
+        self.login(self.regular_user)
+
         self.assertFalse(
-            self.branch_node.restrictedTraverse('@@dossier_with_template/is_available')())
+            self.branch_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
 
     def test_is_available_on_leaf_node_when_feature_is_enabled(self):
+        self.login(self.regular_user)
+
         self.assertTrue(
-            self.leaf_node.restrictedTraverse('@@dossier_with_template/is_available')())
+            self.leaf_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
 
     def test_is_not_available_if_user_does_not_have_add_dossier_permission(self):
-        self.grant('Reader')
-
-        self.assertFalse(api.user.has_permission(
-            'opengever.dossier: Add businesscasedossier', obj=self.leaf_node))
+        self.login(self.regular_user)
+        self.set_workflow_state(
+            'repositoryfolder-state-inactive', self.leaf_repofolder)
 
         self.assertFalse(
-            self.leaf_node.restrictedTraverse('@@dossier_with_template/is_available')())
+            api.user.has_permission(
+                'opengever.dossier: Add businesscasedossier', obj=self.leaf_repofolder))
+
+        self.assertFalse(
+            self.leaf_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
 
     def test_is_available_if_user_has_add_dossier_permission(self):
-        self.grant('Reader')
-
-        api.user.grant_roles(
-            user=api.user.get_current(),
-            obj=self.leaf_node,
-            roles=['Contributor'])
-
-        self.assertFalse(api.user.has_permission(
-            'opengever.dossier: Add businesscasedossier', obj=self.portal))
+        self.login(self.regular_user)
 
         self.assertTrue(api.user.has_permission(
-            'opengever.dossier: Add businesscasedossier', obj=self.leaf_node))
+            'opengever.dossier: Add businesscasedossier', obj=self.leaf_repofolder))
 
         self.assertTrue(
-            self.leaf_node.restrictedTraverse('@@dossier_with_template/is_available')())
+            self.leaf_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
 
     def test_raise_not_found_if_access_on_wizard_if_feature_is_not_available(self):
+        self.login(self.regular_user)
+
         toggle_feature(IDossierTemplateSettings, enabled=False)
 
         with self.assertRaises(Unauthorized):
-            self.leaf_node.restrictedTraverse('@@dossier_with_template')()
+            self.leaf_repofolder.restrictedTraverse('@@dossier_with_template')()
 
         with self.assertRaises(Unauthorized):
-            self.leaf_node.restrictedTraverse('@@add-dossier-from-template')()
+            self.leaf_repofolder.restrictedTraverse('@@add-dossier-from-template')()
 
     @browsing
     def test_only_show_dossiertemplates_without_subdossiers(self, browser):
-        template1 = create(Builder("dossiertemplate")
-                           .within(self.templatefolder)
-                           .titled(u"Template 1"))
-
-        create(Builder("dossiertemplate")
-               .within(template1)
-               .titled(u"Subdossier 1"))
-
-        template2 = create(Builder("dossiertemplate")
-                           .within(self.templatefolder)
-                           .titled(u"Template 2"))
-
-        create(Builder("dossiertemplate")
-               .within(template2)
-               .titled(u"Subdossier 2"))
-
-        browser.login().visit(self.leaf_node)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         self.assertEqual(
-            ['Template 1', 'Template 2'],
+            ['Bauvorhaben klein'],
             browser.css('.listing tr td:nth-child(2)').text)
 
     @browsing
     def test_selectable_templates_are_restricted_when_addable_templates_are_selected(self, browser):
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .titled(u"Template 1"))
-        template2 = create(Builder("dossiertemplate")
-                           .within(self.templatefolder)
-                           .titled(u"Template 2"))
+        self.login(self.administrator, browser=browser)
 
-        leaf_node_2 = create(Builder('repository')
-                             .having(addable_dossier_templates=[template2])
-                             .within(self.branch_node))
+        template = create(Builder("dossiertemplate")
+                          .within(self.templates)
+                          .titled(u"Bauvorhaben gross"))
 
-        browser.login().visit(leaf_node_2)
+        self.set_related_items(
+            self.leaf_repofolder, [template, ],
+            fieldname='addable_dossier_templates')
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         self.assertEqual(
-            ['Template 2'],
+            ['Bauvorhaben gross'],
             browser.css('.listing tr td:nth-child(2)').text)
 
     @browsing
     def test_dossiertemplate_values_are_prefilled_properly_in_the_dossier(self, browser):
-        values = {
-            'title': u'My template',
-            'description': u'Lorem ipsum',
-            'keywords': (u'secret', u'special'),
-            'comments': 'this is very special',
-            'filing_prefix': 'department'
-            }
 
-        create(Builder("dossiertemplate").within(self.templatefolder).having(**values))
-
-        browser.login().visit(self.leaf_node)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
-
         browser.fill({'form.widgets.template': token}).submit()
-
         browser.click_on('Save')
 
         dossier = browser.context
 
-        self.assertEqual(values.get('title'), dossier.title)
-        self.assertEqual(values.get('description'), dossier.description)
-        self.assertEqual(values.get('keywords'), IDossier(dossier).keywords)
-        self.assertEqual(values.get('comments'), IDossier(dossier).comments)
-        self.assertEqual(values.get('filing_prefix'), IDossier(dossier).filing_prefix)
+        self.assertEqual('Bauvorhaben klein', dossier.title)
+        self.assertEqual(u'Lorem ipsum', dossier.description)
+        self.assertEqual((u'secret', u'special'), IDossier(dossier).keywords)
+        self.assertEqual('this is very special', IDossier(dossier).comments)
+        self.assertEqual('department', IDossier(dossier).filing_prefix)
 
     @browsing
     def test_dossiertemplate_do_not_copy_keywords(self, browser):
-        values = {
-            'title': u'My template',
-            'keywords': (u'special', u'secret'),
-            'predefined_keywords': False
-            }
+        self.login(self.regular_user, browser=browser)
 
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .having(**values))
+        self.dossiertemplate.predefined_keywords = False
 
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .having(title=u'Another dossiertemplate',
-                       keywords=(u'do not appear', u'not there')))
-
-        browser.login().visit(self.leaf_node)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
-
         browser.fill({'form.widgets.template': token}).submit()
         browser.click_on('Save')
 
-        dossier = browser.context
-        self.assertEqual((), IDossier(dossier).keywords)
+        self.assertEqual((), IDossier(browser.context).keywords)
 
     @browsing
     def test_dossiertemplate_restrict_keywords(self, browser):
-        values = {
-            'title': u'My template',
-            'keywords': (u'secret\xe4', u'special'),
-            'restrict_keywords': True,
-            'predefined_keywords': True
-            }
+        self.login(self.regular_user, browser=browser)
 
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .having(**values))
+        self.dossiertemplate.restrict_keywords = True
+        self.dossiertemplate.predefined_keywords = True
 
-        browser.login().visit(self.leaf_node)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         token = browser.css(
@@ -468,63 +390,50 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
         # new = browser.css('#' + keywords.attrib['id'] + '_new')
         # self.assertFalse(new, 'It should not be possible to add new terms')
 
-        self.assertItemsEqual(list(values['keywords']),
-                              keywords.options_labels)
+        self.assertItemsEqual([u'secret', u'special'], keywords.options_labels)
         browser.click_on('Save')
-        self.assertItemsEqual((u'secret\xe4', u'special'),
+        self.assertItemsEqual((u'secret', u'special'),
                               IDossier(browser.context).keywords)
 
     @browsing
     def test_redirects_to_dossier_after_creating_dossier_from_template(self, browser):
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .titled(u"My Template"))
+        self.login(self.regular_user, browser=browser)
 
-        browser.login().visit(self.leaf_node)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
-
         browser.fill({'form.widgets.template': token}).submit()
-
         browser.click_on('Save')
 
-        self.assertEqual(self.leaf_node.listFolderContents()[0], browser.context)
+        self.assertEqual(self.leaf_repofolder.listFolderContents()[-1],
+                         browser.context)
 
     @browsing
     def test_redirects_to_first_step_if_the_user_skips_the_first_wizard_step(self, browser):
-        browser.login().visit(self.leaf_node, view="add-dossier-from-template")
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.leaf_repofolder, view="add-dossier-from-template")
 
         self.assertEqual(
-            '{}/dossier_with_template'.format(self.leaf_node.absolute_url()),
+            '{}/dossier_with_template'.format(self.leaf_repofolder.absolute_url()),
             browser.url)
 
     @browsing
     def test_add_recursive_documents_and_subdossiers(self, browser):
-        template = create(Builder("dossiertemplate")
-                          .within(self.templatefolder)
-                          .titled(u'Template'))
-
-        template_subdossier_1 = create(Builder("dossiertemplate")
-                                       .within(template)
-                                       .titled(u'Subdossier 1'))
+        self.login(self.administrator, browser=browser)
 
         create(Builder('document')
                .titled('Document 1')
-               .within(template_subdossier_1)
+               .within(self.subdossiertemplate)
                .with_dummy_content())
 
-        template_subdossier_1_1 = create(Builder("dossiertemplate")
-                                         .within(template_subdossier_1)
-                                         .titled(u'Subdossier 1.1'))
+        create(Builder("dossiertemplate")
+               .within(self.subdossiertemplate)
+               .titled(u'Anfragen 2017'))
 
-        create(Builder('document')
-               .titled('Document 1.1')
-               .within(template_subdossier_1_1)
-               .with_dummy_content())
-
-        browser.login().visit(self.leaf_node)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
@@ -533,51 +442,28 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
 
         dossier = browser.context
 
-        self.assertEqual('Template', dossier.title)
+        self.assertEqual('Bauvorhaben klein', dossier.title)
         self.assertEqual(
-            [u'Subdossier 1'],
+            [u'Anfragen'],
             [obj.title for obj in dossier.listFolderContents()],
             "The content of the root-dossier is not correct."
             )
 
-        subdossier_1 = dossier.listFolderContents()[0]
+        subdossier = dossier.listFolderContents()[0]
         self.assertEqual(
-            [u'Document 1', u'Subdossier 1.1'],
-            [obj.title for obj in subdossier_1.listFolderContents()],
-            "The content of the subdossier 1 is not correct"
-            )
-
-        subdossier_1_1 = subdossier_1.listFolderContents()[1]
-        self.assertEqual(
-            [u'Document 1.1'],
-            [obj.title for obj in subdossier_1_1.listFolderContents()],
-            "The content of the subdossier 1.1 is not correct"
-            )
+            ['Document 1', u'Anfragen 2017'],
+            [obj.title for obj in subdossier.listFolderContents()],
+            "The content of the subdossiertemplate is not correct"
+        )
 
     @browsing
     def test_subdossier_has_same_responsible_as_dossier(self, browser):
-        create(Builder('ogds_user')
-               .id('peter.meier')
-               .having(firstname='Peter', lastname='Meier')
-               .assign_to_org_units([self.org_unit]))
+        self.login(self.regular_user, browser=browser)
 
-        # Reset the cachekey for the users-vocabulary.
-        # This is necessary, otherwise the user wont be listed
-        # in the responsible-autocomplete-widget.
-        getUtility(ISyncStamp).set_sync_stamp(
-            datetime.now().isoformat(), context=self.portal)
-
-        template = create(Builder("dossiertemplate")
-                          .within(self.templatefolder)
-                          .titled(u'Template'))
-
-        create(Builder("dossiertemplate")
-               .within(template)
-               .titled(u'Subdossier'))
-
-        self.leaf_node.restrictedTraverse(
+        self.leaf_repofolder.restrictedTraverse(
             'add-dossier-from-template').form.recursive_content_creation
-        browser.login().visit(self.leaf_node)
+
+        browser.login().visit(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
@@ -590,24 +476,21 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
 
         subdossier = browser.context.listFolderContents()[0]
 
-        self.assertEqual('peter.meier', IDossier(subdossier).responsible)
+        self.assertEqual('hugo.boss', IDossier(subdossier).responsible)
 
     @browsing
     def test_prefill_title_if_no_title_help_is_available(self, browser):
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .titled(u"My Template"))
+        self.login(self.regular_user, browser=browser)
 
-        browser.login().visit(self.leaf_node)
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
-
         browser.fill({'form.widgets.template': token}).submit()
 
         self.assertEqual(
-            "My Template",
+            "Bauvorhaben klein",
             browser.css('#formfield-form-widgets-IOpenGeverBase-title input').first.value)
 
         self.assertEqual(
@@ -615,17 +498,15 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
 
     @browsing
     def test_do_not_fill_title_and_add_title_help_as_description_if_title_help_is_available(self, browser):
-        create(Builder("dossiertemplate")
-               .within(self.templatefolder)
-               .titled(u"My Template")
-               .having(title_help=u"This is a helpt text"))
+        self.login(self.regular_user, browser=browser)
 
-        browser.login().visit(self.leaf_node)
+        self.dossiertemplate.title_help = u"This is a help text"
+
+        browser.open(self.leaf_repofolder)
         factoriesmenu.add('Dossier with template')
 
         token = browser.css(
             'input[name="form.widgets.template"]').first.attrib.get('value')
-
         browser.fill({'form.widgets.template': token}).submit()
 
         self.assertEqual(
@@ -633,7 +514,7 @@ class TestDossierTemplateAddWizard(FunctionalTestCase):
             browser.css('#formfield-form-widgets-IOpenGeverBase-title input').first.value)
 
         self.assertEqual(
-            "This is a helpt text",
+            "This is a help text",
             browser.css('#formfield-form-widgets-IOpenGeverBase-title .formHelp').first.text)
 
 
@@ -643,45 +524,46 @@ DOCUMENTS_LIST_TAB = 'tabbedview_view-documents'
 DOCUMENTS_GALLERY_TAB = 'tabbedview_view-documents-gallery'
 
 
-class TestDossierTemplateOverview(FunctionalTestCase):
+class TestDossierTemplateOverview(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
-
-    def setUp(self):
-        super(TestDossierTemplateOverview, self).setUp()
-        self.dossiertemplate = create(Builder('dossiertemplate')
-                                      .titled(u'My Dossiertemplate')
-                                      .having(description=u'This is a description',
-                                              keywords=(u'chuck', u'james'),
-                                              comments=u'This is a comment',
-                                              filing_prefix='directorate'))
+    features = ('dossiertemplate', )
 
     @browsing
     def test_description_box_shows_description(self, browser):
-        browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
-        self.assertEqual(u'This is a description',
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
+
+        self.assertEqual(u'Lorem ipsum',
                          browser.css('#descriptionBox span').first.text)
 
     @browsing
     def test_keywords_box_shows_keywords_as_list(self, browser):
-        browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
-        self.assertEqual([u'chuck', u'james'],
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
+
+        self.assertEqual([u'secret', u'special'],
                          browser.css('#keywordsBox li span').text)
 
     @browsing
     def test_comments_box_shows_comment(self, browser):
-        browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
-        self.assertEqual(u'This is a comment',
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
+        self.assertEqual(u'this is very special',
                          browser.css('#commentsBox span').first.text)
 
     @browsing
     def test_filing_prefix_box_shows_filing_prefix_title(self, browser):
-        browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
-        self.assertEqual(u'Directorate',
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
+        self.assertEqual(u'Department',
                          browser.css('#filing_prefixBox span').first.text)
 
     @browsing
     def test_document_box_items_are_limited_to_ten_and_sorted_by_sortable_title(self, browser):
+        self.login(self.regular_user, browser=browser)
+
         for i in range(1, 11):
             create(Builder('document')
                    .within(self.dossiertemplate)
@@ -694,7 +576,7 @@ class TestDossierTemplateOverview(FunctionalTestCase):
                .within(self.dossiertemplate)
                .titled(u'B Document'))
 
-        browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
+        browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
 
         self.assertSequenceEqual(
             ['A Document', 'B Document', 'C Document 1', 'C Document 2', 'C Document 3',
@@ -704,11 +586,13 @@ class TestDossierTemplateOverview(FunctionalTestCase):
 
     @browsing
     def test_documents_in_overview_are_linked(self, browser):
+        self.login(self.regular_user, browser=browser)
+
         document = create(Builder('document')
                           .within(self.dossiertemplate)
                           .titled(u'Document 1'))
 
-        browser.login().open(self.dossiertemplate, view=OVERVIEW_TAB)
+        browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
 
         items = browser.css('#documentsBox li:not(.moreLink) a.document_link')
 
@@ -716,20 +600,17 @@ class TestDossierTemplateOverview(FunctionalTestCase):
         self.assertEqual(document.absolute_url(), items.first.get('href'))
 
 
-class TestDossierTemplateSubdossiers(FunctionalTestCase):
+class TestDossierTemplateSubdossiers(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
-
-    def setUp(self):
-        super(TestDossierTemplateSubdossiers, self).setUp()
-        self.dossiertemplate = create(Builder('dossiertemplate')
-                                      .titled(u'My Dossiertemplate'))
+    features = ('dossiertemplate', )
 
     @browsing
     def test_list_subdossiers_alphabetically(self, browser):
+        self.login(self.regular_user, browser=browser)
+
         create(Builder('dossiertemplate')
                .within(self.dossiertemplate)
-               .titled(u'A Subdossier'))
+               .titled(u'AA Subdossier'))
 
         create(Builder('dossiertemplate')
                .within(self.dossiertemplate)
@@ -739,40 +620,30 @@ class TestDossierTemplateSubdossiers(FunctionalTestCase):
                .within(self.dossiertemplate)
                .titled(u'B Subdossier'))
 
-        browser.login().open(self.dossiertemplate, view=SUBDOSSIERS_TAB)
+        browser.open(self.dossiertemplate, view=SUBDOSSIERS_TAB)
 
         self.assertEqual(
-            ['A Subdossier', 'B Subdossier', 'C Subdossier'],
+            ['AA Subdossier', 'Anfragen', 'B Subdossier', 'C Subdossier'],
             browser.css('table.listing a.contenttype-opengever-dossier-dossiertemplate').text)
 
     @browsing
     def test_list_subdossiers_in_subdossiers(self, browser):
-        subdossier_1 = create(Builder('dossiertemplate')
-                              .within(self.dossiertemplate)
-                              .titled(u'B Subdossier'))
+        self.login(self.regular_user, browser=browser)
 
-        create(Builder('dossiertemplate')
-               .within(subdossier_1)
-               .titled(u'A Subdossier'))
-
-        browser.login().open(self.dossiertemplate, view=SUBDOSSIERS_TAB)
+        browser.open(self.dossiertemplate, view=SUBDOSSIERS_TAB)
 
         self.assertEqual(
-            ['A Subdossier', 'B Subdossier'],
+            ['Anfragen'],
             browser.css('table.listing a.contenttype-opengever-dossier-dossiertemplate').text)
 
 
-class TestDossierTemplateDocuments(FunctionalTestCase):
+class TestDossierTemplateDocuments(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+    features = ('dossiertemplate', 'bumblebee')
 
     def setUp(self):
         super(TestDossierTemplateDocuments, self).setUp()
-        self.dossiertemplate = create(Builder('dossiertemplate')
-                                      .titled(u'My Dossiertemplate'))
-
-        subdossier = create(Builder('dossiertemplate')
-                            .within(self.dossiertemplate))
+        self.login(self.regular_user)
 
         create(Builder('document')
                .within(self.dossiertemplate)
@@ -781,12 +652,13 @@ class TestDossierTemplateDocuments(FunctionalTestCase):
                .within(self.dossiertemplate)
                .titled('Document 3'))
         create(Builder('document')
-               .within(subdossier)
+               .within(self.subdossiertemplate)
                .titled('Document 2'))
 
     @browsing
     def test_show_documents_in_list_view_sorted_alphabetically(self, browser):
-        browser.login().open(self.dossiertemplate, view=DOCUMENTS_LIST_TAB)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossiertemplate, view=DOCUMENTS_LIST_TAB)
 
         self.assertEqual(
             ['Document 1', 'Document 2', 'Document 3'],
@@ -794,8 +666,8 @@ class TestDossierTemplateDocuments(FunctionalTestCase):
 
     @browsing
     def test_show_documents_in_gallery_view_sorted_alphabetically(self, browser):
-        activate_bumblebee_feature()
-        browser.login().open(self.dossiertemplate, view=DOCUMENTS_GALLERY_TAB)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossiertemplate, view=DOCUMENTS_GALLERY_TAB)
 
         self.assertEqual(
             ['Document 1', 'Document 2', 'Document 3'],

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -220,6 +220,20 @@ class OpengeverContentFixture(object):
                        'deadline': 10})
             .within(self.tasktemplatefolder)))
 
+        self.dossiertemplate = self.register('dossiertemplate', create(
+            Builder('dossiertemplate')
+            .titled(u'Bauvorhaben klein')
+            .having(**{'description': u'Lorem ipsum',
+                       'keywords': (u'secret', u'special'),
+                       'comments': 'this is very special',
+                       'filing_prefix': 'department'})
+            .within(templates)))
+
+        self.subdossiertemplate = self.register('subdossiertemplate', create(
+            Builder('dossiertemplate')
+            .titled(u'Anfragen')
+            .within(self.dossiertemplate)))
+
     @staticuid()
     def create_committees(self):
         self.committee_container = self.register('committee_container', create(


### PR DESCRIPTION
Currently dossiertemplates are not respecting the maximum dossier depth configuration option. The current behavior is the desired one, for most of the customers, but the behavior should be
configurable. Therefore we add an additional registry option `respect_dossier_depth` to the dossiertemplate settings. Which is disabled by default.

See https://basecamp.com/2768704/projects/14549453/todos/326699123 for
more information.