### PR TITLE
OGGBundle: Support delta imports using GUID:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- OGGBundle: Support delta imports using GUID. [lgraf]
 - OGGBundle: Validate parent_reference early for existence. [lgraf]
 - Add indexer for bundle GUIDs and create index upon bundle import. [lgraf]
 - Fix missing response-variable due to ungrok opengever.document. [elioschmutz]

--- a/docs/public/dev-manual/oggbundle/index.rst
+++ b/docs/public/dev-manual/oggbundle/index.rst
@@ -144,6 +144,12 @@ Pfade / Dateinamen dürfen nur alphanumerische Zeichen, Unterstrich und Bindestr
 Abbildung von Verschachtelung (containment)
 -------------------------------------------
 
+Die hierarchische Beziehung zwischen Objekten wird mittels Parent-Pointers abgebildet.
+
+
+parent_guid
+~~~~~~~~~~~
+
 Da die Daten in den JSON-Dateien nicht verschachtelt abgelegt werden, ist es nötig diese Verschachtelung während dem Import aufzulösen. Diese Verschachtelung wird mittels global eindeutiger ID (GUID) und einem Pointer von Children auf das enthaltende Parent abgebildet. Dazu muss jedes Objekt über eine GUID verfügen. Diese muss im Attribut **guid** gespeichert werden. Die Verschachtelung wird mittels einer Referenz auf das Parent hergestellt, dazu muss jedes Objekt, das ein Parent besitzt, das Attribut **parent\_guid** definieren, und damit auf das Parent referenzieren:
 
 code::
@@ -158,7 +164,17 @@ code::
   ...
   }
 
-Alternativ zur (im Bundle selbst definierten) GUID kann auch das Akzenzeichen eines Objekts als eindeutige Referenz auf das Parent verwendet werden. Die Verwendung des Aktenzeichens als Parent-Pointer erlaubt es, bereits existierende Objekte (die also nicht im referenzierenden Bundle mitgeliefert werden) zu referenzieren, und ermöglicht so partielle Importe. So ist z.B. das importieren von Dokumenten in ein bestehendes Dossier möglich, indem dieses Dossier über sein Aktenzeichen referenziert wird.
+Es ist auch möglich, über die ``parent_guid`` ein Objekt als Parent zu referenzieren, das sich aufgrund eines früheren Imports bereits im System befindet. Dieses Parent-Item muss dann im Bundle nicht mehr mitgeliefert werden (darf aber, solang die GUID gleich bleibt).
+
+Wenn sowohl im Bundle ein Item mit einer bestimmten GUID geliefert wird, und sich auch im System bereits ein Objekt mit identischer GUID befindet, wird das Item aus dem Bundle ignoriert und übersprungen (es werden also auch keine Metadaten des bereits existierenden Objekts aktualisiert).
+
+Dies bedeutet, wenn nacheinander zwei Bundles importiert werden, von denen das zweite *zusätzliche* Daten enthält, wird nur die Differenz importiert (Objekte mit GUIDs welche im ersten Bundle noch nicht existiert haben). Dies setzt aber zwingend voraus, dass für Objekte die als "gleich" / "schon vorhanden" erkannt werden sollen, sich die GUID nicht ändert (ansonsten werden die Objekte erneut importiert werden, und dementsprechend doppelt vorhanden sein).
+
+
+parent_reference
+~~~~~~~~~~~~~~~~
+
+Alternativ zur GUID kann auch das Akzenzeichen eines Objekts als eindeutige Referenz auf das Parent verwendet werden. Die Verwendung des Aktenzeichens als Parent-Pointer erlaubt es, bereits existierende Objekte über deren eindeutiges Aktenzeichen zu referenzieren, und ermöglicht so partielle Importe. So ist z.B. das importieren von Dokumenten in ein bestehendes Dossier möglich, indem dieses Dossier über sein Aktenzeichen referenziert wird.
 
 Wird zur Referenzierung das Aktenzeichen verwendet, muss dazu das Attribut **parent\_reference** (statt **parent\_guid**) gesetzt werden. Das Aktenzeichen in diesem Attribut wird als verschachtelte Arrays von Integern erwartet, welche die einzelnen Komponenten des Aktenzeichens (ohne Formatierung) abbilden. Beispiel: `[[1, 3, 5], [472, 9]` entspricht dem Aktenzeichen `1.3.5 / 472.9` (Position 1.3.5, Dossier 472, Subdossier 9):
 

