### PR TITLE
SPV Word: Meeting View Redesign, Part 1

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
   dependency collective.z3cform.datagridfield. [elioschmutz]
 - Reenable action "move items" for inbox. [tarnap]
 - Fix batch-handling in the showroom overlay for the search-view. [elioschmutz]
+- SPV word: update meeting view with new design. [jone]
 - OGGBundle: Fix tracking of item counts (actual vs. raw). [lgraf]
 - OGGBundle: Support delta imports using GUID. [lgraf]
 - OGGBundle: Validate parent_reference early for existence. [lgraf]

--- a/opengever/base/browser/layout.py
+++ b/opengever/base/browser/layout.py
@@ -1,6 +1,9 @@
+from opengever.base.interfaces import ISQLObjectWrapper
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.meeting import is_word_meeting_implementation_enabled
 from plone.app.layout.globals.layout import LayoutPolicy
+from plone.i18n.normalizer.interfaces import IIDNormalizer
+from zope.component import getUtility
 
 
 class GeverLayoutPolicy(LayoutPolicy):
@@ -11,12 +14,17 @@ class GeverLayoutPolicy(LayoutPolicy):
         """Extends the default body class with the `feature-bumblebee` class, if
         the bumblebeefeature is enabled.
         """
-        body_class = super(GeverLayoutPolicy, self).bodyClass(template, view)
+        classes = [super(GeverLayoutPolicy, self).bodyClass(template, view)]
 
         if is_bumblebee_feature_enabled():
-            body_class = ' '.join((body_class, 'feature-bumblebee'))
+            classes.append('feature-bumblebee')
 
         if is_word_meeting_implementation_enabled():
-            body_class = ' '.join((body_class, 'feature-word-meeting'))
+            classes.append('feature-word-meeting')
 
-        return body_class
+        if ISQLObjectWrapper.providedBy(self.context):
+            normalize = getUtility(IIDNormalizer).normalize
+            classes.append('model-{}'.format(
+                normalize(type(self.context.model).__name__)))
+
+        return ' '.join(classes)

--- a/opengever/base/tests/test_layout.py
+++ b/opengever/base/tests/test_layout.py
@@ -30,3 +30,18 @@ class TestGeverLayoutPolicy(IntegrationTestCase):
         self.activate_feature('word-meeting')
         browser.open()
         self.assertIn(feature_class, browser.css('body').first.classes)
