### PR TITLE
Automatically update gever version in versions.cfg.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Prevent editing agenda item list when meeting has been held. [deiferni]
 - Allow proposal listings to be filtered by proposal title. [deiferni]
 - Allow proposal listings to be sorted by title. [deiferni]
+- Automatically update versions.cfg when releasing with zest.releaser. [deiferni]
 
 
 2017.6.1 (2017-11-02)

--- a/opengever/core/releaser.py
+++ b/opengever/core/releaser.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 import sys
+import re
 
 
 logger = logging.getLogger("opengever.releaser")
@@ -59,3 +60,21 @@ def on_prerelease_middle(data):
     _write_versions_file(data, versions_file_with_pinning)
     logger.info("Pinned opengever.core to '{}' in '{}'".format(
         new_version, VERSIONS_FILE_NAME))
+
+
+def on_postrelease_middle(data):
+    """Remove pinned gever version after release."""
+
+    versions_file = _read_versions_file(data)
+
+    if "opengever.core" not in versions_file:
+        logger.critical("Could not find pinning for 'opengever.core' in "
+                        "file '{}'.".format(VERSIONS_FILE_NAME))
+        sys.exit(1)
+
+    versions_file_without_pinning = re.sub(
+        "^opengever.core = .*$\n*", "", versions_file, flags=re.MULTILINE)
+
+    _write_versions_file(data, versions_file_without_pinning)
+    logger.info("Removed pinning of opengever.core in '{}'".format(
+        VERSIONS_FILE_NAME))

--- a/opengever/core/releaser.py
+++ b/opengever/core/releaser.py
@@ -1,0 +1,61 @@
+import logging
+import os.path
+import sys
+
+
+logger = logging.getLogger("opengever.releaser")
+
+
+VERSIONS_FILE_NAME = "versions.cfg"
+
+
+def _make_versions_file_path(data):
+    """Return versions file path. Validate file exists."""
+
+    repo_root_path = data["reporoot"]
+    versions_file_path = os.path.join(repo_root_path, VERSIONS_FILE_NAME)
+
+    if not os.path.exists(versions_file_path):
+        logger.critical("Could not find 'versions.cfg' at '{}'.".format(
+            repo_root_path))
+        sys.exit(1)
+
+    return versions_file_path
+
+
+def _read_versions_file(data):
+    with open(_make_versions_file_path(data), 'r') as fp:
+        return fp.read()
+
+
+def _write_versions_file(data, text):
+    with open(_make_versions_file_path(data), 'w') as fp:
+        fp.write(text)
+
+
+def on_prerelease_middle(data):
+    """Write new gever version to versions.cfg before creating a release.
+
+    Insert the version pinning at the top of the [versions] section.
+    """
+    versions_file = _read_versions_file(data)
+
+    if "[versions]" not in versions_file:
+        logger.critical("Could not find '[versions]' section in file "
+                        "'{}'.".format(VERSIONS_FILE_NAME))
+        sys.exit(1)
+
+    if "opengever.core" in versions_file:
+        logger.critical("Unexpectedly found pinning for 'opengever.core' in "
+                        "file '{}'.".format(VERSIONS_FILE_NAME))
+        sys.exit(1)
+
+    new_version = data["new_version"]
+    versions_file_with_pinning = versions_file.replace(
+        "[versions]\n",
+        "[versions]\nopengever.core = {}\n\n".format(
+            new_version))
+
+    _write_versions_file(data, versions_file_with_pinning)
+    logger.info("Pinned opengever.core to '{}' in '{}'".format(
+        new_version, VERSIONS_FILE_NAME))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [zest.releaser]
 prereleaser.middle = opengever.core.releaser.on_prerelease_middle
+postreleaser.middle = opengever.core.releaser.on_postrelease_middle

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[zest.releaser]
+prereleaser.middle = opengever.core.releaser.on_prerelease_middle


### PR DESCRIPTION
With this PR we automatically update the released version in `versions.cfg` while creating a release with `zest.releaer`.

- We use https://github.com/zestsoftware/zest.releaser `prerelease` hook to pin the to be released gever version in `versions.cfg` at the same time `setup.py` and `HISTORY.txt` are updated, i.e. when creating the `Preparing release [num]` commit.
- We use the `postrelease` hook to remove the pinning again, i.e. when creating the `Back to development: [num++]` commit.

Example commits:
- prerelease:  https://github.com/4teamwork/opengever.core/commit/23977156bbcff405ebcaae15dafcddee616821f5
- postrelease: https://github.com/4teamwork/opengever.core/commit/935299224b379e2a00c4cd5ee1bb56328b94f2a4

⚠️  todo once approved: 
- [x] update wiki/internal docs