### PR TITLE
Restore mtest to use dotted names for modules

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -85,11 +85,11 @@ def create_test_run_params():
 
     # Manually ordered per metrification
     standalone_modules = (
-        'document',
-        'base',
-        'task',
-        'dossier',
-        'disposition',
+        'opengever.document',
+        'opengever.base',
+        'opengever.task',
+        'opengever.dossier',
+        'opengever.disposition',
         )
 
     # Manually ordered per metrification


### PR DESCRIPTION
I was under the impression using just the module name will do the same test discovery / filtering dance than using the dotted name. Apparently it is not so. This pull request amends that.