### PR TITLE
Remove submitted proposal noword fields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- SPV: Make the considerations field a trix field. [tarnap]
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
 - SPV word: Remove fields which are intended for no word version. [tarnap]
 - Add proper responsible for fixture objects. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
+- SPV word: Remove fields which are intended for no word version. [tarnap]
 - Add proper responsible for fixture objects. [elioschmutz]
 - Add optional header and suffix templates for protocol excerpts. [tarnap]
 - Fix textfilter in sqlsource table listings for oracle backends. [phgross]

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -79,6 +79,11 @@ class SubmittedProposalEditForm(FieldConfigurationMixin,
     fields = field.Fields(SubmittedProposal.model_schema, ignoreContext=True)
     content_type = SubmittedProposal
 
+    def updateFields(self):
+        super(SubmittedProposalEditForm, self).updateFields()
+        if is_word_meeting_implementation_enabled():
+            self.fields = self.fields.omit('considerations', 'excerpts')
+
     def updateWidgets(self):
         super(SubmittedProposalEditForm, self).updateWidgets()
         self.widgets['relatedItems'].mode = HIDDEN_MODE

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -81,6 +81,7 @@ class SubmittedProposalEditForm(FieldConfigurationMixin,
 
     def updateFields(self):
         super(SubmittedProposalEditForm, self).updateFields()
+        self.use_trix('considerations')
         if is_word_meeting_implementation_enabled():
             self.fields = self.fields.omit('considerations', 'excerpts')
 

--- a/opengever/meeting/tests/test_submitted_proposal_word.py
+++ b/opengever/meeting/tests/test_submitted_proposal_word.py
@@ -1,0 +1,19 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import editbar
+from ftw.testbrowser.pages import statusmessages
+from opengever.meeting.model import Proposal
+from opengever.testing import IntegrationTestCase
+
+
+class TestSubmittedProposal(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_submitted_proposal_edit_view_display_word_fields_only(self, browser):
+        word_fields = [u'Title']
+        self.login(self.committee_responsible, browser)
+        browser.visit(self.submitted_proposal, view='edit')
+        self.assertEquals(
+            word_fields,
+            browser.css('form#form > div.field > label').text)


### PR DESCRIPTION
Before:
![submitted_proposal_with_noword_fields](https://user-images.githubusercontent.com/194114/32336317-41725e32-bfef-11e7-9307-fb924b5b3bf1.png)

And now:
![submitted_proposal_without_noword_fields](https://user-images.githubusercontent.com/194114/32336324-470ac578-bfef-11e7-81a8-efffeb97073b.png)


Resolves https://github.com/4teamwork/gever/issues/144