### PR TITLE
Fix agenda items rendering on non-word meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.4 (unreleased)
 ---------------------
 
+- Fix agenda items rendering on non-word meeting. [deiferni]
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
 - Add proper responsible for fixture objects. [elioschmutz]
 - Add optional header and suffix templates for protocol excerpts. [tarnap]

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -355,7 +355,10 @@
     };
 
     Controller.call(this, $("#agendaitemsTemplate").html(), $("#agenda_items tbody"), options);
-    this.navigationTemplate = HBS.compile($("#navigationTemplate").html());
+    if ($("#navigationTemplate").length > 0) {
+      this.navigationTemplate = HBS.compile($("#navigationTemplate").html());
+    }
+
 
     this.fetch = function() { return $.get(viewlet.data().listAgendaItemsUrl); };
 
@@ -369,6 +372,10 @@
     };
 
     this.renderNavigation = function(data) {
+      if (typeof this.navigationTemplate === 'undefined') {
+        return;
+      }
+
       $('.meeting-navigation').html(this.navigationTemplate({agendaitems: data.items}));
       this.updateNavigationScrollArea();
     };


### PR DESCRIPTION
The code expected an element to be present all the time whereas it is only
there when the word-meeting feature flag has been enabled.