### PR TITLE
Allow adding excerpts headers and suffixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add proper responsible for fixture objects. [elioschmutz]
+- Add optional header and suffix templates for protocol excerpts. [tarnap]
 - Also display exceptions on agenda item list to users. [deiferni]
 - Make sure response changes are persistent. [phgross]
 - SPV word: redesign agenda items in meeting view. [jone]

--- a/opengever/meeting/browser/committeecontainer_forms.py
+++ b/opengever/meeting/browser/committeecontainer_forms.py
@@ -23,7 +23,9 @@ class CommitteContainerFieldConfigurationMixin(object):
             self.fields = self.fields.omit('ad_hoc_template',
                                            'paragraph_template',
                                            'protocol_header_template',
-                                           'protocol_suffix_template')
+                                           'protocol_suffix_template',
+                                           'excerpt_header_template',
+                                           'excerpt_suffix_template')
 
 
 class AddForm(CommitteContainerFieldConfigurationMixin, TranslatedTitleAddForm):

--- a/opengever/meeting/browser/committeeforms.py
+++ b/opengever/meeting/browser/committeeforms.py
@@ -51,6 +51,8 @@ class CommitteeFieldConfigurationMixin(object):
                                            'paragraph_template',
                                            'protocol_header_template',
                                            'protocol_suffix_template',
+                                           'excerpt_header_template',
+                                           'excerpt_suffix_template',
                                            'allowed_proposal_templates')
 
 

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -48,7 +48,7 @@ class MergeDocxExcerptCommand(CreateDocumentCommand):
     """Create or update a merged excerpt word file.
     """
 
-    def __init__(self, context, agenda_item, filename, title, lock_document_after_creation=False):
+    def __init__(self, context, agenda_item, filename, title):
         self.agenda_item = agenda_item
         self.excerpt_protocol_data = ExcerptProtocolData(
             self.agenda_item.meeting,

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -61,6 +61,12 @@ class MergeDocxExcerptCommand(CreateDocumentCommand):
             title=title)
 
     def generate_file_data(self):
+        header_template = self.agenda_item.get_excerpt_header_template()
+        suffix_template = self.agenda_item.get_excerpt_suffix_template()
+
+        if header_template is None and suffix_template is None:
+            return self.agenda_item.resolve_document().file.data
+
         with DocxMergeTool() as merge_tool:
             if self.agenda_item.get_excerpt_header_template() is not None:
                 merge_tool.add_sablon(self.get_header_sablon())

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -68,24 +68,20 @@ class MergeDocxExcerptCommand(CreateDocumentCommand):
             return self.agenda_item.resolve_document().file.data
 
         with DocxMergeTool() as merge_tool:
-            if self.agenda_item.get_excerpt_header_template() is not None:
-                merge_tool.add_sablon(self.get_header_sablon())
+
+            if header_template is not None:
+                merge_tool.add_sablon(self.get_sablon(template=header_template))
 
             if self.agenda_item.has_document:
                 merge_tool.add_document(self.agenda_item.resolve_document())
 
-            if self.agenda_item.get_excerpt_suffix_template() is not None:
-                merge_tool.add_sablon(self.get_suffix_sablon())
+            if suffix_template is not None:
+                merge_tool.add_sablon(self.get_sablon(template=suffix_template))
 
             return merge_tool()
 
-    def get_header_sablon(self):
-        return Sablon(self.agenda_item.get_excerpt_header_template()).process(
-            self.excerpt_protocol_data.as_json())
-
-    def get_suffix_sablon(self):
-        return Sablon(self.agenda_item.get_excerpt_suffix_template()).process(
-            self.excerpt_protocol_data.as_json())
+    def get_sablon(self, template):
+        return Sablon(template).process(self.excerpt_protocol_data.as_json())
 
     def execute(self):
         self.set_file(

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -77,6 +77,20 @@ class ICommittee(model.Schema):
         required=False,
     )
 
