### PR TITLE
Squelch an SQLAlchemy stderr bleed from a test

### DIFF
--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -8,12 +8,14 @@ from opengever.ogds.models.query import BaseQuery
 
 
 class ActivityQuery(BaseQuery):
-    pass
+    """Provide accessors to activity."""
+
 
 Activity.query_cls = ActivityQuery
 
 
 class NotificationQuery(BaseQuery):
+    """Provide accessors to notifications."""
 
     def by_user(self, userid):
         return self.filter_by(userid=userid)
@@ -32,14 +34,17 @@ Notification.query_cls = NotificationQuery
 
 
 class ResourceQuery(BaseQuery):
+    """Provide accessors to resources."""
 
     def get_by_oguid(self, oguid):
         return self.filter_by(oguid=oguid).first()
+
 
 Resource.query_cls = ResourceQuery
 
 
 class NotificationDefaultQuery(BaseQuery):
+    """Provide a default accessors to activities."""
 
     def is_dispatch_needed(self, dispatch_setting, kind):
         setting = self.filter_by(kind=kind).first()
@@ -51,10 +56,12 @@ class NotificationDefaultQuery(BaseQuery):
     def by_kind(self, kind):
         return self.filter_by(kind=kind)
 
+
 NotificationDefault.query_cls = NotificationDefaultQuery
 
 
 class SubscriptionQuery(BaseQuery):
+    """Provide accessors to subscriptions."""
 
     def fetch(self, resource, watcher, role):
         return self.filter_by(
@@ -71,8 +78,10 @@ Subscription.query_cls = SubscriptionQuery
 
 
 class WatcherQuery(BaseQuery):
+    """Provide accessors to watchers."""
 
     def get_by_actorid(self, actorid):
         return self.filter_by(actorid=actorid).first()
+
 
 Watcher.query_cls = WatcherQuery


### PR DESCRIPTION
I'm intending on moving to asserting on unclean stderr from a test batch in the CI runs and this is the last one standing in the way.

https://ci.4teamwork.ch/builds/121918/tasks/187756

Querying on an empty notification role target group spits out (retouched for readability):

```
eggs/SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/sql/default_comparator.py:161: 
SAWarning:
The IN-predicate on "notifications.userid" was invoked with an empty sequence.
This results in a contradiction, which nonetheless can be expensive to evaluate.
Consider alternative strategies for improved performance.
```

This breaks the test assertion (to explicitly test for no one having being notified in case no one has registered). Suggestions?