### PR TITLE
Sort meetings in meeting tab of committee

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- SPV: Sort meetings by date. [tarnap]
 - Fix syncing the submitted proposal title to sql. [deiferni]
 - SPV: Fix member links in committee overview. [tarnap]
 - Add date of submission to proposals. [deiferni]

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -198,7 +198,9 @@ class MeetingQuery(BaseQuery):
 
     def pending_meetings(self, committee):
         query = self._committee_meetings(committee)
-        return query.filter(Meeting.workflow_state != Meeting.STATE_CLOSED.name)
+        query = query.filter(Meeting.workflow_state != Meeting.STATE_CLOSED.name)
+        query = query.order_by(Meeting.start.desc())
+        return query
 
     def by_dossier(self, dossier):
         dossier_oguid = Oguid.for_object(dossier)

--- a/opengever/meeting/tests/test_meeting_listings.py
+++ b/opengever/meeting/tests/test_meeting_listings.py
@@ -1,6 +1,9 @@
 from AccessControl import Unauthorized
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import localized_datetime
 from opengever.meeting.tabs.meetinglisting import dossier_link_or_title
 
 
@@ -40,3 +43,22 @@ class TestMeetingListing(IntegrationTestCase):
             'class="contenttype-opengever-meeting-meetingdossier"'
             '>Sitzungsdossier 9/2017</a>',
             result)
+
+    @browsing
+    def test_entries_are_sorted_by_date(self, browser):
+        self.login(self.meeting_user, browser)
+        browser.open(self.committee, view='tabbedview_view-meetings')
+        self.assertEquals(
+            ['Jul 17, 2016', 'Sep 12, 2016'],
+            browser.css('#listing_container tbody tr td:nth-child(4)').text)
+
+        self.login(self.committee_responsible)
+        create(Builder('meeting')
+               .having(committee=self.committee,
+                       start=localized_datetime(2016, 8, 21)))
+
+        self.login(self.meeting_user, browser)
+        browser.open(self.committee, view='tabbedview_view-meetings')
+        self.assertEquals(
+            ['Jul 17, 2016', 'Aug 21, 2016', 'Sep 12, 2016'],
+            browser.css('#listing_container tbody tr td:nth-child(4)').text)


### PR DESCRIPTION
Sorts the list of meetings in the committee tabbed view in the meetings tab.

See also https://github.com/4teamwork/gever/issues/159