### PR TITLE
Allow personal notification settings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Make notification badge a separate channel. [phgross]
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
 - SPV word: Remove fields which are intended for no word version. [tarnap]
+- Add personal notification settings support. [phgross]
 - Add proper responsible for fixture objects. [elioschmutz]
 - Add optional header and suffix templates for protocol excerpts. [tarnap]
 - Fix textfilter in sqlsource table listings for oracle backends. [phgross]

--- a/opengever/activity/dispatcher.py
+++ b/opengever/activity/dispatcher.py
@@ -1,8 +1,12 @@
+from opengever.activity.model import NotificationDefault
+from opengever.activity.model import Subscription
+from opengever.activity.model import Watcher
+from opengever.activity.model.settings import NotificationSetting
+from opengever.base.model import create_session
+from ZODB.POSException import ConflictError
 import logging
 import sys
 import traceback
-from opengever.activity.model import NotificationDefault
-from ZODB.POSException import ConflictError
 
 
 logger = logging.getLogger('opengever.activity')
@@ -13,22 +17,43 @@ class NotificationDispatcher(object):
     enabled_key = None
     roles_key = None
 
-    def get_setting(self, kind):
+    def get_setting(self, kind, userid):
+        setting = NotificationSetting.query.filter_by(
+            kind=kind, userid=userid).first()
+        if setting:
+            return setting
+
         return NotificationDefault.query.by_kind(kind=kind).first()
 
-    def get_roles_to_dispatch(self, kind):
-        setting = self.get_setting(kind)
+    def dispatch_needed(self, notification):
+        userid = notification.userid
+        setting = self.get_setting(notification.activity.kind, userid)
         if not setting:
-            return []
+            return False
 
-        return getattr(setting, self.roles_key)
+        dispatched_roles = getattr(setting, self.roles_key)
+        if not dispatched_roles:
+            return False
+
+        query = create_session().query(Watcher).join(Subscription)
+        query = query.filter(
+            Subscription.resource == notification.activity.resource)
+        query = query.filter(Subscription.role.in_(dispatched_roles))
+
+        for watcher in query:
+            if userid in watcher.get_user_ids():
+                return True
+
+        return False
 
     def dispatch_notifications(self, activity):
         not_dispatched = []
-        roles = self.get_roles_to_dispatch(activity.kind)
-        notifications = activity.get_notifications_for_watcher_roles(roles)
+        notifications = activity.notifications
 
         for notification in notifications:
+            if not self.dispatch_needed(notification):
+                continue
+
             try:
                 self.dispatch_notification(notification)
             except ConflictError:

--- a/opengever/activity/model/__init__.py
+++ b/opengever/activity/model/__init__.py
@@ -4,6 +4,7 @@ from opengever.activity.model.notification import Notification
 from opengever.activity.model.resource import Resource
 from opengever.activity.model.resource import Subscription
 from opengever.activity.model.settings import NotificationDefault
+from opengever.activity.model.settings import NotificationSetting
 from opengever.activity.model.watcher import Watcher
 from opengever.activity.model import query
 
@@ -15,4 +16,5 @@ tables = [
     'watchers',
     'subscriptions',
     'notification_defaults',
+    'notification_settings',
 ]

--- a/opengever/activity/model/settings.py
+++ b/opengever/activity/model/settings.py
@@ -1,24 +1,19 @@
 from opengever.base.model import Base
+from opengever.ogds.models import USER_ID_LENGTH
+from opengever.ogds.models.user import User
 from sqlalchemy import Column
+from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
+from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Sequence
 import json
 
 
-class NotificationDefault(Base):
-
-    __tablename__ = 'notification_defaults'
-
-    notification_default_id = Column('id', Integer,
-                                     Sequence('notification_defaults_id_seq'),
-                                     primary_key=True)
-
-    kind = Column(String(50), nullable=False, unique=True)
+class SettingMixin(object):
 
     _badge_notification_roles = Column('badge_notification_roles', Text)
-
     _mail_notification_roles = Column('mail_notification_roles', Text)
 
     @property
@@ -44,3 +39,26 @@ class NotificationDefault(Base):
     @badge_notification_roles.setter
     def badge_notification_roles(self, roles):
         self._badge_notification_roles = json.dumps(roles)
