### PR TITLE
Display error message to client when state has changed in meantime

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.1 (unreleased)
 ---------------------
 
+- Also display exceptions on agenda item list to users. [deiferni]
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 
 

--- a/opengever/base/browser/resources/Controller.js
+++ b/opengever/base/browser/resources/Controller.js
@@ -303,7 +303,7 @@
         } else {
           request.resolve(data);
         }
-      }).fail(function() { request.reject(); });
+      }).fail(function(response) { request.reject(response.responseJSON); });
 
       request.done(function() {
         if(options.loading) { target.removeClass("loading"); }

--- a/opengever/base/response.py
+++ b/opengever/base/response.py
@@ -17,6 +17,7 @@ class JSONResponse(object):
     def __init__(self, request):
         self.request = request
         self.response = {}
+        self.status = None
 
     def info(self, message):
         """
@@ -32,10 +33,12 @@ class JSONResponse(object):
         self.response['messages'] = self.response.get('messages', []) + [message]
         return self
 
-    def error(self, message):
+    def error(self, message, status=None):
         """
         Append a standardized error message with given message.
         """
+        self.status = status
+
         message = {
             'messageClass': 'error',
             'messageTitle': translate(_('message_title_error',
@@ -84,6 +87,8 @@ class JSONResponse(object):
         By default, no-caching headers are set on the response.
         This can be disabled by setting ``no_cache`` to ``False``.
         """
+        if self.status:
+            self.request.response.setStatus(self.status)
 
         if no_cache:
             self.request.response.setHeader("Cache-Control", "no-store")

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -185,7 +185,7 @@ class AgendaItemsView(BrowserView):
             'edit_document_button': button}
 
     def _get_agenda_items(self):
-        meeting = self.context.model
+        meeting = self.meeting
         agenda_items = []
         for item in meeting.agenda_items:
             data = item.serialize()
@@ -248,7 +248,7 @@ class AgendaItemsView(BrowserView):
         """
         self.require_agendalist_editable()
 
-        self.context.model.reorder_agenda_items(
+        self.meeting.reorder_agenda_items(
             json.loads(self.request.get('sortOrder')))
 
         return JSONResponse(self.request).info(
@@ -305,7 +305,7 @@ class AgendaItemsView(BrowserView):
         """
         meeting_state = self.meeting.get_state()
 
-        if not self.context.model.is_editable():
+        if not self.meeting.is_editable():
             raise Unauthorized("Editing is not allowed")
 
         error_response = self._checkin_proposal_document_before_deciding()
@@ -360,7 +360,7 @@ class AgendaItemsView(BrowserView):
         """Reopen the current agendaitem. Set the workflow state to revision
         to indicate that editing is possible again.
         """
-        if not self.context.model.is_editable():
+        if not self.meeting.is_editable():
             raise Unauthorized("Editing is not allowed")
 
         self.agenda_item.reopen()
@@ -373,7 +373,7 @@ class AgendaItemsView(BrowserView):
         """Revise the current agendaitem. Set the workflow state to decided
         to indicate that editing is no longer possible.
         """
-        if not self.context.model.is_editable():
+        if not self.meeting.is_editable():
             raise Unauthorized("Editing is not allowed")
 
         try:
@@ -471,7 +471,7 @@ class AgendaItemsView(BrowserView):
         """Generate an excerpt of an agenda item and store it in
         the meeting dossier.
         """
-        if not self.context.model.is_editable():
+        if not self.meeting.is_editable():
             raise Unauthorized("Editing is not allowed")
 
         if not self.agenda_item.can_generate_excerpt():

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -103,12 +103,14 @@ def return_jsonified_exceptions(func):
             return JSONResponse(getRequest()).error(
                 _(u'invalid_agenda_item_state',
                   default=u'The agenda item is in an invalid state for '
-                           'this action.')).dump()
+                           'this action.'),
+                status=401).dump()
 
         except Unauthorized:
             return JSONResponse(getRequest()).error(
                 _(u'editing_not_allowed',
-                  default=u'Editing is not allowed.')).dump()
+                  default=u'Editing is not allowed.'),
+                status=401).dump()
 
         except MissingMeetingDossierPermissions:
             return JSONResponse(getRequest()).error(

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -5,6 +5,7 @@ from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.exceptions import MissingAdHocTemplate
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
+from opengever.meeting.exceptions import WrongAgendaItemState
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.service import meeting_service
 from opengever.trash.trash import ITrashable
@@ -375,7 +376,13 @@ class AgendaItemsView(BrowserView):
         if not self.context.model.is_editable():
             raise Unauthorized("Editing is not allowed")
 
-        self.agenda_item.revise()
+        try:
+            self.agenda_item.revise()
+        except WrongAgendaItemState:
+            return JSONResponse(self.request).error(
+                _(u'invalid_agenda_item_state',
+                  default=u'The agenda item is in an invalid state for '
+                           'this action.')).dump()
 
         return JSONResponse(self.request).info(
             _(u'agenda_item_revised',

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -17,7 +17,6 @@ from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from zExceptions import BadRequest
-from zExceptions import Forbidden
 from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
@@ -499,18 +498,8 @@ class AgendaItemsView(BrowserView):
         if not self.meeting.is_editable():
             raise Unauthorized("Editing is not allowed")
 
-        if not self.agenda_item.can_generate_excerpt():
-            raise Forbidden('Generating excerpt is not allowed in this state.')
-
-        try:
-            self.agenda_item.generate_excerpt(title=self.request.form['excerpt_title'])
-        except MissingMeetingDossierPermissions:
-            return (JSONResponse(self.request)
-                    .error(_('error_no_permission_to_add_document',
-                             default=u'Insufficient privileges to add a'
-                             u' document to the meeting dossier.'))
-                    .remain()
-                    .dump())
+        self.agenda_item.generate_excerpt(
+            title=self.request.form['excerpt_title'])
 
         return (JSONResponse(self.request)
                 .info(_('excerpt_generated',

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -116,6 +116,13 @@ def return_jsonified_exceptions(func):
                   default=u'Insufficient privileges to add a '
                           u'document to the meeting dossier.')).dump()
 
+        except MissingAdHocTemplate:
+            return JSONResponse(getRequest()).error(
+                    _('missing_ad_hoc_template',
+                      default=u"No ad-hoc agenda-item template has been "
+                              u"configured.")
+                ).remain().dump()
+
     return wrapper
 
 
@@ -469,15 +476,7 @@ class AgendaItemsView(BrowserView):
                 ).proceed().dump()
 
         if is_word_meeting_implementation_enabled():
-            try:
-                self.meeting.schedule_ad_hoc(title)
-            except MissingAdHocTemplate:
-                return JSONResponse(self.request).error(
-                        _('missing_ad_hoc_template',
-                          default=u"No ad-hoc agenda-item template has been "
-                                  u"configured.")
-                    ).remain().dump()
-
+            self.meeting.schedule_ad_hoc(title)
         else:
             self.meeting.schedule_text(title)
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -98,15 +98,23 @@ def return_jsonified_exceptions(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
+
         except WrongAgendaItemState:
             return JSONResponse(getRequest()).error(
                 _(u'invalid_agenda_item_state',
                   default=u'The agenda item is in an invalid state for '
                            'this action.')).dump()
+
         except Unauthorized:
             return JSONResponse(getRequest()).error(
                 _(u'editing_not_allowed',
                   default=u'Editing is not allowed.')).dump()
+
+        except MissingMeetingDossierPermissions:
+            return JSONResponse(getRequest()).error(
+                _('error_no_permission_to_add_document',
+                  default=u'Insufficient privileges to add a '
+                          u'document to the meeting dossier.')).dump()
 
     return wrapper
 
@@ -469,12 +477,6 @@ class AgendaItemsView(BrowserView):
                           default=u"No ad-hoc agenda-item template has been "
                                   u"configured.")
                     ).remain().dump()
-            except MissingMeetingDossierPermissions:
-                return JSONResponse(self.request).error(
-                        _('error_no_permission_to_add_document',
-                          default=u'Insufficient privileges to add a'
-                                  u' document to the meeting dossier.')
-                       ).remain().dump()
 
         else:
             self.meeting.schedule_text(title)

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -121,10 +121,10 @@ def return_jsonified_exceptions(func):
 
         except MissingAdHocTemplate:
             return JSONResponse(getRequest()).error(
-                    _('missing_ad_hoc_template',
-                      default=u"No ad-hoc agenda-item template has been "
-                              u"configured.")
-                ).remain().dump()
+                _('missing_ad_hoc_template',
+                  default=u"No ad-hoc agenda-item template has been "
+                          u"configured."),
+                status=501).dump()
 
     return wrapper
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -10,7 +10,6 @@ from opengever.meeting.exceptions import MissingMeetingDossierPermissions
 from opengever.meeting.exceptions import WrongAgendaItemState
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.service import meeting_service
-from opengever.trash.trash import ITrashable
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.app.contentlisting.interfaces import IContentListingObject
@@ -326,12 +325,6 @@ class AgendaItemsView(BrowserView):
         the proposal is unscheduled.
         """
         self.require_agendalist_editable()
-
-        # the agenda_item is ad hoc if it has a document but no proposal
-        if self.agenda_item.has_document and not self.agenda_item.has_proposal:
-            document = self.agenda_item.resolve_document()
-            trasher = ITrashable(document)
-            trasher.trash()
 
         self.agenda_item.remove()
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -343,11 +343,9 @@ class AgendaItemsView(BrowserView):
         """Decide the current agendaitem and move the meeting in the
         held state.
         """
+        self.require_editable()
+
         meeting_state = self.meeting.get_state()
-
-        if not self.meeting.is_editable():
-            raise Unauthorized("Editing is not allowed")
-
         error_response = self._checkin_proposal_document_before_deciding()
         if error_response:
             return error_response
@@ -401,8 +399,7 @@ class AgendaItemsView(BrowserView):
         """Reopen the current agendaitem. Set the workflow state to revision
         to indicate that editing is possible again.
         """
-        if not self.meeting.is_editable():
-            raise Unauthorized("Editing is not allowed")
+        self.require_editable()
 
         self.agenda_item.reopen()
 
@@ -415,8 +412,7 @@ class AgendaItemsView(BrowserView):
         """Revise the current agendaitem. Set the workflow state to decided
         to indicate that editing is no longer possible.
         """
-        if not self.meeting.is_editable():
-            raise Unauthorized("Editing is not allowed")
+        self.require_editable()
 
         self.agenda_item.revise()
         return JSONResponse(self.request).info(
@@ -496,8 +492,7 @@ class AgendaItemsView(BrowserView):
         """Generate an excerpt of an agenda item and store it in
         the meeting dossier.
         """
-        if not self.meeting.is_editable():
-            raise Unauthorized("Editing is not allowed")
+        self.require_editable()
 
         self.agenda_item.generate_excerpt(
             title=self.request.form['excerpt_title'])

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -4,6 +4,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.meeting import _
 from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting import require_word_meeting_feature
+from opengever.meeting.exceptions import CannotExecuteTransition
 from opengever.meeting.exceptions import MissingAdHocTemplate
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
 from opengever.meeting.exceptions import WrongAgendaItemState
@@ -99,7 +100,7 @@ def return_jsonified_exceptions(func):
         try:
             return func(*args, **kwargs)
 
-        except WrongAgendaItemState:
+        except (WrongAgendaItemState, CannotExecuteTransition):
             return JSONResponse(getRequest()).error(
                 _(u'invalid_agenda_item_state',
                   default=u'The agenda item is in an invalid state for '

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -17,8 +17,8 @@ from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zExceptions import NotFound
-from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
 from zope.i18n import translate
@@ -104,19 +104,20 @@ def return_jsonified_exceptions(func):
                 _(u'invalid_agenda_item_state',
                   default=u'The agenda item is in an invalid state for '
                            'this action.'),
-                status=401).dump()
+                status=403).dump()
 
-        except Unauthorized:
+        except Forbidden:
             return JSONResponse(getRequest()).error(
                 _(u'editing_not_allowed',
                   default=u'Editing is not allowed.'),
-                status=401).dump()
+                status=403).dump()
 
         except MissingMeetingDossierPermissions:
             return JSONResponse(getRequest()).error(
                 _('error_no_permission_to_add_document',
                   default=u'Insufficient privileges to add a '
-                          u'document to the meeting dossier.')).dump()
+                          u'document to the meeting dossier.'),
+                status=403).dump()
 
         except MissingAdHocTemplate:
             return JSONResponse(getRequest()).error(
@@ -477,11 +478,11 @@ class AgendaItemsView(BrowserView):
 
     def require_editable(self):
         if not self.meeting.is_editable():
-            raise Unauthorized("Editing is not allowed")
+            raise Forbidden("Editing is not allowed")
 
     def require_agendalist_editable(self):
         if not self.meeting.is_agendalist_editable():
-            raise Unauthorized("Editing is not allowed")
+            raise Forbidden("Editing is not allowed")
 
     @return_jsonified_exceptions
     def generate_excerpt(self):

--- a/opengever/meeting/browser/meetings/unscheduled_proposals.py
+++ b/opengever/meeting/browser/meetings/unscheduled_proposals.py
@@ -2,8 +2,8 @@ from opengever.base.response import JSONResponse
 from opengever.meeting import _
 from opengever.meeting.model import Proposal
 from Products.Five.browser import BrowserView
+from zExceptions import Forbidden
 from zExceptions import NotFound
-from zExceptions import Unauthorized
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces.browser import IBrowserView
@@ -32,14 +32,14 @@ class UnscheduledProposalsView(BrowserView):
         return '{}/unscheduled_proposals/{}/schedule'.format(
             self.context.absolute_url(), proposal.proposal_id)
 
-    def check_editable(self):
-        if not self.meeting.is_editable():
-            raise Unauthorized("Editing is not allowed")
+    def require_editable(self):
+        if not self.meeting.is_agendalist_editable():
+            raise Forbidden("Editing is not allowed")
 
     def schedule_proposal(self):
         """Schedule the current proposal on the current meeting.
         """
-        self.check_editable()
+        self.require_editable()
 
         proposal = Proposal.get(self.proposal_id)
         if not proposal:

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -428,12 +428,16 @@
     this.reopen = function(target){
       return $.post(target.attr("href")).done(function() {
         self.updateCloseTransitionActionState();
+      }).fail(function () {
+        self.update();
       });
     };
 
     this.revise = function(target){
-      return $.post(target.attr("href")).done(function() {
+      return $.post(target.attr("href")).always(function() {
         self.updateCloseTransitionActionState();
+      }).fail(function () {
+        self.update();
       });
     };
 

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -48,3 +48,7 @@ class WrongAgendaItemState(Exception):
     """The agenda item is not in the correct state to perform the desired
     action.
     """
+
+
+class CannotExecuteTransition(Exception):
+    """The workflow transition cannot be executed."""

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -42,3 +42,9 @@ class MissingProtocolHeaderTemplate(Exception):
 class MissingParagraphTemplate(Exception):
     """No paragraph template could be found for the committee or its container.
     """
+
+
+class WrongAgendaItemState(Exception):
+    """The agenda item is not in the correct state to perform the desired
+    action.
+    """

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-25 12:53+0000\n"
+"POT-Creation-Date: 2017-10-25 15:34+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -684,6 +684,11 @@ msgstr "Dossier"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "download protocol"
 msgstr "Protokoll herunterladen"
+
+#. Default: "Editing is not allowed."
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+msgid "editing_not_allowed"
+msgstr "Bearbeiten ist nicht erlaubt."
 
 #. Default: "Paragraph must not be empty."
 #: ./opengever/meeting/browser/meetings/agendaitem.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:48+0000\n"
+"POT-Creation-Date: 2017-10-25 12:53+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -790,6 +790,11 @@ msgstr "Sitzung durchführen"
 #: ./opengever/meeting/model/committee.py
 msgid "inactive"
 msgstr "Inaktiv"
+
+#. Default: "The agenda item is in an invalid state for this action."
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+msgid "invalid_agenda_item_state"
+msgstr "Diese Aktion kann im aktuellen Zustand des Traktandums nicht durchgeführt werden."
 
 #. Default: "delete this agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-25 12:53+0000\n"
+"POT-Creation-Date: 2017-10-25 15:34+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -686,6 +686,11 @@ msgstr "Dossier"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "download protocol"
 msgstr "Télécharger le protocole"
+
+#. Default: "Editing is not allowed."
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+msgid "editing_not_allowed"
+msgstr ""
 
 #. Default: "Paragraph must not be empty."
 #: ./opengever/meeting/browser/meetings/agendaitem.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:48+0000\n"
+"POT-Creation-Date: 2017-10-25 12:53+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -792,6 +792,11 @@ msgstr "Tenir une réunion"
 #: ./opengever/meeting/model/committee.py
 msgid "inactive"
 msgstr "Inactif"
+
+#. Default: "The agenda item is in an invalid state for this action."
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+msgid "invalid_agenda_item_state"
+msgstr ""
 
 #. Default: "delete this agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-24 12:48+0000\n"
+"POT-Creation-Date: 2017-10-25 12:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -788,6 +788,11 @@ msgstr ""
 #. Default: "Inactive"
 #: ./opengever/meeting/model/committee.py
 msgid "inactive"
+msgstr ""
+
+#. Default: "The agenda item is in an invalid state for this action."
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+msgid "invalid_agenda_item_state"
 msgstr ""
 
 #. Default: "delete this agenda item"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-25 12:53+0000\n"
+"POT-Creation-Date: 2017-10-25 15:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -682,6 +682,11 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 msgid "download protocol"
+msgstr ""
+
+#. Default: "Editing is not allowed."
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+msgid "editing_not_allowed"
 msgstr ""
 
 #. Default: "Paragraph must not be empty."

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import composite
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 from zope.component import getMultiAdapter
+from opengever.trash.trash import ITrashable
 
 
 class AgendaItem(Base):
@@ -261,6 +262,12 @@ class AgendaItem(Base):
 
     def remove(self):
         assert self.meeting.is_editable()
+
+        # the agenda_item is ad hoc if it has a document but no proposal
+        if self.has_document and not self.has_proposal:
+            document = self.resolve_document()
+            trasher = ITrashable(document)
+            trasher.trash()
 
         session = create_session()
         if self.proposal:

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -425,7 +425,9 @@ class AgendaItem(Base):
         from the ad-hoc agenda items document.
         In both cases the excerpt is stored in the meeting dossier.
         """
-        assert self.can_generate_excerpt()
+        if not self.can_generate_excerpt():
+            raise WrongAgendaItemState()
+
         meeting_dossier = self.meeting.get_dossier()
         source_document = self.resolve_document()
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -11,6 +11,7 @@ from opengever.meeting import _
 from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.meeting import require_word_meeting_feature
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
+from opengever.meeting.exceptions import WrongAgendaItemState
 from opengever.meeting.model import Period
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.workflow import State
@@ -401,7 +402,8 @@ class AgendaItem(Base):
         return False
 
     def revise(self):
-        assert self.is_revise_possible()
+        if not self.is_revise_possible():
+            raise WrongAgendaItemState()
 
         if self.has_proposal:
             self.proposal.revise(self)

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -200,13 +200,13 @@ class TestAgendaItemEdit(TestAgendaItem):
                                  view='agenda_items/12345/edit')
 
     @browsing
