### PR TITLE
Fix links from the committee overview to members

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- SPV: Fix member links in committee overview. [tarnap]
 - SPV: Make the considerations field a trix field. [tarnap]
 - Don't escape description in overview twice for dossier templates. [deiferni]
 - Fix agenda items rendering on non-word meeting. [deiferni]

--- a/opengever/meeting/browser/committee.py
+++ b/opengever/meeting/browser/committee.py
@@ -46,7 +46,8 @@ class CommitteeOverview(BrowserView, GeverTabMixin):
     def current_members(self):
         memberships = self.context.get_active_memberships().all()
         members = [membership.member for membership in memberships]
-        return [member.get_link(self.context) for member in members]
+        committee_container = self.context.get_committee_container()
+        return [member.get_link(committee_container) for member in members]
 
     def period(self):
         period = Period.query.get_current(self.context.load_model())

--- a/opengever/meeting/tests/test_committee_overview.py
+++ b/opengever/meeting/tests/test_committee_overview.py
@@ -57,7 +57,7 @@ class TestCommitteeOverview(FunctionalTestCase):
         browser.login().open(self.committee, view='tabbedview_view-overview')
 
         self.assertEquals(
-            'http://nohost/plone/committee-1/member-1',
+            'http://nohost/plone/member-1',
             browser.css('#current_membersBox li a').first.get('href'))
 
     @browsing


### PR DESCRIPTION
# SPV

> Die Links zu den Mitgliedern werden falsch erstellt, sie zeigen auf das Committee (z.B. … fd/sitzungen/committee-1/member-123), sollten aber auf den CommitteeContainer (z.B. …fd/sitzungen/member-123) zeigen.

Resolves https://github.com/4teamwork/gever/issues/152