### PR TITLE
Add links to meeting and proposal

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
 - SPV word: Remove fields which are intended for no word version. [tarnap]
 - Add personal notification settings support. [phgross]
+- SPV word: Add links to proposal and meeting in document overview. [tarnap]
 - Add proper responsible for fixture objects. [elioschmutz]
 - Add optional header and suffix templates for protocol excerpts. [tarnap]
 - Fix textfilter in sqlsource table listings for oracle backends. [phgross]

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -181,6 +181,33 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
                         content=row.get_content())
             yield data
 
+    def get_meeting_links(self):
+
+        if not hasattr(self.context, 'get_proposal'):
+            return
+
+        proposal = self.context.get_proposal()
+        if proposal is None:
+            return
+
+        proposal_model = proposal.load_model()
+
+        proposal_link = proposal_model.get_link()
+        if proposal_link:
+            yield {
+                'label': _('label_proposal', default='Proposal'),
+                'content': proposal_link,
+            }
+        else:
+            return
+
+        meeting_link = proposal_model.get_meeting_link()
+        if meeting_link:
+            yield {
+                'label': _('label_meeting', default='Meeting'),
+                'content': meeting_link,
+            }
+
     def submitted_documents(self):
         return SubmittedDocument.query.by_source(self.context).all()
 

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -183,9 +183,6 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
 
     def get_meeting_links(self):
 
-        if not hasattr(self.context, 'get_proposal'):
-            return
-
         proposal = self.context.get_proposal()
         if proposal is None:
             return

--- a/opengever/document/browser/templates/overview.pt
+++ b/opengever/document/browser/templates/overview.pt
@@ -11,6 +11,10 @@
                     <th tal:content="row/label">Label</th>
                     <td tal:content="structure row/content">Content</td>
                 </tr>
+                <tr tal:repeat="row view/get_meeting_links">
+                    <th tal:content="row/label">Label</th>
+                    <td tal:content="structure row/content">Content</td>
+                </tr>
             </table>
         </div>
         <div tal:condition="view/show_preview" class="documentPreview">

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -346,33 +346,3 @@ class Document(Item, BaseDocumentMixin):
                 '%s/external_edit' % self.absolute_url(),
                 target='_self',
                 timeout=1000)
-
-    def get_proposal(self):
-        """Return the proposal to which this document belongs.
-
-        This may return a "proposal" or a "submitted proposal".
-        """
-
-        parent = aq_parent(aq_inner(self))
-        if IProposal.providedBy(parent):
-            return parent
-
-        # Find submitted proposal when self is an excerpt document in the
-        # meeting dossier.
-        for relation in getUtility(ICatalog).findRelations({
-                'to_id': getUtility(IIntIds).getId(aq_inner(self)),
-                'from_attribute': 'excerpts'}):
-            # We expect that there are 0 or 1 relation, because this document
-            # cannot be the excerpt of multiple proposals.
-            submitted_proposal = relation.from_object
-            if api.user.has_permission('View', obj=submitted_proposal):
-                return submitted_proposal
-
-        # Find proposal when self is an excerpt in the case dossier.
-        generated_excerpts = GeneratedExcerpt.query.by_document(self).all()
-        if generated_excerpts:
-            proposal = generated_excerpts[0].proposal.resolve_proposal()
-            if api.user.has_permission('View', obj=proposal):
-                return proposal
-
-        return None

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-13 12:25+0000\n"
+"POT-Creation-Date: 2017-11-08 09:02+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -420,6 +420,11 @@ msgstr "Fremdzeichen"
 msgid "label_keywords"
 msgstr "Schlagworte"
 
+#. Default: "Meeting"
+#: ./opengever/document/browser/overview.py
+msgid "label_meeting"
+msgstr "Sitzung"
+
 #. Default: "no"
 #: ./opengever/document/browser/overview.py
 msgid "label_no"
@@ -459,6 +464,11 @@ msgstr "In Papierform aufbewahrt"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_preview"
 msgstr "Vorschau"
+
+#. Default: "Proposal"
+#: ./opengever/document/browser/overview.py
+msgid "label_proposal"
+msgstr "Antrag"
 
 #: ./opengever/document/browser/report.py
 msgid "label_public_trial"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-13 12:25+0000\n"
