### PR TITLE
Make sure response changes are persistent.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Also display exceptions on agenda item list to users. [deiferni]
+- Make sure response changes are persistent. [phgross]
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 
 

--- a/opengever/core/upgrades/20171029220954_make_task_response_changes_persistent/upgrade.py
+++ b/opengever/core/upgrades/20171029220954_make_task_response_changes_persistent/upgrade.py
@@ -1,0 +1,23 @@
+from ftw.upgrade import UpgradeStep
+from opengever.task.adapters import IResponseContainer
+from opengever.task.task import ITask
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+
+
+class MakeTaskResponseChangesPersistent(UpgradeStep):
+    """Make task response changes persistent.
+    """
+
+    def __call__(self):
+        for task in self.objects({'object_provides': ITask.__identifier__},
+                                'Make task responses persistent'):
+            self.make_responses_persistent(task)
+
+    def make_responses_persistent(self, task):
+        responses = IResponseContainer(task)
+        for response in responses:
+            if response.changes:
+                changes = [
+                    PersistentMapping(change) for change in response.changes]
+                response.changes = PersistentList(changes)

--- a/opengever/task/adapters.py
+++ b/opengever/task/adapters.py
@@ -7,6 +7,7 @@ from opengever.task.response_description import ResponseDescription
 from opengever.task.task import ITask
 from persistent import Persistent
 from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
 from zope.container.contained import ObjectAddedEvent
@@ -142,7 +143,7 @@ class Response(Persistent):
     def add_change(self, id, name, before, after):
         """Add a new issue change.
         """