-    def test_update_agenda_item_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_update_agenda_item_raise_forbidden_when_meeting_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
 
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/edit'.format(item.agenda_item_id),
@@ -254,25 +254,25 @@ class TestAgendaItemDelete(TestAgendaItem):
                 view='agenda_items/{}/delete'.format(other_item.agenda_item_id))
 
     @browsing
-    def test_update_agenda_item_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+    def test_update_agenda_item_raise_forbidden_when_agenda_list_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
 
         self.meeting.workflow_state = 'held'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/delete'.format(item.agenda_item_id))
 
     @browsing
-    def test_update_agenda_item_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_update_agenda_item_raise_forbidden_when_meeting_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
 
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/delete'.format(item.agenda_item_id))
@@ -401,13 +401,13 @@ class TestAgendaItemDecide(TestAgendaItem):
                                  view='agenda_items/12345/decide')
 
     @browsing
-    def test_update_agenda_item_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_update_agenda_item_raise_forbidden_when_meeting_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
 
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/decide'.format(item.agenda_item_id))
@@ -482,14 +482,14 @@ class TestAgendaItemReopen(TestAgendaItem):
                                  view='agenda_items/12345/reopen')
 
     @browsing
-    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_raise_forbidden_when_meeting_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
         item.decide()
 
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/reopen'.format(item.agenda_item_id))
@@ -557,14 +557,14 @@ class TestAgendaItemRevise(TestAgendaItem):
                                  view='agenda_items/12345/revise')
 
     @browsing
