### PR TITLE
Adds own field for dossier manager

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - SPV: Fix member links in committee overview. [tarnap]
 - SPV: Make the considerations field a trix field. [tarnap]
 - Don't escape description in overview twice for dossier templates. [deiferni]
+- Add new field dossier_manager to the IProtectDossier behavior to set the dossier-manager manually. [elisochmutz]
 - Fix agenda items rendering on non-word meeting. [deiferni]
 - Add special keywordwidget template for users and groups, showing an icon and links the groups. [elioschmutz]
 - Add the "Protect dossier" functionality to a dossier. [elioschmutz]

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -234,6 +234,13 @@
             "description": "W\u00e4hlen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schreibend Zugriff erhalten sollen. Die Benutzer dieser Gruppe werden dazu berechtigt, das Dossier zu bearbeiten, Inhalte zu erstellen und zu bearbeiten.",
             "_zope_schema_type": "List",
             "default": null
+        },
+        "dossier_manager": {
+            "type": "string",
+            "title": "Dossier-Verwalter",
+            "description": "W\u00e4hlen Sie hier einen Benutzer oder eine Gruppe, welche nach dem Sch\u00fctzen des Dossiers den Schutz anpassen oder wieder aufheben kann. Dies sind normalerweise Sie selbst.",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<G\u00fcltige User-ID oder Gruppen-ID>"
         }
     },
     "required": [
@@ -268,6 +275,7 @@
         "date_of_cassation",
         "date_of_submission",
         "reading",
-        "reading_and_writing"
+        "reading_and_writing",
+        "dossier_manager"
     ]
 }

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -220,27 +220,6 @@
             "format": "date",
             "description": "",
             "_zope_schema_type": "Date"
-        },
-        "reading": {
-            "type": "array",
-            "title": "Lesend",
-            "description": "W\u00e4hlen Sie Benutzer und Gruppen aus, welche im Dossier ausschliesslich lesend Zugriff erhalten sollen.",
-            "_zope_schema_type": "List",
-            "default": null
-        },
-        "reading_and_writing": {
-            "type": "array",
-            "title": "Lesend & schreibend",
-            "description": "W\u00e4hlen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schreibend Zugriff erhalten sollen. Die Benutzer dieser Gruppe werden dazu berechtigt, das Dossier zu bearbeiten, Inhalte zu erstellen und zu bearbeiten.",
-            "_zope_schema_type": "List",
-            "default": null
-        },
-        "dossier_manager": {
-            "type": "string",
-            "title": "Dossier-Verwalter",
-            "description": "W\u00e4hlen Sie hier einen Benutzer oder eine Gruppe, welche nach dem Sch\u00fctzen des Dossiers den Schutz anpassen oder wieder aufheben kann. Dies sind normalerweise Sie selbst.",
-            "_zope_schema_type": "Choice",
-            "_vocabulary": "<G\u00fcltige User-ID oder Gruppen-ID>"
         }
     },
     "required": [
@@ -273,9 +252,6 @@
         "archival_value_annotation",
         "custody_period",
         "date_of_cassation",
-        "date_of_submission",
-        "reading",
-        "reading_and_writing",
-        "dossier_manager"
+        "date_of_submission"
     ]
 }

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -75,9 +75,6 @@ VOCAB_OVERRIDES = {
         'issuer': u'<G\xfcltige User-ID>',
         'responsible': u'<G\xfcltige User-ID>',
     },