-        delta = dict(
+        delta = PersistentMapping(
             id=id,
             name=name,
             before=before,

--- a/opengever/task/tests/test_comment.py
+++ b/opengever/task/tests/test_comment.py
@@ -1,0 +1,187 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import FunctionalTestCase
+
+
+class TestTaskCommentResponseAddFormView(FunctionalTestCase):
+
+    @browsing
+    def test_add_task_comment_response_view_is_available(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        browser.login().visit(task, view="addcommentresponse")
+        self.assertEqual(
+            'Add Comment',
+            browser.css('.documentFirstHeading').first.text)
+
+    @browsing
+    def test_default_task_response_form_fields(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        browser.login().visit(task, view="addcommentresponse")
+        labels = browser.css('#content-core label').text
+
+        # remove empty labels.
+        labels = filter(lambda item: item, labels)
+
+        self.assertEqual(['Response'], labels)
+
+    @browsing
+    def test_add_related_response_object_after_commenting(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        browser.login().visit(task, view="addcommentresponse")
+        browser.fill({'Response': 'I am a comment'}).find('Save').click()
+        browser.open(task, view='tabbedview_view-overview')
+
+        self.assertEqual(
+            'Commented by Test User (test_user_1_)',
+            self.get_latest_answer(browser))
+
+    @browsing
+    def test_text_field_is_required_for_comments(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task').within(dossier))
+
+        browser.login().visit(task, view="addcommentresponse")
+        browser.find('Save').click()
+
+        self.assertEqual(
+            ['There were some errors.'],
+            statusmessages.error_messages())
+
+    @browsing
+    def test_click_on_comment_button_redirects_to_add_comment_view(self, browser):
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        browser.css('.taskCommented').first.click()
+
+        self.assertEqual(
+            '{}/@@addcommentresponse'.format(task.absolute_url()),
+            browser.url)
+
+    @browsing
+    def test_do_not_show_comment_button_if_dossier_is_closed(self, browser):
+        dossier = create(Builder('dossier')
+                         .in_state('dossier-state-resolved'))
+
+        task = create(Builder('task').titled('Task 1').within(dossier))
+        browser.login().open(task, view='tabbedview_view-overview')
+
+        self.assertEqual(0, len(browser.css('.taskCommented')))
+
+    @browsing
+    def test_manager_can_access_addcommentresponse_view_on_open_dossier(self, browser):
+        self.grant('Manager')
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        self.assertEqual(
+            '{}/addcommentresponse'.format(task.absolute_url()),
+            browser.login().open(task, view='addcommentresponse').url)
+
+    @browsing
+    def test_adminstrator_can_access_addcommentresponse_view_on_open_dossier(self, browser):
+        self.grant('Adminstrator')
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        self.assertEqual(
+            '{}/addcommentresponse'.format(task.absolute_url()),
+            browser.login().open(task, view='addcommentresponse').url)
+
+    @browsing
+    def test_contributor_can_access_addcommentresponse_view_on_open_dossier(self, browser):
+        self.grant('Contributor')
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        self.assertEqual(
+            '{}/addcommentresponse'.format(task.absolute_url()),
+            browser.login().open(task, view='addcommentresponse').url)
+
+    @browsing
+    def test_editor_can_access_addcommentresponse_view_on_open_dossier(self, browser):
+        self.grant('Editor')
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        self.assertEqual(
+            '{}/addcommentresponse'.format(task.absolute_url()),
+            browser.login().open(task, view='addcommentresponse').url)
+
+    @browsing
+    def test_reader_can_not_access_addcommentresponse_view_on_open_dossier(self, browser):
+        self.grant('Reader')
+        dossier = create(Builder('dossier'))
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        self.assertEqual(
+            '{}/addcommentresponse'.format(task.absolute_url()),
+            browser.login().open(task, view='addcommentresponse').url)
+
+    @browsing
+    def test_manager_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
+        self.grant('Manager')
+        dossier = create(Builder('dossier')
+                         .in_state('dossier-state-resolved'))
+
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        with browser.expect_unauthorized():
+            browser.login().open(task, view='addcommentresponse')
+
+    @browsing
+    def test_adminstrator_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
+        self.grant('Adminstrator')
+        dossier = create(Builder('dossier')
+                         .in_state('dossier-state-resolved'))
+
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        with browser.expect_unauthorized():
+            browser.login().open(task, view='addcommentresponse')
+
+    @browsing
+    def test_contributor_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
+        self.grant('Contributor')
+        dossier = create(Builder('dossier')
+                         .in_state('dossier-state-resolved'))
+
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        with browser.expect_unauthorized():
+            browser.login().open(task, view='addcommentresponse')
+
+    @browsing
+    def test_editor_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
+        self.grant('Editor')
+        dossier = create(Builder('dossier')
+                         .in_state('dossier-state-resolved'))
+
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        with browser.expect_unauthorized():
+            browser.login().open(task, view='addcommentresponse')
+
+    @browsing
+    def test_reader_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
+        self.grant('Reader')
+        dossier = create(Builder('dossier')
+                         .in_state('dossier-state-resolved'))
+
+        task = create(Builder('task').titled('Task 1').within(dossier))
+
+        with browser.expect_unauthorized():
+            browser.login().open(task, view='addcommentresponse')
+
+    def get_latest_answer(self, browser):
+        latest_answer = browser.css('div.answers .answer').first
+        return latest_answer.css('h3').text[0]

--- a/opengever/task/tests/test_response.py
+++ b/opengever/task/tests/test_response.py
@@ -1,187 +1,25 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.pages import statusmessages
-from opengever.testing import FunctionalTestCase
+from opengever.task.adapters import IResponseContainer
+from opengever.testing import IntegrationTestCase
+from persistent import Persistent
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
 
 
-class TestTaskCommentResponseAddFormView(FunctionalTestCase):
-
-    @browsing
-    def test_add_task_comment_response_view_is_available(self, browser):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        browser.login().visit(task, view="addcommentresponse")
-        self.assertEqual(
-            'Add Comment',
-            browser.css('.documentFirstHeading').first.text)
+class TestTaskResponses(IntegrationTestCase):
 
     @browsing
-    def test_default_task_response_form_fields(self, browser):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
+    def test_response_and_response_changes_are_persistent(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
 
-        browser.login().visit(task, view="addcommentresponse")
-        labels = browser.css('#content-core label').text
+        browser.open(self.task)
+        browser.click_on('task-transition-modify-deadline')
+        browser.fill({'Response': u'Nicht mehr so dringend ...',
+                      'New Deadline': '1.1.2017'})
+        browser.click_on('Save')
 
-        # remove empty labels.
-        labels = filter(lambda item: item, labels)
+        response = IResponseContainer(self.task)[-1]
 
-        self.assertEqual(['Response'], labels)
-
-    @browsing
-    def test_add_related_response_object_after_commenting(self, browser):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        browser.login().visit(task, view="addcommentresponse")
-        browser.fill({'Response': 'I am a comment'}).find('Save').click()
-        browser.open(task, view='tabbedview_view-overview')
-
-        self.assertEqual(
-            'Commented by Test User (test_user_1_)',
-            self.get_latest_answer(browser))
-
-    @browsing
-    def test_text_field_is_required_for_comments(self, browser):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task').within(dossier))
-
-        browser.login().visit(task, view="addcommentresponse")
-        browser.find('Save').click()
-
-        self.assertEqual(
-            ['There were some errors.'],
-            statusmessages.error_messages())
-
-    @browsing
-    def test_click_on_comment_button_redirects_to_add_comment_view(self, browser):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-        browser.login().open(task, view='tabbedview_view-overview')
-
-        browser.css('.taskCommented').first.click()
-
-        self.assertEqual(
-            '{}/@@addcommentresponse'.format(task.absolute_url()),
-            browser.url)
-
-    @browsing
-    def test_do_not_show_comment_button_if_dossier_is_closed(self, browser):
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-
-        task = create(Builder('task').titled('Task 1').within(dossier))
-        browser.login().open(task, view='tabbedview_view-overview')
-
-        self.assertEqual(0, len(browser.css('.taskCommented')))
-
-    @browsing
-    def test_Manager_can_access_addcommentresponse_view_on_open_dossier(self, browser):
-        self.grant('Manager')
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        self.assertEqual(
-            '{}/addcommentresponse'.format(task.absolute_url()),
-            browser.login().open(task, view='addcommentresponse').url)
-
-    @browsing
-    def test_Adminstrator_can_access_addcommentresponse_view_on_open_dossier(self, browser):
-        self.grant('Adminstrator')
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        self.assertEqual(
-            '{}/addcommentresponse'.format(task.absolute_url()),
-            browser.login().open(task, view='addcommentresponse').url)
-
-    @browsing
-    def test_Contributor_can_access_addcommentresponse_view_on_open_dossier(self, browser):
-        self.grant('Contributor')
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        self.assertEqual(
-            '{}/addcommentresponse'.format(task.absolute_url()),
-            browser.login().open(task, view='addcommentresponse').url)
-
-    @browsing
-    def test_Editor_can_access_addcommentresponse_view_on_open_dossier(self, browser):
-        self.grant('Editor')
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        self.assertEqual(
-            '{}/addcommentresponse'.format(task.absolute_url()),
-            browser.login().open(task, view='addcommentresponse').url)
-
-    @browsing
-    def test_Reader_can_not_access_addcommentresponse_view_on_open_dossier(self, browser):
-        self.grant('Reader')
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        self.assertEqual(
-            '{}/addcommentresponse'.format(task.absolute_url()),
-            browser.login().open(task, view='addcommentresponse').url)
-
-    @browsing
-    def test_Manager_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
-        self.grant('Manager')
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        with browser.expect_unauthorized():
-            browser.login().open(task, view='addcommentresponse')
-
-    @browsing
-    def test_Adminstrator_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
-        self.grant('Adminstrator')
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        with browser.expect_unauthorized():
-            browser.login().open(task, view='addcommentresponse')
-
-    @browsing
-    def test_Contributor_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
-        self.grant('Contributor')
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        with browser.expect_unauthorized():
-            browser.login().open(task, view='addcommentresponse')
-
-    @browsing
-    def test_Editor_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
-        self.grant('Editor')
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        with browser.expect_unauthorized():
-            browser.login().open(task, view='addcommentresponse')
-
-    @browsing
-    def test_Reader_can_not_access_addcommentresponse_view_on_closed_dossier(self, browser):
-        self.grant('Reader')
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-
-        task = create(Builder('task').titled('Task 1').within(dossier))
-
-        with browser.expect_unauthorized():
-            browser.login().open(task, view='addcommentresponse')
-
-    def get_latest_answer(self, browser):
-        latest_answer = browser.css('div.answers .answer').first
-        return latest_answer.css('h3').text[0]
+        self.assertIsInstance(response, Persistent)
+        self.assertIsInstance(response.changes, PersistentList)
+        self.assertIsInstance(response.changes[0], PersistentMapping)


### PR DESCRIPTION
PR provides:
 - Fix response change creation for new responses
 - An upgradestep which convert existing response changes (`dict`'s) in to persistent objects (`PersistentMapping`'s)

Closes #3419 