### PR TITLE
OGGBundle: Validate parent_reference early for existence

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- OGGBundle: Validate parent_reference early for existence. [lgraf]
 - Add indexer for bundle GUIDs and create index upon bundle import. [lgraf]
 - Fix missing response-variable due to ungrok opengever.document. [elioschmutz]
 - Ungrok opengever.base. [elioschmutz]

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -123,14 +123,14 @@ class ConstructorSection(object):
             if parent_guid:
                 path = self.bundle.item_by_guid[parent_guid][u'_path']
                 context = traverse(self.site, path, None)
-            elif item.get(u'formatted_refnum'):
+            elif item.get('_formatted_parent_refnum'):
                 path = self.bundle.path_by_reference_number.get(
-                    item[u'formatted_refnum'])
+                    item['_formatted_parent_refnum'])
                 if not path:
                     logger.warning(
                         u'Could not create object with guid `{}`, parent with '
                         'reference number `{}` not found.'.format(
-                            item['guid'], item[u'formatted_refnum']))
+                            item['guid'], item['_formatted_parent_refnum']))
                     continue
 
                 context = traverse(self.site, path, None)

--- a/opengever/bundle/sections/resolveguid.py
+++ b/opengever/bundle/sections/resolveguid.py
@@ -69,6 +69,7 @@ class ResolveGUIDSection(object):
         # Table of formatted refnums that exist in Plone
         self.bundle.existing_refnums = ()
 
+        # Current reference number formatter
         self.formatter = None
 
         self.catalog = api.portal.get_tool('portal_catalog')
@@ -112,11 +113,13 @@ class ResolveGUIDSection(object):
 
             self.bundle.item_by_guid[guid] = item
 
-            if 'parent_reference' in item:
-                parent_refnum = self.get_formatter().list_to_string(
-                    item['parent_reference'])
-                item['_formatted_parent_refnum'] = parent_refnum
-                parent_refnums.append(parent_refnum)
+            parent_reference = item.get('parent_reference')
+            if parent_reference is not None:
+                # Item has a parent pointer via reference number
+                fmt = self.get_formatter()
+                formatted_parent_refnum = fmt.list_to_string(parent_reference)
+                item['_formatted_parent_refnum'] = formatted_parent_refnum
+                parent_refnums.append(formatted_parent_refnum)
 
         log.info('Start building reference mapping')
         self.bundle.path_by_reference_number = self.build_reference_mapping(

--- a/opengever/bundle/sections/resolveguid.py
+++ b/opengever/bundle/sections/resolveguid.py
@@ -12,11 +12,6 @@ from zope.interface import implements
 import logging
 
 
-TYPES_WITHOUT_REFERENCE_NUMBER = [
-    'opengever.task.task',
-    'opengever.meeting.proposal',
-    'opengever.meeting.submittedproposal']
-
 log = logging.getLogger('opengever.bundle.resolveguid')
 log.setLevel(logging.INFO)
 
@@ -64,7 +59,6 @@ class ResolveGUIDSection(object):
         self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
 
         self.bundle.item_by_guid = OrderedDict()
-        self.bundle.path_by_reference_number = OrderedDict()
 
         # Table of formatted refnums that exist in Plone
         self.bundle.existing_refnums = ()
@@ -121,11 +115,6 @@ class ResolveGUIDSection(object):
                 item['_formatted_parent_refnum'] = formatted_parent_refnum
                 parent_refnums.append(formatted_parent_refnum)
 
-        log.info('Start building reference mapping')
-        self.bundle.path_by_reference_number = self.build_reference_mapping(
-            parent_refnums)
-        log.info('Reference mapping built.')
-
         # Verify that all parent containers referenced by refnum exist in Plone
         for formatted_refnum in parent_refnums:
             if formatted_refnum not in self.bundle.existing_refnums:
@@ -134,18 +123,6 @@ class ResolveGUIDSection(object):
                     "Couldn't find container with reference number %s "
                     "(referenced as parent by item by GUID %s )" % (
                         formatted_refnum, guid))
