### PR TITLE
Remove unpermitted link to excerpt document

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - OGGBundle: Do intermediate commits every 1000 items by default. [lgraf]
 - Handle spaces inside groups ids during repository import correctly. [phgross]
+- SPV word: Remove link to proposal excerpt document if no view permission. [tarnap]
 - Avoid id conflicts when setting up a repository. [phgross]
 - Remove the broken and unused fillingnumber-adjustment view to get rid of the grokked
   dependency collective.z3cform.datagridfield. [elioschmutz]

--- a/opengever/meeting/browser/proposaloverview.py
+++ b/opengever/meeting/browser/proposaloverview.py
@@ -2,6 +2,7 @@ from ftw import bumblebee
 from opengever.base.browser.helper import get_css_class
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document import _ as document_mf
+from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting.browser.proposaltransitions import ProposalTransitionController
 from opengever.meeting.interfaces import IHistory
@@ -31,8 +32,7 @@ class OverviewBase(object):
     def get_css_class(self, item):
         """Return the sprite-css-class for the given object.
         """
-        css = get_css_class(item)
-        return '{} {}'.format("rollover-breadcrumb", css)
+        return ' '.join(['rollover-breadcrumb', get_css_class(item)])
 
     def documents(self):
         return IContentListing(self.context.get_documents())
@@ -74,6 +74,9 @@ class OverviewBase(object):
 
         model = self.context.load_model()
         return model.get_state() == model.STATE_DECIDED
+
+    def render_protocol_excerpt_document_link(self):
+        return DocumentLinkWidget(self.context.get_excerpt()).render()
 
 
 class ProposalOverview(OverviewBase, view.DefaultView, GeverTabMixin):

--- a/opengever/meeting/browser/templates/proposaloverview.pt
+++ b/opengever/meeting/browser/templates/proposaloverview.pt
@@ -95,10 +95,7 @@
         <h2 i18n:translate="label_excerpt">Excerpt</h2>
         <ul>
           <li>
-            <a href="" tal:attributes="href excerpt/absolute_url;
-                                       class python:view.get_css_class(excerpt)">
-              <span class="document" tal:content="excerpt/Title" />
-            </a>
+            <span tal:replace="structure view/render_protocol_excerpt_document_link" />
           </li>
         </ul>
       </tal:condition>

--- a/opengever/meeting/tests/test_proposal_overview.py
+++ b/opengever/meeting/tests/test_proposal_overview.py
@@ -1,0 +1,49 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import NoElementFound
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import IntegrationTestCase
+
+
+class TestWordProposalOverview(IntegrationTestCase):
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_proposal_excerpt_document_link(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.schedule_proposal(self.meeting,
+                                             self.submitted_word_proposal)
+        agenda_item.decide()
+        excerpt_document = agenda_item.generate_excerpt(title='The Excerpt')
+        agenda_item.return_excerpt(excerpt_document)
+        browser.open(self.submitted_word_proposal, view='tabbedview_view-overview')
+        statusmessages.assert_no_error_messages()
+
+        browser.css('#excerptBox a').first.click()
+        statusmessages.assert_no_error_messages()
+
+        self.assertEquals(excerpt_document.absolute_url(), browser.url)
+
+    @browsing
+    def test_no_proposal_excerpt_document_link_if_no_permission(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.schedule_proposal(self.meeting,
+                                             self.submitted_word_proposal)
+        agenda_item.decide()
+        excerpt_document = agenda_item.generate_excerpt(title='The Excerpt')
+        agenda_item.return_excerpt(excerpt_document)
+
+        self.login(self.committee_responsible, browser)
+        browser.open(self.submitted_word_proposal, view='tabbedview_view-overview')
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(excerpt_document.absolute_url(),
+                          browser.css('#excerptBox a').first.attrib['href'])
+
+        self.login(self.dossier_responsible, browser)
+        self.meeting_dossier.__ac_local_roles_block__ = True
+        self.meeting_dossier.reindexObjectSecurity()
+
+        self.login(self.committee_responsible, browser)
+        browser.open(self.submitted_word_proposal, view='tabbedview_view-overview')
+        statusmessages.assert_no_error_messages()
+        with self.assertRaises(NoElementFound):
+            browser.css('#excerptBox a').first.click()


### PR DESCRIPTION
When an excerpt was returned, the user sees a link to the excerpt
document in the view of the proposal.
If the user has no permission to view the excerpt document, the link
should not be displayed.

Old:
<img width="1408" alt="12" src="https://user-images.githubusercontent.com/7469/31328531-fd2f6070-acd5-11e7-8ea6-b1a2cf4a0722.png">

New (left: with permission - right: without permission):
![protokollauszug_disabled](https://user-images.githubusercontent.com/194114/31991191-6ee20a9e-b977-11e7-9baa-f12d0663b61d.png)


Resolves https://github.com/4teamwork/gever/issues/132
