### PR TITLE
Prevent editing agenda item list when it should not be allowed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2017.6.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Prevent editing agenda item list when meeting has been held. [deiferni]
 
 
 2017.6.0 (2017-10-27)

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -245,8 +245,7 @@ class AgendaItemsView(BrowserView):
         """Updates the order of the agendaitems. The new sortOrder is expected
         in the request parameter `sortOrder`.
         """
-        if not self.context.model.is_editable():
-            raise Unauthorized("Editing is not allowed")
+        self.check_agendalist_editable()
 
         self.context.model.reorder_agenda_items(
             json.loads(self.request.get('sortOrder')))
@@ -259,8 +258,7 @@ class AgendaItemsView(BrowserView):
         """Updates the title of the agendaitem, with the one given by the
         request parameter `title`.
         """
-        if not self.context.model.is_editable():
-            raise Unauthorized("Editing is not allowed")
+        self.check_agendalist_editable()
 
         title = self.request.get('title')
         if not title:
@@ -286,9 +284,7 @@ class AgendaItemsView(BrowserView):
         proposal, the agenda_item gets deleted. If there is a proposal related,
         the proposal is unscheduled.
         """
-
-        if not self.context.model.is_editable():
-            raise Unauthorized("Editing is not allowed")
+        self.check_agendalist_editable()
 
         # the agenda_item is ad hoc if it has a document but no proposal
         if self.agenda_item.has_document and not self.agenda_item.has_proposal:
@@ -410,7 +406,7 @@ class AgendaItemsView(BrowserView):
         """Schedule the given Paragraph (request parameter `title`) for the current
         meeting.
         """
-        self.check_editable()
+        self.check_agendalist_editable()
 
         title = self.request.get('title')
         if not title:
@@ -426,7 +422,8 @@ class AgendaItemsView(BrowserView):
         """Schedule the given Text (request parameter `title`) for the current
         meeting.
         """
-        self.check_editable()
+        self.check_agendalist_editable()
+
         title = safe_unicode(self.request.get('title'))
         if not title:
             return JSONResponse(self.request).error(
@@ -457,6 +454,10 @@ class AgendaItemsView(BrowserView):
 
     def check_editable(self):
         if not self.meeting.is_editable():
+            raise Unauthorized("Editing is not allowed")
+
+    def check_agendalist_editable(self):
+        if not self.meeting.is_agendalist_editable():
             raise Unauthorized("Editing is not allowed")
 
     def generate_excerpt(self):

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -245,7 +245,7 @@ class AgendaItemsView(BrowserView):
         """Updates the order of the agendaitems. The new sortOrder is expected
         in the request parameter `sortOrder`.
         """
-        self.check_agendalist_editable()
+        self.require_agendalist_editable()
 
         self.context.model.reorder_agenda_items(
             json.loads(self.request.get('sortOrder')))
@@ -258,7 +258,7 @@ class AgendaItemsView(BrowserView):
         """Updates the title of the agendaitem, with the one given by the
         request parameter `title`.
         """
-        self.check_agendalist_editable()
+        self.require_agendalist_editable()
 
         title = self.request.get('title')
         if not title:
@@ -284,7 +284,7 @@ class AgendaItemsView(BrowserView):
         proposal, the agenda_item gets deleted. If there is a proposal related,
         the proposal is unscheduled.
         """
-        self.check_agendalist_editable()
+        self.require_agendalist_editable()
 
         # the agenda_item is ad hoc if it has a document but no proposal
         if self.agenda_item.has_document and not self.agenda_item.has_proposal:
@@ -384,7 +384,7 @@ class AgendaItemsView(BrowserView):
     def edit_document(self):
         """Checkout and open the document with office connector.
         """
-        self.check_editable()
+        self.require_editable()
 
         document = self.agenda_item.resolve_document()
         checkout_manager = getMultiAdapter((document, self.request),
@@ -406,7 +406,7 @@ class AgendaItemsView(BrowserView):
         """Schedule the given Paragraph (request parameter `title`) for the current
         meeting.
         """
-        self.check_agendalist_editable()
+        self.require_agendalist_editable()
 
         title = self.request.get('title')
         if not title:
@@ -422,7 +422,7 @@ class AgendaItemsView(BrowserView):
         """Schedule the given Text (request parameter `title`) for the current
         meeting.
         """
-        self.check_agendalist_editable()
+        self.require_agendalist_editable()
 
         title = safe_unicode(self.request.get('title'))
         if not title:
@@ -452,11 +452,11 @@ class AgendaItemsView(BrowserView):
         return JSONResponse(self.request).info(
             _('text_added', default=u"Text successfully added.")).proceed().dump()
 
-    def check_editable(self):
+    def require_editable(self):
         if not self.meeting.is_editable():
             raise Unauthorized("Editing is not allowed")
 
-    def check_agendalist_editable(self):
+    def require_agendalist_editable(self):
         if not self.meeting.is_agendalist_editable():
             raise Unauthorized("Editing is not allowed")
 

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -254,6 +254,18 @@ class TestAgendaItemDelete(TestAgendaItem):
                 view='agenda_items/{}/delete'.format(other_item.agenda_item_id))
 
     @browsing
+    def test_update_agenda_item_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+        item = create(Builder('agenda_item').having(
+            title=u'foo', meeting=self.meeting))
+
+        self.meeting.workflow_state = 'held'
+
+        with browser.expect_unauthorized():
+            browser.login().open(
+                self.meeting_wrapper,
+                view='agenda_items/{}/delete'.format(item.agenda_item_id))
+
+    @browsing
     def test_update_agenda_item_raise_unauthorized_when_meeting_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
@@ -587,6 +599,14 @@ class TestAgendaItemUpdateOrder(TestAgendaItem):
                           browser.json.get('messages'))
 
     @browsing
+    def test_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+        self.meeting.workflow_state = 'closed'
+
+        with browser.expect_unauthorized():
+            browser.login().open(self.meeting_wrapper,
+                                 view='agenda_items/update_order')
+
+    @browsing
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
@@ -608,6 +628,14 @@ class TestScheduleParagraph(TestAgendaItem):
         self.assertEquals(1, len(agenda_items))
         self.assertEqual(u'Abschnitt A', agenda_items[0].title)
         self.assertTrue(agenda_items[0].is_paragraph)
+
+    @browsing
+    def test_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+        self.meeting.workflow_state = 'held'
+
+        with browser.expect_unauthorized():
+            browser.login().open(self.meeting_wrapper,
+                                 view='agenda_items/schedule_paragraph')
 
     @browsing
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
@@ -633,9 +661,19 @@ class TestScheduleText(TestAgendaItem):
         self.assertFalse(agenda_items[0].is_paragraph)
 
     @browsing
+    def test_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+        self.meeting.workflow_state = 'held'
+
+        with browser.expect_unauthorized():
+            browser.login().open(self.meeting_wrapper,
+                                 view='agenda_items/schedule_text',
+                                 data={'title': u'Baugesuch Herr Maier'})
+
+    @browsing
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
         with browser.expect_unauthorized():
             browser.login().open(self.meeting_wrapper,
-                                 view='agenda_items/schedule_paragraph')
+                                     view='agenda_items/schedule_text',
+                                     data={'title': u'Baugesuch Herr Maier'})


### PR DESCRIPTION
No longer allow the following actions when the meeting has been held:

- schedule paragraphs
- schedule agenda items
- edit agenda item title
- delete agenda items

Fixes #3551.