### PR TITLE
OGGBundle: Do intermediate commits every 1000 items by default

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- OGGBundle: Do intermediate commits every 1000 items by default. [lgraf]
 - Avoid id conflicts when setting up a repository. [phgross]
 - Remove the broken and unused fillingnumber-adjustment view to get rid of the grokked
   dependency collective.z3cform.datagridfield. [elioschmutz]

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -28,6 +28,7 @@ pipeline =
     reindexobject
     savepoint
     progress
+    commit
     post-import-validation
     report
 
@@ -73,6 +74,10 @@ every = 500
 
 [progress]
 blueprint = opengever.bundle.progress
+
+[commit]
+blueprint = opengever.bundle.commit
+every = 1000
 
 [post-import-validation]
 blueprint = opengever.bundle.post_import_validation

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -5,6 +5,7 @@ from opengever.bundle.ldap import DisabledLDAP
 from opengever.bundle.loader import GUID_INDEX_NAME
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
+from opengever.bundle.sections.commit import INTERMEDIATE_COMMITS_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
 from plone import api
@@ -24,6 +25,9 @@ def parse_args(argv):
     parser = argparse.ArgumentParser(description='Import an OGGBundle')
     parser.add_argument('bundle_path',
                         help='Path to the .oggbundle directory')
+    parser.add_argument('--no-intermediate-commits', action='store_true',
+                        help="Don't to intermediate commits")
+
     args = parser.parse_args(argv)
     return args
 
@@ -56,6 +60,7 @@ def import_oggbundle(app, args):
 
     ann = IAnnotations(transmogrifier)
     ann[BUNDLE_PATH_KEY] = args.bundle_path
+    ann[INTERMEDIATE_COMMITS_KEY] = not args.no_intermediate_commits
 
     with DisabledLDAP(plone):
         transmogrifier(u'opengever.bundle.oggbundle')

--- a/opengever/bundle/sections/commit.py
+++ b/opengever/bundle/sections/commit.py
@@ -1,0 +1,37 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from zope.annotation import IAnnotations
+from zope.interface import classProvides, implements
+import logging
+import transaction
+
+
+logger = logging.getLogger('opengever.bundle.commit')
+logger.setLevel(logging.INFO)
+
+
+INTERMEDIATE_COMMITS_KEY = 'intermediate_commits'
+
+
+class CommitSection(object):
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.every = int(options.get('every', 1000))
+        self.previous = previous
+        self.intermediate_commits = IAnnotations(transmogrifier).get(
+            INTERMEDIATE_COMMITS_KEY)
+
+    def __iter__(self):
+        for count, item in enumerate(self.previous, start=1):
+            if count % self.every == 0 and self.intermediate_commits:
+                logger.info("Intermediate commit after %s items..." % count)
+                transaction.commit()
+                logger.info("Commit successful.")
+
+            yield item
+
+        logger.info("Commit after bundle import...")
+        transaction.commit()
+        logger.info("Commit successful.")

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -64,6 +64,11 @@
       />
 
   <utility
+      component=".sections.commit.CommitSection"
+      name="opengever.bundle.commit"
+      />
+
+  <utility
       component=".sections.post_import_validation.PostImportValidationSection"
       name="opengever.bundle.post_import_validation"
       />


### PR DESCRIPTION
OGGBundle: Do intermediate commits every 1000 items by default:

This behavior can be disabled by invoking `bin/instance import`
with the `--no-intermediate-commits` flag.