### PR TITLE
Port mtest to multiprocessing and split out layers

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -1,146 +1,322 @@
-#!/usr/bin/env python3
-
-# Runs the tests in configurably many subprocesses.
-
+#!/usr/bin/env python
+"""A concurrent wrapper for timing xmltestrunner tests for opengever.core."""
+from __future__ import print_function
+from argparse import ArgumentParser
 from copy import copy
 from fnmatch import fnmatch
+from logging import DEBUG
+from logging import Formatter
+from logging import getLogger
+from logging import INFO
+from logging import StreamHandler
+from logging.handlers import MemoryHandler
+from multiprocessing import cpu_count
+from multiprocessing import Pool
+from os import environ
+from os import killpg
+from os import path
+from os import setpgrp
+from os import unlink
+from os import walk
+from signal import SIGINT
+from signal import SIGKILL
+from signal import signal
+from subprocess import PIPE
+from subprocess import Popen
+from time import time
 
-import concurrent.futures
-import os
-import subprocess
-import sys
+
+def humanize_time(seconds):
+    """Humanize a seconds based delta time.
+
+    Only handles time spans up to weeks for simplicity.
+    """
+    minutes, seconds = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    weeks, days = divmod(days, 7)
+
+    seconds = int(round(seconds))
+    minutes = int(round(minutes))
+    hours = int(round(hours))
+    days = int(round(days))
+    weeks = int(round(weeks))
+
+    output = []
+
+    if weeks:
+        output.append('{:02d} weeks'.format(weeks))
+    if days:
+        output.append('{:02d} days'.format(days))
+    if hours:
+        output.append('{:02d} hours'.format(hours))
+    if minutes:
+        output.append('{:02d} minutes'.format(minutes))
+
+    output.append('{:02d} seconds'.format(seconds))
+
+    return ' '.join(output)
 
 
-os.environ['PYTHONDONTWRITEBYTECODE'] = '1'
+def setup_termination():
+    # Set the group flag so that subprocesses will be in the same group.
+    setpgrp()
 
-PROCESSORS = int(os.environ.get('MTEST_PROCESSORS', '4'))
+    def terminate(signum, frame):
+        # Kill the group (including main process) on terminal signal.
+        killpg(0, SIGKILL)
 