-    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_raise_forbidden_when_meeting_is_not_editable(self, browser):
         item = create(Builder('agenda_item').having(
             title=u'foo', meeting=self.meeting))
         item.decide()
 
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(
                 self.meeting_wrapper,
                 view='agenda_items/{}/revise'.format(item.agenda_item_id))
@@ -599,18 +599,18 @@ class TestAgendaItemUpdateOrder(TestAgendaItem):
                           browser.json.get('messages'))
 
     @browsing
-    def test_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+    def test_raise_forbidden_when_agenda_list_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/update_order')
 
     @browsing
-    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_raise_forbidden_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/update_order')
 
@@ -630,18 +630,18 @@ class TestScheduleParagraph(TestAgendaItem):
         self.assertTrue(agenda_items[0].is_paragraph)
 
     @browsing
-    def test_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+    def test_raise_forbidden_when_agenda_list_is_not_editable(self, browser):
         self.meeting.workflow_state = 'held'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/schedule_paragraph')
 
     @browsing
-    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_raise_forbidden_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/schedule_paragraph')
 
@@ -661,19 +661,19 @@ class TestScheduleText(TestAgendaItem):
         self.assertFalse(agenda_items[0].is_paragraph)
 
     @browsing
-    def test_raise_unauthorized_when_agenda_list_is_not_editable(self, browser):
+    def test_raise_forbidden_when_agenda_list_is_not_editable(self, browser):
         self.meeting.workflow_state = 'held'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper,
                                  view='agenda_items/schedule_text',
                                  data={'title': u'Baugesuch Herr Maier'})
 
     @browsing