+    excerpt_header_template = RelationChoice(
+        title=_('label_excerpt_header_template',
+                default='Excerpt header template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
+    excerpt_suffix_template = RelationChoice(
+        title=_('label_excerpt_suffix_template',
+                default='Excerpt suffix template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
     excerpt_template = RelationChoice(
         title=_('Excerpt template'),
         source=sablon_template_source,
@@ -273,6 +287,18 @@ class Committee(ModelContainer):
             return self.protocol_suffix_template.to_object
 
         return self.get_committee_container().get_protocol_suffix_template()
+
+    def get_excerpt_header_template(self):
+        if self.excerpt_header_template:
+            return self.excerpt_header_template.to_object
+
+        return self.get_committee_container().get_excerpt_header_template()
+
+    def get_excerpt_suffix_template(self):
+        if self.excerpt_suffix_template:
+            return self.excerpt_suffix_template.to_object
+
+        return self.get_committee_container().get_excerpt_suffix_template()
 
     def get_excerpt_template(self):
         if self.excerpt_template:

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -34,6 +34,20 @@ class ICommitteeContainer(model.Schema):
         required=False,
     )
 
+    excerpt_header_template = RelationChoice(
+        title=_('label_excerpt_header_template',
+                default='Excerpt header template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
+    excerpt_suffix_template = RelationChoice(
+        title=_('label_excerpt_suffix_template',
+                default='Excerpt suffix template'),
+        source=sablon_template_source,
+        required=False,
+    )
+
     excerpt_template = RelationChoice(
         title=_('Excerpt template'),
         source=sablon_template_source,
@@ -106,6 +120,16 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
 
     def get_protocol_suffix_template(self):
         return getattr(self.protocol_suffix_template, 'to_object', None)
+
+    def get_excerpt_header_template(self):
+        if self.excerpt_header_template:
+            return self.excerpt_header_template.to_object
+        return None
+
+    def get_excerpt_suffix_template(self):
+        if self.excerpt_suffix_template:
+            return self.excerpt_header_template.to_object
+        return None
 
     def get_excerpt_template(self):
         return self.excerpt_template.to_object

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2017-10-31 13:55+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -1109,6 +1109,18 @@ msgstr "Ende"
 #: ./opengever/meeting/browser/templates/proposaloverview.pt
 msgid "label_excerpt"
 msgstr "Protokollauszug"
+
+#. Default: "Excerpt header template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_excerpt_header_template"
+msgstr "Vorlage Kopf für Protokollauszüge"
+
+#. Default: "Excerpt suffix template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_excerpt_suffix_template"
+msgstr "Vorlage Schlussteil für Protokollauszüge"
 
 #. Default: "Excerpts"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1112,6 +1112,18 @@ msgstr "Fin"
 msgid "label_excerpt"
 msgstr "Extrait du protocole"
 
+#. Default: "Excerpt header template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_excerpt_header_template"
+msgstr ""
+
+#. Default: "Excerpt suffix template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_excerpt_suffix_template"
+msgstr ""
+
 #. Default: "Excerpts"
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/proposal.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -1109,6 +1109,18 @@ msgstr ""
 msgid "label_excerpt"
 msgstr ""
 
+#. Default: "Excerpt header template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_excerpt_header_template"
+msgstr ""
+
+#. Default: "Excerpt suffix template"
+#: ./opengever/meeting/committee.py
+#: ./opengever/meeting/committeecontainer.py
+msgid "label_excerpt_suffix_template"
+msgstr ""
+
 #. Default: "Excerpts"
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/proposal.py

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -1,5 +1,4 @@
 from AccessControl import getSecurityManager
-from opengever.base.command import CreateDocumentCommand
 from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
@@ -235,6 +234,12 @@ class AgendaItem(Base):
             return self.proposal.dossier_reference_number
         return None
 
+    def get_excerpt_header_template(self):
+        return self.meeting.committee.get_excerpt_header_template()
+
+    def get_excerpt_suffix_template(self):
+        return self.meeting.committee.get_excerpt_suffix_template()
+
     def get_repository_folder_title(self):
         if self.has_proposal:
             return self.proposal.repository_folder_title
@@ -432,6 +437,9 @@ class AgendaItem(Base):
         from the ad-hoc agenda items document.
         In both cases the excerpt is stored in the meeting dossier.
         """
+
+        from opengever.meeting.command import MergeDocxExcerptCommand
+
         if not self.can_generate_excerpt():
             raise WrongAgendaItemState()
 
@@ -445,12 +453,12 @@ class AgendaItem(Base):
                 'opengever.document: Add document', meeting_dossier):
             raise MissingMeetingDossierPermissions
 
-        excerpt_document = CreateDocumentCommand(
+        excerpt_document = MergeDocxExcerptCommand(
             context=meeting_dossier,
+            agenda_item=self,
             filename=source_document.file.filename,
-            data=source_document.file.data,
-            content_type=source_document.file.contentType,
-            title=title).execute()
+            title=title,
+        ).execute()
 
         if self.has_proposal:
             submitted_proposal = self.proposal.resolve_submitted_proposal()

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -96,6 +96,12 @@ class Committee(Base):
     def get_protocol_suffix_template(self):
         return self.resolve_committee().get_protocol_suffix_template()
 
+    def get_excerpt_header_template(self):
+        return self.resolve_committee().get_excerpt_header_template()
+
+    def get_excerpt_suffix_template(self):
+        return self.resolve_committee().get_excerpt_suffix_template()
+
     def get_excerpt_template(self):
         return self.resolve_committee().get_excerpt_template()
 

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -270,9 +270,7 @@ class TestWordAgendaItem(IntegrationTestCase):
         excerpt_document, = children['added']
         self.assertEquals('Excerption \xc3\x84nderungen',
                           excerpt_document.Title())
-        self.assertEquals(
-            self.submitted_word_proposal.get_proposal_document().file.data,
-            excerpt_document.file.data)
+        self.assertIsNotNone(excerpt_document.file.data)
 
     @browsing
     def test_cannot_create_excerpt_when_meeting_closed(self, browser):

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -27,23 +27,6 @@ class TestCommitteeContainer(IntegrationTestCase):
                          self.committee_container.get_ad_hoc_template())
 
     @browsing
-    def test_can_add_with_ad_hoc_template(self, browser):
-        self.login(self.manager, browser)
-        browser.open()
-        factoriesmenu.add('Committee Container')
-        browser.fill({'Title': u'Sitzungen',
-                      'Protocol header template': self.sablon_template,
-                      'Protocol suffix template': self.sablon_template,
-                      'Excerpt header template': self.sablon_template,
-                      'Excerpt suffix template': self.sablon_template,
-                      'Paragraph template': self.sablon_template,
-                      'Ad hoc agenda item template': self.proposal_template}).save()
-        statusmessages.assert_no_error_messages()
-
-        self.assertEqual(self.proposal_template,
-                         browser.context.get_ad_hoc_template())
-
-    @browsing
     def test_can_configure_paragraph_template(self, browser):
         self.login(self.administrator, browser)
         self.committee_container.paragraph_template = None
@@ -62,7 +45,7 @@ class TestCommitteeContainer(IntegrationTestCase):
                          self.committee_container.get_paragraph_template())
 
     @browsing
-    def test_can_add_with_paragraph_template(self, browser):
+    def test_can_add_with_templates(self, browser):
         self.login(self.manager, browser)
         browser.open()
         factoriesmenu.add('Committee Container')
@@ -71,11 +54,19 @@ class TestCommitteeContainer(IntegrationTestCase):
                       'Protocol suffix template': self.sablon_template,
                       'Excerpt header template': self.sablon_template,
                       'Excerpt suffix template': self.sablon_template,
-                      'Paragraph template': self.sablon_template}).save()
+                      'Paragraph template': self.sablon_template,
+                      'Ad hoc agenda item template': self.proposal_template}).save()
         statusmessages.assert_no_error_messages()
 
+        self.assertEqual(self.proposal_template,
+                         browser.context.get_ad_hoc_template())
         self.assertEqual(self.sablon_template,
                          browser.context.get_paragraph_template())
+        self.assertEqual(self.sablon_template,
+                         browser.context.get_excerpt_header_template())
+        self.assertEqual(self.sablon_template,
+                         browser.context.get_excerpt_suffix_template())
+
 
     @browsing
     def test_visible_fields_in_forms(self, browser):

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -18,6 +18,7 @@ class TestCommitteeContainer(IntegrationTestCase):
 
         browser.open(self.committee_container, view='edit')
         browser.fill({'Ad hoc agenda item template': self.proposal_template}).save()
+        statusmessages.assert_no_error_messages()
 
         statusmessages.assert_message('Changes saved')
 
@@ -33,6 +34,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         browser.fill({'Title': u'Sitzungen',
                       'Protocol header template': self.sablon_template,
                       'Protocol suffix template': self.sablon_template,
+                      'Excerpt header template': self.sablon_template,
+                      'Excerpt suffix template': self.sablon_template,
                       'Paragraph template': self.sablon_template,
                       'Ad hoc agenda item template': self.proposal_template}).save()
         statusmessages.assert_no_error_messages()
@@ -50,6 +53,7 @@ class TestCommitteeContainer(IntegrationTestCase):
 
         browser.open(self.committee_container, view='edit')
         browser.fill({'Paragraph template': self.sablon_template}).save()
+        statusmessages.assert_no_error_messages()
 
         statusmessages.assert_message('Changes saved')
 
@@ -65,6 +69,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         browser.fill({'Title': u'Sitzungen',
                       'Protocol header template': self.sablon_template,
                       'Protocol suffix template': self.sablon_template,
+                      'Excerpt header template': self.sablon_template,
+                      'Excerpt suffix template': self.sablon_template,
                       'Paragraph template': self.sablon_template}).save()
         statusmessages.assert_no_error_messages()
 
@@ -80,6 +86,8 @@ class TestCommitteeContainer(IntegrationTestCase):
         fields = [u'Title',
                   u'Protocol header template',
                   u'Protocol suffix template',
+                  u'Excerpt header template',
+                  u'Excerpt suffix template',
                   u'Agendaitem list template',
                   u'Table of contents template',
                   u'Ad hoc agenda item template',

--- a/opengever/meeting/tests/test_committee_word.py
+++ b/opengever/meeting/tests/test_committee_word.py
@@ -59,6 +59,38 @@ class TestCommitteeWord(IntegrationTestCase):
         self.assertEqual(self.sablon_template,
                          self.committee.get_paragraph_template())
 
+    def test_get_excerpt_header_template_falls_back_to_container(self):
+        self.login(self.administrator)
+        self.assertIsNone(self.committee.excerpt_header_template)
+        self.assertIsNotNone(self.committee_container.excerpt_header_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_excerpt_header_template())
+
+    def test_get_excerpt_header_template_returns_committee_template_if_available(self):
+        self.login(self.administrator)
+        self.committee.excerpt_header_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_excerpt_header_template())
+
+    def test_get_excerpt_suffix_template_falls_back_to_container(self):
+        self.login(self.administrator)
+        self.assertIsNone(self.committee.excerpt_suffix_template)
+        self.assertIsNotNone(self.committee_container.excerpt_suffix_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_excerpt_suffix_template())
+
+    def test_get_excerpt_suffix_template_returns_committee_template_if_available(self):
+        self.login(self.administrator)
+        self.committee.excerpt_suffix_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee.get_excerpt_suffix_template())
+
     def test_get_paragraph_template_returns_committee_template_if_available(self):
         self.login(self.committee_responsible)
         self.committee.paragraph_template = self.as_relation_value(self.sablon_template)
@@ -82,6 +114,8 @@ class TestCommitteeWord(IntegrationTestCase):
                   'Group',
                   'Protocol header template',
                   'Protocol suffix template',
+                  'Excerpt header template',
+                  'Excerpt suffix template',
                   'Agendaitem list template',
                   'Table of contents template',
                   'Linked repository folder',

--- a/opengever/meeting/tests/test_proposal_word.py
+++ b/opengever/meeting/tests/test_proposal_word.py
@@ -229,9 +229,7 @@ class TestProposalWithWord(IntegrationTestCase):
         self.assertEquals(u'excerpt-anderungen.docx',
                           excerpt_document.file.filename)
         self.assertEquals(MIME_DOCX, excerpt_document.file.contentType)
-        self.assertEquals(
-            self.submitted_word_proposal.get_proposal_document().file.data,
-            excerpt_document.file.data)
+        self.assertIsNotNone(excerpt_document.file.data)
 
         # The excerpt document should be referenced as relation.
         excerpts = ISubmittedProposal(self.submitted_word_proposal).excerpts

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -246,6 +246,8 @@ class OpengeverContentFixture(object):
                 excerpt_template=self.sablon_template,
                 protocol_template=self.sablon_template,
                 protocol_header_template=self.sablon_template,
+                excerpt_header_template=self.sablon_template,
+                excerpt_suffix_template=self.sablon_template,
                 paragraph_template=self.sablon_template,
                 )
             ))


### PR DESCRIPTION
A sablon template can be defined on committee or committee container
which will be added (if available) to the created excerpts.
If the committee has no templates available, the template of the
committee container is used.

Since the new excerpts do not only contain the content of the agenda
item document, the tests which previously compared the content of the
generated excerpts with the agenda item documents need to be changed.

The import of the MergeDocxExcerptCommand inside the method of the
AgendaItem is required to get rid of circular imports.

![vorlagen excerpts](https://user-images.githubusercontent.com/194114/32234312-c022445c-be5c-11e7-8d7a-24b62ad5d79b.gif)

Resolves https://github.com/4teamwork/gever/issues/117