### PR TITLE
Fix catalog index name, it is `path`, not `paths`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,7 @@ Changelog
 - Allow proposal listings to be filtered by proposal title. [deiferni]
 - Allow proposal listings to be sorted by title. [deiferni]
 - Automatically update versions.cfg when releasing with zest.releaser. [deiferni]
+- Fix catalog index name in upgrade step. [deiferni]
 
 
 2017.6.1 (2017-11-02)

--- a/opengever/core/upgrades/20171009113732_add_commitee_roles_to_document_workflow/upgrade.py
+++ b/opengever/core/upgrades/20171009113732_add_commitee_roles_to_document_workflow/upgrade.py
@@ -38,7 +38,7 @@ class AddCommitteRolesToDocumentAndMailWorkflows(UpgradeStep):
             return []
 
         query = {
-            'paths': map(methodcaller('getPath'), committee_container_brains),
+            'path': map(methodcaller('getPath'), committee_container_brains),
             'portal_type': WorkflowSecurityUpdater().get_suspected_types(
                 ['opengever_document_workflow',
                  'opengever_mail_workflow'])


### PR DESCRIPTION
This will avoid running the upgrade for every document if we have committee containers in the system.

_This will also need a backport to 2017.6 and another bugfix release._