--- a/opengever/bundle/tests/__init__.py
+++ b/opengever/bundle/tests/__init__.py
@@ -12,3 +12,4 @@ class MockBundle(object):
     def __init__(self):
         self.item_by_guid = OrderedDict()
         self.path_by_refnum_cache = {}
+        self.existing_guids = ()

--- a/opengever/bundle/tests/assets/delta.oggbundle/dossiers.json
+++ b/opengever/bundle/tests/assets/delta.oggbundle/dossiers.json
@@ -1,0 +1,11 @@
+[
+  {
+    "guid": "GUID-dossier-A-1.1-1",
+    "parent_guid": "GUID-repofolder-A-1.1",
+    "reference_number": "1",
+    "responsible": "lukas.graf",
+    "review_state": "dossier-state-active",
+    "start": "2010-11-11",
+    "title": "Dossier 1.1-1 (delta import into existing repofolder)"
+  }
+]

--- a/opengever/bundle/tests/assets/delta_base.oggbundle/repofolders.json
+++ b/opengever/bundle/tests/assets/delta_base.oggbundle/repofolders.json
@@ -1,0 +1,20 @@
+[
+  {
+    "guid": "GUID-repofolder-A-1",
+    "parent_guid": "GUID-reporoot-A",
+    "reference_number_prefix": "1",
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Ordnungsposition 1",
+    "valid_from": "2005-01-01",
+    "valid_until": "2050-01-01"
+  },
+  {
+    "guid": "GUID-repofolder-A-1.1",
+    "parent_guid": "GUID-repofolder-A-1",
+    "reference_number_prefix": "1",
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Ordnungsposition 1.1",
+    "valid_from": "2005-01-01",
+    "valid_until": "2020-01-01"
+  }
+]

--- a/opengever/bundle/tests/assets/delta_base.oggbundle/reporoots.json
+++ b/opengever/bundle/tests/assets/delta_base.oggbundle/reporoots.json
@@ -1,0 +1,28 @@
+[
+  {
+    "guid": "GUID-reporoot-A",
+    "review_state": "repositoryroot-state-active",
+    "title_de": "Ordnungssystem A",
+    "title_fr": "",
+    "valid_from": "2000-01-01",
+    "valid_until": "2099-12-31",
+    "version": "",
+    "_permissions": {
+      "read": [
+        "og_demo-ftw_users"
+      ],
+      "add": [
+        "og_demo-ftw_users"
+      ],
+      "edit": [
+        "og_demo-ftw_users"
+      ],
+      "close": [
+        "og_demo-ftw_users"
+      ],
+      "reactivate": [
+        "og_demo-ftw_users"
+      ]
+    }
+  }
+]

--- a/opengever/bundle/tests/test_business_rule_violations.py
+++ b/opengever/bundle/tests/test_business_rule_violations.py
@@ -2,6 +2,7 @@ from collective.transmogrifier.transmogrifier import Transmogrifier
 from datetime import datetime
 from ftw.testing import freeze
 from opengever.base.security import elevated_privileges
+from opengever.bundle.console import add_guid_index
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.testing import FunctionalTestCase
 from pkg_resources import resource_filename
@@ -36,6 +37,10 @@ class TestBusinessRuleViolations(FunctionalTestCase):
         # layer setup/teardown and isolation of database content is ensured
         # on a per test level we abuse just one test to setup the pipeline and
         # test its data.
+
+        # Create the 'bundle_guid' index. In production, this will be done
+        # by the "bin/instance import" command in opengever.bundle.console
+        add_guid_index()
 
         # load pipeline
         # XXX move this to a layer

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -572,9 +572,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
 
         self.assertEqual(1, len(reporoots))
         self.assertEqual(3, len(repofolders))
-        self.assertEqual(2, len(dossiers))
-        self.assertEqual(3, len(documents))
-        self.assertEqual(2, len(mails))
+        self.assertEqual(3, len(dossiers))
+        self.assertEqual(4, len(documents))
+        self.assertEqual(3, len(mails))
 
     def assert_navigation_portlet_assigned(self, root):
         manager = getUtility(


### PR DESCRIPTION
This allows items in bundles to reference a GUID via `parent_guid` that refers to an object that has previously been imported into Plone.

If an object with the same GUID exists both in Plone as a JSON item in the bundle, the one from Plone is used as the parent container for any items that refer to that GUID.

---

The **report logic** had to change slightly to accommodate this change:
In order to generate the report, we now track the acutal constructed GUIDs in `bundle.constructed_guids`. For generating the report, we simply query the catalog for all these GUIDs.