-BUILDOUT_PATH = os.path.abspath(os.path.join(__file__, '..', '..'))
-OPENGEVER_PATH = os.path.join(BUILDOUT_PATH, 'opengever')
+    signal(SIGINT, terminate)
+
+
+def get_concurrency():
+    # Counter system congestion and hyperthreading, FWIW
+    concurrency = cpu_count() // 2 - 1
+
+    # Make sure we use at least one core
+    if concurrency < 1:
+        concurrency = 1
+
+    return concurrency
+
+
+def create_test_run_params():
+    test_run_params = []
+
+    # Manually ordered per metrification
+    standalone_modules = (
+        'document',
+        'base',
+        'task',
+        'dossier',
+        'disposition',
+        )
+
+    # Manually ordered per metrification
+    standalone_layers = (
+        'opengever.core.testing.MeetingLayer',
+        'opengever.core.testing.opengever.core:functional:zserver',
+        'opengever.core.testing.opengever.core:integration',
+        )
+
+    if CONCURRENCY > 1:
+        module_negation = tuple(''.join(('!', module, )) for module in standalone_modules)
+        layer_negation = tuple(''.join(('!', layer, )) for layer in standalone_layers)
+
+        for layer in standalone_layers:
+            test_run_params.append({
+                'layers': (layer, ),
+                'modules': None,
+                })
+
+        test_run_params.append({
+            'layers': layer_negation,
+            'modules': module_negation,
+            })
+
+        for module in standalone_modules:
+            test_run_params.append({
+                'layers': layer_negation,
+                'modules': (module, ),
+                })
+
+    else:
+        test_run_params.append({
+            'layers': None,
+            'modules': None,
+            })
+
+    return tuple(test_run_params)
+
+
+def remove_bytecode_files(directory_path):
+    logger.info('Removing bytecode files from %s', directory_path)
+    for filename in find_bytecode_files(directory_path):
+        unlink(filename)
+
+
+def find_bytecode_files(directory_path):
+    for root, _, files in walk(directory_path):
+        for name in files:
+            if fnmatch(name, '*.py[co]'):
+                yield path.join(root, name)
+
+
+def run_tests(test_run_params):
+    """Run and time 'bin/test --layer layer -m module [-m module]'.
+
+    Return the module name, layer name and stderr.
+    """
+    params = ['bin/test']
+
+    layers = test_run_params.get('layers', None)
+    modules = test_run_params.get('modules', None)
+
+    if layers:
+        for layer in layers:
+            params.append('--layer')
+            params.append(layer)
+
+    if modules:
+        for module in modules:
+            params.append('-m')
+            params.append(module)
+
+    logger.debug('Start: %s %s', layers, modules)
+
+    # ZServer tests will be run separately of everything else per layer separation
+    env = copy(environ)
+    env['ZSERVER_PORT'] = env.get('PORT1', '55000')
+
+    start = time()
+
+    process = Popen(
+        params,
+        env=env,
+        stderr=PIPE,
+        stdout=PIPE,
+        )
+
+    stdout, stderr = process.communicate()
+    returncode = process.returncode
+
+    runtime = time() - start
+
+    result = {
+        'layers': layers,
+        'modules': modules,
+        'returncode': returncode,
+        'runtime': runtime,
+        'stderr': stderr,
+        'stdout': stdout,
+        }
+
+    logger.debug('Done: %s %s in %s', layers, modules, humanize_time(runtime))
+    if DEBUG_MODE:
+        # This explicitly expects UTF-8 as the runtime locale!
+        if stderr:
+            print(stderr.decode('UTF-8'), end='')
+        if returncode:
+            print(stdout.decode('UTF-8'), end='')
+
+    return result
+
+
+def handle_results(results):
+    success = []
+
+    for result in results:
+        # For some reason we get the test run result dict wrapped in a list
+        returncode = result.get('returncode', 1)
+        stderr = result.get('stderr', None)
+        stdout = result.get('stdout', None)
+
+        if not stderr and not returncode:
+            success.append(True)
+
+        else:
+            success.append(False)
+            # We already printed at test runtime
+            if not DEBUG_MODE:
+                # This explicitly expects UTF-8 as the runtime locale!
+                print(stderr.decode('UTF-8'), end='')
+                if returncode:
+                    print(stdout.decode('UTF-8'), end='')
+
+    # Nothing returned False, everything went fine
+    if all(r is True for r in success):
+        logger.info('No failed tests.')
+        exit(0)
+
+    # Fail per default
+    exit(1)
 
 
 def main():
+    """Discovers and times tests in parallel via multiprocessing.Pool()."""
     # Remove *.py[co] files to avoid race conditions with parallel workers
     # stepping on each other's toes when trying to clean up stale bytecode.
     #
     # Setting PYTHONDONTWRITEBYTECODE is not enough, because running buildout
     # also already precompiles bytecode for some eggs.
+    logger.info('Cleaning bytecode files.')
     remove_bytecode_files(OPENGEVER_PATH)
     remove_bytecode_files('src')
 
-    print("Discovering modules.", flush=True)
+    test_run_params = create_test_run_params()
+    pool = Pool(CONCURRENCY)
 
-    known_very_slow_modules = [
-        'opengever.meeting',
-    ]
+    start = time()
 
-    known_slow_modules = [
-        'opengever.base',
-        'opengever.document',
-        'opengever.dossier',
-        'opengever.task',
-        ]
+    results = tuple(sorted(
+        pool.map(run_tests, test_run_params),
+        key=lambda result: result.get('runtime', 0.0),
+        ))
 
-    modules = []
-    for name in os.listdir('opengever'):
-        if name[0].isalpha():
-            complete_name = 'opengever.' + name
-            if complete_name not in known_slow_modules:
-                if complete_name not in known_very_slow_modules:
-                    modules.append(complete_name)
+    pool.close()
+    pool.join()
 
-    free_cores = PROCESSORS - len(known_very_slow_modules)
+    logger.debug('Aggregate runtime %s.', humanize_time(sum(i.get('runtime', 0.0) for i in results)))
+    logger.debug('Wallclock runtime %s.', humanize_time(time() - start))
 
