### PR TITLE
Don't escape description in overview twice for dossier templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - SPV: Make the considerations field a trix field. [tarnap]
+- Don't escape description in overview twice for dossier templates. [deiferni]
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
 - SPV word: Remove fields which are intended for no word version. [tarnap]
 - Add proper responsible for fixture objects. [elioschmutz]

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -92,6 +92,11 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
         return dict(id='description', content=self.description,
                     is_html=True, label=_("Description"))
 
+    def description(self):
+        return api.portal.get_tool(name='portal_transforms').convertTo(
+            'text/html', self.context.description,
+            mimetype='text/x-web-intelligent').getData()
+
     def is_subdossier_navigation_available(self):
         main_dossier = self.context.get_main_dossier()
         return main_dossier.has_subdossiers()
@@ -161,11 +166,6 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
                 'css_class': 'function-user',
             })
         return users
-
-    def description(self):
-        return api.portal.get_tool(name='portal_transforms').convertTo(
-            'text/html', self.context.description,
-            mimetype='text/x-web-intelligent').getData()
 
     def linked_dossiers(self):
         """Returns a list of dicts representing incoming and outgoing
@@ -241,10 +241,6 @@ class DossierTemplateOverview(DossierOverview):
     def make_filing_prefix_box(self):
         return dict(id='filing_prefix', content=self.context.get_filing_prefix_label(),
                     label=_(u'filing_prefix', default="filing prefix"))
-
-    def make_description_box(self):
-        return dict(id='description', content=self.description(),
-                    label=_(u'label_description', default=u'Description'))
 
     def documents(self):
         return IContentListing(self.catalog(


### PR DESCRIPTION
Transform seems to be applied twice by mistake. We can just use the `super` implementation instead of overriding it with a faulty one.

See https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/160.

