### PR TITLE
Fix upgrade, avoid running for all documents/mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 - Allow proposal listings to be filtered by proposal title. [deiferni]
 - Allow proposal listings to be sorted by title. [deiferni]
+- Prevent upgrade to committee container roles to run for all documents. [deiferni]
 
 
 2017.6.0 (2017-10-27)

--- a/opengever/core/upgrades/20171009113732_add_commitee_roles_to_document_workflow/upgrade.py
+++ b/opengever/core/upgrades/20171009113732_add_commitee_roles_to_document_workflow/upgrade.py
@@ -33,6 +33,10 @@ class AddCommitteRolesToDocumentAndMailWorkflows(UpgradeStep):
     def get_documents_and_mails_in_committee_containers(self):
         committee_container_brains = self.catalog_unrestricted_search(
             {'object_provides': ICommitteeContainer.__identifier__})
+
+        if not committee_container_brains:
+            return []
+
         query = {
             'paths': map(methodcaller('getPath'), committee_container_brains),
             'portal_type': WorkflowSecurityUpdater().get_suspected_types(


### PR DESCRIPTION
If there are no committee containers the upgrade would run with an empty path list and thus not restrict the query at all and update all documents/mails. We should early-abort if there are no commitee containers in the system, i.e. if the first result is empty.

Fixes https://github.com/4teamwork/opengever.sg/issues/209.