### PR TITLE
Update bumblebee checksum when modifying document doc-properties.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Show filterlist also on empty tabbedview listings. [phgross]
 - SPV: Sort meetings by date. [tarnap]
 - SPV: Add concluded meetings to committee overview and reorder the blocks in the columns. [tarnap]
+- Update bumblebee checksum when modifying document doc properties. [deiferni]
 - Fix syncing the submitted proposal title to sql. [deiferni]
 - SPV: Fix member links in committee overview. [tarnap]
 - Add date of submission to proposals. [deiferni]

--- a/opengever/bumblebee/tests/test_document_event_handling.py
+++ b/opengever/bumblebee/tests/test_document_event_handling.py
@@ -1,0 +1,28 @@
+from ftw.bumblebee.interfaces import IBumblebeeDocument
+from opengever.dossier.docprops import DocPropertyWriter
+from opengever.testing import IntegrationTestCase
+
+
+class TestDocPropertywriterBumblebeeChecksum(IntegrationTestCase):
+    """Test that bumblebee checksum remains up to date after we have modified
+    a document with the doc property writer.
+
+    """
+    features = ('update-doc-properties',)
+
+    def test_bumblebee_checksum_updated_when_document_modified(self):
+        self.login(self.dossier_responsible)
+
+        pre_update_checksum = IBumblebeeDocument(self.document).get_checksum()
+
+        DocPropertyWriter(self.document).update_doc_properties(only_existing=False)
+
+        post_update_checksum = IBumblebeeDocument(self.document).get_checksum()
+        self.assertEqual(
+            post_update_checksum,
+            IBumblebeeDocument(self.document).update_checksum(),
+            "Cached checksum and freshly calculated checksums must match.")
+        self.assertNotEqual(
+            pre_update_checksum, post_update_checksum,
+            "Expected bumblebee checksum to change when the document has been "
+            "modified")