-    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_raise_forbidden_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper,
                                      view='agenda_items/schedule_text',
                                      data={'title': u'Baugesuch Herr Maier'})

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -64,8 +64,7 @@ class TestWordAgendaItem(IntegrationTestCase):
                 {u'messageTitle': u'Error',
                  u'message': u'Insufficient privileges to add a document '
                               'to the meeting dossier.',
-                 u'messageClass': u'error'}],
-             u'proceed': False},
+                 u'messageClass': u'error'}]},
             browser.json)
 
     @browsing
@@ -224,10 +223,9 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.assertEquals(
             {u'messages': [
                 {u'messageTitle': u'Error',
-                 u'message': u'Insufficient privileges to add a document'
-                 u' to the meeting dossier.',
-                 u'messageClass': u'error'}],
-             u'proceed': False},
+                 u'message': u'Insufficient privileges to add a document '
+                 u'to the meeting dossier.',
+                 u'messageClass': u'error'}]},
             browser.json)
 
     @browsing

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -56,16 +56,17 @@ class TestWordAgendaItem(IntegrationTestCase):
             self.meeting_dossier.reindexObjectSecurity()
 
         self.login(self.committee_responsible, browser)
-        browser.open(self.meeting, view='agenda_items/schedule_text',
-                     data={'title': u'Fail',
-                           '_authenticator': createToken()})
-        self.assertEquals(
-            {u'messages': [
-                {u'messageTitle': u'Error',
-                 u'message': u'Insufficient privileges to add a document '
-                              'to the meeting dossier.',
-                 u'messageClass': u'error'}]},
-            browser.json)
+        with browser.expect_http_error(code=403):
+            browser.open(self.meeting, view='agenda_items/schedule_text',
+                         data={'title': u'Fail',
+                               '_authenticator': createToken()})
+            self.assertEquals(
+                {u'messages': [
+                    {u'messageTitle': u'Error',
+                     u'message': u'Insufficient privileges to add a document '
+                                  'to the meeting dossier.',
+                     u'messageClass': u'error'}]},
+                browser.json)
 
     @browsing
     def test_edit_ad_hoc_document_possible_when_scheduled(self, browser):
