### PR TITLE
Keep meeting-dossier and meeting title in sync.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 - Allow proposal listings to be filtered by proposal title. [deiferni]
 - Allow proposal listings to be sorted by title. [deiferni]
+- Keep meeting-dossier and meeting title in sync, only allow editing of meeting title. [deiferni]
 
 
 2017.6.3 (2017-11-07)

--- a/opengever/core/upgrades/20171107141117_sync_meeting_title_to_dossier/upgrade.py
+++ b/opengever/core/upgrades/20171107141117_sync_meeting_title_to_dossier/upgrade.py
@@ -1,0 +1,33 @@
+from opengever.base.oguid import Oguid
+from opengever.core.upgrade import SQLUpgradeStep
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+meetings_table = table(
+    "meetings",
+    column("id"),
+    column("title"),
+    column("dossier_admin_unit_id"),
+    column("dossier_int_id"),
+)
+
+
+class SyncMeetingTitleToDossier(SQLUpgradeStep):
+    """Sync meeting title to dossier.
+    """
+
+    def migrate(self):
+        for meeting in self.execute(meetings_table.select()).fetchall():
+            self.sync_title_to_meeting_dossier(meeting)
+
+    def sync_title_to_meeting_dossier(self, meeting):
+        dossier_oguid = Oguid(
+            meeting.dossier_admin_unit_id, meeting.dossier_int_id)
+        dossier = dossier_oguid.resolve_object()
+
+        if not dossier:
+            return
+
+        dossier.title = meeting.title
+        dossier.reindexObject(idxs=['Title', 'SearchableText'])

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -5,83 +5,95 @@ from ftw.testbrowser import browsing
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.mail.behaviors import ISendableDocsContainer
 from opengever.testing import FunctionalTestCase
-from opengever.testing import index_data_for
-from plone.app.testing import TEST_USER_ID
+from opengever.testing import IntegrationTestCase
 from Products.CMFCore.utils import getToolByName
 from zExceptions import Unauthorized
 
 
-class TestDossier(FunctionalTestCase):
+class TestDossier(IntegrationTestCase):
 
     builder_id = 'dossier'
     portal_type = 'opengever.dossier.businesscasedossier'
 
-    def setUp(self):
-        super(TestDossier, self).setUp()
-        self.dossier = self.create_test_dossier()
-
-    def create_test_dossier(self):
-        return create(Builder(self.builder_id)
-                      .titled(u'Test Dossier')
-                      .having(responsible=TEST_USER_ID))
+    @property
+    def dossier_to_test(self):
+        return self.dossier
 
     def test_get_main_dossier_returns_self_when_is_already_root(self):
-        self.assertEqual(self.dossier, self.dossier.get_main_dossier())
+        self.login(self.dossier_responsible)
+
+        self.assertEqual(self.dossier_to_test,
+                         self.dossier_to_test.get_main_dossier())
 
     def test_get_main_dossier_returns_main_for_nested_dossiers(self):
-        sub1 = create(Builder(self.builder_id).within(self.dossier))
+        self.login(self.dossier_responsible)
+
+        sub1 = create(Builder(self.builder_id).within(self.dossier_to_test))
         sub2 = create(Builder(self.builder_id).within(sub1))
 
-        self.assertEqual(self.dossier, sub1.get_main_dossier())
-        self.assertEqual(self.dossier, sub2.get_main_dossier())
+        self.assertEqual(self.dossier_to_test,
+                         sub1.get_main_dossier())
+        self.assertEqual(self.dossier_to_test,
+                         sub2.get_main_dossier())
 
     def test_falsy_has_subdossiers(self):
-        self.assertFalse(self.dossier.has_subdossiers())
+        self.login(self.dossier_responsible)
+
+        self.assertFalse(self.archive_dossier.has_subdossiers())
 
     def test_truthy_has_subdossiers(self):
-        create(Builder(self.builder_id).within(self.dossier))
+        self.login(self.dossier_responsible)
+
         self.assertTrue(self.dossier.has_subdossiers())
 
     def test_truthy_has_subdossiers_closed_dossiers(self):
+        self.login(self.dossier_responsible)
+
         create(Builder(self.builder_id)
-               .within(self.dossier)
+               .within(self.dossier_to_test)
                .in_state('dossier-state-resolved'))
