### PR TITLE
Add proper responsible for fixture objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.1 (unreleased)
 ---------------------
 
+- Add proper responsible for fixture objects. [elioschmutz]
 - Also display exceptions on agenda item list to users. [deiferni]
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -476,7 +476,7 @@ class TestDossierTemplateAddWizard(IntegrationTestCase):
 
         subdossier = browser.context.listFolderContents()[0]
 
-        self.assertEqual('hugo.boss', IDossier(subdossier).responsible)
+        self.assertEqual(self.dossier_responsible.getId(), IDossier(subdossier).responsible)
 
     @browsing
     def test_prefill_title_if_no_title_help_is_available(self, browser):

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -89,12 +89,13 @@ class TestOverview(IntegrationTestCase):
 
         handler = IParticipationAware(self.dossier)
         participation = handler.create_participation(
-            contact='robert.ziegler', roles=['regard'])
+            contact='kathi.barfuss', roles=['regard'])
         handler.append_participiation(participation)
 
         browser.open(self.dossier, view='tabbedview_view-overview')
-        self.assertEqual(
-            ['Ziegler Robert (robert.ziegler)'],
+        self.assertListEqual(
+            [u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+             u'Ziegler Robert (robert.ziegler)'],
             browser.css('#participantsBox li:not(.moreLink) a').text)
 
     @browsing

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -342,7 +342,7 @@ class OpengeverContentFixture(object):
                     u' Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
                     keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
                     start=date(2016, 1, 1),
-                    responsible='hugo.boss')))
+                    responsible=self.dossier_responsible.getId())))
 
         create(Builder('contact_participation')
                .for_contact(self.meier_ag)
@@ -446,7 +446,7 @@ class OpengeverContentFixture(object):
                     keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
                     start=date(2000, 1, 1),
                     end=date(2015, 12, 31),
-                    responsible='hugo.boss')
+                    responsible=self.dossier_responsible.getId())
             .in_state('dossier-state-resolved')))
 
     @staticuid()
@@ -455,7 +455,7 @@ class OpengeverContentFixture(object):
             Builder('dossier').within(self.repofolder00)
             .titled(u'An empty dossier')
             .having(start=date(2016, 1, 1),
-                    responsible='hugo.boss')))
+                    responsible=self.dossier_responsible.getId())))
 
     @staticuid()
     def create_emails(self):


### PR DESCRIPTION
This PR fixes an issue if you try to edit an object created through the `OpengeverContentFixture` with the testbrowser.

The responsible `hugo.boss` does not exist.