@@ -191,7 +192,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.assertEquals(self.meeting.model.STATE_CLOSED,
                           self.meeting.model.get_state())
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.open(self.agenda_item_url(agenda_item, 'generate_excerpt'))
 
     @browsing
@@ -199,7 +200,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_ad_hoc(self.meeting, u'ad-hoc')
 
-        with browser.expect_http_error(reason='Unauthorized'):
+        with browser.expect_http_error(code=403):
             browser.open(
                 self.agenda_item_url(agenda_item, 'generate_excerpt'),
                 data={'excerpt_title': u'foo'})
@@ -219,16 +220,17 @@ class TestWordAgendaItem(IntegrationTestCase):
             agenda_item.decide()
 
         self.login(self.regular_user, browser)
-        browser.open(
-            self.agenda_item_url(agenda_item, 'generate_excerpt'),
-            data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
-        self.assertEquals(
-            {u'messages': [
-                {u'messageTitle': u'Error',
-                 u'message': u'Insufficient privileges to add a document '
-                 u'to the meeting dossier.',
-                 u'messageClass': u'error'}]},
-            browser.json)
+        with browser.expect_http_error(code=403):
+            browser.open(
+                self.agenda_item_url(agenda_item, 'generate_excerpt'),
+                data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
+            self.assertEquals(
+                {u'messages': [
+                    {u'messageTitle': u'Error',
+                     u'message': u'Insufficient privileges to add a document '
+                     u'to the meeting dossier.',
+                     u'messageClass': u'error'}]},
+                browser.json)
 
     @browsing
     def test_excerpts_listed_in_meeting_ad_hoc_item_data(self, browser):

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -199,8 +199,10 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_ad_hoc(self.meeting, u'ad-hoc')
 
-        with browser.expect_http_error(reason='Forbidden'):
-            browser.open(self.agenda_item_url(agenda_item, 'generate_excerpt'))
+        with browser.expect_http_error(reason='Unauthorized'):
+            browser.open(
+                self.agenda_item_url(agenda_item, 'generate_excerpt'),
+                data={'excerpt_title': u'foo'})
 
     @browsing
     def test_error_when_no_access_to_meeting_dossier(self, browser):

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -317,10 +317,9 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.assertEquals(
             {u'messages': [
                 {u'messageTitle': u'Error',
-                 u'message': u'Insufficient privileges to add a document'
-                 u' to the meeting dossier.',
-                 u'messageClass': u'error'}],
-             u'proceed': False},
+                 u'message': u'Insufficient privileges to add a document '
+                 u'to the meeting dossier.',
+                 u'messageClass': u'error'}]},
             browser.json)
 
     @browsing

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -292,8 +292,10 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(self.meeting,
                                              self.submitted_word_proposal)