-        self.assertTrue(self.dossier.has_subdossiers())
-
-    def assert_searchable_text(self, expected, dossier):
-        values = index_data_for(dossier).get('SearchableText')
-        values.sort()
-
-        self.assertEquals(expected, values)
+        self.assertTrue(self.dossier_to_test.has_subdossiers())
 
     def test_is_marked_as_sendable_docs_container(self):
+        self.login(self.dossier_responsible)
+
         self.assertTrue(
-            ISendableDocsContainer.providedBy(self.dossier),
+            ISendableDocsContainer.providedBy(self.dossier_to_test),
             'The dossier is not marked with the ISendableDocsContainer')
 
     @browsing
     def test_tabbedview_tabs(self, browser):
+        self.login(self.dossier_responsible, browser)
+
         expected_tabs = ['Overview', 'Subdossiers', 'Documents', 'Tasks',
                          'Participants', 'Trash', 'Journal', 'Info']
 
-        browser.login().open(self.dossier, view='tabbed_view')
+        browser.open(self.dossier_to_test, view='tabbed_view')
         self.assertEquals(expected_tabs, browser.css('li.formTab').text)
 
     def test_use_the_dossier_workflow(self):
+        self.login(self.dossier_responsible)
+
         wf_tool = getToolByName(self.portal, 'portal_workflow')
         self.assertEquals('opengever_dossier_workflow',
-                          wf_tool.getWorkflowsFor(self.dossier)[0].id)
+                          wf_tool.getWorkflowsFor(self.dossier_to_test)[0].id)
 
     def test_mail_is_not_listed_in_factory_menu(self):
-        menu = FactoriesMenu(self.dossier)
-        menu_items = menu.getMenuItems(self.dossier, self.dossier.REQUEST)
+        self.login(self.dossier_responsible)
+
+        menu = FactoriesMenu(self.dossier_to_test)
+        menu_items = menu.getMenuItems(
+            self.dossier_to_test, self.dossier_to_test.REQUEST)
 
         self.assertNotIn('ftw.mail.mail',
                          [item.get('id') for item in menu_items])
 
     def test_factory_menu_sorting(self):
