### PR TITLE
Fix fetch new showroom items in serach-view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Remove the broken and unused fillingnumber-adjustment view to get rid of the grokked
   dependency collective.z3cform.datagridfield. [elioschmutz]
 - Reenable action "move items" for inbox. [tarnap]
+- Fix batch-handling in the showroom overlay for the search-view. [elioschmutz]
 - OGGBundle: Fix tracking of item counts (actual vs. raw). [lgraf]
 - OGGBundle: Support delta imports using GUID. [lgraf]
 - OGGBundle: Validate parent_reference early for existence. [lgraf]


### PR DESCRIPTION
The showroom search-view implementation for fetching new objects will use the default
next/previous button urls of the searchform to request new objects based on the current search
params.

If we load only the first next or previous batch-slice, this will work well. But if we
reach the end/beginning of the second batch-slice, it will reuse the same fetch-link as for
the first request, because the search-view itself will not update its buttons after fetching
new objects through the showroom.

To solve this issue, we implement a new class for handling the current request-urls for the
tail/head function of the showroom.

There is a side-issue (not required for this PR!): https://github.com/4teamwork/ftw.showroom/issues/45 - The issue describes a bad behavior where it is possible, that the next/previous batch-slice will be swapped with the after-next/previous batch slice. 

closes #3535 