-        with browser.expect_http_error(reason='Forbidden'):
-            browser.open(self.agenda_item_url(agenda_item, 'generate_excerpt'))
+        with browser.expect_http_error(reason='Unauthorized'):
+            browser.open(
+                self.agenda_item_url(agenda_item, 'generate_excerpt'),
+                data={'excerpt_title': u'foo'})
 
     @browsing
     def test_error_when_no_access_to_meeting_dossier(self, browser):

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -284,7 +284,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.assertEquals(self.meeting.model.STATE_CLOSED,
                           self.meeting.model.get_state())
 
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.open(self.agenda_item_url(agenda_item, 'generate_excerpt'))
 
     @browsing
@@ -292,7 +292,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(self.meeting,
                                              self.submitted_word_proposal)
-        with browser.expect_http_error(reason='Unauthorized'):
+        with browser.expect_http_error(code=403):
             browser.open(
                 self.agenda_item_url(agenda_item, 'generate_excerpt'),
                 data={'excerpt_title': u'foo'})
@@ -313,16 +313,17 @@ class TestWordAgendaItem(IntegrationTestCase):
             agenda_item.decide()
 
         self.login(self.regular_user, browser)
-        browser.open(
-            self.agenda_item_url(agenda_item, 'generate_excerpt'),
-            data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
-        self.assertEquals(
-            {u'messages': [
-                {u'messageTitle': u'Error',
-                 u'message': u'Insufficient privileges to add a document '
-                 u'to the meeting dossier.',
-                 u'messageClass': u'error'}]},
-            browser.json)
+        with browser.expect_http_error(code=403):
+            browser.open(
+                self.agenda_item_url(agenda_item, 'generate_excerpt'),
+                data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
+            self.assertEquals(
+                {u'messages': [
+                    {u'messageTitle': u'Error',
+                     u'message': u'Insufficient privileges to add a document '
+                     u'to the meeting dossier.',
+                     u'messageClass': u'error'}]},
+                browser.json)
 
     @browsing
     def test_excerpts_listed_in_meeting_item_data(self, browser):

--- a/opengever/meeting/tests/test_unit_workflow.py
+++ b/opengever/meeting/tests/test_unit_workflow.py
@@ -1,7 +1,8 @@
-from unittest import TestCase
+from opengever.meeting.exceptions import CannotExecuteTransition
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
+from unittest import TestCase
 
 
 class SomethingWithWorkflow(object):
@@ -94,7 +95,7 @@ class TestUnitWorkflow(TestCase):
 
     def test_does_not_perform_unavailable_transition(self):
         obj = SomethingWithWorkflow(initial_state=self.pending.name)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(CannotExecuteTransition):
             self.workflow.execute_transition(None, obj, self.submit.name)
 
     def test_does_not_perform_invalid_transition(self):

--- a/opengever/meeting/tests/test_unscheduled_proposals.py
+++ b/opengever/meeting/tests/test_unscheduled_proposals.py
@@ -108,11 +108,11 @@ class TestScheduleProposal(TestUnscheduledProposals):
                           agenda_items[0].decision)
 
     @browsing
-    def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):
+    def test_raise_forbidden_when_meeting_is_not_editable(self, browser):
         self.meeting.workflow_state = 'closed'
 
         view = 'unscheduled_proposals/1/schedule'
