### PR TITLE
Fix OGMail searchable text extender.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - SPV: Sort meetings by date. [tarnap]
 - SPV: Add concluded meetings to committee overview and reorder the blocks in the columns. [tarnap]
 - Update bumblebee checksum when modifying document doc properties. [deiferni]
+- Fix OGMail searchable text extender. [elioschmutz]
 - Fix syncing the submitted proposal title to sql. [deiferni]
 - SPV: Fix member links in committee overview. [tarnap]
 - Add date of submission to proposals. [deiferni]

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -10,8 +10,8 @@ from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
 from opengever.ogds.base.actor import Actor
+from plone import api
 from plone.indexer import indexer
-from Products.CMFCore.utils import getToolByName
 from Products.CMFDiffTool.utils import safe_utf8
 from ZODB.POSException import ConflictError
 from zope.component import adapter
@@ -40,7 +40,7 @@ class DefaultDocumentIndexer(object):
         file_ = self.context.get_file()
         if file_:
             filename = file_.filename
-            transform_tool = getToolByName(self.context, 'portal_transforms')
+            transform_tool = api.portal.get_tool('portal_transforms')
             try:
                 plain_text = transform_tool.convertTo(
                     'text/plain',

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -157,7 +157,7 @@ class TestDefaultDocumentIndexer(MockTestCase):
 
         # Sample document containing our file
         doc1 = self.mocker.mock()
-        self.expect(doc1.file).result(sample_file).count(1, None)
+        self.expect(doc1.get_file()).result(sample_file).count(1, None)
 
         # datastream returned by transform
         expected_fulltext = 'FULLTEXT'
@@ -195,7 +195,7 @@ class TestDefaultDocumentIndexer(MockTestCase):
 
         # Sample document containing our file
         doc1 = self.mocker.mock()
-        self.expect(doc1.file).result(sample_file).count(1, None)
+        self.expect(doc1.get_file()).result(sample_file).count(1, None)
 
         def raise_transform_exception(*args, **kwargs):
             raise Exception("This transform failed!")

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -9,8 +9,10 @@ from opengever.testing import index_data_for
 from opengever.testing import obj2brain
 from plone.dexterity.utils import createContentInContainer
 from plone.namedfile.file import NamedBlobFile
+from Products.CMFCore.interfaces import ISiteRoot
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapter
+from zope.component.hooks import setSite
 import datetime
 
 
@@ -164,6 +166,11 @@ class TestDefaultDocumentIndexer(MockTestCase):
         stream = self.mocker.mock()
         self.expect(stream.getData()).result(expected_fulltext)
 
+        # Mock portal object for getSite()
+        site = self.providing_stub(interfaces=[ISiteRoot])
+        self.expect(site.aq_chain).result([site])
+        setSite(site)
+
         # Mock the portal_transforms tool
         mock_portal_transforms = self.mocker.mock()
         self.expect(mock_portal_transforms.convertTo(
@@ -199,6 +206,11 @@ class TestDefaultDocumentIndexer(MockTestCase):
 
         def raise_transform_exception(*args, **kwargs):
             raise Exception("This transform failed!")
+
+        # Mock portal object for getSite()
+        site = self.providing_stub(interfaces=[ISiteRoot])
+        self.expect(site.aq_chain).result([site])
+        setSite(site)
 
         # Mock the portal_transforms tool to raise an exception
         mock_portal_transforms = self.mocker.mock()

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -37,11 +37,6 @@
       name="checked_out"
       />
 
-  <adapter
-      factory=".indexer.SearchableTextExtender"
-      name="IOGMail"
-      />
-
   <plone:behavior
       title="ISendableDocsContainer behavior"
       description="generates an email adress for a dossier"

--- a/opengever/mail/indexer.py
+++ b/opengever/mail/indexer.py
@@ -1,12 +1,5 @@
-from collective import dexteritytextindexer
 from ftw.mail.mail import IMail
-from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
-from opengever.document.behaviors.metadata import IDocumentMetadata
 from plone.indexer import indexer
-from Products.CMFDiffTool.utils import safe_utf8
-from zope.component import adapter
-from zope.component import getAdapter, getUtility
-from zope.interface import implementer
 
 
 @indexer(IMail)
@@ -16,30 +9,3 @@ def checked_out(obj):
     empty string."""
 
     return ''
-
-
-@implementer(dexteritytextindexer.IDynamicTextIndexExtender)
-@adapter(IMail)
-class SearchableTextExtender(object):
-    """Specifix SearchableText Extender for the mail"""
-
-    def __init__(self, context):
-        self.context = context
-
-    def __call__(self):
-        searchable = []
-        # append some other attributes to the searchableText index
-        # reference_number
-        refNumb = getAdapter(self.context, IReferenceNumber)
-        searchable.append(refNumb.get_number())
-
-        # sequence_number
-        seqNumb = getUtility(ISequenceNumber)
-        searchable.append(str(seqNumb.get_number(self.context)))
-
-        # keywords
-        keywords = IDocumentMetadata(self.context).keywords
-        if keywords:
-            searchable.extend(safe_utf8(keyword) for keyword in keywords)
-
-        return ' '.join(searchable)

--- a/opengever/mail/overrides.zcml
+++ b/opengever/mail/overrides.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.mail">
+
+  <include package="z3c.unconfigure" file="meta.zcml" />
+
+  <unconfigure>
+
+    <adapter
+        for="ftw.mail.mail.IMail"
+        factory="ftw.mail.mail.SearchableTextExtender"
+        />
+
+  </unconfigure>
+
+</configure>

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -36,6 +36,6 @@ class TestMailIndexers(IntegrationTestCase):
     def test_reference_number(self):
         self.login(self.regular_user)
         extender = getAdapter(
-            self.mail_eml, IDynamicTextIndexExtender, u'IOGMail')
+            self.mail_eml, IDynamicTextIndexExtender, u'IDocumentSchema')
 
         self.assertEquals('Client1 1.1 / 1 / 12 12', extender())

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ setup(name='opengever.core',
           'z3c.formwidget.query',
           'z3c.relationfield',
           'z3c.saconfig',
+          'z3c.unconfigure',
           'zc.relation',
           'zope.globalrequest',
           # -*- Extra requirements: -*-

--- a/versions.cfg
+++ b/versions.cfg
@@ -215,6 +215,7 @@ z3c.dependencychecker = 1.11
 z3c.jbot = 0.7.2
 z3c.pt = 3.0
 z3c.saconfig = 0.14
+z3c.unconfigure = 1.0.1
 zc.buildout = 2.9.4
 zope.sqlalchemy = 0.7.7
 zptlint = 0.2.4


### PR DESCRIPTION
This PR fixes the unicode-issue due to 

- unconfiguring the ftw.mail searchableTextExtender which uses the html_to_text transform
- registering the document searchableTextExtender for IBaseDocument instead the more specific `IDocumentSchema`
- Removing the `OGMail` searchableTextExtender because it's the same implementation like the one of the document.

Before:
![screen1](https://user-images.githubusercontent.com/557005/32854310-804a4062-ca3e-11e7-9811-2977d0eaeb62.gif)

After:
![screen1](https://user-images.githubusercontent.com/557005/32854245-48345244-ca3e-11e7-83cf-5be87d59b66d.gif)


Closes #2462 