### PR TITLE
officeatwork fallout salvage - port OfficeConnector template tests to integration tests

### DIFF
--- a/opengever/officeconnector/tests/test_templates.py
+++ b/opengever/officeconnector/tests/test_templates.py
@@ -1,1972 +1,1343 @@
-from ftw.builder import Builder
-from ftw.builder import create
-from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testbrowser import browsing
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.officeconnector.interfaces import IOfficeConnectorSettings
-from opengever.testing import FunctionalTestCase
-from plone import api
-
-import transaction
+from opengever.testing import IntegrationTestCase
 
 
-class TestOCTemplatesDossierOpenWithoutFile(FunctionalTestCase):
-    """Test templates on documents for OfficeConnector compatibility.
-
-    Dossier: open
-    Document: without file
-    """
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def setUp(self):
-        super(TestOCTemplatesDossierOpenWithoutFile, self).setUp()
-
-        self.root = create(Builder('repository_root'))
-        self.repo = create(Builder('repository').within(self.root))
-        self.dossier = create(Builder('dossier').within(self.repo))
-        self.document = create(Builder('document').within(self.dossier))
+class TestFileActionButtonTemplates(IntegrationTestCase):
 
     @browsing
-    def test_overview(self, browser):
-        browser.login()
+    def test_overview_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
 
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_tooltip(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-    @browsing
-    def test_bumblebee(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-    @browsing
-    def test_tabbed(self, browser):
-        browser.login()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-
-class TestOCTemplatesDossierInactiveWithoutFile(FunctionalTestCase):
-    """Test templates on documents for OfficeConnector compatibility.
-
-    Dossier: inactive
-    Document: without file
-    """
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def setUp(self):
-        super(TestOCTemplatesDossierInactiveWithoutFile, self).setUp()
-
-        self.root = create(Builder('repository_root'))
-        self.repo = create(Builder('repository').within(self.root))
-        self.dossier = create(Builder('dossier')
-                              .within(self.repo)
-                              .in_state('dossier-state-inactive'))
-        self.document = create(Builder('document').within(self.dossier))
-
-    @browsing
-    def test_overview(self, browser):
-        browser.login()
+    def test_overview_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
+    @browsing
+    def test_tooltip_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
+        browser.open(self.document, view='tooltip')
 
-        transaction.commit()
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
+
+    @browsing
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_dossier_documents_view_open(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_inactive(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_resolved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+
+class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
+    features = (
+        'bumblebee',
+        )
+
+    @browsing
+    def test_overview_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
 
     @browsing
-    def test_tooltip(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-    @browsing
-    def test_bumblebee(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-    @browsing
-    def test_tabbed(self, browser):
-        browser.login()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-
-class TestOCTemplatesDossierResolvedWithoutFile(FunctionalTestCase):
-    """Test templates on documents for OfficeConnector compatibility.
-
-    Dossier: resolved
-    Document: without file
-    """
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def setUp(self):
-        super(TestOCTemplatesDossierResolvedWithoutFile, self).setUp()
-
-        self.root = create(Builder('repository_root'))
-        self.repo = create(Builder('repository').within(self.root))
-        self.dossier = create(Builder('dossier')
-                              .within(self.repo)
-                              .in_state('dossier-state-resolved'))
-        self.document = create(Builder('document').within(self.dossier))
-
-    @browsing
-    def test_overview(self, browser):
-        browser.login()
+    def test_overview_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual([],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_tooltip(self, browser):
-        browser.login()
+    def test_tooltip_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
         browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_tooltip_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
         browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
 
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_bumblebee(self, browser):
-        browser.login()
+    def test_tooltip_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Open detail view'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_tabbed(self, browser):
-        browser.login()
+    def test_tooltip_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.document, view='tooltip')
 
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-
-class TestOCTemplatesDossierOpenWithFile(FunctionalTestCase):
-    """Test templates on documents for OfficeConnector compatibility.
-
-    Dossier: open
-    Document: with file
-    Mail: with file
-    """
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def setUp(self):
-        super(TestOCTemplatesDossierOpenWithFile, self).setUp()
-
-        self.root = create(Builder('repository_root'))
-
-        self.repo = create(Builder('repository')
-                           .within(self.root))
-
-        self.dossier = create(Builder('dossier')
-                              .within(self.repo))
-
-        self.document = create(Builder('document')
-                               .within(self.dossier)
-                               .attach_file_containing(bumblebee_asset(
-                                   'example.docx').bytes(),
-                                   u'example.docx'))
-
-        self.mail = create(Builder('mail')
-                           .within(self.dossier)
-                           .with_dummy_message())
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_overview(self, browser):
-        browser.login()
+    def test_dossier_documents_view_open(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_inactive(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_resolved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_bumblebee_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
+
+    @browsing
+    def test_bumblebee_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+
+class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
+    features = (
+        'officeconnector-attach',
+        )
+
+    @browsing
+    def test_overview_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Checkout and edit',
-                          'Download copy'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        self.assertIn(self.document.absolute_url() + '/editing_document',
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tabbedview_view-overview')
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Checkout and edit',
-                          'Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
 
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
-        self.assertIn(self.document.absolute_url() + '/editing_document',
-                      browser.css('a.function-edit').first.get('href'))
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Checkout and edit',
-                          'Download copy'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        self.assertIn("javascript:officeConnectorCheckout('",
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tabbedview_view-overview')
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Checkout and edit',
-                          'Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        self.assertIn("javascript:officeConnectorCheckout('",
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tabbedview_view-overview')
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
     @browsing
-    def test_tooltip(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn(self.document.absolute_url() + '/editing_document',
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        self.assertIn(self.document.absolute_url() + '/editing_document',
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorCheckout('",
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        self.assertIn("javascript:officeConnectorCheckout('",
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-    @browsing
-    def test_bumblebee(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-        self.assertIn(self.document.absolute_url() + '/editing_document',
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        self.assertIn(self.document.absolute_url() + '/editing_document',
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorCheckout('",
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Checkout and edit',
-                          'Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        self.assertIn("javascript:officeConnectorCheckout('",
-                      browser.css('a.function-edit').first.get('href'))
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Edit metadata',
-                          'Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-    @browsing
-    def test_tabbed(self, browser):
-        browser.login()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual(['Create Task',
-                          u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Checkout',
-                          'Cancel',
-                          'Checkin with comment',
-                          'Checkin without comment',
-                          'Export selection',
-                          'Move Items',
-                          'trashed'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-
-class TestOCTemplatesDossierInactiveWithFile(FunctionalTestCase):
-    """Test templates on documents for OfficeConnector compatibility.
-
-    Dossier: inactive
-    Document: with file
-    Mail: with file
-    """
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def setUp(self):
-        super(TestOCTemplatesDossierInactiveWithFile, self).setUp()
-
-        self.root = create(Builder('repository_root'))
-
-        self.repo = create(Builder('repository')
-                           .within(self.root))
-
-        self.dossier = create(Builder('dossier')
-                              .within(self.repo)
-                              .in_state('dossier-state-inactive'))
-
-        self.document = create(Builder('document')
-                               .within(self.dossier)
-                               .attach_file_containing(bumblebee_asset(
-                                   'example.docx').bytes(),
-                                   u'example.docx'))
-
-        self.mail = create(Builder('mail')
-                           .within(self.dossier)
-                           .with_dummy_message())
-
-    @browsing
-    def test_overview(self, browser):
-        browser.login()
+    def test_overview_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
+    @browsing
+    def test_tooltip_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        browser.open(self.document, view='tooltip')
 
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
+    @browsing
+    def test_tooltip_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
+        browser.open(self.document, view='tooltip')
 
-        transaction.commit()
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
+
+    @browsing
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+    @browsing
+    def test_tooltip_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+    @browsing
+    def test_dossier_documents_view_open(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertIn('Attach selection', actions)
+        self.assertIn('Checkout', actions)
+        self.assertNotIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_inactive(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertNotIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_resolved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertNotIn('Send as email', actions)
+
+
+class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase):  # noqa
+    features = (
+        'bumblebee',
+        'officeconnector-attach',
+        )
+
+    @browsing
+    def test_overview_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
 
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
 
     @browsing
-    def test_tooltip(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        browser.open(self.mail, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-    @browsing
-    def test_bumblebee(self, browser):
-        browser.login()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        browser.open(self.mail, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-    @browsing
-    def test_tabbed(self, browser):
-        browser.login()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.dossier, view='tabbedview_view-documents')
-
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
-
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-
-class TestOCTemplatesDossierResolvedWithFile(FunctionalTestCase):
-    """Test templates on documents for OfficeConnector compatibility.
-
-    Dossier: resolved
-    Document: with file
-    Mail: with file
-    """
-
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-
-    def setUp(self):
-        super(TestOCTemplatesDossierResolvedWithFile, self).setUp()
-
-        self.root = create(Builder('repository_root'))
-
-        self.repo = create(Builder('repository')
-                           .within(self.root))
-
-        self.dossier = create(Builder('dossier')
-                              .within(self.repo)
-                              .in_state('dossier-state-resolved'))
-
-        self.document = create(Builder('document')
-                               .within(self.dossier)
-                               .attach_file_containing(bumblebee_asset(
-                                   'example.docx').bytes(),
-                                   u'example.docx'))
-
-        self.mail = create(Builder('mail')
-                           .within(self.dossier)
-                           .with_dummy_message())
-
-    @browsing
-    def test_overview(self, browser):
-        browser.login()
+    def test_overview_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_overview_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         browser.open(self.document, view='tabbedview_view-overview')
 
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
-        browser.open(self.mail, view='tabbedview_view-overview')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
     @browsing
-    def test_tooltip(self, browser):
-        browser.login()
+    def test_tooltip_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
         browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='tooltip')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_bumblebee(self, browser):
-        browser.login()
+    def test_tooltip_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.document, view='tooltip')
 
-        self.assertEqual(['Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
 
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
-
-        browser.open(self.document, view='bumblebee-overlay-listing')
-
-        self.assertEqual(['Download copy',
-                          'Attach to email',
-                          'Open as PDF',
-                          'Open detail view'],
-                         browser.css('.file-action-buttons a').text)
-
-        self.assertIn("javascript:officeConnectorAttach('",
-                      browser.css('a.function-attach')[0].get('href'))
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
 
     @browsing
-    def test_tabbed(self, browser):
-        browser.login()
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+    @browsing
+    def test_tooltip_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+    @browsing
+    def test_dossier_documents_view_open(self, browser):
+        self.login(self.regular_user, browser)
 
         browser.open(self.dossier, view='tabbedview_view-documents')
 
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertIn('Attach selection', actions)
+        self.assertIn('Checkout', actions)
+        self.assertNotIn('Send as email', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_dossier_documents_view_inactive(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.dossier, view='tabbedview_view-documents')
 
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertNotIn('Send as email', actions)
 
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
-
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            False,
-            interface=IOfficeConnectorSettings)
-
-        api.portal.set_registry_record(
-            'direct_checkout_and_edit_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
-
-        transaction.commit()
+    @browsing
+    def test_dossier_documents_view_resolved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         browser.open(self.dossier, view='tabbedview_view-documents')
 
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Send as email',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertNotIn('Send as email', actions)
 
-        api.portal.set_registry_record(
-            'attach_to_outlook_enabled',
-            True,
-            interface=IOfficeConnectorSettings)
+    @browsing
+    def test_bumblebee_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
 
-        transaction.commit()
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertNotIn('javascript:', checkout_url)
+
+    @browsing
+    def test_bumblebee_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+    @browsing
+    def test_bumblebee_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+        attach_url = browser.css('.function-attach')[0].get('href')
+        self.assertIn('javascript:', attach_url)
+
+
+class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
+    features = (
+        'officeconnector-checkout',
+        )
+
+    @browsing
+    def test_overview_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertIn('javascript:', checkout_url)
+
+    @browsing
+    def test_overview_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertIn('javascript:', checkout_url)
+
+    @browsing
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_dossier_documents_view_open(self, browser):
+        self.login(self.regular_user, browser)
+
+        # Open Dossier
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_inactive(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         browser.open(self.dossier, view='tabbedview_view-documents')
 
-        self.assertEqual([u'More actions \u25bc',
-                          'Export as Zip',
-                          'Copy Items',
-                          'Attach selection',
-                          'Export selection',
-                          'Move Items'],
-                         browser.css('.tabbedview-action-list a').text)
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
 
-        self.assertIn("javascript:officeConnectorMultiAttach('",
-                      browser.css('a.tabbedview-menu-attach_documents')[0]
-                      .get('href'))
+    @browsing
+    def test_dossier_documents_view_resolved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+
+class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCase):  # noqa
+    features = (
+        'bumblebee',
+        'officeconnector-checkout',
+        )
+
+    @browsing
+    def test_overview_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertIn('javascript:', checkout_url)
+
+    @browsing
+    def test_overview_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_overview_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertIn('javascript:', checkout_url)
+
+    @browsing
+    def test_tooltip_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_tooltip_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='tooltip')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_dossier_documents_view_open(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_inactive(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_dossier_documents_view_resolved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.dossier, view='tabbedview_view-documents')
+
+        actions = browser.css('.tabbedview-action-list a').text
+        self.assertNotIn('Attach selection', actions)
+        self.assertNotIn('Checkout', actions)
+        self.assertIn('Send as email', actions)
+
+    @browsing
+    def test_bumblebee_open_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_open_with_file(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertIn('Checkout and edit', actions)
+
+        checkout_url = browser.css('.function-edit')[0].get('href')
+        self.assertIn('javascript:', checkout_url)
+
+    @browsing
+    def test_bumblebee_inactive_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_inactive_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_resolved_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.document.file = None
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)
+
+    @browsing
+    def test_bumblebee_resolved_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+
+        actions = browser.css('.file-action-buttons a').text
+        self.assertNotIn('Attach to email', actions)
+        self.assertNotIn('Checkout and edit', actions)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -40,6 +40,8 @@ FEATURE_FLAGS = {
     'ech0147-import': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_import_enabled',
     'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
     'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
+    'officeconnector-attach': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.attach_to_outlook_enabled',
+    'officeconnector-checkout': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.direct_checkout_and_edit_enabled',
     'word-meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_word_implementation_enabled',
     }
 

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -30,19 +30,18 @@ import timeit
 
 
 FEATURE_FLAGS = {
-    'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
-    'word-meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_word_implementation_enabled',
-    'dossiertemplate': ('opengever.dossier.dossiertemplate'
-                        '.interfaces.IDossierTemplateSettings.is_feature_enabled'),
+    'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled',
+    'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
+    'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
+    'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
+    'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
+    'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',
     'ech0147-import': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_import_enabled',
     'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
-    'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
-    'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
-    'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled',
-    'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
-    'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties'
-}
+    'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
+    'word-meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_word_implementation_enabled',
+    }
 
 FEATURE_PROFILES = {
     'filing_number': 'opengever.dossier:filing',


### PR DESCRIPTION
* Add a document without a file to the fixtures
  * Permanently fix a bumblebee test in regards of incoming data - did I break the test?
* Add the Office Connector features to the fixtures
* Port the Office Connector template tests to integration tests