+"POT-Creation-Date: 2017-11-08 09:02+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -417,6 +417,11 @@ msgstr "Code externe"
 msgid "label_keywords"
 msgstr "Mots-clés"
 
+#. Default: "Meeting"
+#: ./opengever/document/browser/overview.py
+msgid "label_meeting"
+msgstr "Séance"
+
 #. Default: "no"
 #: ./opengever/document/browser/overview.py
 msgid "label_no"
@@ -456,6 +461,11 @@ msgstr "Conservé sous forme papier"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_preview"
 msgstr "Aperçu"
+
+#. Default: "Proposal"
+#: ./opengever/document/browser/overview.py
+msgid "label_proposal"
+msgstr "Proposition"
 
 #: ./opengever/document/browser/report.py
 msgid "label_public_trial"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-13 12:25+0000\n"
+"POT-Creation-Date: 2017-11-08 09:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -418,6 +418,11 @@ msgstr ""
 msgid "label_keywords"
 msgstr ""
 
+#. Default: "Meeting"
+#: ./opengever/document/browser/overview.py
+msgid "label_meeting"
+msgstr ""
+
 #. Default: "no"
 #: ./opengever/document/browser/overview.py
 msgid "label_no"
@@ -456,6 +461,11 @@ msgstr ""
 #: ./opengever/document/behaviors/metadata.py
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_preview"
+msgstr ""
+
+#. Default: "Proposal"
+#: ./opengever/document/browser/overview.py
+msgid "label_proposal"
 msgstr ""
 
 #: ./opengever/document/browser/report.py

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -484,8 +484,13 @@ class Meeting(Base, SQLFormSupport):
 
     def get_link(self):
         url = self.get_url()
-        link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
-            url, escape_html(self.get_title()), self.css_class)
+        if api.user.has_permission('View',
+                                   obj=self.committee.resolve_committee()):
+            link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
+                url, escape_html(self.get_title()), self.css_class)
+        else:
+            link = u'<span title="{0}" class="{1}">{0}</a>'.format(
+                escape_html(self.get_title()), self.css_class)
         return link
 
     def get_url(self, context=None, view='view'):

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -215,22 +215,36 @@ class Proposal(Base):
         return '/'.join((admin_unit.public_url, physical_path))
 
     def get_link(self, include_icon=True):
+        proposal_ = self.resolve_proposal()
+        as_link = proposal_ is None or api.user.has_permission('View', obj=proposal_)
         return self._get_link(self.get_url(),
                               self.title,
-                              include_icon=include_icon)
+                              include_icon=include_icon,
+                              as_link=as_link)
 
     def get_submitted_link(self, include_icon=True):
+        proposal_ = self.resolve_submitted_proposal()
+        as_link = proposal_ is None or api.user.has_permission('View', obj=proposal_)
         return self._get_link(self.get_submitted_url(),
                               self.submitted_title,
-                              include_icon=include_icon)
+                              include_icon=include_icon,
+                              as_link=as_link)
 
-    def _get_link(self, url, title, include_icon=True):
+    def _get_link(self, url, title, include_icon=True, as_link=True):
         title = escape_html(title)
+        if as_link:
+            if include_icon:
+                link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
+                    url, title, self.css_class)
+            else:
+                link = u'<a href="{0}" title="{1}">{1}</a>'.format(url, title)
+            return link
+
         if include_icon:
-            link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
-                url, title, self.css_class)
+            link = u'<span title="{0}" class="{1}">{0}</span>'.format(
+                title, self.css_class)
         else:
-            link = u'<a href="{0}" title="{1}">{1}</a>'.format(url, title)
+            link = u'<span title="{0}">{0}</a>'.format(title)
         return link
 
     def getPath(self):