--- a/opengever/bumblebee/tests/test_document_event_handling.py
+++ b/opengever/bumblebee/tests/test_document_event_handling.py
@@ -8,7 +8,7 @@ class TestDocPropertywriterBumblebeeChecksum(IntegrationTestCase):
     a document with the doc property writer.
 
     """
-    features = ('update-doc-properties',)
+    features = ('doc-properties',)
 
     def test_bumblebee_checksum_updated_when_document_modified(self):
         self.login(self.dossier_responsible)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -119,13 +119,13 @@
   <subscriber
       for="opengever.document.document.IDocumentSchema
            opengever.document.interfaces.IObjectBeforeCheckInEvent"
-      handler=".handlers.update_docproperties"
+      handler=".handlers.before_documend_checked_in"
       />
 
   <subscriber
       for="opengever.document.document.IDocumentSchema
            zope.lifecycleevent.IObjectMovedEvent"
-      handler=".handlers.update_moved_doc_properties"
+      handler=".handlers.document_moved_or_added"
       />
 
   <subscriber

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -10,11 +10,11 @@ def checked_out(context, event):
     _update_docproperties(context)
 
 
-def update_docproperties(context, event):
+def before_documend_checked_in(context, event):
     _update_docproperties(context)
 
 
-def update_moved_doc_properties(context, event):
+def document_moved_or_added(context, event):
     if IObjectRemovedEvent.providedBy(event):
         return
 

--- a/opengever/dossier/docprops.py
+++ b/opengever/dossier/docprops.py
@@ -23,7 +23,9 @@ from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryAdapter
+from zope.event import notify
 from zope.interface import implementer
+from zope.lifecycleevent import ObjectModifiedEvent
 from zope.publisher.interfaces.browser import IBrowserRequest
 import os
 
@@ -102,6 +104,8 @@ class DocPropertyWriter(object):
                 with open(tmpfile.path) as processed_tmpfile:
                     file_data = processed_tmpfile.read()
                 self.document.file.data = file_data
+
+                notify(ObjectModifiedEvent(self.document))
 
             return changed
 

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -3,12 +3,12 @@ from plone.app.testing import TEST_USER_ID
 
 
 EXPECTED_USER_DOC_PROPERTIES = {
-    'User.ID': TEST_USER_ID,
-    'User.FullName': u'M\xfcller Peter',
-    'ogg.user.userid': TEST_USER_ID,
-    'ogg.user.title': u'M\xfcller Peter',
-    'ogg.user.firstname': u'Peter',
-    'ogg.user.lastname': u'M\xfcller',
+    'User.ID': 'kathi.barfuss',
+    'User.FullName': u'B\xe4rfuss K\xe4thi',
+    'ogg.user.userid': 'kathi.barfuss',
+    'ogg.user.title': u'B\xe4rfuss K\xe4thi',
+    'ogg.user.firstname': u'K\xe4thi',
+    'ogg.user.lastname': u'B\xe4rfuss',
     'ogg.user.directorate': u'Staatsarchiv',
     'ogg.user.directorate_abbr': u'Arch',
     'ogg.user.department': u'Staatskanzlei',
@@ -51,20 +51,20 @@ OGDS_USER_ATTRIBUTES = {
 }
 
 EXPECTED_DOSSIER_PROPERTIES = {
-    'Dossier.ReferenceNumber': 'Client1 / 1',
-    'Dossier.Title': 'My dossier',
-    'ogg.dossier.title': 'My dossier',
-    'ogg.dossier.reference_number': 'Client1 / 1',
+    'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
+    'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+    'ogg.dossier.title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+    'ogg.dossier.reference_number': 'Client1 1.1 / 1',
     'ogg.dossier.sequence_number': '1',
 }
 
 EXPECTED_DOCUMENT_PROPERTIES = {
-    'Document.ReferenceNumber': 'Client1 / 1 / 1',
-    'Document.SequenceNumber': '1',
-    'ogg.document.title': "My Document",
-    'ogg.document.reference_number': 'Client1 / 1 / 1',
-    'ogg.document.sequence_number': '1',
-    'ogg.document.document_author': u'M\xfcller Peter',
+    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 4',
+    'Document.SequenceNumber': '4',
+    'ogg.document.title': u'Vertr\xe4gsentwurf',
+    'ogg.document.reference_number': 'Client1 1.1 / 1 / 4',
+    'ogg.document.sequence_number': '4',
+    'ogg.document.document_author': TEST_USER_ID,
     'ogg.document.document_date': datetime(2010, 1, 3),
     'ogg.document.document_type': u'Contract',
     'ogg.document.reception_date': datetime(2010, 1, 3),

--- a/opengever/dossier/tests/test_default_doc_property_adapters.py
+++ b/opengever/dossier/tests/test_default_doc_property_adapters.py
@@ -1,61 +1,43 @@
-from datetime import datetime
-from ftw.builder import Builder
-from ftw.builder import create
 from opengever.dossier.interfaces import IDocProperties
 from opengever.dossier.interfaces import IDocPropertyProvider
 from opengever.dossier.tests import EXPECTED_DOC_PROPERTIES
 from opengever.dossier.tests import EXPECTED_DOCUMENT_PROPERTIES
 from opengever.dossier.tests import EXPECTED_DOSSIER_PROPERTIES
 from opengever.dossier.tests import EXPECTED_USER_DOC_PROPERTIES
-from opengever.dossier.tests import OGDS_USER_ATTRIBUTES
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
+from opengever.testing import IntegrationTestCase
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
 
 
-class TestDocProperties(FunctionalTestCase):
+class TestDocProperties(IntegrationTestCase):
 
-    use_default_fixture = False
-
-    def setUp(self):
-        super(TestDocProperties, self).setUp()
-        user, org_unit, admin_unit = create(
-            Builder('fixture')
-            .with_all_unit_setup()
-            .with_user(**OGDS_USER_ATTRIBUTES))
-
-        self.dossier = create(Builder('dossier').titled(u'My dossier'))
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .titled("My Document")
-            .having(document_date=datetime(2010, 1, 3),
-                    document_author=TEST_USER_ID,
-                    document_type='contract',
-                    receipt_date=datetime(2010, 1, 3),
-                    delivery_date=datetime(2010, 1, 3))
-            .with_asset_file('with_gever_properties.docx'))
-
-        self.member = self.login()
+    maxDiff = None
 
     def test_default_doc_properties_adapter(self):
+        self.login(self.regular_user)
+
         docprops = getMultiAdapter(
             (self.document, self.portal.REQUEST), IDocProperties)
         all_properties = docprops.get_properties()
-        self.assertItemsEqual(EXPECTED_DOC_PROPERTIES, all_properties)
-
-    def test_default_dossier_doc_properties_provider(self):
-        dossier_adapter = getAdapter(self.dossier, IDocPropertyProvider)
-        self.assertItemsEqual(EXPECTED_DOSSIER_PROPERTIES,
-                              dossier_adapter.get_properties())
-
-    def test_default_member_doc_properties_provider(self):
-        member_adapter = getAdapter(self.member, IDocPropertyProvider)
-        self.assertItemsEqual(EXPECTED_USER_DOC_PROPERTIES,
-                              member_adapter.get_properties())
+        self.assertEqual(EXPECTED_DOC_PROPERTIES, all_properties)
 
     def test_default_document_doc_properties_provider(self):
+        self.login(self.regular_user)
+
         document_adapter = getAdapter(self.document, IDocPropertyProvider)
-        self.assertItemsEqual(EXPECTED_DOCUMENT_PROPERTIES,
-                              document_adapter.get_properties())
+        self.assertEqual(EXPECTED_DOCUMENT_PROPERTIES,
+                         document_adapter.get_properties())
+
+    def test_default_dossier_doc_properties_provider(self):
+        self.login(self.regular_user)
+
+        dossier_adapter = getAdapter(self.dossier, IDocPropertyProvider)
+        self.assertEqual(EXPECTED_DOSSIER_PROPERTIES,
+                         dossier_adapter.get_properties())
+
+    def test_default_member_doc_properties_provider(self):
+        self.login(self.regular_user)
+
+        member_adapter = getAdapter(self.regular_user, IDocPropertyProvider)
+        self.assertEqual(EXPECTED_USER_DOC_PROPERTIES,
+                         member_adapter.get_properties())

--- a/opengever/dossier/tests/test_doc_property_writer.py
+++ b/opengever/dossier/tests/test_doc_property_writer.py
@@ -25,7 +25,7 @@ class TestDocPropertyWriter(IntegrationTestCase):
 
     maxDiff = None
 
-    features = ('update-doc-properties',)
+    features = ('doc-properties',)
 
     def test_export_is_enabled_when_feature_is_enabled(self):
         self.login(self.regular_user)

--- a/opengever/dossier/tests/test_doc_property_writer.py
+++ b/opengever/dossier/tests/test_doc_property_writer.py
@@ -1,117 +1,85 @@
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.testing import freeze
 from ooxml_docprops import read_properties
 from opengever.dossier.docprops import DocPropertyWriter
 from opengever.dossier.docprops import TemporaryDocFile
 from opengever.dossier.tests import EXPECTED_DOC_PROPERTIES
-from opengever.dossier.tests import OGDS_USER_ATTRIBUTES
 from opengever.journal.handlers import DOC_PROPERTIES_UPDATED
 from opengever.journal.tests.utils import get_journal_entry
 from opengever.journal.tests.utils import get_journal_length
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
+from opengever.testing import assets
+from opengever.testing import IntegrationTestCase
+from plone.namedfile.file import NamedBlobFile
 
 
-class TestDocPropertyWriter(FunctionalTestCase):
+class TestDocPropertyWriterExportDisabled(IntegrationTestCase):
 
-    use_default_fixture = False
+    def test_export_is_disabled_when_feature_is_not_enabled(self):
+        self.login(self.regular_user)
+
+        self.assertFalse(DocPropertyWriter(self.document).is_export_enabled())
+
+
+class TestDocPropertyWriter(IntegrationTestCase):
+
     maxDiff = None
 
-    def setUp(self):
-        super(TestDocPropertyWriter, self).setUp()
+    features = ('update-doc-properties',)
 
-        user, org_unit, admin_unit = create(
-            Builder('fixture')
-            .with_all_unit_setup()
-            .with_user(**OGDS_USER_ATTRIBUTES))
+    def test_export_is_enabled_when_feature_is_enabled(self):
+        self.login(self.regular_user)
 
-        self.set_docproperty_export_enabled(True)
-
-        self.dossier = create(Builder('dossier').titled(u'My dossier'))
-
-    @property
-    def writer(self):
-        return DocPropertyWriter(self.document)
-
-    def tearDown(self):
-        self.set_docproperty_export_enabled(False)
-        super(TestDocPropertyWriter, self).tearDown()
-
-    def test_with_file(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .with_asset_file('with_gever_properties.docx'))
-
-        self.assertTrue(self.writer.has_file())
-        self.document.file = None
-        self.assertFalse(self.writer.has_file())
-
-    def test_is_export_enabled(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .with_asset_file('with_gever_properties.docx'))
-
-        self.assertTrue(self.writer.is_export_enabled())
-        self.set_docproperty_export_enabled(False)
-        self.assertFalse(self.writer.is_export_enabled())
+        self.assertTrue(DocPropertyWriter(self.document).is_export_enabled())
 
     def test_is_supported_file(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .with_asset_file('with_gever_properties.docx'))
+        self.login(self.regular_user)
 
-        self.assertTrue(self.writer.is_supported_file())
+        writer = DocPropertyWriter(self.document)
+
+        self.assertTrue(writer.is_supported_file())
+
         self.document.file.contentType = 'text/foo'
-        self.assertFalse(self.writer.is_supported_file())
+        self.assertFalse(writer.is_supported_file())
+
+    def test_has_file(self):
+        self.login(self.dossier_responsible)
+
+        self.assertTrue(DocPropertyWriter(self.document).has_file())
+
+        self.document.file = None
+        self.assertFalse(DocPropertyWriter(self.document).has_file())
 
     def test_document_with_gever_properties_is_updated_with_all_properties(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .titled("My Document")
-            .having(document_date=datetime(2010, 1, 3),
-                    document_author=TEST_USER_ID,
-                    document_type='contract',
-                    receipt_date=datetime(2010, 1, 3),
-                    delivery_date=datetime(2010, 1, 3))
-            .with_asset_file('with_gever_properties.docx'))
+        self.login(self.regular_user)
+        self.with_asset_file('with_gever_properties.docx')
 
-        self.writer.update_doc_properties(only_existing=True)
+        DocPropertyWriter(self.document).update_doc_properties(only_existing=True)
 
         with TemporaryDocFile(self.document.file) as tmpfile:
             properties = read_properties(tmpfile.path)
             self.assertItemsEqual(EXPECTED_DOC_PROPERTIES.items(), properties)
 
     def test_overwrites_properties_of_wrong_type(self):
-        frozen_date = datetime(2010, 1, 1)
-        with freeze(frozen_date):
-            self.document = create(
-                Builder('document')
-                .within(self.dossier)
-                .titled("Document with prop of wrong type")
-                .with_asset_file('with_property_of_wrong_type.docx'))
+        self.login(self.regular_user)
+        self.with_asset_file('with_property_of_wrong_type.docx')
+
+        DocPropertyWriter(self.document).update_doc_properties(only_existing=False)
 
         with TemporaryDocFile(self.document.file) as tmpfile:
-            self.assertIn(
-                ('ogg.document.document_date', frozen_date,),
-                list(read_properties(tmpfile.path)))
+            properties = dict(read_properties(tmpfile.path))
+            self.assertEqual(
+                datetime(2010, 1, 3),
+                properties['ogg.document.document_date'])
 
     def test_files_with_custom_properties_are_not_updated(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .titled("Document with custom props")
-            .with_asset_file('with_custom_properties.docx'))
+        self.login(self.regular_user)
+        self.with_asset_file('with_custom_properties.docx')
 
         expected_doc_properties = [('Test', 'Peter',)]
 
-        writer = DocPropertyWriter(self.document)
-        writer.update_doc_properties(only_existing=True)
+        DocPropertyWriter(self.document).update_doc_properties(only_existing=True)
+
         with TemporaryDocFile(self.document.file) as tmpfile:
             properties = read_properties(tmpfile.path)
             self.assertItemsEqual(expected_doc_properties, properties)
@@ -121,34 +89,18 @@ class TestDocPropertyWriter(FunctionalTestCase):
         self.assertNotEqual(entry['action']['type'], DOC_PROPERTIES_UPDATED)
 
     def test_properties_can_be_added_to_file_without_properties(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .titled("My Document")
-            .having(document_date=datetime(2010, 1, 3),
-                    document_author=TEST_USER_ID,
-                    document_type='contract',
-                    receipt_date=datetime(2010, 1, 3),
-                    delivery_date=datetime(2010, 1, 3))
-            .with_asset_file('without_custom_properties.docx'))
+        self.login(self.regular_user)
+        self.with_asset_file('without_custom_properties.docx')
 
-        writer = DocPropertyWriter(self.document)
-        writer.update_doc_properties(only_existing=False)
+        DocPropertyWriter(self.document).update_doc_properties(only_existing=False)
+
         with TemporaryDocFile(self.document.file) as tmpfile:
             properties = read_properties(tmpfile.path)
             self.assertItemsEqual(EXPECTED_DOC_PROPERTIES.items(), properties)
 
     def test_writes_additional_recipient_property_providers(self):
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .titled("My Document")
-            .having(document_date=datetime(2010, 1, 3),
-                    document_author=TEST_USER_ID,
-                    document_type='contract',
-                    receipt_date=datetime(2010, 1, 3),
-                    delivery_date=datetime(2010, 1, 3))
-            .with_asset_file('without_custom_properties.docx'))
+        self.login(self.regular_user)
+        self.with_asset_file('without_custom_properties.docx')
 
         peter = create(Builder('person')
                        .having(firstname=u'Peter',
@@ -177,7 +129,10 @@ class TestDocPropertyWriter(FunctionalTestCase):
 
         with TemporaryDocFile(self.document.file) as tmpfile:
             properties = read_properties(tmpfile.path)
-            self.assertItemsEqual(
-                EXPECTED_DOC_PROPERTIES.items() +
-                additional_recipient_properties.items(),
-                properties)
+            self.assertDictContainsSubset(
+                additional_recipient_properties,
+                dict(properties))
+
+    def with_asset_file(self, filename):
+        self.document.file = NamedBlobFile(
+            assets.load(filename), filename=unicode(filename))

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -13,12 +13,22 @@ class TestUserDetails(IntegrationTestCase):
         self.assertEquals([u'B\xe4rfuss K\xe4thi (kathi.barfuss)'],
                           browser.css('h1.documentFirstHeading').text)
 
-        metadata = browser.css('.vertical').first.lists()
-
-        self.assertEquals(
-            ['Name', u'B\xe4rfuss K\xe4thi (kathi.barfuss)'], metadata[0])
-        self.assertEquals(['Active', 'Yes'], metadata[1])
-        self.assertEquals(['Email', 'kathi.barfuss@gever.local'], metadata[2])
+        metadata = dict(browser.css('.vertical').first.lists())
+        self.assertDictContainsSubset({
+            'Address': 'Kappelenweg 13 Postfach 1234 1234 Vorkappelen Schweiz',
+            'Department': 'Staatskanzlei (SK)',
+            'Description': 'nix',
+            'Directorate': 'Staatsarchiv (Arch)',
+            'Email': 'foo@example.com',
+            'Email 2': 'bar@example.com',
+            'Fax': '012 34 56 77',
+            'Mobile phone': '012 34 56 76',
+            'Name': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+            'Office phone': '012 34 56 78',
+            'Salutation': 'Prof. Dr.',
+            'Teams': u'Projekt \xdcberbaung Dorfmatte',
+            'URL': 'http://www.example.com',
+             }, metadata)
 
     @browsing
     def test_user_details_return_not_found_for_not_exisiting_user(self, browser):

--- a/opengever/tabbedview/tests/test_document_listing.py
+++ b/opengever/tabbedview/tests/test_document_listing.py
@@ -7,18 +7,22 @@ class TestDocumentListing(IntegrationTestCase):
     @browsing
     def test_lists_documents(self, browser):
         self.login(self.dossier_responsible, browser)
+
         browser.open(self.dossier, view='tabbedview_view-documents')
         self.maxDiff = None
+
+        listings = browser.css('.listing').first.dicts()
+
         self.assertIn(
             {'': '',
              'Checked out by': '',
-             'Delivery Date': '',
-             'Document Author': '',
-             'Document Date': '31.08.2016',
+             'Delivery Date': '03.01.2010',
+             'Document Author': 'test_user_1_',
+             'Document Date': '03.01.2010',
              'Public Trial': 'unchecked',
-             'Receipt Date': '',
+             'Receipt Date': '03.01.2010',
              'Reference Number': 'Client1 1.1 / 1 / 4',
              'Sequence Number': '4',
              'Subdossier': '',
              'Title': u'Vertr\xe4gsentwurf'},
-            browser.css('.listing').first.dicts())
+            listings)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -21,6 +21,7 @@ from operator import methodcaller
 from plone import api
 from plone.app.testing import login
 from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_ID
 from time import time
 from zope.component.hooks import getSite
 import logging
@@ -99,7 +100,24 @@ class OpengeverContentFixture(object):
         self.dossier_responsible = self.create_user(
             'dossier_responsible', u'Robert', u'Ziegler')
         self.regular_user = self.create_user(
-            'regular_user', u'K\xe4thi', u'B\xe4rfuss')
+            'regular_user', u'K\xe4thi', u'B\xe4rfuss',
+            address1='Kappelenweg 13',
+            address2='Postfach 1234',
+            city='Vorkappelen',
+            country='Schweiz',
+            department='Staatskanzlei',
+            department_abbr='SK',
+            description='nix',
+            directorate='Staatsarchiv',
+            directorate_abbr='Arch',
+            email2='bar@example.com',
+            email='foo@example.com',
+            phone_fax='012 34 56 77',
+            phone_mobile='012 34 56 76',
+            phone_office='012 34 56 78',
+            salutation='Prof. Dr.',
+            url='http://www.example.com',
+            zip_code='1234')
         self.meeting_user = self.create_user(
             'meeting_user', u'Herbert', u'J\xe4ger')
         self.secretariat_user = self.create_user(
@@ -415,9 +433,14 @@ class OpengeverContentFixture(object):
                .for_dossier(self.dossier)
                .with_roles(['final-drawing', 'participation']))
 
-        document = self.register('document', create(
+        self.document = self.register('document', create(
             Builder('document').within(self.dossier)
             .titled(u'Vertr\xe4gsentwurf')
+            .having(document_date=datetime(2010, 1, 3),
+                    document_author=TEST_USER_ID,
+                    document_type='contract',
+                    receipt_date=datetime(2010, 1, 3),
+                    delivery_date=datetime(2010, 1, 3))
             .with_asset_file('vertragsentwurf.docx')))
 
         task = self.register('task', create(
@@ -429,7 +452,7 @@ class OpengeverContentFixture(object):
                     task_type='correction',
                     deadline=date(2016, 11, 1))
             .in_state('task-state-in-progress')
-            .relate_to(document)))
+            .relate_to(self.document)))
 
         self.register('subtask', create(
             Builder('task').within(task)
@@ -440,7 +463,7 @@ class OpengeverContentFixture(object):
                     task_type='correction',
                     deadline=date(2016, 11, 1))
             .in_state('task-state-resolved')
-            .relate_to(document)))
+            .relate_to(self.document)))
 
         self.register('taskdocument', create(
             Builder('document').within(task)
@@ -452,7 +475,7 @@ class OpengeverContentFixture(object):
             Builder('proposal').within(self.dossier)
             .having(title=u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen',
                     committee=self.committee.load_model())
-            .relate_to(document)
+            .relate_to(self.document)
             .as_submitted()))
         self.register_path(
             'submitted_proposal',
@@ -477,7 +500,7 @@ class OpengeverContentFixture(object):
                 Builder('proposal').within(self.dossier)
                 .having(title=u'\xc4nderungen am Personalreglement',
                         committee=self.committee.load_model())
-                .relate_to(document)
+                .relate_to(self.document)
                 .with_proposal_file(assets.load('vertragsentwurf.docx'))
                 .as_submitted()))
             self.register_path(
@@ -696,7 +719,8 @@ class OpengeverContentFixture(object):
         """
         self._lookup_table[attrname] = ('raw', value)
 
