### PR TITLE
Fix zip export when agendaitemlisttemplate missing

### DIFF
--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -5,6 +5,7 @@ from opengever.meeting.command import AgendaItemListOperations
 from opengever.meeting.command import CreateGeneratedDocumentCommand
 from opengever.meeting.command import MergeDocxProtocolCommand
 from opengever.meeting.command import ProtocolOperations
+from opengever.meeting.exceptions import AgendaItemListMissingTemplate
 from opengever.meeting.interfaces import IMeetingWrapper
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
@@ -48,7 +49,10 @@ class MeetingZipExport(BrowserView):
                 self.add_agenda_item_proposal_documents(generator)
 
             # Agenda items list
-            generator.add_file(*self.get_agendaitem_list())
+            try:
+                generator.add_file(*self.get_agendaitem_list())
+            except AgendaItemListMissingTemplate:
+                pass
 
             # Return zip
             zip_file = generator.generate()

--- a/opengever/meeting/tests/test_zipexport.py
+++ b/opengever/meeting/tests/test_zipexport.py
@@ -1,0 +1,29 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import IntegrationTestCase
+
+
+class TestZipExportWithWord(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_meeting_can_be_exported_to_zip_when_agenda_item_list_template_is_missing(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.committee.agendaitem_list_template = None
+        self.committee_container.agendaitem_list_template = None
+        browser.open(self.meeting, view='export-meeting-zip')
+        statusmessages.assert_no_error_messages()
+
+
+class TestZipExportWithoutWord(IntegrationTestCase):
+
+    features = ('meeting',)
+
+    @browsing
+    def test_meeting_can_be_exported_to_zip_when_agenda_item_list_template_is_missing(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.committee.agendaitem_list_template = None
+        self.committee_container.agendaitem_list_template = None
+        browser.open(self.meeting, view='export-meeting-zip')
+        statusmessages.assert_no_error_messages()


### PR DESCRIPTION
The creation of the zip file fails when there is no agenda item list
template.
The export itself should work when there is no agenda item list
template, the agenda item list should not be included in the zip file in
that case.
Since getting the agenda item list template is obfuscated, a try-except
is used to prevent the server error.

Resolves #3338