-        with browser.expect_unauthorized():
+        with browser.expect_http_error(code=403):
             browser.login().open(self.meeting_wrapper, view=view)
 
     @browsing

--- a/opengever/meeting/tests/test_unscheduled_proposals.py
+++ b/opengever/meeting/tests/test_unscheduled_proposals.py
@@ -86,7 +86,7 @@ class TestScheduleProposal(TestUnscheduledProposals):
             proposal.load_model().proposal_id)
         browser.login().open(self.meeting_wrapper, view=view)
 
-        agenda_items =  Meeting.get(self.meeting.meeting_id).agenda_items
+        agenda_items = Meeting.get(self.meeting.meeting_id).agenda_items
         self.assertEquals(1, len(agenda_items))
         self.assertTrue(agenda_items[0].has_proposal)
         self.assertEqual(proposal.load_model(), agenda_items[0].proposal)
@@ -103,8 +103,9 @@ class TestScheduleProposal(TestUnscheduledProposals):
             proposal.load_model().proposal_id)
         browser.login().open(self.meeting_wrapper, view=view)
 
-        agenda_items =  Meeting.get(self.meeting.meeting_id).agenda_items
-        self.assertEquals(u'<div>Project allowed.</div>',agenda_items[0].decision)
+        agenda_items = Meeting.get(self.meeting.meeting_id).agenda_items
+        self.assertEquals(u'<div>Project allowed.</div>',
+                          agenda_items[0].decision)
 
     @browsing
     def test_raise_unauthorized_when_meeting_is_not_editable(self, browser):

