### PR TITLE
LDAP sync: skip referral's on each ldap search.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Skip documents without a file in eCH-0147 exports. [phgross]
 - Include mails in eCH-0147 exports. [phgross]
+- LDAP sync: skip referral's on each ldap search, also for the user import. [phgross]
 - OGGBundle: Do intermediate commits every 1000 items by default. [lgraf]
 - Handle spaces inside groups ids during repository import correctly. [phgross]
 - SPV word: Remove link to proposal excerpt document if no view permission. [tarnap]

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -398,7 +398,7 @@ class LDAPSearch(object):
             ldap_name = schema_map['ldap_name']
             public_name = schema_map['public_name']
 
-            if not ldap_name in attrs:
+            if ldap_name not in attrs:
                 # Attribute not set (different from "present with None value")
                 continue
 
@@ -415,7 +415,7 @@ class LDAPSearch(object):
 
         # Process remaining attributes
         for key in attrs:
-            if not key in mapped_attr_names:
+            if key not in mapped_attr_names:
                 if self._is_multivalued(attrs['objectClass'], key):
                     value = attrs[key]
                 else:
@@ -486,7 +486,7 @@ class LDAPSearch(object):
         First look in our internal cache, and in case of a miss, get the info
         from the schema and cache it.
         """
-        if not attr_name in self._multivaluedness:
+        if attr_name not in self._multivaluedness:
             self._multivaluedness[attr_name] = self._check_if_multivalued(
                 obj_classes, attr_name)
         return self._multivaluedness[attr_name]


### PR DESCRIPTION
With #2710 we already skip those referral's in the groups import, but same problem happens during user import.

The PR renames also the `filter` parameter to `search_filter`, to avoiding "conflicts".

Closes https://sentry.4teamwork.ch/sentry/onegov-gever/issues/4306/