+
+
+class NotificationDefault(SettingMixin, Base):
+
+    __tablename__ = 'notification_defaults'
+
+    notification_default_id = Column('id', Integer,
+                                     Sequence('notification_defaults_id_seq'),
+                                     primary_key=True)
+    kind = Column(String(50), nullable=False, unique=True)
+
+
+class NotificationSetting(SettingMixin, Base):
+
+    __tablename__ = 'notification_settings'
+
+    notification_settings_id = Column('id', Integer,
+                                      Sequence('notification_settings_id_seq'),
+                                      primary_key=True)
+
+    kind = Column(String(50), nullable=False)
+    userid = Column(String(USER_ID_LENGTH), ForeignKey(User.userid))
+    user = relationship(User, backref="settings")

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -419,7 +419,31 @@ class TestDispatchers(ActivityTestCase):
                        watcher=peter,
                        role=TASK_RESPONSIBLE_ROLE))
 
-    def test_check_for_notification_default(self):
+    def test_uses_personal_setting_if_exists(self):
+        create(Builder('notification_default_setting')
+               .having(kind='task-added',
+                       mail_notification_roles=[WATCHER_ROLE,
+                                                TASK_RESPONSIBLE_ROLE]))
+
+        create(Builder('notification_setting')
+               .having(kind='task-added', userid='hugo'))
+
+
+        self.center.add_activity(
+            Oguid('fd', '123'),
+            'task-added',
+            {'en': 'Kennzahlen 2014 erfassen'},
+            {'en': 'Task added'},
+            {'en': 'Task bla accepted by Peter'},
+            'hugo.boss',
+            {'en': None})
+
+        self.assertEquals(1, len(self.dispatcher.notified))
+        self.assertEquals(
+            ['peter'],
+            [note.userid for note in self.dispatcher.notified])
+
+    def test_uses_notification_default_as_fallback(self):
         setting = create(Builder('notification_default_setting')
                          .having(kind='task-added',
                                  mail_notification_roles=[

--- a/opengever/core/upgrades/20171108134921_add_notification_settings_table/upgrade.py
+++ b/opengever/core/upgrades/20171108134921_add_notification_settings_table/upgrade.py
@@ -1,0 +1,30 @@
+from opengever.core.upgrade import SchemaMigration
+from opengever.ogds.models import USER_ID_LENGTH
+from opengever.ogds.models.user import User  # noqa
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import Text
+from sqlalchemy.schema import Sequence
+
+
+class AddNotificationSettingsTable(SchemaMigration):
+    """Add NotificationSettings table.
+    """
+
+    def migrate(self):
+        self.add_notification_settings_table()
+
+    def add_notification_settings_table(self):
+        self.op.create_table(
+            'notification_settings',
+            Column('id', Integer,
+                   Sequence('notification_settings_id_seq'), primary_key=True),
+
+            Column('kind', String(50), nullable=False),
+            Column('userid', String(USER_ID_LENGTH), ForeignKey(User.userid)),
+            Column('badge_notification_roles', Text),
+            Column('mail_notification_roles', Text))
+
+        self.ensure_sequence_exists('notification_settings_id_seq')

--- a/opengever/testing/builders/activity.py
+++ b/opengever/testing/builders/activity.py
@@ -2,6 +2,7 @@ from ftw.builder import builder_registry
 from opengever.activity.model import Activity
 from opengever.activity.model import Notification
 from opengever.activity.model import NotificationDefault
+from opengever.activity.model import NotificationSetting
 from opengever.activity.model import Resource
 from opengever.activity.model import Subscription
 from opengever.activity.model import Watcher
@@ -101,3 +102,11 @@ class NotificationDefaultBuilder(SqlObjectBuilder):
 
 builder_registry.register('notification_default_setting',
                           NotificationDefaultBuilder)
+
+
+class NotificationSettingBuilder(SqlObjectBuilder):
+
+    mapped_class = NotificationSetting
+
+
+builder_registry.register('notification_setting', NotificationSettingBuilder)


### PR DESCRIPTION
Add new model NotificationSetting, which stores the personal notification settings, in the same manner than we have stored the settings for the complete installation. The NotificationDispatchers checks first for a personal setting and uses the notification_defaults as a fallback when deciding if a notification has to be dispatched ... 

The form, where a user can add and edit those personal settings will follow in a separate PR. 

This is a part of OGIP 29