-    if PROCESSORS == 1:
-        # Just run everything sequentially in one job
-        batches = known_very_slow_modules + known_slow_modules + modules
-
-    elif free_cores > 0:
-        # Create as many test batches as there are non-dedicated runners
-        batches = [[] for n in range(free_cores)]
-
-        # Round robin the known slow modules across the test runners
-        for i, module in enumerate(known_slow_modules + modules):
-            batches[i % free_cores].append(module)
-
-        # Append the known very slow modules as their dedicated test runners
-        for module in known_very_slow_modules:
-            batches.append([module])
-
-    else:
-        # We can only run the dedicated very slow ones separate from the rest
-        batches = []
-        for module in known_very_slow_modules:
-            batches.append(known_very_slow_modules)
-        batches.append(modules)
-
-    # Guard against empty batches in case of more processors than modules
-    # Get worker ZSERVER_PORT from the jenkins port allocator
-    # The jenkins port allocator enumerates starting from 1
-    # Default to 55000 + i
-    batches = [
-        (os.environ.get('PORT{}'.format(i + 1), str(55000 + i)), batch)
-        for i, batch in enumerate(batches)
-        if batch
-        ]
-
-    print("Running tests with {} processors.".format(PROCESSORS), flush=True)
-    with concurrent.futures.ProcessPoolExecutor(max_workers=PROCESSORS) as executor:  # noqa
-        outputs = executor.map(run_tests, batches)
-
-    failed_tests = False
-    for output in outputs:
-        if output:
-            # This is a tuple of stdout and stderr as bytestrings
-            for out in output:
-                if out:
-                    failed_tests = True
-                    # This explicitly expects UTF-8 as the runtime locale!
-                    print(out.decode('UTF-8'), end='', flush=True)
-
-    if failed_tests:
-        sys.exit(1)
-
-    print("No failed tests.", flush=True)
+    handle_results(results)
 
 
-def remove_bytecode_files(path):
-    print("Removing bytecode files from {}".format(path), flush=True)
-    for filename in find_bytecode_files(path):
-        os.unlink(filename)
+# Having the __main__ guard is necessary for multiprocessing.Pool().
+if __name__ == '__main__':
+    # Globals
+    environ['PYTHONUNBUFFERED'] = '1'
+    environ['PYTHONDONTWRITEBYTECODE'] = '1'
 
+    DEBUG_MODE = False
 
-def find_bytecode_files(path):
-    for root, dirs, files in os.walk(path):
-        for name in files:
-            if fnmatch(name, '*.py[co]'):
-                yield os.path.join(root, name)
+    CONCURRENCY = int(environ.get('MTEST_PROCESSORS', get_concurrency()))
 
+    BUILDOUT_PATH = path.abspath(path.join(__file__, '..', '..'))
+    OPENGEVER_PATH = path.join(BUILDOUT_PATH, 'opengever')
 
-def run_tests(runtime_params):
-    arguments = ['bin/test']
-    for module in runtime_params[1]:
-        arguments.append('-m')
-        arguments.append(module)
+    # CLI arguments
+    parser = ArgumentParser(description='Run tests in parallel.')
 
