### PR TITLE
Sort committees in committee vocabulary

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.5.2 (unreleased)
 ---------------------
 
+- Sort entries in committee vocabulary by committee title. [tarnap]
 - Skip documents without a file in eCH-0147 exports. [phgross]
 - Include mails in eCH-0147 exports. [phgross]
 - OGGBundle: Do intermediate commits every 1000 items by default. [lgraf]

--- a/opengever/meeting/tests/test_committee_vocabulary.py
+++ b/opengever/meeting/tests/test_committee_vocabulary.py
@@ -1,0 +1,17 @@
+from opengever.meeting.model import Committee
+from opengever.meeting.vocabulary import CommitteeVocabulary
+from opengever.testing import IntegrationTestCase
+
+
+class TestCommitteeVocabulary(IntegrationTestCase):
+
+    def test_get_committees_returns_list_sorted_by_title(self):
+        simple_vocabulary = CommitteeVocabulary()
+        titles_from_vocabulary = [term.title
+                                  for term in simple_vocabulary(context=None)]
+        unsorted_titles = [committee.title for committee in Committee.query.all()]
+        sorted_titles = [u'Kommission f\xfcr Verkehr',
+                         u'Rechnungspr\xfcfungskommission']
+
+        self.assertNotEquals(unsorted_titles, titles_from_vocabulary)
+        self.assertEquals(sorted_titles, titles_from_vocabulary)

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -19,16 +19,15 @@ from zope.schema.vocabulary import SimpleVocabulary
 class CommitteeVocabulary(object):
 
     def __call__(self, context):
-        terms = []
-
-        for committee in self.get_committees():
-            terms.append(SimpleTerm(value=committee,
-                                    token=committee.committee_id,
-                                    title=committee.title))
-        return SimpleVocabulary(terms)
+        return SimpleVocabulary([
+            SimpleTerm(value=committee,
+                       token=committee.committee_id,
+                       title=committee.title)
+            for committee in self.get_committees()
+        ])
 
     def get_committees(self):
-        return Committee.query.all()
+        return Committee.query.order_by('title').all()
 
 
 class ActiveCommitteeVocabulary(CommitteeVocabulary):


### PR DESCRIPTION
This vocabulary is used to display the committees in the form to add
proposals.
These committees should be sorted by their title.

Before:
<img width="1408" alt="bildschirmfoto 2017-10-19 um 11 24 43" src="https://user-images.githubusercontent.com/7469/31764039-55c7f98a-b4c0-11e7-9f2e-e1087e582002.png">

Now:
![sorted_committees_in_proposal_add_form_word](https://user-images.githubusercontent.com/194114/32095599-fe7da19e-bb03-11e7-9ae7-85f048dd36e7.png)

I split the PR into two commits, the first one contains the test (which fails), the second one contains the changes letting the test pass.
As soon as this PR is approved, the two commits are going to be squashed.

Resolves https://github.com/4teamwork/gever/issues/141