### PR TITLE
Make sure `plone.rest` directives are loaded when used.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,7 @@ Changelog
 - Allow proposal listings to be filtered by proposal title. [deiferni]
 - Allow proposal listings to be sorted by title. [deiferni]
 - Pin plone.restapi to 1.0a23. [deiferni]
+- Make sure `plone.rest` directives are loaded when used. [deiferni]
 
 
 2017.6.2 (2017-11-07)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -5,6 +5,8 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.api">
 
+  <include package="plone.rest" file="meta.zcml" />
+
   <configure zcml:condition="installed plone.restapi">
     <adapter factory=".summary.GeverJSONSummarySerializer" />
     <adapter factory=".fields.ChoiceFieldDeserializer" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -6,13 +6,10 @@
     i18n_domain="opengever.api">
 
   <include package="plone.rest" file="meta.zcml" />
-
-  <configure zcml:condition="installed plone.restapi">
-    <adapter factory=".summary.GeverJSONSummarySerializer" />
-    <adapter factory=".fields.ChoiceFieldDeserializer" />
-  </configure>
-
   <include package="opengever.document" file="permissions.zcml" />
+
+  <adapter factory=".summary.GeverJSONSummarySerializer" />
+  <adapter factory=".fields.ChoiceFieldDeserializer" />
 
   <plone:service
       method="POST"


### PR DESCRIPTION
This PR ensures that `plone.restapi` directives are loaded before using them. 

Also drops the no longer needed conditional in an adapter definition.