+
+    @browsing
+    def test_no_model_class_on_regular_content(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        self.assertEquals([],
+                          filter(lambda classname: classname.startswith('model-'),
+                                 browser.css('body').first.classes))
+
+    @browsing
+    def test_model_class_on_sql_wrapper(self, browser):
+        self.login(self.committee_responsible, browser)
+        map(self.activate_feature, ('meeting', 'word-meeting'))
+        browser.open(self.meeting)
+        self.assertIn('model-meeting', browser.css('body').first.classes)

--- a/opengever/base/tests/test_layout.py
+++ b/opengever/base/tests/test_layout.py
@@ -1,45 +1,32 @@
 from ftw.testbrowser import browsing
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.testing import FunctionalTestCase
-from plone import api
-import transaction
+from opengever.testing import IntegrationTestCase
 
 
-class TestGeverLayoutPolicy(FunctionalTestCase):
+class TestGeverLayoutPolicy(IntegrationTestCase):
+
     @browsing
-    def test_bumblebee_feature_body_class_is_not_present_if_feature_is_disabled(self, browser):
-        browser.login().visit()
-        self.assertNotIn(
-            'feature-bumblebee',
-            browser.css('body').first.get('class').split(' '))
+    def test_bumblebee_feature(self, browser):
+        self.login(self.regular_user, browser)
+        feature_class = 'feature-bumblebee'
+
+        self.deactivate_feature('bumblebee')
+        browser.open()
+        self.assertNotIn(feature_class, browser.css('body').first.classes)
+
+        self.activate_feature('bumblebee')
+        browser.open()
+        self.assertIn(feature_class, browser.css('body').first.classes)
 
     @browsing
     def test_word_meeting_feature_presence(self, browser):
-        browser.login()
-        prefix = 'opengever.meeting.interfaces.IMeetingSettings'
-        meeting_feature = prefix + '.is_feature_enabled'
-        api.portal.set_registry_record(meeting_feature, True)
+        self.login(self.regular_user, browser)
+        self.activate_feature('meeting')
+        feature_class = 'feature-word-meeting'
 
-        word_feature = prefix + '.is_word_implementation_enabled'
+        self.deactivate_feature('word-meeting')
+        browser.open()
+        self.assertNotIn(feature_class, browser.css('body').first.classes)
 
-        api.portal.set_registry_record(word_feature, False)
-        transaction.commit()
-        self.assertNotIn('feature-word-meeting',
-                         browser.open().css('body').first.classes)
-
-        api.portal.set_registry_record(word_feature, True)
-        transaction.commit()
-        self.assertIn('feature-word-meeting',
-                      browser.open().css('body').first.classes)
-
-
-class TestGeverLayoutPolicyBumblebeeFeature(FunctionalTestCase):
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    @browsing
-    def test_bumblebee_feature_body_class_is_present_if_feature_is_enabled(self, browser):
-        browser.login().visit()
-        self.assertIn(
-            'feature-bumblebee',
-            browser.css('body').first.get('class').split(' '))
+        self.activate_feature('word-meeting')
+        browser.open()
+        self.assertIn(feature_class, browser.css('body').first.classes)

--- a/opengever/base/viewlets/byline.pt
+++ b/opengever/base/viewlets/byline.pt
@@ -11,7 +11,7 @@
     <tal:repeat tal:repeat="item view/get_items">
       <li tal:attributes="class item/class" tal:condition="item/content">
          <span class="label"><span tal:content="item/label"></span>:</span>
-         <span tal:condition="not: item/replace" tal:content="item/content"></span>
+         <span tal:condition="not: item/replace" tal:content="item/content" class="value"></span>
          <span tal:condition="item/replace" tal:replace="structure item/content"></span>
       </li>
     </tal:repeat>

--- a/opengever/document/contentlisting.py
+++ b/opengever/document/contentlisting.py
@@ -34,8 +34,8 @@ class DocumentContentListingObject(RealContentListingObject):
     def is_bumblebeeable(self):
         return is_bumblebee_feature_enabled()
 
-    def render_link(self):
-        return DocumentLinkWidget(self).render()
+    def render_link(self, **kwargs):
+        return DocumentLinkWidget(self).render(**kwargs)
 
     def get_breadcrumbs(self):
         breadcrumbs_view = getMultiAdapter((self._realobject, getRequest()),

--- a/opengever/document/tests/test_document_link_widget.py
+++ b/opengever/document/tests/test_document_link_widget.py
@@ -64,6 +64,24 @@ class TestDocumentLinkWidget(FunctionalTestCase):
         self.assertEquals('You are not allowed to view this document.',
                           link.get('title'))
 
+    @browsing
+    def test_title_can_be_overriden(self, browser):
+        document = create(Builder('document')
+                          .titled('Protocol of the 37th meeting in 2016'))
+        browser.open_html(DocumentLinkWidget(document).render(title='Protocol'))
+
+        link = browser.css('a.document_link').first
+        self.assertEquals('Protocol', link.text)
+
+    @browsing
+    def test_title_can_disable_icon(self, browser):
+        document = create(Builder('document').titled('Important'))
+        browser.open_html(DocumentLinkWidget(document).render())
+        icon_css_class = 'contenttype-opengever-document-document'
+        self.assertIn(icon_css_class, browser.css('a.document_link').first.classes)
+        browser.open_html(DocumentLinkWidget(document).render(show_icon=False))
+        self.assertNotIn(icon_css_class, browser.css('a.document_link').first.classes)
+
 
 class TestDocumentLinkWidgetWithActivatedBumblebee(FunctionalTestCase):
 

--- a/opengever/document/widgets/document_link.py
+++ b/opengever/document/widgets/document_link.py
@@ -20,16 +20,22 @@ class DocumentLinkWidget(object):
         return api.portal.get().absolute_url()
 
     def get_css_class(self):
-        classes = ['document_link', self.document.ContentTypeClass()]
+        classes = ['document_link']
+        if self.show_icon:
+            classes.append(self.document.ContentTypeClass())
         if self.context.is_removed:
             classes.append('removed_document')
 
         return ' '.join(classes)
 
     def get_title(self):
+        if self.title is not None:
+            return self.title
         return self.document.Title().decode('utf-8')
 
-    def render(self):
+    def render(self, title=None, show_icon=True):
+        self.title = title
+        self.show_icon = show_icon
         return self.template(self, self.request)
 
     def is_view_allowed(self):

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -226,6 +226,9 @@ class AgendaItemsView(BrowserView):
                         view='agenda_items/{}/generate_excerpt'.format(
                             item.agenda_item_id))
 
+                if item.is_decided():
+                    data['css_class'] += ' decided'
+
             agenda_items.append(data)
         return agenda_items
 

--- a/opengever/meeting/browser/meetings/byline.py
+++ b/opengever/meeting/browser/meetings/byline.py
@@ -1,0 +1,70 @@
+from opengever.base.browser.helper import get_css_class
+from opengever.base.utils import escape_html
+from opengever.base.viewlets.byline import BylineBase
+from opengever.meeting import _
+from opengever.meeting import is_word_meeting_implementation_enabled
+from opengever.tabbedview.helper import linked
+from plone import api
+from Products.CMFPlone.utils import safe_unicode
+from zope.i18n import translate
+
+
+class MeetingByline(BylineBase):
+
+    def byline_items(self):
+        meeting = self.context.model
+        yield {'class': 'byline-meeting-wf-state-{}'.format(meeting.workflow_state),
+               'label': _('meeting_byline_workflow_state', default='State'),
+               'content': meeting.get_state().title}
+
+        yield {'label': _('meeting_byline_start', default='Start'),
+               'content': meeting.get_start()}
+
+        if meeting.get_end():
+            yield {'label': _('meeting_byline_end', default='End'),
+                   'content': meeting.get_end()}
+
+        if meeting.presidency:
+            yield {'label': _('meeting_byline_presidency', default='Presidency'),
+                   'content': meeting.presidency.fullname}
+
+        if meeting.secretary:
+            yield {'label': _('meeting_byline_secretary', default='Secretary'),
+                   'content':  meeting.secretary.fullname}
+
+        if meeting.location:
+            yield {'label': _('meeting_byline_location', default='Location'),
+                   'content': meeting.location}
+
+        dossier = meeting.get_dossier()
+        if api.user.has_permission('View', obj=dossier):
+            dossier_html = linked(dossier, dossier.Title())
+        else:
+            no_access_tooltip = safe_unicode(translate(
+                _(u'You are not allowed to view the meeting dossier.'),
+                context=self.request))
+            dossier_html = (
+                u'<span class="{classes}">'
+                u'<span class="no_access" title="{no_access_tooltip}">'
+                u'{title}</span></span>').format(
+                    classes=safe_unicode(get_css_class(dossier)),
+                    no_access_tooltip=escape_html(no_access_tooltip),
+                    title=escape_html(safe_unicode(dossier.Title())))
+
+        yield {'label': _('meeting_byline_meetin_dossier', default='Meeting dossier'),
+               'content': dossier_html,
+               'replace': True}
+
+    def get_items(self):
+        if not is_word_meeting_implementation_enabled():
+            return []
+
+        items = []
+
+        for item in self.byline_items():
+            item['content'] = safe_unicode(item['content'])
+            item.setdefault('class', '')
+            item.setdefault('replace', False)
+            items.append(item)
+
+        return items

--- a/opengever/meeting/browser/meetings/byline.py
+++ b/opengever/meeting/browser/meetings/byline.py
@@ -24,13 +24,14 @@ class MeetingByline(BylineBase):
             yield {'label': _('meeting_byline_end', default='End'),
                    'content': meeting.get_end()}
 
-        if meeting.presidency:
-            yield {'label': _('meeting_byline_presidency', default='Presidency'),
-                   'content': meeting.presidency.fullname}
-
-        if meeting.secretary:
-            yield {'label': _('meeting_byline_secretary', default='Secretary'),
-                   'content':  meeting.secretary.fullname}
+        yield self.get_role_item(
+            'byline-presidency',
+            _('meeting_byline_presidency', default='Presidency'),
+            meeting.presidency)
+        yield self.get_role_item(
+            'byline-secretary',
+            _('meeting_byline_secretary', default='Secretary'),
+            meeting.secretary)
 
         if meeting.location:
             yield {'label': _('meeting_byline_location', default='Location'),
@@ -54,6 +55,16 @@ class MeetingByline(BylineBase):
         yield {'label': _('meeting_byline_meetin_dossier', default='Meeting dossier'),
                'content': dossier_html,
                'replace': True}
+
+    def get_role_item(self, classname, label, member):
+        if member:
+            return {'class': classname,
+                    'label': label,
+                    'content': member.fullname}
+        else:
+            return {'class': classname + ' hidden',
+                    'label': label,
+                    'content': ' '}
 
     def get_items(self):
         if not is_word_meeting_implementation_enabled():

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -111,4 +111,12 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:viewlet
+      name="plone.belowcontenttitle.documentbyline"
+      for="opengever.meeting.interfaces.IMeetingWrapper"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+      class=".byline.MeetingByline"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -111,6 +111,14 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IMeetingWrapper"
+      name="participants"
+      class=".participants.ParticipantsView"
+      permission="zope2.View"
+      allowed_interface=".participants.IParticipantsActions"
+      />
+
   <browser:viewlet
       name="plone.belowcontenttitle.documentbyline"
       for="opengever.meeting.interfaces.IMeetingWrapper"

--- a/opengever/meeting/browser/meetings/edit_meeting.py
+++ b/opengever/meeting/browser/meetings/edit_meeting.py
@@ -57,6 +57,12 @@ class EditMeetingView(ModelEditForm):
 
         self.lock()
 
+    def updateFields(self):
+        super(EditMeetingView, self).updateFields()
+        self.fields = (self.fields.omit('presidency')
+                       .omit('secretary')
+                       .omit('participants'))
+
     def is_available_for_current_user(self):
         """Check whether the current meeting can be safely unlocked.
 

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -246,7 +246,7 @@ class MeetingView(BrowserView):
         return self.context.get_unscheduled_proposals()
 
     def get_protocol_document_label(self):
-        if self.model.get_state() == self.model.STATE_PENDING:
+        if self.model.is_pending():
             return _(u'document_label_pre_protocol', u'Pre-protocol')
         else:
             return _(u'document_label_protocol', u'Protocol')
@@ -475,7 +475,7 @@ class MeetingView(BrowserView):
             'Modify portal content',
             obj=self.model.committee.resolve_committee())
 
-        if self.model.get_state() == self.model.STATE_CLOSED:
+        if self.model.is_closed():
             infos['is_closed'] = True
             infos['reopen_url'] = can_change and transition_controller.url_for(
                 self.context, self.model, 'closed-held')

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -242,10 +242,21 @@ class MeetingView(BrowserView):
     def unscheduled_proposals(self):
         return self.context.get_unscheduled_proposals()
 
+    def get_protocol_document_label(self):
+        if self.model.get_state() == self.model.STATE_PENDING:
+            return _(u'document_label_pre_protocol', u'Pre-protocol')
+        else:
+            return _(u'document_label_protocol', u'Protocol')
+
     def get_protocol_document(self):
         if self.model.protocol_document:
             return IContentListingObject(
                 self.model.protocol_document.resolve_document())
+
+    def get_protocol_document_link(self):
+        document = self.get_protocol_document()
+        return document.render_link(title=self.get_protocol_document_label(),
+                                    show_icon=False)
 
     def get_agendaitem_list_document(self):
         if self.model.agendaitem_list_document:

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -348,6 +348,10 @@ class MeetingView(BrowserView):
         else:
             return self.render_handlebars_agendaitems_template_noword()
 
+    def render_handlebars_navigation_template(self):
+        return prepare_handlebars_template(
+            TEMPLATES_DIR.joinpath('navigation-word.html'))
+
     def render_handlebars_agendaitems_template_noword(self):
         return prepare_handlebars_template(
             TEMPLATES_DIR.joinpath('agendaitems-noword.html'),

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -252,6 +252,12 @@ class MeetingView(BrowserView):
             return IContentListingObject(
                 self.model.agendaitem_list_document.resolve_document())
 
+    def get_agendaitem_list_document_link(self):
+        document = self.get_agendaitem_list_document()
+        return document.render_link(title=_(u'document_label_agenda_item_list',
+                                            default=u'Agenda item list'),
+                                    show_icon=False)
+
     def url_protocol(self):
         return self.model.get_url(view='protocol')
 

--- a/opengever/meeting/browser/meetings/participants.py
+++ b/opengever/meeting/browser/meetings/participants.py
@@ -1,0 +1,95 @@
+from functools import wraps
+from opengever.base.response import JSONResponse
+from opengever.meeting import _
+from opengever.meeting import require_word_meeting_feature
+from opengever.meeting.model.membership import Membership
+from Products.Five.browser import BrowserView
+from zope.interface import Interface
+import json
+
+
+MSG_SAVE_FAILURE = _(u'Failed to save.')
+MSG_NOT_ALLOWED_TO_CHANGE_MEETING = _(
+    u'You are not allowed to change the meeting details.')
+
+
+class IParticipantsActions(Interface):
+
+    def change_role():
+        """Change the role of a participant.
+        """
+
+    def change_presence():
+        """Change the presence of a participant.
+        """
+
+
+def require_meeting_edit_permission(func):
+    """Decorator for protecting an endpoint to require an editable meeting.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if not self.meeting.is_editable():
+            return (JSONResponse(self.request)
+                    .error(MSG_NOT_ALLOWED_TO_CHANGE_MEETING)
+                    .remain()
+                    .dump())
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+class ParticipantsView(BrowserView):
+
+    def __init__(self, context, request):
+        super(ParticipantsView, self).__init__(context, request)
+        self.meeting = self.context.model
+
+    @require_word_meeting_feature
+    @require_meeting_edit_permission
+    def change_role(self):
+        """Change the role of a participant.
+        """
+        response = JSONResponse(self.request)
+        role = self.request.form.get('role', None)
+        member = self.get_member()
+        if role is None or member is None:
+            return response.error(MSG_SAVE_FAILURE).remain().dump()
+
+        if self.meeting.presidency == member:
+            self.meeting.presidency = None
+        if self.meeting.secretary == member:
+            self.meeting.secretary = None
+
+        if role == 'presidency':
+            self.meeting.presidency = member
+        elif role == 'secretary':
+            self.meeting.secretary = member
+        return response.proceed().dump()
+
+    @require_word_meeting_feature
+    @require_meeting_edit_permission
+    def change_presence(self):
+        """Change the presence of a participant.
+        """
+        response = JSONResponse(self.request)
+        present = self.request.form.get('present', None)
+        member = self.get_member()
+        if not present or not member:
+            return response.error(MSG_SAVE_FAILURE).remain().dump()
+
+        present = json.loads(present)
+        if present and member not in self.meeting.participants:
+            self.meeting.participants.append(member)
+        elif not present and member in self.meeting.participants:
+            self.meeting.participants.remove(member)
+        return response.proceed().dump()
+
+    def get_member(self):
+        member_id = self.request.form.get('member_id', None)
+        if not member_id:
+            return None
+        memberships = Membership.query.for_meeting(self.meeting).filter_by(
+            member_id=member_id).first()
+        if not memberships:
+            return None
+        return memberships.member

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -1,6 +1,6 @@
 <script id="agendaitemsTemplate" type="text/x-handlebars-template">
   {{#each agendaitems}}
-  <tr class="{{css_class}} word-feature agenda_item" data-uid={{id}}>
+  <tr class="{{css_class}} word-feature agenda_item" data-uid="{{id}}" id="ai{{id}}">
     {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
     <td class="title">
       {{#if decision_number}}

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -171,7 +171,8 @@
                 <tal:block tal:replace="structure view/render_handlebars_navigation_template"></tal:block>
               </nav>
 
-              <div class="meeting-process">
+              <div class="meeting-process"
+                   tal:define="closing_infos view/get_closing_infos">
 
                 <div class="agenda-item-list-doc meeting-document"
                      tal:define="agendaitem_list_document view/get_agendaitem_list_document">
@@ -218,6 +219,16 @@
 
                 </div>
 
+                <div class="meeting-workflow">
+                  <div class="meeting-closed"
+                       tal:condition="closing_infos/is_closed"
+                       i18n:translate="label_meeting_closed">Meeting closed</div>
+                  <a class="reopen-meeting"
+                     tal:condition="closing_infos/reopen_url"
+                     tal:attributes="href closing_infos/reopen_url"
+                     i18n:translate="action_reopen_meeting">Reopen meeting</a>
+                </div>
+
                 <div class="protocol-doc meeting-document"
                      tal:define="protocol_document view/get_protocol_document">
 
@@ -259,6 +270,17 @@
                     </div>
                   </tal:GENERATED>
 
+                </div>
+
+                <div class="meeting-workflow" tal:condition="meeting/is_editable">
+                  <div class="close-meeting" tal:condition="closing_infos/close_url">
+                    <a tal:attributes="href closing_infos/close_url"
+                       i18n:translate="action_close_meeting">Close meeting</a>
+                    <div class="close-meeting-helptext"
+                         i18n:translate="msg_require_all_agenda_items_decided_for_closing">
+                      The meeting can only be closed when all agenda items are decided.
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -9,7 +9,19 @@
   <metal:title metal:fill-slot="content-title">
     <metal:use use-macro="context/@@gever-macros/js_default_error_messages" />
     <div id="tabbedview-header">
-      <h1 class="memberHeading meeting-view-heading documentFirstHeading" tal:content="view/model/get_title" />
+      <h1 class="memberHeading meeting-view-heading documentFirstHeading">
+        <span tal:content="view/model/get_title" />
+        <span class="meeting-number"
+              tal:define="meeting view/model"
+              tal:condition="meeting/meeting_number"
+              i18n:attributes="title"
+              title="Meeting number">
+          #
+          <tal:YEAR replace="meeting/start/year" />
+          /
+          <tal:MEETING_NUMBER replace="meeting/meeting_number" />
+        </span>
+      </h1>
     </div>
   </metal:title>
 
@@ -136,14 +148,6 @@
         </div>
 
         <div class="meeting-metadata">
-          <table class="meeting-metadata">
-
-            <tr>
-              <th i18n:translate="view_label_meeting_number">Meeting number:</th>
-              <td tal:content="meeting/meeting_number" />
-            </tr>
-
-          </table>
           <table class="meeting-metadata">
 
             <tr>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -138,50 +138,12 @@
           <table class="meeting-metadata">
 
             <tr>
-              <th i18n:translate="view_label_meeting_status">Status:</th>
-              <td>
-                <span tal:attributes="class python: 'wf-meeting-state-' + meeting.workflow_state"
-                      tal:content="python: meeting.get_state().title" />
-              </td>
-            </tr>
-
-            <tr>
-              <th i18n:translate="view_label_meeting_start">Meeting start:</th>
-              <td tal:content="meeting/get_start" />
-            </tr>
-
-            <tr tal:define="end meeting/get_end"
-                tal:condition="end">
-              <th i18n:translate="view_label_meeting_end">Meeting end:</th>
-              <td tal:content="end" />
-            </tr>
-
-            <tr>
-              <th i18n:translate="view_label_meeting_location">Location:</th>
-              <td tal:content="meeting/location" />
-            </tr>
-
-            <tr>
               <th i18n:translate="view_label_meeting_number">Meeting number:</th>
               <td tal:content="meeting/meeting_number" />
             </tr>
 
           </table>
           <table class="meeting-metadata">
-
-            <tr tal:define="presidency meeting/presidency">
-              <th i18n:translate="view_label_presidency">Presidency:</th>
-              <td tal:condition="presidency"
-                  tal:content="structure meeting/presidency/get_title" />
-              <td tal:condition="not:presidency">-</td>
-            </tr>
-
-            <tr tal:define="secretary meeting/secretary">
-              <th i18n:translate="view_label_secretary">Secretary:</th>
-              <td tal:condition="secretary"
-                  tal:content="structure meeting/secretary/get_title" />
-              <td tal:condition="not:secretary">-</td>
-            </tr>
 
             <tr>
               <th i18n:translate="view_label_participants">Participants:</th>
@@ -206,16 +168,6 @@
           </table>
 
           <table class="meeting-metadata">
-
-            <tr>
-              <th i18n:translate="view_label_dossier">Meeting dossier:</th>
-              <td tal:define="dossier meeting/get_dossier">
-                <a tal:attributes="href dossier/absolute_url;
-                                   class python: view.get_css_class(dossier)"
-                   tal:content="dossier/title" />
-              </td>
-              <td></td>
-            </tr>
 
             <tr tal:define="agendaitem_list_document view/get_agendaitem_list_document">
               <th i18n:translate="view_label_agendaitem_list">Agenda item list:</th>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -167,6 +167,10 @@
 
           <div class="panes">
             <div id="tab-overview">
+              <nav class="meeting-navigation">
+                <tal:block tal:replace="structure view/render_handlebars_navigation_template"></tal:block>
+              </nav>
+
               <div class="meeting-process">
 
                 <div class="agenda-item-list-doc meeting-document"

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -16,7 +16,8 @@
   <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core"
                         tal:define="meeting view/model;
-                                    unscheduled_proposals view/unscheduled_proposals">
+                                    unscheduled_proposals view/unscheduled_proposals;
+                                    toLocalizedTime nocall:context/@@plone/toLocalizedTime">
 
       <div id="opengever_meeting_meeting"
            class="word-feature"
@@ -169,40 +170,6 @@
 
           <table class="meeting-metadata">
 
-            <tr tal:define="agendaitem_list_document view/get_agendaitem_list_document">
-              <th i18n:translate="view_label_agendaitem_list">Agenda item list:</th>
-              <td class="agendaitem-list">
-                <div tal:condition="not:agendaitem_list_document"
-                     i18n:translate="label_no_agendaitem_list">No agenda item list has been generated yet.</div>
-
-                <div tal:condition="agendaitem_list_document"
-                     class="agendaitem_list-file">
-                  <a tal:replace="structure agendaitem_list_document/render_link" />
-                </div>
-              </td>
-              <td class="item agendaitem-list-buttons">
-                <span>
-                  <a class="generate-agendaitem-list"
-                     tal:condition="python: meeting.is_editable() and not view.has_agendaitem_list_document()"
-                     tal:attributes="href view/url_generate_agendaitem_list;"
-                     i18n:attributes="title"
-                     title="generate new agenda item list as word document" />
-
-                  <a class="download-agendaitem-list-btn"
-                     tal:condition="python: meeting.is_editable() and agendaitem_list_document"
-                     tal:attributes="href view/url_download_agendaitem_list"
-                     i18n:attributes="title"
-                     title="Download agenda item list" />
-
-                  <a class="refresh-agendaitem-list"
-                     tal:condition="python: meeting.is_editable() and view.has_agendaitem_list_document()"
-                     tal:attributes="href view/url_generate_agendaitem_list;"
-                     i18n:attributes="title"
-                     title="generate new version as word document" />
-                </span>
-              </td>
-            </tr>
-
             <tr tal:define="protocol_document view/get_protocol_document">
               <th i18n:translate="view_label_protocol">Protocol:</th>
               <td class="protocol">
@@ -238,6 +205,71 @@
             </tr>
 
           </table>
+        </div>
+
+
+
+
+        <div class="sidebar">
+          <ul class="formTabs">
+            <li class="formTab">
+              <a href="#tab-overview" i18n:translate="tab_overview">Overview</a>
+            </li>
+          </ul>
+
+          <div class="panes">
+            <div id="tab-overview">
+              <div class="meeting-process">
+
+                <div class="agenda-item-list-doc meeting-document"
+                     tal:define="agendaitem_list_document view/get_agendaitem_list_document">
+
+                  <div class="document-actions">
+                    <a class="action generate"
+                       tal:condition="meeting/is_editable"
+                       tal:attributes="href view/url_generate_agendaitem_list"
+                       i18n:translate="action_generate_document"
+                       i18n:attributes="title action_generate_document"
+                       title=""></a>
+
+                    <a class="action download"
+                       tal:condition="agendaitem_list_document"
+                       tal:attributes="href view/url_download_agendaitem_list"
+                       i18n:translate="action_download_document"
+                       i18n:attributes="title action_download_document"
+                       title=""></a>
+                  </div>
+
+                  <tal:NOT_GENERATED tal:condition="not:agendaitem_list_document">
+                    <div class="document-label"
+                         i18n:translate="document_label_agenda_item_list">
+                      Agenda item list
+                    </div>
+                    <div class="document-created"
+                         i18n:translate="document_not_yet_generated">
+                      Not yet generated.
+                    </div>
+                  </tal:NOT_GENERATED>
+
+                  <tal:GENERATED tal:condition="agendaitem_list_document">
+                    <div class="document-label">
+                      <a tal:replace="structure view/get_agendaitem_list_document_link" />
+                    </div>
+                    <div class="document-created"
+                         i18n:translate="document_created_at">
+                      Created at
+                      <tal:date
+                          replace="python:toLocalizedTime(agendaitem_list_document.getObject().ModificationDate(), long_format=1)"
+                          i18n:name="date" />
+                    </div>
+                  </tal:GENERATED>
+
+                </div>
+              </div>
+
+
+            </div>
+          </div>
         </div>
 
 

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -147,39 +147,21 @@
           </form>
         </div>
 
-        <div class="meeting-metadata">
-          <table class="meeting-metadata">
-
-            <tr>
-              <th i18n:translate="view_label_participants">Participants:</th>
-              <td>
-                <ul>
-                  <li tal:repeat="participant meeting/participants"
-                      tal:content="structure participant/get_title"></li>
-                </ul>
-              </td>
-            </tr>
-
-            <tr tal:condition="meeting/get_other_participants_list">
-              <th></th>
-              <td>
-                <ul>
-                  <li tal:repeat="participant meeting/get_other_participants_list"
-                      tal:content="structure participant"></li>
-                </ul>
-              </td>
-            </tr>
-
-          </table>
-        </div>
 
 
-
-
-        <div class="sidebar">
+        <div class="sidebar"
+             tal:define="participants view/get_participants">
           <ul class="formTabs">
             <li class="formTab">
               <a href="#tab-overview" i18n:translate="tab_overview">Overview</a>
+            </li>
+            <li class="formTab">
+              <a href="#tab-participants" i18n:translate="tab_participants">
+                <span class="participants_count"
+                      i18n:name="count"
+                      tal:content="python:len(participants)" />
+                Participants
+              </a>
             </li>
           </ul>
 
@@ -275,7 +257,68 @@
 
                 </div>
               </div>
+            </div>
 
+
+            <div id="tab-participants">
+              <a id="clear-participants-filter"
+                 title="Clear filter"
+                 i18n:attributes="title" />
+              <input id="participants-filter"
+                     placeholder="Filter participants"
+                     i18n:attributes="placeholder" />
+
+              <ul class="participant-list">
+                <li tal:repeat="participant participants"
+                    tal:define="cls python:meeting.is_editable() and 'editable' or '';
+                                cls string:participant folded ${cls}"
+                    tal:attributes="data-member-id participant/member_id;
+                                    class cls">
+                  <div tal:attributes="class participant/presence_cssclass" />
+                  <div class="fullname" tal:content="participant/fullname" />
+                  <a class="email" tal:condition="participant/email"
+                     tal:attributes="href string:mailto:${participant/email}"
+                     i18n:attributes="title"
+                     title="send email" />
+                  <div class="role"
+                       tal:content="participant/role/label"
+                       tal:attributes="data-rolename participant/role/name"/>
+
+                  <div class="select-role-wrapper" tal:condition="meeting/is_editable">
+                    <select class="role"
+                            tal:attributes="data-url string:${context/absolute_url}/participants/change_role;
+                                            data-member_id participant/member_id">
+                      <option value=""></option>
+                      <option value="presidency" i18n:translate="meeting_role_presidency">Presidency</option>
+                      <option value="secretary" i18n:translate="meeting_role_secretary">Secretary</option>
+                    </select>
+                  </div>
+
+                  <div class="change_presence" tal:condition="meeting/is_editable">
+                    <input type="checkbox"
+                           tal:attributes="id string:presence-${participant/member_id};
+                                           data-url string:${context/absolute_url}/participants/change_presence;
+                                           data-member_id participant/member_id"
+                           class="excused" />
+                    <label i18n:translate="excused"
+                           tal:attributes="for string:presence-${participant/member_id}">Excused</label>
+                  </div>
+
+                </li>
+              </ul>
+
+              <div class="other_participants"
+                   tal:define="other_participants meeting/get_other_participants_list"
+                   tal:condition="other_participants">
+                <div class="other_participants_label"
+                     i18n:translate="label_other_participants">Other Participants</div>
+                <ul class="participant-list">
+                  <li class="participant"
+                      tal:repeat="participant other_participants">
+                    <div class="fullname" tal:content="participant" />
+                  </li>
+                </ul>
+              </div>
 
             </div>
           </div>

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -167,44 +167,6 @@
             </tr>
 
           </table>
-
-          <table class="meeting-metadata">
-
-            <tr tal:define="protocol_document view/get_protocol_document">
-              <th i18n:translate="view_label_protocol">Protocol:</th>
-              <td class="protocol">
-                <div tal:condition="not:protocol_document"
-                     i18n:translate="label_no_protocol">No protocol has been generated yet.</div>
-
-                <div tal:condition="protocol_document"
-                     class="protocol-file">
-                  <a tal:replace="structure protocol_document/render_link" />
-                </div>
-              </td>
-              <td class="protocol-buttons">
-                <span>
-                  <a class="generate-protocol"
-                     tal:condition="python: meeting.is_editable() and not view.has_protocol_document()"
-                     tal:attributes="href view/url_generate_protocol;"
-                     i18n:attributes="title"
-                     title="generate new protocol as word document" />
-
-                  <a class="download-protocol-btn"
-                     tal:condition="python: meeting.is_editable() and protocol_document"
-                     tal:attributes="href view/url_download_protocol"
-                     i18n:attributes="title"
-                     title="download protocol" />
-
-                  <a class="refresh-protocol"
-                     tal:condition="python: meeting.is_editable() and view.has_protocol_document()"
-                     tal:attributes="href view/url_generate_protocol;"
-                     i18n:attributes="title"
-                     title="generate new version as word document" />
-                </span>
-              </td>
-            </tr>
-
-          </table>
         </div>
 
 
@@ -260,6 +222,49 @@
                       Created at
                       <tal:date
                           replace="python:toLocalizedTime(agendaitem_list_document.getObject().ModificationDate(), long_format=1)"
+                          i18n:name="date" />
+                    </div>
+                  </tal:GENERATED>
+
+                </div>
+
+                <div class="protocol-doc meeting-document"
+                     tal:define="protocol_document view/get_protocol_document">
+
+                  <div class="document-actions">
+                    <a class="action generate"
+                       tal:condition="meeting/is_editable"
+                       tal:attributes="href view/url_generate_protocol"
+                       i18n:translate="action_generate_document"
+                       i18n:attributes="title action_generate_document"
+                       title=""></a>
+
+                    <a class="action download"
+                       tal:condition="protocol_document"
+                       tal:attributes="href view/url_download_protocol"
+                       i18n:translate="action_download_document"
+                       i18n:attributes="title action_download_document"
+                       title=""></a>
+                  </div>
+
+                  <tal:NOT_GENERATED tal:condition="not:protocol_document">
+                    <div class="document-label"
+                         tal:content="view/get_protocol_document_label" />
+                    <div class="document-created"
+                         i18n:translate="document_not_yet_generated">
+                      Not yet generated.
+                    </div>
+                  </tal:NOT_GENERATED>
+
+                  <tal:GENERATED tal:condition="protocol_document">
+                    <div class="document-label">
+                      <a tal:replace="structure view/get_protocol_document_link" />
+                    </div>
+                    <div class="document-created"
+                         i18n:translate="document_created_at">
+                      Created at
+                      <tal:date
+                          replace="python:toLocalizedTime(protocol_document.getObject().ModificationDate(), long_format=1)"
                           i18n:name="date" />
                     </div>
                   </tal:GENERATED>

--- a/opengever/meeting/browser/meetings/templates/navigation-word.html
+++ b/opengever/meeting/browser/meetings/templates/navigation-word.html
@@ -1,0 +1,12 @@
+<script id="navigationTemplate" type="text/x-handlebars-template">
+  <ul>
+    {{#each agendaitems}}
+    <li>
+      <a href="#ai{{id}}" class="{{css_class}}">
+        <span class="number">{{number}}</span>
+        <span class="title">{{title}}</span>
+      </a>
+    </li>
+    {{/each}}
+  </ul>
+</script>

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -1,4 +1,4 @@
-(function(global, $, Controller, EditboxController, Pin) {
+(function(global, $, Controller, EditboxController, Pin, HBS) {
 
   "use strict";
 
@@ -317,15 +317,21 @@
     };
 
     Controller.call(this, $("#agendaitemsTemplate").html(), $("#agenda_items tbody"), options);
+    this.navigationTemplate = HBS.compile($("#navigationTemplate").html());
 
     this.fetch = function() { return $.get(viewlet.data().listAgendaItemsUrl); };
 
     this.render = function(data) {
+      self.renderNavigation(data);
       return self.template({
         agendaitems: data.items,
         editable: viewlet.data().editable,
         agendalist_editable: viewlet.data().agendalist_editable
       });
+    };
+
+    this.renderNavigation = function(data) {
+      $('.meeting-navigation').html(this.navigationTemplate({agendaitems: data.items}));
     };
 
     this.openModal = function(target) {
@@ -461,6 +467,12 @@
       });
     };
 
+    this.navigationClick = function(target) {
+      $('html, body').animate({
+        scrollTop: $(target.attr('href')).offset().top
+      }, 150);
+    };
+
     this.events = [
       {
         method: "click",
@@ -580,6 +592,14 @@
         method: "click",
         target: "#confirm_hold_meeting .decline",
         callback: this.declineDecide
+      },
+      {
+        method: "click",
+        target: ".meeting-navigation a",
+        callback: this.navigationClick,
+        options: {
+          prevent: false
+        }
       }
     ];
 
@@ -759,4 +779,4 @@
     });
   });
 
-}(window, window.jQuery, window.Controller, window.EditboxController, window.Pin));
+}(window, window.jQuery, window.Controller, window.EditboxController, window.Pin, window.Handlebars));

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -174,7 +174,7 @@
     this.events = [
       {
         method: "click",
-        target: "#pending-closed",
+        target: "#pending-closed, #held-closed, .close-meeting a",
         callback: this.openModal,
         options: {
           update: true
@@ -182,15 +182,7 @@
       },
       {
         method: "click",
-        target: "#held-closed",
-        callback: this.openModal,
-        options: {
-          update: true
-        }
-      },
-      {
-        method: "click",
-        target: "#closed-held",
+        target: "#closed-held, .reopen-meeting",
         callback: this.reopenMeeting,
         options: {
           update: true
@@ -399,6 +391,7 @@
     this.onRender = function() {
       this.outlet.sortable(sortableSettings);
       $(document).trigger("agendaItemsReady");
+      this.updateCloseTransitionActionState();
     };
 
     this.onUpdateFail = function(data) { self.messageFactory.shout(data.messages); };
@@ -426,17 +419,22 @@
         if (data.redirectUrl){
           window.location = data.redirectUrl;
         }
+        self.updateCloseTransitionActionState();
       });
     };
 
     this.declineDecide = function() { holdDialog.close(); };
 
     this.reopen = function(target){
-      return $.post(target.attr("href"));
+      return $.post(target.attr("href")).done(function() {
+        self.updateCloseTransitionActionState();
+      });
     };
 
     this.revise = function(target){
-      return $.post(target.attr("href"));
+      return $.post(target.attr("href")).done(function() {
+        self.updateCloseTransitionActionState();
+      });
     };
 
     this.editDocument = function(target) {
@@ -492,6 +490,15 @@
       $('.panes').height(null);
       $('.panes').height(Math.max($('.panes').height(),
                                   $('#content-core').height()));
+    };
+
+    this.updateCloseTransitionActionState = function() {
+      if($('.decide-agenda-item, .revise-agenda-item').length > 0) {
+        $('.close-meeting').addClass('disabled');
+      } else {
+        $('.close-meeting').removeClass('disabled');
+      }
+      this.updateNavigationScrollArea();
     };
 
     this.events = [

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -332,6 +332,7 @@
 
     this.renderNavigation = function(data) {
       $('.meeting-navigation').html(this.navigationTemplate({agendaitems: data.items}));
+      this.updateNavigationScrollArea();
     };
 
     this.openModal = function(target) {
@@ -471,6 +472,26 @@
       $('html, body').animate({
         scrollTop: $(target.attr('href')).offset().top
       }, 150);
+    };
+
+    this.updateNavigationScrollArea = function() {
+      /** When necessary, make the navigation scrollable, so that the
+          meeting process area also has enough space. **/
+      $('.meeting-navigation').css('max-height', '');
+      /** Let the navigation have the screen size minues the size of the
+          meeting process div. **/
+      var navigation_max_height = $(window).height() - $('.meeting-process').outerHeight();
+      if($('.meeting-navigation').height() > navigation_max_height) {
+        $('.meeting-navigation').addClass('scroll');
+      } else {
+        $('.meeting-navigation').removeClass('scroll');
+      }
+      $('.meeting-navigation').css('max-height', navigation_max_height);
+
+      /** Set the container height so that stickyness works. */
+      $('.panes').height(null);
+      $('.panes').height(Math.max($('.panes').height(),
+                                  $('#content-core').height()));
     };
 
     this.events = [

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -402,6 +402,7 @@
       this.currentDecideTarget = target;
       if(viewlet.data().agendalist_editable) {
         holdDialog.load();
+        return null;
       }
       else {
         return this.confirmDecide(target);
@@ -448,11 +449,10 @@
     this.generateExcerpt = function(target, event) {
       var link = self.currentItem[0].href;
       self = this;
-      return $.post(link, $('#confirm_create_excerpt form').serialize())
-              .always(function() {
-                self.closeModal();
-              });
-    }
+      return $.post(link, $('#confirm_create_excerpt form').serialize()).always(function() {
+        self.closeModal();
+      });
+    };
 
     this.returnExcerpt = function() {
       self = this;
@@ -705,6 +705,7 @@
         return false;
       }
       title.val(initialTitle + ", " + formatDate(date));
+      return true;
     }
 
     this.trackDate = function(target, event) { applyDate(applyTimezone(event.date)); };

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -579,6 +579,9 @@
       window.addEventListener("pageshow", function() {
         agendaItemController.update();
       });
+
+      $('#opengever_meeting_meeting .sidebar > ul.formTabs').tabs(
+            '.sidebar .panes > div', {current: 'selected'});
     }
 
     if ($(".template-add-meeting").length) {

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -330,9 +330,10 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
             context=getRequest())
 
         Versioner(document).create_version(comment)
-
         new_version = document.get_current_version_id()
         self.meeting.protocol_document.generated_version = new_version
+        document.setModificationDate(DateTime())
+        document.reindexObject(idxs=['modified'])
 
         return document
 

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from opengever.base import advancedjson
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.interfaces import IDataCollector
@@ -404,9 +405,10 @@ class UpdateGeneratedDocumentCommand(object):
             context=getRequest())
 
         Versioner(document).create_version(comment)
-
         new_version = document.get_current_version_id()
         self.generated_document.generated_version = new_version
+        document.setModificationDate(DateTime())
+        document.reindexObject(idxs=['modified'])
 
         return document
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-10-24 12:48+0000\n"
-"PO-Revision-Date: 2017-10-20 16:49+0200\n"
+"PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -396,6 +396,11 @@ msgstr "Sie haben nicht die nötigen Rechte, um Änderungen vorzunehmen."
 msgid "You are not allowed to view the meeting dossier."
 msgstr "Sie haben nicht die nötigen Rechte, um das Sitzungsdossier anzusehen."
 
+#. Default: "Close meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_close_meeting"
+msgstr "Sitzung abschliessen"
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "action_download_document"
 msgstr "Dokument herunterladen"
@@ -403,6 +408,11 @@ msgstr "Dokument herunterladen"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "action_generate_document"
 msgstr "Dokument neu generieren"
+
+#. Default: "Reopen meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_reopen_meeting"
+msgstr "Sitzung wieder öffnen"
 
 #. Default: "Active"
 #: ./opengever/meeting/browser/documents/proposalstab.py
@@ -1129,6 +1139,11 @@ msgstr "Eigenschaften"
 msgid "label_meeting"
 msgstr "Sitzung"
 
+#. Default: "Meeting closed"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "label_meeting_closed"
+msgstr "Sitzung abgeschlossen"
+
 #. Default: "Member"
 #: ./opengever/meeting/browser/memberships.py
 msgid "label_member"
@@ -1529,6 +1544,11 @@ msgstr "Der Antrag wurde wieder eröffnet."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
 msgstr "Antrag erfolgreich eingereicht."
+
+#. Default: "The meeting can only be closed when all agenda items are decided."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "msg_require_all_agenda_items_decided_for_closing"
+msgstr "Die Sitzung kann erst abgeschlossen werden wenn alle Traktanden beschlossen sind."
 
 #. Default: "The object was deleted successfully."
 #: ./opengever/meeting/browser/views.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-10-24 12:47+0000\n"
-"PO-Revision-Date: 2017-10-11 09:21+0200\n"
+"PO-Revision-Date: 2017-10-20 16:49+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -152,7 +152,6 @@ msgid "Documents"
 msgstr "Dokumente"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Download agenda item list"
 msgstr "Traktandenliste herunterladen"
 
@@ -379,6 +378,14 @@ msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "You are not allowed to view the meeting dossier."
 msgstr "Sie haben nicht die nötigen Rechte, um das Sitzungsdossier anzusehen."
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_download_document"
+msgstr "Dokument herunterladen"
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_generate_document"
+msgstr "Dokument neu generieren"
 
 #. Default: "Active"
 #: ./opengever/meeting/browser/documents/proposalstab.py
@@ -616,6 +623,22 @@ msgstr "Für diese Gruppe werden automatisch Berechtigungen auf dem Gremium verg
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
+#. Default: "Created at ${date}"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_created_at"
+msgstr "Erstellt am ${date} Uhr"
+
+#. Default: "Agenda item list"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_label_agenda_item_list"
+msgstr "Traktandenliste"
+
+#. Default: "Not yet generated."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_not_yet_generated"
+msgstr "Noch nicht generiert."
+
 #. Default: "Dossier"
 #: ./opengever/meeting/tabs/meetinglisting.py
 msgid "dossier"
@@ -677,7 +700,6 @@ msgid "filename_repository_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} nach Ordnungsposition"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new agenda item list as word document"
 msgstr "Traktandenliste als Worddokument generieren"
 
@@ -1095,7 +1117,6 @@ msgstr "Nächste Sitzung:"
 
 #. Default: "No agenda item list has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_agendaitem_list"
 msgstr "Es wurde noch keine Traktandenliste generiert."
 
@@ -1663,6 +1684,11 @@ msgstr "Anträge"
 msgid "tab_matches"
 msgstr "${amount} Treffer"
 
+#. Default: "Overview"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "tab_overview"
+msgstr "Übersicht"
+
 #. Default: "Text successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
@@ -1696,11 +1722,6 @@ msgstr "Zwischentitel einfügen:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
-
-#. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_agendaitem_list"
-msgstr "Traktandenliste:"
 
 #. Default: "Meeting number:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -241,6 +241,7 @@ msgid "Meeting Dossier"
 msgstr "Sitzungsdossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
@@ -1728,11 +1729,6 @@ msgstr "Zwischentitel einfügen:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
-
-#. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_number"
-msgstr "Sitzungsnummer:"
 
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:47+0000\n"
+"POT-Creation-Date: 2017-10-24 12:48+0000\n"
 "PO-Revision-Date: 2017-10-20 16:49+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -634,6 +634,16 @@ msgstr "Erstellt am ${date} Uhr"
 msgid "document_label_agenda_item_list"
 msgstr "Traktandenliste"
 
+#. Default: "Pre-protocol"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "document_label_pre_protocol"
+msgstr "Vorprotokoll"
+
+#. Default: "Protocol"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "document_label_protocol"
+msgstr "Protokoll"
+
 #. Default: "Not yet generated."
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "document_not_yet_generated"
@@ -645,7 +655,6 @@ msgid "dossier"
 msgstr "Dossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
 
@@ -708,12 +717,10 @@ msgid "generate new excerpt"
 msgstr "Neuer Protokollauszug generieren"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new protocol as word document"
 msgstr "Protokoll als Worddokument generieren"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new version as word document"
 msgstr "Neue Version als Worddokument generieren"
 
@@ -1137,7 +1144,6 @@ msgstr "Keine Anträge eingereicht"
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_protocol"
 msgstr "Es wurde noch kein Protokoll generiert."
 
@@ -1732,11 +1738,6 @@ msgstr "Sitzungsnummer:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
 msgstr "Teilnehmer:"
-
-#. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_protocol"
-msgstr "Protokoll:"
 
 #. Default: "Schedule ad hoc agenda item:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -109,6 +109,10 @@ msgstr "Die Mitgliedschaft kann nicht geändert werden, weil sie eine bestehende
 msgid "Choose Agenda Items"
 msgstr "Traktanden auswählen"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Clear filter"
+msgstr "Filter leeren"
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Close all proposals."
 msgstr "Alle Anträge werden abgeschlossen."
@@ -187,6 +191,14 @@ msgstr "Protokollauszüge"
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Export settings"
 msgstr "Export-Einstellungen"
+
+#: ./opengever/meeting/browser/meetings/participants.py
+msgid "Failed to save."
+msgstr "Speichern fehlgeschlagen."
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Filter participants"
+msgstr "Teilnehmer filtern"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Generate excerpts for all proposals."
@@ -375,6 +387,10 @@ msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs übers
 #: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
+
+#: ./opengever/meeting/browser/meetings/participants.py
+msgid "You are not allowed to change the meeting details."
+msgstr "Sie haben nicht die nötigen Rechte, um Änderungen vorzunehmen."
 
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "You are not allowed to view the meeting dossier."
@@ -698,6 +714,11 @@ msgstr "Protokollauszug erfolgreich generiert."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
 msgstr "Der Protokollauszug wurde an den Antragsteller zurückgesendet."
+
+#. Default: "Excused"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "excused"
+msgstr "Entschuldigt"
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
@@ -1150,6 +1171,7 @@ msgstr "Es wurde noch kein Protokoll generiert."
 
 #. Default: "Other Participants"
 #: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_other_participants"
 msgstr "Weitere Teilnehmende"
 
@@ -1388,6 +1410,18 @@ msgstr "Beginn"
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "meeting_byline_workflow_state"
 msgstr "Status"
+
+#. Default: "Presidency"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "meeting_role_presidency"
+msgstr "Vorsitz"
+
+#. Default: "Secretary"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "meeting_role_secretary"
+msgstr "Protokollführung"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
@@ -1667,6 +1701,10 @@ msgstr "Traktandiert"
 msgid "secretary"
 msgstr "Protokollführer"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "send email"
+msgstr "E-Mail senden"
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "status"
 msgstr "Status"
@@ -1695,6 +1733,11 @@ msgstr "${amount} Treffer"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "tab_overview"
 msgstr "Übersicht"
+
+#. Default: "${count} Participants"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "tab_participants"
+msgstr "${count} Teilnehmer"
 
 #. Default: "Text successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -1729,11 +1772,6 @@ msgstr "Zwischentitel einfügen:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
 msgstr "Traktanden"
-
-#. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_participants"
-msgstr "Teilnehmer:"
 
 #. Default: "Schedule ad hoc agenda item:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:44+0000\n"
+"POT-Creation-Date: 2017-10-24 12:47+0000\n"
 "PO-Revision-Date: 2017-10-11 09:21+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -375,6 +375,10 @@ msgstr "Das Dokument wurde durch eine neuere Version des Protokollauszugs übers
 #: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Mit einer neuen Version der Sitzung ${title} aktualisiert."
+
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "You are not allowed to view the meeting dossier."
+msgstr "Sie haben nicht die nötigen Rechte, um das Sitzungsdossier anzusehen."
 
 #. Default: "Active"
 #: ./opengever/meeting/browser/documents/proposalstab.py
@@ -1322,6 +1326,41 @@ msgstr "Sprache"
 msgid "location"
 msgstr "Ort"
 
+#. Default: "End"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_end"
+msgstr "Ende"
+
+#. Default: "Location"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_location"
+msgstr "Ort"
+
+#. Default: "Meeting dossier"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_meetin_dossier"
+msgstr "Sitzungsdossier"
+
+#. Default: "Presidency"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_presidency"
+msgstr "Vorsitz"
+
+#. Default: "Secretary"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_secretary"
+msgstr "Protokollführung"
+
+#. Default: "Start"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_start"
+msgstr "Beginn"
+
+#. Default: "State"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_workflow_state"
+msgstr "Status"
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
 msgstr "Sitzungsdossier"
@@ -1663,45 +1702,15 @@ msgstr "Traktanden"
 msgid "view_label_agendaitem_list"
 msgstr "Traktandenliste:"
 
-#. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_dossier"
-msgstr "Sitzungsdossier:"
-
-#. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_end"
-msgstr "Sitzungsende:"
-
-#. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_location"
-msgstr "Ort:"
-
 #. Default: "Meeting number:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_number"
 msgstr "Sitzungsnummer:"
 
-#. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_start"
-msgstr "Beginn:"
-
-#. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_status"
-msgstr "Status:"
-
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
 msgstr "Teilnehmer:"
-
-#. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_presidency"
-msgstr "Vorsitz:"
 
 #. Default: "Protocol:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -1717,8 +1726,3 @@ msgstr "Traktandum einfügen:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_proposal"
 msgstr "Antrag traktandieren:"
-
-#. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_secretary"
-msgstr "Protokollführung:"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:47+0000\n"
+"POT-Creation-Date: 2017-10-24 12:48+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -636,6 +636,16 @@ msgstr ""
 msgid "document_label_agenda_item_list"
 msgstr ""
 
+#. Default: "Pre-protocol"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "document_label_pre_protocol"
+msgstr ""
+
+#. Default: "Protocol"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "document_label_protocol"
+msgstr ""
+
 #. Default: "Not yet generated."
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "document_not_yet_generated"
@@ -647,7 +657,6 @@ msgid "dossier"
 msgstr "Dossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "download protocol"
 msgstr "Télécharger le protocole"
 
@@ -710,12 +719,10 @@ msgid "generate new excerpt"
 msgstr "Générer un nouvel extrait de protocole"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new protocol as word document"
 msgstr "Générer le protocole comme document Word"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new version as word document"
 msgstr "Générer une nouvelle version comme document Word"
 
@@ -1139,7 +1146,6 @@ msgstr "Aucune proposition n'a été soumise."
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_protocol"
 msgstr "Aucun protocole n'a été généré encore."
 
@@ -1733,11 +1739,6 @@ msgstr ""
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
-msgstr ""
-
-#. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -243,6 +243,7 @@ msgid "Meeting Dossier"
 msgstr "Dossier de réunion"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Meeting number"
 msgstr "Numéro de la réunion"
 
@@ -1729,11 +1730,6 @@ msgstr ""
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
-msgstr ""
-
-#. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Participants:"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -398,12 +398,22 @@ msgstr ""
 msgid "You are not allowed to view the meeting dossier."
 msgstr ""
 
+#. Default: "Close meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_close_meeting"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "action_download_document"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "action_generate_document"
+msgstr ""
+
+#. Default: "Reopen meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_reopen_meeting"
 msgstr ""
 
 #. Default: "Active"
@@ -1131,6 +1141,11 @@ msgstr "Propriétés"
 msgid "label_meeting"
 msgstr "Séance"
 
+#. Default: "Meeting closed"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "label_meeting_closed"
+msgstr ""
+
 #. Default: "Member"
 #: ./opengever/meeting/browser/memberships.py
 msgid "label_member"
@@ -1531,6 +1546,11 @@ msgstr "La proposition a été réactivée."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
 msgstr "Proposition soumise avec succès."
+
+#. Default: "The meeting can only be closed when all agenda items are decided."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "msg_require_all_agenda_items_decided_for_closing"
+msgstr ""
 
 #. Default: "The object was deleted successfully."
 #: ./opengever/meeting/browser/views.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:44+0000\n"
+"POT-Creation-Date: 2017-10-24 12:47+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -377,6 +377,10 @@ msgstr "Le document a été écrasé par une version plus récente de l'extrait 
 #: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé par une nouvelle version de la réunion ${title}."
+
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "You are not allowed to view the meeting dossier."
+msgstr ""
 
 #. Default: "Active"
 #: ./opengever/meeting/browser/documents/proposalstab.py
@@ -1324,6 +1328,41 @@ msgstr "Langue"
 msgid "location"
 msgstr "Lieu"
 
+#. Default: "End"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_end"
+msgstr ""
+
+#. Default: "Location"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_location"
+msgstr ""
+
+#. Default: "Meeting dossier"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_meetin_dossier"
+msgstr ""
+
+#. Default: "Presidency"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_presidency"
+msgstr ""
+
+#. Default: "Secretary"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_secretary"
+msgstr ""
+
+#. Default: "Start"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_start"
+msgstr ""
+
+#. Default: "State"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_workflow_state"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
 msgstr "Dossier de la réunion"
@@ -1665,44 +1704,14 @@ msgstr ""
 msgid "view_label_agendaitem_list"
 msgstr ""
 
-#. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_dossier"
-msgstr ""
-
-#. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_end"
-msgstr ""
-
-#. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_location"
-msgstr ""
-
 #. Default: "Meeting number:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_number"
 msgstr ""
 
-#. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_start"
-msgstr ""
-
-#. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_status"
-msgstr ""
-
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
-msgstr ""
-
-#. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
@@ -1718,9 +1727,4 @@ msgstr ""
 #. Default: "Schedule proposal:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_proposal"
-msgstr ""
-
-#. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_secretary"
 msgstr ""

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -111,6 +111,10 @@ msgstr "Impossible de changer l'adhésion, parce qu'elle se chevauche avec une a
 msgid "Choose Agenda Items"
 msgstr "Choisir les points du l'ordre du jour"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Clear filter"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Close all proposals."
 msgstr "Toutes les propositions sont clôturées."
@@ -189,6 +193,14 @@ msgstr "Extraits de protocole"
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Export settings"
 msgstr "Paramètres de l'export"
+
+#: ./opengever/meeting/browser/meetings/participants.py
+msgid "Failed to save."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Filter participants"
+msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Generate excerpts for all proposals."
@@ -377,6 +389,10 @@ msgstr "Le document a été écrasé par une version plus récente de l'extrait 
 #: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
 msgstr "Actualisé par une nouvelle version de la réunion ${title}."
+
+#: ./opengever/meeting/browser/meetings/participants.py
+msgid "You are not allowed to change the meeting details."
+msgstr ""
 
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "You are not allowed to view the meeting dossier."
@@ -699,6 +715,11 @@ msgstr ""
 #. Default: "Excerpt was returned to proposer."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
+msgstr ""
+
+#. Default: "Excused"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "excused"
 msgstr ""
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
@@ -1152,6 +1173,7 @@ msgstr "Aucun protocole n'a été généré encore."
 
 #. Default: "Other Participants"
 #: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_other_participants"
 msgstr "Autres participants"
 
@@ -1389,6 +1411,18 @@ msgstr ""
 #. Default: "State"
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "meeting_byline_workflow_state"
+msgstr ""
+
+#. Default: "Presidency"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "meeting_role_presidency"
+msgstr ""
+
+#. Default: "Secretary"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "meeting_role_secretary"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -1669,6 +1703,10 @@ msgstr "Mis à l'ordre du jour"
 msgid "secretary"
 msgstr "Secrétaire"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "send email"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "status"
 msgstr "État"
@@ -1696,6 +1734,11 @@ msgstr "${amount} résultats"
 #. Default: "Overview"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "tab_overview"
+msgstr ""
+
+#. Default: "${count} Participants"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "tab_participants"
 msgstr ""
 
 #. Default: "Text successfully added."
@@ -1730,11 +1773,6 @@ msgstr ""
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
-msgstr ""
-
-#. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -154,7 +154,6 @@ msgid "Documents"
 msgstr "Documents"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Download agenda item list"
 msgstr ""
 
@@ -380,6 +379,14 @@ msgstr "Actualisé par une nouvelle version de la réunion ${title}."
 
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "You are not allowed to view the meeting dossier."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_download_document"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_generate_document"
 msgstr ""
 
 #. Default: "Active"
@@ -618,6 +625,22 @@ msgstr "Pour ce groupe, les autorisations sont attribuées automatiquement au co
 msgid "document_checkout_not_allowed"
 msgstr ""
 
+#. Default: "Created at ${date}"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_created_at"
+msgstr ""
+
+#. Default: "Agenda item list"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_label_agenda_item_list"
+msgstr ""
+
+#. Default: "Not yet generated."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_not_yet_generated"
+msgstr ""
+
 #. Default: "Dossier"
 #: ./opengever/meeting/tabs/meetinglisting.py
 msgid "dossier"
@@ -679,7 +702,6 @@ msgid "filename_repository_toc"
 msgstr "Table de matière ${period} ${committee} selon l'ordre des points"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new agenda item list as word document"
 msgstr ""
 
@@ -1097,7 +1119,6 @@ msgstr "Prochaine réunion:"
 
 #. Default: "No agenda item list has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_agendaitem_list"
 msgstr ""
 
@@ -1665,6 +1686,11 @@ msgstr "Propositions"
 msgid "tab_matches"
 msgstr "${amount} résultats"
 
+#. Default: "Overview"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "tab_overview"
+msgstr ""
+
 #. Default: "Text successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
@@ -1697,11 +1723,6 @@ msgstr ""
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
-msgstr ""
-
-#. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting number:"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -151,7 +151,6 @@ msgid "Documents"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Download agenda item list"
 msgstr ""
 
@@ -377,6 +376,14 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "You are not allowed to view the meeting dossier."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_download_document"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_generate_document"
 msgstr ""
 
 #. Default: "Active"
@@ -615,6 +622,22 @@ msgstr ""
 msgid "document_checkout_not_allowed"
 msgstr ""
 
+#. Default: "Created at ${date}"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_created_at"
+msgstr ""
+
+#. Default: "Agenda item list"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_label_agenda_item_list"
+msgstr ""
+
+#. Default: "Not yet generated."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "document_not_yet_generated"
+msgstr ""
+
 #. Default: "Dossier"
 #: ./opengever/meeting/tabs/meetinglisting.py
 msgid "dossier"
@@ -676,7 +699,6 @@ msgid "filename_repository_toc"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new agenda item list as word document"
 msgstr ""
 
@@ -1094,7 +1116,6 @@ msgstr ""
 
 #. Default: "No agenda item list has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_agendaitem_list"
 msgstr ""
 
@@ -1662,6 +1683,11 @@ msgstr ""
 msgid "tab_matches"
 msgstr ""
 
+#. Default: "Overview"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "tab_overview"
+msgstr ""
+
 #. Default: "Text successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
@@ -1694,11 +1720,6 @@ msgstr ""
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
-msgstr ""
-
-#. Default: "Agenda item list:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_agendaitem_list"
 msgstr ""
 
 #. Default: "Meeting number:"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -240,6 +240,7 @@ msgid "Meeting Dossier"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Meeting number"
 msgstr ""
 
@@ -1726,11 +1727,6 @@ msgstr ""
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
-msgstr ""
-
-#. Default: "Meeting number:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_number"
 msgstr ""
 
 #. Default: "Participants:"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:47+0000\n"
+"POT-Creation-Date: 2017-10-24 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -633,6 +633,16 @@ msgstr ""
 msgid "document_label_agenda_item_list"
 msgstr ""
 
+#. Default: "Pre-protocol"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "document_label_pre_protocol"
+msgstr ""
+
+#. Default: "Protocol"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "document_label_protocol"
+msgstr ""
+
 #. Default: "Not yet generated."
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "document_not_yet_generated"
@@ -644,7 +654,6 @@ msgid "dossier"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "download protocol"
 msgstr ""
 
@@ -707,12 +716,10 @@ msgid "generate new excerpt"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new protocol as word document"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "generate new version as word document"
 msgstr ""
 
@@ -1136,7 +1143,6 @@ msgstr ""
 
 #. Default: "No protocol has been generated yet."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_no_protocol"
 msgstr ""
 
@@ -1730,11 +1736,6 @@ msgstr ""
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
-msgstr ""
-
-#. Default: "Protocol:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_protocol"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -395,12 +395,22 @@ msgstr ""
 msgid "You are not allowed to view the meeting dossier."
 msgstr ""
 
+#. Default: "Close meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_close_meeting"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "action_download_document"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "action_generate_document"
+msgstr ""
+
+#. Default: "Reopen meeting"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "action_reopen_meeting"
 msgstr ""
 
 #. Default: "Active"
@@ -1128,6 +1138,11 @@ msgstr ""
 msgid "label_meeting"
 msgstr ""
 
+#. Default: "Meeting closed"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "label_meeting_closed"
+msgstr ""
+
 #. Default: "Member"
 #: ./opengever/meeting/browser/memberships.py
 msgid "label_member"
@@ -1527,6 +1542,11 @@ msgstr ""
 #. Default: "Proposal successfully submitted."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
+msgstr ""
+
+#. Default: "The meeting can only be closed when all agenda items are decided."
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "msg_require_all_agenda_items_decided_for_closing"
 msgstr ""
 
 #. Default: "The object was deleted successfully."

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:44+0000\n"
+"POT-Creation-Date: 2017-10-24 12:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -373,6 +373,10 @@ msgstr ""
 
 #: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "You are not allowed to view the meeting dossier."
 msgstr ""
 
 #. Default: "Active"
@@ -1321,6 +1325,41 @@ msgstr ""
 msgid "location"
 msgstr ""
 
+#. Default: "End"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_end"
+msgstr ""
+
+#. Default: "Location"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_location"
+msgstr ""
+
+#. Default: "Meeting dossier"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_meetin_dossier"
+msgstr ""
+
+#. Default: "Presidency"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_presidency"
+msgstr ""
+
+#. Default: "Secretary"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_secretary"
+msgstr ""
+
+#. Default: "Start"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_start"
+msgstr ""
+
+#. Default: "State"
+#: ./opengever/meeting/browser/meetings/byline.py
+msgid "meeting_byline_workflow_state"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "meetingdossier"
 msgstr ""
@@ -1662,44 +1701,14 @@ msgstr ""
 msgid "view_label_agendaitem_list"
 msgstr ""
 
-#. Default: "Meeting dossier:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_dossier"
-msgstr ""
-
-#. Default: "Meeting end:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_end"
-msgstr ""
-
-#. Default: "Location:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_location"
-msgstr ""
-
 #. Default: "Meeting number:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_meeting_number"
 msgstr ""
 
-#. Default: "Meeting start:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_start"
-msgstr ""
-
-#. Default: "Status:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_meeting_status"
-msgstr ""
-
 #. Default: "Participants:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_participants"
-msgstr ""
-
-#. Default: "Presidency:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_presidency"
 msgstr ""
 
 #. Default: "Protocol:"
@@ -1715,9 +1724,4 @@ msgstr ""
 #. Default: "Schedule proposal:"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_schedule_proposal"
-msgstr ""
-
-#. Default: "Secretary:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_secretary"
 msgstr ""

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -108,6 +108,10 @@ msgstr ""
 msgid "Choose Agenda Items"
 msgstr ""
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Clear filter"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "Close all proposals."
 msgstr ""
@@ -185,6 +189,14 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/excerpt.pt
 msgid "Export settings"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/participants.py
+msgid "Failed to save."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "Filter participants"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -373,6 +385,10 @@ msgstr ""
 
 #: ./opengever/meeting/command.py
 msgid "Updated with a newer generated version from meeting ${title}."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/participants.py
+msgid "You are not allowed to change the meeting details."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/byline.py
@@ -696,6 +712,11 @@ msgstr ""
 #. Default: "Excerpt was returned to proposer."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
+msgstr ""
+
+#. Default: "Excused"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "excused"
 msgstr ""
 
 #. Default: "Alphabetical Toc ${period} ${committee}"
@@ -1149,6 +1170,7 @@ msgstr ""
 
 #. Default: "Other Participants"
 #: ./opengever/meeting/browser/meetings/protocol.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_other_participants"
 msgstr ""
 
@@ -1386,6 +1408,18 @@ msgstr ""
 #. Default: "State"
 #: ./opengever/meeting/browser/meetings/byline.py
 msgid "meeting_byline_workflow_state"
+msgstr ""
+
+#. Default: "Presidency"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "meeting_role_presidency"
+msgstr ""
+
+#. Default: "Secretary"
+#: ./opengever/meeting/browser/meetings/meeting.py
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "meeting_role_secretary"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -1666,6 +1700,10 @@ msgstr ""
 msgid "secretary"
 msgstr ""
 
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "send email"
+msgstr ""
+
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "status"
 msgstr ""
@@ -1693,6 +1731,11 @@ msgstr ""
 #. Default: "Overview"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "tab_overview"
+msgstr ""
+
+#. Default: "${count} Participants"
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "tab_participants"
 msgstr ""
 
 #. Default: "Text successfully added."
@@ -1727,11 +1770,6 @@ msgstr ""
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "view_label_agenda_items"
-msgstr ""
-
-#. Default: "Participants:"
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "view_label_participants"
 msgstr ""
 
 #. Default: "Schedule ad hoc agenda item:"

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -277,7 +277,13 @@ class Meeting(Base, SQLFormSupport):
     def is_agendalist_editable(self):
         if not self.is_editable():
             return False
+        return self.is_pending()
+
+    def is_pending(self):
         return self.get_state() == self.STATE_PENDING
+
+    def is_closed(self):
+        return self.get_state() == self.STATE_CLOSED
 
     def has_protocol_document(self):
         return self.protocol_document is not None

--- a/opengever/meeting/tests/pages/meeting_view.py
+++ b/opengever/meeting/tests/pages/meeting_view.py
@@ -1,10 +1,12 @@
 from ftw.testbrowser import browser
-from operator import methodcaller
+from opengever.testing.pages import byline
 
 
 def metadata(**kwargs):
-    """Return the meeting metadata as lists of labels and values.
+    """Return the meeting metadata as a dict of labels and values.
     """
-    return reduce(list.__add__,
-                  map(methodcaller('lists', **kwargs),
-                      browser.css('table.meeting-metadata')))
+    data = byline.text_dict()
+    for table in browser.css('table.meeting-metadata'):
+        for row in table.lists():
+            data[row[0]] = row[1]
+    return data

--- a/opengever/meeting/tests/pages/meeting_view.py
+++ b/opengever/meeting/tests/pages/meeting_view.py
@@ -1,12 +1,9 @@
 from ftw.testbrowser import browser
-from opengever.testing.pages import byline
 
 
-def metadata(**kwargs):
-    """Return the meeting metadata as a dict of labels and values.
-    """
-    data = byline.text_dict()
-    for table in browser.css('table.meeting-metadata'):
-        for row in table.lists():
-            data[row[0]] = row[1]
-    return data
+def participants():
+    return [{'fullname': participant.css('.fullname').first.text,
+             'email': participant.css('.email').first.text,
+             'present': 'present' in participant.css('.presence').first.classes,
+             'role': participant.css('div.role').first.text}
+            for participant in browser.css('.participant-list .participant')]

--- a/opengever/meeting/tests/test_meeting_byline.py
+++ b/opengever/meeting/tests/test_meeting_byline.py
@@ -1,0 +1,37 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.testing.pages import byline
+
+
+class TestMeetingByline(IntegrationTestCase):
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_items(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting)
+        self.assertEquals(
+            [('State:', 'Pending'),
+             ('Start:', 'Sep 12, 2016 05:30 PM'),
+             ('End:', 'Sep 12, 2016 07:00 PM'),
+             ('Presidency:', u'Sch\xf6ller Heidrun'),
+             ('Secretary:', u'M\xfcller Henning'),
+             ('Location:', u'B\xfcren an der Aare'),
+             ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
+            byline.text_items())
+
+    @browsing
+    def test_dossier_link(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting)
+        byline.by_label()['Meeting dossier:'].css('a').first.click()
+        self.assertEquals(self.meeting_dossier, browser.context)
+
+    @browsing
+    def test_dossier_not_linked_when_unauthorized(self, browser):
+        self.login(self.meeting_user, browser)
+        self.meeting_dossier.__ac_local_roles_block__ = True
+        browser.open(self.meeting)
+        item = byline.by_label()['Meeting dossier:']
+        self.assertFalse(item.css('a'))
+        self.assertTrue(item.css('span.no_access').first)

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -7,7 +7,6 @@ from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import create_session
 from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
-from opengever.testing.pages import byline
 
 
 class TestEditMeeting(IntegrationTestCase):
@@ -36,21 +35,17 @@ class TestEditMeeting(IntegrationTestCase):
         self.assertEquals(u'9. Sitzung der Rechnungspr\xfcfungskommission',
                           plone.first_heading())
         self.assertEquals(
-            [('State:', 'Pending'),
-             ('Start:', 'Sep 12, 2016 05:30 PM'),
-             ('End:', 'Sep 12, 2016 07:00 PM'),
-             ('Presidency:', u'Sch\xf6ller Heidrun'),
-             ('Secretary:', u'M\xfcller Henning'),
-             ('Location:', u'B\xfcren an der Aare'),
-             ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
-            byline.text_items())
-
-        self.assertEquals(
-            [['Meeting number:', ''],
-             ['Participants:', u'Wendler Jens (jens-wendler@gmail.com)'
-              u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
-             ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
-             ['Protocol:', 'No protocol has been generated yet.', '']],
+            {'State:': 'Pending',
+             'Start:': 'Sep 12, 2016 05:30 PM',
+             'End:': 'Sep 12, 2016 07:00 PM',
+             'Presidency:': u'Sch\xf6ller Heidrun',
+             'Secretary:': u'M\xfcller Henning',
+             'Location:': u'B\xfcren an der Aare',
+             'Meeting dossier:': 'Sitzungsdossier 9/2017',
+             'Meeting number:': '',
+             'Participants:': u'Wendler Jens (jens-wendler@gmail.com)'
+             u' W\xf6lfl Gerda (g.woelfl@hotmail.com)',
+             'Protocol:': 'No protocol has been generated yet.'},
             meeting_view.metadata())
 
         editbar.contentview('Edit').click()
@@ -68,21 +63,17 @@ class TestEditMeeting(IntegrationTestCase):
 
         self.assertEquals('New Meeting Title', plone.first_heading())
         self.assertEquals(
-            [('State:', 'Pending'),
-             ('Start:', 'Oct 13, 2016 08:00 AM'),
-             ('End:', 'Oct 13, 2016 10:00 AM'),
-             ('Presidency:', u'W\xf6lfl Gerda'),
-             ('Secretary:', 'Wendler Jens'),
-             ('Location:', 'Sitzungszimmer 3'),
-             ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
-            byline.text_items())
-
-        self.assertEquals(
-            [['Meeting number:', ''],
-             ['Participants:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
-             ['', 'Staatsanwalt'],
-             ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
-             ['Protocol:', 'No protocol has been generated yet.', '']],
+            {'State:': 'Pending',
+             'Start:': 'Oct 13, 2016 08:00 AM',
+             'End:': 'Oct 13, 2016 10:00 AM',
+             'Presidency:': u'W\xf6lfl Gerda',
+             'Secretary:': u'Wendler Jens',
+             'Location:': u'Sitzungszimmer 3',
+             'Meeting dossier:': 'Sitzungsdossier 9/2017',
+             'Meeting number:': '',
+             'Participants:': u'Sch\xf6ller Heidrun (h.schoeller@web.de)',
+             '': 'Staatsanwalt',
+             'Protocol:': 'No protocol has been generated yet.'},
             meeting_view.metadata())
 
     @browsing

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -5,8 +5,8 @@ from ftw.testbrowser.pages import statusmessages
 from ftw.testing import freeze
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import create_session
-from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
+from opengever.testing.pages import byline
 
 
 class TestEditMeeting(IntegrationTestCase):
@@ -41,17 +41,11 @@ class TestEditMeeting(IntegrationTestCase):
              'Presidency:': u'Sch\xf6ller Heidrun',
              'Secretary:': u'M\xfcller Henning',
              'Location:': u'B\xfcren an der Aare',
-             'Meeting dossier:': 'Sitzungsdossier 9/2017',
-             'Participants:': u'Wendler Jens (jens-wendler@gmail.com)'
-             u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'},
-            meeting_view.metadata())
+             'Meeting dossier:': 'Sitzungsdossier 9/2017'},
+            byline.text_dict())
 
         editbar.contentview('Edit').click()
         browser.fill({'Title': u'New Meeting Title',
-                      'Presidency': u'W\xf6lfl Gerda (g.woelfl@hotmail.com)',
-                      'Secretary': u'Wendler Jens (jens-wendler@gmail.com)',
-                      'Participants': [
-                          u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
                       'Other Participants': 'Staatsanwalt',
                       'Protocol start-page': '27',
                       'Location': 'Sitzungszimmer 3',
@@ -64,13 +58,11 @@ class TestEditMeeting(IntegrationTestCase):
             {'State:': 'Pending',
              'Start:': 'Oct 13, 2016 08:00 AM',
              'End:': 'Oct 13, 2016 10:00 AM',
-             'Presidency:': u'W\xf6lfl Gerda',
-             'Secretary:': u'Wendler Jens',
+             'Presidency:': u'Sch\xf6ller Heidrun',
+             'Secretary:': u'M\xfcller Henning',
              'Location:': u'Sitzungszimmer 3',
-             'Meeting dossier:': 'Sitzungsdossier 9/2017',
-             'Participants:': u'Sch\xf6ller Heidrun (h.schoeller@web.de)',
-             '': 'Staatsanwalt'},
-            meeting_view.metadata())
+             'Meeting dossier:': 'Sitzungsdossier 9/2017'},
+            byline.text_dict())
 
     @browsing
     def test_edit_meeting_locks_the_content(self, browser1):

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -44,8 +44,7 @@ class TestEditMeeting(IntegrationTestCase):
              'Meeting dossier:': 'Sitzungsdossier 9/2017',
              'Meeting number:': '',
              'Participants:': u'Wendler Jens (jens-wendler@gmail.com)'
-             u' W\xf6lfl Gerda (g.woelfl@hotmail.com)',
-             'Protocol:': 'No protocol has been generated yet.'},
+             u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'},
             meeting_view.metadata())
 
         editbar.contentview('Edit').click()
@@ -72,8 +71,7 @@ class TestEditMeeting(IntegrationTestCase):
              'Meeting dossier:': 'Sitzungsdossier 9/2017',
              'Meeting number:': '',
              'Participants:': u'Sch\xf6ller Heidrun (h.schoeller@web.de)',
-             '': 'Staatsanwalt',
-             'Protocol:': 'No protocol has been generated yet.'},
+             '': 'Staatsanwalt'},
             meeting_view.metadata())
 
     @browsing

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -7,6 +7,7 @@ from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import create_session
 from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
+from opengever.testing.pages import byline
 
 
 class TestEditMeeting(IntegrationTestCase):
@@ -35,16 +36,19 @@ class TestEditMeeting(IntegrationTestCase):
         self.assertEquals(u'9. Sitzung der Rechnungspr\xfcfungskommission',
                           plone.first_heading())
         self.assertEquals(
-            [['Status:', 'Pending'],
-             ['Meeting start:', 'Sep 12, 2016 05:30 PM'],
-             ['Meeting end:', 'Sep 12, 2016 07:00 PM'],
-             ['Location:', u'B\xfcren an der Aare'],
-             ['Meeting number:', ''],
-             ['Presidency:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
-             ['Secretary:', u'M\xfcller Henning (h.mueller@gmx.ch)'],
+            [('State:', 'Pending'),
+             ('Start:', 'Sep 12, 2016 05:30 PM'),
+             ('End:', 'Sep 12, 2016 07:00 PM'),
+             ('Presidency:', u'Sch\xf6ller Heidrun'),
+             ('Secretary:', u'M\xfcller Henning'),
+             ('Location:', u'B\xfcren an der Aare'),
+             ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
+            byline.text_items())
+
+        self.assertEquals(
+            [['Meeting number:', ''],
              ['Participants:', u'Wendler Jens (jens-wendler@gmail.com)'
               u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
-             ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
              ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
              ['Protocol:', 'No protocol has been generated yet.', '']],
             meeting_view.metadata())
@@ -64,16 +68,19 @@ class TestEditMeeting(IntegrationTestCase):
 
         self.assertEquals('New Meeting Title', plone.first_heading())
         self.assertEquals(
-            [['Status:', 'Pending'],
-             ['Meeting start:', 'Oct 13, 2016 08:00 AM'],
-             ['Meeting end:', 'Oct 13, 2016 10:00 AM'],
-             ['Location:', 'Sitzungszimmer 3'],
-             ['Meeting number:', ''],
-             ['Presidency:', u'W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
-             ['Secretary:', 'Wendler Jens (jens-wendler@gmail.com)'],
+            [('State:', 'Pending'),
+             ('Start:', 'Oct 13, 2016 08:00 AM'),
+             ('End:', 'Oct 13, 2016 10:00 AM'),
+             ('Presidency:', u'W\xf6lfl Gerda'),
+             ('Secretary:', 'Wendler Jens'),
+             ('Location:', 'Sitzungszimmer 3'),
+             ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
+            byline.text_items())
+
+        self.assertEquals(
+            [['Meeting number:', ''],
              ['Participants:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
              ['', 'Staatsanwalt'],
-             ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
              ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
              ['Protocol:', 'No protocol has been generated yet.', '']],
             meeting_view.metadata())

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -42,7 +42,6 @@ class TestEditMeeting(IntegrationTestCase):
              'Secretary:': u'M\xfcller Henning',
              'Location:': u'B\xfcren an der Aare',
              'Meeting dossier:': 'Sitzungsdossier 9/2017',
-             'Meeting number:': '',
              'Participants:': u'Wendler Jens (jens-wendler@gmail.com)'
              u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'},
             meeting_view.metadata())
@@ -69,7 +68,6 @@ class TestEditMeeting(IntegrationTestCase):
              'Secretary:': u'Wendler Jens',
              'Location:': u'Sitzungszimmer 3',
              'Meeting dossier:': 'Sitzungsdossier 9/2017',
-             'Meeting number:': '',
              'Participants:': u'Sch\xf6ller Heidrun (h.schoeller@web.de)',
              '': 'Staatsanwalt'},
             meeting_view.metadata())

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -141,3 +141,42 @@ class TestWordMeetingView(IntegrationTestCase):
               'present': True,
               'role': ''}],
             meeting_view.participants())
+
+    def test_get_closing_infos(self):
+        """The get_close_meeting_render_infos provides infos for rendering.
+
+        Components:
+        - Disabled close-meeting transition action (when not yet ready).
+        - Enabled close-meeting transition action.
+        - Repoen-meeting transition action.
+        """
+
+        self.maxDiff = None
+        self.login(self.committee_responsible)
+        view = self.meeting.restrictedTraverse('view')
+
+        self.assertEquals(
+            {'is_closed': False,
+             'close_url': self.get_meeting_transition_url('pending-closed'),
+             'reopen_url': None},
+            view.get_closing_infos())
+
+        self.meeting.model.workflow_state = self.meeting.model.STATE_HELD.name
+        self.assertEquals(
+            {'is_closed': False,
+             'close_url': self.get_meeting_transition_url('held-closed'),
+             'reopen_url': None},
+            view.get_closing_infos())
+
+        self.meeting.model.workflow_state = self.meeting.model.STATE_CLOSED.name
+        self.assertEquals(
+            {'is_closed': True,
+             'close_url': None,
+             'reopen_url': self.get_meeting_transition_url('closed-held')},
+            view.get_closing_infos())
+
+    def get_meeting_transition_url(self, transition_name):
+        transition_controller = self.meeting.model.workflow.transition_controller
+        return transition_controller.url_for(self.meeting,
+                                             self.meeting.model,
+                                             transition_name)

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
 from ftw.testing import freeze
+from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
 from opengever.testing.pages import byline
 import pytz
@@ -117,3 +118,26 @@ class TestWordMeetingView(IntegrationTestCase):
         self.login(self.meeting_user, browser)
         browser.open(self.meeting, view='agenda_items/list')
         self.assertNotIn('return_link', browser.json['items'][0]['excerpts'][0])
+
+    @browsing
+    def test_participants(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting)
+        self.assertEquals(
+            [{'fullname': u'M\xfcller Henning',
+              'email': '',
+              'present': False,
+              'role': 'Secretary'},
+             {'fullname': u'Sch\xf6ller Heidrun',
+              'email': '',
+              'present': False,
+              'role': 'Presidency'},
+             {'fullname': 'Wendler Jens',
+              'email': '',
+              'present': True,
+              'role': ''},
+             {'fullname': u'W\xf6lfl Gerda',
+              'email': '',
+              'present': True,
+              'role': ''}],
+            meeting_view.participants())

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
-from opengever.meeting.tests.pages import meeting_view
+from ftw.testing import freeze
 from opengever.testing import IntegrationTestCase
 from opengever.testing.pages import byline
+import pytz
 
 
 class TestWordMeetingView(IntegrationTestCase):
@@ -24,14 +26,6 @@ class TestWordMeetingView(IntegrationTestCase):
              ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
             byline.text_items())
 
-        self.assertEquals(
-            [['Meeting number:', ''],
-             ['Participants:', u'Wendler Jens (jens-wendler@gmail.com)'
-              u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
-             ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
-             ['Protocol:', 'No protocol has been generated yet.', '']],
-            meeting_view.metadata())
-
     @browsing
     def test_meeting_dossier_link(self, browser):
         self.login(self.committee_responsible, browser)
@@ -40,16 +34,33 @@ class TestWordMeetingView(IntegrationTestCase):
         self.assertEquals(self.meeting_dossier.absolute_url(), browser.url)
 
     @browsing
-    def test_agenda_item_url(self, browser):
+    def test_agenda_items_list_document(self, browser):
         self.login(self.committee_responsible, browser)
 
         browser.open(self.meeting)
-        browser.css('.generate-agendaitem-list').first.click()
-        link = browser.css('.download-agendaitem-list-btn').first
+        docnode = browser.css('.meeting-document.agenda-item-list-doc').first
+        self.assertFalse(docnode.css('div.document-label a'))
+        self.assertEquals('Agenda item list', docnode.css('.document-label').first.text)
+        self.assertEquals('Not yet generated.', docnode.css('.document-created').first.text)
+        self.assertTrue(docnode.css('.action.generate'))
+        self.assertFalse(docnode.css('.action.download'))
 
-        self.assertEquals(
-            self.meeting.model.agendaitem_list_document.get_download_url(),
-            link.attrib['href'])
+        with freeze(datetime(2016, 9, 2, 10, 15, 1, tzinfo=pytz.UTC)) as clock:
+            docnode.css('.action.generate').first.click()
+            docnode = browser.css('.meeting-document.agenda-item-list-doc').first
+            self.assertTrue(docnode.css('div.document-label a'))
+            self.assertEquals('Agenda item list', docnode.css('.document-label').first.text)
+            self.assertEquals('Created at Sep 02, 2016 11:15 AM', docnode.css('.document-created').first.text)
+            self.assertTrue(docnode.css('.action.generate'))
+            self.assertTrue(docnode.css('.action.download'))
+
+            self.assertEquals(self.meeting.model.agendaitem_list_document.get_download_url(),
+                              docnode.css('.action.download').first.attrib['href'])
+
+            clock.forward(hours=1)
+            docnode.css('.action.generate').first.click()
+            docnode = browser.css('.meeting-document.agenda-item-list-doc').first
+            self.assertEquals('Created at Sep 02, 2016 12:15 PM', docnode.css('.document-created').first.text)
 
     @browsing
     def test_close_transition_closes_meeting(self, browser):

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -2,6 +2,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
 from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
+from opengever.testing.pages import byline
 
 
 class TestWordMeetingView(IntegrationTestCase):
@@ -14,16 +15,19 @@ class TestWordMeetingView(IntegrationTestCase):
 
         self.maxDiff = None
         self.assertEquals(
-            [['Status:', 'Pending'],
-             ['Meeting start:', 'Sep 12, 2016 05:30 PM'],
-             ['Meeting end:', 'Sep 12, 2016 07:00 PM'],
-             ['Location:', u'B\xfcren an der Aare'],
-             ['Meeting number:', ''],
-             ['Presidency:', u'Sch\xf6ller Heidrun (h.schoeller@web.de)'],
-             ['Secretary:', u'M\xfcller Henning (h.mueller@gmx.ch)'],
+            [('State:', 'Pending'),
+             ('Start:', 'Sep 12, 2016 05:30 PM'),
+             ('End:', 'Sep 12, 2016 07:00 PM'),
+             ('Presidency:', u'Sch\xf6ller Heidrun'),
+             ('Secretary:', u'M\xfcller Henning'),
+             ('Location:', u'B\xfcren an der Aare'),
+             ('Meeting dossier:', 'Sitzungsdossier 9/2017')],
+            byline.text_items())
+
+        self.assertEquals(
+            [['Meeting number:', ''],
              ['Participants:', u'Wendler Jens (jens-wendler@gmail.com)'
               u' W\xf6lfl Gerda (g.woelfl@hotmail.com)'],
-             ['Meeting dossier:', 'Sitzungsdossier 9/2017', ''],
              ['Agenda item list:', 'No agenda item list has been generated yet.', ''],
              ['Protocol:', 'No protocol has been generated yet.', '']],
             meeting_view.metadata())

--- a/opengever/meeting/tests/test_participants_view.py
+++ b/opengever/meeting/tests/test_participants_view.py
@@ -1,0 +1,83 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestParticipantsView(IntegrationTestCase):
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_change_role(self, browser):
+        self.login(self.committee_responsible, browser)
+        meeting = self.meeting.model
+        member = self.committee_participant_1.model
+        self.assertNotEqual(member, meeting.presidency)
+
+        browser.open(self.meeting, view='participants/change_role',
+                     data={'member_id': member.member_id,
+                           'role': 'presidency'})
+        self.assertEqual({u'proceed': True}, browser.json)
+        self.assertEqual(member, meeting.presidency)
+
+        browser.open(self.meeting, view='participants/change_role',
+                     data={'member_id': member.member_id,
+                           'role': 'secretary'})
+        self.assertEqual({u'proceed': True}, browser.json)
+        self.assertEqual(member, meeting.secretary)
+        self.assertIsNone(meeting.presidency)
+
+        browser.open(self.meeting, view='participants/change_role',
+                     data={'member_id': member.member_id,
+                           'role': ''})
+        self.assertEqual({u'proceed': True}, browser.json)
+        self.assertIsNone(meeting.secretary)
+        self.assertIsNone(meeting.presidency)
+
+    @browsing
+    def test_meeting_user_cannot_change_role(self, browser):
+        self.login(self.meeting_user, browser)
+        member = self.committee_participant_1.model
+        browser.open(self.meeting, view='participants/change_role',
+                     data={'member_id': member.member_id,
+                           'role': 'presidency'})
+        self.assertEqual(
+            {u'messages': [{u'message': u'You are not allowed to change'
+                            ' the meeting details.',
+                            u'messageClass': u'error',
+                            u'messageTitle': u'Error'}],
+             u'proceed': False},
+            browser.json)
+
+    @browsing
+    def test_change_presence(self, browser):
+        self.login(self.committee_responsible, browser)
+        meeting = self.meeting.model
+        member = self.committee_participant_2.model
+        self.assertIn(member, meeting.participants)
+
+        browser.open(self.meeting, view='participants/change_presence',
+                     data={'member_id': member.member_id,
+                           'present': json.dumps(False)})
+        self.assertEqual({u'proceed': True}, browser.json)
+        self.assertNotIn(member, meeting.participants)
+
+        browser.open(self.meeting, view='participants/change_presence',
+                     data={'member_id': member.member_id,
+                           'present': json.dumps(True)})
+        self.assertEqual({u'proceed': True}, browser.json)
+        self.assertIn(member, meeting.participants)
+
+    @browsing
+    def test_meeting_user_cannot_change_presence(self, browser):
+        self.login(self.meeting_user, browser)
+        member = self.committee_participant_1.model
+        browser.open(self.meeting, view='participants/change_presence',
+                     data={'member_id': member.member_id,
+                           'present': json.dumps(True)})
+        self.assertEqual(
+            {u'messages': [{u'message': u'You are not allowed to change'
+                            ' the meeting details.',
+                            u'messageClass': u'error',
+                            u'messageTitle': u'Error'}],
+             u'proceed': False},
+            browser.json)

--- a/opengever/meeting/tests/test_protocol_word.py
+++ b/opengever/meeting/tests/test_protocol_word.py
@@ -18,7 +18,7 @@ class TestProtocolWithWord(IntegrationTestCase):
 
         browser.open(meeting.get_url())
         # generate first protocol
-        browser.css('.generate-protocol').first.click()
+        browser.css('.meeting-document.protocol-doc .action.generate').first.click()
 
         statusmessages.assert_message(
             u'Protocol for meeting 9. Sitzung der '
@@ -28,7 +28,7 @@ class TestProtocolWithWord(IntegrationTestCase):
         self.assertEqual(0, meeting.protocol_document.generated_version)
 
         # update already generated protocol
-        browser.css('.refresh-protocol').first.click()
+        browser.css('.meeting-document.protocol-doc .action.generate').first.click()
 
         statusmessages.assert_message(
             u'Protocol for meeting 9. Sitzung der '
@@ -48,7 +48,7 @@ class TestProtocolWithWord(IntegrationTestCase):
 
         browser.open(meeting.get_url())
         # generate first protocol
-        browser.css('.generate-protocol').first.click()
+        browser.css('.meeting-document.protocol-doc .action.generate').first.click()
 
         statusmessages.assert_message(
             u'Protocol for meeting 9. Sitzung der '
@@ -58,7 +58,7 @@ class TestProtocolWithWord(IntegrationTestCase):
         self.assertEqual(0, meeting.protocol_document.generated_version)
 
         # update already generated protocol
-        browser.css('.refresh-protocol').first.click()
+        browser.css('.meeting-document.protocol-doc .action.generate').first.click()
 
         statusmessages.assert_message(
             u'Protocol for meeting 9. Sitzung der '

--- a/opengever/testing/pages/byline.py
+++ b/opengever/testing/pages/byline.py
@@ -21,5 +21,10 @@ def items(browser=default_browser):
     return items
 
 
+def by_label(browser=default_browser):
+    return {label_node.text: text_node
+            for label_node, text_node in items(browser=browser)}
+
+
 def div(browser=default_browser):
     return browser.css('.documentByLine').first


### PR DESCRIPTION
This pull requests contains multiple steps in the redesign process of the meeting view with the word feature enabled.
See current layout screenshot for reference at the bottom.

Belongs to: https://github.com/4teamwork/gever/issues/106
⚠️ Requires https://github.com/4teamwork/plonetheme.teamraum/pull/593
Closes https://github.com/4teamwork/gever/issues/126

## Byline

Move parts of the metadata to the newly displayed byline:
![bildschirmfoto 2017-10-23 um 19 25 57](https://user-images.githubusercontent.com/7469/31903308-0b633b96-b828-11e7-8c9a-ca064a763f12.png)

## Move documents to sidebar

- Move "agenda items list" and "protocol" to sidebar.
- Call it "Vorprotokoll" until the meeting is closed.

![bildschirmfoto 2017-10-23 um 19 27 53](https://user-images.githubusercontent.com/7469/31903424-5402cf88-b828-11e7-893a-65fb461035cc.png)


## Show meeting number after title
- Meeting number appears when meeting is closed.

![bildschirmfoto 2017-10-23 um 19 38 39 2](https://user-images.githubusercontent.com/7469/31903871-d5f31556-b829-11e7-8cf3-779a719f2556.png)


## Show and manage participants in new tab
- List all participants in the participants tab.
- Allow to select role.
- Allow to "excuse" participants.
- Provide filter because this list can get very long.
- Show additional participants.

![bildschirmfoto 2017-10-23 um 19 31 16](https://user-images.githubusercontent.com/7469/31903639-f9dae27e-b828-11e7-8428-376a9c6cf6e9.png)


## Add a navigation
- The navigation shows all agenda items.
- A check-indicator helps to identify whether agenda items are decided.
- Clicking on the navigation scrolls to the agenda item.
- The navigation gets sticky when scrolling the page down.
- The navigation compensates for the process-area below by reducing the height and showing a scrollbar when having many agenda items.

![bildschirmfoto 2017-10-23 um 19 33 57 2](https://user-images.githubusercontent.com/7469/31903755-66320e8e-b829-11e7-8f5c-fd59cb6b6ce7.png)


## Add buttons for transitions to the sidebar
- The primary transition is "close meeting" with a large button.
- The button is deactivated when not all agenda items are decided.

![bildschirmfoto 2017-10-23 um 19 33 57](https://user-images.githubusercontent.com/7469/31903847-c7340070-b829-11e7-9d08-a6cb18ce2451.png)
![bildschirmfoto 2017-10-23 um 19 38 26](https://user-images.githubusercontent.com/7469/31903848-c802efe8-b829-11e7-91e6-7bfda8d1ae6c.png)
![bildschirmfoto 2017-10-23 um 19 38 39](https://user-images.githubusercontent.com/7469/31903850-c9688e6a-b829-11e7-897d-ee2ae743f5e6.png)




## Current layout for reference
<img width="1431" alt="bildschirmfoto 2017-10-23 um 19 22 33" src="https://user-images.githubusercontent.com/7469/31903167-a200ecac-b827-11e7-877e-550281076756.png">


## Security-Checks
The links and actions in the view are protected so that the user cannot trigger things which she/he is not allowed to. 
![bildschirmfoto 2017-10-24 um 08 20 51](https://user-images.githubusercontent.com/7469/31927455-65083810-b894-11e7-8413-942be39370e0.png)

Resolves https://github.com/4teamwork/gever/issues/126