### PR TITLE
Fix textfilter in sqlsource table listings for oracle backends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Add proper responsible for fixture objects. [elioschmutz]
 - Add optional header and suffix templates for protocol excerpts. [tarnap]
+- Fix textfilter in sqlsource table listings for oracle backends. [phgross]
 - Also display exceptions on agenda item list to users. [deiferni]
 - Make sure response changes are persistent. [phgross]
 - SPV word: redesign agenda items in meeting view. [jone]

--- a/opengever/base/model.py
+++ b/opengever/base/model.py
@@ -48,6 +48,12 @@ def create_session():
     return Session()
 
 
+def is_oracle():
+    """Returns a new sql session bound to the defined named scope.
+    """
+    return 'oracle' in create_session().connection().dialect.name
+
+
 class UTCDateTime(types.TypeDecorator):
     """Sqlalchemy does not support timezone aware datetimes for Sqlite and
     MySQL backend. Therefore we have to ensure that timezone aware datetimes


### PR DESCRIPTION
Oracle raises an "ORA-00906: missing left parenthesis" erorr when
casting a integer column to a string and querying it with ilike.

Therefore I add a special handling for oracle backends, which solves
the issue https://sentry.4teamwork.ch/sentry/onegov-gever/issues/3749/
when filtering in task listings like the MyTasks tab.


Not valid Query 
```
SELECT tasks.id, tasks.admin_unit_id [...]
FROM tasks
WHERE tasks.responsible IN ('hugo.boss') AND (lower(CAST(tasks.sequence_number AS VARCHAR)) LIKE lower('%phip%')) ORDER BY created DESC
```

Valid query
```
SELECT tasks.id, tasks.admin_unit_id [...]
FROM tasks
WHERE tasks.responsible IN ('hugo.boss') AND (tasks.sequence_number LIKE lower('%phip%')) ORDER BY created DESC
```