-
-    def get_relative_path(self, brain):
-        """Returns the path relative to the plone site for the given brain.
-        """
-        return '/'.join(brain.getPath().split('/')[2:])
-
-    def build_reference_mapping(self, reference_numbers):
-        catalog = api.portal.get_tool('portal_catalog')
-        brains = catalog.unrestrictedSearchResults(reference=reference_numbers)
-        return {
-            brain.reference: self.get_relative_path(brain) for brain in brains
-            if brain.portal_type not in TYPES_WITHOUT_REFERENCE_NUMBER}
 
     def build_tree(self):
         """Build a tree from the flat list of items.

--- a/opengever/bundle/sections/resolveguid.py
+++ b/opengever/bundle/sections/resolveguid.py
@@ -100,7 +100,7 @@ class ResolveGUIDSection(object):
         self.bundle.existing_refnums = self.get_existing_refnums()
 
         # Keep track of all reference numbers referred to in bundle items
-        used_ref_numbers = []
+        parent_refnums = []
 
         for item in self.previous:
             if 'guid' not in item:
@@ -116,15 +116,15 @@ class ResolveGUIDSection(object):
                 parent_refnum = self.get_formatter().list_to_string(
                     item['parent_reference'])
                 item['_formatted_parent_refnum'] = parent_refnum
-                used_ref_numbers.append(parent_refnum)
+                parent_refnums.append(parent_refnum)
 
         log.info('Start building reference mapping')
         self.bundle.path_by_reference_number = self.build_reference_mapping(
-            used_ref_numbers)
+            parent_refnums)
         log.info('Reference mapping built.')
 
         # Verify that all parent containers referenced by refnum exist in Plone
-        for formatted_refnum in used_ref_numbers:
+        for formatted_refnum in parent_refnums:
             if formatted_refnum not in self.bundle.existing_refnums:
                 # Reference number of referenced parent not found in catalog
                 raise ReferenceNumberNotFound(

--- a/opengever/bundle/sections/resolveguid.py
+++ b/opengever/bundle/sections/resolveguid.py
@@ -96,10 +96,10 @@ class ResolveGUIDSection(object):
             self.bundle.item_by_guid[guid] = item
 
             if 'parent_reference' in item:
-                reference_number = self.get_formatter().list_to_string(
+                parent_refnum = self.get_formatter().list_to_string(
                     item['parent_reference'])
-                item['formatted_refnum'] = reference_number
-                used_ref_numbers.append(reference_number)
+                item['_formatted_parent_refnum'] = parent_refnum
+                used_ref_numbers.append(parent_refnum)
 
         log.info('Start building reference mapping')
         self.bundle.path_by_reference_number = self.build_reference_mapping(

--- a/opengever/bundle/tests/__init__.py
+++ b/opengever/bundle/tests/__init__.py
@@ -11,4 +11,4 @@ class MockTransmogrifier(object):
 class MockBundle(object):
     def __init__(self):
         self.item_by_guid = OrderedDict()
-        self.path_by_reference_number = OrderedDict()
+        self.path_by_refnum_cache = {}

--- a/opengever/bundle/tests/assets/invalid_parent_reference.oggbundle/dossiers.json
+++ b/opengever/bundle/tests/assets/invalid_parent_reference.oggbundle/dossiers.json
@@ -1,0 +1,11 @@
+[
+  {
+    "guid": "GUID-dossier-A-7.7.7-1",
+    "parent_reference": [[7, 7, 7]],
+    "reference_number": "1",
+    "responsible": "lukas.graf",
+    "review_state": "dossier-state-active",
+    "start": "2010-11-11",
+    "title": "Dossier 7.7.7-1 (invalid parent_reference)"
+  }
+]

--- a/opengever/bundle/tests/test_business_rule_violations.py
+++ b/opengever/bundle/tests/test_business_rule_violations.py
@@ -122,9 +122,10 @@ class TestBusinessRuleViolations(FunctionalTestCase):
         subobject_types = [o.portal_type for o in folder.objectValues()]
 
         self.assertNotIn('opengever.document.document', subobject_types)
+
         self.assertIn(
             'Could not create object at '
-            '/plone/ordnungssystem-a/ordnungsposition-1 with guid '
+            'ordnungssystem-a/ordnungsposition-1 with guid '
             'GUID-document-A-1-disallowed-subobject-type. '
             'Disallowed subobject type: opengever.document.document',
             self.log.getvalue())

--- a/opengever/bundle/tests/test_invalid_parent_reference.py
+++ b/opengever/bundle/tests/test_invalid_parent_reference.py
@@ -1,0 +1,33 @@
+from collective.transmogrifier.transmogrifier import Transmogrifier
+from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
+from opengever.bundle.sections.resolveguid import ReferenceNumberNotFound
+from opengever.testing import FunctionalTestCase
+from pkg_resources import resource_filename
+from plone import api
+from zope.annotation import IAnnotations
+
+
+class TestInvalidParentReference(FunctionalTestCase):
+
+    def test_oggbundle_transmogrifier(self):
+        # this is a bit hackish, but since builders currently don't work in
+        # layer setup/teardown and isolation of database content is ensured
+        # on a per test level we abuse just one test to setup the pipeline and
+        # test its data.
+
+        # load pipeline
+        # XXX move this to a layer
+        self.grant("Manager")
+
+        transmogrifier = Transmogrifier(api.portal.get())
+        IAnnotations(transmogrifier)[BUNDLE_PATH_KEY] = resource_filename(
+            'opengever.bundle.tests',
+            'assets/invalid_parent_reference.oggbundle')
+
+        with self.assertRaises(ReferenceNumberNotFound) as cm:
+            transmogrifier(u'opengever.bundle.oggbundle')
+
+        self.assertEqual(
+            "Couldn't find container with reference number Client1 7.7.7 "
+            "(referenced as parent by item by GUID GUID-dossier-A-7.7.7-1 )",
+            cm.exception.message)

--- a/opengever/bundle/tests/test_section_constructor.py
+++ b/opengever/bundle/tests/test_section_constructor.py
@@ -183,11 +183,11 @@ class TestConstructor(IntegrationTestCase):
         self.assertFalse(hasattr(aq_base(content), 'title_de'))
         self.assertFalse(hasattr(aq_base(content), 'title_Fr'))
 
-    def test_use_formatted_refnum_for_container_path(self):
+    def test_use_formatted_parent_refnum_for_container_path(self):
         item = {
             u"guid": "12345xy",
             u"_type": u"ftw.mail.mail",
-            u"formatted_refnum": "Client 1.1 / 1",
+            u"_formatted_parent_refnum": "Client 1.1 / 1",
             u"title": u"My Mail",
             u"_path": u"/foo/bar"
         }

--- a/opengever/bundle/tests/test_section_resolveguid.py
+++ b/opengever/bundle/tests/test_section_resolveguid.py
@@ -111,23 +111,6 @@ class TestResolveGUID(IntegrationTestCase):
             set(all_reference_numbers_in_catalog),
             set(self.bundle.existing_refnums))
 
-    def test_defines_path_by_reference_number_mapping(self):
-        self.login(self.regular_user)
-
-        items = [
-            {'guid': 'a1',
-             'parent_reference': [[1, 1], [1]]},
-            {'guid': 'b1',
-             'parent_reference': [[1, 1]]}
-        ]
-        section = self.setup_section(previous=items)
-        list(section)
-
-        self.assertEqual(
-            {'Client1 1.1': 'ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
-             'Client1 1.1 / 1': 'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1'},
-            self.bundle.path_by_reference_number)
-
     def test_parent_reference_number_is_added_to_the_items(self):
         self.login(self.regular_user)
 

--- a/opengever/bundle/tests/test_section_resolveguid.py
+++ b/opengever/bundle/tests/test_section_resolveguid.py
@@ -4,13 +4,16 @@ from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.resolveguid import DuplicateGuid
 from opengever.bundle.sections.resolveguid import MissingGuid
 from opengever.bundle.sections.resolveguid import MissingParent
+from opengever.bundle.sections.resolveguid import ReferenceNumberNotFound
 from opengever.bundle.sections.resolveguid import ResolveGUIDSection
 from opengever.bundle.tests import MockBundle
 from opengever.bundle.tests import MockTransmogrifier
 from opengever.testing import IntegrationTestCase
+from plone import api
 from zope.annotation import IAnnotations
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
+import Missing
 
 
 class TestResolveGUID(IntegrationTestCase):
@@ -81,6 +84,32 @@ class TestResolveGUID(IntegrationTestCase):
 
         list(section)
         self.assertEqual(item, self.bundle.item_by_guid['marvin'])
+
+    def test_catches_invalid_parent_reference_early(self):
+        self.login(self.regular_user)
+
+        items = [
+            {'guid': 'a1',
+             'parent_reference': [[7, 7], [7]]}
+        ]
+        section = self.setup_section(previous=items)
+        with self.assertRaises(ReferenceNumberNotFound):
+            list(section)
+
+    def test_builds_list_of_all_existing_refnums(self):
+        self.login(self.regular_user)
+
+        section = self.setup_section(previous=[])
+        list(section)
+
+        catalog = api.portal.get_tool('portal_catalog')
+        all_reference_numbers_in_catalog = [
+            b.reference for b in catalog.unrestrictedSearchResults()
+            if not b.reference == Missing.Value]
+
+        self.assertEqual(
+            set(all_reference_numbers_in_catalog),
+            set(self.bundle.existing_refnums))
 
     def test_defines_path_by_reference_number_mapping(self):
         self.login(self.regular_user)

--- a/opengever/bundle/tests/test_section_resolveguid.py
+++ b/opengever/bundle/tests/test_section_resolveguid.py
@@ -112,9 +112,9 @@ class TestResolveGUID(IntegrationTestCase):
         items = list(section)
 
         self.assertEquals(
-            [{'guid': 'a1', 'formatted_refnum': u'Client1 1.1 / 1',
+            [{'guid': 'a1', '_formatted_parent_refnum': u'Client1 1.1 / 1',
               'parent_reference': [[1, 1], [1]], '_nesting_depth': 1},
-             {'guid': 'b1', 'formatted_refnum': u'Client1 1.1',
+             {'guid': 'b1', '_formatted_parent_refnum': u'Client1 1.1',
               'parent_reference': [[1, 1]], '_nesting_depth': 1}],
             items)
 
@@ -131,8 +131,8 @@ class TestResolveGUID(IntegrationTestCase):
         items = list(section)
 
         self.assertEquals(
-            [{'guid': 'a1', 'formatted_refnum': u'Client1 1.1 / 1',
+            [{'guid': 'a1', '_formatted_parent_refnum': u'Client1 1.1 / 1',
               'parent_reference': [[1, 1], [1]], '_nesting_depth': 1},
-             {'guid': 'b1', 'formatted_refnum': u'Client1 1.1',
+             {'guid': 'b1', '_formatted_parent_refnum': u'Client1 1.1',
               'parent_reference': [[1, 1]], '_nesting_depth': 1}],
             items)


### PR DESCRIPTION
All reference numbers used in `parent_reference` parent pointers **must exist** according to the Plone catalog, otherwise we **abort early**.

So we build a flat list of reference numbers that exist in the Plone catalog first, and make sure each `parent_reference` pointer we encounter points to a reference number that actually exists.

The **(cached) lookup** for actually turning the reference number into a path happens later, in the `ConstructorSection`, but at that point we can be sure each one is resolvable to a path because we found it in the catalog earlier.

Also includes some cleanup and refactorings.