### PR TITLE
eCH-0147 export: Handling for mails and documents without a file

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Skip documents without a file in eCH-0147 exports. [phgross]
 - Include mails in eCH-0147 exports. [phgross]
 - OGGBundle: Do intermediate commits every 1000 items by default. [lgraf]
 - Handle spaces inside groups ids during repository import correctly. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Include mails in eCH-0147 exports. [phgross]
 - OGGBundle: Do intermediate commits every 1000 items by default. [lgraf]
 - Handle spaces inside groups ids during repository import correctly. [phgross]
 - Avoid id conflicts when setting up a repository. [phgross]

--- a/opengever/ech0147/model.py
+++ b/opengever/ech0147/model.py
@@ -75,7 +75,7 @@ class MessageT1(object):
     def add_object(self, obj):
         if IDossierMarker.providedBy(obj):
             self.dossiers.append(Dossier(obj, u'files'))
-        elif IBaseDocument.providedBy(obj):
+        elif IBaseDocument.providedBy(obj) and obj.get_file():
             self.documents.append(Document(obj, u'files'))
 
     def binding(self):
@@ -166,7 +166,7 @@ class Dossier(object):
         for obj in objs:
             if IDossierMarker.providedBy(obj):
                 self.dossiers.append(Dossier(obj, self.path))
-            elif IBaseDocument.providedBy(obj):
+            elif IBaseDocument.providedBy(obj) and obj.get_file():
                 self.documents.append(Document(obj, self.path))
 
     def binding(self):

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -70,6 +70,8 @@ class TestMessageModel(IntegrationTestCase):
         self.assertEqual(
             [u'files/dossier-1/dossier-2/ubersicht-der-vertrage-von-2016.xlsx',
              u'files/dossier-1/vertragsentwurf.docx',
+             u'files/dossier-1/die-burgschaft.eml',
+             u'files/dossier-1/testm\xe4il.msg',
              u'files/dossier-1/initialvertrag-fur-bearbeitung-8-sitzung-der.docx',  # noqa
              u'files/vertragsentwurf.docx'],
             zipfile.arcnames)
@@ -105,11 +107,12 @@ class TestDossierModel(IntegrationTestCase):
         self.assertEqual(
             base_path + '/' + self.dossier.getId(), dossier.path)
 
-    def test_dossier_contains_documents(self):
+    def test_dossier_contains_documents_and_mails(self):
+        documentish_types = ['opengever.document.document', 'ftw.mail.mail']
         dossier = Dossier(self.dossier, u'files')
         self.assertItemsEqual(
             [d for d in self.dossier.objectValues()
-                if d.portal_type == 'opengever.document.document'],
+             if d.portal_type in documentish_types],
             [d.obj for d in dossier.documents])
 
     def test_dossier_contains_subdossiers(self):

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -115,6 +115,12 @@ class TestDossierModel(IntegrationTestCase):
              if d.portal_type in documentish_types],
             [d.obj for d in dossier.documents])
 
+    def test_documents_without_a_file_are_skipped(self):
+        self.document.file = None
+        dossier = Dossier(self.dossier, u'files')
+
+        self.assertNotIn(self.document, [d.obj for d in dossier.documents])
+
     def test_dossier_contains_subdossiers(self):
         dossier = Dossier(self.dossier, u'files')
         self.assertItemsEqual(


### PR DESCRIPTION
- Include mails in eCH-0147 exports.
- Skip documents without a file in eCH-0147 exports (Documents without a file are not supported by the eCH-0147 standard).

Closes #3509