-    def create_user(self, attrname, firstname, lastname, globalroles=(), group=None):
+    def create_user(self, attrname, firstname, lastname,
+                    globalroles=(), group=None, **kwargs):
         """Create an OGDS user and a Plone user.
         The user is member of the current org unit user group.
         The ``attrname`` is the attribute name used to access this user
@@ -717,7 +741,8 @@ class OpengeverContentFixture(object):
                .id(plone_user.getId())
                .having(firstname=firstname, lastname=lastname, email=email)
                .assign_to_org_units([self.org_unit])
-               .in_group(group))
+               .in_group(group)
+               .having(**kwargs))
 
         self._lookup_table[attrname] = ('user', plone_user.getId())
         return plone_user

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -41,6 +41,7 @@ FEATURE_FLAGS = {
     'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
     'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled',
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
+    'update-doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties'
 }
 
 FEATURE_PROFILES = {

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -41,7 +41,7 @@ FEATURE_FLAGS = {
     'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
     'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled',
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
-    'update-doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties'
+    'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties'
 }
 
 FEATURE_PROFILES = {


### PR DESCRIPTION
Update bumblebee checksum when modifying a document's doc-properties.

Fire a modified event when we modify the document. Bumblebee listens to those so we can be sure that the cached document checksum will always be correct after adding doc-properties to a docx file.

This fixes an issue where the bumblebee checksum is not updated after creating/modifying a document and thus the bumblebee preview image or overlay could not be rendered.

As discussed there is no upgrade step here since fixing this would include re-calculating the checksum for every document. We will provide a button with which an `Administrator` and `Manager` can attempt to re-render the bumblebee preview, see https://github.com/4teamwork/opengever.core/issues/3619 for a suggestion.

Fixes https://github.com/4teamwork/gever/issues/156.