--- a/opengever/meeting/workflow.py
+++ b/opengever/meeting/workflow.py
@@ -1,3 +1,6 @@
+from opengever.meeting.exceptions import CannotExecuteTransition
+
+
 class State(object):
 
     def __init__(self, name, is_default=False, title=None):
@@ -50,7 +53,10 @@ class Transition(object):
         return self._visible and self.condition()
 
     def execute(self, obj, model):
-        assert self.can_execute(model)
+        if not self.can_execute(model):
+            raise CannotExecuteTransition(
+                "Cannot execute transition {} from {} to {}".format(
+                    self.title, self.state_from, self.state_to))
         model.workflow_state = self.state_to
 
     def get_validation_errors(self, model):


### PR DESCRIPTION
This PR changes the behaviour of the agenda item list view to also display error messages to users when an ajax request failed because the servers state has changed in the meantime. We also trigger a reload of the agenda-item list for some of these cases to display the current state.

![screen shot 2017-10-26 at 15 28 13](https://user-images.githubusercontent.com/736583/32055517-577285a0-ba62-11e7-96b5-7b4fffe3c33f.png)

Changes include:
- throw exceptions in model instead of `assert` statements
- catch exceptions in controller/view and display messages to users
- also use correct status codes in json responses instead of 200 everywhere
- always display the error messages in a json response instead of just for succeeded responses

Closes #2436.

