### PR TITLE
OGGBundle: Fix tracking of item counts (actual vs. raw)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- OGGBundle: Fix tracking of item counts (actual vs. raw). [lgraf]
 - OGGBundle: Support delta imports using GUID. [lgraf]
 - OGGBundle: Validate parent_reference early for existence. [lgraf]
 - Add indexer for bundle GUIDs and create index upon bundle import. [lgraf]

--- a/opengever/bundle/sections/progress.py
+++ b/opengever/bundle/sections/progress.py
@@ -36,10 +36,11 @@ class ProgressSection(object):
         self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
         self.interval = int(options.get('interval', 100))
         self.count = 0
-        self.total = sum(self.bundle.stats['bundle_counts'].values())
+        self.total = sum(self.bundle.stats['bundle_counts_raw'].values())
 
     def __iter__(self):
-        logger.info("Migrating %s items total." % self.total)
+        logger.info(
+            "Starting migration (%s raw items total in bundle)" % self.total)
 
         for item in self.previous:
             self.count += 1

--- a/opengever/bundle/tests/__init__.py
+++ b/opengever/bundle/tests/__init__.py
@@ -13,3 +13,4 @@ class MockBundle(object):
         self.item_by_guid = OrderedDict()
         self.path_by_refnum_cache = {}
         self.existing_guids = ()
+        self.stats = {}


### PR DESCRIPTION
Because already existing items still supplied in bundle will be filtered and not constructed again, the actual item count may deviate from the raw number of item in the bundle's JSON
files.

Therefore we list those counts separately, to make the available information more clear.

Example output:
```
2017-10-20 16:08:02 INFO opengever.bundle.loader Raw items in bundle <Bundle opengever/bundle/tests/assets/basic.oggbundle/>
2017-10-20 16:08:02 INFO opengever.bundle.loader ================================================================================
2017-10-20 16:08:02 INFO opengever.bundle.loader documents.json       8
2017-10-20 16:08:02 INFO opengever.bundle.loader repofolders.json     3
2017-10-20 16:08:02 INFO opengever.bundle.loader reporoots.json       1
2017-10-20 16:08:02 INFO opengever.bundle.loader dossiers.json        4
2017-10-20 16:08:02 INFO opengever.bundle.loader
2017-10-20 16:08:02 INFO opengever.bundle.progress Starting migration (16 raw items total in bundle)
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid Skipping existing GUID 754daf80623f45659004a8c38c78dc3e when building tree
[...]
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid Skipping existing GUID 0970e3800a78407ea2558d718739961f when building tree
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid Actual items about to be migrated
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid ================================================================================
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid documents.json       1
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid dossiers.json        1
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid About to migrate 2 actual items total.
2017-10-20 16:08:02 INFO opengever.bundle.resolveguid
[...]
2017-10-20 16:08:04 INFO opengever.bundle.progress Done. Processed 2 items total.
[...]
Imported objects:
=================
opengever.dossier.businesscasedossier: 1
opengever.repository.repositoryfolder: 0
opengever.repository.repositoryroot: 0
ftw.mail.mail: 0
opengever.document.document: 1
```