-    env = copy(os.environ)
-    env['ZSERVER_PORT'] = runtime_params[0]
-
-    test_run = subprocess.Popen(
-        arguments,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
+    parser.add_argument(
+        '-d',
+        '--debug',
+        help='Set the log level to debug.',
+        action='store_true',
         )
 
-    # The pipe buffer is only 4k in size, so we need to constantly fetch it
-    output = test_run.communicate()
+    parser.add_argument(
+        '-j',
+        '--jobs',
+        help='Set the testing concurrency level.',
+        )
 
-    if test_run.returncode != 0:
-        # Only return output if we have a failed test
-        return output
-    return None
+    args = parser.parse_args()
 
+    if args.jobs:
+        CONCURRENCY = int(args.jobs)
 
-if __name__ == '__main__':
+    if args.debug:
+        DEBUG_MODE = True
+        default_loglevel = DEBUG
+    else:
+        default_loglevel = INFO
+
+    # Logging
+    logger = getLogger('mtest')
+    logger.setLevel(default_loglevel)
+
+    # Set up logging to stdout
+    stream_handler = StreamHandler()
+    stream_handler.setLevel(default_loglevel)
+    log_formatter = Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    stream_handler.setFormatter(log_formatter)
+
+    # Buffer log messages so we do not get broken-by-racecondition debug log lines in stdout
+    memory_handler = MemoryHandler(4096, flushLevel=DEBUG, target=stream_handler)
+    memory_handler.setLevel(default_loglevel)
+
+    logger.addHandler(memory_handler)
+
+    setup_termination()
     main()


### PR DESCRIPTION
Current test timings on my laptop with this layer split:

```
 0.033%                     policy               02 seconds
 0.037%                     sphinx               02 seconds
 0.037%            policytemplates               02 seconds
 0.144%                    testing               09 seconds
 0.144%                        api               09 seconds
 0.150%                    ech0147               10 seconds
 0.182%               contentstats               12 seconds
 0.460%                      debug               30 seconds
 0.616%               officeatwork               40 seconds
 0.654%                   portlets               43 seconds
 0.670%                    sharing               44 seconds
 0.691%                 repository               45 seconds
 0.727%                     bundle               48 seconds
 0.735%                    locking               48 seconds
 0.737%                       core               48 seconds
 0.759%                      quota               50 seconds
 0.766%             advancedsearch               50 seconds
 0.796%                      setup               52 seconds
 0.840%                globalindex               55 seconds
 0.938%                       ogds    01 minutes 02 seconds
 1.023%              usermigration    01 minutes 07 seconds
 1.128%                   activity    01 minutes 14 seconds
 1.302%            officeconnector    01 minutes 26 seconds
 1.310%                    journal    01 minutes 26 seconds
 1.352%              tasktemplates    01 minutes 29 seconds
 1.363%                    private    01 minutes 29 seconds
 1.414%                      latex    01 minutes 33 seconds
 1.478%                 tabbedview    01 minutes 37 seconds
 1.500%                      trash    01 minutes 38 seconds
 1.685%             examplecontent    01 minutes 51 seconds
 1.929%                    contact    02 minutes 07 seconds
 2.459%                      inbox    02 minutes 41 seconds
 2.652%                  bumblebee    02 minutes 54 seconds
 2.948%                    meeting    03 minutes 14 seconds
 3.377%                       mail    03 minutes 42 seconds
 3.796%    core:functional:zserver    04 minutes 09 seconds
 5.123%                disposition    05 minutes 36 seconds
 7.255%                       base    07 minutes 56 seconds
 7.311%                       task    07 minutes 60 seconds
 7.987%                    dossier    08 minutes 44 seconds
 8.434%                   document    09 minutes 14 seconds
 9.170%           core:integration    10 minutes 02 seconds
13.886%               MeetingLayer    15 minutes 12 seconds

Total:     01 hours 49 minutes 25 seconds
Wallclock:          38 minutes 43 seconds
```

What:
* No longer depends on Python 3
* Splits out the slow layers to run as separate processes
  * This thins down the slowest modules to their leanest
  * Reduces on duplicated layer setup time across workers
* Always run the ZServer layer separate of everything else
  * Lets us get rid of the port management for the most part
  * The layer separation is a greedy match (`functional` would match `functional:zserver`)
* Negates these layers from the other runs
* Changes the list of known slow modules
  * We also now have only one tier of slow modules instead of two
  * Splits off the slow modules onto their own processes
* Clumps the remaining modules onto a single batch
  * This is now the batch to finish last
* The meeting layer is now the second slowest batch
* Logs
  * Nicer output
* Has a debug mode for local running
  * More information
  * Early failure prints
* Concurrency control
  * Per default uses (up to) `system threads // 2 - 1` processes
  * Can be overridden by `MTEST_PROCESSORS`
  * Both can be overridden with the new `-j` flag
* Has rough CLI documentation built in
  * `-h`

Gains:
* 12min runs
* Everything ported off the functional tests directly lands us wallclock time savings
  * After a bit this will be true of the MeetingLayer tests instead
  * We can then decide whether to tackle that or change the module list to accommodate
* When the integration tests are the longest run it can easily be chunked over multiple workers
* Also trips up on an unclean stderr
* 5min .. 8min runs should be possible
  * Pushing any further would require the ability to chunk tests within a layer