### PR TITLE
officeatwork fallout salvage - OfficeConnector endpoint logic reordering

### DIFF
--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -19,6 +19,9 @@ import json
 class OfficeConnectorURL(Service):
     """Create oc:<JWT> URLs for javascript to fetch and pass to the OS."""
 
+    def render(self):
+        pass
+
     def create_officeconnector_url_json(self, payload):
         self.request.response.setHeader('Content-Type', 'application/json')
 


### PR DESCRIPTION
As the main thing itself got canned, I'm slowly on the side starting to rebase and cherry-pick useful stuff onto master.

* Please pylint
* Reorder the Office Connector endpoint logic to 'fail per default'