-    'opengever.dossier.behaviors.protect_dossier.IProtectDossier': {
-        'dossier_manager': u'<G\xfcltige User-ID oder Gruppen-ID>',
-    }
 }
 
 DEFAULT_OVERRIDES = {
@@ -104,6 +101,10 @@ IGNORED_FIELDS = [
     'opengever.document.behaviors.metadata.IDocumentMetadata.thumbnail',
     'opengever.dossier.behaviors.dossier.IDossier.temporary_former_reference_number',  # noqa
     'opengever.mail.mail.IMail.message_source',
+    'opengever.dossier.behaviors.protect_dossier.IProtectDossier.reading',
+    'opengever.dossier.behaviors.protect_dossier.IProtectDossier.reading_and_writing',
+    'opengever.dossier.behaviors.protect_dossier.IProtectDossier.dossier_manager',
+
 ]
 
 # Dropped from OGGBundle schema dumps

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -75,6 +75,9 @@ VOCAB_OVERRIDES = {
         'issuer': u'<G\xfcltige User-ID>',
         'responsible': u'<G\xfcltige User-ID>',
     },
+    'opengever.dossier.behaviors.protect_dossier.IProtectDossier': {
+        'dossier_manager': u'<G\xfcltige User-ID oder Gruppen-ID>',
+    }
 }
 
 DEFAULT_OVERRIDES = {

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -94,6 +94,7 @@ DOSSIER_DEFAULTS = {
     'start': FROZEN_TODAY,
     'reading': [],
     'reading_and_writing': [],
+    'dossier_manager': None,
 }
 DOSSIER_FORM_DEFAULTS = {
     'responsible': TEST_USER_ID,

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -327,6 +327,16 @@
                     "_zope_schema_type": "List",
                     "default": null
                 },
+                "dossier_manager": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Dossier-Verwalter",
+                    "description": "W\u00e4hlen Sie hier einen Benutzer oder eine Gruppe, welche nach dem Sch\u00fctzen des Dossiers den Schutz anpassen oder wieder aufheben kann. Dies sind normalerweise Sie selbst.",
+                    "_zope_schema_type": "Choice",
+                    "_vocabulary": "<G\u00fcltige User-ID oder Gruppen-ID>"
+                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -417,7 +427,8 @@
                 "date_of_cassation",
                 "date_of_submission",
                 "reading",
-                "reading_and_writing"
+                "reading_and_writing",
+                "dossier_manager"
             ]
         },
         "permission": {

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -307,36 +307,6 @@
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
-                "reading": {
-                    "type": [
-                        "null",
-                        "array"
-                    ],
-                    "title": "Lesend",
-                    "description": "W\u00e4hlen Sie Benutzer und Gruppen aus, welche im Dossier ausschliesslich lesend Zugriff erhalten sollen.",
-                    "_zope_schema_type": "List",
-                    "default": null
-                },
-                "reading_and_writing": {
-                    "type": [
-                        "null",
-                        "array"
-                    ],
-                    "title": "Lesend & schreibend",
-                    "description": "W\u00e4hlen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schreibend Zugriff erhalten sollen. Die Benutzer dieser Gruppe werden dazu berechtigt, das Dossier zu bearbeiten, Inhalte zu erstellen und zu bearbeiten.",
-                    "_zope_schema_type": "List",
-                    "default": null
-                },
-                "dossier_manager": {
-                    "type": [
-                        "null",
-                        "string"
-                    ],
-                    "title": "Dossier-Verwalter",
-                    "description": "W\u00e4hlen Sie hier einen Benutzer oder eine Gruppe, welche nach dem Sch\u00fctzen des Dossiers den Schutz anpassen oder wieder aufheben kann. Dies sind normalerweise Sie selbst.",
-                    "_zope_schema_type": "Choice",
-                    "_vocabulary": "<G\u00fcltige User-ID oder Gruppen-ID>"
-                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -425,10 +395,7 @@
                 "archival_value_annotation",
                 "custody_period",
                 "date_of_cassation",
-                "date_of_submission",
-                "reading",
-                "reading_and_writing",
-                "dossier_manager"
+                "date_of_submission"
             ]
         },
         "permission": {

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-30 19:14+0000\n"
+"POT-Creation-Date: 2017-11-09 15:26+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -270,6 +270,11 @@ msgstr "Dokument aus Vorlage erstellen"
 msgid "create_dossier_with_template"
 msgstr "Geschäftsdossier aus Vorlage erstellen"
 
+#. Default: "This user or group will get the dossier manager role after protecting the dossier."
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "description_dossier_manager"
+msgstr "Wählen Sie hier einen Benutzer oder eine Gruppe, welche nach dem Schützen des Dossiers den Schutz anpassen oder wieder aufheben kann. Dies sind normalerweise Sie selbst."
+
 #. Default: "The defined keywords will be preselected for new dossies from template."
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
@@ -514,6 +519,11 @@ msgstr "Zielposition / Zieldossier"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_documents"
 msgstr "Dokumente"
+
+#. Default: "Dossier manager"
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "label_dossier_manager"
+msgstr "Dossier-Verwalter"
 
 #. Default: "Create Dossier note"
 #: ./opengever/dossier/viewlets/templates/note.pt

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-30 19:14+0000\n"
+"POT-Creation-Date: 2017-11-09 15:26+0000\n"
 "PO-Revision-Date: 2017-09-03 09:00+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -268,6 +268,11 @@ msgstr "Créer un document à partir d'un modèle"
 msgid "create_dossier_with_template"
 msgstr "Créer un dossier d'affaire à partir du modèle"
 
+#. Default: "This user or group will get the dossier manager role after protecting the dossier."
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "description_dossier_manager"
+msgstr ""
+
 #. Default: "The defined keywords will be preselected for new dossies from template."
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
@@ -512,6 +517,11 @@ msgstr "Destination (position/dossier)"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_documents"
 msgstr "Documents"
+
+#. Default: "Dossier manager"
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "label_dossier_manager"
+msgstr ""
 
 #. Default: "Create Dossier note"
 #: ./opengever/dossier/viewlets/templates/note.pt

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-30 19:14+0000\n"
+"POT-Creation-Date: 2017-11-09 15:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -269,6 +269,11 @@ msgstr ""
 msgid "create_dossier_with_template"
 msgstr ""
 
+#. Default: "This user or group will get the dossier manager role after protecting the dossier."
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "description_dossier_manager"
+msgstr ""
+
 #. Default: "The defined keywords will be preselected for new dossies from template."
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
@@ -512,6 +517,11 @@ msgstr ""
 #: ./opengever/dossier/browser/overview.py
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_documents"
+msgstr ""
+
+#. Default: "Dossier manager"
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "label_dossier_manager"
 msgstr ""
 
 #. Default: "Create Dossier note"

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -92,6 +92,7 @@ class TestProtectDossierBehavior(IntegrationTestCase):
         form = browser.find_form_by_field('Reading')
         form.find_widget('Reading').fill('projekt_a')
         form.find_widget('Reading and writing').fill('projekt_b')
+        form.find_widget('Dossier manager').fill(self.dossier_manager.getId())
         browser.click_on('Save')
 
         self.assertEqual(['projekt_a'], IProtectDossier(self.dossier).reading)
@@ -119,6 +120,7 @@ class TestProtectDossierBehavior(IntegrationTestCase):
         browser.open(self.dossier, view="@@edit")
         form = browser.find_form_by_field('Reading')
         form.find_widget('Reading').fill(self.regular_user.getId())
+        form.find_widget('Dossier manager').fill(self.dossier_manager.getId())
         browser.click_on('Save')
 
         self.assert_local_roles(
@@ -170,6 +172,7 @@ class TestProtectDossierBehavior(IntegrationTestCase):
         dossier_protector.reading = [self.regular_user.getId(), 'projekt_a']
         dossier_protector.reading_and_writing = [self.secretariat_user.getId(),
                                                  'projekt_b']
+        dossier_protector.dossier_manager = self.dossier_manager.getId()
         dossier_protector.protect()
 
         self.assert_local_roles(
@@ -197,6 +200,7 @@ class TestProtectDossierBehavior(IntegrationTestCase):
 
         dossier_protector = IProtectDossier(self.dossier)
         dossier_protector.reading = [self.regular_user.getId()]
+        dossier_protector.dossier_manager = self.dossier_manager.getId()
         dossier_protector.protect()
 
         self.assert_local_roles(
@@ -206,18 +210,15 @@ class TestProtectDossierBehavior(IntegrationTestCase):
     def test_reindex_object_security_on_dossier(self):
         self.login(self.dossier_manager)
 
-        dossier_protector = IProtectDossier(self.dossier)
-        dossier_protector.reading = []
-        dossier_protector.reading_and_writing = []
-        dossier_protector.protect()
-
         self.assertItemsEqual(
             ['Administrator', 'Contributor', 'Editor', 'Manager', 'Reader',
-             'user:fa_users'],
+             'user:fa_users', 'user:{}'.format(self.regular_user.getId())],
             self.get_allowed_roles_and_users_for(self.dossier))
 
+        dossier_protector = IProtectDossier(self.dossier)
         dossier_protector.reading = [self.regular_user.getId()]
         dossier_protector.reading_and_writing = []
+        dossier_protector.dossier_manager = self.dossier_manager.getId()
         dossier_protector.protect()
 
         self.assertItemsEqual(

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -99,6 +99,27 @@ class TestProtectDossierBehavior(IntegrationTestCase):
         self.assertEqual(['projekt_b'], IProtectDossier(self.dossier).reading_and_writing)
 
     @browsing
+    def test_current_user_is_default_dossier_manager(self, browser):
+        self.login(self.dossier_manager, browser)
+
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
+        field = browser.find('Dossier manager')
+        selected_option = filter(lambda x: x.attrib.get('selected'),
+                                 field.css('option'))[0]
+
+        self.assertEqual(
+            u'Fr\xfchling F\xe4ivel (faivel.fruhling)',
+            selected_option.text)
+
+        browser.fill({'Title': 'My Dossier'})
+        browser.click_on('Save')
+
+        self.assertEqual(
+            self.dossier_manager.getId(),
+            IProtectDossier(browser.context).dossier_manager)
+
+    @browsing
     def test_add_dossier_will_enable_dossier_protection(self, browser):
         self.login(self.dossier_manager, browser)
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -72,6 +72,7 @@ class BaseMultipleSourcesQuerySource(BaseQuerySoure):
         raise NotImplemented
 
     def getTerm(self, value):
+        term = None
         for source in self.source_instances:
             try:
                 term = source.getTerm(value)
@@ -87,6 +88,7 @@ class BaseMultipleSourcesQuerySource(BaseQuerySoure):
         return term
 
     def getTermByToken(self, token):
+        term = None
         for source in self.source_instances:
             try:
                 term = source.getTerm(token)
@@ -426,14 +428,15 @@ class AllUsersSource(AllUsersInboxesAndTeamsSource):
         if not token:
             raise LookupError('A token "userid" is required.')
 
-        try:
-            value = token
-            return self.getTerm(value)
-        except orm.exc.NoResultFound:
-            raise LookupError
+        value = token
+        return self.getTerm(value)
 
     def getTerm(self, value):
-        user = self.base_query.filter(User.userid == value).one()
+        try:
+            user = self.base_query.filter(User.userid == value).one()
+        except orm.exc.NoResultFound:
+            raise LookupError(
+                'No row was user was found with userid: {}'.format(value))
 
         token = value
         title = u'{} ({})'.format(user.fullname(),


### PR DESCRIPTION
Add new field dossier_manager to the IProtectDossier behavior to set the dossier-manager manually.

The field "dossier_manager" is not read-only as described in the requirements. A manager or a dossier-manager can change this field. This is required if you need to add i.e. a group instead only a user as a dossier-manager or if the manager wants to change the dossier-manager.

![screen1](https://user-images.githubusercontent.com/557005/32725632-2acb1fa4-c876-11e7-9839-c23c154e2805.gif)
