### PR TITLE
Fix ie11 action buttons, don't put title into action link.

### DIFF
--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -200,16 +200,12 @@
                     <a class="action generate"
                        tal:condition="meeting/is_editable"
                        tal:attributes="href view/url_generate_agendaitem_list"
-                       i18n:translate="action_generate_document"
-                       i18n:attributes="title action_generate_document"
-                       title=""></a>
+                       i18n:attributes="title action_generate_document"></a>
 
                     <a class="action download"
                        tal:condition="agendaitem_list_document"
                        tal:attributes="href view/url_download_agendaitem_list"
-                       i18n:translate="action_download_document"
-                       i18n:attributes="title action_download_document"
-                       title=""></a>
+                       i18n:attributes="title action_download_document"></a>
                   </div>
 
                   <tal:NOT_GENERATED tal:condition="not:agendaitem_list_document">
@@ -255,16 +251,12 @@
                     <a class="action generate"
                        tal:condition="meeting/is_editable"
                        tal:attributes="href view/url_generate_protocol"
-                       i18n:translate="action_generate_document"
-                       i18n:attributes="title action_generate_document"
-                       title=""></a>
+                       i18n:attributes="title action_generate_document"></a>
 
                     <a class="action download"
                        tal:condition="protocol_document"
                        tal:attributes="href view/url_download_protocol"
-                       i18n:translate="action_download_document"
-                       i18n:attributes="title action_download_document"
-                       title=""></a>
+                       i18n:attributes="title action_download_document"></a>
                   </div>
 
                   <tal:NOT_GENERATED tal:condition="not:protocol_document">


### PR DESCRIPTION
This allows us to not hide the link on ie11 which caused issues with displaying the fa-icon.

⚠️  requires https://github.com/4teamwork/plonetheme.teamraum/pull/596.

now correctly displays the document actions on ie11:
![screen shot 2017-11-07 at 10 51 25](https://user-images.githubusercontent.com/736583/32487679-a307bbd8-c3aa-11e7-8b98-38554fe99c1a.png)

Fixes https://github.com/4teamwork/gever/issues/146.