-        menu = FactoriesMenu(self.dossier)
-        menu_items = menu.getMenuItems(self.dossier, self.dossier.REQUEST)
+        self.login(self.dossier_responsible)
+
+        menu = FactoriesMenu(self.dossier_to_test)
+        menu_items = menu.getMenuItems(
+            self.dossier_to_test, self.dossier_to_test.REQUEST)
 
         self.assertEquals(
             [u'Document',
@@ -93,26 +105,31 @@ class TestDossier(FunctionalTestCase):
             [item.get('title') for item in menu_items])
 
     def test_subdossier_add_form_is_called_add_subdossier(self):
-        add_form = self.dossier.unrestrictedTraverse(
+        self.login(self.dossier_responsible)
+
+        add_form = self.dossier_to_test.unrestrictedTraverse(
             '++add++{}'.format(self.portal_type))
 
         self.assertEquals('Add Subdossier', add_form.label())
 
     def test_subdossier_edit_form_is_called_edit_subdossier(self):
-        sub = create(Builder(self.builder_id).within(self.dossier))
+        self.login(self.dossier_responsible)
+
+        sub = create(Builder(self.builder_id).within(self.dossier_to_test))
         edit_form = sub.unrestrictedTraverse('@@edit')
         self.assertEquals('Edit Subdossier', edit_form.label)
 
     def test_nested_subdossiers_is_not_possible_by_default(self):
-        sub = create(Builder('dossier').within(self.dossier))
+        self.login(self.dossier_responsible)
+
+        sub = create(Builder('dossier').within(self.dossier_to_test))
 
         self.assertNotIn(self.portal_type,
                          [fti.id for fti in sub.allowedContentTypes()])
 
     @browsing
     def test_visiting_dossier_add_form_on_branch_node_raise_unauthorized(self, browser):
-        branch_node = create(Builder('repository'))
-        create(Builder('repository').within(branch_node))
+        self.login(self.dossier_responsible, browser)
 
         # XXX This causes an infinite redirection loop between ++add++ and
         # reqiure_login. By enabling exception_bubbling we can catch the
@@ -120,62 +137,58 @@ class TestDossier(FunctionalTestCase):
         browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
             # with browser.expect_unauthorized():
-            browser.login().open(
-                branch_node, view='++add++{}'.format(self.portal_type))
+            browser.open(
+                self.repository_root,
+                view='++add++{}'.format(self.portal_type))
 
     def get_factory_menu_items(self, obj):
         menu = FactoriesMenu(obj)
-        return menu.getMenuItems(self.dossier, self.dossier.REQUEST)
+        return menu.getMenuItems(self.dossier_to_test,
+                                 self.dossier_to_test.REQUEST)
 
     def test_default_addable_types(self):
-        self.grant('Contributor')
+        self.login(self.dossier_responsible)
         self.assertItemsEqual(
             ['opengever.document.document', 'ftw.mail.mail',
              'opengever.dossier.businesscasedossier', 'opengever.task.task'],
-            [fti.id for fti in self.dossier.allowedContentTypes()])
+            [fti.id for fti in self.dossier_to_test.allowedContentTypes()])
 
     @browsing
     def test_regular_user_can_add_new_keywords_in_dossier(self, browser):
-        self.grant('Reader', 'Contributor', 'Editor')
-        browser.login().visit(self.dossier, view='@@edit')
+        self.login(self.dossier_responsible, browser)
+        browser.visit(self.dossier_to_test, view='@@edit')
 
         keywords = browser.find_field_by_text(u'Keywords')
         new = browser.css('#' + keywords.attrib['id'] + '_new').first
-        new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
+        new.text = u'New Item\nN\xf6i 3'
         browser.find_button_by_label('Save').click()
 
-        browser.visit(self.dossier, view='edit')
+        browser.visit(self.dossier_to_test, view='edit')
         keywords = browser.find_field_by_text(u'Keywords')
-        self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
+        self.assertTupleEqual(('Finanzverwaltung', 'New Item',
+                               'N=C3=B6i 3', 'Vertr=C3=A4ge'),
                               tuple(keywords.value))
 
     @browsing
-    def test_keyords_are_linked_to_search_on_overview(self, browser):
-        self.grant('Manager')
-        dossier1 = create(Builder(self.builder_id)
-                          .titled(u'Test Dossier')
-                          .having(responsible=TEST_USER_ID,
-                                  keywords=(u'new 1', u'n\xf6i 2')))
-        dossier2 = create(Builder(self.builder_id)
-                          .titled(u'Test Dossier 2')
-                          .having(responsible=TEST_USER_ID,
-                                  keywords=(u'n\xf6i 2', )))
+    def test_keywords_are_linked_to_search_on_overview(self, browser):
+        self.login(self.dossier_responsible, browser)
 
-        browser.exception_bubbling = True
-        browser.login().visit(dossier1, view='@@tabbedview_view-overview')
-        browser.find_link_by_text('new 1').click()
+        browser.visit(self.dossier_to_test, view='@@tabbedview_view-overview')
+        browser.find_link_by_text(u'Finanzverwaltung').click()
         search_result = browser.css('.searchResults dt a')
 
-        self.assertEquals(1, len(search_result), 'Expect one result')
-        self.assertEquals(dossier1.Title(), search_result.first.text)
+        self.assertEquals(2, len(search_result))
+        self.assertEquals(self.dossier.title, search_result.first.text)
+        self.assertIn(self.meeting_dossier.title, search_result.text)
 
-        browser.visit(dossier1, view='@@tabbedview_view-overview')
-        browser.find_link_by_text(u'n\xf6i 2').click()
+        browser.visit(self.dossier_to_test, view='@@tabbedview_view-overview')
+        browser.find_link_by_text(u'Vertr\xe4ge').click()
         search_result = browser.css('.searchResults dt a')
 
-        self.assertEquals(2, len(search_result), 'Expect two result')
-        self.assertIn(dossier1.Title(), search_result.text)
-        self.assertIn(dossier2.Title(), search_result.text)
+        self.assertEquals(3, len(search_result))
+        self.assertIn(self.dossier.title, search_result.text)
+        self.assertIn(self.meeting_dossier.title, search_result.text)
+        self.assertIn(self.archive_dossier.title, search_result.text)
 
 
 class TestMeetingFeatureTypes(FunctionalTestCase):
@@ -184,7 +197,7 @@ class TestMeetingFeatureTypes(FunctionalTestCase):
 
     def setUp(self):
         super(TestMeetingFeatureTypes, self).setUp()
-        self.dossier = create(Builder('dossier'))
+        self.dossier_to_test = create(Builder('dossier'))
 
     def test_meeting_feature_enabled_addable_types(self):
         self.grant('Contributor')
@@ -192,4 +205,4 @@ class TestMeetingFeatureTypes(FunctionalTestCase):
             ['opengever.document.document', 'ftw.mail.mail',
              'opengever.dossier.businesscasedossier', 'opengever.task.task',
              'opengever.meeting.proposal'],
-            [fti.id for fti in self.dossier.allowedContentTypes()])
+            [fti.id for fti in self.dossier_to_test.allowedContentTypes()])

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -233,6 +233,14 @@
         />
   </class>
 
