### PR TITLE
Reenable copy items action in inbox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -504,6 +504,7 @@ Objects
     - self.franz_meier
     - self.hanspeter_duerr
   - self.inbox
+    - self.inbox_document
   - self.repository_root
     - self.branch_repofolder
       - self.leaf_repofolder

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Avoid id conflicts when setting up a repository. [phgross]
 - Remove the broken and unused fillingnumber-adjustment view to get rid of the grokked
   dependency collective.z3cform.datagridfield. [elioschmutz]
+- Reenable action "move items" for inbox. [tarnap]
 - OGGBundle: Fix tracking of item counts (actual vs. raw). [lgraf]
 - OGGBundle: Support delta imports using GUID. [lgraf]
 - OGGBundle: Validate parent_reference early for existence. [lgraf]

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -65,7 +65,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertEqual(
-            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-11/bumblebee-open-pdf?filename=die-burgschaft.pdf',
+            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12/bumblebee-open-pdf?filename=die-burgschaft.pdf',
             adapter.get_open_as_pdf_url())
 
     def test_handles_non_ascii_characters_in_filename(self):
@@ -75,7 +75,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertEqual(
-            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-11/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
+            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
             adapter.get_open_as_pdf_url())
 
 

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -161,14 +161,14 @@ class TestContentStatsIntegration(IntegrationTestCase):
             (self.portal, self.portal.REQUEST),
             IStatsProvider, name='checked_out_docs')
 
-        self.assertEqual({'checked_out': 0, 'checked_in': 15},
+        self.assertEqual({'checked_out': 0, 'checked_in': 16},
                          stats_provider.get_raw_stats())
 
         # Check out a document
         getMultiAdapter((self.document, self.document.REQUEST),
                         ICheckinCheckoutManager).checkout()
 
-        self.assertEqual({'checked_out': 1, 'checked_in': 14},
+        self.assertEqual({'checked_out': 1, 'checked_in': 15},
                          stats_provider.get_raw_stats())
 
     def test_file_mimetypes_provider(self):
@@ -180,7 +180,8 @@ class TestContentStatsIntegration(IntegrationTestCase):
         self.assertEqual({
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 1,
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 10,
-            'message/rfc822': 2},
+            'message/rfc822': 2,
+            'text/plain': 1},
             stats_provider.get_raw_stats())
 
     @browsing
@@ -193,7 +194,8 @@ class TestContentStatsIntegration(IntegrationTestCase):
         self.assertEquals([
             ['', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '1'],
             ['', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', '10'],
-            ['', 'message/rfc822', '2']],
+            ['', 'message/rfc822', '2'],
+            ['', 'text/plain', '1']],
             table.lists())
 
     @browsing
@@ -204,7 +206,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-checked_out_docs').first
 
         self.assertEquals(
-            [['', 'checked_in', '15'], ['', 'checked_out', '0']],
+            [['', 'checked_in', '16'], ['', 'checked_out', '0']],
             table.lists())
 
         # Check out a document
@@ -215,5 +217,5 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-checked_out_docs').first
 
         self.assertEquals(
-            [['', 'checked_in', '14'], ['', 'checked_out', '1']],
+            [['', 'checked_in', '15'], ['', 'checked_out', '1']],
             table.lists())

--- a/opengever/inbox/browser/tabs.py
+++ b/opengever/inbox/browser/tabs.py
@@ -78,7 +78,6 @@ class InboxDocuments(Documents):
     depth = 1
 
     disabled_actions = ['create_task',
-                        'move_items',
                         'submit_additional_documents']
 
     @property

--- a/opengever/inbox/tests/test_move_items.py
+++ b/opengever/inbox/tests/test_move_items.py
@@ -1,0 +1,32 @@
+from Acquisition import aq_parent
+from Acquisition import aq_inner
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
+from opengever.testing import IntegrationTestCase
+from plone import api
+from plone.uuid.interfaces import IUUID
+
+
+class TestMoveItemsWithBrowser(IntegrationTestCase):
+    
+    @browsing
+    def test_move_items_to_repository(self, browser):
+        self.login(self.secretariat_user, browser)
+        
+        paths = ['/'.join(self.inbox_document.getPhysicalPath())]
+
+        uid = IUUID(self.inbox_document)
+
+        # copy the document
+        browser.open(self.inbox, {'paths:list': paths}, view='copy_items')
+        assert_no_error_messages()
+
+        # move the document
+        browser.open(self.dossier, {'paths:list': paths}, view='move_items')
+        browser.fill({'Destination': self.dossier})
+    
+        browser.css('#form-buttons-button_submit').first.click()
+        assert_no_error_messages()
+
+        inbox_document = api.content.get(UID=uid)
+        self.assertEquals(self.dossier, aq_parent(aq_inner(inbox_document)))

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -38,4 +38,4 @@ class TestMailIndexers(IntegrationTestCase):
         extender = getAdapter(
             self.mail_eml, IDynamicTextIndexExtender, u'IOGMail')
 
-        self.assertEquals('Client1 1.1 / 1 / 11 11', extender())
+        self.assertEquals('Client1 1.1 / 1 / 12 12', extender())

--- a/opengever/tabbedview/tests/test_document_listing.py
+++ b/opengever/tabbedview/tests/test_document_listing.py
@@ -17,8 +17,8 @@ class TestDocumentListing(IntegrationTestCase):
              'Document Date': '31.08.2016',
              'Public Trial': 'unchecked',
              'Receipt Date': '',
-             'Reference Number': 'Client1 1.1 / 1 / 3',
-             'Sequence Number': '3',
+             'Reference Number': 'Client1 1.1 / 1 / 4',
+             'Sequence Number': '4',
              'Subdossier': '',
              'Title': u'Vertr\xe4gsentwurf'},
             browser.css('.listing').first.dicts())

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -310,6 +310,10 @@ class OpengeverContentFixture(object):
             .having(id='eingangskorb',
                     responsible_org_unit='fa',
                     inbox_group=self.org_unit.inbox_group)))
+        self.register('inbox_document', create(
+            Builder('document').within(self.inbox)
+            .titled(u'Dokument im Eingangsk\xf6rbli')
+            .with_asset_file('text.txt')))
         self.inbox.manage_setLocalRoles(
             self.secretariat_user.getId(), ('Contributor', 'Editor', 'Reader'))
         self.inbox.reindexObjectSecurity()


### PR DESCRIPTION
Reenables copy items action for inbox.

It was disabled because a customer wanted it to be disabled.
Now its a sensible action, needed for several customers.

![move_inbox_documents__2](https://user-images.githubusercontent.com/194114/31889834-6f12ebcc-b801-11e7-974d-0d9aa963feb3.gif)

Resolves #3426

