### PR TITLE
Fix syncing the submitted proposal title to sql.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- Fix syncing the submitted proposal title to sql. [deiferni]
 - SPV: Fix member links in committee overview. [tarnap]
 - SPV: Make the considerations field a trix field. [tarnap]
 - Don't escape description in overview twice for dossier templates. [deiferni]

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -257,6 +257,9 @@ class SQLUpgradeStep(UpgradeStep):
         raise NotImplementedError()
 
     def execute(self, statement):
+        """Execute statement and make sure the datamanger sees the changes."""
+
+        mark_changed(self.session)
         return self.connection.execute(statement)
 
     def _setup_db_connection(self):

--- a/opengever/core/upgrades/20171115090641_fix_submitted_proposal_title_sync/upgrade.py
+++ b/opengever/core/upgrades/20171115090641_fix_submitted_proposal_title_sync/upgrade.py
@@ -1,0 +1,38 @@
+from opengever.core.upgrade import SQLUpgradeStep
+from opengever.ogds.base.utils import get_current_admin_unit
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+
+
+proposals_table = table(
+    "proposals",
+    column("submitted_int_id"),
+    column("submitted_admin_unit_id"),
+    column("submitted_title"),
+)
+
+
+class FixSubmittedProposalTitleSync(SQLUpgradeStep):
+    """Fix submitted proposal title sync.
+    """
+
+    def migrate(self):
+        self.admin_unit_id = get_current_admin_unit().id()
+        self.intids = getUtility(IIntIds)
+
+        self.resync_submitted_proposal_title()
+
+    def resync_submitted_proposal_title(self):
+        for submitted_proposal in self.objects(
+                {'portal_type': 'opengever.meeting.submittedproposal'},
+                'Fix submitted proposal title sync.'):
+
+            intid = self.intids.getId(submitted_proposal)
+            title = submitted_proposal.title
+
+            self.execute(proposals_table.update()
+                .values(submitted_title=title)
+                .where(proposals_table.c.submitted_admin_unit_id == self.admin_unit_id)
+                .where(proposals_table.c.submitted_int_id == intid))

--- a/opengever/meeting/browser/createsubmittedproposal.py
+++ b/opengever/meeting/browser/createsubmittedproposal.py
@@ -33,6 +33,9 @@ class CreateSubmittedProposal(BrowserView):
                 'IProposal')
             collector.insert(data['field-data'])
 
+            # sync data to proposal after inserting field data
+            submitted_proposal.sync_model(proposal_model=proposal)
+
             if is_word_meeting_implementation_enabled():
                 submitted_proposal.create_proposal_document(
                     filename=data['file']['filename'],

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -425,7 +425,6 @@ class SubmittedProposal(ProposalBase):
             id=cls.generate_submitted_proposal_id(proposal),
             container=container)
 
-        submitted_proposal.sync_model(proposal_model=proposal)
         return submitted_proposal
 
     @classmethod

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -307,6 +307,21 @@ class TestProposal(IntegrationTestCase):
             browser.css('.portalMessage.info a').first.get('href'))
 
     @browsing
+    def test_regression_submitted_proposal_title_synced_on_submission(self, browser):
+        """Test a regression for a proposal without attachments."""
+
+        self.login(self.dossier_responsible, browser)
+        proposal_model = self.draft_proposal.load_model()
+
+        browser.open(self.draft_proposal, view='tabbedview_view-overview')
+        browser.click_on('Submit')
+        statusmessages.assert_no_error_messages()
+        statusmessages.assert_message('Proposal successfully submitted.')
+
+        self.assertEqual(u'Antrag f\xfcr Kreiselbau',
+                         proposal_model.submitted_title)
+
+    @browsing
     def test_proposal_can_be_cancelled(self, browser):
         self.login(self.dossier_responsible, browser)
         self.assertEqual(Proposal.STATE_PENDING, self.draft_proposal.get_state())


### PR DESCRIPTION
The title and other proposal-model attributes should only be synced after
they have been set from the attribute data provided as JSON in the request.

We have not noticed this is a problem so far because the test tests with
attachments which cause an object modified event to be fired later. Same for
the word implementation since creating the word document fires a modified
event, too.

Also contains a critical fix for `SQLUpgradeStep` that ensures statements always are picked up as changes by the zope datamanager.

_Should be backported as a bugfix level release._

Fixes #3607.