+  <!-- MeetingDossier edit form  -->
+  <browser:page
+      for="opengever.meeting.interfaces.IMeetingDossier"
+      class=".meetingdossier_forms.MeetingDossierEditForm"
+      name="edit"
+      permission="cmf.ModifyPortalContent"
+      />
+
   <browser:page
       for="*"
       class=".excerpt.RecieveExcerptDocumentView"

--- a/opengever/meeting/browser/meetingdossier_forms.py
+++ b/opengever/meeting/browser/meetingdossier_forms.py
@@ -1,6 +1,23 @@
+from opengever.base.behaviors.utils import hide_fields_from_behavior
+from opengever.dossier.browser.forms import DossierAddForm
 from opengever.dossier.browser.forms import DossierAddView
+from opengever.dossier.browser.forms import DossierEditForm
+
+
+class MeetingDossierAddForm(DossierAddForm):
+
+    def updateFields(self):
+        super(MeetingDossierAddForm, self).updateFields()
+        hide_fields_from_behavior(self, ['IOpenGeverBase.title'])
 
 
 class MeetingDossierAddView(DossierAddView):
-    """Add view for opengever.meeting.dossier
-    """
+
+    form = MeetingDossierAddForm
+
+
+class MeetingDossierEditForm(DossierEditForm):
+
+    def updateFields(self):
+        super(MeetingDossierEditForm, self).updateFields()
+        hide_fields_from_behavior(self, ['IOpenGeverBase.title'])

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -205,16 +205,14 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
         return WrappedForm
 
     def __call__(self):
+        """Inject meeting title into meeting dossier add form."""
+
         title_key = 'form.widgets.IOpenGeverBase.title'
 
         if title_key not in self.request.form:
             dm = getUtility(IWizardDataStorage)
             data = dm.get_data(get_dm_key())
-
-            start_date = api.portal.get_localized_time(datetime=data['start'])
-            default_title = _(u'Meeting on ${date}',
-                              mapping={'date': start_date})
-            self.request.set(title_key, default_title)
+            self.request.set(title_key, data.get('title'))
 
         return super(AddMeetingDossierView, self).__call__()
 

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -355,8 +355,15 @@ class Meeting(Base, SQLFormSupport):
 
     def update_model(self, data):
         """Manually set the modified timestamp when updating meetings."""
+
         super(Meeting, self).update_model(data)
         self.modified = utcnow_tz_aware()
+
+        meeting_dossier = self.get_dossier()
+        title = data.get('title')
+        if meeting_dossier and title:
+            meeting_dossier.title = title
+            meeting_dossier.reindexObject()
 
     def get_title(self):
         return self.title

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -84,6 +84,7 @@ class TestMeeting(FunctionalTestCase):
         # create meeting
         browser.login().open(self.committee, view='add-meeting')
         browser.fill({
+            'Title': u'M\xe4\xe4hting',
             'Start': '01.01.2010 10:00',
             'End': '01.01.2010 11:00',
             'Location': 'Somewhere',
@@ -111,7 +112,7 @@ class TestMeeting(FunctionalTestCase):
                          meeting.participants)
         dossier = meeting.dossier_oguid.resolve_object()
         self.assertIsNotNone(dossier)
-        self.assertEquals(u'Meeting on Jan 01, 2010', dossier.title)
+        self.assertEquals(u'M\xe4\xe4hting', dossier.title)
         self.assertIsNotNone(meeting.modified)
 
     @browsing

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -90,8 +90,6 @@ class TestMeeting(FunctionalTestCase):
         }).submit()
 
         # create dossier
-        self.assertEqual(u'Meeting on Jan 01, 2010',
-                         browser.find('Title').value)
         browser.find('Save').click()
 
         # back to meeting page