--- a/opengever/meeting/tests/test_overview_meeting_links.py
+++ b/opengever/meeting/tests/test_overview_meeting_links.py
@@ -1,0 +1,88 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from operator import attrgetter
+
+
+class TestDocumentOverviewMeetingLinks(IntegrationTestCase):
+
+    features = ('meeting', 'word-meeting')
+
+    @browsing
+    def test_overview_displays_link_to_proposal(self, browser):
+        expected_fields = sorted([
+            'Title', 'Document Date', 'Document Type', 'Author', 'creator',
+            'Description', 'Foreign Reference', 'Checked out', 'File',
+            'Digital Available', 'Preserved as paper', 'Date of receipt',
+            'Date of delivery', 'Related Documents', 'Classification',
+            'Privacy layer', 'Public Trial', 'Public trial statement',
+            'Submitted with', 'Proposal',
+        ])
+
+        self.login(self.secretariat_user, browser)
+        browser.open(self.word_proposal.get_proposal_document(),
+                     view='tabbedview_view-overview')
+        fields = dict(zip(
+            browser.css('.documentMetadata th').text,
+            map(attrgetter('innerHTML'), browser.css('.documentMetadata td')),
+        ))
+
+        self.assertEquals(expected_fields,
+                          sorted(fields.keys()))
+        self.assertEquals(
+            u'<a href="http://nohost/plone/ordnungssystem/fuhrung/'
+            u'vertrage-und-vereinbarungen/dossier-1/proposal-4" '
+            u'title="\xc4nderungen am Personalreglement" '
+            u'class="contenttype-opengever-meeting-proposal">'
+            u'\xc4nderungen am Personalreglement</a>',
+            fields['Proposal']
+        )
+
+    @browsing
+    def test_overview_displays_link_to_meeting(self, browser):
+        expected_fields = sorted([
+            'Title', 'Document Date', 'Document Type', 'Author', 'creator',
+            'Description', 'Foreign Reference', 'Checked out', 'File',
+            'Digital Available', 'Preserved as paper', 'Date of receipt',
+            'Date of delivery', 'Related Documents', 'Classification',
+            'Privacy layer', 'Public Trial', 'Public trial statement',
+            'Submitted with', 'Proposal', 'Meeting',
+        ])
+        with self.login(self.committee_responsible, browser):
+            self.word_proposal.load_model().schedule(self.meeting.model)
+
+            browser.open(self.word_proposal.get_proposal_document(),
+                         view='tabbedview_view-overview')
+            fields = dict(zip(
+                browser.css('.documentMetadata th').text,
+                map(attrgetter('innerHTML'), browser.css('.documentMetadata td')),
+            ))
+            self.assertEquals(expected_fields,
+                              sorted(fields.keys()))
+            self.assertEquals(
+                u'<a href="http://nohost/plone/opengever-meeting-committeecontainer'
+                u'/committee-1/meeting-1/view" title="9. Sitzung der '
+                u'Rechnungspr\xfcfungskommission" class="'
+                u'contenttype-opengever-meeting-meeting">9. Sitzung der '
+                u'Rechnungspr\xfcfungskommission</a>',
+                fields['Meeting'],
+            )
+
+        with self.login(self.secretariat_user, browser):
+            browser.open(self.word_proposal.get_proposal_document(),
+                         view='tabbedview_view-overview')
+            fields = dict(zip(
+                browser.css('.documentMetadata th').text,
+                map(attrgetter('innerHTML'), browser.css('.documentMetadata td')),
+            ))
+
+            self.assertEquals(expected_fields,
+                              sorted(fields.keys()))
+            self.assertEquals(
+                u'<span title="9. Sitzung der '
+                u'Rechnungspr\xfcfungskommission" class="'
+                u'contenttype-opengever-meeting-meeting">9. Sitzung der '
+                u'Rechnungspr\xfcfungskommission</span>',
+                fields['Meeting'],
+            )

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -81,7 +81,7 @@ class TestDossierProposalListing(IntegrationTestCase):
         with self.login(self.committee_responsible):
             self.schedule_proposal(self.meeting, self.submitted_proposal)
 
-        self.login(self.dossier_responsible, browser)
+        self.login(self.committee_responsible, browser)
         browser.open(self.dossier, view='tabbedview_view-proposals')
 
         elem = proposals_table(browser).rows[1].css(


### PR DESCRIPTION
The document overview should display links to the meeting or the proposal if there is any proposal / meeting associated to the document displayed.
Also the link should be "disabled" if the user has no view permission.

Resolves https://github.com/4teamwork/gever/issues/100