--- a/opengever/meeting/tests/test_meeting_dossier.py
+++ b/opengever/meeting/tests/test_meeting_dossier.py
@@ -1,19 +1,12 @@
 from ftw.contentmenu.menu import FactoriesMenu
 from ftw.testbrowser import browsing
-from opengever.dossier.tests.test_dossier import TestDossier
+from opengever.testing import IntegrationTestCase
 from plone import api
 
 
-class TestMeetingDossier(TestDossier):
+class TestMeetingDossier(IntegrationTestCase):
 
     features = ('meeting',)
-
-    builder_id = 'meeting_dossier'
-    portal_type = 'opengever.meeting.meetingdossier'
-
-    @property
-    def dossier_to_test(self):
-        return self.meeting_dossier
 
     @browsing
     def test_add_meeting_menu_not_visible(self, browser):
@@ -67,7 +60,7 @@ class TestMeetingDossier(TestDossier):
         self.login(self.dossier_responsible, browser)
 
         browser.open(self.leaf_repofolder,
-                     view='++add++{}'.format(self.portal_type))
+                     view='++add++opengever.meeting.meetingdossier')
 
         self.assertIsNotNone(
             browser.css('[name="form.widgets.IOpenGeverBase.title"]'),

--- a/opengever/meeting/tests/test_meeting_dossier.py
+++ b/opengever/meeting/tests/test_meeting_dossier.py
@@ -61,3 +61,28 @@ class TestMeetingDossier(TestDossier):
 
         browser.open(self.dossier, view='tabbed_view')
         self.assertEquals(expected_tabs, browser.css('li.formTab').text)
+
+    @browsing
+    def test_title_field_hidden_in_meeting_dossier_add_form(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        browser.open(self.leaf_repofolder,
+                     view='++add++{}'.format(self.portal_type))
+
+        self.assertIsNotNone(
+            browser.css('[name="form.widgets.IOpenGeverBase.title"]'),
+            'Hidden title field not found.')
+        self.assertIsNone(
+            browser.find('Title'), 'Title field is unexpectedly visible.')
+
+    @browsing
+    def test_title_field_hidden_in_meeting_dossier_edit_form(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        browser.open(self.meeting_dossier, view='@@edit')
+
+        self.assertIsNotNone(
+            browser.css('[name="form.widgets.IOpenGeverBase.title"]'),
+            'Hidden title field not found.')
+        self.assertIsNone(
+            browser.find('Title'), 'Title field is unexpectedly visible.')

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -61,8 +61,10 @@ class TestEditMeeting(IntegrationTestCase):
              'Presidency:': u'Sch\xf6ller Heidrun',
              'Secretary:': u'M\xfcller Henning',
              'Location:': u'Sitzungszimmer 3',
-             'Meeting dossier:': 'Sitzungsdossier 9/2017'},
+             'Meeting dossier:': 'New Meeting Title'},
             byline.text_dict())
+
+        self.assertEquals('New Meeting Title', self.meeting_dossier.title)
 
     @browsing
     def test_edit_meeting_locks_the_content(self, browser1):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -452,7 +452,7 @@ class OpengeverContentFixture(object):
             Builder('dossier').within(self.repofolder00)
             .titled(u'Archiv Vertr\xe4ge')
             .having(description=u'Archiv der Vertr\xe4ge vor 2016.',
-                    keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
+                    keywords=(u'Vertr\xe4ge'),
                     start=date(2000, 1, 1),
                     end=date(2015, 12, 31),
                     responsible=self.dossier_responsible.getId())
@@ -492,6 +492,7 @@ class OpengeverContentFixture(object):
             .titled(u'Sitzungsdossier 9/2017')
             .having(start=date(2016, 9, 12),
                     relatedDossier=[self.dossier],
+                    keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
                     responsible=self.committee_responsible.getId())))
         self.meeting = create(
             Builder('meeting')


### PR DESCRIPTION
Currently meeting and meeting-dossier titles can be edited separately, and also the default title suggestions are different from each other. This is confusing for the users. We want to merge meetings and meeting-dossiers in the near future. One step in that direction is to let meeting-dossiers and meetings always have the same title.

This PR introduces the following changes:
- meeting will (for now) contain the master title
- titles on meeting-dossiers are no longer editable
- when creating a meeting-dossier it will have the same title as the corresponding meeting
- the meeting title is always synced to the meeting dossier when a meeting is edited

Also this PR adds an upgrade step to rename meeting-dossiers.

Closes https://github.com/4teamwork/gever/issues/145.